### PR TITLE
MAINT: re-enable integTest task in OpenSearch sink plugin

### DIFF
--- a/.github/workflows/data-prepper-trace-analytics-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-e2e-tests.yml
@@ -29,9 +29,10 @@ jobs:
       with:
         repository: 'opensearch-project/OpenSearch'
         path: OpenSearch
+        ref: '1.0.0-alpha1'
     - name: Build OpenSearch
       working-directory: ./OpenSearch
-      run: ./gradlew publishToMavenLocal
+      run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha1 -Dbuild.snapshot=false
     - name: Checkout Data-Prepper
       uses: actions/checkout@v2
     - name: Grant execute permission for gradlew

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,7 +36,7 @@ jobs:
     # TODO: replace with OpenSearch cluster
     - name: Run ODFE docker
       run: |
-        export version=1.12.0
+        export version=1.13.2
         docker pull amazon/opendistro-for-elasticsearch:$version
         docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -d amazon/opendistro-for-elasticsearch:$version
         sleep 90

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,7 +36,8 @@ jobs:
     # TODO: replace with OpenSearch cluster
     - name: Run ODFE docker
       run: |
-        export version=1.13.2
+    # TODO: need to bump into 1.13.2 after dealing with the breaking change in ISM: https://github.com/opendistro-for-elasticsearch/index-management/blob/main/release-notes/opendistro-for-elasticsearch-index-management.release-notes-1.13.0.0.md#breaking-changes
+        export version=1.12.0
         docker pull amazon/opendistro-for-elasticsearch:$version
         docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -d amazon/opendistro-for-elasticsearch:$version
         sleep 90

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,6 +33,7 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
+    # TODO: replace with OpenSearch cluster
     - name: Run ODFE docker
       run: |
         export version=1.12.0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,9 +35,9 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build
     # TODO: replace with OpenSearch cluster
+    # TODO: need to bump into 1.13.2 after dealing with the breaking change in ISM: https://github.com/opendistro-for-elasticsearch/index-management/blob/main/release-notes/opendistro-for-elasticsearch-index-management.release-notes-1.13.0.0.md#breaking-changes
     - name: Run ODFE docker
       run: |
-    # TODO: need to bump into 1.13.2 after dealing with the breaking change in ISM: https://github.com/opendistro-for-elasticsearch/index-management/blob/main/release-notes/opendistro-for-elasticsearch-index-management.release-notes-1.13.0.0.md#breaking-changes
         export version=1.12.0
         docker pull amazon/opendistro-for-elasticsearch:$version
         docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -d amazon/opendistro-for-elasticsearch:$version

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,7 +35,7 @@ jobs:
       run: ./gradlew build
     - name: Run ODFE docker
       run: |
-        export version=1.9.0
+        export version=1.12.0
         docker pull amazon/opendistro-for-elasticsearch:$version
         docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -d amazon/opendistro-for-elasticsearch:$version
         sleep 90

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,9 +24,10 @@ jobs:
       with:
         repository: 'opensearch-project/OpenSearch'
         path: OpenSearch
+        ref: '1.0.0-alpha1'
     - name: Build OpenSearch
       working-directory: ./OpenSearch
-      run: ./gradlew publishToMavenLocal
+      run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha1 -Dbuild.snapshot=false
     - name: Checkout Data-Prepper
       uses: actions/checkout@v2
     - name: Grant execute permission for gradlew

--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -12,7 +12,7 @@
 //preferably try to main the alphabetical order
 ext.versionMap = [
         opentelemetry_proto    : '1.0.1-alpha',
-        es_version: '1.0.0'
+        es_version: '1.0.0-alpha1'
 ]
 
 ext.coreProjects = [project(':data-prepper-api'), project(':data-prepper-core'), project('data-prepper-plugins:common')]

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -49,7 +49,7 @@ dependencies {
     integrationTestImplementation 'com.google.protobuf:protobuf-java-util:3.13.0'
     integrationTestImplementation "com.linecorp.armeria:armeria:1.0.0"
     integrationTestImplementation "com.linecorp.armeria:armeria-grpc:1.0.0"
-    integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${versionMap.es_version}-SNAPSHOT"
+    integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${versionMap.es_version}"
     integrationTestImplementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
 }
 

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "${es_group}.gradle:build-tools:${es_version}-SNAPSHOT"
+        classpath "${es_group}.gradle:build-tools:${es_version}"
     }
 }
 
@@ -49,7 +49,7 @@ dependencies {
     compile project(':data-prepper-api')
     testCompile project(':data-prepper-api').sourceSets.test.output
     compile project(':data-prepper-plugins:common')
-    implementation "org.opensearch.client:opensearch-rest-high-level-client:${es_version}-SNAPSHOT"
+    implementation "org.opensearch.client:opensearch-rest-high-level-client:${es_version}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.3"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3"
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
@@ -59,7 +59,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2") {
         exclude group:'org.hamcrest' // workaround for jarHell
     }
-    testImplementation "org.opensearch.test:framework:${es_version}-SNAPSHOT"
+    testImplementation "org.opensearch.test:framework:${es_version}"
     testImplementation "commons-io:commons-io:2.8.0"
 }
 

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -101,7 +101,7 @@ test {
 }
 
 testClusters.integTest {
-    testDistribution = "OSS"
+    testDistribution = "INTEG_TEST"
 }
 
 integTest {
@@ -142,7 +142,6 @@ jacocoTestCoverageVerification {
     }
 }
 
-integTest.enabled = false // TODO: enable once we have the correct tar.gz file
 checkstyleMain.ignoreFailures = true
 checkstyleTest.ignoreFailures = true
 forbiddenApis.ignoreFailures = true

--- a/data-prepper-plugins/otel-trace-group-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-group-prepper/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compile project(':data-prepper-api')
     compile project(':data-prepper-plugins:opensearch')
     testCompile project(':data-prepper-api').sourceSets.test.output
-    implementation "org.opensearch.client:opensearch-rest-high-level-client:${es_version}-SNAPSHOT"
+    implementation "org.opensearch.client:opensearch-rest-high-level-client:${es_version}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.3"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3"
     implementation "io.micrometer:micrometer-core:1.6.6"

--- a/examples/dev/trace-analytics-sample-app/Dockerfile
+++ b/examples/dev/trace-analytics-sample-app/Dockerfile
@@ -2,7 +2,8 @@ FROM gradle:jdk14 AS builder
 COPY . /home/gradle/src
 WORKDIR /home/gradle/src
 # TODO: replace local built OpenSearch artifact with the public artifact
-RUN git clone https://github.com/opensearch-project/OpenSearch.git && cd OpenSearch && ./gradlew publishToMavenLocal
+RUN git clone https://github.com/opensearch-project/OpenSearch.git && cd OpenSearch && git checkout 1.0.0-alpha1 -b alpha1-release
+&& ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha1 -Dbuild.snapshot=false
 WORKDIR /home/gradle/src/data-prepper-core
 RUN gradle clean jar --daemon
 

--- a/examples/dev/trace-analytics-sample-app/Dockerfile
+++ b/examples/dev/trace-analytics-sample-app/Dockerfile
@@ -2,7 +2,7 @@ FROM gradle:jdk14 AS builder
 COPY . /home/gradle/src
 WORKDIR /home/gradle/src
 # TODO: replace local built OpenSearch artifact with the public artifact
-RUN git clone https://github.com/opensearch-project/OpenSearch.git && cd OpenSearch && git checkout 1.0.0-alpha1 -b alpha1-release
+RUN git clone https://github.com/opensearch-project/OpenSearch.git && cd OpenSearch && git checkout 1.0.0-alpha1 -b alpha1-release \
 && ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha1 -Dbuild.snapshot=false
 WORKDIR /home/gradle/src/data-prepper-core
 RUN gradle clean jar --daemon

--- a/research/zipkin-elastic-to-otel/build.gradle
+++ b/research/zipkin-elastic-to-otel/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation "org.apache.commons:commons-lang3:3.11"
     implementation "com.linecorp.armeria:armeria:1.0.0"
     implementation "com.linecorp.armeria:armeria-grpc:1.0.0"
-    implementation "org.opensearch.client:opensearch-rest-high-level-client:${es_version}-SNAPSHOT"
+    implementation "org.opensearch.client:opensearch-rest-high-level-client:${es_version}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
 }


### PR DESCRIPTION
Signed-off-by: qchea <qchea@amazon.com>

### Description
This PR

(1) Nail down local build of OS version to 1.0.0-alpha1
(2) re-enable integTest
(3) bumped the ODFE docker version used in github workflow
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
