### PR TITLE
MAINT: renaming elasticsearch to opensearch -- second pass

### DIFF
--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -12,7 +12,7 @@
 //preferably try to main the alphabetical order
 ext.versionMap = [
         opentelemetry_proto    : '1.0.1-alpha',
-        es_version: '1.0.0-alpha1'
+        opensearch_version: '1.0.0-alpha1'
 ]
 
 ext.coreProjects = [project(':data-prepper-api'), project(':data-prepper-core'), project('data-prepper-plugins:common')]

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -49,7 +49,7 @@ dependencies {
     integrationTestImplementation 'com.google.protobuf:protobuf-java-util:3.13.0'
     integrationTestImplementation "com.linecorp.armeria:armeria:1.0.0"
     integrationTestImplementation "com.linecorp.armeria:armeria-grpc:1.0.0"
-    integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${versionMap.es_version}"
+    integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${versionMap.opensearch_version}"
     integrationTestImplementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
 }
 

--- a/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndRawSpanTest.java
+++ b/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndRawSpanTest.java
@@ -160,7 +160,7 @@ public class EndToEndRawSpanTest {
         final List<Map<String, Object>> sources = new ArrayList<>();
         searchHits.forEach(hit -> {
             Map<String, Object> source = hit.getSourceAsMap();
-            // Elasticsearch API identifies Number type by range, need to convert to Long
+            // OpenSearch API identifies Number type by range, need to convert to Long
             if (source.containsKey(TraceGroup.TRACE_GROUP_DURATION_IN_NANOS_FIELD)) {
                 final Long durationInNanos = ((Number) source.get(TraceGroup.TRACE_GROUP_DURATION_IN_NANOS_FIELD)).longValue();
                 source.put(TraceGroup.TRACE_GROUP_DURATION_IN_NANOS_FIELD, durationInNanos);

--- a/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndRawSpanTest.java
+++ b/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndRawSpanTest.java
@@ -107,7 +107,7 @@ public class EndToEndRawSpanTest {
         sendExportTraceServiceRequestToSource(DATA_PREPPER_PORT_2, exportTraceServiceRequestTrace2BatchWithRoot);
         sendExportTraceServiceRequestToSource(DATA_PREPPER_PORT_2, exportTraceServiceRequestTrace1BatchNoRoot);
 
-        //Verify data in elasticsearch sink
+        //Verify data in elasticsearch backend
         final List<Map<String, Object>> expectedDocuments = getExpectedDocuments(
                 exportTraceServiceRequestTrace1BatchWithRoot, exportTraceServiceRequestTrace1BatchNoRoot,
                 exportTraceServiceRequestTrace2BatchWithRoot, exportTraceServiceRequestTrace2BatchNoRoot);

--- a/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndServiceMapTest.java
+++ b/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndServiceMapTest.java
@@ -76,7 +76,7 @@ public class EndToEndServiceMapTest {
         sendExportTraceServiceRequestToSource(DATA_PREPPER_PORT_1, exportTraceServiceRequest11);
         sendExportTraceServiceRequestToSource(DATA_PREPPER_PORT_2, exportTraceServiceRequest12);
 
-        //Verify data in elasticsearch sink
+        //Verify data in elasticsearch backend
         final List<EndToEndTestSpan> testDataSet1 = Stream.of(TEST_TRACE_1_BATCH_1, TEST_TRACE_1_BATCH_2)
                 .flatMap(Collection::stream).collect(Collectors.toList());
         final List<Map<String, Object>> possibleEdges = getPossibleEdges(TEST_TRACEID_1, testDataSet1);

--- a/data-prepper-plugins/blocking-buffer/README.md
+++ b/data-prepper-plugins/blocking-buffer/README.md
@@ -15,9 +15,9 @@ buffer:
 - batch_size => An `int` representing max number of records the buffer returns on read. Default is `8`.
 
 ##Metrics
-This plugin inherits the common metrics defined in [AbstractBuffer](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java)
+This plugin inherits the common metrics defined in [AbstractBuffer](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java)
 
 ## Developer Guide
 This plugin is compatible with Java 14. See 
-- [CONTRIBUTING](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md) 
-- [monitoring](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/docs/readme/monitoring.md)
+- [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md) 
+- [monitoring](https://github.com/opensearch-project/data-prepper/blob/main/docs/readme/monitoring.md)

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -116,7 +116,7 @@ Default value is false. Set it to true for [Service map trace analytics](#servic
 
 - <a name="template_file"></a>`template_file`(optional): A json file path to be read as index template for custom data ingestion. The json file content should be the json value of
 `"template"` key in the json content of elasticsearch [Index templates API](https://www.elastic.co/guide/en/elasticsearch/reference/7.8/index-templates.html), 
-e.g. [otel-v1-apm-span-index-template.json](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/data-prepper-plugins/elasticsearch/src/main/resources/otel-v1-apm-span-index-template.json)
+e.g. [otel-v1-apm-span-index-template.json](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/elasticsearch/src/main/resources/otel-v1-apm-span-index-template.json)
 
 - `dlq_file`(optional): A String of absolute file path for DLQ failed output records. Defaults to null.
 If not provided, failed records will be written into the default data-prepper log file (`logs/Data-Prepper.log`).
@@ -127,7 +127,7 @@ If a single record turns out to be larger than the set bulk size, it will be sen
 
 ## Metrics
 
-Besides common metrics in [AbstractSink](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/sink/AbstractSink.java), elasticsearch sink introduces the following custom metrics.
+Besides common metrics in [AbstractSink](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/sink/AbstractSink.java), elasticsearch sink introduces the following custom metrics.
 
 ### Timer
 
@@ -144,5 +144,5 @@ Besides common metrics in [AbstractSink](https://github.com/opendistro-for-elast
 
 This plugin is compatible with Java 8. See 
 
-- [CONTRIBUTING](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md) 
-- [monitoring](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/docs/readme/monitoring.md)
+- [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md) 
+- [monitoring](https://github.com/opensearch-project/data-prepper/blob/main/docs/readme/monitoring.md)

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -116,7 +116,7 @@ Default value is false. Set it to true for [Service map trace analytics](#servic
 
 - <a name="template_file"></a>`template_file`(optional): A json file path to be read as index template for custom data ingestion. The json file content should be the json value of
 `"template"` key in the json content of elasticsearch [Index templates API](https://www.elastic.co/guide/en/elasticsearch/reference/7.8/index-templates.html), 
-e.g. [otel-v1-apm-span-index-template.json](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/elasticsearch/src/main/resources/otel-v1-apm-span-index-template.json)
+e.g. [otel-v1-apm-span-index-template.json](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/opensearch/src/main/resources/otel-v1-apm-span-index-template.json)
 
 - `dlq_file`(optional): A String of absolute file path for DLQ failed output records. Defaults to null.
 If not provided, failed records will be written into the default data-prepper log file (`logs/Data-Prepper.log`).

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -1,10 +1,10 @@
-# Elasticsearch sink
+# OpenSearch sink
 
-This is the Data Prepper Elasticsearch sink plugin that sends records to Elasticsearch cluster via REST client. You can use the sink to send data to Amazon Elasticsearch Service or Opendistro for Elasticsearch.
+This is the Data Prepper OpenSearch sink plugin that sends records to Elasticsearch cluster via REST client. You can use the sink to send data to Amazon Elasticsearch Service or Opendistro for Elasticsearch.
 
 ## Usages
 
-The Elasticsearch sink should be configured as part of Data Prepper pipeline yaml file.
+The OpenSearch sink should be configured as part of Data Prepper pipeline yaml file.
 
 ### Raw span trace analytics
 
@@ -12,7 +12,7 @@ The Elasticsearch sink should be configured as part of Data Prepper pipeline yam
 pipeline:
   ...
   sink:
-    elasticsearch:
+    opensearch:
       hosts: ["https://localhost:9200"]
       cert: path/to/cert
       username: YOUR_USERNAME_HERE
@@ -22,7 +22,7 @@ pipeline:
       bulk_size: 4
 ```
 
-The elasticsearch sink will reserve `otel-v1-apm-span-*` as index pattern and `otel-v1-apm-span` as index alias for record ingestion.
+The OpenSearch sink will reserve `otel-v1-apm-span-*` as index pattern and `otel-v1-apm-span` as index alias for record ingestion.
 
 ### </a>Service map trace analytics
 
@@ -30,7 +30,7 @@ The elasticsearch sink will reserve `otel-v1-apm-span-*` as index pattern and `o
 pipeline:
   ...
   sink:
-    elasticsearch:
+    opensearch:
       hosts: ["https://localhost:9200"]
       cert: path/to/cert
       username: YOUR_USERNAME_HERE
@@ -40,17 +40,17 @@ pipeline:
       bulk_size: 4
 ```
 
-The elasticsearch sink will reserve `otel-v1-apm-service-map` as index for record ingestion.
+The OpenSearch sink will reserve `otel-v1-apm-service-map` as index for record ingestion.
 
 ### Amazon Elasticsearch Service
 
-The elasticsearch sink can also be configured for Amazon Elasticsearch Service domain. See [security](security.md) for details.
+The OpenSearch sink can also be configured for Amazon Elasticsearch Service domain. See [security](security.md) for details.
 
 ```
 pipeline:
   ...
   sink:
-    elasticsearch:
+    opensearch:
       hosts: ["https://your-amazon-elasticssearch-service-endpoint"]
       aws_sigv4: true 
       cert: path/to/cert
@@ -127,7 +127,7 @@ If a single record turns out to be larger than the set bulk size, it will be sen
 
 ## Metrics
 
-Besides common metrics in [AbstractSink](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/sink/AbstractSink.java), elasticsearch sink introduces the following custom metrics.
+Besides common metrics in [AbstractSink](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/sink/AbstractSink.java), OpenSearch sink introduces the following custom metrics.
 
 ### Timer
 

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
-        es_version = System.getProperty("es.version", "${versionMap.es_version}")
-        es_group = "org.opensearch"
+        opensearch_version = System.getProperty("opensearch.version", "${versionMap.opensearch_version}")
+        opensearch_group = "org.opensearch"
         distribution = 'oss-zip'
     }
 
@@ -12,7 +12,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "${es_group}.gradle:build-tools:${es_version}"
+        classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
     }
 }
 
@@ -49,17 +49,17 @@ dependencies {
     compile project(':data-prepper-api')
     testCompile project(':data-prepper-api').sourceSets.test.output
     compile project(':data-prepper-plugins:common')
-    implementation "org.opensearch.client:opensearch-rest-high-level-client:${es_version}"
+    implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.3"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3"
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     implementation "com.amazonaws:aws-java-sdk-core:1.11.1001"
     implementation "com.github.awslabs:aws-request-signing-apache-interceptor:b3772780da"
-    implementation "io.micrometer:micrometer-core:1.6.5"
+    implementation "io.micrometer:micrometer-core:1.6.6"
     testImplementation("junit:junit:4.13.2") {
         exclude group:'org.hamcrest' // workaround for jarHell
     }
-    testImplementation "org.opensearch.test:framework:${es_version}"
+    testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "commons-io:commons-io:2.8.0"
 }
 

--- a/data-prepper-plugins/opensearch/odfe_security.md
+++ b/data-prepper-plugins/opensearch/odfe_security.md
@@ -1,11 +1,11 @@
 ## Open Distro For Elasticsearch
 
 
-The Elasticsearch sink can send trace data to opendistro-for-elasticsearch (ODFE) cluster by administrative credentials as follows:
+The OpenSearch sink can send trace data to opendistro-for-elasticsearch (ODFE) cluster by administrative credentials as follows:
 
 ```
 sink:
-  - elasticsearch:
+  - opensearch:
       ...
       username: "admin"
       password: "admin"

--- a/data-prepper-plugins/opensearch/security.md
+++ b/data-prepper-plugins/opensearch/security.md
@@ -1,10 +1,10 @@
-# Elasticsearch Sink Security
+# OpenSearch Sink Security
 
 This document provides more details about the security settings of the sink.
 
 ## AWS Elasticsearch Service
 
-Elasticsearch sink is capable of sending data to Amazon Elasticsearch domain which use Identity and Access Management. The plugin uses the default credential chain. Run `aws configure` using the AWS CLI to set your credentials. 
+OpenSearch sink is capable of sending data to Amazon Elasticsearch domain which use Identity and Access Management. The plugin uses the default credential chain. Run `aws configure` using the AWS CLI to set your credentials. 
 
 You should ensure that the credentials you configure have the required permissions. Below is an example Resource based policy, with required set of permissions that is required for the sink to work,
 
@@ -42,13 +42,13 @@ Please check this [doc](https://docs.aws.amazon.com/elasticsearch-service/latest
 
 ### Fine-Grained Access Control (FGAC) in Amazon Elasticsearch Service
 
-The Elasticsearch sink creates an [Index State Management (ISM)](https://opendistro.github.io/for-elasticsearch-docs/docs/ism/) policy for Trace Analytics indices but Amazon Elasticsearch Service allows only the `master user` to create an ISM policy. So,
+The OpenSearch sink creates an [Index State Management (ISM)](https://opendistro.github.io/for-elasticsearch-docs/docs/ism/) policy for Trace Analytics indices but Amazon Elasticsearch Service allows only the `master user` to create an ISM policy. So,
  
  * If you use IAM for your master user in FGAC domain, configure the sink as below,
   
   ```
   sink:
-      elasticsearch:
+      opensearch:
         hosts: ["https://your-fgac-amazon-elasticssearch-service-endpoint"]
         aws_sigv4: true 
   ```
@@ -58,7 +58,7 @@ Run `aws configure` using the AWS CLI to set your credentials to the master IAM 
  
  ```
  sink:
-     elasticsearch:
+     opensearch:
        hosts: ["https://your-fgac-amazon-elasticssearch-service-endpoint"]
        aws_sigv4: false
        username: "master-username"

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -86,7 +86,7 @@ public class OpenSearchSink extends AbstractSink<Record<String>> {
   }
 
   public void start() throws IOException {
-    LOG.info("Starting Elasticsearch sink");
+    LOG.info("Starting OpenSearch sink");
     restHighLevelClient = esSinkConfig.getConnectionConfiguration().createClient();
     final String ismPolicyId = IndexStateManagement.checkAndCreatePolicy(restHighLevelClient, indexType);
     if (!esSinkConfig.getIndexConfiguration().getIndexTemplate().isEmpty()) {
@@ -103,7 +103,7 @@ public class OpenSearchSink extends AbstractSink<Record<String>> {
             this::logFailure,
             pluginMetrics,
             bulkRequestSupplier);
-    LOG.info("Started Elasticsearch sink");
+    LOG.info("Started OpenSearch sink");
   }
 
   @Override

--- a/data-prepper-plugins/otel-trace-group-prepper/README.md
+++ b/data-prepper-plugins/otel-trace-group-prepper/README.md
@@ -18,7 +18,7 @@ pipeline:
         password: YOUR_PASSWORD_HERE
 ``` 
 
-See [odfe_security.md](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/data-prepper-plugins/elasticsearch/odfe_security.md) for detailed explanation.
+See [odfe_security.md](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/elasticsearch/odfe_security.md) for detailed explanation.
 
 ### Amazon Elasticsearch Service
 
@@ -33,7 +33,7 @@ pipeline:
         insecure: false
 ```
 
-See [security.md](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/data-prepper-plugins/elasticsearch/security.md) for detailed explanation.
+See [security.md](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/opensearch/security.md) for detailed explanation.
 
 ## Configuration
 
@@ -63,5 +63,5 @@ Default is null.
 
 This plugin is compatible with Java 8. See 
 
-- [CONTRIBUTING](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md) 
-- [monitoring](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/docs/readme/monitoring.md)
+- [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md) 
+- [monitoring](https://github.com/opensearch-project/data-prepper/blob/main/docs/readme/monitoring.md)

--- a/data-prepper-plugins/otel-trace-group-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-group-prepper/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 ext {
-    es_version = System.getProperty("es.version", "${versionMap.es_version}")
+    opensearch_version = System.getProperty("opensearch.version", "${versionMap.opensearch_version}")
 }
 
 repositories {
@@ -26,7 +26,7 @@ dependencies {
     compile project(':data-prepper-api')
     compile project(':data-prepper-plugins:opensearch')
     testCompile project(':data-prepper-api').sourceSets.test.output
-    implementation "org.opensearch.client:opensearch-rest-high-level-client:${es_version}"
+    implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.3"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3"
     implementation "io.micrometer:micrometer-core:1.6.6"

--- a/data-prepper-plugins/otel-trace-raw-prepper/README.md
+++ b/data-prepper-plugins/otel-trace-raw-prepper/README.md
@@ -15,7 +15,7 @@ prepper:
 * `trace_flush_interval`: An `int` represents the time interval in seconds to flush all the descendant spans without any root span. Default to 180.
 
 ## Metrics
-Apart from common metrics in [AbstractPrepper](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/AbstractPrepper.java), otel-trace-raw-prepper introduces the following custom metrics.
+Apart from common metrics in [AbstractPrepper](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/AbstractPrepper.java), otel-trace-raw-prepper introduces the following custom metrics.
 
 ### Counter
 - `spanProcessingErrors`: records the number of processing exceptions for invalid spans.
@@ -24,5 +24,5 @@ Apart from common metrics in [AbstractPrepper](https://github.com/opendistro-for
 
 ## Developer Guide
 This plugin is compatible with Java 8. See 
-- [CONTRIBUTING](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md) 
-- [monitoring](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/docs/readme/monitoring.md)
+- [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md) 
+- [monitoring](https://github.com/opensearch-project/data-prepper/blob/main/docs/readme/monitoring.md)

--- a/data-prepper-plugins/otel-trace-source/README.md
+++ b/data-prepper-plugins/otel-trace-source/README.md
@@ -30,5 +30,5 @@ source:
 
 ## Developer Guide
 This plugin is compatible with Java 8. See 
-- [CONTRIBUTING](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md) 
-- [monitoring](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/docs/readme/monitoring.md)
+- [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md) 
+- [monitoring](https://github.com/opensearch-project/data-prepper/blob/main/docs/readme/monitoring.md)

--- a/data-prepper-plugins/peer-forwarder/README.md
+++ b/data-prepper-plugins/peer-forwarder/README.md
@@ -37,7 +37,7 @@ DNS discovery is recommended when scaling out a Data Prepper cluster. The core c
 See the /examples/dev/k8s directory for a working example using minikube.
 
 #### With a custom DNS server
-A DNS server (like [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html)) can be configured to maintain a list of Data Prepper hosts via config files. Data Prepper hosts must be configured to use the custom DNS server as their DNS provider. The list of hosts must be manually updated whenever a new Data Prepper host is created. See the [/examples/dev/dns directory](https://github.com/opendistro-for-elasticsearch/data-prepper/tree/master/examples/dev/dns) for a set of sample dnsmasq configuration files.
+A DNS server (like [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html)) can be configured to maintain a list of Data Prepper hosts via config files. Data Prepper hosts must be configured to use the custom DNS server as their DNS provider. The list of hosts must be manually updated whenever a new Data Prepper host is created. See the [/examples/dev/dns directory](https://github.com/opensearch-project/data-prepper/tree/master/examples/dev/dns) for a set of sample dnsmasq configuration files.
 
 #### With Amazon Route 53 Private Hosted Zones
 [Private hosted zones](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html) enable Amazon Route 53 to "respond to DNS queries for a domain and its subdomains within one or more VPCs that you create with the Amazon VPC service." Similar to the custom DNS server approach, except that Route 53 maintains the list of Data Prepper hosts. Suffers from the same drawback in that the list must be manually kept up-to-date.
@@ -54,7 +54,7 @@ A DNS server (like [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html)) can
 
 ## Metrics
 
-Besides common metrics in [AbstractPrepper](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/AbstractPrepper.java), peer-forwarder introduces the following custom metrics.
+Besides common metrics in [AbstractPrepper](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/AbstractPrepper.java), peer-forwarder introduces the following custom metrics.
 
 ### Timer
 
@@ -73,5 +73,5 @@ Besides common metrics in [AbstractPrepper](https://github.com/opendistro-for-el
 
 This plugin is compatible with Java 14. See 
 
-- [CONTRIBUTING](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md) 
-- [monitoring](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/docs/readme/monitoring.md)
+- [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md) 
+- [monitoring](https://github.com/opensearch-project/data-prepper/blob/main/docs/readme/monitoring.md)

--- a/data-prepper-plugins/service-map-stateful/README.md
+++ b/data-prepper-plugins/service-map-stateful/README.md
@@ -14,7 +14,7 @@ prepper:
 * window_duration(Optional) => An `int` represents the fixed time window in seconds to evaluate service-map relationships. Default is ```180```. 
 
 ## Metrics
-Besides common metrics in [AbstractPrepper](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/AbstractPrepper.java), service-map-stateful prepper introduces the following custom metrics.
+Besides common metrics in [AbstractPrepper](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/AbstractPrepper.java), service-map-stateful prepper introduces the following custom metrics.
 
 ### Gauge
 - `spansDbSize`: measures total spans byte sizes in MapDB across the current and previous window durations.
@@ -22,5 +22,5 @@ Besides common metrics in [AbstractPrepper](https://github.com/opendistro-for-el
 
 ## Developer Guide
 This plugin is compatible with Java 8. See 
-- [CONTRIBUTING](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md) 
-- [monitoring](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/docs/readme/monitoring.md)
+- [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md) 
+- [monitoring](https://github.com/opensearch-project/data-prepper/blob/main/docs/readme/monitoring.md)

--- a/deployment-template/k8s/README.md
+++ b/deployment-template/k8s/README.md
@@ -16,7 +16,7 @@ Contains a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configm
 
 #### pipelines.yaml
 This file contains the standard Trace Analytics usecase pipeline configuration. A few adjustments are needed by the user:
-1. Replace the 2 `stdout` sinks with Elasticsearch sinks to actually send data to Elasticsearch.
+1. Replace the 2 `stdout` sinks with OpenSearch sinks to actually send data to Elasticsearch.
 2. Optionally enable TLS by providing the necessary key files for the `otel_trace_source` and `peer_forwarder` plugins.
 
 #### data-prepper-config.yaml

--- a/docs/dev/trace-analytics-rfc.md
+++ b/docs/dev/trace-analytics-rfc.md
@@ -64,9 +64,9 @@ We are building two preppers for the Trace Analytics feature,
 * *service-map-prepper* -  This prepper will perform the required preprocessing on the trace data and build metadata to display the service-map kibana dashboards.
 
 
-##### Elasticsearch sink
+##### OpenSearch sink
 
-We will build a generic sink that will write the data to Elasticsearch as the destination. The Elasticsearch sink will have configuration options related to elasticsearch cluster like endpoint, SSL/Username, index name, index template, index state management, etc. 
+We will build a generic sink that will write the data to Elasticsearch as the destination. The OpenSearch sink will have configuration options related to elasticsearch cluster like endpoint, SSL/Username, index name, index template, index state management, etc. 
 For the trace analytics feature, the sink will have specific configurations which will make the sink to use indices and index templates specific to the feature. Trace analytics specific Elasticsearch indices are,
                                                                                                                                                                  
 * *apm-trace-raw-v1* -  This index will store the output from otel-trace-raw-prepper. 
@@ -87,4 +87,4 @@ NOTE: The above Kibana dashboards are mockup UIs, they are subject to changes.
 
 
 ## Providing Feedback
-If you have comments or feedback on our plans for Trace Analytics, please comment on this [github issue](https://github.com/opendistro-for-elasticsearch/simple-ingest-transformation-utility-pipeline/issues/39)
+If you have comments or feedback on our plans for Trace Analytics, please comment on this [github issue](https://github.com/opensearch-project/simple-ingest-transformation-utility-pipeline/issues/39)

--- a/docs/readme/project_setup.md
+++ b/docs/readme/project_setup.md
@@ -40,4 +40,4 @@ APIs are available:
   * returns JVM metrics in Prometheus text format
 
 ### Running the example app
-To run the example app against your local changes, use the docker found [here](https://github.com/opendistro-for-elasticsearch/data-prepper/tree/master/examples/dev/trace-analytics-sample-app)
+To run the example app against your local changes, use the docker found [here](https://github.com/opensearch-project/data-prepper/tree/master/examples/dev/trace-analytics-sample-app)

--- a/docs/readme/trace_overview.md
+++ b/docs/readme/trace_overview.md
@@ -32,9 +32,9 @@ We have two preppers for the Trace Analytics feature,
 * *service_map_stateful* -  This prepper performs the required preprocessing on the trace data and build metadata to display the service-map kibana dashboards.
 
 
-### Elasticsearch sink
+### OpenSearch sink
 
-We have a generic sink that writes the data to Elasticsearch as the destination. The [elasticsearch sink](../../data-prepper-plugins/elasticsearch/README.md) has configuration options related to elasticsearch cluster like endpoint, SSL/Username, index name, index template, index state management, etc. 
+We have a generic sink that writes the data to Elasticsearch as the destination. The [opensearch sink](../../data-prepper-plugins/opensearch/README.md) has configuration options related to elasticsearch cluster like endpoint, SSL/Username, index name, index template, index state management, etc. 
 For the trace analytics feature, the sink has specific configurations which enables the sink to use indices and index templates specific to this feature. Trace analytics specific Elasticsearch indices are,
                                                                                                                                                                  
 * *otel-v1-apm-span* -  This index stores the output from [otel-trace-raw-prepper](../../data-prepper-plugins/otel-trace-raw-prepper/README.md). 

--- a/docs/readme/trace_setup.md
+++ b/docs/readme/trace_setup.md
@@ -121,7 +121,7 @@ service-map-pipeline:
 
 ### Sink Setup
 
-In the above trace analytics configuration yaml file, we use elasticsearch as the sink. This sink could be Amazon Elasticsearch domain or Opendistro for Elasticsearch. You can configure this according to your setup. Please check the [Data Prepper OpenSearch Sink](../../data-prepper-plugins/opensearch/README.md#Configuration) for more details. 
+In the above trace analytics configuration yaml file, we use opensearch as the sink. This sink could be Amazon Elasticsearch domain or Opendistro for Elasticsearch. You can configure this according to your setup. Please check the [Data Prepper OpenSearch Sink](../../data-prepper-plugins/opensearch/README.md#Configuration) for more details. 
 
 
 ## Getting Started

--- a/docs/readme/trace_setup.md
+++ b/docs/readme/trace_setup.md
@@ -79,7 +79,7 @@ raw-pipeline:
          # default value is 512
          buffer_size: 512
          # The raw prepper does bulk request to your elasticsearch sink, so configure the batch_size higher.
-         # If you use the recommended otel-collector setup each ExportTraceRequest could contain max 50 spans. https://github.com/opendistro-for-elasticsearch/data-prepper/tree/v0.7.x/deployment/aws
+         # If you use the recommended otel-collector setup each ExportTraceRequest could contain max 50 spans. https://github.com/opensearch-project/data-prepper/tree/v0.7.x/deployment/aws
          # With 64 as batch size each worker thread could process upto 3200 spans (64 * 50)
          batch_size: 64
   prepper:

--- a/docs/readme/trace_setup.md
+++ b/docs/readme/trace_setup.md
@@ -78,14 +78,14 @@ raw-pipeline:
          # Make sure you configure sufficient heap
          # default value is 512
          buffer_size: 512
-         # The raw prepper does bulk request to your elasticsearch sink, so configure the batch_size higher.
+         # The raw prepper does bulk request to your OpenSearch sink, so configure the batch_size higher.
          # If you use the recommended otel-collector setup each ExportTraceRequest could contain max 50 spans. https://github.com/opensearch-project/data-prepper/tree/v0.7.x/deployment/aws
          # With 64 as batch size each worker thread could process upto 3200 spans (64 * 50)
          batch_size: 64
   prepper:
     - otel_trace_raw_prepper:
   sink:
-    - elasticsearch:
+    - opensearch:
         hosts: [ "your-es-endpoint" ]
         trace_analytics_raw: true
 service-map-pipeline:
@@ -112,7 +112,7 @@ service-map-pipeline:
          # Make sure buffer_size >= workers * batch_size
          batch_size: 8
   sink:
-    - elasticsearch:
+    - opensearch:
         hosts: [ "your-es-endpoint" ]
         trace_analytics_service_map: true
         # Add aws_sigv4 configuration for Amazon Elasticsearch
@@ -121,7 +121,7 @@ service-map-pipeline:
 
 ### Sink Setup
 
-In the above trace analytics configuration yaml file, we use elasticsearch as the sink. This sink could be Amazon Elasticsearch domain or Opendistro for Elasticsearch. You can configure this according to your setup. Please check the [Data Prepper Elasticsearch Sink](../../data-prepper-plugins/elasticsearch/README.md#Configuration) for more details. 
+In the above trace analytics configuration yaml file, we use elasticsearch as the sink. This sink could be Amazon Elasticsearch domain or Opendistro for Elasticsearch. You can configure this according to your setup. Please check the [Data Prepper OpenSearch Sink](../../data-prepper-plugins/opensearch/README.md#Configuration) for more details. 
 
 
 ## Getting Started

--- a/research/zipkin-elastic-to-otel/build.gradle
+++ b/research/zipkin-elastic-to-otel/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 ext {
-    es_version = System.getProperty("es.version", "${versionMap.es_version}")
+    opensearch_version = System.getProperty("opensearch.version", "${versionMap.opensearch_version}")
 }
 
 group 'com.amazon'
@@ -46,7 +46,7 @@ dependencies {
     implementation "org.apache.commons:commons-lang3:3.11"
     implementation "com.linecorp.armeria:armeria:1.0.0"
     implementation "com.linecorp.armeria:armeria-grpc:1.0.0"
-    implementation "org.opensearch.client:opensearch-rest-high-level-client:${es_version}"
+    implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
 }


### PR DESCRIPTION
### Description
This PR

1. renames es version to opensearch version
2. fixes hyperlinks to redirect to opensearch-project
3. rename elasticsearch into opensearch wherever proper in .md
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
