### PR TITLE
MAINT: use OpenSearch 1.0.0-beta1 docker image for testing

### DIFF
--- a/.github/workflows/opensearch-sink-odfe-before-1_13_0-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-odfe-before-1_13_0-integration-tests.yml
@@ -40,5 +40,5 @@ jobs:
           sleep 90
       - name: Run ODFE tests
         run: |
-          ./gradlew :data-prepper-plugins:opensearch:test --tests "com.amazon.dataprepper.plugins.sink.opensearch.ODFETests.testODFEConnection" -Dodfe.host=https://localhost:9200 -Dodfe.user=admin -Dodfe.password=admin
-          ./gradlew :data-prepper-plugins:opensearch:integTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchSinkIT" -Dodfe=true -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Duser=admin -Dpassword=admin
+          ./gradlew :data-prepper-plugins:opensearch:test --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchTests.testOpenSearchConnection" -Dos.host=https://localhost:9200 -Dos.user=admin -Dos.password=admin
+          ./gradlew :data-prepper-plugins:opensearch:integTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchSinkIT" -Dos=true -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Duser=admin -Dpassword=admin

--- a/.github/workflows/opensearch-sink-odfe-since-1_13_0-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-odfe-since-1_13_0-integration-tests.yml
@@ -40,5 +40,5 @@ jobs:
           sleep 90
       - name: Run ODFE tests
         run: |
-          ./gradlew :data-prepper-plugins:opensearch:test --tests "com.amazon.dataprepper.plugins.sink.opensearch.ODFETests.testODFEConnection" -Dodfe.host=https://localhost:9200 -Dodfe.user=admin -Dodfe.password=admin
-          ./gradlew :data-prepper-plugins:opensearch:integTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchSinkIT" -Dodfe=true -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Duser=admin -Dpassword=admin
+          ./gradlew :data-prepper-plugins:opensearch:test --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchTests.testOpenSearchConnection" -Dos.host=https://localhost:9200 -Dos.user=admin -Dos.password=admin
+          ./gradlew :data-prepper-plugins:opensearch:integTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchSinkIT" -Dos=true -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Duser=admin -Dpassword=admin

--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -32,13 +32,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: Run ODFE docker
+      - name: Run OpenSearch docker
         run: |
           export version=1.0.0-beta1
           docker pull opensearchstaging/opensearch:$version
           docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -d opensearchstaging/opensearch:$version
           sleep 90
-      - name: Run ODFE tests
+      - name: Run OpenSearch tests
         run: |
-          ./gradlew :data-prepper-plugins:opensearch:test --tests "com.amazon.dataprepper.plugins.sink.opensearch.ODFETests.testODFEConnection" -Dodfe.host=https://localhost:9200 -Dodfe.user=admin -Dodfe.password=admin
-          ./gradlew :data-prepper-plugins:opensearch:integTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchSinkIT" -Dodfe=true -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Duser=admin -Dpassword=admin
+          ./gradlew :data-prepper-plugins:opensearch:test --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchTests.testOpenSearchConnection" -Dos.host=https://localhost:9200 -Dos.user=admin -Dos.password=admin
+          ./gradlew :data-prepper-plugins:opensearch:integTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchSinkIT" -Dos=true -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Duser=admin -Dpassword=admin

--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -1,0 +1,44 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Data Prepper OpenSearchSink integration tests with OpenSearch
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  integration_tests:
+    strategy:
+      matrix:
+        java: [14]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      # TODO: replace local built OpenSearch artifact with the public artifact
+      - name: Checkout OpenSearch
+        uses: actions/checkout@v2
+        with:
+          repository: 'opensearch-project/OpenSearch'
+          path: OpenSearch
+          ref: '1.0.0-beta1'
+      - name: Build OpenSearch
+        working-directory: ./OpenSearch
+        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false
+      - name: Checkout Data-Prepper
+        uses: actions/checkout@v2
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Run ODFE docker
+        run: |
+          export version=1.0.0-beta1
+          docker pull opensearchstaging/opensearch:$version
+          docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -d opensearchstaging/opensearch:$version
+          sleep 90
+      - name: Run ODFE tests
+        run: |
+          ./gradlew :data-prepper-plugins:opensearch:test --tests "com.amazon.dataprepper.plugins.sink.opensearch.ODFETests.testODFEConnection" -Dodfe.host=https://localhost:9200 -Dodfe.user=admin -Dodfe.password=admin
+          ./gradlew :data-prepper-plugins:opensearch:integTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchSinkIT" -Dodfe=true -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Duser=admin -Dpassword=admin

--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0.0-beta1'
+          ref: '1.0.0-alpha2'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
         run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false

--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
           ref: '1.0.0-alpha2'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha2 -Dbuild.snapshot=false
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
       - name: Grant execute permission for gradlew

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -125,16 +125,16 @@ def removeDataPrepperDockerContainer(final DockerStopContainer stopDataPrepperDo
 }
 
 /**
- * ODFE Docker tasks
+ * OpenSearch Docker tasks
  */
-task pullOdfeDockerImage(type: DockerPullImage) {
+task pullOpenSearchDockerImage(type: DockerPullImage) {
     image = 'amazon/opendistro-for-elasticsearch:1.13.2'
 }
 
-task createOdfeDockerContainer(type: DockerCreateContainer) {
+task createOpenSearchDockerContainer(type: DockerCreateContainer) {
     dependsOn createDataPrepperNetwork
-    dependsOn pullOdfeDockerImage
-    targetImageId pullOdfeDockerImage.image
+    dependsOn pullOpenSearchDockerImage
+    targetImageId pullOpenSearchDockerImage.image
     containerName = "node-0.example.com"
     hostConfig.portBindings = ['9200:9200', '9600:9600']
     hostConfig.autoRemove = true
@@ -142,26 +142,26 @@ task createOdfeDockerContainer(type: DockerCreateContainer) {
     envVars = ['discovery.type':'single-node']
 }
 
-task startOdfeDockerContainer(type: DockerStartContainer) {
-    dependsOn createOdfeDockerContainer
-    targetContainerId createOdfeDockerContainer.getContainerId()
+task startOpenSearchDockerContainer(type: DockerStartContainer) {
+    dependsOn createOpenSearchDockerContainer
+    targetContainerId createOpenSearchDockerContainer.getContainerId()
 
     doLast {
         sleep(90*1000)
     }
 }
 
-task stopOdfeDockerContainer(type: DockerStopContainer) {
-    targetContainerId createOdfeDockerContainer.getContainerId()
+task stopOpenSearchDockerContainer(type: DockerStopContainer) {
+    targetContainerId createOpenSearchDockerContainer.getContainerId()
 }
 
 /**
- * End to end test. Spins up ODFE and DataPrepper docker containers, then runs the integ test
+ * End to end test. Spins up OpenSearch and DataPrepper docker containers, then runs the integ test
  * Stops the docker containers when finished
  */
 task rawSpanEndToEndTest(type: Test) {
     dependsOn build
-    dependsOn startOdfeDockerContainer
+    dependsOn startOpenSearchDockerContainer
     def createDataPrepper1Task = createDataPrepperDockerContainer(
             "rawSpanDataPrepper1", "data-prepper1", 21890, 4900, "/app/${RAW_SPAN_PIPELINE_YAML}")
     def createDataPrepper2Task = createDataPrepperDockerContainer(
@@ -170,8 +170,8 @@ task rawSpanEndToEndTest(type: Test) {
     def startDataPrepper2Task = startDataPrepperDockerContainer(createDataPrepper2Task as DockerCreateContainer)
     dependsOn startDataPrepper1Task
     dependsOn startDataPrepper2Task
-    startDataPrepper1Task.mustRunAfter 'startOdfeDockerContainer'
-    startDataPrepper2Task.mustRunAfter 'startOdfeDockerContainer'
+    startDataPrepper1Task.mustRunAfter 'startOpenSearchDockerContainer'
+    startDataPrepper2Task.mustRunAfter 'startOpenSearchDockerContainer'
     // wait for data-preppers to be ready
     doFirst {
         sleep(10*1000)
@@ -186,7 +186,7 @@ task rawSpanEndToEndTest(type: Test) {
         includeTestsMatching "com.amazon.dataprepper.integration.EndToEndRawSpanTest*"
     }
 
-    finalizedBy stopOdfeDockerContainer
+    finalizedBy stopOpenSearchDockerContainer
     def stopDataPrepper1Task = stopDataPrepperDockerContainer(startDataPrepper1Task as DockerStartContainer)
     def stopDataPrepper2Task = stopDataPrepperDockerContainer(startDataPrepper2Task as DockerStartContainer)
     finalizedBy stopDataPrepper1Task
@@ -198,7 +198,7 @@ task rawSpanEndToEndTest(type: Test) {
 
 task serviceMapEndToEndTest(type: Test) {
     dependsOn build
-    dependsOn startOdfeDockerContainer
+    dependsOn startOpenSearchDockerContainer
     def createDataPrepper1Task = createDataPrepperDockerContainer(
             "serviceMapDataPrepper1", "data-prepper1", 21890, 4900, "/app/${SERVICE_MAP_PIPELINE_YAML}")
     def createDataPrepper2Task = createDataPrepperDockerContainer(
@@ -207,8 +207,8 @@ task serviceMapEndToEndTest(type: Test) {
     def startDataPrepper2Task = startDataPrepperDockerContainer(createDataPrepper2Task as DockerCreateContainer)
     dependsOn startDataPrepper1Task
     dependsOn startDataPrepper2Task
-    startDataPrepper1Task.mustRunAfter 'startOdfeDockerContainer'
-    startDataPrepper2Task.mustRunAfter 'startOdfeDockerContainer'
+    startDataPrepper1Task.mustRunAfter 'startOpenSearchDockerContainer'
+    startDataPrepper2Task.mustRunAfter 'startOpenSearchDockerContainer'
     // wait for data-preppers to be ready
     doFirst {
         sleep(10*1000)
@@ -223,7 +223,7 @@ task serviceMapEndToEndTest(type: Test) {
         includeTestsMatching "com.amazon.dataprepper.integration.EndToEndServiceMapTest*"
     }
 
-    finalizedBy stopOdfeDockerContainer
+    finalizedBy stopOpenSearchDockerContainer
     def stopDataPrepper1Task = stopDataPrepperDockerContainer(startDataPrepper1Task as DockerStartContainer)
     def stopDataPrepper2Task = stopDataPrepperDockerContainer(startDataPrepper2Task as DockerStartContainer)
     finalizedBy stopDataPrepper1Task

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -128,7 +128,7 @@ def removeDataPrepperDockerContainer(final DockerStopContainer stopDataPrepperDo
  * OpenSearch Docker tasks
  */
 task pullOpenSearchDockerImage(type: DockerPullImage) {
-    image = 'amazon/opendistro-for-elasticsearch:1.13.2'
+    image = 'opensearchstaging/opensearch:1.0.0-beta1'
 }
 
 task createOpenSearchDockerContainer(type: DockerCreateContainer) {

--- a/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndServiceMapTest.java
+++ b/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndServiceMapTest.java
@@ -88,7 +88,7 @@ public class EndToEndServiceMapTest {
 
         // Wait for service map prepper by 2 * window_duration
         Thread.sleep(6000);
-        await().atMost(10, TimeUnit.SECONDS).untilAsserted(
+        await().atMost(20, TimeUnit.SECONDS).untilAsserted(
                 () -> {
                     final List<Map<String, Object>> foundSources = getSourcesFromIndex(restHighLevelClient, SERVICE_MAP_INDEX_NAME);
                     foundSources.forEach(source -> source.remove("hashId"));

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -91,13 +91,13 @@ configurations.all {
 }
 
 test {
-    if (System.getProperty("odfe.host") == null) {
-        exclude '**/ODFETests.class'
+    if (System.getProperty("os.host") == null) {
+        exclude '**/OpenSearchTests.class'
     }
-    systemProperty "odfe.host", System.getProperty("odfe.host")
-    if (System.getProperty("odfe.user") != null) {
-        systemProperty "odfe.user", System.getProperty("odfe.user")
-        systemProperty "odfe.password", System.getProperty("odfe.password")
+    systemProperty "os.host", System.getProperty("os.host")
+    if (System.getProperty("os.user") != null) {
+        systemProperty "os.user", System.getProperty("os.user")
+        systemProperty "os.password", System.getProperty("os.password")
     }
 }
 
@@ -108,7 +108,7 @@ testClusters.integTest {
 integTest {
     systemProperty 'tests.security.manager', 'false'
 
-    systemProperty "odfe", System.getProperty("odfe")
+    systemProperty "os", System.getProperty("os")
     systemProperty "user", System.getProperty("user")
     systemProperty "password", System.getProperty("password")
 }

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/IndexStateManagement.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/IndexStateManagement.java
@@ -44,6 +44,7 @@ public class IndexStateManagement {
     public static Optional<String> checkAndCreatePolicy(
             final RestHighLevelClient restHighLevelClient, final String indexType) throws IOException {
         if (indexType.equals(IndexConstants.RAW)) {
+            // TODO: replace with new _opensearch API
             final String endPoint = "/_opendistro/_ism/policies/" + IndexConstants.RAW_ISM_POLICY;
             Request request = createPolicyRequestFromFile(endPoint, IndexConstants.RAW_ISM_FILE_WITH_ISM_TEMPLATE);
             try {

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -96,7 +96,7 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     assertFalse((boolean)mappings.get("date_detection"));
     sink.shutdown();
 
-    if (isODFE()) {
+    if (isOSBundle()) {
       // Check managed index
       await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
         assertEquals(IndexConstants.RAW_ISM_POLICY, getIndexPolicyId(index)); }
@@ -118,7 +118,7 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     assertEquals(true, checkIsWriteIndex(EntityUtils.toString(response.getEntity()), indexAlias, rolloverIndexName));
     sink.shutdown();
 
-    if (isODFE()) {
+    if (isOSBundle()) {
       // Check managed index
       assertEquals(IndexConstants.RAW_ISM_POLICY, getIndexPolicyId(rolloverIndexName));
     }
@@ -230,7 +230,7 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     assertFalse((boolean)mappings.get("date_detection"));
     sink.shutdown();
 
-    if (isODFE()) {
+    if (isOSBundle()) {
       // Check managed index
       assertNull(getIndexPolicyId(indexAlias));
     }
@@ -410,28 +410,28 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     return policyId;
   }
 
-  public static boolean isODFE() {
-    final boolean odfeFlag = Optional.ofNullable(System.getProperty("odfe"))
+  public static boolean isOSBundle() {
+    final boolean osFlag = Optional.ofNullable(System.getProperty("os"))
             .map("true"::equalsIgnoreCase).orElse(false);
-    if (odfeFlag) {
+    if (osFlag) {
       // currently only external cluster is supported for security enabled testing
       if (!Optional.ofNullable(System.getProperty("tests.rest.cluster")).isPresent()) {
-        throw new RuntimeException("cluster url should be provided for security enabled ODFE testing");
+        throw new RuntimeException("cluster url should be provided for security enabled OpenSearch testing");
       }
     }
 
-    return odfeFlag;
+    return osFlag;
   }
 
   @Override
   protected String getProtocol() {
-    return isODFE() ? "https" : "http";
+    return isOSBundle() ? "https" : "http";
   }
 
   @Override
   protected RestClient buildClient(final Settings settings, final HttpHost[] hosts) throws IOException {
     final RestClientBuilder builder = RestClient.builder(hosts);
-    if (isODFE()) {
+    if (isOSBundle()) {
       configureHttpsClient(builder, settings);
     } else {
       configureClient(builder, settings);
@@ -443,7 +443,7 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
 
   @SuppressWarnings("unchecked")
   @After
-  protected void wipeAllODFEIndices() throws IOException {
+  protected void wipeAllOpenSearchIndices() throws IOException {
     final Response response = client().performRequest(new Request("GET", "/_cat/indices?format=json&expand_wildcards=all"));
     final XContentType xContentType = XContentType.fromMediaTypeOrFormat(response.getEntity().getContentType().getValue());
     try (
@@ -510,7 +510,7 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
   }
 
   /**
-   * wipeAllIndices won't work since it cannot delete security index. Use wipeAllODFEIndices instead.
+   * wipeAllIndices won't work since it cannot delete security index. Use wipeAllOpenSearchIndices instead.
    */
   @Override
   protected boolean preserveIndicesUponCompletion() {

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -400,6 +400,7 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
   }
 
   private String getIndexPolicyId(final String index) throws IOException {
+    // TODO: replace with new _opensearch API
     final Request request = new Request(HttpMethod.GET, "/_opendistro/_ism/explain/" + index);
     final Response response = client().performRequest(request);
     final String responseBody = EntityUtils.toString(response.getEntity());

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchTests.java
@@ -23,14 +23,14 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
-public class ODFETests {
+public class OpenSearchTests {
     @Test
-    public void testODFEConnection() throws IOException {
-        final String host = System.getProperty("odfe.host");
+    public void testOpenSearchConnection() throws IOException {
+        final String host = System.getProperty("os.host");
         final ConnectionConfiguration.Builder builder = new ConnectionConfiguration.Builder(
                 Collections.singletonList(host));
-        final String user = System.getProperty("odfe.user");
-        final String password = System.getProperty("odfe.password");
+        final String user = System.getProperty("os.user");
+        final String password = System.getProperty("os.password");
         if (user != null) {
             builder.withUsername(user);
             builder.withPassword(password);


### PR DESCRIPTION
### Description
This PR

(1) Replaces ODFE docker image with OS staging docker image for tests including

- opensearch sink integration tests
- service map e2e tests

(2) Replaces class and variable names including ODFE with OpenSearch

Note: items remain to be replaced

(1) ODFE REST APIs: e.g. _opendistro/..
(2) ODFE image in examples
(3) ODFE or opendistro in docs
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
