### PR TITLE
MAINT: bump to OS 1.0 and data prepper 1.0.0.0-rc1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: 'bug, untriaged, Beta'
 assignees: ''
 
 ---

--- a/.github/workflows/data-prepper-trace-analytics-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-e2e-tests.yml
@@ -24,10 +24,10 @@ jobs:
       with:
         repository: 'opensearch-project/OpenSearch'
         path: OpenSearch
-        ref: '1.0.0-beta1'
+        ref: '1.0'
     - name: Build OpenSearch
       working-directory: ./OpenSearch
-      run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false
+      run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
     - name: Checkout Data-Prepper
       uses: actions/checkout@v2
     - name: Grant execute permission for gradlew

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,10 +24,10 @@ jobs:
       with:
         repository: 'opensearch-project/OpenSearch'
         path: OpenSearch
-        ref: '1.0.0-beta1'
+        ref: '1.0'
     - name: Build OpenSearch
       working-directory: ./OpenSearch
-      run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false
+      run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
     - name: Checkout Data-Prepper
       uses: actions/checkout@v2
     - name: Grant execute permission for gradlew

--- a/.github/workflows/opensearch-sink-odfe-before-1_13_0-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-odfe-before-1_13_0-integration-tests.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0.0-beta1'
+          ref: '1.0'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
       - name: Grant execute permission for gradlew

--- a/.github/workflows/opensearch-sink-odfe-before-1_13_0-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-odfe-before-1_13_0-integration-tests.yml
@@ -40,5 +40,5 @@ jobs:
           sleep 90
       - name: Run ODFE tests
         run: |
-          ./gradlew :data-prepper-plugins:opensearch:test --tests "com.amazon.dataprepper.plugins.sink.opensearch.ODFETests.testODFEConnection" -Dodfe.host=https://localhost:9200 -Dodfe.user=admin -Dodfe.password=admin
-          ./gradlew :data-prepper-plugins:opensearch:integTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchSinkIT" -Dodfe=true -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Duser=admin -Dpassword=admin
+          ./gradlew :data-prepper-plugins:opensearch:test --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchTests.testOpenSearchConnection" -Dos.host=https://localhost:9200 -Dos.user=admin -Dos.password=admin
+          ./gradlew :data-prepper-plugins:opensearch:integTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchSinkIT" -Dos=true -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Duser=admin -Dpassword=admin

--- a/.github/workflows/opensearch-sink-odfe-since-1_13_0-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-odfe-since-1_13_0-integration-tests.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0.0-beta1'
+          ref: '1.0'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
       - name: Grant execute permission for gradlew

--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -24,17 +24,17 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0.0-alpha2'
+          ref: '1.0'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha2 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run OpenSearch docker
         run: |
-          export version=1.0.0-beta1
+          export version=1.0.0-rc1
           docker pull opensearchstaging/opensearch:$version
           docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -d opensearchstaging/opensearch:$version
           sleep 90

--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Data Prepper OpenSearchSink integration tests with ODFE >= 1.13.0
+name: Data Prepper OpenSearchSink integration tests with OpenSearch
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -24,21 +24,21 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0.0-beta1'
+          ref: '1.0.0-alpha2'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha2 -Dbuild.snapshot=false
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: Run ODFE docker
+      - name: Run OpenSearch docker
         run: |
-          export version=1.13.2
-          docker pull amazon/opendistro-for-elasticsearch:$version
-          docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -d amazon/opendistro-for-elasticsearch:$version
+          export version=1.0.0-beta1
+          docker pull opensearchstaging/opensearch:$version
+          docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -d opensearchstaging/opensearch:$version
           sleep 90
-      - name: Run ODFE tests
+      - name: Run OpenSearch tests
         run: |
           ./gradlew :data-prepper-plugins:opensearch:test --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchTests.testOpenSearchConnection" -Dos.host=https://localhost:9200 -Dos.user=admin -Dos.password=admin
           ./gradlew :data-prepper-plugins:opensearch:integTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchSinkIT" -Dos=true -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Duser=admin -Dpassword=admin

--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -12,7 +12,7 @@
 //preferably try to main the alphabetical order
 ext.versionMap = [
         opentelemetry_proto    : '1.0.1-alpha',
-        opensearch_version: '1.0.0-beta1'
+        opensearch_version: '1.0.0-rc1'
 ]
 
 ext.coreProjects = [project(':data-prepper-api'), project(':data-prepper-core'), project('data-prepper-plugins:common')]

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@
 apply from: file("${rootDir}/build-resources.gradle")
 allprojects {
     group = 'com.amazon'
-    version = '1.0.0.0-beta1'
+    version = '1.0.0.0-rc1'
     repositories {
         mavenCentral()
         maven { url "https://jitpack.io" }

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -128,7 +128,7 @@ def removeDataPrepperDockerContainer(final DockerStopContainer stopDataPrepperDo
  * OpenSearch Docker tasks
  */
 task pullOpenSearchDockerImage(type: DockerPullImage) {
-    image = 'opensearchstaging/opensearch:1.0.0-beta1'
+    image = 'opensearchstaging/opensearch:1.0.0-rc1'
 }
 
 task createOpenSearchDockerContainer(type: DockerCreateContainer) {

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -125,16 +125,16 @@ def removeDataPrepperDockerContainer(final DockerStopContainer stopDataPrepperDo
 }
 
 /**
- * ODFE Docker tasks
+ * OpenSearch Docker tasks
  */
-task pullOdfeDockerImage(type: DockerPullImage) {
-    image = 'amazon/opendistro-for-elasticsearch:1.13.2'
+task pullOpenSearchDockerImage(type: DockerPullImage) {
+    image = 'opensearchstaging/opensearch:1.0.0-beta1'
 }
 
-task createOdfeDockerContainer(type: DockerCreateContainer) {
+task createOpenSearchDockerContainer(type: DockerCreateContainer) {
     dependsOn createDataPrepperNetwork
-    dependsOn pullOdfeDockerImage
-    targetImageId pullOdfeDockerImage.image
+    dependsOn pullOpenSearchDockerImage
+    targetImageId pullOpenSearchDockerImage.image
     containerName = "node-0.example.com"
     hostConfig.portBindings = ['9200:9200', '9600:9600']
     hostConfig.autoRemove = true
@@ -142,26 +142,26 @@ task createOdfeDockerContainer(type: DockerCreateContainer) {
     envVars = ['discovery.type':'single-node']
 }
 
-task startOdfeDockerContainer(type: DockerStartContainer) {
-    dependsOn createOdfeDockerContainer
-    targetContainerId createOdfeDockerContainer.getContainerId()
+task startOpenSearchDockerContainer(type: DockerStartContainer) {
+    dependsOn createOpenSearchDockerContainer
+    targetContainerId createOpenSearchDockerContainer.getContainerId()
 
     doLast {
         sleep(90*1000)
     }
 }
 
-task stopOdfeDockerContainer(type: DockerStopContainer) {
-    targetContainerId createOdfeDockerContainer.getContainerId()
+task stopOpenSearchDockerContainer(type: DockerStopContainer) {
+    targetContainerId createOpenSearchDockerContainer.getContainerId()
 }
 
 /**
- * End to end test. Spins up ODFE and DataPrepper docker containers, then runs the integ test
+ * End to end test. Spins up OpenSearch and DataPrepper docker containers, then runs the integ test
  * Stops the docker containers when finished
  */
 task rawSpanEndToEndTest(type: Test) {
     dependsOn build
-    dependsOn startOdfeDockerContainer
+    dependsOn startOpenSearchDockerContainer
     def createDataPrepper1Task = createDataPrepperDockerContainer(
             "rawSpanDataPrepper1", "data-prepper1", 21890, 4900, "/app/${RAW_SPAN_PIPELINE_YAML}")
     def createDataPrepper2Task = createDataPrepperDockerContainer(
@@ -170,8 +170,8 @@ task rawSpanEndToEndTest(type: Test) {
     def startDataPrepper2Task = startDataPrepperDockerContainer(createDataPrepper2Task as DockerCreateContainer)
     dependsOn startDataPrepper1Task
     dependsOn startDataPrepper2Task
-    startDataPrepper1Task.mustRunAfter 'startOdfeDockerContainer'
-    startDataPrepper2Task.mustRunAfter 'startOdfeDockerContainer'
+    startDataPrepper1Task.mustRunAfter 'startOpenSearchDockerContainer'
+    startDataPrepper2Task.mustRunAfter 'startOpenSearchDockerContainer'
     // wait for data-preppers to be ready
     doFirst {
         sleep(10*1000)
@@ -186,7 +186,7 @@ task rawSpanEndToEndTest(type: Test) {
         includeTestsMatching "com.amazon.dataprepper.integration.EndToEndRawSpanTest*"
     }
 
-    finalizedBy stopOdfeDockerContainer
+    finalizedBy stopOpenSearchDockerContainer
     def stopDataPrepper1Task = stopDataPrepperDockerContainer(startDataPrepper1Task as DockerStartContainer)
     def stopDataPrepper2Task = stopDataPrepperDockerContainer(startDataPrepper2Task as DockerStartContainer)
     finalizedBy stopDataPrepper1Task
@@ -198,7 +198,7 @@ task rawSpanEndToEndTest(type: Test) {
 
 task serviceMapEndToEndTest(type: Test) {
     dependsOn build
-    dependsOn startOdfeDockerContainer
+    dependsOn startOpenSearchDockerContainer
     def createDataPrepper1Task = createDataPrepperDockerContainer(
             "serviceMapDataPrepper1", "data-prepper1", 21890, 4900, "/app/${SERVICE_MAP_PIPELINE_YAML}")
     def createDataPrepper2Task = createDataPrepperDockerContainer(
@@ -207,8 +207,8 @@ task serviceMapEndToEndTest(type: Test) {
     def startDataPrepper2Task = startDataPrepperDockerContainer(createDataPrepper2Task as DockerCreateContainer)
     dependsOn startDataPrepper1Task
     dependsOn startDataPrepper2Task
-    startDataPrepper1Task.mustRunAfter 'startOdfeDockerContainer'
-    startDataPrepper2Task.mustRunAfter 'startOdfeDockerContainer'
+    startDataPrepper1Task.mustRunAfter 'startOpenSearchDockerContainer'
+    startDataPrepper2Task.mustRunAfter 'startOpenSearchDockerContainer'
     // wait for data-preppers to be ready
     doFirst {
         sleep(10*1000)
@@ -223,7 +223,7 @@ task serviceMapEndToEndTest(type: Test) {
         includeTestsMatching "com.amazon.dataprepper.integration.EndToEndServiceMapTest*"
     }
 
-    finalizedBy stopOdfeDockerContainer
+    finalizedBy stopOpenSearchDockerContainer
     def stopDataPrepper1Task = stopDataPrepperDockerContainer(startDataPrepper1Task as DockerStartContainer)
     def stopDataPrepper2Task = stopDataPrepperDockerContainer(startDataPrepper2Task as DockerStartContainer)
     finalizedBy stopDataPrepper1Task

--- a/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndServiceMapTest.java
+++ b/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndServiceMapTest.java
@@ -88,7 +88,7 @@ public class EndToEndServiceMapTest {
 
         // Wait for service map prepper by 2 * window_duration
         Thread.sleep(6000);
-        await().atMost(10, TimeUnit.SECONDS).untilAsserted(
+        await().atMost(20, TimeUnit.SECONDS).untilAsserted(
                 () -> {
                     final List<Map<String, Object>> foundSources = getSourcesFromIndex(restHighLevelClient, SERVICE_MAP_INDEX_NAME);
                     foundSources.forEach(source -> source.remove("hashId"));

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -91,13 +91,13 @@ configurations.all {
 }
 
 test {
-    if (System.getProperty("odfe.host") == null) {
-        exclude '**/ODFETests.class'
+    if (System.getProperty("os.host") == null) {
+        exclude '**/OpenSearchTests.class'
     }
-    systemProperty "odfe.host", System.getProperty("odfe.host")
-    if (System.getProperty("odfe.user") != null) {
-        systemProperty "odfe.user", System.getProperty("odfe.user")
-        systemProperty "odfe.password", System.getProperty("odfe.password")
+    systemProperty "os.host", System.getProperty("os.host")
+    if (System.getProperty("os.user") != null) {
+        systemProperty "os.user", System.getProperty("os.user")
+        systemProperty "os.password", System.getProperty("os.password")
     }
 }
 
@@ -108,7 +108,7 @@ testClusters.integTest {
 integTest {
     systemProperty 'tests.security.manager', 'false'
 
-    systemProperty "odfe", System.getProperty("odfe")
+    systemProperty "os", System.getProperty("os")
     systemProperty "user", System.getProperty("user")
     systemProperty "password", System.getProperty("password")
 }

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/IndexStateManagement.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/IndexStateManagement.java
@@ -45,7 +45,7 @@ public class IndexStateManagement {
             final RestHighLevelClient restHighLevelClient, final String indexType) throws IOException {
         if (indexType.equals(IndexConstants.RAW)) {
             // TODO: replace with new _opensearch API
-            final String endPoint = "/_plugins/_ism/policies/" + IndexConstants.RAW_ISM_POLICY;
+            final String endPoint = "/_opendistro/_ism/policies/" + IndexConstants.RAW_ISM_POLICY;
             Request request = createPolicyRequestFromFile(endPoint, IndexConstants.RAW_ISM_FILE_WITH_ISM_TEMPLATE);
             try {
                 restHighLevelClient.getLowLevelClient().performRequest(request);

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/IndexStateManagement.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/IndexStateManagement.java
@@ -45,7 +45,7 @@ public class IndexStateManagement {
             final RestHighLevelClient restHighLevelClient, final String indexType) throws IOException {
         if (indexType.equals(IndexConstants.RAW)) {
             // TODO: replace with new _opensearch API
-            final String endPoint = "/_opendistro/_ism/policies/" + IndexConstants.RAW_ISM_POLICY;
+            final String endPoint = "/_plugins/_ism/policies/" + IndexConstants.RAW_ISM_POLICY;
             Request request = createPolicyRequestFromFile(endPoint, IndexConstants.RAW_ISM_FILE_WITH_ISM_TEMPLATE);
             try {
                 restHighLevelClient.getLowLevelClient().performRequest(request);

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/IndexStateManagement.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/IndexStateManagement.java
@@ -44,6 +44,7 @@ public class IndexStateManagement {
     public static Optional<String> checkAndCreatePolicy(
             final RestHighLevelClient restHighLevelClient, final String indexType) throws IOException {
         if (indexType.equals(IndexConstants.RAW)) {
+            // TODO: replace with new _opensearch API
             final String endPoint = "/_opendistro/_ism/policies/" + IndexConstants.RAW_ISM_POLICY;
             Request request = createPolicyRequestFromFile(endPoint, IndexConstants.RAW_ISM_FILE_WITH_ISM_TEMPLATE);
             try {

--- a/data-prepper-plugins/opensearch/src/main/resources/otel-v1-apm-span-index-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/otel-v1-apm-span-index-template.json
@@ -40,11 +40,11 @@
         "type": "keyword"
       },
       "traceGroup": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "traceGroupFields": {
         "properties": {
-          "name": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
           "endTime": {
             "type": "date_nanos"
           },

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -401,13 +401,13 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
 
   private String getIndexPolicyId(final String index) throws IOException {
     // TODO: replace with new _opensearch API
-    final Request request = new Request(HttpMethod.GET, "/_opendistro/_ism/explain/" + index);
+    final Request request = new Request(HttpMethod.GET, "/_plugins/_ism/explain/" + index);
     final Response response = client().performRequest(request);
     final String responseBody = EntityUtils.toString(response.getEntity());
 
     @SuppressWarnings("unchecked")
     final String policyId = (String) ((Map<String, Object>)createParser(XContentType.JSON.xContent(),
-            responseBody).map().get(index)).get("index.opendistro.index_state_management.policy_id");
+            responseBody).map().get(index)).get("index.plugins.index_state_management.policy_id");
     return policyId;
   }
 

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -399,15 +399,20 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     return mappings;
   }
 
+  @SuppressWarnings("unchecked")
   private String getIndexPolicyId(final String index) throws IOException {
     // TODO: replace with new _opensearch API
-    final Request request = new Request(HttpMethod.GET, "/_plugins/_ism/explain/" + index);
+    final Request request = new Request(HttpMethod.GET, "/_opendistro/_ism/explain/" + index);
     final Response response = client().performRequest(request);
     final String responseBody = EntityUtils.toString(response.getEntity());
 
-    @SuppressWarnings("unchecked")
-    final String policyId = (String) ((Map<String, Object>)createParser(XContentType.JSON.xContent(),
+    String policyId = (String) ((Map<String, Object>)createParser(XContentType.JSON.xContent(),
             responseBody).map().get(index)).get("index.plugins.index_state_management.policy_id");
+    // If backend is ODFE
+    if (policyId == null) {
+      policyId = (String) ((Map<String, Object>)createParser(XContentType.JSON.xContent(),
+              responseBody).map().get(index)).get("index.opendistro.index_state_management.policy_id");
+    }
     return policyId;
   }
 

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -96,7 +96,7 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     assertFalse((boolean)mappings.get("date_detection"));
     sink.shutdown();
 
-    if (isODFE()) {
+    if (isOSBundle()) {
       // Check managed index
       await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
         assertEquals(IndexConstants.RAW_ISM_POLICY, getIndexPolicyId(index)); }
@@ -118,7 +118,7 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     assertEquals(true, checkIsWriteIndex(EntityUtils.toString(response.getEntity()), indexAlias, rolloverIndexName));
     sink.shutdown();
 
-    if (isODFE()) {
+    if (isOSBundle()) {
       // Check managed index
       assertEquals(IndexConstants.RAW_ISM_POLICY, getIndexPolicyId(rolloverIndexName));
     }
@@ -230,7 +230,7 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     assertFalse((boolean)mappings.get("date_detection"));
     sink.shutdown();
 
-    if (isODFE()) {
+    if (isOSBundle()) {
       // Check managed index
       assertNull(getIndexPolicyId(indexAlias));
     }
@@ -400,6 +400,7 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
   }
 
   private String getIndexPolicyId(final String index) throws IOException {
+    // TODO: replace with new _opensearch API
     final Request request = new Request(HttpMethod.GET, "/_opendistro/_ism/explain/" + index);
     final Response response = client().performRequest(request);
     final String responseBody = EntityUtils.toString(response.getEntity());
@@ -410,28 +411,28 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     return policyId;
   }
 
-  public static boolean isODFE() {
-    final boolean odfeFlag = Optional.ofNullable(System.getProperty("odfe"))
+  public static boolean isOSBundle() {
+    final boolean osFlag = Optional.ofNullable(System.getProperty("os"))
             .map("true"::equalsIgnoreCase).orElse(false);
-    if (odfeFlag) {
+    if (osFlag) {
       // currently only external cluster is supported for security enabled testing
       if (!Optional.ofNullable(System.getProperty("tests.rest.cluster")).isPresent()) {
-        throw new RuntimeException("cluster url should be provided for security enabled ODFE testing");
+        throw new RuntimeException("cluster url should be provided for security enabled OpenSearch testing");
       }
     }
 
-    return odfeFlag;
+    return osFlag;
   }
 
   @Override
   protected String getProtocol() {
-    return isODFE() ? "https" : "http";
+    return isOSBundle() ? "https" : "http";
   }
 
   @Override
   protected RestClient buildClient(final Settings settings, final HttpHost[] hosts) throws IOException {
     final RestClientBuilder builder = RestClient.builder(hosts);
-    if (isODFE()) {
+    if (isOSBundle()) {
       configureHttpsClient(builder, settings);
     } else {
       configureClient(builder, settings);
@@ -443,7 +444,7 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
 
   @SuppressWarnings("unchecked")
   @After
-  protected void wipeAllODFEIndices() throws IOException {
+  protected void wipeAllOpenSearchIndices() throws IOException {
     final Response response = client().performRequest(new Request("GET", "/_cat/indices?format=json&expand_wildcards=all"));
     final XContentType xContentType = XContentType.fromMediaTypeOrFormat(response.getEntity().getContentType().getValue());
     try (
@@ -510,7 +511,7 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
   }
 
   /**
-   * wipeAllIndices won't work since it cannot delete security index. Use wipeAllODFEIndices instead.
+   * wipeAllIndices won't work since it cannot delete security index. Use wipeAllOpenSearchIndices instead.
    */
   @Override
   protected boolean preserveIndicesUponCompletion() {

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchTests.java
@@ -23,14 +23,14 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
-public class ODFETests {
+public class OpenSearchTests {
     @Test
-    public void testODFEConnection() throws IOException {
-        final String host = System.getProperty("odfe.host");
+    public void testOpenSearchConnection() throws IOException {
+        final String host = System.getProperty("os.host");
         final ConnectionConfiguration.Builder builder = new ConnectionConfiguration.Builder(
                 Collections.singletonList(host));
-        final String user = System.getProperty("odfe.user");
-        final String password = System.getProperty("odfe.password");
+        final String user = System.getProperty("os.user");
+        final String password = System.getProperty("os.password");
         if (user != null) {
             builder.withUsername(user);
             builder.withPassword(password);

--- a/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/model/RawSpan.java
+++ b/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/model/RawSpan.java
@@ -196,7 +196,7 @@ public final class RawSpan {
         return attributes;
     }
 
-    @JsonUnwrapped(prefix="traceGroup.")
+    @JsonUnwrapped
     public TraceGroup getTraceGroup() {
         return traceGroup;
     }

--- a/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/model/TraceGroup.java
+++ b/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/model/TraceGroup.java
@@ -6,9 +6,13 @@ import io.opentelemetry.proto.trace.v1.Span;
 import java.util.Objects;
 
 public class TraceGroup {
+    @JsonProperty("traceGroup")
     private final String name;
+    @JsonProperty("traceGroupFields.endTime")
     private final String endTime;
+    @JsonProperty("traceGroupFields.statusCode")
     private final Integer statusCode;
+    @JsonProperty("traceGroupFields.durationInNanos")
     private final Long durationInNanos;
 
     public String getName() {

--- a/data-prepper-plugins/otel-trace-raw-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OTelTraceRawPrepperTest.java
+++ b/data-prepper-plugins/otel-trace-raw-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OTelTraceRawPrepperTest.java
@@ -247,10 +247,10 @@ public class OTelTraceRawPrepperTest {
         for (Record<String> record: records) {
             final String spanJson = record.getData();
             Map<String, Object> spanMap = OBJECT_MAPPER.readValue(spanJson, new TypeReference<Map<String, Object>>() {});
-            final String traceGroupName = (String) spanMap.get("traceGroup.name");
-            final String traceGroupEndTime = (String) spanMap.get("traceGroup.endTime");
-            final Number traceGroupDurationInNanos = (Number) spanMap.get("traceGroup.durationInNanos");
-            final Number traceGroupStatusCode = (Number) spanMap.get("traceGroup.statusCode");
+            final String traceGroupName = (String) spanMap.get("traceGroup");
+            final String traceGroupEndTime = (String) spanMap.get("traceGroupFields.endTime");
+            final Number traceGroupDurationInNanos = (Number) spanMap.get("traceGroupFields.durationInNanos");
+            final Number traceGroupStatusCode = (Number) spanMap.get("traceGroupFields.statusCode");
             if (Stream.of(traceGroupName, traceGroupEndTime, traceGroupDurationInNanos, traceGroupStatusCode).allMatch(Objects::isNull)) {
                 count += 1;
             }

--- a/examples/dev/trace-analytics-sample-app/Dockerfile
+++ b/examples/dev/trace-analytics-sample-app/Dockerfile
@@ -2,8 +2,8 @@ FROM gradle:jdk14 AS builder
 COPY . /home/gradle/src
 WORKDIR /home/gradle/src
 # TODO: replace local built OpenSearch artifact with the public artifact
-RUN git clone https://github.com/opensearch-project/OpenSearch.git && cd OpenSearch && git checkout 1.0.0-beta1 -b beta1-release \
-&& ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false
+RUN git clone https://github.com/opensearch-project/OpenSearch.git && cd OpenSearch && git checkout 1.0 -b rc1-release \
+&& ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
 WORKDIR /home/gradle/src/data-prepper-core
 RUN gradle clean jar --daemon
 


### PR DESCRIPTION
### Description
Also merged stuff from main branch about Opensearch integration tests

Note: I keep the old ISM API for testing with ODFE and also maintain applicability to AES. But the index setting name has to be new in OpenSearch backend. Thus I have to check both `index.plugins.index_state_management.policy_id` and `index.opendistro.index_state_management.policy_id`
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
