### PR TITLE
Use JUnit Jupiter for all projects and added Mockito to all projects

### DIFF
--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -11,8 +11,10 @@
 
 //preferably try to main the alphabetical order
 ext.versionMap = [
-        opentelemetry_proto    : '1.0.1-alpha',
-        opensearch_version: '1.0.0-alpha2'
+        junitJupiter : '5.7.2',
+        mockito : '3.11.2',
+        opentelemetryProto : '1.0.1-alpha',
+        opensearchVersion : '1.0.0-alpha2'
 ]
 
 ext.coreProjects = [project(':data-prepper-api'), project(':data-prepper-core'), project('data-prepper-plugins:common')]

--- a/build.gradle
+++ b/build.gradle
@@ -49,13 +49,15 @@ subprojects {
         }
     }
     dependencies {
-        implementation "com.google.guava:guava:29.0-jre"
-        implementation "org.apache.logging.log4j:log4j-core:2.14.0"
-        implementation "org.slf4j:slf4j-api:1.7.30"
-        implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.14.0"
-        testImplementation("junit:junit:4.13") {
-            exclude group: 'org.hamcrest' // workaround for jarHell
-        }
+        implementation 'com.google.guava:guava:29.0-jre'
+        implementation 'org.apache.logging.log4j:log4j-core:2.14.0'
+        implementation 'org.slf4j:slf4j-api:1.7.30'
+        implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.0'
+        testImplementation platform("org.junit:junit-bom:${versionMap.junitJupiter}")
+        testImplementation 'org.junit.jupiter:junit-jupiter'
+        testImplementation 'org.junit.vintage:junit-vintage-engine'
+        testImplementation "org.mockito:mockito-core:${versionMap.mockito}"
+        testImplementation "org.mockito:mockito-junit-jupiter:${versionMap.mockito}"
     }
     build.dependsOn test
     jacocoTestReport {
@@ -75,7 +77,7 @@ configure(coreProjects) {
         }
     }
     test {
-        useJUnit()
+        useJUnitPlatform()
         finalizedBy jacocoTestReport // report is always generated after tests run
     }
     jacocoTestCoverageVerification {

--- a/data-prepper-benchmarks/service-map-stateful-benchmarks/build.gradle
+++ b/data-prepper-benchmarks/service-map-stateful-benchmarks/build.gradle
@@ -25,5 +25,5 @@ repositories {
 
 dependencies {
     implementation project(':data-prepper-plugins:service-map-stateful')
-    jmh "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
+    jmh "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
 }

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     implementation "io.micrometer:micrometer-registry-cloudwatch2:1.7.2"
     implementation "software.amazon.awssdk:cloudwatch:2.17.15"
     testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "org.mockito:mockito-core:3.11.2"
 }
 
 jar {

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -37,21 +37,25 @@ sourceSets {
     }
 }
 
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntime.extendsFrom testRuntime
+}
+
 repositories {
     // TODO: replace local built OpenSearch artifact with the public artifact
     mavenLocal()
 }
 
 dependencies {
-    integrationTestCompile("junit:junit:4.13")
     integrationTestCompile project(':data-prepper-plugins:opensearch')
     integrationTestCompile project(':data-prepper-plugins:otel-trace-group-prepper')
     integrationTestImplementation "org.awaitility:awaitility:4.0.3"
-    integrationTestImplementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
+    integrationTestImplementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
     integrationTestImplementation 'com.google.protobuf:protobuf-java-util:3.13.0'
     integrationTestImplementation "com.linecorp.armeria:armeria:1.0.0"
     integrationTestImplementation "com.linecorp.armeria:armeria-grpc:1.0.0"
-    integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${versionMap.opensearch_version}"
+    integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${versionMap.opensearchVersion}"
     integrationTestImplementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
 }
 

--- a/data-prepper-plugins/blocking-buffer/build.gradle
+++ b/data-prepper-plugins/blocking-buffer/build.gradle
@@ -14,7 +14,6 @@ plugins {
 }
 dependencies {
     implementation project(':data-prepper-api')
-    testImplementation "junit:junit:4.13.2"
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/common/build.gradle
+++ b/data-prepper-plugins/common/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.4"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.4"
     implementation "org.reflections:reflections:0.9.12"
-    testImplementation "junit:junit:4.13.2"
     testImplementation "commons-io:commons-io:2.11.0"
 }
 

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "${versionMap.opensearch_version}")
+        opensearch_version = System.getProperty("opensearch.version", "${versionMap.opensearchVersion}")
         opensearch_group = "org.opensearch"
         distribution = 'oss-zip'
     }
@@ -62,7 +62,11 @@ dependencies {
     implementation 'software.amazon.awssdk:sts:2.17.15'
     implementation 'software.amazon.awssdk:url-connection-client:2.17.15'
     implementation "io.micrometer:micrometer-core:1.7.2"
-    testImplementation("junit:junit:4.13.2") {
+    // The OpenSearch build-tools plugin appears to be preventing Gradle's platform
+    // support from working correctly, so we have to specify the JUnit versions here.
+    testImplementation "org.junit.jupiter:junit-jupiter:${versionMap.junitJupiter}"
+    testImplementation "org.junit.vintage:junit-vintage-engine:${versionMap.junitJupiter}"
+    testImplementation('junit:junit:4.13.2') {
         exclude group:'org.hamcrest' // workaround for jarHell
     }
     testImplementation "org.awaitility:awaitility:4.1.0"
@@ -89,11 +93,14 @@ configurations.all {
         force 'joda-time:joda-time:2.10.10'
         force 'org.yaml:snakeyaml:1.29'
         force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.4'
-        force 'junit:junit:4.13'
+        force 'junit:junit:4.13.2'
         force "org.slf4j:slf4j-api:1.7.32"
         force "org.apache.logging.log4j:log4j-api:2.14.1"
         force "org.apache.logging.log4j:log4j-core:2.14.1"
     }
+    // The OpenSearch plugins appear to provide their own version of Mockito
+    // which is causing problems, so we exclude it.
+    exclude group: 'org.mockito'
 }
 
 test {

--- a/data-prepper-plugins/otel-trace-group-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-group-prepper/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 ext {
-    opensearch_version = System.getProperty("opensearch.version", "${versionMap.opensearch_version}")
+    opensearch_version = System.getProperty("opensearch.version", "${versionMap.opensearchVersion}")
 }
 
 repositories {
@@ -30,6 +30,4 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.4"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.4"
     implementation "io.micrometer:micrometer-core:1.7.2"
-    testImplementation "org.mockito:mockito-core:3.11.2"
-    testImplementation "junit:junit:4.13.2"
 }

--- a/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation project(':data-prepper-plugins:common')
     implementation 'commons-codec:commons-codec:1.15'
     testImplementation project(':data-prepper-api').sourceSets.test.output
-    implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
+    implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
     implementation 'com.google.protobuf:protobuf-java-util:3.17.3'
     implementation "com.linecorp.armeria:armeria:1.9.2"
     implementation "com.linecorp.armeria:armeria-grpc:1.9.2"
@@ -26,7 +26,7 @@ dependencies {
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.4"
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
     testImplementation 'org.assertj:assertj-core:3.20.2'
-    testImplementation "org.mockito:mockito-inline:3.11.2"
+    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
     testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.awaitility:awaitility:4.1.0"
 }

--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation project(':data-prepper-plugins:blocking-buffer')
     implementation 'commons-codec:commons-codec:1.15'
     testImplementation project(':data-prepper-api').sourceSets.test.output
-    implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
+    implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
     implementation "commons-io:commons-io:2.11.0"
     implementation "com.amazonaws:aws-java-sdk-s3:1.12.43"
     implementation "com.amazonaws:aws-java-sdk-acm:1.12.43"
@@ -31,18 +31,9 @@ dependencies {
     implementation "org.bouncycastle:bcprov-jdk15on:1.69"
     implementation "org.bouncycastle:bcpkix-jdk15on:1.69"
     testImplementation 'org.assertj:assertj-core:3.20.2'
-    testImplementation "org.mockito:mockito-inline:3.11.2"
+    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
     testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation(platform('org.junit:junit-bom:5.7.2'))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-    // TODO: update versionMap to use a higher version of mockito for all subprojects
-    testImplementation("org.mockito:mockito-core:3.11.2")
-    testImplementation("org.mockito:mockito-junit-jupiter:3.11.2")
     testImplementation("commons-io:commons-io:2.10.0")
-}
-
-test {
-    useJUnitPlatform()
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/peer-forwarder/build.gradle
+++ b/data-prepper-plugins/peer-forwarder/build.gradle
@@ -23,7 +23,7 @@ repositories {
 dependencies {
     implementation project(':data-prepper-api')
     testImplementation project(':data-prepper-api').sourceSets.test.output
-    implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
+    implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
     implementation "com.linecorp.armeria:armeria:1.9.2"
     implementation "com.linecorp.armeria:armeria-grpc:1.9.2"
     implementation(platform('software.amazon.awssdk:bom:2.17.15'))
@@ -33,19 +33,10 @@ dependencies {
     implementation "commons-io:commons-io:2.11.0"
     implementation "org.apache.commons:commons-lang3:3.12.0"
     implementation "commons-validator:commons-validator:1.7"
-    testImplementation(platform('org.junit:junit-bom:5.7.2'))
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
     testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "org.mockito:mockito-inline:3.11.2"
-    testImplementation "org.mockito:mockito-core:3.11.2"
-    testImplementation 'org.mockito:mockito-junit-jupiter:3.11.2'
+    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
     testImplementation "commons-io:commons-io:2.10.0"
     testImplementation 'org.awaitility:awaitility:4.1.0'
-}
-
-test {
-    useJUnitPlatform()
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -29,9 +29,9 @@ dependencies {
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "io.micrometer:micrometer-core:1.7.2"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.4"
-    implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
+    implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
     testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "org.mockito:mockito-inline:3.11.2"
+    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
 }
 
 jacocoTestCoverageVerification {

--- a/research/zipkin-elastic-to-otel/build.gradle
+++ b/research/zipkin-elastic-to-otel/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 ext {
-    opensearch_version = System.getProperty("opensearch.version", "${versionMap.opensearch_version}")
+    opensearch_version = System.getProperty("opensearch.version", "${versionMap.opensearchVersion}")
 }
 
 group 'com.amazon'
@@ -49,5 +49,5 @@ dependencies {
     implementation "com.linecorp.armeria:armeria-grpc:1.0.0"
     implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
-    implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
+    implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
 }


### PR DESCRIPTION
### Description

This PR updates the entire project to use JUnit Jupiter as the test framework. No tests have been updated, but the JUnit Vintage Engine will allow the old JUnit 4 tests to continue to run. Over time as developers work on different tests, we can update those tests to JUnit 5 without having to make build changes.

Additionally, I made some stylistic improvements:
* Build files are Groovy, where camelCase should be used rather than snake_case. So I updated the versionMap accordingly.
* Groovy's double quoted strings are GStrings, which are interpolated. Where that interpolation was not necessary, I converted these to standard strings which have a single quote.
 
### Issues Resolved
N/A
 
### Check List
- [  ] New functionality includes testing.
  - [ X ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
