### PR TITLE
Updated the build to use OpenSearch 1.0.0.

### DIFF
--- a/.github/workflows/data-prepper-trace-analytics-raw-span-compatibility-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-compatibility-e2e-tests.yml
@@ -22,16 +22,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
-    # TODO: replace local built OpenSearch artifact with the public artifact
-    - name: Checkout OpenSearch
-      uses: actions/checkout@v2
-      with:
-        repository: 'opensearch-project/OpenSearch'
-        path: OpenSearch
-        ref: '1.0.0-alpha2'
-    - name: Build OpenSearch
-      working-directory: ./OpenSearch
-      run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha2 -Dbuild.snapshot=false
     - name: Checkout Data-Prepper
       uses: actions/checkout@v2
     - name: Grant execute permission for gradlew

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
@@ -22,16 +22,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      # TODO: replace local built OpenSearch artifact with the public artifact
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/OpenSearch'
-          path: OpenSearch
-          ref: '1.0.0-alpha2'
-      - name: Build OpenSearch
-        working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha2 -Dbuild.snapshot=false
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
       - name: Grant execute permission for gradlew

--- a/.github/workflows/data-prepper-trace-analytics-service-map-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-service-map-e2e-tests.yml
@@ -22,16 +22,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      # TODO: replace local built OpenSearch artifact with the public artifact
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/OpenSearch'
-          path: OpenSearch
-          ref: '1.0.0-alpha2'
-      - name: Build OpenSearch
-        working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha2 -Dbuild.snapshot=false
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
       - name: Grant execute permission for gradlew

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,16 +22,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
-    # TODO: replace local built OpenSearch artifact with the public artifact
-    - name: Checkout OpenSearch
-      uses: actions/checkout@v2
-      with:
-        repository: 'opensearch-project/OpenSearch'
-        path: OpenSearch
-        ref: '1.0.0-alpha2'
-    - name: Build OpenSearch
-      working-directory: ./OpenSearch
-      run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha2 -Dbuild.snapshot=false
     - name: Checkout Data-Prepper
       uses: actions/checkout@v2
     - name: Grant execute permission for gradlew

--- a/.github/workflows/opensearch-sink-odfe-before-1_13_0-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-odfe-before-1_13_0-integration-tests.yml
@@ -22,16 +22,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      # TODO: replace local built OpenSearch artifact with the public artifact
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/OpenSearch'
-          path: OpenSearch
-          ref: '1.0.0-alpha2'
-      - name: Build OpenSearch
-        working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha2 -Dbuild.snapshot=false
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
       - name: Grant execute permission for gradlew

--- a/.github/workflows/opensearch-sink-odfe-since-1_13_0-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-odfe-since-1_13_0-integration-tests.yml
@@ -22,16 +22,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      # TODO: replace local built OpenSearch artifact with the public artifact
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/OpenSearch'
-          path: OpenSearch
-          ref: '1.0.0-alpha2'
-      - name: Build OpenSearch
-        working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha2 -Dbuild.snapshot=false
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
       - name: Grant execute permission for gradlew

--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -18,25 +18,15 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      # TODO: replace local built OpenSearch artifact with the public artifact
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/OpenSearch'
-          path: OpenSearch
-          ref: '1.0.0-alpha2'
-      - name: Build OpenSearch
-        working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha2 -Dbuild.snapshot=false
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run OpenSearch docker
         run: |
-          export version=1.0.0-beta1
-          docker pull opensearchstaging/opensearch:$version
-          docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -d opensearchstaging/opensearch:$version
+          export version=1.0.0
+          docker pull opensearchproject/opensearch:$version
+          docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -d opensearchproject/opensearch:$version
           sleep 90
       - name: Run OpenSearch tests
         run: |

--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
         run: chmod +x gradlew
       - name: Run OpenSearch docker
         run: |
-          export version=1.0.0
+          export version=1.0.1
           docker pull opensearchproject/opensearch:$version
           docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -d opensearchproject/opensearch:$version
           sleep 90

--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -14,7 +14,7 @@ ext.versionMap = [
         junitJupiter : '5.7.2',
         mockito : '3.11.2',
         opentelemetryProto : '1.0.1-alpha',
-        opensearchVersion : '1.0.0-alpha2'
+        opensearchVersion : '1.0.0'
 ]
 
 ext.coreProjects = [project(':data-prepper-api'), project(':data-prepper-core'), project('data-prepper-plugins:common')]

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
     
     repositories {
         mavenCentral()
-        maven { url "https://jitpack.io" }
+        maven { url 'https://jitpack.io' }
     }
 
     spotless {

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -42,16 +42,6 @@ configurations {
     integrationTestRuntime.extendsFrom testRuntime
 }
 
-repositories {
-    // TODO: Replace with Maven Central once it has synced
-    maven {
-        url 'https://aws.oss.sonatype.org/content/repositories/releases/'
-        content {
-            includeGroupByRegex 'org\\.opensearch.*'
-        }
-    }
-}
-
 dependencies {
     integrationTestCompile project(':data-prepper-plugins:opensearch')
     integrationTestCompile project(':data-prepper-plugins:otel-trace-group-prepper')

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -43,8 +43,13 @@ configurations {
 }
 
 repositories {
-    // TODO: replace local built OpenSearch artifact with the public artifact
-    mavenLocal()
+    // TODO: Replace with Maven Central once it has synced
+    maven {
+        url 'https://aws.oss.sonatype.org/content/repositories/releases/'
+        content {
+            includeGroupByRegex 'org\\.opensearch.*'
+        }
+    }
 }
 
 dependencies {

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -6,9 +6,14 @@ buildscript {
     }
 
     repositories {
-        maven { url "https://plugins.gradle.org/m2/" }
-        // TODO: replace local built OpenSearch artifact with the public artifact
-        mavenLocal()
+        maven { url 'https://plugins.gradle.org/m2/' }
+        // TODO: Replace with Maven Central once it has synced
+        maven {
+            url 'https://aws.oss.sonatype.org/content/repositories/releases/'
+            content {
+                includeGroupByRegex 'org\\.opensearch.*'
+            }
+        }
     }
 
     dependencies {
@@ -41,8 +46,13 @@ ext {
 }
 
 repositories {
-    // TODO: replace local built OpenSearch artifact with the public artifact
-    mavenLocal()
+    // TODO: Replace with Maven Central once it has synced
+    maven {
+        url 'https://aws.oss.sonatype.org/content/repositories/releases/'
+        content {
+            includeGroupByRegex 'org\\.opensearch.*'
+        }
+    }
 }
 
 dependencies {

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -7,13 +7,7 @@ buildscript {
 
     repositories {
         maven { url 'https://plugins.gradle.org/m2/' }
-        // TODO: Replace with Maven Central once it has synced
-        maven {
-            url 'https://aws.oss.sonatype.org/content/repositories/releases/'
-            content {
-                includeGroupByRegex 'org\\.opensearch.*'
-            }
-        }
+        mavenCentral()
     }
 
     dependencies {
@@ -43,16 +37,6 @@ apply plugin: 'opensearch.rest-test'
 ext {
     licenseFile = rootProject.file('LICENSE')
     noticeFile = rootProject.file('NOTICE')
-}
-
-repositories {
-    // TODO: Replace with Maven Central once it has synced
-    maven {
-        url 'https://aws.oss.sonatype.org/content/repositories/releases/'
-        content {
-            includeGroupByRegex 'org\\.opensearch.*'
-        }
-    }
 }
 
 dependencies {

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -474,8 +474,9 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     final Response response = client().performRequest(request);
     final String responseBody = EntityUtils.toString(response.getEntity());
 
+    // TODO: This is a difference between OpenSearch and ODFE
     @SuppressWarnings("unchecked") final String policyId = (String) ((Map<String, Object>) createParser(XContentType.JSON.xContent(),
-            responseBody).map().get(index)).get("index.opendistro.index_state_management.policy_id");
+            responseBody).map().get(index)).get("index.plugins.index_state_management.policy_id");
     return policyId;
   }
 

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -474,9 +474,8 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     final Response response = client().performRequest(request);
     final String responseBody = EntityUtils.toString(response.getEntity());
 
-    // TODO: This is a difference between OpenSearch and ODFE
     @SuppressWarnings("unchecked") final String policyId = (String) ((Map<String, Object>) createParser(XContentType.JSON.xContent(),
-            responseBody).map().get(index)).get("index.plugins.index_state_management.policy_id");
+            responseBody).map().get(index)).get("index.opendistro.index_state_management.policy_id");
     return policyId;
   }
 

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchTests.java
@@ -11,12 +11,11 @@
 
 package com.amazon.dataprepper.plugins.sink.opensearch;
 
-import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
-import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.opensearch.client.RequestOptions;
+import org.junit.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.rest.RestStatus;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -36,8 +35,16 @@ public class OpenSearchTests {
             builder.withPassword(password);
         }
         final RestHighLevelClient client = builder.build().createClient();
-        final ClusterHealthRequest request = new ClusterHealthRequest().waitForYellowStatus();
-        final ClusterHealthResponse response = client.cluster().health(request, RequestOptions.DEFAULT);
-        assertEquals(RestStatus.OK, response.status());
+
+        // TODO: Use the REST High Level client in OpenSearch 1.0.1 or 1.1, where this will work.
+        // https://github.com/opensearch-project/OpenSearch/issues/922
+        final Request request = new Request("GET", "_cluster/health");
+        request.addParameter("master_timeout", "30s");
+        request.addParameter("level", "cluster");
+        request.addParameter("timeout", "30s");
+        request.addParameter("wait_for_status", "yellow");
+
+        final Response response = client.getLowLevelClient().performRequest(request);
+        assertEquals(RestStatus.OK.getStatus(), response.getStatusLine().getStatusCode());
     }
 }

--- a/data-prepper-plugins/otel-trace-group-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-group-prepper/build.gradle
@@ -17,16 +17,6 @@ ext {
     opensearch_version = System.getProperty("opensearch.version", "${versionMap.opensearchVersion}")
 }
 
-repositories {
-    // TODO: Replace with Maven Central once it has synced
-    maven {
-        url 'https://aws.oss.sonatype.org/content/repositories/releases/'
-        content {
-            includeGroupByRegex 'org\\.opensearch.*'
-        }
-    }
-}
-
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:opensearch')

--- a/data-prepper-plugins/otel-trace-group-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-group-prepper/build.gradle
@@ -18,8 +18,13 @@ ext {
 }
 
 repositories {
-    // TODO: replace local built OpenSearch artifact with the public artifact
-    mavenLocal()
+    // TODO: Replace with Maven Central once it has synced
+    maven {
+        url 'https://aws.oss.sonatype.org/content/repositories/releases/'
+        content {
+            includeGroupByRegex 'org\\.opensearch.*'
+        }
+    }
 }
 
 dependencies {

--- a/examples/dev/k8s/sample-project-applications.yaml
+++ b/examples/dev/k8s/sample-project-applications.yaml
@@ -37,7 +37,7 @@ spec:
           value: https://odfe:9200
         - name: OPENSEARCH_URL
           value: https://odfe:9200
-        image: opensearchstaging/opensearch-dashboards:1.0.0
+        image: opensearchproject/opensearch-dashboards:1.0.0
         imagePullPolicy: ""
         name: opensearch-dashboard
         ports:
@@ -135,7 +135,7 @@ spec:
       - env:
         - name: discovery.type
           value: single-node
-        image: opensearchstaging/opensearch:1.0.0
+        image: opensearchproject/opensearch:1.0.0
         imagePullPolicy: ""
         name: odfe
         ports:

--- a/examples/dev/trace-analytics-sample-app/Dockerfile
+++ b/examples/dev/trace-analytics-sample-app/Dockerfile
@@ -1,12 +1,7 @@
 FROM gradle:jdk14 AS builder
 COPY . /home/gradle/src
 WORKDIR /home/gradle/src
-# TODO: replace local built OpenSearch artifact with the public artifact
-RUN tar -xzf opensearch-build-1_0_0-alpha2.tar.gz
-RUN mkdir -p ~/.m2/repository/org
-RUN mv opensearch-build-1_0_0-alpha2 ~/.m2/repository/org/opensearch
-WORKDIR /home/gradle/src/data-prepper-core
-RUN gradle clean jar --daemon
+RUN gradle -p data-prepper-core clean jar --no-daemon
 
 FROM amazoncorretto:15-al2-full
 EXPOSE 21890

--- a/examples/dev/trace-analytics-sample-app/docker-compose.yml
+++ b/examples/dev/trace-analytics-sample-app/docker-compose.yml
@@ -76,7 +76,7 @@ services:
 
   opensearch:
     container_name: node-0.example.com
-    image: opensearchstaging/opensearch:1.0.0
+    image: opensearchproject/opensearch:1.0.0
     ports:
       - "9200:9200"
       - "9600:9600"
@@ -87,7 +87,7 @@ services:
 
   opensearch-dashboard:
     container_name: opensearch-dashboard
-    image: opensearchstaging/opensearch-dashboards:1.0.0
+    image: opensearchproject/opensearch-dashboards:1.0.0
     ports:
       - 5601:5601
     expose:

--- a/research/zipkin-elastic-to-otel/build.gradle
+++ b/research/zipkin-elastic-to-otel/build.gradle
@@ -25,13 +25,6 @@ sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
-    // TODO: Replace with Maven Central once it has synced
-    maven {
-        url 'https://aws.oss.sonatype.org/content/repositories/releases/'
-        content {
-            includeGroupByRegex 'org\\.opensearch.*'
-        }
-    }
 }
 
 application {

--- a/research/zipkin-elastic-to-otel/build.gradle
+++ b/research/zipkin-elastic-to-otel/build.gradle
@@ -25,8 +25,13 @@ sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
-    // TODO: replace local built OpenSearch artifact with the public artifact
-    mavenLocal()
+    // TODO: Replace with Maven Central once it has synced
+    maven {
+        url 'https://aws.oss.sonatype.org/content/repositories/releases/'
+        content {
+            includeGroupByRegex 'org\\.opensearch.*'
+        }
+    }
 }
 
 application {


### PR DESCRIPTION
This PR updates Data Prepper to use OpenSearch 1.0.0 (release version). It is using the OpenSearch artifacts from Maven Central. The integration tests run against OpenSearch 1.0.1 due to backward compatibility limitations in 1.0.0.

### Description

* Added the AWS Sonatype Maven repository
* Updated to OpenSearch 1.0.0
* Change to support both OpenSearch 1.0.0 and ODFE in the integration tests
* GitHub build simplifications
* Docker changes
 
### Issues Resolved

None
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
