### PR TITLE
Gradle & dependabot improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,11 @@
 version: 2
 updates:
 - package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: monthly
+
+- package-ecosystem: gradle
   directory: "/data-prepper-api"
   schedule:
     interval: monthly

--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,8 @@ subprojects {
     }
     dependencies {
         implementation 'com.google.guava:guava:29.0-jre'
-        implementation 'org.apache.logging.log4j:log4j-core:2.14.0'
+        implementation platform('io.micrometer:micrometer-bom:1.7.3')
         implementation 'org.slf4j:slf4j-api:1.7.30'
-        implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.0'
         testImplementation platform("org.junit:junit-bom:${versionMap.junitJupiter}")
         testImplementation 'org.junit.jupiter:junit-jupiter'
         testImplementation 'org.junit.vintage:junit-vintage-engine'
@@ -65,6 +64,14 @@ subprojects {
     }
 
     task allDeps(type: DependencyReportTask) {}
+}
+
+configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
+    dependencies {
+        implementation platform('com.fasterxml.jackson:jackson-bom:2.12.5')
+        implementation platform('software.amazon.awssdk:bom:2.17.15')
+        implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.67')
+    }
 }
 
 configure(coreProjects) {

--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -13,9 +13,9 @@ plugins {
 
 }
 dependencies {
-    implementation "io.micrometer:micrometer-core:1.7.2"
+    implementation 'io.micrometer:micrometer-core'
 
-    testImplementation "org.hamcrest:hamcrest:2.2"
+    testImplementation 'org.hamcrest:hamcrest:2.2'
 }
 jacocoTestCoverageVerification {
     dependsOn jacocoTestReport

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -24,16 +24,19 @@ dependencies {
     implementation project(':data-prepper-plugins')
     implementation project(':data-prepper-plugins:common')
     testImplementation project(':data-prepper-plugins:common').sourceSets.test.output
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.4"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.5"
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation "javax.validation:validation-api:2.0.1.Final"
     implementation "org.apache.bval:bval-extras:2.0.5"
     implementation "org.apache.bval:bval-jsr:2.0.5"
     implementation "org.reflections:reflections:0.9.12"
-    implementation "io.micrometer:micrometer-core:1.7.3"
-    implementation "io.micrometer:micrometer-registry-prometheus:1.7.3"
-    implementation "io.micrometer:micrometer-registry-cloudwatch2:1.7.3"
-    implementation "software.amazon.awssdk:cloudwatch:2.17.15"
+    implementation 'io.micrometer:micrometer-core'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-registry-cloudwatch2'
+    implementation 'software.amazon.awssdk:cloudwatch'
+    implementation platform('org.apache.logging.log4j:log4j-bom:2.14.1')
+    implementation 'org.apache.logging.log4j:log4j-core'
+    implementation 'org.apache.logging.log4j:log4j-slf4j-impl'
     testImplementation "org.hamcrest:hamcrest:2.2"
 }
 

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -51,7 +51,7 @@ dependencies {
     integrationTestImplementation "com.linecorp.armeria:armeria:1.0.0"
     integrationTestImplementation "com.linecorp.armeria:armeria-grpc:1.0.0"
     integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${versionMap.opensearchVersion}"
-    integrationTestImplementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
+    integrationTestImplementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 /**

--- a/data-prepper-plugins/common/build.gradle
+++ b/data-prepper-plugins/common/build.gradle
@@ -14,10 +14,10 @@ plugins {
 }
 dependencies {
     api project(':data-prepper-api')
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.5"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.5"
-    implementation "org.reflections:reflections:0.9.12"
-    testImplementation "commons-io:commons-io:2.11.0"
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+    implementation 'org.reflections:reflections:0.9.12'
+    testImplementation 'commons-io:commons-io:2.11.0'
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -44,8 +44,8 @@ dependencies {
     testImplementation project(':data-prepper-api').sourceSets.test.output
     api project(':data-prepper-plugins:common')
     implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.4"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.4"
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     implementation 'software.amazon.awssdk:auth:2.17.15'
     implementation 'software.amazon.awssdk:http-client-spi:2.17.15'
@@ -55,7 +55,7 @@ dependencies {
     implementation 'software.amazon.awssdk:utils:2.17.15'
     implementation 'software.amazon.awssdk:sts:2.17.15'
     implementation 'software.amazon.awssdk:url-connection-client:2.17.15'
-    implementation "io.micrometer:micrometer-core:1.7.2"
+    implementation 'io.micrometer:micrometer-core:1.7.3'
     // The OpenSearch build-tools plugin appears to be preventing Gradle's platform
     // support from working correctly, so we have to specify the JUnit versions here.
     testImplementation "org.junit.jupiter:junit-jupiter:${versionMap.junitJupiter}"
@@ -75,12 +75,12 @@ compileJava.options.warnings = false
 configurations.all {
     resolutionStrategy {
         force 'com.amazonaws:aws-java-sdk-core:1.12.67'
-        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3'
-        force 'com.fasterxml.jackson.core:jackson-annotations:2.12.4'
-        force 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
-        force 'com.fasterxml.jackson.core:jackson-core:2.12.4'
-        force 'com.fasterxml.jackson:jackson-bom:2.12.4'
-        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.4'
+        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.5'
+        force 'com.fasterxml.jackson.core:jackson-annotations:2.12.5'
+        force 'com.fasterxml.jackson.core:jackson-databind:2.12.5'
+        force 'com.fasterxml.jackson.core:jackson-core:2.12.5'
+        force 'com.fasterxml.jackson:jackson-bom:2.12.5'
+        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.5'
         force 'commons-logging:commons-logging:1.2'
         force 'org.apache.httpcomponents:httpclient:4.5.13'
         force "org.hdrhistogram:HdrHistogram:2.1.12"

--- a/data-prepper-plugins/otel-trace-group-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-group-prepper/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation project(':data-prepper-plugins:opensearch')
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.5"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.5"
-    implementation "io.micrometer:micrometer-core:1.7.3"
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+    implementation 'io.micrometer:micrometer-core'
 }

--- a/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
@@ -22,8 +22,8 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-java-util:3.17.3'
     implementation "com.linecorp.armeria:armeria:1.9.2"
     implementation "com.linecorp.armeria:armeria-grpc:1.9.2"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.5"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.5"
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
     testImplementation 'org.assertj:assertj-core:3.20.2'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"

--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -20,13 +20,13 @@ dependencies {
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
     implementation "commons-io:commons-io:2.11.0"
-    implementation "com.amazonaws:aws-java-sdk-s3:1.12.67"
-    implementation "com.amazonaws:aws-java-sdk-acm:1.12.43"
+    implementation 'com.amazonaws:aws-java-sdk-s3'
+    implementation 'com.amazonaws:aws-java-sdk-acm'
     implementation 'com.google.protobuf:protobuf-java-util:3.17.3'
     implementation "com.linecorp.armeria:armeria:1.9.2"
     implementation "com.linecorp.armeria:armeria-grpc:1.9.2"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.5"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.5"
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation "org.apache.commons:commons-lang3:3.12.0"
     implementation "org.bouncycastle:bcprov-jdk15on:1.69"
     implementation "org.bouncycastle:bcpkix-jdk15on:1.69"

--- a/data-prepper-plugins/peer-forwarder/build.gradle
+++ b/data-prepper-plugins/peer-forwarder/build.gradle
@@ -26,9 +26,8 @@ dependencies {
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
     implementation "com.linecorp.armeria:armeria:1.9.2"
     implementation "com.linecorp.armeria:armeria-grpc:1.9.2"
-    implementation(platform('software.amazon.awssdk:bom:2.17.15'))
-    implementation "com.amazonaws:aws-java-sdk-s3:1.12.43"
-    implementation "com.amazonaws:aws-java-sdk-acm:1.12.59"
+    implementation 'com.amazonaws:aws-java-sdk-s3'
+    implementation 'com.amazonaws:aws-java-sdk-acm'
     implementation 'software.amazon.awssdk:servicediscovery'
     implementation "commons-io:commons-io:2.11.0"
     implementation "org.apache.commons:commons-lang3:3.12.0"

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     implementation project(':data-prepper-plugins:common')
     implementation project(':data-prepper-plugins:mapdb-prepper-state')
     testImplementation project(':data-prepper-api').sourceSets.test.output
-    implementation "io.micrometer:micrometer-core:1.7.3"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.5"
+    implementation 'io.micrometer:micrometer-core'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
     testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"

--- a/research/zipkin-elastic-to-otel/build.gradle
+++ b/research/zipkin-elastic-to-otel/build.gradle
@@ -46,6 +46,6 @@ dependencies {
     implementation "com.linecorp.armeria:armeria:1.0.0"
     implementation "com.linecorp.armeria:armeria-grpc:1.0.0"
     implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
 }


### PR DESCRIPTION
### Description

Our dependency versions are not always in sync across projects and dependabot merges can take a very long time because many versions are repeated. This commit consolidates some of the common dependencies which are used in different projects. The root project now includes new BOM files in all projects except `data-prepper-api`. Even though adding it to `data-prepper-api` would likely not be problematic, I wanted to avoid making any appearance of extra dependencies since this project could be used by plugins.

The follow dependencies now have BOM files:
* Micrometer
* Jackson
* AWS Java SDK v2
* AWS Java SDK v1

Additionally, I noticed that dependabot is not configured for the root Gradle project. I added this as well. 

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
