### PR TITLE
MAINT: specifies JUnit 5 in subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ subprojects {
         testImplementation "org.mockito:mockito-core:${versionMap.mockito}"
         testImplementation "org.mockito:mockito-junit-jupiter:${versionMap.mockito}"
     }
+    test {
+        useJUnitPlatform()
+    }
     build.dependsOn test
     jacocoTestReport {
         dependsOn test // tests are required to run before generating the report
@@ -67,10 +70,6 @@ subprojects {
 }
 
 configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
-    test {
-        useJUnitPlatform()
-    }
-
     dependencies {
         implementation platform('com.fasterxml.jackson:jackson-bom:2.12.5')
         implementation platform('software.amazon.awssdk:bom:2.17.15')

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,10 @@ subprojects {
 }
 
 configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
+    test {
+        useJUnitPlatform()
+    }
+
     dependencies {
         implementation platform('com.fasterxml.jackson:jackson-bom:2.12.5')
         implementation platform('software.amazon.awssdk:bom:2.17.15')
@@ -84,7 +88,6 @@ configure(coreProjects) {
         }
     }
     test {
-        useJUnitPlatform()
         finalizedBy jacocoTestReport // report is always generated after tests run
     }
     jacocoTestCoverageVerification {

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -98,6 +98,9 @@ configurations.all {
 }
 
 test {
+    // Workaround: opensearch plugin is not compatible with JUnitPlatform
+    useJUnit()
+
     if (System.getProperty("os.host") == null) {
         exclude '**/OpenSearchTests.class'
     }


### PR DESCRIPTION
Signed-off-by: qchea <qchea@amazon.com>

### Description
This PR refactors the specification on JUnit Platform from coreProjects into all subprojects.

Note: we have to force useJUnit() in opensearch plugin due to the incompatibility of opensearch gradle plugins with JunitPlatform
 
### Issues Resolved
[List any issues this PR will resolve]
None
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
