### PR TITLE
ENH: new Buffer::writeAll API

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
@@ -86,6 +86,33 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
     }
 
     /**
+     * Records metrics for ingress, time elapsed, and timeouts, while calling the doWrite method
+     * to perform the actual write
+     *
+     * @param records          the Record to add
+     * @param timeoutInMillis how long to wait before giving up
+     * @throws Exception
+     */
+    @Override
+    public void writeAll(Collection<T> records, int timeoutInMillis) throws Exception {
+        long startTime = System.nanoTime();
+
+        try {
+            final int size = records.size();
+            doWriteAll(records, timeoutInMillis);
+            recordsWrittenCounter.increment(size);
+            recordsInBuffer.addAndGet(size);
+        } catch (Exception e) {
+            if (e instanceof TimeoutException) {
+                writeTimeoutCounter.increment();
+            }
+            throw e;
+        } finally {
+            writeTimer.record(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    /**
      * Records egress and time elapsed metrics, while calling the doRead function to
      * do the actual read
      *
@@ -121,6 +148,15 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
      * @throws TimeoutException
      */
     public abstract void doWrite(T record, int timeoutInMillis) throws TimeoutException;
+
+    /**
+     * This method should implement the logic for writing to the  buffer
+     *
+     * @param records          Record to write to buffer
+     * @param timeoutInMillis Timeout for write operation in millis
+     * @throws Exception
+     */
+    public abstract void doWriteAll(Collection<T> records, int timeoutInMillis) throws Exception;
 
     /**
      * This method should implement the logic for reading from the buffer

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
@@ -86,10 +86,10 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
     }
 
     /**
-     * Records metrics for ingress, time elapsed, and timeouts, while calling the doWrite method
+     * Records metrics for ingress, time elapsed, and timeouts, while calling the doWriteAll method
      * to perform the actual write
      *
-     * @param records          the Record to add
+     * @param records          the collection of Record to add
      * @param timeoutInMillis how long to wait before giving up
      * @throws Exception
      */

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/Buffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/Buffer.java
@@ -33,6 +33,14 @@ public interface Buffer<T extends Record<?>> {
     void write(T record, int timeoutInMillis) throws TimeoutException;
 
     /**
+     * Atomically writes collection of records into the buffer
+     *
+     * @param records the collection of records to add
+     * @param timeoutInMillis how long to wait before giving up
+     */
+    void writeAll(Collection<T> records, int timeoutInMillis) throws Exception;
+
+    /**
      * Retrieves and removes the batch of records from the head of the queue. The batch size is defined/determined by
      * the configuration attribute "batch_size" or the @param timeoutInMillis
      * @param timeoutInMillis how long to wait before giving up

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/PayloadSizeOverflowException.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/PayloadSizeOverflowException.java
@@ -1,0 +1,26 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ *
+ *  Modifications Copyright OpenSearch Contributors. See
+ *  GitHub history for details.
+ */
+
+package com.amazon.dataprepper.model.buffer;
+
+public class PayloadSizeOverflowException extends Exception {
+    public PayloadSizeOverflowException(final Throwable cause) {
+        super(cause);
+    }
+
+    public PayloadSizeOverflowException(final String message) {
+        super(message);
+    }
+
+    public PayloadSizeOverflowException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
@@ -33,20 +33,26 @@ import java.util.concurrent.TimeoutException;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Statistic;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class AbstractBufferTest {
+    private static final String BUFFER_NAME = "testBuffer";
+    private static final String PIPELINE_NAME = "pipelineName";
+
+    private PluginSetting testPluginSetting;
+
+    @Before
+    public void setUp() {
+        MetricsTestUtil.initMetrics();
+        testPluginSetting = new PluginSetting(BUFFER_NAME, Collections.emptyMap());
+        testPluginSetting.setPipelineName(PIPELINE_NAME);
+    }
 
     @Test
     public void testWriteMetrics() throws TimeoutException {
         // Given
-        final String bufferName = "testBuffer";
-        final String pipelineName = "pipelineName";
-        MetricsTestUtil.initMetrics();
-
-        PluginSetting pluginSetting = new PluginSetting(bufferName, Collections.emptyMap());
-        pluginSetting.setPipelineName(pipelineName);
-        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferImpl(pluginSetting);
+        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferImpl(testPluginSetting);
 
         // When
         for(int i=0; i<5; i++) {
@@ -55,9 +61,9 @@ public class AbstractBufferTest {
 
         // Then
         final List<Measurement> recordsWrittenMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_WRITTEN).toString());
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.RECORDS_WRITTEN).toString());
         final List<Measurement> writeTimeMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.WRITE_TIME_ELAPSED).toString());
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.WRITE_TIME_ELAPSED).toString());
         Assert.assertEquals(1, recordsWrittenMeasurements.size());
         Assert.assertEquals(5.0, recordsWrittenMeasurements.get(0).getValue(), 0);
         Assert.assertEquals(5.0, MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.COUNT).getValue(), 0);
@@ -71,13 +77,7 @@ public class AbstractBufferTest {
     @Test
     public void testWriteAllMetrics() throws Exception {
         // Given
-        final String bufferName = "testBuffer";
-        final String pipelineName = "pipelineName";
-        MetricsTestUtil.initMetrics();
-
-        PluginSetting pluginSetting = new PluginSetting(bufferName, Collections.emptyMap());
-        pluginSetting.setPipelineName(pipelineName);
-        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferImpl(pluginSetting);
+        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferImpl(testPluginSetting);
         final Collection<Record<String>> testRecords = new ArrayList<>();
         for(int i=0; i<5; i++) {
             testRecords.add(new Record<>(UUID.randomUUID().toString()));
@@ -88,9 +88,9 @@ public class AbstractBufferTest {
 
         // Then
         final List<Measurement> recordsWrittenMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_WRITTEN).toString());
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.RECORDS_WRITTEN).toString());
         final List<Measurement> writeTimeMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.WRITE_TIME_ELAPSED).toString());
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.WRITE_TIME_ELAPSED).toString());
         Assert.assertEquals(1, recordsWrittenMeasurements.size());
         Assert.assertEquals(5.0, recordsWrittenMeasurements.get(0).getValue(), 0);
         Assert.assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.COUNT).getValue(), 0);
@@ -104,13 +104,7 @@ public class AbstractBufferTest {
     @Test
     public void testReadMetrics() throws Exception {
         // Given
-        final String bufferName = "testBuffer";
-        final String pipelineName = "pipelineName";
-        MetricsTestUtil.initMetrics();
-
-        PluginSetting pluginSetting = new PluginSetting(bufferName, Collections.emptyMap());
-        pluginSetting.setPipelineName(pipelineName);
-        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferImpl(pluginSetting);
+        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferImpl(testPluginSetting);
         final Collection<Record<String>> testRecords = new ArrayList<>();
         for(int i=0; i<5; i++) {
             testRecords.add(new Record<>(UUID.randomUUID().toString()));
@@ -122,13 +116,13 @@ public class AbstractBufferTest {
 
         // Then
         final List<Measurement> recordsReadMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_READ).toString());
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.RECORDS_READ).toString());
         final List<Measurement> recordsInFlightMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_INFLIGHT).toString());
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.RECORDS_INFLIGHT).toString());
         final List<Measurement> recordsProcessedMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(MetricNames.RECORDS_PROCESSED).toString());
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(MetricNames.RECORDS_PROCESSED).toString());
         final List<Measurement> readTimeMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.READ_TIME_ELAPSED).toString());
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.READ_TIME_ELAPSED).toString());
         Assert.assertEquals(1, recordsReadMeasurements.size());
         Assert.assertEquals(5.0, recordsReadMeasurements.get(0).getValue(), 0);
         Assert.assertEquals(1, recordsInFlightMeasurements.size());
@@ -148,13 +142,7 @@ public class AbstractBufferTest {
     @Test
     public void testCheckpointMetrics() throws Exception {
         // Given
-        final String bufferName = "testBuffer";
-        final String pipelineName = "pipelineName";
-        MetricsTestUtil.initMetrics();
-
-        PluginSetting pluginSetting = new PluginSetting(bufferName, Collections.emptyMap());
-        pluginSetting.setPipelineName(pipelineName);
-        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferImpl(pluginSetting);
+        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferImpl(testPluginSetting);
         final Collection<Record<String>> testRecords = new ArrayList<>();
         for(int i=0; i<5; i++) {
             testRecords.add(new Record<>(UUID.randomUUID().toString()));
@@ -162,7 +150,7 @@ public class AbstractBufferTest {
         abstractBuffer.writeAll(testRecords, 1000);
         final Map.Entry<Collection<Record<String>>, CheckpointState> readResult = abstractBuffer.read(1000);
         final List<Measurement> checkpointTimeMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.CHECKPOINT_TIME_ELAPSED).toString());
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.CHECKPOINT_TIME_ELAPSED).toString());
         Assert.assertEquals(0.0, MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.COUNT).getValue(), 0);
         Assert.assertEquals(0.0, MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.TOTAL_TIME).getValue(), 0);
 
@@ -172,9 +160,9 @@ public class AbstractBufferTest {
         // Then
         Assert.assertEquals(0, abstractBuffer.getRecordsInFlight());
         final List<Measurement> recordsInFlightMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_INFLIGHT).toString());
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.RECORDS_INFLIGHT).toString());
         final List<Measurement> recordsProcessedMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(MetricNames.RECORDS_PROCESSED).toString());
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(MetricNames.RECORDS_PROCESSED).toString());
         final Measurement recordsInFlightMeasurement = recordsInFlightMeasurements.get(0);
         final Measurement recordsProcessedMeasurement = recordsProcessedMeasurements.get(0);
         Assert.assertEquals(0.0, recordsInFlightMeasurement.getValue(), 0);
@@ -189,18 +177,13 @@ public class AbstractBufferTest {
     @Test
     public void testWriteTimeoutMetric() throws TimeoutException {
         // Given
-        final String bufferName = "testBuffer";
-        final String pipelineName = "pipelineName";
-        MetricsTestUtil.initMetrics();
-        PluginSetting pluginSetting = new PluginSetting(bufferName, Collections.emptyMap());
-        pluginSetting.setPipelineName(pipelineName);
-        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferTimeoutImpl(pluginSetting);
+        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferTimeoutImpl(testPluginSetting);
 
         // When/Then
         Assert.assertThrows(TimeoutException.class, () -> abstractBuffer.write(new Record<>(UUID.randomUUID().toString()), 1000));
 
         final List<Measurement> timeoutMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.WRITE_TIMEOUTS).toString());
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.WRITE_TIMEOUTS).toString());
         Assert.assertEquals(1, timeoutMeasurements.size());
         Assert.assertEquals(1.0, timeoutMeasurements.get(0).getValue(), 0);
     }
@@ -208,12 +191,7 @@ public class AbstractBufferTest {
     @Test
     public void testWriteAllTimeoutMetric() throws TimeoutException {
         // Given
-        final String bufferName = "testBuffer";
-        final String pipelineName = "pipelineName";
-        MetricsTestUtil.initMetrics();
-        PluginSetting pluginSetting = new PluginSetting(bufferName, Collections.emptyMap());
-        pluginSetting.setPipelineName(pipelineName);
-        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferTimeoutImpl(pluginSetting);
+        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferTimeoutImpl(testPluginSetting);
         final Collection<Record<String>> testRecords = Arrays.asList(
                 new Record<>(UUID.randomUUID().toString()), new Record<>(UUID.randomUUID().toString()));
 
@@ -221,7 +199,7 @@ public class AbstractBufferTest {
         Assert.assertThrows(TimeoutException.class, () -> abstractBuffer.writeAll(testRecords, 1000));
 
         final List<Measurement> timeoutMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.WRITE_TIMEOUTS).toString());
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.WRITE_TIMEOUTS).toString());
         Assert.assertEquals(1, timeoutMeasurements.size());
         Assert.assertEquals(1.0, timeoutMeasurements.get(0).getValue(), 0);
     }
@@ -229,10 +207,7 @@ public class AbstractBufferTest {
     @Test
     public void testWriteRuntimeException() {
         // Given
-        final String bufferName = "testBuffer";
-        final String pipelineName = "pipelineName";
-        MetricsTestUtil.initMetrics();
-        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferNpeImpl(bufferName, pipelineName);
+        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferNpeImpl(BUFFER_NAME, PIPELINE_NAME);
 
         // When/Then
         Assert.assertThrows(NullPointerException.class, () -> abstractBuffer.write(new Record<>(UUID.randomUUID().toString()), 1000));
@@ -241,10 +216,7 @@ public class AbstractBufferTest {
     @Test
     public void testWriteAllRuntimeException() {
         // Given
-        final String bufferName = "testBuffer";
-        final String pipelineName = "pipelineName";
-        MetricsTestUtil.initMetrics();
-        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferNpeImpl(bufferName, pipelineName);
+        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferNpeImpl(BUFFER_NAME, PIPELINE_NAME);
         final Collection<Record<String>> testRecords = Arrays.asList(
                 new Record<>(UUID.randomUUID().toString()), new Record<>(UUID.randomUUID().toString()));
 

--- a/data-prepper-plugins/blocking-buffer/src/test/java/com/amazon/dataprepper/plugins/buffer/blockingbuffer/BlockingBufferTests.java
+++ b/data-prepper-plugins/blocking-buffer/src/test/java/com/amazon/dataprepper/plugins/buffer/blockingbuffer/BlockingBufferTests.java
@@ -11,14 +11,19 @@
 
 package com.amazon.dataprepper.plugins.buffer.blockingbuffer;
 
+import com.amazon.dataprepper.model.buffer.PayloadSizeOverflowException;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.CheckpointState;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -77,6 +82,18 @@ public class BlockingBufferTests {
         blockingBuffer.write(null, TEST_WRITE_TIMEOUT);
     }
 
+    @Test(expected = PayloadSizeOverflowException.class)
+    public void testWriteAllPayloadSizeOverflow() throws Exception {
+        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(TEST_BUFFER_SIZE, TEST_BATCH_SIZE,
+                TEST_PIPELINE_NAME);
+        assertThat(blockingBuffer, notNullValue());
+        final Collection<Record<String>> testRecords = new ArrayList<>();
+        for (int i = 0; i < TEST_BUFFER_SIZE + 1; i++) {
+            testRecords.add(new Record<>(UUID.randomUUID().toString()));
+        }
+        blockingBuffer.writeAll(testRecords, TEST_WRITE_TIMEOUT);
+    }
+
     @Test(expected = TimeoutException.class)
     public void testNoEmptySpaceWriteOnly() throws TimeoutException {
         final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(1, TEST_BATCH_SIZE,
@@ -84,6 +101,19 @@ public class BlockingBufferTests {
         assertThat(blockingBuffer, notNullValue());
         blockingBuffer.write(new Record<>("FILL_THE_BUFFER"), TEST_WRITE_TIMEOUT);
         blockingBuffer.write(new Record<>("TIMEOUT"), TEST_WRITE_TIMEOUT);
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void testNoEmptySpaceWriteAllOnly() throws Exception {
+        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(2, TEST_BATCH_SIZE,
+                TEST_PIPELINE_NAME);
+        assertThat(blockingBuffer, notNullValue());
+        final Collection<Record<String>> testRecords = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            testRecords.add(new Record<>(UUID.randomUUID().toString()));
+        }
+        blockingBuffer.write(new Record<>("FILL_THE_BUFFER"), TEST_WRITE_TIMEOUT);
+        blockingBuffer.writeAll(testRecords, TEST_WRITE_TIMEOUT);
     }
 
     @Test
@@ -97,7 +127,10 @@ public class BlockingBufferTests {
         blockingBuffer.read(TEST_BATCH_READ_TIMEOUT);
 
         // Then
-        assertThrows(TimeoutException.class, () -> blockingBuffer.write(new Record<>("TIMEOUT"), TEST_WRITE_TIMEOUT));
+        final Record<String> timeoutRecord = new Record<>("TIMEOUT");
+        assertThrows(TimeoutException.class, () -> blockingBuffer.write(timeoutRecord, TEST_WRITE_TIMEOUT));
+        assertThrows(
+                TimeoutException.class, () -> blockingBuffer.writeAll(Collections.singletonList(timeoutRecord), TEST_WRITE_TIMEOUT));
     }
 
     @Test
@@ -113,7 +146,27 @@ public class BlockingBufferTests {
         blockingBuffer.checkpoint(readResult.getValue());
 
         // Then
-        blockingBuffer.write(new Record<>("TIMEOUT"), TEST_WRITE_TIMEOUT);
+        blockingBuffer.write(new Record<>("REFILL_THE_BUFFER"), TEST_WRITE_TIMEOUT);
+    }
+
+    @Test
+    public void testWriteAllIntoEmptySpaceAfterCheckedRead() throws Exception {
+        // Given
+        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(2, TEST_BATCH_SIZE,
+                TEST_PIPELINE_NAME);
+        assertThat(blockingBuffer, notNullValue());
+        final Collection<Record<String>> testRecords = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            testRecords.add(new Record<>(UUID.randomUUID().toString()));
+        }
+        blockingBuffer.writeAll(testRecords, TEST_WRITE_TIMEOUT);
+
+        // When
+        final Map.Entry<Collection<Record<String>>, CheckpointState> readResult = blockingBuffer.read(TEST_BATCH_READ_TIMEOUT);
+        blockingBuffer.checkpoint(readResult.getValue());
+
+        // Then
+        blockingBuffer.writeAll(testRecords, TEST_WRITE_TIMEOUT);
     }
 
     @Test

--- a/data-prepper-plugins/blocking-buffer/src/test/java/com/amazon/dataprepper/plugins/buffer/blockingbuffer/BlockingBufferTests.java
+++ b/data-prepper-plugins/blocking-buffer/src/test/java/com/amazon/dataprepper/plugins/buffer/blockingbuffer/BlockingBufferTests.java
@@ -87,10 +87,7 @@ public class BlockingBufferTests {
         final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(TEST_BUFFER_SIZE, TEST_BATCH_SIZE,
                 TEST_PIPELINE_NAME);
         assertThat(blockingBuffer, notNullValue());
-        final Collection<Record<String>> testRecords = new ArrayList<>();
-        for (int i = 0; i < TEST_BUFFER_SIZE + 1; i++) {
-            testRecords.add(new Record<>(UUID.randomUUID().toString()));
-        }
+        final Collection<Record<String>> testRecords = generateBatchRecords(TEST_BUFFER_SIZE + 1);
         blockingBuffer.writeAll(testRecords, TEST_WRITE_TIMEOUT);
     }
 
@@ -104,14 +101,11 @@ public class BlockingBufferTests {
     }
 
     @Test(expected = TimeoutException.class)
-    public void testNoEmptySpaceWriteAllOnly() throws Exception {
+    public void testNoAvailSpaceWriteAllOnly() throws Exception {
         final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(2, TEST_BATCH_SIZE,
                 TEST_PIPELINE_NAME);
         assertThat(blockingBuffer, notNullValue());
-        final Collection<Record<String>> testRecords = new ArrayList<>();
-        for (int i = 0; i < 2; i++) {
-            testRecords.add(new Record<>(UUID.randomUUID().toString()));
-        }
+        final Collection<Record<String>> testRecords = generateBatchRecords(2);
         blockingBuffer.write(new Record<>("FILL_THE_BUFFER"), TEST_WRITE_TIMEOUT);
         blockingBuffer.writeAll(testRecords, TEST_WRITE_TIMEOUT);
     }
@@ -155,10 +149,7 @@ public class BlockingBufferTests {
         final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(2, TEST_BATCH_SIZE,
                 TEST_PIPELINE_NAME);
         assertThat(blockingBuffer, notNullValue());
-        final Collection<Record<String>> testRecords = new ArrayList<>();
-        for (int i = 0; i < 2; i++) {
-            testRecords.add(new Record<>(UUID.randomUUID().toString()));
-        }
+        final Collection<Record<String>> testRecords = generateBatchRecords(2);
         blockingBuffer.writeAll(testRecords, TEST_WRITE_TIMEOUT);
 
         // When
@@ -237,5 +228,13 @@ public class BlockingBufferTests {
         final PluginSetting testSettings = new PluginSetting(pluginName, settings);
         testSettings.setPipelineName(TEST_PIPELINE_NAME);
         return testSettings;
+    }
+
+    private Collection<Record<String>> generateBatchRecords(final int numRecords) {
+        final Collection<Record<String>> results = new ArrayList<>();
+        for (int i = 0; i < numRecords; i++) {
+            results.add(new Record<>(UUID.randomUUID().toString()));
+        }
+        return results;
     }
 }


### PR DESCRIPTION
### Description
This PR
- Adds `writeAll` API at Buffer interface
- Implements writeAll API at AbstractBuffer as wrapper around abstract method `doWriteAll`
- Add corresponding test cases for writeAll and refactor existing test cases in AbstractBuffer
- Implements doWriteAll API in BlockingBuffer plugin
- Add test cases to cover the new doWriteAll implementation in BlockingBufferTests.

Note: usage of the new Buffer API in source plugin will be reserved in later PRs.
 
### Issues Resolved
#315 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
