### PR TITLE
Grok Prepper Matching Functionality

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PluginSetting.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PluginSetting.java
@@ -254,13 +254,13 @@ public class PluginSetting {
         throw new IllegalArgumentException(String.format(UNEXPECTED_ATTRIBUTE_TYPE_MSG, object.getClass(), attribute));
     }
 
-    private <T> void checkObjectType(String attribute, Object object, Class<T> type) {
+    private <T> void checkObjectType(final String attribute, final Object object, final Class<T> type) {
         if (!(type.isAssignableFrom(object.getClass()))){
             throw new IllegalArgumentException(String.format(UNEXPECTED_ATTRIBUTE_TYPE_MSG, object.getClass(), attribute));
         }
     }
 
-    private <T> void checkObjectForListType(String attribute, Object object, Class<T> type) {
+    private <T> void checkObjectForListType(final String attribute, final Object object, final Class<T> type) {
         checkObjectType(attribute, object, List.class);
 
         ((List<?>) object).forEach(o -> {

--- a/data-prepper-plugins/grok-prepper/README.md
+++ b/data-prepper-plugins/grok-prepper/README.md
@@ -24,7 +24,9 @@ prepper:
 
 ## Notes on Patterns
 
-The Grok Prepper internally uses the [java-grok Library](https://github.com/thekrakken/java-grok), so any patterns compatible there are compatible with Grok Prepper.
+The Grok Prepper uses the [java-grok Library](https://github.com/thekrakken/java-grok) internally and supports all java-grok Library compatible patterns.
+
+[Default Patterns](https://github.com/thekrakken/java-grok/blob/master/src/main/resources/patterns/patterns)
 
 ## Metrics
 

--- a/data-prepper-plugins/grok-prepper/README.md
+++ b/data-prepper-plugins/grok-prepper/README.md
@@ -1,1 +1,36 @@
+# Grok Prepper
 
+This is a prepper that takes unstructured data and utilizes pattern matching
+to structure and extract important fields for easier and more insightful aggregation and analysis.
+
+## Usages
+
+Example `.yaml` configuration
+
+```
+prepper:
+  - grok:
+     match:
+       message: [ "%{COMMONAPACHELOG}" ]
+```
+
+## Configuration
+
+* `match` (Optional): A `Map<String, List<String>>` that specifies which fields of a Record to match which patterns against. Default value is `{}`
+
+* `keep_empty_captures` (Optional): A `boolean` that specifies whether `null` captures should be kept. Default value is `false`
+
+* `named_captures_only` (Optional): A `boolean` that specifies whether to only keep named captures. Default value is `true`
+
+## Notes on Patterns
+
+The Grok Prepper internally uses the [java-grok Library](https://github.com/thekrakken/java-grok), so any patterns compatible there are compatible with Grok Prepper.
+
+## Metrics
+
+TBD
+
+## Developer Guide
+This plugin is compatible with Java 14. See
+- [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md)
+- [monitoring](https://github.com/opensearch-project/data-prepper/blob/main/docs/readme/monitoring.md)

--- a/data-prepper-plugins/grok-prepper/build.gradle
+++ b/data-prepper-plugins/grok-prepper/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation "io.krakens:java-grok:0.1.9"
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     testImplementation "org.hamcrest:hamcrest:2.2"
+    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/grok-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepper.java
+++ b/data-prepper-plugins/grok-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepper.java
@@ -139,7 +139,7 @@ public class GrokPrepper extends AbstractPrepper<Record<String>, Record<String>>
                 continue;
             }
 
-            if (List.class.isAssignableFrom(original.get(updateEntry.getKey()).getClass())) {
+            if (original.get(updateEntry.getKey()) != null && List.class.isAssignableFrom(original.get(updateEntry.getKey()).getClass())) {
                 ((List<Object>) original.get(updateEntry.getKey())).add(updateEntry.getValue());
             } else {
                 List<Object> values = new ArrayList<>(Collections.singletonList(original.get(updateEntry.getKey())));

--- a/data-prepper-plugins/grok-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepper.java
+++ b/data-prepper-plugins/grok-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepper.java
@@ -71,14 +71,14 @@ public class GrokPrepper extends AbstractPrepper<Record<String>, Record<String>>
     public Collection<Record<String>> doExecute(final Collection<Record<String>> records) {
         final List<Record<String>> recordsOut = new LinkedList<>();
 
-        for (Record<String> record : records) {
+        for (final Record<String> record : records) {
             try {
                 final Map<String, Object> recordMap = OBJECT_MAPPER.readValue(record.getData(), MAP_TYPE_REFERENCE);
 
                 for (final Map.Entry<String, List<Grok>> entry : fieldToGrok.entrySet()) {
                     for (final Grok grok : entry.getValue()) {
                         if (recordMap.containsKey(entry.getKey())) {
-                            Match match = grok.match(recordMap.get(entry.getKey()).toString());
+                            final Match match = grok.match(recordMap.get(entry.getKey()).toString());
                             match.setKeepEmptyCaptures(grokPrepperConfig.isKeepEmptyCaptures());
 
                             mergeCaptures(recordMap, match.capture());

--- a/data-prepper-plugins/grok-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepper.java
+++ b/data-prepper-plugins/grok-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepper.java
@@ -19,22 +19,49 @@ import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.prepper.AbstractPrepper;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
 
+import io.krakens.grok.api.Grok;
+import io.krakens.grok.api.GrokCompiler;
+import io.krakens.grok.api.Match;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 
 @DataPrepperPlugin(name = "grok", type = PluginType.PREPPER)
 public class GrokPrepper extends AbstractPrepper<Record<String>, Record<String>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrokPrepper.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {};
+
+    private final GrokCompiler grokCompiler;
+    private final Map<String, List<Grok>> fieldToGrok;
     private final GrokPrepperConfig grokPrepperConfig;
 
     public GrokPrepper(final PluginSetting pluginSetting) {
         super(pluginSetting);
         grokPrepperConfig = GrokPrepperConfig.buildConfig(pluginSetting);
+        grokCompiler = GrokCompiler.newInstance();
+        fieldToGrok = new LinkedHashMap<>();
+
+        registerPatterns();
+
+        for (Map.Entry<String, List<String>> entry : grokPrepperConfig.getMatch().entrySet()) {
+            fieldToGrok.put(entry.getKey(), entry.getValue().stream().map(item -> grokCompiler.compile(item, grokPrepperConfig.isNamedCapturesOnly())).collect(Collectors.toList()));
+        }
     }
 
     /**
@@ -43,10 +70,38 @@ public class GrokPrepper extends AbstractPrepper<Record<String>, Record<String>>
      *
      * @param records Input records that will be modified/processed
      * @return Record  modified output records
-    */
+     */
     @Override
     public Collection<Record<String>> doExecute(Collection<Record<String>> records) {
-        return records;
+        final List<Record<String>> recordsOut = new LinkedList<>();
+
+        for (Record<String> record : records) {
+            try {
+                final Map<String, Object> recordMap = OBJECT_MAPPER.readValue(record.getData(), MAP_TYPE_REFERENCE);
+                final Map<String, Object> grokkedLog = new HashMap<>();
+
+                for (Map.Entry<String, List<Grok>> entry : fieldToGrok.entrySet()) {
+                    for (Grok grok : entry.getValue()) {
+                        if (recordMap.containsKey(entry.getKey())) {
+                            Match match = grok.match(recordMap.get(entry.getKey()).toString());
+                            match.setKeepEmptyCaptures(grokPrepperConfig.isKeepEmptyCaptures());
+
+                            mergeUpdateWithOriginalMap(grokkedLog, match.capture());
+                        }
+                    }
+                }
+
+                mergeUpdateWithOriginalMap(recordMap, grokkedLog);
+
+                final Record<String> grokkedRecord = new Record<>(OBJECT_MAPPER.writeValueAsString(recordMap), record.getMetadata());
+                recordsOut.add(grokkedRecord);
+
+            } catch (JsonProcessingException e) {
+                LOG.error("Failed to parse the record [{}]", record.getData());
+                recordsOut.add(record);
+            }
+        }
+        return recordsOut;
     }
 
     @Override
@@ -62,5 +117,35 @@ public class GrokPrepper extends AbstractPrepper<Record<String>, Record<String>>
     @Override
     public void shutdown() {
 
+    }
+
+    private void registerPatterns() {
+        grokCompiler.registerDefaultPatterns();
+    }
+
+    /**
+     * merge key value pairs from updates Map with the original Map. If keys in the updates Map already exist in the original Map,
+     * the value for that key in the original Map will be made a List<String>, and the values from updates will be appended. For collisions
+     * where the value is not of type String, updates will be ignored
+     *
+     * @param original The original Map to be updated with values from key value pairs from updates
+     * @param updates The updates Map that contains key value pairs to be merged with original
+     */
+    private void mergeUpdateWithOriginalMap(final Map<String, Object> original, final Map<String, Object> updates) {
+        for (Map.Entry<String, Object> updateEntry : updates.entrySet()) {
+
+            if (!(original.containsKey(updateEntry.getKey()))) {
+                original.put(updateEntry.getKey(), updateEntry.getValue());
+                continue;
+            }
+
+            if (List.class.isAssignableFrom(original.get(updateEntry.getKey()).getClass())) {
+                ((List<Object>) original.get(updateEntry.getKey())).add(updateEntry.getValue());
+            } else {
+                List<Object> values = new ArrayList<>(Collections.singletonList(original.get(updateEntry.getKey())));
+                values.add(updateEntry.getValue());
+                original.put(updateEntry.getKey(), values);
+            }
+        }
     }
 }

--- a/data-prepper-plugins/grok-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepper.java
+++ b/data-prepper-plugins/grok-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepper.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -78,7 +77,6 @@ public class GrokPrepper extends AbstractPrepper<Record<String>, Record<String>>
         for (Record<String> record : records) {
             try {
                 final Map<String, Object> recordMap = OBJECT_MAPPER.readValue(record.getData(), MAP_TYPE_REFERENCE);
-                final Map<String, Object> grokkedLog = new HashMap<>();
 
                 for (Map.Entry<String, List<Grok>> entry : fieldToGrok.entrySet()) {
                     for (Grok grok : entry.getValue()) {
@@ -86,12 +84,10 @@ public class GrokPrepper extends AbstractPrepper<Record<String>, Record<String>>
                             Match match = grok.match(recordMap.get(entry.getKey()).toString());
                             match.setKeepEmptyCaptures(grokPrepperConfig.isKeepEmptyCaptures());
 
-                            mergeUpdateWithOriginalMap(grokkedLog, match.capture());
+                            mergeUpdateWithOriginalMap(recordMap, match.capture());
                         }
                     }
                 }
-
-                mergeUpdateWithOriginalMap(recordMap, grokkedLog);
 
                 final Record<String> grokkedRecord = new Record<>(OBJECT_MAPPER.writeValueAsString(recordMap), record.getMetadata());
                 recordsOut.add(grokkedRecord);
@@ -123,29 +119,28 @@ public class GrokPrepper extends AbstractPrepper<Record<String>, Record<String>>
         grokCompiler.registerDefaultPatterns();
     }
 
-    /**
-     * merge key value pairs from updates Map with the original Map. If keys in the updates Map already exist in the original Map,
-     * the value for that key in the original Map will be made a List<String>, and the values from updates will be appended. For collisions
-     * where the value is not of type String, updates will be ignored
-     *
-     * @param original The original Map to be updated with values from key value pairs from updates
-     * @param updates The updates Map that contains key value pairs to be merged with original
-     */
     private void mergeUpdateWithOriginalMap(final Map<String, Object> original, final Map<String, Object> updates) {
         for (Map.Entry<String, Object> updateEntry : updates.entrySet()) {
-
             if (!(original.containsKey(updateEntry.getKey()))) {
                 original.put(updateEntry.getKey(), updateEntry.getValue());
                 continue;
             }
 
-            if (original.get(updateEntry.getKey()) != null && List.class.isAssignableFrom(original.get(updateEntry.getKey()).getClass())) {
-                ((List<Object>) original.get(updateEntry.getKey())).add(updateEntry.getValue());
+            if (original.get(updateEntry.getKey()) instanceof List) {
+                mergeValueWithValues(updateEntry.getValue(), (List<Object>) original.get(updateEntry.getKey()));
             } else {
                 List<Object> values = new ArrayList<>(Collections.singletonList(original.get(updateEntry.getKey())));
-                values.add(updateEntry.getValue());
+                mergeValueWithValues(updateEntry.getValue(), values);
                 original.put(updateEntry.getKey(), values);
             }
+        }
+    }
+
+    private void mergeValueWithValues(final Object value, final List<Object> values) {
+        if (value instanceof List) {
+            values.addAll((List<Object>) value);
+        } else {
+            values.add(value);
         }
     }
 }

--- a/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperIT.java
+++ b/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperIT.java
@@ -1,0 +1,286 @@
+package com.amazon.dataprepper.plugins.prepper.grok;
+
+import com.amazon.dataprepper.model.configuration.PluginSetting;
+import com.amazon.dataprepper.model.record.Record;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class GrokPrepperIT {
+    private PluginSetting pluginSetting;
+    private GrokPrepper grokPrepper;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {};
+    private final String PLUGIN_NAME = "grok";
+
+    @BeforeEach
+    public void setup() {
+
+        pluginSetting = completePluginSettingForGrokPrepper(
+                GrokPrepperConfig.DEFAULT_BREAK_ON_MATCH,
+                GrokPrepperConfig.DEFAULT_KEEP_EMPTY_CAPTURES,
+                Collections.emptyMap(),
+                GrokPrepperConfig.DEFAULT_NAMED_CAPTURES_ONLY,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                GrokPrepperConfig.DEFAULT_PATTERNS_FILES_GLOB,
+                Collections.emptyMap(),
+                GrokPrepperConfig.DEFAULT_TIMEOUT_MILLIS,
+                GrokPrepperConfig.TARGET);
+
+        pluginSetting.setPipelineName("grokPipeline");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        grokPrepper.shutdown();
+    }
+
+    private PluginSetting completePluginSettingForGrokPrepper(final boolean breakOnMatch,
+                                                              final boolean keepEmptyCaptures,
+                                                              final Map<String, List<String>> match,
+                                                              final boolean namedCapturesOnly,
+                                                              final List<String> overwrite,
+                                                              final List<String> patternsDir,
+                                                              final String patternsFilesGlob,
+                                                              final Map<String, String> patternDefinitions,
+                                                              final int timeoutMillis,
+                                                              final String target) {
+        final Map<String, Object> settings = new HashMap<>();
+        settings.put(GrokPrepperConfig.BREAK_ON_MATCH, breakOnMatch);
+        settings.put(GrokPrepperConfig.NAMED_CAPTURES_ONLY, namedCapturesOnly);
+        settings.put(GrokPrepperConfig.MATCH, match);
+        settings.put(GrokPrepperConfig.KEEP_EMPTY_CAPTURES, keepEmptyCaptures);
+        settings.put(GrokPrepperConfig.OVERWRITE, overwrite);
+        settings.put(GrokPrepperConfig.PATTERNS_DIR, patternsDir);
+        settings.put(GrokPrepperConfig.PATTERN_DEFINITIONS, patternDefinitions);
+        settings.put(GrokPrepperConfig.PATTERNS_FILES_GLOB, patternsFilesGlob);
+        settings.put(GrokPrepperConfig.TIMEOUT_MILLIS, timeoutMillis);
+        settings.put(GrokPrepperConfig.TARGET, target);
+
+        return new PluginSetting(PLUGIN_NAME, settings);
+    }
+
+    @Test
+    public void testSingleMatchSinglePatternWithDefaults() throws JsonProcessingException {
+        final Map<String, List<String>> matchConfig = new HashMap<>();
+        matchConfig.put("message", Collections.singletonList("%{COMMONAPACHELOG}"));
+
+        pluginSetting.getSettings().put(GrokPrepperConfig.MATCH, matchConfig);
+        grokPrepper = new GrokPrepper(pluginSetting);
+
+        String testData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\"}";
+        Record<String> record = new Record<>(testData);
+
+        String resultData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
+                .concat("\"clientip\":\"127.0.0.1\",")
+                .concat("\"ident\":\"user-identifier\",")
+                .concat("\"auth\":\"frank\",")
+                .concat("\"timestamp\":\"10/Oct/2000:13:55:36 -0700\",")
+                .concat("\"verb\":\"GET\",")
+                .concat("\"request\":\"/apache_pb.gif\",")
+                .concat("\"httpversion\":\"1.0\",")
+                .concat("\"response\":\"200\",")
+                .concat("\"bytes\":\"2326\"}");
+
+        Record<String> resultRecord = new Record<>(resultData);
+
+        List<Record<String>> grokkedRecords = (List<Record<String>>) grokPrepper.doExecute(Collections.singletonList(record));
+
+        assertThat(grokkedRecords.size(), equalTo(1));
+        assertThat(grokkedRecords.get(0), notNullValue());
+        assertThat(equalRecords(grokkedRecords.get(0), resultRecord), equalTo(true));
+    }
+
+    @Test
+    public void testSingleMatchMultiplePatternWithDefaults() throws JsonProcessingException {
+        final Map<String, List<String>> matchConfig = new HashMap<>();
+        final List<String> patternsToMatchMessage = new ArrayList<>();
+        patternsToMatchMessage.add("%{COMMONAPACHELOG}");
+        patternsToMatchMessage.add("%{IPORHOST:custom_client_field}");
+
+        matchConfig.put("message", patternsToMatchMessage);
+
+        pluginSetting.getSettings().put(GrokPrepperConfig.MATCH, matchConfig);
+        grokPrepper = new GrokPrepper(pluginSetting);
+
+        String testData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\"}";
+        Record<String> record = new Record<>(testData);
+
+        String resultData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
+                .concat("\"clientip\":\"127.0.0.1\",")
+                .concat("\"ident\":\"user-identifier\",")
+                .concat("\"auth\":\"frank\",")
+                .concat("\"timestamp\":\"10/Oct/2000:13:55:36 -0700\",")
+                .concat("\"verb\":\"GET\",")
+                .concat("\"request\":\"/apache_pb.gif\",")
+                .concat("\"httpversion\":\"1.0\",")
+                .concat("\"response\":\"200\",")
+                .concat("\"custom_client_field\":\"127.0.0.1\",")
+                .concat("\"bytes\":\"2326\"}");
+
+        Record<String> resultRecord = new Record<>(resultData);
+
+        List<Record<String>> grokkedRecords = (List<Record<String>>) grokPrepper.doExecute(Collections.singletonList(record));
+
+        assertThat(grokkedRecords.size(), equalTo(1));
+        assertThat(grokkedRecords.get(0), notNullValue());
+        assertThat(equalRecords(grokkedRecords.get(0), resultRecord), equalTo(true));
+    }
+
+    @Test
+    public void testSingleMatchTypeConversionWithDefaults() throws JsonProcessingException {
+        final Map<String, List<String>> matchConfig = new HashMap<>();
+        matchConfig.put("message", Collections.singletonList("\"(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})\" %{NUMBER:response:int} (?:%{NUMBER:bytes:float}|-)"));
+
+        pluginSetting.getSettings().put(GrokPrepperConfig.MATCH, matchConfig);
+        grokPrepper = new GrokPrepper(pluginSetting);
+
+        String testData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\"}";
+        Record<String> record = new Record<>(testData);
+
+        String resultData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
+                .concat("\"verb\":\"GET\",")
+                .concat("\"request\":\"/apache_pb.gif\",")
+                .concat("\"httpversion\":\"1.0\",")
+                .concat("\"response\":200,")
+                .concat("\"bytes\":2326.0}");
+
+        Record<String> resultRecord = new Record<>(resultData);
+
+        List<Record<String>> grokkedRecords = (List<Record<String>>) grokPrepper.doExecute(Collections.singletonList(record));
+
+        assertThat(grokkedRecords.size(), equalTo(1));
+        assertThat(grokkedRecords.get(0), notNullValue());
+        assertThat(equalRecords(grokkedRecords.get(0), resultRecord), equalTo(true));
+    }
+
+    @Test
+    public void testMultipleMatchWithDefaults() throws JsonProcessingException {
+        final Map<String, List<String>> matchConfig = new HashMap<>();
+        matchConfig.put("message", Collections.singletonList("%{COMMONAPACHELOG}"));
+        matchConfig.put("extra_field", Collections.singletonList("%{GREEDYDATA} %{IPORHOST:host}"));
+
+        pluginSetting.getSettings().put(GrokPrepperConfig.MATCH, matchConfig);
+        grokPrepper = new GrokPrepper(pluginSetting);
+
+        String testData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
+                .concat("\"extra_field\":\"My host IP is 192.0.2.1\"}");
+
+        Record<String> record = new Record<>(testData);
+
+        String resultData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
+                .concat("\"extra_field\":\"My host IP is 192.0.2.1\",")
+                .concat("\"clientip\":\"127.0.0.1\",")
+                .concat("\"ident\":\"user-identifier\",")
+                .concat("\"auth\":\"frank\",")
+                .concat("\"timestamp\":\"10/Oct/2000:13:55:36 -0700\",")
+                .concat("\"verb\":\"GET\",")
+                .concat("\"request\":\"/apache_pb.gif\",")
+                .concat("\"httpversion\":\"1.0\",")
+                .concat("\"response\":\"200\",")
+                .concat("\"bytes\":\"2326\",")
+                .concat("\"host\":\"192.0.2.1\"}");
+
+        Record<String> resultRecord = new Record<>(resultData);
+
+        List<Record<String>> grokkedRecords = (List<Record<String>>) grokPrepper.doExecute(Collections.singletonList(record));
+
+        assertThat(grokkedRecords.size(), equalTo(1));
+        assertThat(grokkedRecords.get(0), notNullValue());
+        assertThat(equalRecords(grokkedRecords.get(0), resultRecord), equalTo(true));
+    }
+
+    @Test
+    public void testMatchWithKeepEmptyCapturesTrue() throws JsonProcessingException {
+        final Map<String, List<String>> matchConfig = new HashMap<>();
+        matchConfig.put("message", Collections.singletonList("%{COMMONAPACHELOG}"));
+
+        pluginSetting.getSettings().put(GrokPrepperConfig.MATCH, matchConfig);
+        pluginSetting.getSettings().put(GrokPrepperConfig.KEEP_EMPTY_CAPTURES, true);
+        grokPrepper = new GrokPrepper(pluginSetting);
+
+        String testData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\"}";
+        Record<String> record = new Record<>(testData);
+
+        String resultData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
+                .concat("\"clientip\":\"127.0.0.1\",")
+                .concat("\"ident\":\"user-identifier\",")
+                .concat("\"auth\":\"frank\",")
+                .concat("\"timestamp\":\"10/Oct/2000:13:55:36 -0700\",")
+                .concat("\"verb\":\"GET\",")
+                .concat("\"request\":\"/apache_pb.gif\",")
+                .concat("\"rawrequest\":null,")
+                .concat("\"httpversion\":\"1.0\",")
+                .concat("\"response\":\"200\",")
+                .concat("\"bytes\":\"2326\"}");
+
+        Record<String> resultRecord = new Record<>(resultData);
+
+        List<Record<String>> grokkedRecords = (List<Record<String>>) grokPrepper.doExecute(Collections.singletonList(record));
+
+        assertThat(grokkedRecords.size(), equalTo(1));
+        assertThat(grokkedRecords.get(0), notNullValue());
+        assertThat(equalRecords(grokkedRecords.get(0), resultRecord), equalTo(true));
+    }
+
+    @Test
+    public void testMatchWithNamedCapturesOnlyFalse() throws JsonProcessingException {
+        final Map<String, List<String>> matchConfig = new HashMap<>();
+        matchConfig.put("message", Collections.singletonList("%{GREEDYDATA} %{IPORHOST:host} %{NUMBER}"));
+
+        pluginSetting.getSettings().put(GrokPrepperConfig.MATCH, matchConfig);
+        pluginSetting.getSettings().put(GrokPrepperConfig.NAMED_CAPTURES_ONLY, false);
+        grokPrepper = new GrokPrepper(pluginSetting);
+
+        String testData = "{\"message\":\"This is my greedy data before matching 192.0.2.1 123456\"}";
+        Record<String> record = new Record<>(testData);
+
+        String resultData = "{\"message\":\"This is my greedy data before matching 192.0.2.1 123456\","
+                .concat("\"NUMBER\":\"123456\",")
+                .concat("\"GREEDYDATA\":\"This is my greedy data before matching\",")
+                .concat("\"host\":\"192.0.2.1\"}");
+
+        Record<String> resultRecord = new Record<>(resultData);
+
+        List<Record<String>> grokkedRecords = (List<Record<String>>) grokPrepper.doExecute(Collections.singletonList(record));
+
+        assertThat(grokkedRecords.size(), equalTo(1));
+        assertThat(grokkedRecords.get(0), notNullValue());
+        assertThat(equalRecords(grokkedRecords.get(0), resultRecord), equalTo(true));
+    }
+
+    @Test
+    public void testCompileNonRegisteredPattern() {
+
+        grokPrepper = new GrokPrepper(pluginSetting);
+
+        final Map<String, List<String>> matchConfig = new HashMap<>();
+        matchConfig.put("message", Collections.singletonList("%{NONEXISTENTPATTERN}"));
+
+        pluginSetting.getSettings().put(GrokPrepperConfig.MATCH, matchConfig);
+
+        assertThrows(IllegalArgumentException.class, () -> new GrokPrepper(pluginSetting));
+    }
+
+    private boolean equalRecords(final Record<String> first, final Record<String> second) throws JsonProcessingException {
+        final Map<String, Object> recordMapFirst = OBJECT_MAPPER.readValue(first.getData(), MAP_TYPE_REFERENCE);
+        final Map<String, Object> recordMapSecond = OBJECT_MAPPER.readValue(second.getData(), MAP_TYPE_REFERENCE);
+
+        return recordMapFirst.equals(recordMapSecond);
+    }
+}

--- a/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperIT.java
+++ b/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperIT.java
@@ -44,6 +44,10 @@ public class GrokPrepperIT {
                 GrokPrepperConfig.TARGET);
 
         pluginSetting.setPipelineName("grokPipeline");
+
+        // This is a COMMONAPACHELOG pattern with the following format
+        // COMMONAPACHELOG %{IPORHOST:clientip} %{USER:ident} %{USER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" %{NUMBER:response} (?:%{NUMBER:bytes}|-)
+        // Note that rawrequest is missing from the log below, which means that it will not be captured unless keep_empty_captures is true
         messageInput = "\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\"";
     }
 

--- a/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperTests.java
+++ b/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperTests.java
@@ -11,34 +11,78 @@
 
 package com.amazon.dataprepper.plugins.prepper.grok;
 
-import com.amazon.dataprepper.model.record.Record;
 
 import com.amazon.dataprepper.model.configuration.PluginSetting;
+import io.krakens.grok.api.Grok;
+import io.krakens.grok.api.GrokCompiler;
+import io.krakens.grok.api.Match;
+import com.amazon.dataprepper.model.record.Record;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.Mock;
+import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
 
 @ExtendWith(MockitoExtension.class)
 public class GrokPrepperTests {
 
-    PluginSetting pluginSetting;
+    private PluginSetting pluginSetting;
     private GrokPrepper grokPrepper;
+    private Collection<Record<String>> records;
+
+    @Mock
+    private GrokCompiler grokCompiler;
+
+    @Mock
+    private Match match;
+
+    @Mock
+    private Grok grok;
+
+    private final String PLUGIN_NAME = "grok";
+    private Map<String, Object> capture;
 
     @BeforeEach
     public void setup() {
-        pluginSetting = new PluginSetting(
-                "grok",
-                null
-                );
-        pluginSetting.setPipelineName("grokPipeline");
+
+        capture = new HashMap<>();
+        capture.put("field_capture_1", "value_capture_1");
+        capture.put("field_capture_2", "value_capture_2");
+        capture.put("field_capture_3", "value_capture_3");
+
+        final Map<String, List<String>> matchConfig = new HashMap<>();
+        matchConfig.put("message", new ArrayList<String>(){{ add("%{COMMONAPACHELOG"); }});
+
+        when(GrokCompiler.newInstance()).thenReturn(grokCompiler);
+        when(grokCompiler.compile(anyString(), anyBoolean())).thenReturn(grok);
+        when(grok.match(anyString())).thenReturn(match);
+        when(match.capture()).thenReturn(capture);
+
+        pluginSetting = completePluginSettingForGrokPrepper(
+                GrokPrepperConfig.DEFAULT_BREAK_ON_MATCH,
+                GrokPrepperConfig.DEFAULT_KEEP_EMPTY_CAPTURES,
+                matchConfig,
+                GrokPrepperConfig.DEFAULT_NAMED_CAPTURES_ONLY,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                GrokPrepperConfig.DEFAULT_PATTERNS_FILES_GLOB,
+                Collections.emptyMap(),
+                GrokPrepperConfig.DEFAULT_TIMEOUT_MILLIS,
+                GrokPrepperConfig.TARGET);
+
         grokPrepper = new GrokPrepper(pluginSetting);
     }
 
@@ -48,6 +92,34 @@ public class GrokPrepperTests {
     }
 
     @Test
+
+
+    private PluginSetting completePluginSettingForGrokPrepper(final boolean breakOnMatch,
+                                                              final boolean keepEmptyCaptures,
+                                                              final Map<String, List<String>> match,
+                                                              final boolean namedCapturesOnly,
+                                                              final List<String> overwrite,
+                                                              final List<String> patternsDir,
+                                                              final String patternsFilesGlob,
+                                                              final Map<String, String> patternDefinitions,
+                                                              final int timeoutMillis,
+                                                              final String target) {
+        final Map<String, Object> settings = new HashMap<>();
+        settings.put(GrokPrepperConfig.BREAK_ON_MATCH, breakOnMatch);
+        settings.put(GrokPrepperConfig.NAMED_CAPTURES_ONLY, namedCapturesOnly);
+        settings.put(GrokPrepperConfig.MATCH, match);
+        settings.put(GrokPrepperConfig.KEEP_EMPTY_CAPTURES, keepEmptyCaptures);
+        settings.put(GrokPrepperConfig.OVERWRITE, overwrite);
+        settings.put(GrokPrepperConfig.PATTERNS_DIR, patternsDir);
+        settings.put(GrokPrepperConfig.PATTERN_DEFINITIONS, patternDefinitions);
+        settings.put(GrokPrepperConfig.PATTERNS_FILES_GLOB, patternsFilesGlob);
+        settings.put(GrokPrepperConfig.TIMEOUT_MILLIS, timeoutMillis);
+        settings.put(GrokPrepperConfig.TARGET, target);
+
+        return new PluginSetting(PLUGIN_NAME, settings);
+    }
+
+   /* @Test
     public void testGrokPrepper() {
         String testData = "{\"message\": \"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\"}";
         Record<String> record = new Record<>(testData);
@@ -56,5 +128,5 @@ public class GrokPrepperTests {
 
         assertThat(grokkedRecords.size(), equalTo(1));
         assertThat(grokkedRecords.get(0), equalTo(record));
-    }
+    }*/
 }

--- a/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperTests.java
+++ b/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperTests.java
@@ -67,7 +67,7 @@ public class GrokPrepperTests {
 
     @BeforeEach
     public void setup() {
-        final Map<String, List<String>> matchConfig = new HashMap<>();:
+        final Map<String, List<String>> matchConfig = new HashMap<>();
         matchConfig.put("message", Collections.singletonList("%{COMMONAPACHELOG}"));
 
         pluginSetting = completePluginSettingForGrokPrepper(

--- a/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperTests.java
+++ b/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperTests.java
@@ -29,7 +29,6 @@ import org.mockito.Mock;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -38,6 +37,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
@@ -80,7 +80,7 @@ public class GrokPrepperTests {
             }});
 
             grokCompilerMockedStatic.when(GrokCompiler::newInstance).thenReturn(grokCompiler);
-            when(grokCompiler.compile(anyString(), anyBoolean())).thenReturn(grok);
+            when(grokCompiler.compile(eq(matchConfig.get("message").get(0)), anyBoolean())).thenReturn(grok);
             when(grok.match(anyString())).thenReturn(match);
             when(match.capture()).thenReturn(capture);
 
@@ -107,7 +107,7 @@ public class GrokPrepperTests {
     }
 
     @Test
-    public void singleMatchMergeTest() throws JsonProcessingException {
+    public void testMatchMerge() throws JsonProcessingException {
 
         String testData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\"}";
         Record<String> record = new Record<>(testData);
@@ -127,7 +127,7 @@ public class GrokPrepperTests {
     }
 
     @Test
-    public void singleMatchMergeCollisionStringsTest() throws JsonProcessingException {
+    public void testMatchMergeCollisionStrings() throws JsonProcessingException {
         String testData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
                 .concat("\"field_capture_1\":\"value_capture_collision\"}");
 
@@ -149,7 +149,7 @@ public class GrokPrepperTests {
     }
 
     @Test
-    public void singleMatchMergeCollisionIntsTest() throws JsonProcessingException {
+    public void testMatchMergeCollisionInts() throws JsonProcessingException {
         capture.put("field_capture_1", 20);
 
         String testData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
@@ -173,17 +173,17 @@ public class GrokPrepperTests {
     }
 
     @Test
-    public void singleMatchMergeCollisionMixedTypesTest() throws JsonProcessingException {
-        capture.put("field_capture_1", "20");
+    public void testMatchMergeCollisionWithListMixedTypes() throws JsonProcessingException {
+        capture.put("field_capture_1", "30");
 
         String testData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
-                .concat("\"field_capture_1\": 10}");
+                .concat("\"field_capture_1\":[10,\"20\"]}");
 
         Record<String> record = new Record<>(testData);
 
         String resultData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
-                .concat("\"field_capture_1\":[ 10,")
-                .concat("\"20\" ],")
+                .concat("\"field_capture_1\":[10,")
+                .concat("\"20\",\"30\"],")
                 .concat("\"field_capture_2\":\"value_capture_2\",")
                 .concat("\"field_capture_3\":\"value_capture_3\"}");
 

--- a/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperTests.java
+++ b/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperTests.java
@@ -67,10 +67,8 @@ public class GrokPrepperTests {
 
     @BeforeEach
     public void setup() {
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", new ArrayList<String>() {{
-            add("%{COMMONAPACHELOG}");
-        }});
+        final Map<String, List<String>> matchConfig = new HashMap<>();:
+        matchConfig.put("message", Collections.singletonList("%{COMMONAPACHELOG}"));
 
         pluginSetting = completePluginSettingForGrokPrepper(
                 GrokPrepperConfig.DEFAULT_BREAK_ON_MATCH,

--- a/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperTests.java
+++ b/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperTests.java
@@ -38,7 +38,6 @@ import java.util.UUID;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mockStatic;
@@ -97,7 +96,7 @@ public class GrokPrepperTests {
 
         messageInput = UUID.randomUUID().toString();
 
-        when(grok.match(anyString())).thenReturn(match);
+        when(grok.match(messageInput)).thenReturn(match);
         when(match.capture()).thenReturn(capture);
     }
 

--- a/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperTests.java
+++ b/data-prepper-plugins/grok-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepperTests.java
@@ -13,6 +13,9 @@ package com.amazon.dataprepper.plugins.prepper.grok;
 
 
 import com.amazon.dataprepper.model.configuration.PluginSetting;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.krakens.grok.api.Grok;
 import io.krakens.grok.api.GrokCompiler;
 import io.krakens.grok.api.Match;
@@ -20,6 +23,7 @@ import com.amazon.dataprepper.model.record.Record;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.Mock;
 import org.junit.jupiter.api.Test;
@@ -31,8 +35,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 
@@ -41,7 +49,8 @@ public class GrokPrepperTests {
 
     private PluginSetting pluginSetting;
     private GrokPrepper grokPrepper;
-    private Collection<Record<String>> records;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {};
 
     @Mock
     private GrokCompiler grokCompiler;
@@ -58,32 +67,38 @@ public class GrokPrepperTests {
     @BeforeEach
     public void setup() {
 
-        capture = new HashMap<>();
-        capture.put("field_capture_1", "value_capture_1");
-        capture.put("field_capture_2", "value_capture_2");
-        capture.put("field_capture_3", "value_capture_3");
+        try (MockedStatic<GrokCompiler> grokCompilerMockedStatic = mockStatic(GrokCompiler.class)) {
 
-        final Map<String, List<String>> matchConfig = new HashMap<>();
-        matchConfig.put("message", new ArrayList<String>(){{ add("%{COMMONAPACHELOG"); }});
+            capture = new HashMap<>();
+            capture.put("field_capture_1", "value_capture_1");
+            capture.put("field_capture_2", "value_capture_2");
+            capture.put("field_capture_3", "value_capture_3");
 
-        when(GrokCompiler.newInstance()).thenReturn(grokCompiler);
-        when(grokCompiler.compile(anyString(), anyBoolean())).thenReturn(grok);
-        when(grok.match(anyString())).thenReturn(match);
-        when(match.capture()).thenReturn(capture);
+            final Map<String, List<String>> matchConfig = new HashMap<>();
+            matchConfig.put("message", new ArrayList<String>() {{
+                add("%{COMMONAPACHELOG");
+            }});
 
-        pluginSetting = completePluginSettingForGrokPrepper(
-                GrokPrepperConfig.DEFAULT_BREAK_ON_MATCH,
-                GrokPrepperConfig.DEFAULT_KEEP_EMPTY_CAPTURES,
-                matchConfig,
-                GrokPrepperConfig.DEFAULT_NAMED_CAPTURES_ONLY,
-                Collections.emptyList(),
-                Collections.emptyList(),
-                GrokPrepperConfig.DEFAULT_PATTERNS_FILES_GLOB,
-                Collections.emptyMap(),
-                GrokPrepperConfig.DEFAULT_TIMEOUT_MILLIS,
-                GrokPrepperConfig.TARGET);
+            grokCompilerMockedStatic.when(GrokCompiler::newInstance).thenReturn(grokCompiler);
+            when(grokCompiler.compile(anyString(), anyBoolean())).thenReturn(grok);
+            when(grok.match(anyString())).thenReturn(match);
+            when(match.capture()).thenReturn(capture);
 
-        grokPrepper = new GrokPrepper(pluginSetting);
+            pluginSetting = completePluginSettingForGrokPrepper(
+                    GrokPrepperConfig.DEFAULT_BREAK_ON_MATCH,
+                    GrokPrepperConfig.DEFAULT_KEEP_EMPTY_CAPTURES,
+                    matchConfig,
+                    GrokPrepperConfig.DEFAULT_NAMED_CAPTURES_ONLY,
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    GrokPrepperConfig.DEFAULT_PATTERNS_FILES_GLOB,
+                    Collections.emptyMap(),
+                    GrokPrepperConfig.DEFAULT_TIMEOUT_MILLIS,
+                    GrokPrepperConfig.TARGET);
+
+            pluginSetting.setPipelineName("grokPipeline");
+            grokPrepper = new GrokPrepper(pluginSetting);
+        }
     }
 
     @AfterEach
@@ -92,7 +107,94 @@ public class GrokPrepperTests {
     }
 
     @Test
+    public void singleMatchMergeTest() throws JsonProcessingException {
 
+        String testData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\"}";
+        Record<String> record = new Record<>(testData);
+
+        String resultData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
+                                .concat("\"field_capture_1\":\"value_capture_1\",")
+                                .concat("\"field_capture_2\":\"value_capture_2\",")
+                                .concat("\"field_capture_3\":\"value_capture_3\"}");
+
+        Record<String> resultRecord = new Record<>(resultData);
+
+        List<Record<String>> grokkedRecords = (List<Record<String>>) grokPrepper.doExecute(Collections.singletonList(record));
+
+        assertThat(grokkedRecords.size(), equalTo(1));
+        assertThat(grokkedRecords.get(0), notNullValue());
+        assertThat(equalRecords(grokkedRecords.get(0), resultRecord), equalTo(true));
+    }
+
+    @Test
+    public void singleMatchMergeCollisionStringsTest() throws JsonProcessingException {
+        String testData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
+                .concat("\"field_capture_1\":\"value_capture_collision\"}");
+
+        Record<String> record = new Record<>(testData);
+
+        String resultData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
+                .concat("\"field_capture_1\":[\"value_capture_collision\",")
+                .concat("\"value_capture_1\"],")
+                .concat("\"field_capture_2\":\"value_capture_2\",")
+                .concat("\"field_capture_3\":\"value_capture_3\"}");
+
+        Record<String> resultRecord = new Record<>(resultData);
+
+        List<Record<String>> grokkedRecords = (List<Record<String>>) grokPrepper.doExecute(Collections.singletonList(record));
+
+        assertThat(grokkedRecords.size(), equalTo(1));
+        assertThat(grokkedRecords.get(0), notNullValue());
+        assertThat(equalRecords(grokkedRecords.get(0), resultRecord), equalTo(true));
+    }
+
+    @Test
+    public void singleMatchMergeCollisionIntsTest() throws JsonProcessingException {
+        capture.put("field_capture_1", 20);
+
+        String testData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
+                .concat("\"field_capture_1\": 10}");
+
+        Record<String> record = new Record<>(testData);
+
+        String resultData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
+                .concat("\"field_capture_1\":[ 10,")
+                .concat("20 ],")
+                .concat("\"field_capture_2\":\"value_capture_2\",")
+                .concat("\"field_capture_3\":\"value_capture_3\"}");
+
+        Record<String> resultRecord = new Record<>(resultData);
+
+        List<Record<String>> grokkedRecords = (List<Record<String>>) grokPrepper.doExecute(Collections.singletonList(record));
+
+        assertThat(grokkedRecords.size(), equalTo(1));
+        assertThat(grokkedRecords.get(0), notNullValue());
+        assertThat(equalRecords(grokkedRecords.get(0), resultRecord), equalTo(true));
+    }
+
+    @Test
+    public void singleMatchMergeCollisionMixedTypesTest() throws JsonProcessingException {
+        capture.put("field_capture_1", "20");
+
+        String testData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
+                .concat("\"field_capture_1\": 10}");
+
+        Record<String> record = new Record<>(testData);
+
+        String resultData = "{\"message\":\"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\","
+                .concat("\"field_capture_1\":[ 10,")
+                .concat("\"20\" ],")
+                .concat("\"field_capture_2\":\"value_capture_2\",")
+                .concat("\"field_capture_3\":\"value_capture_3\"}");
+
+        Record<String> resultRecord = new Record<>(resultData);
+
+        List<Record<String>> grokkedRecords = (List<Record<String>>) grokPrepper.doExecute(Collections.singletonList(record));
+
+        assertThat(grokkedRecords.size(), equalTo(1));
+        assertThat(grokkedRecords.get(0), notNullValue());
+        assertThat(equalRecords(grokkedRecords.get(0), resultRecord), equalTo(true));
+    }
 
     private PluginSetting completePluginSettingForGrokPrepper(final boolean breakOnMatch,
                                                               final boolean keepEmptyCaptures,
@@ -119,14 +221,10 @@ public class GrokPrepperTests {
         return new PluginSetting(PLUGIN_NAME, settings);
     }
 
-   /* @Test
-    public void testGrokPrepper() {
-        String testData = "{\"message\": \"127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] BEF25A72965 \\\"GET /apache_pb.gif HTTP/1.0\\\" 200 2326\"}";
-        Record<String> record = new Record<>(testData);
+    private boolean equalRecords(final Record<String> first, final Record<String> second) throws JsonProcessingException {
+        final Map<String, Object> recordMapFirst = OBJECT_MAPPER.readValue(first.getData(), MAP_TYPE_REFERENCE);
+        final Map<String, Object> recordMapSecond = OBJECT_MAPPER.readValue(second.getData(), MAP_TYPE_REFERENCE);
 
-        List<Record<String>> grokkedRecords = (List<Record<String>>) grokPrepper.doExecute(Collections.singletonList(record));
-
-        assertThat(grokkedRecords.size(), equalTo(1));
-        assertThat(grokkedRecords.get(0), equalTo(record));
-    }*/
+        return recordMapFirst.equals(recordMapSecond);
+    }
 }


### PR DESCRIPTION
Signed-off-by: graytaylor0 33740195+graytaylor0@users.noreply.github.com

### Description
* Grok matching functionality (single/mutli field, single/multi pattern)
* Support for named_captures_only
* Support for keep_empty_captures
* Unit tests for Grok Prepper and Integration tests using java-grok library
 
### Issues Resolved
#304 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
