### PR TITLE
Use Mockito 3.* instead of Securemock 1.2 in order to be able to mock final classes

### DIFF
--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -66,6 +66,8 @@ dependencies {
     testImplementation "org.awaitility:awaitility:4.1.0"
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "commons-io:commons-io:2.11.0"
+    testImplementation 'net.bytebuddy:byte-buddy:1.11.18'
+    testImplementation 'net.bytebuddy:byte-buddy-agent:1.11.18'
 }
 
 // Workaround for Werror
@@ -94,7 +96,7 @@ configurations.all {
     }
     // The OpenSearch plugins appear to provide their own version of Mockito
     // which is causing problems, so we exclude it.
-    exclude group: 'org.mockito'
+    exclude (group: 'org.elasticsearch', module: "securemock");
 }
 
 test {

--- a/data-prepper-plugins/opensearch/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/opensearch/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,3 @@
+# To enable mocking of final classes with vanilla Mockito
+# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
+mock-maker-inline


### PR DESCRIPTION
### Description
Problem: Unable to mock many final classes the Opensearch Sink plugin depend on, so our ability to write unit tests was extremely limited. 

Root cause of the problem: The setup remove dependency on Mockito (3.x) in favor of Elastic Search Securemock (v1.2 which wraps Mockito 1.x). However, Mockito 1.x doesn't allow mocking final classes. 

Solution: 
1. excluding securemock 
2. enable mocking of final classes with vanilla Mockito 

 
### Issues Resolved
This is to enable me to continue unit-testing changes proposed in https://github.com/opensearch-project/data-prepper/issues/310
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
