### PR TITLE
updated to use latest opensearch instead of opendistro for elasticsearch

### DIFF
--- a/examples/jaeger-hotrod/docker-compose.yml
+++ b/examples/jaeger-hotrod/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   data-prepper:
     restart: unless-stopped
     container_name: data-prepper
-    image: amazon/opendistro-for-elasticsearch-data-prepper:latest
+    image: opensearchproject/data-prepper:latest
     volumes:
       - ../trace_analytics_no_ssl.yml:/usr/share/data-prepper/pipelines.yaml
       - ../data-prepper-config.yaml:/usr/share/data-prepper/data-prepper-config.yaml
@@ -13,7 +13,7 @@ services:
     networks:
       - my_network
     depends_on:
-      - opendistro-for-elasticsearch
+      - "opensearch"
   otel-collector:
     container_name: otel-collector
     image: otel/opentelemetry-collector:0.24.0
@@ -52,28 +52,36 @@ services:
       - jaeger-agent
     networks:
       - my_network
-  opendistro-for-elasticsearch:
+  opensearch:
     container_name: node-0.example.com
-    image: amazon/opendistro-for-elasticsearch:1.12.0
-    ports:
-      - '9200:9200'
-      - '9600:9600'
+    image: opensearchproject/opensearch:latest
     environment:
       - discovery.type=single-node
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+        hard: 65536
+    ports:
+      - 9200:9200
+      - 9600:9600 # required for Performance Analyzer
     networks:
       - my_network
-  kibana:
-    build:
-      context: ../..
-      dockerfile: examples/kibana-trace-analytics/Dockerfile
-    container_name: odfe-kibana
+  dashboards:
+    image: opensearchproject/opensearch-dashboards:latest
+    container_name: opensearch-dashboards
     ports:
       - 5601:5601
     expose:
       - "5601"
     environment:
-      ELASTICSEARCH_URL: https://node-0.example.com:9200
-      ELASTICSEARCH_HOSTS: https://node-0.example.com:9200
+      OPENSEARCH_HOSTS: '["https://node-0.example.com:9200"]'
+    depends_on:
+      - opensearch
     networks:
       - my_network
 networks:


### PR DESCRIPTION
### Description
This change uses the latest version of opensearch and opensearch dashboards images instead of elasticsearch with opendistro plugins.
 
### Issues Resolved
The sample with opendistro for elasticsearch images have conflict with latest data-prepper plugins. 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
