### PR TITLE
MAINT: sync opensearch version in e2e

### DIFF
--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -150,7 +150,7 @@ def createDataPrepperDockerContainerFromPullImage(final String taskBaseName, fin
  * OpenSearch Docker tasks
  */
 task pullOpenSearchDockerImage(type: DockerPullImage) {
-    image = 'opensearchproject/opensearch:1.0.0'
+    image = "opensearchproject/opensearch:${versionMap.opensearchVersion}"
 }
 
 task createOpenSearchDockerContainer(type: DockerCreateContainer) {


### PR DESCRIPTION
Signed-off-by: qchea <qchea@amazon.com>

### Description
This PR syncs the Opensearch backend version used in end-to-end tests with that in `build-resources.gradle` in an attempt to resolve the flaky tests.

Note: root cause for e2e flaky failure: For some reason, opensearch:1.0.0 docker container failed to run in CI as follows:

```
> Task :data-prepper-core:createOpenSearchDockerContainer
Created container with ID 'node-0.example.com'.

> Task :data-prepper-core:startOpenSearchDockerContainer
Starting container with ID 'd13be9c57160894ca5b24f738a841aa133d1ad8f0f8e257d664eb9ea3e1c758f'.

> Task :data-prepper-core:logOpenSearchDockerContainer
Logs for container with ID 'd13be9c57160894ca5b24f738a841aa133d1ad8f0f8e257d664eb9ea3e1c758f'.
Killing opensearch process 12
Killing performance analyzer process 13
```

which lead to data-prepper running failure as the opensearch sink could not connect to Opensearch backend. This issue also persists for 1.0.1. We need to see if this issue persists in opensearch 1.1.0. 

I already opened an issue for opensearch engine: https://github.com/opensearch-project/OpenSearch/issues/1350
 
### Issues Resolved
#366 (attempt to resolve)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
