### PR TITLE
updating jaeger-hotrod readme with OpenSearch migration missed in #356

### DIFF
--- a/examples/jaeger-hotrod/README.md
+++ b/examples/jaeger-hotrod/README.md
@@ -1,6 +1,6 @@
 ## Jaeger Hot Rod
 
-This demo will use the revered Jaeger Hotrod app. The purpose of this demo is to experience the Trace Analytics feature using an existing Jaeger based application. For this demo we use the Jager Hotrod App, Jaeger Agent, OpenTelemetry collector and Data Prepper.
+This demo will use the revered Jaeger Hotrod app. The purpose of this demo is to experience the Trace Analytics feature using an existing Jaeger based application. For this demo we use the Jager Hotrod App, Jaeger Agent, OpenTelemetry collector, OpenSearch and Data Prepper.
 
 #### Required:
 * Docker - we recommend allowing Docker to use at least 4 GB of RAM in Preferences > Resources.
@@ -10,10 +10,10 @@ This demo will use the revered Jaeger Hotrod app. The purpose of this demo is to
 docker-compose up -d --build
 ``` 
 
-The above command will start the Jaeger Hotrod sample, Jaeger Agent, OpenTelemetry Collector, Data Prepper, ODFE and Kibana. Wait for few minutes for all the containers to come up, the DataPrepper will restart till elasticsearch becomes available.
+The above command will start the Jaeger Hotrod sample, Jaeger Agent, OpenTelemetry Collector, Data Prepper, OpenSearch and OpenSearch Dashboards. Wait for few minutes for all the containers to come up, the DataPrepper will restart until OpenSearch becomes available.
 
 After successful start, 
 
 * use the hot rod app at localhost:8080 
-* check the traces in kibana trace analytics dashboards at localhost:5601/app/traceAnalytics#/dashboard
+* check the traces in OpenSearch Dashboards trace analytics dashboards at localhost:5601/app/trace-analytics-dashboards#/
 


### PR DESCRIPTION
Signed-off-by: cmanning09 <cmanning09@users.noreply.github.com>

### Description
[Describe what this change achieves]
Replacing URLs and references to, elasticsearch, ODFE and Kibana with OpenSearch and OpenSearch Dashboards
 
### Issues Resolved
- No issues. Follow up from my PR review.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ x ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
