### PR TITLE
Fix IndexConfiguration.Builder replicas number

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -102,7 +102,7 @@ public class IndexConfiguration {
             builder = builder.withTemplateFile(templateFile);
         }
         builder = builder.withNumShards(pluginSetting.getIntegerOrDefault(NUM_SHARDS, 0));
-        builder = builder.withNumShards(pluginSetting.getIntegerOrDefault(NUM_REPLICAS, 0));
+        builder = builder.withNumReplicas(pluginSetting.getIntegerOrDefault(NUM_REPLICAS, 0));
         final Long batchSize = pluginSetting.getLongOrDefault(BULK_SIZE, DEFAULT_BULK_SIZE);
         builder = builder.withBulkSize(batchSize);
         final String documentId = pluginSetting.getStringOrDefault(DOCUMENT_ID_FIELD, null);


### PR DESCRIPTION
### Description
The IndexConfiguration.Builder should set correct settings based on argument. This fixes that.
 
### Issues Resolved
None
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
