### PR TITLE
Short guide to migrating to from Open Distro Data Prepper

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,5 +1,9 @@
 # Getting Started with Data Prepper
 
+If you are migrating from Open Distro Data Prepper,
+visit the [Migrating from Open Distro](migrating_from_opendistro.md) page.
+Otherwise, please continue.
+
 ## Installation
 
 There are two ways to install Data Prepper for running.

--- a/docs/migrating_from_opendistro.md
+++ b/docs/migrating_from_opendistro.md
@@ -1,0 +1,25 @@
+# Migrating from Open Distro Data Prepper
+
+Starting with Data Prepper 1.1, there is only one distribution of
+Data Prepper - Open Search Data Prepper. This document is here to help existing users migrate
+from the old Open Distro Data Prepper to OpenSearch Data Prepper.
+
+
+### Change your Pipeline Configuration
+
+The `elasticsearch` sink has changed to `opensearch`. You will
+need to change your existing pipeline to use the `opensearch` plugin
+instead of `elasticsearch`.
+
+Please note that while the plugin is titled `opensearch` it remains compatible
+with Open Distro and ElasticSearch 7.x.
+
+### Update Docker Image
+
+The Open Distro Data Prepper Docker image was located at `amazon/opendistro-for-elasticsearch-data-prepper`.
+You will need to change this value to `opensearchproject/opensearch-data-prepper`.
+
+## More Information
+
+You can find more information about Data Prepper configurations
+by going to the [Getting Started](getting_started.md) guide.


### PR DESCRIPTION
### Description

This is a short guide to migrating to OpenSearch Data Prepper from Open Distro Data Prepper. It is mostly copied from the [Open Distro README](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/README.md).

I will be submitting updated text for our Docker Hub README page to indicate that it is deprecated. I would like for it to link to this documentation in this repository, rather than linking back to the old GitHub repository.
 
### Issues Resolved

None
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
