### PR TITLE
implementing trace models and extending event implementation

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/Event.java
@@ -11,6 +11,8 @@
 
 package com.amazon.dataprepper.model.event;
 
+import java.util.List;
+
 /**
  * All data flowing through Data Prepper will be represented as events. An event is the base representation of data.
  * An event can be defined as a collection of key-value pairs and the following interface represents the contract with this model.
@@ -42,6 +44,16 @@ public interface Event {
      * @since 1.2
      */
     <T> T get(String key, Class<T> clazz);
+
+    /**
+     * Retrieves the given key from the Event as a List
+     *
+     * @param key the value to retrieve from
+     * @param clazz the return type of elements in the list
+     * @return List<T> a list of clazz elements
+     * @since 1.2
+     */
+    <T> List<T> getList(String key, Class<T> clazz);
 
     /**
      * Deletes the given key from the Event

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
@@ -37,7 +37,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * A Jackson Implementation of {@link Event} interface. This implementation relies heavily on JsonNode to manage the keys of the event.
  * <p>
  * This implementation supports [JsonPointer](https://datatracker.ietf.org/doc/html/rfc6901) for keys to access nested structures.
- * For example using the key "fizz/buzz" would allow a user to retrieve the number 42 using {@link #get(String, Class)} from the nested structure below.
+ * For example using the key "/fizz/buzz" would allow a user to retrieve the number 42 using {@link #get(String, Class)} from the nested structure below.
+ * Additionally, a key structure without a prefixed "/" will access the same value: "fizz/buzz"
  * <p>
  *     {
  *         "foo": "bar"
@@ -143,7 +144,7 @@ public class JacksonEvent implements Event {
             return null;
         }
 
-        return mapToObject(key, node, clazz);
+        return mapNodeToObject(key, node, clazz);
     }
 
     private JsonNode getNode(final String key) {
@@ -151,7 +152,7 @@ public class JacksonEvent implements Event {
         return jsonNode.at(jsonPointer);
     }
 
-    private <T> T mapToObject(final String key, final JsonNode node, final Class<T> clazz) {
+    private <T> T mapNodeToObject(final String key, final JsonNode node, final Class<T> clazz) {
         try {
             return mapper.treeToValue(node, clazz);
         } catch (final JsonProcessingException e) {
@@ -178,10 +179,10 @@ public class JacksonEvent implements Event {
             return null;
         }
 
-        return mapToList(key, node, clazz);
+        return mapNodeToList(key, node, clazz);
     }
 
-    private <T> List<T> mapToList(final String key, final JsonNode node, final Class<T> clazz) {
+    private <T> List<T> mapNodeToList(final String key, final JsonNode node, final Class<T> clazz) {
         try {
             final ObjectReader reader = mapper.readerFor(TypeFactory.defaultInstance().constructCollectionType(List.class, clazz));
             return reader.readValue(node);

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/DefaultLink.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/DefaultLink.java
@@ -40,23 +40,28 @@ public class DefaultLink implements Link {
         this.droppedAttributesCount = builder.droppedAttributesCount == null ? 0 : builder.droppedAttributesCount;
     }
 
-    @Override public String getTraceId() {
+    @Override
+    public String getTraceId() {
         return traceId;
     }
 
-    @Override public String getSpanId() {
+    @Override
+    public String getSpanId() {
         return spanId;
     }
 
-    @Override public String getTraceState() {
+    @Override
+    public String getTraceState() {
         return traceState;
     }
 
-    @Override public Map<String, Object> getAttributes() {
+    @Override
+    public Map<String, Object> getAttributes() {
         return attributes;
     }
 
-    @Override public Integer getDroppedAttributesCount() {
+    @Override
+    public Integer getDroppedAttributesCount() {
         return droppedAttributesCount;
     }
 

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/DefaultLink.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/DefaultLink.java
@@ -1,0 +1,148 @@
+package com.amazon.dataprepper.model.trace;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * The default implementation of {@link Link}, a pointer from the current span to another span in a trace.
+ *
+ * @since 1.2
+ */
+public class DefaultLink implements Link {
+
+    private String traceId;
+    private String spanId;
+    private String traceState;
+    private Map<String, Object> attributes;
+    private Integer droppedAttributesCount;
+
+    // required for serialization
+    DefaultLink() {}
+
+    private DefaultLink(final Builder builder) {
+
+        checkNotNull(builder.traceId, "traceId cannot be null");
+        checkArgument(!builder.traceId.isEmpty(), "traceId cannot be an empty string");
+        this.traceId = builder.traceId;
+
+        checkNotNull(builder.spanId, "spanId cannot be null");
+        checkArgument(!builder.spanId.isEmpty(), "spanId cannot be an empty String");
+        this.spanId = builder.spanId;
+
+        checkNotNull(builder.traceState, "traceState cannot be null");
+        checkArgument(!builder.traceState.isEmpty(), "traceState cannot be an empty String");
+        this.traceState = builder.traceState;
+
+        this.attributes = builder.attributes == null ? new HashMap<>() : builder.attributes;
+        this.droppedAttributesCount = builder.droppedAttributesCount == null ? 0 : builder.droppedAttributesCount;
+    }
+
+    @Override public String getTraceId() {
+        return traceId;
+    }
+
+    @Override public String getSpanId() {
+        return spanId;
+    }
+
+    @Override public String getTraceState() {
+        return traceState;
+    }
+
+    @Override public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override public Integer getDroppedAttributesCount() {
+        return droppedAttributesCount;
+    }
+
+    public boolean equals(final Object other) {
+
+        if (other instanceof DefaultLink) {
+            final DefaultLink o = (DefaultLink) other;
+            return (traceId.equals(o.traceId) && spanId.equals(o.spanId) && traceState.equals(o.traceState) && attributes.equals(o.attributes)
+                    && droppedAttributesCount.equals(o.droppedAttributesCount));
+        }
+        return false;
+    }
+
+    /**
+     * Builder for creating {@link DefaultLink}
+     * @since 1.2
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String traceId;
+        private String spanId;
+        private String traceState;
+        private Map<String, Object> attributes;
+        private Integer droppedAttributesCount;
+
+        /**
+         * Sets the trace id for the {@link Link}
+         * @param traceId
+         * @since 1.2
+         */
+        public Builder withTraceId(final String traceId) {
+            this.traceId = traceId;
+            return this;
+        }
+
+        /**
+         * Sets the span id
+         * @param spanId
+         * @since 1.2
+         */
+        public Builder withSpanId(final String spanId) {
+            this.spanId = spanId;
+            return this;
+        }
+
+        /**
+         * Sets the trace state
+         * @param traceState
+         * @since 1.2
+         */
+        public Builder withTraceState(final String traceState) {
+            this.traceState = traceState;
+            return this;
+        }
+
+        /**
+         * Optional - sets the attributes for {@link DefaultLink}. Default is an empty map.
+         * @param attributes the attributes to associate with this event.
+         * @since 1.2
+         */
+        public Builder withAttributes(final Map<String, Object> attributes) {
+            this.attributes = attributes;
+            return this;
+        }
+
+        /**
+         * Optional - sets the dropped attribute count for {@link DefaultLink}. Default is 0.
+         * @param droppedAttributesCount the total number of dropped attributes
+         * @since 1.2
+         */
+        public Builder withDroppedAttributesCount(final Integer droppedAttributesCount) {
+            this.droppedAttributesCount = droppedAttributesCount;
+            return this;
+        }
+
+        /**
+         * Returns a newly created {@link DefaultLink}.
+         * @return a DefaultLink
+         * @since 1.2
+         */
+        public DefaultLink build() {
+            return new DefaultLink(this);
+        }
+    }
+}

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/DefaultSpanEvent.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/DefaultSpanEvent.java
@@ -1,0 +1,130 @@
+package com.amazon.dataprepper.model.trace;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * The default implementation of {@link SpanEvent}, timestamped annotation of associated attributes for a span.
+ *
+ * @since 1.2
+ */
+public class DefaultSpanEvent implements SpanEvent {
+
+    private String name;
+    private String time;
+    private Map<String, Object> attributes;
+    private Integer droppedAttributesCount;
+
+    // required for serialization
+    DefaultSpanEvent() {}
+
+    private DefaultSpanEvent(final Builder builder) {
+        checkNotNull(builder.name, "name cannot be null");
+        checkArgument(!builder.name.isEmpty(), "name cannot be an empty string");
+        this.name = builder.name;
+
+        checkNotNull(builder.time, "time cannot be null");
+        checkArgument(!builder.time.isEmpty(), "time cannot be an empty string");
+        this.time = builder.time;
+
+        this.attributes = builder.attributes == null ? new HashMap<>() : builder.attributes;
+        this.droppedAttributesCount = builder.droppedAttributesCount == null ? 0 : builder.droppedAttributesCount;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getTime() {
+        return time;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Integer getDroppedAttributesCount() {
+        return droppedAttributesCount;
+    }
+
+    public boolean equals(final Object other) {
+
+        if (other instanceof DefaultSpanEvent) {
+            final DefaultSpanEvent o = (DefaultSpanEvent) other;
+            return (name.equals(o.name) && time.equals(o.time) && attributes.equals(o.attributes)
+                    && droppedAttributesCount.equals(o.droppedAttributesCount));
+        }
+        return false;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for creating {@link DefaultSpanEvent}
+     * @since 1.2
+     */
+    public static class Builder {
+        private String name;
+        private String time;
+        private Map<String, Object> attributes;
+        private Integer droppedAttributesCount;
+
+        /**
+         * Sets the name for the {@link DefaultSpanEvent}
+         * @param name
+         * @since 1.2
+         */
+        public Builder withName(final String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the time for the {@link DefaultSpanEvent}
+         * @param time
+         * @since 1.2
+         */
+        public Builder withTime(final String time) {
+            this.time = time;
+            return this;
+        }
+
+        /**
+         * Optional - sets the attributes for {@link DefaultSpanEvent}. Default is an empty map.
+         * @param attributes the attributes to associate with this event.
+         * @since 1.2
+         */
+        public Builder withAttributes(final Map<String, Object> attributes) {
+            this.attributes = attributes;
+            return this;
+        }
+
+        /**
+         * Optional - sets the dropped attribute count for {@link DefaultSpanEvent}. Default is 0.
+         * @param droppedAttributesCount the total number of dropped attributes
+         * @since 1.2
+         */
+        public Builder withDroppedAttributesCount(final Integer droppedAttributesCount) {
+            this.droppedAttributesCount = droppedAttributesCount;
+            return this;
+        }
+
+        /**
+         * Returns a newly created {@link DefaultSpanEvent}.
+         * @return a DefaultSpanEvent
+         * @since 1.2
+         */
+        public DefaultSpanEvent build() {
+            return new DefaultSpanEvent(this);
+        }
+    }
+}

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/DefaultTraceGroupFields.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/DefaultTraceGroupFields.java
@@ -29,15 +29,18 @@ public class DefaultTraceGroupFields implements TraceGroupFields {
         this.statusCode = builder.statusCode;
     }
 
-    @Override public String getEndTime() {
+    @Override
+    public String getEndTime() {
         return endTime;
     }
 
-    @Override public Long getDurationInNanos() {
+    @Override
+    public Long getDurationInNanos() {
         return durationInNanos;
     }
 
-    @Override public Integer getStatusCode() {
+    @Override
+    public Integer getStatusCode() {
         return statusCode;
     }
 

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/DefaultTraceGroupFields.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/DefaultTraceGroupFields.java
@@ -1,0 +1,82 @@
+package com.amazon.dataprepper.model.trace;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * The default implementation of {@link TraceGroupFields}, the attributes associated with an entire trace.
+ *
+ * @since 1.2
+ */
+public class DefaultTraceGroupFields implements TraceGroupFields {
+
+    private String endTime;
+    private Long durationInNanos;
+    private Integer statusCode;
+
+    // required for serialization
+    DefaultTraceGroupFields() {}
+
+    private DefaultTraceGroupFields(final Builder builder) {
+
+        checkNotNull(builder.durationInNanos, "durationInNanos cannot be null");
+        checkNotNull(builder.statusCode, "statusCode cannot be null");
+        checkNotNull(builder.endTime, "endTime cannot be null");
+        checkArgument(!builder.endTime.isEmpty(), "endTime cannot be an empty string");
+
+        this.endTime = builder.endTime;
+        this.durationInNanos = builder.durationInNanos;
+        this.statusCode = builder.statusCode;
+    }
+
+    @Override public String getEndTime() {
+        return endTime;
+    }
+
+    @Override public Long getDurationInNanos() {
+        return durationInNanos;
+    }
+
+    @Override public Integer getStatusCode() {
+        return statusCode;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for creating {@link DefaultTraceGroupFields}
+     * @since 1.2
+     */
+    public static class Builder {
+
+        private String endTime;
+        private Long durationInNanos;
+        private Integer statusCode;
+
+        public Builder withEndTime(final String endTime) {
+            this.endTime = endTime;
+            return this;
+        }
+
+        public Builder withDurationInNanos(final Long durationInNanos) {
+            this.durationInNanos = durationInNanos;
+            return this;
+        }
+
+        public Builder withStatusCode(final Integer statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+
+        /**
+         * Returns a newly created {@link DefaultTraceGroupFields}.
+         * @return a DefaultTraceGroupFields
+         * @since 1.2
+         */
+        public DefaultTraceGroupFields build() {
+            return new DefaultTraceGroupFields(this);
+        }
+    }
+}

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/JacksonSpan.java
@@ -5,11 +5,9 @@ import com.amazon.dataprepper.model.event.JacksonEvent;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -39,8 +37,10 @@ public class JacksonSpan extends JacksonEvent implements Span {
     private static final String DURATION_IN_NANOS_KEY = "durationInNanos";
     private static final String TRACE_GROUP_FIELDS_KEY = "traceGroupFields";
 
-    private static final List<String> ALL_KEYS = Arrays.asList(TRACE_ID_KEY, SPAN_ID_KEY, TRACE_STATE_KEY, PARENT_SPAN_ID_KEY, PARENT_SPAN_ID_KEY,
-            NAME_KEY, KIND_KEY, START_TIME_KEY, END_TIME_KEY, TRACE_GROUP_KEY, DURATION_IN_NANOS_KEY, TRACE_GROUP_FIELDS_KEY);
+    private static final List<String>
+            REQUIRED_NON_EMPTY_KEYS = Arrays.asList(TRACE_ID_KEY, SPAN_ID_KEY, TRACE_STATE_KEY, PARENT_SPAN_ID_KEY, PARENT_SPAN_ID_KEY,
+            NAME_KEY, KIND_KEY, START_TIME_KEY, END_TIME_KEY, TRACE_GROUP_KEY);
+    private static final List<String> REQUIRED_NON_NULL_KEYS = Arrays.asList(DURATION_IN_NANOS_KEY, TRACE_GROUP_FIELDS_KEY);
 
     protected JacksonSpan(final Builder builder) {
         super(builder);
@@ -50,71 +50,88 @@ public class JacksonSpan extends JacksonEvent implements Span {
         checkAndSetDefaultValues();
     }
 
-    @Override public String getTraceId() {
+    @Override
+    public String getTraceId() {
         return this.get(TRACE_ID_KEY, String.class);
     }
 
-    @Override public String getSpanId() {
+    @Override
+    public String getSpanId() {
         return this.get(SPAN_ID_KEY, String.class);
     }
 
-    @Override public String getTraceState() {
+    @Override
+    public String getTraceState() {
         return this.get(TRACE_STATE_KEY, String.class);
     }
 
-    @Override public String getParentSpanId() {
+    @Override
+    public String getParentSpanId() {
         return this.get(PARENT_SPAN_ID_KEY, String.class);
     }
 
-    @Override public String getName() {
+    @Override
+    public String getName() {
         return this.get(NAME_KEY, String.class);
     }
 
-    @Override public String getKind() {
+    @Override
+    public String getKind() {
         return this.get(KIND_KEY, String.class);
     }
 
-    @Override public String getStartTime() {
+    @Override
+    public String getStartTime() {
         return this.get(START_TIME_KEY, String.class);
     }
 
-    @Override public String getEndTime() {
+    @Override
+    public String getEndTime() {
         return this.get(END_TIME_KEY, String.class);
     }
 
-    @Override public Map<String, Object> getAttributes() {
+    @Override
+    public Map<String, Object> getAttributes() {
         return this.get(ATTRIBUTES_KEY, Map.class);
     }
 
-    @Override public Integer getDroppedAttributesCount() {
+    @Override
+    public Integer getDroppedAttributesCount() {
         return this.get(DROPPED_ATTRIBUTES_COUNT_KEY, Integer.class);
     }
 
-    @Override public List<? extends SpanEvent> getEvents() {
+    @Override
+    public List<? extends SpanEvent> getEvents() {
         return this.getList(EVENTS_KEY, DefaultSpanEvent.class);
     }
 
-    @Override public Integer getDroppedEventsCount() {
+    @Override
+    public Integer getDroppedEventsCount() {
         return this.get(DROPPED_EVENTS_COUNT_KEY, Integer.class);
     }
 
-    @Override public List<? extends Link> getLinks() {
+    @Override
+    public List<? extends Link> getLinks() {
         return this.getList(LINKS_KEY, DefaultLink.class);
     }
 
-    @Override public Integer getDroppedLinksCount() {
+    @Override
+    public Integer getDroppedLinksCount() {
         return this.get(DROPPED_LINKS_COUNT_KEY, Integer.class);
     }
 
-    @Override public String getTraceGroup() {
+    @Override
+    public String getTraceGroup() {
         return this.get(TRACE_GROUP_KEY, String.class);
     }
 
-    @Override public Long getDurationInNanos() {
+    @Override
+    public Long getDurationInNanos() {
         return this.get(DURATION_IN_NANOS_KEY, Long.class);
     }
 
-    @Override public TraceGroupFields getTraceGroupFields() {
+    @Override
+    public TraceGroupFields getTraceGroupFields() {
         return this.get(TRACE_GROUP_FIELDS_KEY, DefaultTraceGroupFields.class);
     }
 
@@ -152,18 +169,16 @@ public class JacksonSpan extends JacksonEvent implements Span {
      * Builder for creating {@link JacksonSpan}
      * @since 1.2
      */
-    public static class Builder  extends JacksonEvent.Builder<Builder> {
+    public static class Builder extends JacksonEvent.Builder<Builder> {
 
-        private Map<String, Object> data;
-
-        private Set<String> remainingRequiredFields;
+        private final Map<String, Object> data;
 
         public Builder() {
             data = new HashMap();
-            remainingRequiredFields = new HashSet(ALL_KEYS);
         }
 
-        @Override public Builder getThis() {
+        @Override
+        public Builder getThis() {
             return this;
         }
 
@@ -173,9 +188,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withSpanId(final String spanId) {
-            checkNotNull(spanId, "spanId cannot be null");
-            checkArgument(!spanId.isEmpty(), "spanId cannot be an empty string");
-            putAndMarkAsProvided(SPAN_ID_KEY, spanId);
+            data.put(SPAN_ID_KEY, spanId);
             return this;
         }
 
@@ -185,9 +198,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withTraceId(final String traceId) {
-            checkNotNull(traceId, "traceId cannot be null");
-            checkArgument(!traceId.isEmpty(), "traceId cannot be an empty string");
-            putAndMarkAsProvided(TRACE_ID_KEY, traceId);
+            data.put(TRACE_ID_KEY, traceId);
             return this;
         }
 
@@ -197,9 +208,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withTraceState(final String traceState) {
-            checkNotNull(traceState, "traceState cannot be null");
-            checkArgument(!traceState.isEmpty(), "traceState cannot be an empty string");
-            putAndMarkAsProvided(TRACE_STATE_KEY, traceState);
+            data.put(TRACE_STATE_KEY, traceState);
             return this;
         }
 
@@ -209,9 +218,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withParentSpanId(final String parentSpanId) {
-            checkNotNull(parentSpanId, "parentSpanId cannot be null");
-            checkArgument(!parentSpanId.isEmpty(), "parentSpanId cannot be an empty string");
-            putAndMarkAsProvided(PARENT_SPAN_ID_KEY, parentSpanId);
+            data.put(PARENT_SPAN_ID_KEY, parentSpanId);
             return this;
         }
 
@@ -221,9 +228,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withName(final String name) {
-            checkNotNull(name, "name cannot be null");
-            checkArgument(!name.isEmpty(), "name cannot be an empty string");
-            putAndMarkAsProvided(NAME_KEY, name);
+            data.put(NAME_KEY, name);
             return this;
         }
 
@@ -233,9 +238,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withKind(final String kind) {
-            checkNotNull(kind, "kind cannot be null");
-            checkArgument(!kind.isEmpty(), "kind cannot be an empty string");
-            putAndMarkAsProvided(KIND_KEY, kind);
+            data.put(KIND_KEY, kind);
             return this;
         }
 
@@ -245,9 +248,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withStartTime(final String startTime) {
-            checkNotNull(startTime, "startTime cannot be null");
-            checkArgument(!startTime.isEmpty(), "startTime cannot be an empty string");
-            putAndMarkAsProvided(START_TIME_KEY, startTime);
+            data.put(START_TIME_KEY, startTime);
             return this;
         }
 
@@ -257,9 +258,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withEndTime(final String endTime) {
-            checkNotNull(endTime, "endTime cannot be null");
-            checkArgument(!endTime.isEmpty(), "endTime cannot be an empty string");
-            putAndMarkAsProvided(END_TIME_KEY, endTime);
+            data.put(END_TIME_KEY, endTime);
             return this;
         }
 
@@ -269,7 +268,6 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withAttributes(final Map<String, Object> attributes) {
-            checkNotNull(attributes, "attributes cannot be null");
             data.put(ATTRIBUTES_KEY, attributes);
             return this;
         }
@@ -280,7 +278,6 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withDroppedAttributesCount(final Integer droppedAttributesCount) {
-            checkNotNull(droppedAttributesCount, "droppedAttributesCount cannot be null");
             data.put(DROPPED_ATTRIBUTES_COUNT_KEY, droppedAttributesCount);
             return this;
         }
@@ -291,7 +288,6 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withEvents(final List<SpanEvent> events) {
-            checkNotNull(events, "events cannot be null");
             data.put(EVENTS_KEY, events);
             return this;
         }
@@ -302,7 +298,6 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withDroppedEventsCount(final Integer droppedEventsCount) {
-            checkNotNull(droppedEventsCount, "droppedEventsCount cannot be null");
             data.put(DROPPED_EVENTS_COUNT_KEY, droppedEventsCount);
             return this;
         }
@@ -313,7 +308,6 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withLinks(final List<Link> links) {
-            checkNotNull(links, "links cannot be null");
             data.put(LINKS_KEY, links);
             return this;
         }
@@ -324,7 +318,6 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withDroppedLinksCount(final Integer droppedLinksCount) {
-            checkNotNull(droppedLinksCount, "droppedLinksCount cannot be null");
             data.put(DROPPED_LINKS_COUNT_KEY, droppedLinksCount);
             return this;
         }
@@ -335,9 +328,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withTraceGroup(final String traceGroup) {
-            checkNotNull(traceGroup, "traceGroup cannot be null");
-            checkArgument(!traceGroup.isEmpty(), "traceGroup cannot be an empty string");
-            putAndMarkAsProvided(TRACE_GROUP_KEY, traceGroup);
+            data.put(TRACE_GROUP_KEY, traceGroup);
             return this;
         }
 
@@ -347,8 +338,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withDurationInNanos(final Long durationInNanos) {
-            checkNotNull(durationInNanos, "durationInNanos cannot be null");
-            putAndMarkAsProvided(DURATION_IN_NANOS_KEY, durationInNanos);
+            data.put(DURATION_IN_NANOS_KEY, durationInNanos);
             return this;
         }
 
@@ -358,14 +348,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public Builder withTraceGroupFields(final TraceGroupFields traceGroupFields) {
-            checkNotNull(traceGroupFields, "traceGroupFields cannot be null");
-            putAndMarkAsProvided(TRACE_GROUP_FIELDS_KEY, traceGroupFields);
-            return this;
-        }
-
-        private Builder putAndMarkAsProvided(final String key, final Object value) {
-            data.put(key, value);
-            remainingRequiredFields.remove(key);
+            data.put(TRACE_GROUP_FIELDS_KEY, traceGroupFields);
             return this;
         }
 
@@ -375,11 +358,23 @@ public class JacksonSpan extends JacksonEvent implements Span {
          * @since 1.2
          */
         public JacksonSpan build() {
-            checkArgument(remainingRequiredFields.isEmpty(),
-                    String.format("The following values were not provided and  are required: %s", remainingRequiredFields));
+            validateParameters();
             this.withData(data);
             this.withEventType(EventType.TRACE.toString());
             return new JacksonSpan(this);
+        }
+
+        private void validateParameters() {
+            REQUIRED_NON_EMPTY_KEYS.forEach(key -> {
+                final String value = (String) data.get(key);
+                checkNotNull(value, String.format("%s cannot be null", key));
+                checkArgument(!value.isEmpty(),  String.format("%s cannot be an empty string", key));
+            });
+
+            REQUIRED_NON_NULL_KEYS.forEach(key -> {
+                final Object value = data.get(key);
+                checkNotNull(value, String.format("%s cannot be null", key));
+            });
         }
 
     }

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/JacksonSpan.java
@@ -1,0 +1,386 @@
+package com.amazon.dataprepper.model.trace;
+
+import com.amazon.dataprepper.model.event.EventType;
+import com.amazon.dataprepper.model.event.JacksonEvent;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A Jackson implementation for {@link Span}. This class extends the {@link JacksonEvent}.
+ *
+ * @since 1.2
+ */
+public class JacksonSpan extends JacksonEvent implements Span {
+
+    private static final String TRACE_ID_KEY = "traceId";
+    private static final String SPAN_ID_KEY = "spanId";
+    private static final String TRACE_STATE_KEY = "traceState";
+    private static final String PARENT_SPAN_ID_KEY = "parentSpanId";
+    private static final String NAME_KEY = "name";
+    private static final String KIND_KEY = "kind";
+    private static final String START_TIME_KEY = "startTime";
+    private static final String END_TIME_KEY = "endTime";
+    private static final String ATTRIBUTES_KEY = "attributes";
+    private static final String DROPPED_ATTRIBUTES_COUNT_KEY = "droppedAttributesCount";
+    private static final String EVENTS_KEY = "events";
+    private static final String DROPPED_EVENTS_COUNT_KEY = "droppedEventsCount";
+    private static final String LINKS_KEY = "links";
+    private static final String DROPPED_LINKS_COUNT_KEY = "droppedLinksCount";
+    private static final String TRACE_GROUP_KEY = "traceGroup";
+    private static final String DURATION_IN_NANOS_KEY = "durationInNanos";
+    private static final String TRACE_GROUP_FIELDS_KEY = "traceGroupFields";
+
+    private static final List<String> ALL_KEYS = Arrays.asList(TRACE_ID_KEY, SPAN_ID_KEY, TRACE_STATE_KEY, PARENT_SPAN_ID_KEY, PARENT_SPAN_ID_KEY,
+            NAME_KEY, KIND_KEY, START_TIME_KEY, END_TIME_KEY, TRACE_GROUP_KEY, DURATION_IN_NANOS_KEY, TRACE_GROUP_FIELDS_KEY);
+
+    protected JacksonSpan(final Builder builder) {
+        super(builder);
+
+        checkArgument(this.getMetadata().getEventType().equals("TRACE"), "eventType must be of type Trace");
+
+        checkAndSetDefaultValues();
+    }
+
+    @Override public String getTraceId() {
+        return this.get(TRACE_ID_KEY, String.class);
+    }
+
+    @Override public String getSpanId() {
+        return this.get(SPAN_ID_KEY, String.class);
+    }
+
+    @Override public String getTraceState() {
+        return this.get(TRACE_STATE_KEY, String.class);
+    }
+
+    @Override public String getParentSpanId() {
+        return this.get(PARENT_SPAN_ID_KEY, String.class);
+    }
+
+    @Override public String getName() {
+        return this.get(NAME_KEY, String.class);
+    }
+
+    @Override public String getKind() {
+        return this.get(KIND_KEY, String.class);
+    }
+
+    @Override public String getStartTime() {
+        return this.get(START_TIME_KEY, String.class);
+    }
+
+    @Override public String getEndTime() {
+        return this.get(END_TIME_KEY, String.class);
+    }
+
+    @Override public Map<String, Object> getAttributes() {
+        return this.get(ATTRIBUTES_KEY, Map.class);
+    }
+
+    @Override public Integer getDroppedAttributesCount() {
+        return this.get(DROPPED_ATTRIBUTES_COUNT_KEY, Integer.class);
+    }
+
+    @Override public List<? extends SpanEvent> getEvents() {
+        return this.getList(EVENTS_KEY, DefaultSpanEvent.class);
+    }
+
+    @Override public Integer getDroppedEventsCount() {
+        return this.get(DROPPED_EVENTS_COUNT_KEY, Integer.class);
+    }
+
+    @Override public List<? extends Link> getLinks() {
+        return this.getList(LINKS_KEY, DefaultLink.class);
+    }
+
+    @Override public Integer getDroppedLinksCount() {
+        return this.get(DROPPED_LINKS_COUNT_KEY, Integer.class);
+    }
+
+    @Override public String getTraceGroup() {
+        return this.get(TRACE_GROUP_KEY, String.class);
+    }
+
+    @Override public Long getDurationInNanos() {
+        return this.get(DURATION_IN_NANOS_KEY, Long.class);
+    }
+
+    @Override public TraceGroupFields getTraceGroupFields() {
+        return this.get(TRACE_GROUP_FIELDS_KEY, DefaultTraceGroupFields.class);
+    }
+
+    private void checkAndSetDefaultValues() {
+        if (this.getAttributes() == null ) {
+            this.put(ATTRIBUTES_KEY, new HashMap<>());
+        }
+
+        if (this.getDroppedAttributesCount() == null) {
+            this.put(DROPPED_ATTRIBUTES_COUNT_KEY, 0);
+        }
+
+        if (this.getLinks() == null) {
+            this.put(LINKS_KEY, new LinkedList<>());
+        }
+
+        if (this.getDroppedLinksCount() == null) {
+            this.put(DROPPED_LINKS_COUNT_KEY, 0);
+        }
+
+        if (this.getEvents() == null) {
+            this.put(EVENTS_KEY, new LinkedList<>());
+        }
+
+        if (this.getDroppedEventsCount() == null) {
+            this.put(DROPPED_EVENTS_COUNT_KEY, 0);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for creating {@link JacksonSpan}
+     * @since 1.2
+     */
+    public static class Builder  extends JacksonEvent.Builder<Builder> {
+
+        private Map<String, Object> data;
+
+        private Set<String> remainingRequiredFields;
+
+        public Builder() {
+            data = new HashMap();
+            remainingRequiredFields = new HashSet(ALL_KEYS);
+        }
+
+        @Override public Builder getThis() {
+            return this;
+        }
+
+        /**
+         * Sets the span id.
+         * @param spanId
+         * @since 1.2
+         */
+        public Builder withSpanId(final String spanId) {
+            checkNotNull(spanId, "spanId cannot be null");
+            checkArgument(!spanId.isEmpty(), "spanId cannot be an empty string");
+            putAndMarkAsProvided(SPAN_ID_KEY, spanId);
+            return this;
+        }
+
+        /**
+         * Sets the trace id for the span.
+         * @param traceId
+         * @since 1.2
+         */
+        public Builder withTraceId(final String traceId) {
+            checkNotNull(traceId, "traceId cannot be null");
+            checkArgument(!traceId.isEmpty(), "traceId cannot be an empty string");
+            putAndMarkAsProvided(TRACE_ID_KEY, traceId);
+            return this;
+        }
+
+        /**
+         * Sets the trace state
+         * @param traceState
+         * @since 1.2
+         */
+        public Builder withTraceState(final String traceState) {
+            checkNotNull(traceState, "traceState cannot be null");
+            checkArgument(!traceState.isEmpty(), "traceState cannot be an empty string");
+            putAndMarkAsProvided(TRACE_STATE_KEY, traceState);
+            return this;
+        }
+
+        /**
+         * Sets the parent span id.
+         * @param parentSpanId
+         * @since 1.2
+         */
+        public Builder withParentSpanId(final String parentSpanId) {
+            checkNotNull(parentSpanId, "parentSpanId cannot be null");
+            checkArgument(!parentSpanId.isEmpty(), "parentSpanId cannot be an empty string");
+            putAndMarkAsProvided(PARENT_SPAN_ID_KEY, parentSpanId);
+            return this;
+        }
+
+        /**
+         * Sets the span name
+         * @param name
+         * @since 1.2
+         */
+        public Builder withName(final String name) {
+            checkNotNull(name, "name cannot be null");
+            checkArgument(!name.isEmpty(), "name cannot be an empty string");
+            putAndMarkAsProvided(NAME_KEY, name);
+            return this;
+        }
+
+        /**
+         * Sets the type of span
+         * @param kind
+         * @since 1.2
+         */
+        public Builder withKind(final String kind) {
+            checkNotNull(kind, "kind cannot be null");
+            checkArgument(!kind.isEmpty(), "kind cannot be an empty string");
+            putAndMarkAsProvided(KIND_KEY, kind);
+            return this;
+        }
+
+        /**
+         * Sets the start time of the span
+         * @param startTime
+         * @since 1.2
+         */
+        public Builder withStartTime(final String startTime) {
+            checkNotNull(startTime, "startTime cannot be null");
+            checkArgument(!startTime.isEmpty(), "startTime cannot be an empty string");
+            putAndMarkAsProvided(START_TIME_KEY, startTime);
+            return this;
+        }
+
+        /**
+         * Sets the end time of the span
+         * @param endTime
+         * @since 1.2
+         */
+        public Builder withEndTime(final String endTime) {
+            checkNotNull(endTime, "endTime cannot be null");
+            checkArgument(!endTime.isEmpty(), "endTime cannot be an empty string");
+            putAndMarkAsProvided(END_TIME_KEY, endTime);
+            return this;
+        }
+
+        /**
+         * Optional - sets the attributes for {@link JacksonSpan}. Default is an empty map.
+         * @param attributes the attributes to associate with this event.
+         * @since 1.2
+         */
+        public Builder withAttributes(final Map<String, Object> attributes) {
+            checkNotNull(attributes, "attributes cannot be null");
+            data.put(ATTRIBUTES_KEY, attributes);
+            return this;
+        }
+
+        /**
+         * Optional - sets the dropped attribute count for {@link JacksonSpan}. Default is 0.
+         * @param droppedAttributesCount the total number of dropped attributes
+         * @since 1.2
+         */
+        public Builder withDroppedAttributesCount(final Integer droppedAttributesCount) {
+            checkNotNull(droppedAttributesCount, "droppedAttributesCount cannot be null");
+            data.put(DROPPED_ATTRIBUTES_COUNT_KEY, droppedAttributesCount);
+            return this;
+        }
+
+        /**
+         * Optional - sets the events for {@link JacksonSpan}. Default is an empty list.
+         * @param events the events to associate.
+         * @since 1.2
+         */
+        public Builder withEvents(final List<SpanEvent> events) {
+            checkNotNull(events, "events cannot be null");
+            data.put(EVENTS_KEY, events);
+            return this;
+        }
+
+        /**
+         * Optional - sets the dropped events count for {@link JacksonSpan}. Default is 0.
+         * @param droppedEventsCount the total number of dropped events
+         * @since 1.2
+         */
+        public Builder withDroppedEventsCount(final Integer droppedEventsCount) {
+            checkNotNull(droppedEventsCount, "droppedEventsCount cannot be null");
+            data.put(DROPPED_EVENTS_COUNT_KEY, droppedEventsCount);
+            return this;
+        }
+
+        /**
+         * Optional - sets the links for {@link JacksonSpan}. Default is an empty list.
+         * @param links the links to associate.
+         * @since 1.2
+         */
+        public Builder withLinks(final List<Link> links) {
+            checkNotNull(links, "links cannot be null");
+            data.put(LINKS_KEY, links);
+            return this;
+        }
+
+        /**
+         * Optional - sets the dropped links count for {@link JacksonSpan}. Default is 0.
+         * @param droppedLinksCount the total number of dropped links
+         * @since 1.2
+         */
+        public Builder withDroppedLinksCount(final Integer droppedLinksCount) {
+            checkNotNull(droppedLinksCount, "droppedLinksCount cannot be null");
+            data.put(DROPPED_LINKS_COUNT_KEY, droppedLinksCount);
+            return this;
+        }
+
+        /**
+         * Sets the trace group name
+         * @param traceGroup
+         * @since 1.2
+         */
+        public Builder withTraceGroup(final String traceGroup) {
+            checkNotNull(traceGroup, "traceGroup cannot be null");
+            checkArgument(!traceGroup.isEmpty(), "traceGroup cannot be an empty string");
+            putAndMarkAsProvided(TRACE_GROUP_KEY, traceGroup);
+            return this;
+        }
+
+        /**
+         * Sets the duration of the span
+         * @param durationInNanos
+         * @since 1.2
+         */
+        public Builder withDurationInNanos(final Long durationInNanos) {
+            checkNotNull(durationInNanos, "durationInNanos cannot be null");
+            putAndMarkAsProvided(DURATION_IN_NANOS_KEY, durationInNanos);
+            return this;
+        }
+
+        /**
+         * Sets the trace group fields
+         * @param traceGroupFields
+         * @since 1.2
+         */
+        public Builder withTraceGroupFields(final TraceGroupFields traceGroupFields) {
+            checkNotNull(traceGroupFields, "traceGroupFields cannot be null");
+            putAndMarkAsProvided(TRACE_GROUP_FIELDS_KEY, traceGroupFields);
+            return this;
+        }
+
+        private Builder putAndMarkAsProvided(final String key, final Object value) {
+            data.put(key, value);
+            remainingRequiredFields.remove(key);
+            return this;
+        }
+
+        /**
+         * Returns a newly created {@link JacksonSpan}
+         * @return a JacksonSpan
+         * @since 1.2
+         */
+        public JacksonSpan build() {
+            checkArgument(remainingRequiredFields.isEmpty(),
+                    String.format("The following values were not provided and  are required: %s", remainingRequiredFields));
+            this.withData(data);
+            this.withEventType(EventType.TRACE.toString());
+            return new JacksonSpan(this);
+        }
+
+    }
+}

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/Span.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/Span.java
@@ -85,7 +85,7 @@ public interface Span extends Event {
      * @return a List of {@link SpanEvent}s
      * @since 1.2
      */
-    List<SpanEvent> getEvents();
+    List<? extends SpanEvent> getEvents();
 
     /**
      * Gets the total number of discarded events. 0 indicates no events were dropped.
@@ -98,7 +98,7 @@ public interface Span extends Event {
      * @return a List of {@link Link}s
      * @since 1.2
      */
-    List<Link> getLinks();
+    List<? extends Link> getLinks();
 
     /**
      * Gets the total number of dropped links. 0 indicates no links were dropped.

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/JacksonEventTest.java
@@ -157,6 +157,17 @@ public class JacksonEventTest {
     }
 
     @Test
+    public void testGetList_withIncorrectPojo() {
+        final String key = "foo.bar";
+        final String nestedValue = UUID.randomUUID().toString();
+        final TestObject value = new TestObject(nestedValue);
+
+        event.put(key, Arrays.asList(value));
+
+        assertThrows(RuntimeException.class, () -> event.getList(key, UUID.class));
+    }
+
+    @Test
     public void testGet_withEmptyEvent() {
         final String key = "foo/bar";
 

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/DefaultLinkTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/DefaultLinkTest.java
@@ -1,0 +1,204 @@
+package com.amazon.dataprepper.model.trace;
+
+import com.amazon.dataprepper.model.event.TestObject;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DefaultLinkTest {
+
+    private static final String TEST_SPAN_ID = UUID.randomUUID().toString();
+    private static final String TEST_TRACE_ID = UUID.randomUUID().toString();
+    private static final String TEST_TRACE_STATE = UUID.randomUUID().toString();
+    private static final Map<String, Object> TEST_ATTRIBUTES = ImmutableMap.of("key1", UUID.randomUUID(), "key2", UUID.randomUUID().toString());
+    private static final Integer TEST_DROPPED_ATTRIBUTE_COUNT = 8;
+
+    private DefaultLink.Builder builder;
+
+    private DefaultLink defaultLink;
+
+    @BeforeEach
+    public void setup() {
+
+        builder = DefaultLink.builder()
+                .withAttributes(TEST_ATTRIBUTES)
+                .withDroppedAttributesCount(TEST_DROPPED_ATTRIBUTE_COUNT)
+                .withSpanId(TEST_SPAN_ID)
+                .withTraceId(TEST_TRACE_ID)
+                .withTraceState(TEST_TRACE_STATE);
+
+        defaultLink = builder.build();
+    }
+
+    @Test
+    public void testGetSpanId() {
+        final String spanId = defaultLink.getSpanId();
+        assertThat(spanId, is(equalTo(TEST_SPAN_ID)));
+    }
+
+    @Test
+    public void testGetTraceId() {
+        final String traceId = defaultLink.getTraceId();
+        assertThat(traceId, is(equalTo(TEST_TRACE_ID)));
+    }
+
+    @Test
+    public void testGetTraceState() {
+        final String traceState = defaultLink.getTraceState();
+        assertThat(traceState, is(equalTo(TEST_TRACE_STATE)));
+    }
+
+    @Test
+    public void testGetAttributes() {
+        final Map<String,Object> attributes = defaultLink.getAttributes();
+        assertThat(attributes, is(equalTo(TEST_ATTRIBUTES)));
+    }
+
+    @Test
+    public void testGetDroppedAttributesCount() {
+        final Integer droppedAttributesCount = defaultLink.getDroppedAttributesCount();
+        assertThat(droppedAttributesCount, is(equalTo(TEST_DROPPED_ATTRIBUTE_COUNT)));
+    }
+
+    @Test
+    public void testEquals_withDifferentObject() {
+        assertThat(defaultLink, is(not(equalTo(new TestObject()))));
+    }
+
+    @Test
+    public void testEquals_withDifferentSpanId() {
+        final DefaultLink spanEvent = builder
+                .withSpanId(UUID.randomUUID().toString())
+                .build();
+        assertThat(defaultLink, is(not(equalTo(spanEvent))));
+    }
+
+    @Test
+    public void testEquals_withDifferentTraceId() {
+        final DefaultLink spanEvent = builder
+                .withTraceId(UUID.randomUUID().toString())
+                .build();
+        assertThat(defaultLink, is(not(equalTo(spanEvent))));
+    }
+
+    @Test
+    public void testEquals_withDifferentTraceState() {
+        final DefaultLink spanEvent = builder
+                .withTraceState(UUID.randomUUID().toString())
+                .build();
+        assertThat(defaultLink, is(not(equalTo(spanEvent))));
+    }
+
+    @Test
+    public void testEquals_withDifferentAttributes() {
+        final DefaultLink spanEvent = builder
+                .withAttributes(null)
+                .build();
+        assertThat(defaultLink, is(not(equalTo(spanEvent))));
+    }
+
+    @Test
+    public void testEquals_withDifferentDroppedAttributesCount() {
+        final DefaultLink spanEvent = builder
+                .withDroppedAttributesCount(29034)
+                .build();
+        assertThat(defaultLink, is(not(equalTo(spanEvent))));
+    }
+
+    @Test
+    public void testEquals() {
+        final DefaultLink spanEvent = DefaultLink.builder()
+                .withAttributes(TEST_ATTRIBUTES)
+                .withDroppedAttributesCount(TEST_DROPPED_ATTRIBUTE_COUNT)
+                .withSpanId(TEST_SPAN_ID)
+                .withTraceId(TEST_TRACE_ID)
+                .withTraceState(TEST_TRACE_STATE)
+                .build();
+        assertThat(defaultLink, is(equalTo(spanEvent)));
+    }
+
+    @Test
+    public void testBuilder() {
+
+        final DefaultLink defaultLink = builder.build();
+
+        assertThat(defaultLink, is(notNullValue()));
+    }
+
+    @Test
+    public void testBuilder_withMissingSpanId_throwsNullPointerException() {
+
+        builder.withSpanId(null);
+
+        assertThrows(NullPointerException.class, builder::build);
+    }
+
+    @Test
+    public void testBuilder_withMissingTraceId_throwsNullPointerException() {
+
+        builder.withTraceId(null);
+
+        assertThrows(NullPointerException.class, builder::build);
+    }
+
+    @Test
+    public void testBuilder_withMissingTraceState_throwsNullPointerException() {
+
+        builder.withTraceState(null);
+
+        assertThrows(NullPointerException.class, builder::build);
+    }
+
+    @Test
+    public void testBuilder_withEmptySpanId_throwsIllegalArgumentException() {
+
+        builder.withSpanId("");
+
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    public void testBuilder_withEmptyTraceId_throwsIllegalArgumentException() {
+
+        builder.withTraceId("");
+
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    public void testBuilder_withEmptyTraceState_throwsIllegalArgumentException() {
+
+        builder.withTraceState("");
+
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    public void testBuilder_withMissingAttributes_setsAttributesToEmptySet() {
+
+        final DefaultLink result = builder.withAttributes(null)
+                .build();
+
+        assertThat(result.getAttributes(), is(equalTo(new HashMap<>())));
+    }
+
+    @Test
+    public void testBuilder_withMissingDroppedAttributesCount_setsCountToZero() {
+
+        final DefaultLink result = builder.withDroppedAttributesCount(null)
+                .build();
+
+        assertThat(result.getDroppedAttributesCount(), is(equalTo(0)));
+    }
+}

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/DefaultLinkTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/DefaultLinkTest.java
@@ -129,11 +129,23 @@ public class DefaultLinkTest {
     }
 
     @Test
-    public void testBuilder() {
+    public void testBuilder_withAllParameters_createsLink() {
 
-        final DefaultLink defaultLink = builder.build();
+        final DefaultLink defaultLink = DefaultLink.builder()
+                .withAttributes(TEST_ATTRIBUTES)
+                .withDroppedAttributesCount(TEST_DROPPED_ATTRIBUTE_COUNT)
+                .withSpanId(TEST_SPAN_ID)
+                .withTraceId(TEST_TRACE_ID)
+                .withTraceState(TEST_TRACE_STATE)
+                .build();
 
         assertThat(defaultLink, is(notNullValue()));
+    }
+
+    @Test
+    public void testBuilder_withoutParameters_throwsNullPointerException() {
+        final DefaultLink.Builder builder = DefaultLink.builder();
+        assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/DefaultSpanEventTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/DefaultSpanEventTest.java
@@ -113,9 +113,20 @@ public class DefaultSpanEventTest {
     }
 
     @Test
-    public void testBuilder() {
-        final DefaultSpanEvent spanEvent = builder.build();
+    public void testBuilder_withValidParameters_createsEvent() {
+        final DefaultSpanEvent spanEvent = DefaultSpanEvent.builder()
+                .withName(TEST_NAME)
+                .withTime(TEST_TIME)
+                .withAttributes(TEST_ATTRIBUTES)
+                .withDroppedAttributesCount(TEST_DROPPED_ATTRIBUTE_COUNT)
+                .build();
         assertThat(spanEvent, is(notNullValue()));
+    }
+
+    @Test
+    public void testBuilder_withoutParameters_throwsNullPointerException() {
+        final DefaultSpanEvent.Builder builder = DefaultSpanEvent.builder();
+        assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/DefaultSpanEventTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/DefaultSpanEventTest.java
@@ -1,0 +1,159 @@
+package com.amazon.dataprepper.model.trace;
+
+import com.amazon.dataprepper.model.event.TestObject;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DefaultSpanEventTest {
+
+    private static final String TEST_NAME = UUID.randomUUID().toString();
+    private static final String TEST_TIME = UUID.randomUUID().toString();
+    private static final Map<String, Object> TEST_ATTRIBUTES = ImmutableMap.of("key1", UUID.randomUUID(), "key2", UUID.randomUUID().toString());
+    private static final Integer TEST_DROPPED_ATTRIBUTE_COUNT = 3;
+
+    private DefaultSpanEvent defaultSpanEvent;
+
+    private DefaultSpanEvent.Builder builder;
+
+    @BeforeEach
+    public void setup() {
+
+        builder = DefaultSpanEvent.builder()
+                .withName(TEST_NAME)
+                .withTime(TEST_TIME)
+                .withAttributes(TEST_ATTRIBUTES)
+                .withDroppedAttributesCount(TEST_DROPPED_ATTRIBUTE_COUNT);
+
+        defaultSpanEvent = builder.build();
+    }
+
+    @Test
+    public void testGetName() {
+        final String name = defaultSpanEvent.getName();
+        assertThat(name, is(equalTo(TEST_NAME)));
+    }
+
+    @Test
+    public void testGetTime() {
+        final String time = defaultSpanEvent.getTime();
+        assertThat(time, is(equalTo(TEST_TIME)));
+    }
+
+
+    @Test
+    public void testGetAttributes() {
+        final Map<String,Object> attributes = defaultSpanEvent.getAttributes();
+        assertThat(attributes, is(equalTo(TEST_ATTRIBUTES)));
+    }
+
+    @Test
+    public void testGetDroppedAttributesCount() {
+        final Integer droppedAttributesCount = defaultSpanEvent.getDroppedAttributesCount();
+        assertThat(droppedAttributesCount, is(equalTo(TEST_DROPPED_ATTRIBUTE_COUNT)));
+    }
+
+    @Test
+    public void testEquals_withDifferentObject() {
+        assertThat(defaultSpanEvent, is(not(equalTo(new TestObject()))));
+    }
+
+    @Test
+    public void testEquals_withDifferentTime() {
+        final DefaultSpanEvent spanEvent = builder
+                .withTime(UUID.randomUUID().toString())
+                .build();
+        assertThat(defaultSpanEvent, is(not(equalTo(spanEvent))));
+    }
+
+    @Test
+    public void testEquals_withDifferentName() {
+        final DefaultSpanEvent spanEvent = builder
+                .withName(UUID.randomUUID().toString())
+                .build();
+        assertThat(defaultSpanEvent, is(not(equalTo(spanEvent))));
+    }
+
+    @Test
+    public void testEquals_withDifferentAttributes() {
+        final DefaultSpanEvent spanEvent = builder
+                .withAttributes(null)
+                .build();
+        assertThat(defaultSpanEvent, is(not(equalTo(spanEvent))));
+    }
+
+    @Test
+    public void testEquals_withDifferentDroppedAttributesCount() {
+        final DefaultSpanEvent spanEvent = builder
+                .withDroppedAttributesCount(29034)
+                .build();
+        assertThat(defaultSpanEvent, is(not(equalTo(spanEvent))));
+    }
+
+    @Test
+    public void testEquals() {
+        final DefaultSpanEvent spanEvent = DefaultSpanEvent.builder()
+                .withName(TEST_NAME)
+                .withTime(TEST_TIME)
+                .withAttributes(TEST_ATTRIBUTES)
+                .withDroppedAttributesCount(TEST_DROPPED_ATTRIBUTE_COUNT)
+                .build();
+        assertThat(defaultSpanEvent, is(equalTo(spanEvent)));
+    }
+
+    @Test
+    public void testBuilder() {
+        final DefaultSpanEvent spanEvent = builder.build();
+        assertThat(spanEvent, is(notNullValue()));
+    }
+
+    @Test
+    public void testBuilder_withMissingName_throwsNullPointerException() {
+        builder.withName(null);
+        assertThrows(NullPointerException.class, builder::build);
+    }
+
+    @Test
+    public void testBuilder_withEmptyName_throwsIllegalArgumentException() {
+        builder.withName("");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    public void testBuilder_withMissingTime_throwsNullPointerException() {
+        builder.withTime(null);
+        assertThrows(NullPointerException.class, builder::build);
+    }
+
+    @Test
+    public void testBuilder_withEmptyTime_throwsIllegalArgumentException() {
+        builder.withTime("");
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    public void testBuilder_withMissingAttributes_setsAttributesToEmptySet() {
+
+        final DefaultSpanEvent result = builder.withAttributes(null)
+                .build();
+        assertThat(result.getAttributes(), is(equalTo(new HashMap<>())));
+    }
+
+    @Test
+    public void testBuilder_withMissingDroppedAttributesCount_setsCountToZero() {
+        final DefaultSpanEvent result = builder.withDroppedAttributesCount(null)
+                .build();
+        assertThat(result.getDroppedAttributesCount(), is(equalTo(0)));
+    }
+}

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/DefaultTraceGroupFieldsTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/DefaultTraceGroupFieldsTest.java
@@ -49,7 +49,7 @@ public class DefaultTraceGroupFieldsTest {
     }
 
     @Test
-    public void testBuild() {
+    public void testBuilder_withAllParameters_createsTraceGroupFields() {
 
         final DefaultTraceGroupFields result = DefaultTraceGroupFields.builder()
                 .withDurationInNanos(TEST_DURATION)
@@ -58,6 +58,12 @@ public class DefaultTraceGroupFieldsTest {
                 .build();
 
         assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void testBuilder_withoutParameters_throws_nullPointerException() {
+        final DefaultTraceGroupFields.Builder builder = DefaultTraceGroupFields.builder();
+        assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/DefaultTraceGroupFieldsTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/DefaultTraceGroupFieldsTest.java
@@ -1,0 +1,103 @@
+package com.amazon.dataprepper.model.trace;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DefaultTraceGroupFieldsTest {
+
+    private static final String TEST_END_TIME = UUID.randomUUID().toString();
+    private static final Long TEST_DURATION = 123L;
+    private static final Integer TEST_STATUS_CODE = 200;
+
+    private DefaultTraceGroupFields defaultTraceGroupFields;
+
+    @BeforeEach
+    public void setup() {
+        defaultTraceGroupFields = DefaultTraceGroupFields.builder()
+                .withDurationInNanos(TEST_DURATION)
+                .withStatusCode(TEST_STATUS_CODE)
+                .withEndTime(TEST_END_TIME)
+                .build();
+    }
+
+    @Test
+    public void testGetDurationInNanos() {
+        final Long durationInNanos = defaultTraceGroupFields.getDurationInNanos();
+
+        assertThat(durationInNanos, is(TEST_DURATION));
+    }
+
+    @Test
+    public void testGetStatusCode() {
+        final Integer statusCode = defaultTraceGroupFields.getStatusCode();
+
+        assertThat(statusCode, is(TEST_STATUS_CODE));
+    }
+
+    @Test
+    public void testGetEndTime() {
+        final String endTime = defaultTraceGroupFields.getEndTime();
+
+        assertThat(endTime, is(TEST_END_TIME));
+    }
+
+    @Test
+    public void testBuild() {
+
+        final DefaultTraceGroupFields result = DefaultTraceGroupFields.builder()
+                .withDurationInNanos(TEST_DURATION)
+                .withStatusCode(TEST_STATUS_CODE)
+                .withEndTime(TEST_END_TIME)
+                .build();
+
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void testBuilder_throwsNullPointerException_whenEndTimeIsMissing() {
+
+        final DefaultTraceGroupFields.Builder builder = DefaultTraceGroupFields.builder()
+                .withDurationInNanos(TEST_DURATION)
+                .withStatusCode(TEST_STATUS_CODE);
+
+        assertThrows(NullPointerException.class, builder::build);
+    }
+
+    @Test
+    public void testBuilder_throwsIllegalArgumentException_whenEndTimeIsEmptyString() {
+
+        final DefaultTraceGroupFields.Builder builder = DefaultTraceGroupFields.builder()
+                .withDurationInNanos(TEST_DURATION)
+                .withStatusCode(TEST_STATUS_CODE)
+                .withEndTime("");
+
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    public void testBuilder_throwsNullPointerException_whenStatusCodeIsMissing() {
+
+        final DefaultTraceGroupFields.Builder builder = DefaultTraceGroupFields.builder()
+                .withDurationInNanos(123L)
+                .withEndTime(TEST_END_TIME);
+
+        assertThrows(NullPointerException.class, builder::build);
+    }
+
+    @Test
+    public void testBuilder_throwsNullPointerException_whenDurationIsMissing() {
+
+        final DefaultTraceGroupFields.Builder builder = DefaultTraceGroupFields.builder()
+                .withStatusCode(200)
+                .withEndTime(TEST_END_TIME);
+
+        assertThrows(NullPointerException.class, builder::build);
+    }
+}

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/JacksonSpanTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/JacksonSpanTest.java
@@ -4,9 +4,6 @@ import com.amazon.dataprepper.model.event.JacksonEvent;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -23,7 +20,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@ExtendWith(MockitoExtension.class)
 public class JacksonSpanTest {
 
     private static final String TEST_TRACE_ID =  UUID.randomUUID().toString();
@@ -45,10 +41,8 @@ public class JacksonSpanTest {
     
     private JacksonSpan jacksonSpan;
 
-    @Mock(serializable = true)
     private DefaultLink defaultLink;
 
-    @Mock(serializable = true)
     private DefaultSpanEvent defaultSpanEvent;
 
     private DefaultTraceGroupFields defaultTraceGroupFields;
@@ -206,104 +200,146 @@ public class JacksonSpanTest {
     }
     
     @Test
-    public void testBuilder() {
-        final JacksonSpan result = builder.build();
+    public void testBuilder_withAllParameters_createsSpan() {
+        final JacksonSpan result = JacksonSpan.builder()
+                .withSpanId(TEST_SPAN_ID)
+                .withTraceId(TEST_TRACE_ID)
+                .withTraceState(TEST_TRACE_STATE)
+                .withParentSpanId(TEST_PARENT_SPAN_ID)
+                .withName(TEST_NAME)
+                .withKind(TEST_KIND)
+                .withStartTime(TEST_START_TIME)
+                .withEndTime(TEST_END_TIME)
+                .withAttributes(TEST_ATTRIBUTES)
+                .withDroppedAttributesCount(TEST_DROPPED_ATTRIBUTES_COUNT)
+                .withEvents(Arrays.asList(defaultSpanEvent))
+                .withDroppedEventsCount(TEST_DROPPED_EVENTS_COUNT)
+                .withLinks(Arrays.asList(defaultLink))
+                .withDroppedLinksCount(TEST_DROPPED_LINKS_COUNT)
+                .withTraceGroup(TEST_TRACE_GROUP)
+                .withDurationInNanos(TEST_DURATION_IN_NANOS)
+                .withTraceGroupFields(defaultTraceGroupFields)
+                .build();
 
         assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void testBuilder_withoutParameters_throwsNullPointerException() {
+        final JacksonEvent.Builder builder = JacksonSpan.builder();
+        assertThrows(NullPointerException.class, builder::build);
     }
     
     @Test
     public void testBuilder_withoutTraceId_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> builder.withTraceId(null));
+        builder.withTraceId(null);
+        assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptyTraceId_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> builder.withTraceId(""));
+        builder.withTraceId("");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withoutSpanId_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> builder.withSpanId(null));
+        builder.withSpanId(null);
+        assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptySpanId_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> builder.withSpanId(""));
+        builder.withSpanId("");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withoutTraceState_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> builder.withTraceState(null));
+        builder.withTraceState(null);
+        assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptyTraceState_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> builder.withTraceState(""));
+        builder.withTraceState("");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withoutParentSpanId_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> builder.withParentSpanId(null));
+        builder.withParentSpanId(null);
+        assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptyParentSpanId_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> builder.withParentSpanId(""));
+        builder.withParentSpanId("");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withoutName_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> builder.withName(null));
+        builder.withName(null);
+        assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptyName_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> builder.withName(""));
+        builder.withName("");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withoutKind_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> builder.withKind(null));
+        builder.withKind(null);
+        assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptyKind_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> builder.withKind(""));
+        builder.withKind("");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withoutStartTime_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> builder.withStartTime(null));
+        builder.withStartTime(null);
+        assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptyStartTime_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> builder.withStartTime(""));
+        builder.withStartTime("");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withoutEndTime_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> builder.withEndTime(null));
+        builder.withEndTime(null);
+        assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptyEndTime_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> builder.withEndTime(""));
+        builder.withEndTime("");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withoutTraceGroup_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> builder.withTraceGroup(null));
+        builder.withTraceGroup(null);
+        assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test
     public void testBuilder_withEmptyTraceGroup_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> builder.withTraceGroup(""));
+        builder.withTraceGroup("");
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test
-    public void testBuilder_allRequiredParameters() {
+    public void testBuilder_allRequiredParameters_createsSpanWithDefaultValues() {
 
         final JacksonSpan span = JacksonSpan.builder()
                 .withSpanId(TEST_SPAN_ID)
@@ -330,7 +366,43 @@ public class JacksonSpanTest {
     }
 
     @Test
-    public void testBuilder_missingRequiredParameters() {
+    public void testBuilder_withNullAttributes_createsSpanWithDefaultValue() {
+        final JacksonSpan span = builder.withAttributes(null).build();
+        assertThat(span.getAttributes(), is(equalTo(new HashMap<>())));
+    }
+
+    @Test
+    public void testBuilder_withNullDroppedAttributesCount_createsSpanWithDefaultValue() {
+        final JacksonSpan span = builder.withDroppedAttributesCount(null).build();
+        assertThat(span.getDroppedAttributesCount(), is(equalTo(0)));
+    }
+
+    @Test
+    public void testBuilder_withNullEvents_createsSpanWithDefaultValue() {
+        final JacksonSpan span = builder.withEvents(null).build();
+        assertThat(span.getEvents(), is(equalTo(new LinkedList<>())));
+    }
+
+    @Test
+    public void testBuilder_withNullDroppedEventsCount_createsSpanWithDefaultValue() {
+        final JacksonSpan span = builder.withDroppedEventsCount(null).build();
+        assertThat(span.getDroppedEventsCount(), is(equalTo(0)));
+    }
+
+    @Test
+    public void testBuilder_withNullLinks_createsSpanWithDefaultValue() {
+        final JacksonSpan span = builder.withLinks(null).build();
+        assertThat(span.getLinks(), is(equalTo(new LinkedList<>())));
+    }
+
+    @Test
+    public void testBuilder_withNullDroppedLinksCount_createsSpanWithDefaultValue() {
+        final JacksonSpan span = builder.withDroppedLinksCount(null).build();
+        assertThat(span.getDroppedLinksCount(), is(equalTo(0)));
+    }
+
+    @Test
+    public void testBuilder_missingRequiredParameters_throwsNullPointerException() {
 
         final JacksonEvent.Builder builder = JacksonSpan.builder()
                 .withSpanId(TEST_SPAN_ID)
@@ -343,6 +415,6 @@ public class JacksonSpanTest {
                 .withTraceGroup(TEST_TRACE_GROUP)
                 .withDurationInNanos(TEST_DURATION_IN_NANOS);
 
-        assertThrows(IllegalArgumentException.class, builder::build);
+        assertThrows(NullPointerException.class, builder::build);
     }
 }

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/JacksonSpanTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/JacksonSpanTest.java
@@ -1,0 +1,348 @@
+package com.amazon.dataprepper.model.trace;
+
+import com.amazon.dataprepper.model.event.JacksonEvent;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+public class JacksonSpanTest {
+
+    private static final String TEST_TRACE_ID =  UUID.randomUUID().toString();
+    private static final String TEST_SPAN_ID =  UUID.randomUUID().toString();
+    private static final String TEST_TRACE_STATE =  UUID.randomUUID().toString();
+    private static final String TEST_PARENT_SPAN_ID =  UUID.randomUUID().toString();
+    private static final String TEST_NAME =  UUID.randomUUID().toString();
+    private static final String TEST_KIND =  UUID.randomUUID().toString();
+    private static final String TEST_START_TIME =  UUID.randomUUID().toString();
+    private static final String TEST_END_TIME =  UUID.randomUUID().toString();
+    private static final Map<String, Object> TEST_ATTRIBUTES = ImmutableMap.of("key1", new Date().getTime(), "key2", UUID.randomUUID().toString());
+    private static final Integer TEST_DROPPED_ATTRIBUTES_COUNT = 8;
+    private static final Integer TEST_DROPPED_EVENTS_COUNT =  45;
+    private static final Integer TEST_DROPPED_LINKS_COUNT =  21;
+    private static final String TEST_TRACE_GROUP =  UUID.randomUUID().toString();
+    private static final Long TEST_DURATION_IN_NANOS =  537L;
+
+    private JacksonSpan.Builder builder;
+    
+    private JacksonSpan jacksonSpan;
+
+    @Mock(serializable = true)
+    private DefaultLink defaultLink;
+
+    @Mock(serializable = true)
+    private DefaultSpanEvent defaultSpanEvent;
+
+    private DefaultTraceGroupFields defaultTraceGroupFields;
+    
+    @BeforeEach
+    public void setup() {
+
+        // Elected to use actual data objects instead of mocking as mockito would require public setters or altering the underlying
+        // object mapper in the JacksonEvent class to correctly serialize this objects.
+        defaultSpanEvent = DefaultSpanEvent.builder()
+                .withName(UUID.randomUUID().toString())
+                .withTime(UUID.randomUUID().toString())
+                .build();
+
+        defaultLink = DefaultLink.builder()
+                .withTraceId(UUID.randomUUID().toString())
+                .withSpanId(UUID.randomUUID().toString())
+                .withTraceState(UUID.randomUUID().toString())
+                .build();
+
+        defaultTraceGroupFields = DefaultTraceGroupFields.builder()
+                .withDurationInNanos(123L)
+                .withStatusCode(201)
+                .withEndTime("the End")
+                .build();
+        
+        builder = JacksonSpan.builder()
+                .withSpanId(TEST_SPAN_ID)
+                .withTraceId(TEST_TRACE_ID)
+                .withTraceState(TEST_TRACE_STATE)
+                .withParentSpanId(TEST_PARENT_SPAN_ID)
+                .withName(TEST_NAME)
+                .withKind(TEST_KIND)
+                .withStartTime(TEST_START_TIME)
+                .withEndTime(TEST_END_TIME)
+                .withAttributes(TEST_ATTRIBUTES)
+                .withDroppedAttributesCount(TEST_DROPPED_ATTRIBUTES_COUNT)
+                .withEvents(Arrays.asList(defaultSpanEvent))
+                .withDroppedEventsCount(TEST_DROPPED_EVENTS_COUNT)
+                .withLinks(Arrays.asList(defaultLink))
+                .withDroppedLinksCount(TEST_DROPPED_LINKS_COUNT)
+                .withTraceGroup(TEST_TRACE_GROUP)
+                .withDurationInNanos(TEST_DURATION_IN_NANOS)
+                .withTraceGroupFields(defaultTraceGroupFields);
+
+        jacksonSpan = builder.build();
+    }
+
+    @Test
+    public void testGetSpanId() {
+        final String spanId = jacksonSpan.getSpanId();
+        assertThat(spanId, is(equalTo(TEST_SPAN_ID)));
+    }
+
+    @Test
+    public void testGetTraceId() {
+        final String traceId = jacksonSpan.getTraceId();
+        assertThat(traceId, is(equalTo(TEST_TRACE_ID)));
+    }
+
+    @Test
+    public void testGetTraceState() {
+        final String traceState = jacksonSpan.getTraceState();
+        assertThat(traceState, is(equalTo(TEST_TRACE_STATE)));
+    }
+
+    @Test
+    public void testGetParentSpanId() {
+        final String parentSpanId = jacksonSpan.getParentSpanId();
+        assertThat(parentSpanId, is(equalTo(TEST_PARENT_SPAN_ID)));
+    }
+
+    @Test
+    public void testGetName() {
+        final String name = jacksonSpan.getName();
+        assertThat(name, is(equalTo(TEST_NAME)));
+    }
+
+    @Test
+    public void testGetKind() {
+        final String kind = jacksonSpan.getKind();
+        assertThat(kind, is(equalTo(TEST_KIND)));
+    }
+
+    @Test
+    public void testGetStartTime() {
+        final String GetStartTime = jacksonSpan.getStartTime();
+        assertThat(GetStartTime, is(equalTo(TEST_START_TIME)));
+    }
+
+    @Test
+    public void testGetEndTime() {
+        final String endTime = jacksonSpan.getEndTime();
+        assertThat(endTime, is(equalTo(TEST_END_TIME)));
+    }
+
+    @Test
+    public void testGetAttributes() {
+        final Map<String,Object> attributes = jacksonSpan.getAttributes();
+
+        TEST_ATTRIBUTES.keySet().forEach(key -> {
+            assertThat(attributes, hasKey(key));
+            assertThat(attributes.get(key), is(equalTo(TEST_ATTRIBUTES.get(key))));
+                }
+        );
+    }
+
+    @Test
+    public void testGetDroppedAttributesCount() {
+        final Integer droppedAttributesCount = jacksonSpan.getDroppedAttributesCount();
+        assertThat(droppedAttributesCount, is(equalTo(TEST_DROPPED_ATTRIBUTES_COUNT)));
+    }
+
+    @Test
+    public void testGetEvents() {
+        final List events = jacksonSpan.getEvents();
+        assertThat(events, is(equalTo(Arrays.asList(defaultSpanEvent))));
+    }
+
+    @Test
+    public void testGetDroppedEventsCount() {
+        final Integer droppedEventsCount = jacksonSpan.getDroppedEventsCount();
+        assertThat(droppedEventsCount, is(equalTo(TEST_DROPPED_EVENTS_COUNT)));
+    }
+
+    @Test
+    public void testGetLinks() {
+        final List links = jacksonSpan.getLinks();
+        assertThat(links, is(equalTo(Arrays.asList(defaultLink))));
+    }
+
+    @Test
+    public void testGetDroppedLinksCount() {
+        final Integer droppedLinksCount = jacksonSpan.getDroppedLinksCount();
+        assertThat(droppedLinksCount, is(equalTo(TEST_DROPPED_LINKS_COUNT)));
+    }
+
+    @Test
+    public void testGetTraceGroup() {
+        final String traceGroup = jacksonSpan.getTraceGroup();
+        assertThat(traceGroup, is(equalTo(TEST_TRACE_GROUP)));
+    }
+
+    @Test
+    public void testGetDurationInNanos() {
+        final Long durationInNanos = jacksonSpan.getDurationInNanos();
+
+        assertThat(durationInNanos, is(TEST_DURATION_IN_NANOS));
+    }
+
+    @Test
+    public void testGetTraceGroupFields() {
+        final TraceGroupFields traceGroupFields = jacksonSpan.getTraceGroupFields();
+        assertThat(traceGroupFields, is(equalTo(traceGroupFields)));
+    }
+    
+    @Test
+    public void testBuilder() {
+        final JacksonSpan result = builder.build();
+
+        assertThat(result, is(notNullValue()));
+    }
+    
+    @Test
+    public void testBuilder_withoutTraceId_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> builder.withTraceId(null));
+    }
+
+    @Test
+    public void testBuilder_withEmptyTraceId_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> builder.withTraceId(""));
+    }
+
+    @Test
+    public void testBuilder_withoutSpanId_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> builder.withSpanId(null));
+    }
+
+    @Test
+    public void testBuilder_withEmptySpanId_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> builder.withSpanId(""));
+    }
+
+    @Test
+    public void testBuilder_withoutTraceState_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> builder.withTraceState(null));
+    }
+
+    @Test
+    public void testBuilder_withEmptyTraceState_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> builder.withTraceState(""));
+    }
+
+    @Test
+    public void testBuilder_withoutParentSpanId_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> builder.withParentSpanId(null));
+    }
+
+    @Test
+    public void testBuilder_withEmptyParentSpanId_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> builder.withParentSpanId(""));
+    }
+
+    @Test
+    public void testBuilder_withoutName_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> builder.withName(null));
+    }
+
+    @Test
+    public void testBuilder_withEmptyName_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> builder.withName(""));
+    }
+
+    @Test
+    public void testBuilder_withoutKind_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> builder.withKind(null));
+    }
+
+    @Test
+    public void testBuilder_withEmptyKind_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> builder.withKind(""));
+    }
+
+    @Test
+    public void testBuilder_withoutStartTime_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> builder.withStartTime(null));
+    }
+
+    @Test
+    public void testBuilder_withEmptyStartTime_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> builder.withStartTime(""));
+    }
+
+    @Test
+    public void testBuilder_withoutEndTime_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> builder.withEndTime(null));
+    }
+
+    @Test
+    public void testBuilder_withEmptyEndTime_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> builder.withEndTime(""));
+    }
+
+    @Test
+    public void testBuilder_withoutTraceGroup_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> builder.withTraceGroup(null));
+    }
+
+    @Test
+    public void testBuilder_withEmptyTraceGroup_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> builder.withTraceGroup(""));
+    }
+
+    @Test
+    public void testBuilder_allRequiredParameters() {
+
+        final JacksonSpan span = JacksonSpan.builder()
+                .withSpanId(TEST_SPAN_ID)
+                .withTraceId(TEST_TRACE_ID)
+                .withTraceState(TEST_TRACE_STATE)
+                .withParentSpanId(TEST_PARENT_SPAN_ID)
+                .withName(TEST_NAME)
+                .withKind(TEST_KIND)
+                .withStartTime(TEST_START_TIME)
+                .withEndTime(TEST_END_TIME)
+                .withTraceGroup(TEST_TRACE_GROUP)
+                .withDurationInNanos(TEST_DURATION_IN_NANOS)
+                .withTraceGroupFields(defaultTraceGroupFields)
+                .getThis()
+                .build();
+
+        assertThat(span, is(notNullValue()));
+        assertThat(span.getAttributes(), is(equalTo(new HashMap<>())));
+        assertThat(span.getDroppedAttributesCount(), is(equalTo(0)));
+        assertThat(span.getEvents(), is(equalTo(new LinkedList<>())));
+        assertThat(span.getDroppedEventsCount(), is(equalTo(0)));
+        assertThat(span.getLinks(), is(equalTo(new LinkedList<>())));
+        assertThat(span.getDroppedLinksCount(), is(equalTo(0)));
+    }
+
+    @Test
+    public void testBuilder_missingRequiredParameters() {
+
+        final JacksonEvent.Builder builder = JacksonSpan.builder()
+                .withSpanId(TEST_SPAN_ID)
+                .withTraceId(TEST_TRACE_ID)
+                .withTraceState(TEST_TRACE_STATE)
+                .withParentSpanId(TEST_PARENT_SPAN_ID)
+                .withName(TEST_NAME)
+                .withStartTime(TEST_START_TIME)
+                .withEndTime(TEST_END_TIME)
+                .withTraceGroup(TEST_TRACE_GROUP)
+                .withDurationInNanos(TEST_DURATION_IN_NANOS);
+
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Christopher Manning <cmanning09@users.noreply.github.com>

### Description
- Implements all trace models
- Extends event interface to eliminate unchecked casting of ArrayNode elements.
- Updated Trace interface
 
### Issues Resolved
resolves #472 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
