### PR TITLE
Initial support for plugin configuration classes

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/annotations/DataPrepperPlugin.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/annotations/DataPrepperPlugin.java
@@ -12,6 +12,7 @@
 package com.amazon.dataprepper.model.annotations;
 
 import com.amazon.dataprepper.model.PluginType;
+import com.amazon.dataprepper.model.configuration.PluginSetting;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -66,4 +67,15 @@ public @interface DataPrepperPlugin {
      * @since 1.2
      */
     Class<?> pluginType() default Void.class;
+
+    /**
+     * The configuration type which the plugin takes in the constructor.
+     * <p>
+     * By default, this value is a {@link PluginSetting}, but you can provide
+     * a POJO object to facilitate cleaner code in your plugins.
+     *
+     * @return The Java class type for plugin configurations
+     * @since 1.2
+     */
+    Class<?> pluginConfigurationType() default PluginSetting.class;
 }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginConfigurationConverter.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginConfigurationConverter.java
@@ -1,0 +1,25 @@
+package com.amazon.dataprepper.plugin;
+
+import com.amazon.dataprepper.model.configuration.PluginSetting;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
+import java.util.Objects;
+
+class PluginConfigurationConverter {
+    private final ObjectMapper objectMapper;
+
+    PluginConfigurationConverter() {
+        this.objectMapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    }
+
+    public Object convert(final Class<?> pluginConfigurationType, final PluginSetting pluginSetting) {
+        Objects.requireNonNull(pluginConfigurationType);
+        Objects.requireNonNull(pluginSetting);
+
+        if(pluginConfigurationType.equals(PluginSetting.class))
+            return pluginSetting;
+
+        return objectMapper.convertValue(pluginSetting.getSettings(), pluginConfigurationType);
+    }
+}

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/DefaultPluginFactoryTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/DefaultPluginFactoryTest.java
@@ -29,6 +29,7 @@ class DefaultPluginFactoryTest {
 
     private PluginProviderLoader pluginProviderLoader;
     private PluginCreator pluginCreator;
+    private PluginConfigurationConverter pluginConfigurationConverter;
     private Collection<PluginProvider> pluginProviders;
     private PluginProvider firstPluginProvider;
     private Class<?> baseClass;
@@ -39,6 +40,7 @@ class DefaultPluginFactoryTest {
     void setUp() {
         pluginProviderLoader = mock(PluginProviderLoader.class);
         pluginCreator = mock(PluginCreator.class);
+        pluginConfigurationConverter = mock(PluginConfigurationConverter.class);
 
         pluginProviders = new ArrayList<>();
         given(pluginProviderLoader.getPluginProviders()).willReturn(pluginProviders);
@@ -52,7 +54,7 @@ class DefaultPluginFactoryTest {
     }
 
     private DefaultPluginFactory createObjectUnderTest() {
-        return new DefaultPluginFactory(pluginProviderLoader, pluginCreator);
+        return new DefaultPluginFactory(pluginProviderLoader, pluginCreator, pluginConfigurationConverter);
     }
 
     @Test
@@ -136,7 +138,10 @@ class DefaultPluginFactoryTest {
         void loadPlugin_should_create_a_new_instance_of_the_first_plugin_found() {
 
             final TestSink expectedInstance = mock(TestSink.class);
-            given(pluginCreator.newPluginInstance(expectedPluginClass, pluginSetting))
+            final Object convertedConfiguration = mock(Object.class);
+            given(pluginConfigurationConverter.convert(PluginSetting.class, pluginSetting))
+                    .willReturn(convertedConfiguration);
+            given(pluginCreator.newPluginInstance(expectedPluginClass, convertedConfiguration, pluginName))
                     .willReturn(expectedInstance);
 
             assertThat(createObjectUnderTest().loadPlugin(baseClass, pluginSetting),
@@ -155,7 +160,7 @@ class DefaultPluginFactoryTest {
 
         @ParameterizedTest
         @ValueSource(ints = {-100, -2, -1})
-        void loadPlugins_should_throw_for_invalid_number_of_instances(int numberOfInstances) {
+        void loadPlugins_should_throw_for_invalid_number_of_instances(final int numberOfInstances) {
 
             final DefaultPluginFactory objectUnderTest = createObjectUnderTest();
             assertThrows(IllegalArgumentException.class, () -> objectUnderTest.loadPlugins(
@@ -178,7 +183,10 @@ class DefaultPluginFactoryTest {
         @Test
         void loadPlugins_should_return_a_single_instance_when_the_the_numberOfInstances_is_1() {
             final TestSink expectedInstance = mock(TestSink.class);
-            given(pluginCreator.newPluginInstance(expectedPluginClass, pluginSetting))
+            final Object convertedConfiguration = mock(Object.class);
+            given(pluginConfigurationConverter.convert(PluginSetting.class, pluginSetting))
+                    .willReturn(convertedConfiguration);
+            given(pluginCreator.newPluginInstance(expectedPluginClass, convertedConfiguration, pluginName))
                     .willReturn(expectedInstance);
 
             final List<?> plugins = createObjectUnderTest().loadPlugins(
@@ -194,7 +202,11 @@ class DefaultPluginFactoryTest {
             final TestSink expectedInstance1 = mock(TestSink.class);
             final TestSink expectedInstance2 = mock(TestSink.class);
             final TestSink expectedInstance3 = mock(TestSink.class);
-            given(pluginCreator.newPluginInstance(expectedPluginClass, pluginSetting))
+            final Object convertedConfiguration = mock(Object.class);
+            given(pluginConfigurationConverter.convert(PluginSetting.class, pluginSetting))
+                    .willReturn(convertedConfiguration);
+
+            given(pluginCreator.newPluginInstance(expectedPluginClass, convertedConfiguration, pluginName))
                     .willReturn(expectedInstance1)
                     .willReturn(expectedInstance2)
                     .willReturn(expectedInstance3);

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginConfigurationConverterTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginConfigurationConverterTest.java
@@ -1,0 +1,81 @@
+package com.amazon.dataprepper.plugin;
+
+import com.amazon.dataprepper.model.configuration.PluginSetting;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+class PluginConfigurationConverterTest {
+    private PluginSetting pluginSetting;
+
+    static class TestConfiguration {
+        private String myValue;
+
+        public String getMyValue() {
+            return myValue;
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        pluginSetting = mock(PluginSetting.class);
+    }
+
+    private PluginConfigurationConverter createObjectUnderTest() {
+        return new PluginConfigurationConverter();
+    }
+
+    @Test
+    void convert_with_null_configurationType_should_throw() {
+        final PluginConfigurationConverter objectUnderTest = createObjectUnderTest();
+
+        assertThrows(NullPointerException.class,
+                () -> objectUnderTest.convert(null, pluginSetting));
+    }
+
+    @Test
+    void convert_with_null_pluginSetting_should_throw() {
+        final PluginConfigurationConverter objectUnderTest = createObjectUnderTest();
+
+        assertThrows(NullPointerException.class,
+                () -> objectUnderTest.convert(PluginSetting.class, null));
+    }
+
+    @Test
+    void convert_with_PluginSetting_target_should_return_pluginSetting_object_directly() {
+        assertThat(createObjectUnderTest().convert(PluginSetting.class, pluginSetting),
+                sameInstance(pluginSetting));
+
+        then(pluginSetting).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void convert_with_other_target_should_return_pluginSetting_object_directly() {
+
+        final String value = UUID.randomUUID().toString();
+        given(pluginSetting.getSettings())
+                .willReturn(Collections.singletonMap("my_value", value));
+
+        final Object convertedConfiguration = createObjectUnderTest().convert(TestConfiguration.class, pluginSetting);
+
+        assertThat(convertedConfiguration, notNullValue());
+        assertThat(convertedConfiguration, instanceOf(TestConfiguration.class));
+
+        final TestConfiguration convertedTestConfiguration = (TestConfiguration) convertedConfiguration;
+
+        assertThat(convertedTestConfiguration.getMyValue(), equalTo(value));
+    }
+
+}

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginCreatorTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginCreatorTest.java
@@ -6,6 +6,8 @@ import com.amazon.dataprepper.model.plugin.PluginInvocationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -15,6 +17,7 @@ import static org.mockito.Mockito.mock;
 class PluginCreatorTest {
 
     private PluginSetting pluginSetting;
+    private String pluginName;
 
     public static class ValidPluginClass {
         private final PluginSetting pluginSetting;
@@ -40,6 +43,8 @@ class PluginCreatorTest {
     @BeforeEach
     void setUp() {
         pluginSetting = mock(PluginSetting.class);
+
+        pluginName = UUID.randomUUID().toString();
     }
 
     private PluginCreator createObjectUnderTest() {
@@ -47,20 +52,20 @@ class PluginCreatorTest {
     }
 
     @Test
-    void newPluginInstance_should_create_new_instance_from_PluginSettings() {
+    void newPluginInstance_should_create_new_instance_from_pluginConfiguration() {
 
-        final ValidPluginClass instance = createObjectUnderTest().newPluginInstance(ValidPluginClass.class, pluginSetting);
+        final ValidPluginClass instance = createObjectUnderTest().newPluginInstance(ValidPluginClass.class, pluginSetting, pluginName);
 
         assertThat(instance, notNullValue());
         assertThat(instance.pluginSetting, equalTo(pluginSetting));
     }
 
     @Test
-    void newPluginInstance_should_throw_if_no_constructor_with_PluginSetting() {
+    void newPluginInstance_should_throw_if_no_constructor_with_pluginConfiguration() {
 
         final PluginCreator objectUnderTest = createObjectUnderTest();
         assertThrows(InvalidPluginDefinitionException.class,
-                () -> objectUnderTest.newPluginInstance(PluginClassWithoutConstructor.class, pluginSetting));
+                () -> objectUnderTest.newPluginInstance(PluginClassWithoutConstructor.class, pluginSetting, pluginName));
     }
 
     @Test
@@ -68,7 +73,7 @@ class PluginCreatorTest {
 
         final PluginCreator objectUnderTest = createObjectUnderTest();
         assertThrows(InvalidPluginDefinitionException.class,
-                () -> objectUnderTest.newPluginInstance(AbstractPluginClass.class, pluginSetting));
+                () -> objectUnderTest.newPluginInstance(AbstractPluginClass.class, pluginSetting, pluginName));
     }
 
     @Test
@@ -76,6 +81,6 @@ class PluginCreatorTest {
 
         final PluginCreator objectUnderTest = createObjectUnderTest();
         assertThrows(PluginInvocationException.class,
-                () -> objectUnderTest.newPluginInstance(AlwaysThrowingPluginClass.class, pluginSetting));
+                () -> objectUnderTest.newPluginInstance(AlwaysThrowingPluginClass.class, pluginSetting, pluginName));
     }
 }

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/StringPrepper.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/StringPrepper.java
@@ -23,12 +23,24 @@ import java.util.Collection;
  * An simple String implementation of {@link Prepper} which generates new Records with upper case or lowercase content. The current
  * simpler implementation does not handle errors (if any).
  */
-@DataPrepperPlugin(name = "string_converter", pluginType = Prepper.class)
+@DataPrepperPlugin(name = "string_converter", pluginType = Prepper.class, pluginConfigurationType = StringPrepper.Configuration.class)
 public class StringPrepper implements Prepper<Record<String>, Record<String>> {
 
     public static final String UPPER_CASE = "upper_case";
 
     private final boolean upperCase;
+
+    public static class Configuration {
+        private boolean upperCase = true;
+
+        public boolean getUpperCase() {
+            return upperCase;
+        }
+
+        public void setUpperCase(final boolean upperCase) {
+            this.upperCase = upperCase;
+        }
+    }
 
     /**
      * Mandatory constructor for Data Prepper Component - This constructor is used by Data Prepper
@@ -36,10 +48,10 @@ public class StringPrepper implements Prepper<Record<String>, Record<String>> {
      * has access to pluginSetting metadata from pipeline
      * pluginSetting file.
      *
-     * @param pluginSetting instance with metadata information from pipeline pluginSetting file.
+     * @param configuration instance with metadata information from pipeline pluginSetting file.
      */
-    public StringPrepper(final PluginSetting pluginSetting) {
-        this.upperCase = pluginSetting.getBooleanOrDefault(UPPER_CASE, true);
+    public StringPrepper(final Configuration configuration) {
+        this.upperCase = configuration.getUpperCase();
     }
 
     @Override

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/StringPrepperTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/StringPrepperTests.java
@@ -11,66 +11,83 @@
 
 package com.amazon.dataprepper.plugins.prepper;
 
-import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class StringPrepperTests {
-
-    private final String PLUGIN_NAME = "string_converter";
 
     private final String UPPERCASE_TEST_STRING = "data_prepper";
     private final String LOWERCASE_TEST_STRING = "STRING_CONVERTER";
     private final Record<String> TEST_RECORD_1 = new Record<>(UPPERCASE_TEST_STRING);
     private final Record<String> TEST_RECORD_2 = new Record<>(LOWERCASE_TEST_STRING);
     private final List<Record<String>> TEST_RECORDS = Arrays.asList(TEST_RECORD_1, TEST_RECORD_2);
+    private StringPrepper.Configuration configuration;
+
+    @BeforeEach
+    void setUp() {
+        configuration = new StringPrepper.Configuration();
+    }
+
+    private StringPrepper createObjectUnderTest() {
+        return new StringPrepper(configuration);
+    }
 
     @Test
     public void testStringPrepperDefault() {
-        final StringPrepper stringPrepper = new StringPrepper(new PluginSetting(PLUGIN_NAME, new HashMap<>()));
+
+        final StringPrepper stringPrepper = createObjectUnderTest();
         final List<Record<String>> modifiedRecords = (List<Record<String>>) stringPrepper.execute(TEST_RECORDS);
         stringPrepper.shutdown();
 
         final List<String> modifiedRecordData = modifiedRecords.stream().map(Record::getData).collect(Collectors.toList());
         final List<String> expectedRecordData = Arrays.asList(UPPERCASE_TEST_STRING.toUpperCase(), LOWERCASE_TEST_STRING);
 
-        assertEquals(expectedRecordData, modifiedRecordData);
+        assertThat(modifiedRecordData, equalTo(expectedRecordData));
     }
 
     @Test
     public void testStringPrepperLowerCase() {
-        final StringPrepper stringPrepper = new StringPrepper(completePluginSettingForStringPrepper(false));
+        configuration.setUpperCase(false);
+        final StringPrepper stringPrepper = createObjectUnderTest();
         final List<Record<String>> modifiedRecords = (List<Record<String>>) stringPrepper.execute(TEST_RECORDS);
         stringPrepper.shutdown();
 
         final List<String> modifiedRecordData = modifiedRecords.stream().map(Record::getData).collect(Collectors.toList());
         final List<String> expectedRecordData = Arrays.asList(UPPERCASE_TEST_STRING, LOWERCASE_TEST_STRING.toLowerCase());
 
-        assertTrue(modifiedRecordData.containsAll(expectedRecordData));
-        assertTrue(expectedRecordData.containsAll(modifiedRecordData));
+        assertThat(modifiedRecordData.size(), equalTo(2));
+        assertThat(modifiedRecordData, hasItems(UPPERCASE_TEST_STRING, LOWERCASE_TEST_STRING.toLowerCase()));
+    }
+
+    @Test
+    public void testStringPrepperUpperCase() {
+        configuration.setUpperCase(true);
+        final StringPrepper stringPrepper = createObjectUnderTest();
+        final List<Record<String>> modifiedRecords = (List<Record<String>>) stringPrepper.execute(TEST_RECORDS);
+        stringPrepper.shutdown();
+
+        final List<String> modifiedRecordData = modifiedRecords.stream().map(Record::getData).collect(Collectors.toList());
+        final List<String> expectedRecordData = Arrays.asList(UPPERCASE_TEST_STRING.toUpperCase(), LOWERCASE_TEST_STRING);
+
+        assertThat(modifiedRecordData, equalTo(expectedRecordData));
     }
 
     @Test
     public void testPrepareForShutdown() {
-        final StringPrepper stringPrepper = new StringPrepper(new PluginSetting(PLUGIN_NAME, new HashMap<>()));
+        final StringPrepper stringPrepper = createObjectUnderTest();
 
         stringPrepper.prepareForShutdown();
 
-        assertTrue(stringPrepper.isReadyForShutdown());
+        assertThat(stringPrepper.isReadyForShutdown(), equalTo(true));
     }
 
-    private PluginSetting completePluginSettingForStringPrepper(final boolean upperCase) {
-        final Map<String, Object> settings = new HashMap<>();
-        settings.put(StringPrepper.UPPER_CASE, upperCase);
-        return new PluginSetting(PLUGIN_NAME, settings);
-    }
 }


### PR DESCRIPTION
### Description

This PR includes code which provides a mechanism for converting from `PluginSetting` into a custom class as defined by the plugin in `@DataPrepperPlugin`. This is the first PR for some of the work proposed in #469 for straightforward use-cases.
 
### Issues Resolved

Provides some functionality for #469.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
