### PR TITLE
Support index-type parameter

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -113,10 +113,10 @@ Default is null.
       "traceGroupName": "MakePayement.auto"
     }
 ```
-- `trace_analytics_raw`(optional, deprecated): A boolean flag indicates APM trace analytics raw span data type.
+- `trace_analytics_raw`(optional, deprecated in favor of `index_type`): A boolean flag indicates APM trace analytics raw span data type.
 Default value is false. Set it to true for [Raw span trace analytics](#raw_span_trace_analytics). Set it to false for [Service map trace analytics](#service_map_trace_analytics).
 
-- `trace_analytics_service_map`(optional, deprecated): A boolean flag indicates APM trace analytics service map data type.
+- `trace_analytics_service_map`(optional, deprecated in favor of `index_type`): A boolean flag indicates APM trace analytics service map data type.
 Default value is false. Set it to true for [Service map trace analytics](#service_map_trace_analytics). Set it to false for [Raw span trace analytics](#raw_span_trace_analytics).
 
 - <a name="index"></a>`index`: A String used as index name for custom data type. Applicable and required only If index_type is explicitly `custom` or defaults to be `custom` while both `trace_analytics_raw` and `trace_analytics_service_map` are set to false.

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -78,45 +78,48 @@ Default is null.
 
 - `password`(optional): A String of password used in the [internal users](https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles) of ODFE cluster. Default is null.
 
-- `proxy`(optional): A String of the address of a forward HTTP proxy. The format is like "<host-name-or-ip>:<port>". Examples: "example.com:8100", "http://example.com:8100", "112.112.112.112:8100". Note: port number cannot be omitted.
+- `proxy`(optional): A String of the address of a forward HTTP proxy. The format is like "<host-name-or-ip>:\<port\>". Examples: "example.com:8100", "http://example.com:8100", "112.112.112.112:8100". Note: port number cannot be omitted.
 
-- `trace_analytics_raw`(optional): A boolean flag indicates APM trace analytics raw span data type. e.g.
+- `index_type` (optional): a String from the list [`custom`, `trace-analytics-raw`, `trace-analytics-service-map`], which represents an index type. Defaults to `custom`. This index_type instructs Sink plugin what type of data it is handling. 
+
 ```
-{
-  "traceId":"bQ/2NNEmtuwsGAOR5ntCNw==",
-  "spanId":"mnO/qUT5ye4=",
-  "name":"io.opentelemetry.auto.servlet-3.0",
-  "kind":"SERVER",
-  "status":{},
-  "startTime":"2020-08-20T05:40:46.041011600Z",
-  "endTime":"2020-08-20T05:40:46.089556800Z",
-  ...
-}
+    APM trace analytics raw span data type example:
+    {
+    "traceId":"bQ/2NNEmtuwsGAOR5ntCNw==",
+    "spanId":"mnO/qUT5ye4=",
+    "name":"io.opentelemetry.auto.servlet-3.0",
+    "kind":"SERVER",
+    "status":{},
+    "startTime":"2020-08-20T05:40:46.041011600Z",
+    "endTime":"2020-08-20T05:40:46.089556800Z",
+    ...
+    }
+
+    APM trace analytics service map data type example:
+    {
+      "hashId": "aQ/2NNEmtuwsGAOR5ntCNwk=",
+      "serviceName": "Payment",
+      "kind": "Client",
+      "target":
+      {
+        "domain": "Purchase",
+        "resource": "Buy"
+      },
+      "destination":
+      {
+        "domain": "Purchase",
+        "resource": "Buy"
+      },
+      "traceGroupName": "MakePayement.auto"
+    }
 ```
+- `trace_analytics_raw`(optional, deprecated): A boolean flag indicates APM trace analytics raw span data type.
 Default value is false. Set it to true for [Raw span trace analytics](#raw_span_trace_analytics). Set it to false for [Service map trace analytics](#service_map_trace_analytics).
 
-- `trace_analytics_service_map`(optional): A boolean flag indicates APM trace analytics service map data type. e.g.
-```
-{
-  "hashId": "aQ/2NNEmtuwsGAOR5ntCNwk=",
-  "serviceName": "Payment",
-  "kind": "Client",
-  "target":
-  {
-    "domain": "Purchase",
-    "resource": "Buy"
-  },
-  "destination":
-  {
-    "domain": "Purchase",
-    "resource": "Buy"
-  },
-  "traceGroupName": "MakePayement.auto"
-}
-```
+- `trace_analytics_service_map`(optional, deprecated): A boolean flag indicates APM trace analytics service map data type.
 Default value is false. Set it to true for [Service map trace analytics](#service_map_trace_analytics). Set it to false for [Raw span trace analytics](#raw_span_trace_analytics).
 
-- <a name="index"></a>`index`: A String used as index name for custom data type. Applicable and required only If both `trace_analytics_raw` and `trace_analytics_service_map` are set to false.
+- <a name="index"></a>`index`: A String used as index name for custom data type. Applicable and required only If index_type is explicitly `custom` or defaults to be `custom` while both `trace_analytics_raw` and `trace_analytics_service_map` are set to false.
 
 - <a name="template_file"></a>`template_file`(optional): A json file path to be read as index template for custom data ingestion. The json file content should be the json value of
 `"template"` key in the json content of elasticsearch [Index templates API](https://www.elastic.co/guide/en/elasticsearch/reference/7.8/index-templates.html), 

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -89,13 +89,10 @@ public class IndexConfiguration {
 
     private void determineIndexType(Builder builder) {
         if(builder.indexType != null) {
-            Optional<IndexType> mappedIndexType = IndexType.get(builder.indexType);
-            if (mappedIndexType.isPresent()) {
-                indexType = mappedIndexType.get();
-            } else {
-                throw new IllegalArgumentException("Value of the parameter, index_type, must be from the list: "
-                        + IndexType.getIndexTypeValueStrings());
-            }
+            Optional<IndexType> mappedIndexType = IndexType.getByValue(builder.indexType);
+            mappedIndexType.ifPresent(type -> {indexType = type;});
+            mappedIndexType.orElseThrow(() -> new IllegalArgumentException("Value of the parameter, index_type, must be from the list: "
+                    + IndexType.getIndexTypeValues()));
         } else if (builder.isTraceAnalyticsRaw && builder.isTraceAnalyticsServiceMap) {
             throw new IllegalStateException("trace_analytics_raw and trace_analytics_service_map cannot be both true.");
         } else if (builder.isTraceAnalyticsRaw) {

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -90,8 +90,8 @@ public class IndexConfiguration {
     private void determineIndexType(Builder builder) {
         if(builder.indexType != null) {
             Optional<IndexType> mappedIndexType = IndexType.getByValue(builder.indexType);
-            mappedIndexType.ifPresent(type -> {indexType = type;});
-            mappedIndexType.orElseThrow(() -> new IllegalArgumentException("Value of the parameter, index_type, must be from the list: "
+            indexType = mappedIndexType.orElseThrow(
+                    () -> new IllegalArgumentException("Value of the parameter, index_type, must be from the list: "
                     + IndexType.getIndexTypeValues()));
         } else if (builder.isTraceAnalyticsRaw && builder.isTraceAnalyticsServiceMap) {
             throw new IllegalStateException("trace_analytics_raw and trace_analytics_service_map cannot be both true.");

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexType.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexType.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public enum IndexType {
     TRACE_ANALYTICS_RAW("trace-analytics-raw"),
@@ -12,7 +13,9 @@ public enum IndexType {
 
     private final String value;
 
-    // Reverse-lookup map for getting a IndexType from a name
+    /**
+     * This is a reverse-lookup map for getting a IndexType from a value.
+     */
     private static final Map<String, IndexType> STRING_TO_INDEX_TYPE_MAP = new HashMap<>();
 
     static {
@@ -28,11 +31,24 @@ public enum IndexType {
         return value;
     }
 
+    /**
+     * This is for getting an IndexType enum from a given string value.
+     * @param value The string value of an IndexType enum
+     * @return IndexType enum matching the string value
+     */
     static Optional<IndexType> getByValue(final String value) {
         return Optional.ofNullable(STRING_TO_INDEX_TYPE_MAP.get(value));
     }
 
+    /**
+     * This flattens all values into a string which can be used for logging or showing what values are supported
+     * for the index_type parameter
+     * @return a string containing all values that are supported for the index_type parameter
+     */
     static String getIndexTypeValues() {
-        return Arrays.toString(IndexType.values());
+        return Arrays.stream(IndexType.values())
+                .map(IndexType::getValue)
+                .collect(Collectors.toList())
+                .toString();
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexType.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexType.java
@@ -1,7 +1,42 @@
 package com.amazon.dataprepper.plugins.sink.opensearch.index;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 public enum IndexType {
-    TRACE_ANALYTICS_RAW,
-    TRACE_ANALYTICS_SERVICE_MAP,
-    CUSTOM;
+    TRACE_ANALYTICS_RAW("trace-analytics-raw"),
+    TRACE_ANALYTICS_SERVICE_MAP("trace-analytics-service-map"),
+    CUSTOM("custom");
+
+    private final String valueString;
+
+    // Reverse-lookup map for getting a IndexType from a name
+    private static final Map<String, IndexType> STRING_TO_INDEX_TYPE_MAP = new HashMap<>();
+
+    static {
+        Arrays.stream(IndexType.values())
+                .forEach(indexType -> STRING_TO_INDEX_TYPE_MAP.put(indexType.valueString, indexType));
+    }
+
+    IndexType(final String name){
+        this.valueString = name;
+    }
+
+    public String getValueString(){
+        return valueString;
+    }
+
+    public static Optional<IndexType> get(final String value) {
+        return Optional.ofNullable(STRING_TO_INDEX_TYPE_MAP.get(value));
+    }
+
+    public static List<String> getIndexTypeValueStrings() {
+        return Arrays.stream(IndexType.values())
+                .map(IndexType::getValueString)
+                .collect(Collectors.toList());
+    }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexType.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexType.java
@@ -2,41 +2,37 @@ package com.amazon.dataprepper.plugins.sink.opensearch.index;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public enum IndexType {
     TRACE_ANALYTICS_RAW("trace-analytics-raw"),
     TRACE_ANALYTICS_SERVICE_MAP("trace-analytics-service-map"),
     CUSTOM("custom");
 
-    private final String valueString;
+    private final String value;
 
     // Reverse-lookup map for getting a IndexType from a name
     private static final Map<String, IndexType> STRING_TO_INDEX_TYPE_MAP = new HashMap<>();
 
     static {
         Arrays.stream(IndexType.values())
-                .forEach(indexType -> STRING_TO_INDEX_TYPE_MAP.put(indexType.valueString, indexType));
+                .forEach(indexType -> STRING_TO_INDEX_TYPE_MAP.put(indexType.value, indexType));
     }
 
-    IndexType(final String name){
-        this.valueString = name;
+    IndexType(final String value){
+        this.value = value;
     }
 
-    public String getValueString(){
-        return valueString;
+    String getValue(){
+        return value;
     }
 
-    public static Optional<IndexType> get(final String value) {
+    static Optional<IndexType> getByValue(final String value) {
         return Optional.ofNullable(STRING_TO_INDEX_TYPE_MAP.get(value));
     }
 
-    public static List<String> getIndexTypeValueStrings() {
-        return Arrays.stream(IndexType.values())
-                .map(IndexType::getValueString)
-                .collect(Collectors.toList());
+    static String getIndexTypeValues() {
+        return Arrays.toString(IndexType.values());
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertTrue;
 public class IndexConfigurationTests {
     private static final String DEFAULT_TEMPLATE_FILE = "test-template-withshards.json";
     private static final String TEST_CUSTOM_INDEX_POLICY_FILE = "test-custom-index-policy-file.json";
+    private static final String INDEX_TYPE = "index_type";
 
     @Test
     public void testRawAPMSpan() {
@@ -163,7 +164,7 @@ public class IndexConfigurationTests {
     }
 
     @Test
-    public void testReadIndexConfigRaw() {
+    public void testReadIndexConfig_RawFlag() {
         final PluginSetting pluginSetting = generatePluginSetting(
                 true, null, null, null, null, null);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
@@ -177,9 +178,50 @@ public class IndexConfigurationTests {
     }
 
     @Test
-    public void testReadIndexConfigServiceMap() {
+    public void testReadIndexConfig_RawIndexType() {
+        final Map<String, Object> metadata = initializeConfigMetaData(
+                null, null, null, null, null, null);
+        metadata.put(INDEX_TYPE, IndexType.TRACE_ANALYTICS_RAW.getValueString());
+        final PluginSetting pluginSetting = getPluginSetting(metadata);
+        final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
+        final URL expTemplateFile = indexConfiguration
+                .getClass().getClassLoader().getResource(RAW_DEFAULT_TEMPLATE_FILE);
+        assertEquals(IndexType.TRACE_ANALYTICS_RAW, indexConfiguration.getIndexType());
+        assertEquals(TYPE_TO_DEFAULT_ALIAS.get(IndexType.TRACE_ANALYTICS_RAW), indexConfiguration.getIndexAlias());
+        assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
+        assertEquals(5, indexConfiguration.getBulkSize());
+        assertEquals("spanId", indexConfiguration.getDocumentIdField());
+    }
+
+    @Test
+    public void testReadIndexConfig_InvalidIndexTypeValueString() {
+        final Map<String, Object> metadata = initializeConfigMetaData(
+                null, null, null, null, null, null);
+        metadata.put(INDEX_TYPE, "i-am-an-illegitimate-index-type");
+        final PluginSetting pluginSetting = getPluginSetting(metadata);
+        assertThrows(IllegalArgumentException.class, () -> IndexConfiguration.readIndexConfig(pluginSetting));
+    }
+
+    @Test
+    public void testReadIndexConfig_ServiceMapFlag() {
         final PluginSetting pluginSetting = generatePluginSetting(
                 null, true, null, null, null, null);
+        final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
+        final URL expTemplateFile = indexConfiguration
+                .getClass().getClassLoader().getResource(SERVICE_MAP_DEFAULT_TEMPLATE_FILE);
+        assertEquals(IndexType.TRACE_ANALYTICS_SERVICE_MAP, indexConfiguration.getIndexType());
+        assertEquals(TYPE_TO_DEFAULT_ALIAS.get(IndexType.TRACE_ANALYTICS_SERVICE_MAP), indexConfiguration.getIndexAlias());
+        assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
+        assertEquals(5, indexConfiguration.getBulkSize());
+        assertEquals("hashId", indexConfiguration.getDocumentIdField());
+    }
+
+    @Test
+    public void testReadIndexConfig_ServiceMapIndexType() {
+        final Map<String, Object> metadata = initializeConfigMetaData(
+                null, null, null, null, null, null);
+        metadata.put(INDEX_TYPE, IndexType.TRACE_ANALYTICS_SERVICE_MAP.getValueString());
+        final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         final URL expTemplateFile = indexConfiguration
                 .getClass().getClassLoader().getResource(SERVICE_MAP_DEFAULT_TEMPLATE_FILE);
@@ -215,9 +257,37 @@ public class IndexConfigurationTests {
         assertEquals(testIdField, indexConfiguration.getDocumentIdField());
     }
 
+    @Test
+    public void testReadIndexConfig_ExplicitCustomIndexType() throws MalformedURLException {
+        final String defaultTemplateFilePath = Objects.requireNonNull(
+                getClass().getClassLoader().getResource(DEFAULT_TEMPLATE_FILE)).getFile();
+        final String testIndexAlias = "foo";
+        final long testBulkSize = 10L;
+        final String testIdField = "someId";
+        final Map<String, Object> metadata = initializeConfigMetaData(
+                true, false, testIndexAlias, defaultTemplateFilePath, testBulkSize, testIdField);
+        metadata.put(INDEX_TYPE, IndexType.CUSTOM.getValueString());
+        final PluginSetting pluginSetting = getPluginSetting(metadata);
+        final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
+        assertEquals(IndexType.CUSTOM, indexConfiguration.getIndexType());
+        assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
+        assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
+        assertEquals(testBulkSize, indexConfiguration.getBulkSize());
+        assertEquals(testIdField, indexConfiguration.getDocumentIdField());
+    }
+
     private PluginSetting generatePluginSetting(
             final Boolean isRaw, final Boolean isServiceMap, final String indexAlias,
             final String templateFilePath, final Long bulkSize, final String documentIdField) {
+        final Map<String, Object> metadata = initializeConfigMetaData(isRaw, isServiceMap, indexAlias, templateFilePath, bulkSize, documentIdField);
+        return getPluginSetting(metadata);
+    }
+
+    private PluginSetting getPluginSetting(Map<String, Object> metadata) {
+        return new PluginSetting("opensearch", metadata);
+    }
+
+    private Map<String, Object> initializeConfigMetaData(Boolean isRaw, Boolean isServiceMap, String indexAlias, String templateFilePath, Long bulkSize, String documentIdField) {
         final Map<String, Object> metadata = new HashMap<>();
         if (isRaw != null) {
             metadata.put(IndexConfiguration.TRACE_ANALYTICS_RAW_FLAG, isRaw);
@@ -237,7 +307,6 @@ public class IndexConfigurationTests {
         if (documentIdField != null) {
             metadata.put(IndexConfiguration.DOCUMENT_ID_FIELD, documentIdField);
         }
-
-        return new PluginSetting("opensearch", metadata);
+        return metadata;
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -181,7 +181,7 @@ public class IndexConfigurationTests {
     public void testReadIndexConfig_RawIndexType() {
         final Map<String, Object> metadata = initializeConfigMetaData(
                 null, null, null, null, null, null);
-        metadata.put(INDEX_TYPE, IndexType.TRACE_ANALYTICS_RAW.getValueString());
+        metadata.put(INDEX_TYPE, IndexType.TRACE_ANALYTICS_RAW.getValue());
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         final URL expTemplateFile = indexConfiguration
@@ -220,7 +220,7 @@ public class IndexConfigurationTests {
     public void testReadIndexConfig_ServiceMapIndexType() {
         final Map<String, Object> metadata = initializeConfigMetaData(
                 null, null, null, null, null, null);
-        metadata.put(INDEX_TYPE, IndexType.TRACE_ANALYTICS_SERVICE_MAP.getValueString());
+        metadata.put(INDEX_TYPE, IndexType.TRACE_ANALYTICS_SERVICE_MAP.getValue());
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         final URL expTemplateFile = indexConfiguration
@@ -266,7 +266,7 @@ public class IndexConfigurationTests {
         final String testIdField = "someId";
         final Map<String, Object> metadata = initializeConfigMetaData(
                 true, false, testIndexAlias, defaultTemplateFilePath, testBulkSize, testIdField);
-        metadata.put(INDEX_TYPE, IndexType.CUSTOM.getValueString());
+        metadata.put(INDEX_TYPE, IndexType.CUSTOM.getValue());
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         assertEquals(IndexType.CUSTOM, indexConfiguration.getIndexType());

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexTypeTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexTypeTests.java
@@ -1,0 +1,26 @@
+package com.amazon.dataprepper.plugins.sink.opensearch.index;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class IndexTypeTests {
+
+    @Test
+    public void getByValue() {
+        assertEquals(Optional.empty(), IndexType.getByValue(null));
+        assertEquals(Optional.empty(), IndexType.getByValue("illegal-index-type"));
+        assertEquals(Optional.of(IndexType.CUSTOM), IndexType.getByValue("custom"));
+        assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_RAW), IndexType.getByValue("trace-analytics-raw"));
+        assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_SERVICE_MAP), IndexType.getByValue("trace-analytics-service-map"));
+    }
+
+    @Test
+    public void getIndexTypeValues() {
+        assertEquals("[trace-analytics-raw, trace-analytics-service-map, custom]", IndexType.getIndexTypeValues());
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Han Jiang <jianghan@amazon.com>

### Description
We are adding the following parameter support to OpenSearch Sink plugin configuration: 

Parameter | Required | Description | Additional Comments
-- | -- | -- | --
index_type | No | Default: custom <br>One string value from the index types that Data Prepper supports: trace-analytics-raw, trace-analytics-service-map, custom | We consider two parameters, "trace_analytics_raw" and "trace_analytics_service_map", as deprecated.  If customers are using  "trace_analytics_raw" and "trace_analytics_service_map", we will show a warning on console notifying customers that they are using a parameter which will be removed and that they should use index_type instead. We will remove the two deprecated parameters in a future major version release of Data Prepper, likely in 2022.

### Issues Resolved
Originally, this is proposed in the [Sink Updates RFC] (https://github.com/opensearch-project/data-prepper/issues/310)

### Check List
- [ x] New functionality includes testing.
  - [ x] All tests pass
- [x ] New functionality has been documented.
  - [ x] New functionality has javadoc added
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).

