### PR TITLE
Added Project Resources to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,19 @@ who wants to run Data Prepper.
 Please read the [Trace Analytics](docs/trace_analytics.md) guide to get started with using
 Data Prepper for trace analytics use cases.
 
+## Project Resources
+
+* [Downloads](https://opensearch.org/downloads.html)
+* [Documentation](https://opensearch.org/docs/latest/monitoring-plugins/trace/data-prepper/)
+* [Configuration Reference](https://opensearch.org/docs/latest/monitoring-plugins/trace/data-prepper-reference/)
+* Need help? Try the [Data Prepper category](https://discuss.opendistrocommunity.dev/c/data-prepper/61) in the OpenSearch forums
+* [Project Principles](https://opensearch.org/#principles)
+
 ## Contribute
 
 We invite developers from the larger OpenSearch community to contribute and help improve test coverage and give us feedback on where improvements can be made in design, code and documentation. You can look at [contribution guide](CONTRIBUTING.md) for more information on how to contribute.
 
-If you are looking to contribute code, or just to build from source, please see our [Developer Guilde](docs/developer_guide.md).
+If you are looking to contribute code, or just to build from source, please see our [Developer Guide](docs/developer_guide.md).
 
 ## Code of Conduct
 


### PR DESCRIPTION
### Description

This adds a small "Project Resources" section to the README. I based it on the OpenSearch README. One of the main links I wanted to get in was the link to the Data Prepper forum so that people visiting the project can find the forum easily.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
