### PR TITLE
Updated Maintainers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,9 +3,9 @@
 | --------------- | --------- | ----------- |
 | Qi Chen | [chenqi0805](https://github.com/chenqi0805) | Amazon |
 | Taylor Gray | [graytaylor0](https://github.com/graytaylor0) | Amazon |
-| Lane Holloway | [laneholloway](https://github.com/laneholloway) | Amazon |
 | Han Jiang | [jianghancn](https://github.com/jianghancn) | Amazon |
 | Dinu John |  [dinujoh](https://github.com/dinujoh) | Amazon |
 | Christopher Manning | [cmanning09](https://github.com/cmanning09) | Amazon |
+| Asif Sohail Mohammed | [asifsmohammed](https://github.com/asifsmohammed) | Amazon |
 | Shivani Shukla | [sshivanii](https://github.com/sshivanii) | Amazon |
 | David Venable | [dlvenable](https://github.com/dlvenable) | Amazon |


### PR DESCRIPTION
### Description

Updated the maintainers list to be current as of Nov 1, 2021.
 
### Issues Resolved

None
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
