### PR TITLE
Warning for disabled SSL with http/otel trace source, document setting up SSL

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
@@ -51,7 +51,8 @@ public class DataPrepperServer {
                 LOG.info("Creating Data Prepper server with TLS");
                 this.server = createHttpsServer(port, keyStoreFilePath, keyStorePassword, privateKeyPassword);
             } else {
-                LOG.info("Creating Data Prepper server without TLS");
+                LOG.warn("Creating Data Prepper server without TLS. This is not secure.");
+                LOG.warn("In order to set up TLS for the Data Prepper server, go here: https://github.com/opensearch-project/data-prepper/blob/main/docs/configuration.md#server-configuration");
                 this.server = createHttpServer(port);
             }
         } catch (IOException e) {

--- a/data-prepper-plugins/http-source/README.md
+++ b/data-prepper-plugins/http-source/README.md
@@ -6,9 +6,9 @@ This is a source plugin that supports HTTP protocol. Currently ONLY support Json
 
 ## Usages
 Currently, we are exposing `/log/ingest` URI path for http log ingestion. Example `.yaml` configuration:
-```
+```yaml
 source:
-    - http:
+   http:
 ```
 
 ### Response status
@@ -29,11 +29,37 @@ source:
 
 ### SSL
 
-* ssl(Optional) => A `boolean` enables TLS/SSL. Default is ```true```.
+* ssl(Optional) => A `boolean` enables TLS/SSL. Default is ```false```.
 * ssl_certificate_file(Optional) => A `String` represents the SSL certificate chain file path. Required if ```ssl``` is set to ```true```.
 * ssl_key_file(Optional) => A `String` represents the SSL key file path. Only decrypted key file is supported. Required if ```ssl``` is set to ```true```.
 
-## Metrics
+### Example to enable SSL using OpenSSL
+
+Create the following http source configuration in your `pipeline.yaml`.
+
+```yaml
+source:
+   http:
+       ssl: true
+       ssl_certificate_file: "/full/path/to/certfile.crt"
+       ssl_key_file: "/full/path/to/keyfile.key"
+```
+
+Generate a private key named `keyfile.key`, along with a self-signed certificate file named `certfile.crt`.
+
+```
+openssl req  -nodes -new -x509  -keyout keyfile.key -out certfile.crt -subj "/L=test/O=Example Com Inc./OU=Example Com Inc. Root CA/CN=Example Com Inc. Root CA"
+```
+
+Make sure to replace the paths for the `ssl_certificate_file` and `ssl_key_file` for the http source configuration with the actual paths of the files.
+
+Send a sample log with the following https curl command
+
+```
+curl -k -XPOST -H "Content-Type: application/json" -d '[{"log": "sample log"}]' https://localhost:2021/log/ingest
+```
+
+# Metrics
 
 ### Counter
 - `requestsReceived`: measures total number of requests received by `/log/ingest` endpoint.

--- a/data-prepper-plugins/http-source/src/main/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSource.java
+++ b/data-prepper-plugins/http-source/src/main/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSource.java
@@ -58,7 +58,7 @@ public class HTTPSource implements Source<Record<String>> {
         if (server == null) {
             final ServerBuilder sb = Server.builder();
             if (sourceConfig.isSsl()) {
-                LOG.info("SSL/TLS is enabled.");
+                LOG.info("Creating http source with SSL/TLS enabled.");
                 final CertificateProvider certificateProvider = certificateProviderFactory.getCertificateProvider();
                 final Certificate certificate = certificateProvider.getCertificate();
                 // TODO: enable encrypted key with password
@@ -68,6 +68,8 @@ public class HTTPSource implements Source<Record<String>> {
                         )
                 );
             } else {
+                LOG.warn("Creating http source without SSL/TLS. This is not secure.");
+                LOG.warn("In order to set up TLS for the http source, go here: https://github.com/opensearch-project/data-prepper/tree/main/data-prepper-plugins/http-source#ssl");
                 sb.http(sourceConfig.getPort());
             }
             sb.maxNumConnections(sourceConfig.getMaxConnectionCount());

--- a/data-prepper-plugins/otel-trace-source/README.md
+++ b/data-prepper-plugins/otel-trace-source/README.md
@@ -7,7 +7,7 @@ This is a source which follows the [OTLP Protocol](https://github.com/open-telem
 Example `.yaml` configuration:
 ```
 source:
-    - otel_trace_source:
+    otel_trace_source:
 ```
 
 ## Configurations
@@ -28,6 +28,34 @@ source:
 * useAcmCertForSSL(Optional) => A boolean enables TLS/SSL using certificate and private key from AWS Certificate Manager (ACM). Default is ```false```.
 * acmCertificateArn(Optional) => A `String` represents the ACM certificate ARN. ACM certificate take preference over S3 or local file system certificate. Required if ```useAcmCertForSSL``` is set to ```true```.
 * awsRegion(Optional) => A `String` represents the AWS region to use ACM or S3. Required if ```useAcmCertForSSL``` is set to ```true``` or ```sslKeyCertChainFile``` and ```sslKeyFile``` is ```AWS S3 path```.
+
+
+### Example to enable SSL using OpenSSL
+
+Create the following otel-trace-source configuration in your `pipeline.yaml`.
+
+```yaml
+source:
+  otel_trace_source:
+      ssl: true
+      sslKeyCertChainFile: "/full/path/to/certfile.crt"
+      sslKeyFile: "/full/path/to/keyfile.key"
+      unframed_requests: true
+```
+
+Generate a private key named `keyfile.key`, along with a self-signed certificate named `certfile.crt`.
+
+```
+openssl req  -nodes -new -x509  -keyout keyfile.key -out certfile.crt -subj "/L=test/O=Example Com Inc./OU=Example Com Inc. Root CA/CN=Example Com Inc. Root CA"
+```
+
+Make sure to replace the paths for the `sslKeyCertChainFile` and `sslKeyFile` for the otel-trace-source configuration with the actual paths of the files.
+
+Send a sample span with the following https curl command
+
+```
+curl -k -H 'Content-Type: application/json; charset=utf-8'  -d '{"resourceSpans":[{"instrumentationLibrarySpans":[{"spans":[{"spanId":"AAAAAAAAAAM=","name":"test-span"}]}]}]}' https://localhost:21890/opentelemetry.proto.collector.trace.v1.TraceService/Export
+```
 
 ## Metrics
 

--- a/data-prepper-plugins/otel-trace-source/README.md
+++ b/data-prepper-plugins/otel-trace-source/README.md
@@ -5,7 +5,7 @@ This is a source which follows the [OTLP Protocol](https://github.com/open-telem
 
 ## Usages
 Example `.yaml` configuration:
-```
+```yaml
 source:
     otel_trace_source:
 ```
@@ -51,7 +51,7 @@ openssl req  -nodes -new -x509  -keyout keyfile.key -out certfile.crt -subj "/L=
 
 Make sure to replace the paths for the `sslKeyCertChainFile` and `sslKeyFile` for the otel-trace-source configuration with the actual paths of the files.
 
-Send a sample span with the following https curl command
+Send a sample span with the following https curl command:
 
 ```
 curl -k -H 'Content-Type: application/json; charset=utf-8'  -d '{"resourceSpans":[{"instrumentationLibrarySpans":[{"spans":[{"spanId":"AAAAAAAAAAM=","name":"test-span"}]}]}]}' https://localhost:21890/opentelemetry.proto.collector.trace.v1.TraceService/Export

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
@@ -99,6 +99,8 @@ public class OTelTraceSource implements Source<Record<ExportTraceServiceRequest>
                     )
                 );
             } else {
+                LOG.warn("Creating otel_trace_source without SSL/TLS. This is not secure.");
+                LOG.warn("In order to set up TLS for the otel_trace_source, go here: https://github.com/opensearch-project/data-prepper/tree/main/data-prepper-plugins/otel-trace-source#ssl");
                 sb.http(oTelTraceSourceConfig.getPort());
             }
 

--- a/docs/core_apis.md
+++ b/docs/core_apis.md
@@ -32,16 +32,22 @@ You can configure your Data Prepper core APIs through the `data-prepper-config.y
 
 Many of the Getting Started guides in this project disable SSL on the endpoint.
 
-```
+```yaml
 ssl: false
 ```
 
 To enable SSL on your Data Prepper endpoint, configure your `data-prepper-config.yaml`
 with the following:
 
-```
+```yaml
 ssl: true
-keyStoreFilePath: "/usr/share/data-prepper/keystore.jks"
+keyStoreFilePath: "/usr/share/data-prepper/keystore.p12"
 keyStorePassword: "secret"
 privateKeyPassword: "secret"
+```
+
+If you are using a self-signed certificate, you must add the `-k` flag to curl requests.
+
+```
+curl -k -X POST http://localhost:4900/shutdown
 ```

--- a/docs/core_apis.md
+++ b/docs/core_apis.md
@@ -46,8 +46,10 @@ keyStorePassword: "secret"
 privateKeyPassword: "secret"
 ```
 
-If you are using a self-signed certificate, you must add the `-k` flag to curl requests.
+For more information on configuring your Data Prepper server with SSL, see [Server Configuration](https://github.com/opensearch-project/data-prepper/blob/main/docs/configuration.md#server-configuration). 
+
+If you are using a self-signed certificate, you can add the `-k` flag to quickly test out sending curl requests for the core APIs with SSL.
 
 ```
-curl -k -X POST http://localhost:4900/shutdown
+curl -k -X POST https://localhost:4900/shutdown
 ```


### PR DESCRIPTION
Signed-off-by: Taylor Gray <33740195+graytaylor0@users.noreply.github.com>

### Description
Warnings added if SSL is disabled for data prepper server, otel-trace-source, or http source. These warnings contain links to documentation that provides example guidance for users to set up ssl for themselves for each of these three servers.
 
### Issues Resolved
Closes #521 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
