### PR TITLE
integrating event model into log ingestion plugins, updated sink to support both string and event type

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/Event.java
@@ -76,4 +76,17 @@ public interface Event {
      */
     EventMetadata getMetadata();
 
+    /**
+     * Checks if the key exists.
+     * @param key
+     * @return returns true if the key exists, otherwise false
+     */
+    boolean containsKey(String key);
+
+    /**
+     * Checks if the value stored for the key is list
+     * @param key
+     * @return returns true if the key is a list, otherwise false
+     */
+    boolean isValueAList(String key);
 }

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/Event.java
@@ -80,6 +80,7 @@ public interface Event {
      * Checks if the key exists.
      * @param key
      * @return returns true if the key exists, otherwise false
+     * @since 1.2
      */
     boolean containsKey(String key);
 
@@ -87,6 +88,7 @@ public interface Event {
      * Checks if the value stored for the key is list
      * @param key
      * @return returns true if the key is a list, otherwise false
+     * @since 1.2
      */
     boolean isValueAList(String key);
 }

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
@@ -89,9 +89,8 @@ public class JacksonEvent implements Event {
             } catch (final JsonProcessingException e) {
                 throw new IllegalArgumentException("Unable to convert data into an event");
             }
-        } else {
-            return mapper.valueToTree(data);
         }
+        return mapper.valueToTree(data);
     }
 
     /**
@@ -257,11 +256,11 @@ public class JacksonEvent implements Event {
 
     @Override
     public boolean isValueAList(final String key) {
-        try {
-            return getList(key, Object.class) != null;
-        } catch (final Exception e) {
-            return false;
-        }
+        final String trimmedKey = checkAndTrimKey(key);
+
+        final JsonNode node = getNode(trimmedKey);
+
+        return node.isArray();
     }
 
     private String checkAndTrimKey(final String key) {

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
@@ -13,6 +13,7 @@ package com.amazon.dataprepper.model.event;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -57,6 +58,8 @@ public class JacksonEvent implements Event {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {};
+
     private final EventMetadata eventMetadata;
 
     private final JsonNode jsonNode;
@@ -73,12 +76,22 @@ public class JacksonEvent implements Event {
             this.eventMetadata = builder.eventMetadata;
         }
 
-        if (builder.data == null) {
-            this.jsonNode = mapper.valueToTree(new HashMap<>());
-        } else {
-            this.jsonNode = mapper.valueToTree(builder.data);
-        }
+        this.jsonNode = getInitialJsonNode(builder.data);
+    }
 
+    private JsonNode getInitialJsonNode(final Object data) {
+
+        if (data == null) {
+            return mapper.valueToTree(new HashMap<>());
+        } else if (data instanceof String) {
+            try {
+                return mapper.readTree((String) data);
+            } catch (final JsonProcessingException e) {
+                throw new IllegalArgumentException("Unable to convert data into an event");
+            }
+        } else {
+            return mapper.valueToTree(data);
+        }
     }
 
     /**
@@ -232,6 +245,25 @@ public class JacksonEvent implements Event {
         return eventMetadata;
     }
 
+    @Override
+    public boolean containsKey(final String key) {
+
+        final String trimmedKey = checkAndTrimKey(key);
+
+        final JsonNode node = getNode(trimmedKey);
+
+        return !node.isMissingNode();
+    }
+
+    @Override
+    public boolean isValueAList(final String key) {
+        try {
+            return getList(key, Object.class) != null;
+        } catch (final Exception e) {
+            return false;
+        }
+    }
+
     private String checkAndTrimKey(final String key) {
         checkKey(key);
         return trimKey(key);
@@ -278,6 +310,7 @@ public class JacksonEvent implements Event {
      * @since 1.2
      */
     public abstract static class Builder<T extends Builder<T>> {
+
         private EventMetadata eventMetadata;
         private Object data;
         private String eventType;

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/JacksonEventTest.java
@@ -223,6 +223,45 @@ public class JacksonEventTest {
         assertThat(result, is(nullValue()));
     }
 
+    @Test
+    public void testContainsKey_withKey() {
+        final String key = "foo";
+
+        event.put(key, UUID.randomUUID());
+        assertThat(event.containsKey(key), is(true));
+    }
+
+    @Test
+    public void testContainsKey_withouthKey() {
+        final String key = "foo";
+
+        event.put(key, UUID.randomUUID());
+        assertThat(event.containsKey("bar"), is(false));
+    }
+
+    @Test
+    public void testIsValueAList_withAList() {
+        final String key = "foo";
+        final List<Integer> numbers = Arrays.asList(1, 2, 3);
+
+        event.put(key, numbers);
+        assertThat(event.isValueAList(key), is(true));
+    }
+
+    @Test
+    public void testIsValueAList_withoutAList() {
+        final String key = "foo";
+        event.put(key, UUID.randomUUID());
+        assertThat(event.isValueAList(key), is(false));
+    }
+
+    @Test
+    public void testIsValueAList_withNull() {
+        final String key = "foo";
+        event.put(key, null);
+        assertThat(event.isValueAList(key), is(false));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"", "withSpecialChars*$%", "-withPrefixDash", "\\-withEscapeChars", "\\\\/withMultipleEscapeChars",
             "withDashSuffix-", "withDashSuffix-/nestedKey", "withDashPrefix/-nestedKey", "_withUnderscorePrefix", "withUnderscoreSuffix_",
@@ -351,4 +390,33 @@ public class JacksonEventTest {
 
         assertThat(event.get("field1", String.class), is(equalTo(value)));
     }
+
+    @Test
+    public void testBuild_withStringData() {
+
+        final String jsonString = "{\"foo\": \"bar\"}";
+
+        event = JacksonEvent.builder()
+                .withEventType(eventType)
+                .withData(jsonString)
+                .getThis()
+                .build();
+
+        assertThat(event.get("foo", String.class), is(equalTo("bar")));
+    }
+
+    @Test
+    public void testBuild_withInvalidStringData() {
+
+        final String jsonString = "foobar";
+
+        final JacksonEvent.Builder builder = JacksonEvent.builder()
+                .withEventType(eventType)
+                .withData(jsonString)
+                .getThis();
+
+        assertThrows(IllegalArgumentException.class, () -> builder.build());
+    }
+
+
 }

--- a/data-prepper-plugins/grok-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepper.java
+++ b/data-prepper-plugins/grok-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepper.java
@@ -215,9 +215,9 @@ public class GrokPrepper extends AbstractPrepper<Record<Event>, Record<Event>> {
 
         for (final Map.Entry<String, List<Grok>> entry : fieldToGrok.entrySet()) {
             for (final Grok grok : entry.getValue()) {
-                final String field = event.get(entry.getKey(), String.class);
-                if (!field.isEmpty()) {
-                    final Match match = grok.match(field);
+                final String value = event.get(entry.getKey(), String.class);
+                if (!value.isEmpty()) {
+                    final Match match = grok.match(value);
                     match.setKeepEmptyCaptures(grokPrepperConfig.isKeepEmptyCaptures());
 
                     final Map<String, Object> captures = match.capture();
@@ -272,9 +272,9 @@ public class GrokPrepper extends AbstractPrepper<Record<Event>, Record<Event>> {
             }
 
             if (event.isValueAList(updateEntry.getKey())) {
-                final List<Object> fieldList = event.getList(updateEntry.getKey(), Object.class);
-                mergeValueWithValues(updateEntry.getValue(), fieldList);
-                event.put(updateEntry.getKey(), fieldList);
+                final List<Object> values = event.getList(updateEntry.getKey(), Object.class);
+                mergeValueWithValues(updateEntry.getValue(), values);
+                event.put(updateEntry.getKey(), values);
             } else {
                 final Object fieldObject = event.get(updateEntry.getKey(), Object.class);
                 final List<Object> values = new ArrayList<>(Collections.singletonList(fieldObject));

--- a/data-prepper-plugins/http-source/src/main/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSource.java
+++ b/data-prepper-plugins/http-source/src/main/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSource.java
@@ -19,6 +19,7 @@ import com.amazon.dataprepper.model.buffer.Buffer;
 import com.amazon.dataprepper.model.configuration.PluginModel;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.plugin.PluginFactory;
+import com.amazon.dataprepper.model.log.Log;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.source.Source;
 import com.amazon.dataprepper.plugins.certificate.CertificateProvider;
@@ -38,7 +39,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 @DataPrepperPlugin(name = "http", pluginType = Source.class, pluginConfigurationType = HTTPSourceConfig.class)
-public class HTTPSource implements Source<Record<String>> {
+public class HTTPSource implements Source<Record<Log>> {
     private static final Logger LOG = LoggerFactory.getLogger(HTTPSource.class);
 
     private final HTTPSourceConfig sourceConfig;
@@ -67,7 +68,7 @@ public class HTTPSource implements Source<Record<String>> {
     }
 
     @Override
-    public void start(final Buffer<Record<String>> buffer) {
+    public void start(final Buffer<Record<Log>> buffer) {
         if (buffer == null) {
             throw new IllegalStateException("Buffer provided is null");
         }

--- a/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/LogHTTPServiceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/LogHTTPServiceTest.java
@@ -13,6 +13,7 @@ package com.amazon.dataprepper.plugins.source.loghttp;
 
 import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.buffer.Buffer;
+import com.amazon.dataprepper.model.log.Log;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -106,7 +107,7 @@ class LogHTTPServiceTest {
                 }
         );
 
-        Buffer<Record<String>> blockingBuffer = new BlockingBuffer<>(TEST_BUFFER_CAPACITY, 8, "test-pipeline");
+        Buffer<Record<Log>> blockingBuffer = new BlockingBuffer<>(TEST_BUFFER_CAPACITY, 8, "test-pipeline");
         logHTTPService = new LogHTTPService(TEST_TIMEOUT_IN_MILLIS, blockingBuffer, pluginMetrics);
     }
 

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -143,6 +143,9 @@ public class OpenSearchSink extends AbstractSink<Record<Object>> {
     }
   }
 
+
+  // Temporary function to support both trace and log ingestion pipelines.
+  // TODO: This function should be removed with the completion of: https://github.com/opensearch-project/data-prepper/issues/546
   private String getDocument(final Object object) {
     if (object instanceof String) {
       return (String) object;

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -13,6 +13,7 @@ package com.amazon.dataprepper.plugins.sink.opensearch;
 
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
+import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.sink.AbstractSink;
 import com.amazon.dataprepper.model.sink.Sink;
@@ -46,7 +47,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 @DataPrepperPlugin(name = "opensearch", pluginType = Sink.class)
-public class OpenSearchSink extends AbstractSink<Record<String>> {
+public class OpenSearchSink extends AbstractSink<Record<Object>> {
   public static final String BULKREQUEST_LATENCY = "bulkRequestLatency";
   public static final String BULKREQUEST_ERRORS = "bulkRequestErrors";
 
@@ -111,13 +112,13 @@ public class OpenSearchSink extends AbstractSink<Record<String>> {
   }
 
   @Override
-  public void doOutput(final Collection<Record<String>> records) {
+  public void doOutput(final Collection<Record<Object>> records) {
     if (records.isEmpty()) {
       return;
     }
     BulkRequest bulkRequest = bulkRequestSupplier.get();
-    for (final Record<String> record : records) {
-      final String document = record.getData();
+    for (final Record<Object> record : records) {
+      final String document = getDocument(record.getData());
       final IndexRequest indexRequest = new IndexRequest().source(document, XContentType.JSON);
       try {
         final Map<String, Object> source = getMapFromJson(document);
@@ -139,6 +140,16 @@ public class OpenSearchSink extends AbstractSink<Record<String>> {
     // Flush the remaining requests
     if (bulkRequest.numberOfActions() > 0) {
       flushBatch(bulkRequest);
+    }
+  }
+
+  private String getDocument(final Object object) {
+    if (object instanceof String) {
+      return (String) object;
+    } else if (object instanceof Event) {
+      return ((Event) object).toJsonString();
+    } else {
+      throw new RuntimeException("Invalid record type. OpenSearch sink only supports String and Events");
     }
   }
 


### PR DESCRIPTION
integrating event model into log ingestion plugins, updated sink to support both string and event type. I apologize for the large PR. Unfortunately, doing this in smaller chunks is impossible without breaking the pipeline support.

Signed-off-by: Christopher Manning <cmanning09@users.noreply.github.com>

### Description
- Introduced a `containsKey` and `isValueAList` to the event interface for calling functions to validate the contents of the event.
- Updated JacksonEvent constructor to support Json string.
- Updated HTTP Source plugin to use new log model as a `Record<Log>`
- Updated Grok Prepper to use `Event` model to support grepping on any structure as a `Record<Event>`
- Updated OpenSearch sink to support String and Event data types as a `Record<Object>`. I selected objects to be generic. enough to support both data types. Once trace plugins support Events this can be set to `Record<Event>` in #546  The record construct will be eliminated in 2.0. OpenSearch Sink will only process `Event`s in 2.0.
- Updated all unit tests
- Ran Data Prepper locally with OpenSearch and invoked the HTTP Source endpoint using the FluentBit and Apache log generator from the log ingestion demo guide
 
### Issues Resolved
Resolves: #538 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
