### PR TITLE
Support HTTP Basic authentication on the core Data Prepper APIs

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
@@ -46,6 +46,7 @@ public class DataPrepper {
 
     private static final CompositeMeterRegistry systemMeterRegistry = new CompositeMeterRegistry();
 
+    private final PluginFactory pluginFactory = new DefaultPluginFactory();
     private Map<String, Pipeline> transformationPipelines;
 
     private static volatile DataPrepper dataPrepper;
@@ -130,7 +131,6 @@ public class DataPrepper {
      */
     public boolean execute(final String configurationFileLocation) {
         LOG.info("Using {} configuration file", configurationFileLocation);
-        final PluginFactory pluginFactory = new DefaultPluginFactory();
         final PipelineParser pipelineParser = new PipelineParser(configurationFileLocation, pluginFactory);
         transformationPipelines = pipelineParser.parseConfiguration();
         if (transformationPipelines.size() == 0) {
@@ -166,6 +166,9 @@ public class DataPrepper {
         if (transformationPipelines.containsKey(pipeline)) {
             transformationPipelines.get(pipeline).shutdown();
         }
+    }
+    public PluginFactory getPluginFactory() {
+        return pluginFactory;
     }
 
     public Map<String, Pipeline> getTransformationPipelines() {

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/DataPrepperConfiguration.java
@@ -11,6 +11,7 @@
 
 package com.amazon.dataprepper.parser.model;
 
+import com.amazon.dataprepper.model.configuration.PluginModel;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,6 +33,7 @@ public class DataPrepperConfiguration {
     private String keyStorePassword = "";
     private String privateKeyPassword = "";
     private List<MetricRegistryType> metricRegistries = DEFAULT_METRIC_REGISTRY_TYPE;
+    private PluginModel authentication;
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
 
@@ -59,8 +61,10 @@ public class DataPrepperConfiguration {
             @JsonProperty("keyStorePassword") final String keyStorePassword,
             @JsonProperty("privateKeyPassword") final String privateKeyPassword,
             @JsonProperty("serverPort") final String serverPort,
-            @JsonProperty("metricRegistries") final List<MetricRegistryType> metricRegistries
-    ) {
+            @JsonProperty("metricRegistries") final List<MetricRegistryType> metricRegistries,
+            @JsonProperty("authentication") final PluginModel authentication
+            ) {
+        this.authentication = authentication;
         setSsl(ssl);
         this.keyStoreFilePath = keyStoreFilePath != null ? keyStoreFilePath : "";
         this.keyStorePassword = keyStorePassword != null ? keyStorePassword : "";
@@ -97,6 +101,10 @@ public class DataPrepperConfiguration {
         if (ssl != null) {
             this.ssl = ssl;
         }
+    }
+
+    public PluginModel getAuthentication() {
+        return authentication;
     }
 
     private void setServerPort(final String serverPort) {

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperCoreAuthenticationProvider.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperCoreAuthenticationProvider.java
@@ -1,0 +1,26 @@
+package com.amazon.dataprepper.pipeline.server;
+
+import com.sun.net.httpserver.Authenticator;
+
+/**
+ * Pluggable interface for authentication of core Data Prepper APIs.
+ *
+ * @since 1.2
+ */
+public interface DataPrepperCoreAuthenticationProvider {
+    /**
+     * The plugin name for the plugin which allows unauthenticated
+     * requests. This plugin will disable authentication.
+     *
+     * @since 1.2
+     */
+    String UNAUTHENTICATED_PLUGIN_NAME = "unauthenticated";
+
+    /**
+     * Gets the Sun HTTP Server {@link Authenticator}.
+     *
+     * @return the authenticator instance
+     * @since 1.2
+     */
+    Authenticator getAuthenticator();
+}

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/HttpBasicAuthenticationConfig.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/HttpBasicAuthenticationConfig.java
@@ -1,0 +1,30 @@
+package com.amazon.dataprepper.pipeline.server;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Configuration class for Core API HTTP Basic authentication
+ *
+ * @since 1.2
+ */
+public class HttpBasicAuthenticationConfig {
+    private final String username;
+    private final String password;
+
+    @JsonCreator
+    public HttpBasicAuthenticationConfig(
+            @JsonProperty("username") final String username,
+            @JsonProperty("password") final String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugins/HttpBasicDataPrepperCoreAuthenticationProvider.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugins/HttpBasicDataPrepperCoreAuthenticationProvider.java
@@ -1,0 +1,52 @@
+package com.amazon.dataprepper.plugins;
+
+import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
+import com.amazon.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import com.amazon.dataprepper.pipeline.server.DataPrepperCoreAuthenticationProvider;
+import com.amazon.dataprepper.pipeline.server.HttpBasicAuthenticationConfig;
+import com.sun.net.httpserver.Authenticator;
+import com.sun.net.httpserver.BasicAuthenticator;
+
+import java.util.Objects;
+
+/**
+ * The plugin for HTTP Basic authentication of the core Data Prepper APIs.
+ *
+ * @since 1.2
+ */
+@DataPrepperPlugin(name = "http_basic",
+        pluginType = DataPrepperCoreAuthenticationProvider.class,
+        pluginConfigurationType = HttpBasicAuthenticationConfig.class)
+public class HttpBasicDataPrepperCoreAuthenticationProvider implements DataPrepperCoreAuthenticationProvider {
+
+    private final HttpBasicAuthenticationConfig httpBasicAuthenticationConfig;
+    private final CoreAuthenticator coreAuthenticator;
+
+    @DataPrepperPluginConstructor
+    public HttpBasicDataPrepperCoreAuthenticationProvider(final HttpBasicAuthenticationConfig httpBasicAuthenticationConfig) {
+        this.httpBasicAuthenticationConfig = httpBasicAuthenticationConfig;
+        Objects.requireNonNull(this.httpBasicAuthenticationConfig);
+        Objects.requireNonNull(httpBasicAuthenticationConfig.getUsername());
+        Objects.requireNonNull(httpBasicAuthenticationConfig.getPassword());
+
+        coreAuthenticator = new CoreAuthenticator();
+    }
+
+    @Override
+    public Authenticator getAuthenticator() {
+        return coreAuthenticator;
+    }
+
+    private class CoreAuthenticator extends BasicAuthenticator {
+
+        CoreAuthenticator() {
+            super("core");
+        }
+
+        @Override
+        public boolean checkCredentials(final String username, final String password) {
+            return httpBasicAuthenticationConfig.getUsername().equals(username) &&
+                    httpBasicAuthenticationConfig.getPassword().equals(password);
+        }
+    }
+}

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugins/UnauthenticatedDataPrepperCoreAuthenticationProvider.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugins/UnauthenticatedDataPrepperCoreAuthenticationProvider.java
@@ -1,0 +1,19 @@
+package com.amazon.dataprepper.plugins;
+
+import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
+import com.amazon.dataprepper.pipeline.server.DataPrepperCoreAuthenticationProvider;
+import com.sun.net.httpserver.Authenticator;
+
+/**
+ * The plugin for unauthenticated core Data Prepper APIs.
+ *
+ * @since 1.2
+ */
+@DataPrepperPlugin(name = DataPrepperCoreAuthenticationProvider.UNAUTHENTICATED_PLUGIN_NAME,
+        pluginType = DataPrepperCoreAuthenticationProvider.class)
+public class UnauthenticatedDataPrepperCoreAuthenticationProvider implements DataPrepperCoreAuthenticationProvider {
+    @Override
+    public Authenticator getAuthenticator() {
+        return null;
+    }
+}

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/TestDataProvider.java
@@ -49,6 +49,7 @@ public class TestDataProvider {
     public static final String NO_PIPELINES_EXECUTE_CONFIG_FILE = "src/test/resources/no_pipelines_to_execute.yml";
     public static final String VALID_DATA_PREPPER_CONFIG_FILE = "src/test/resources/valid_data_prepper_config.yml";
     public static final String VALID_DATA_PREPPER_CONFIG_FILE_WITH_TLS = "src/test/resources/valid_data_prepper_config_with_tls.yml";
+    public static final String VALID_DATA_PREPPER_CONFIG_FILE_WITH_BASIC_AUTHENTICATION = "src/test/resources/valid_data_prepper_config_with_basic_authentication.yml";
     public static final String VALID_DATA_PREPPER_DEFAULT_LOG4J_CONFIG_FILE = "src/test/resources/valid_data_prepper_config_default_log4j.yml";
     public static final String VALID_DATA_PREPPER_SOME_DEFAULT_CONFIG_FILE = "src/test/resources/valid_data_prepper_some_default_config.yml";
     public static final String VALID_DATA_PREPPER_CLOUDWATCH_METRICS_CONFIG_FILE = "src/test/resources/valid_data_prepper_cloudwatch_metrics_config.yml";

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/model/DataPrepperConfigurationTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/model/DataPrepperConfigurationTests.java
@@ -13,7 +13,7 @@ package com.amazon.dataprepper.parser.model;
 
 import org.hamcrest.Matchers;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
@@ -21,9 +21,14 @@ import static com.amazon.dataprepper.TestDataProvider.INVALID_DATA_PREPPER_CONFI
 import static com.amazon.dataprepper.TestDataProvider.INVALID_PORT_DATA_PREPPER_CONFIG_FILE;
 import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_CLOUDWATCH_METRICS_CONFIG_FILE;
 import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_CONFIG_FILE;
+import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_CONFIG_FILE_WITH_BASIC_AUTHENTICATION;
 import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_MULTIPLE_METRICS_CONFIG_FILE;
 import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_SOME_DEFAULT_CONFIG_FILE;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DataPrepperConfigurationTests {
 
@@ -65,15 +70,28 @@ public class DataPrepperConfigurationTests {
         assertThat(dataPrepperConfiguration.getMetricRegistryTypes(), Matchers.hasItem(MetricRegistryType.CloudWatch));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidConfig() {
-            final DataPrepperConfiguration dataPrepperConfiguration =
-                    DataPrepperConfiguration.fromFile(new File(INVALID_DATA_PREPPER_CONFIG_FILE));
+    @Test
+    void testConfigurationWithHttpBasic() {
+        final DataPrepperConfiguration dataPrepperConfiguration =
+                DataPrepperConfiguration.fromFile(new File(VALID_DATA_PREPPER_CONFIG_FILE_WITH_BASIC_AUTHENTICATION));
+
+        assertThat(dataPrepperConfiguration, notNullValue());
+        assertThat(dataPrepperConfiguration.getAuthentication(), notNullValue());
+        assertThat(dataPrepperConfiguration.getAuthentication().getPluginName(), equalTo("http_basic"));
+        assertThat(dataPrepperConfiguration.getAuthentication().getPluginSettings(), notNullValue());
+        assertThat(dataPrepperConfiguration.getAuthentication().getPluginSettings(), hasKey("username"));
+        assertThat(dataPrepperConfiguration.getAuthentication().getPluginSettings(), hasKey("password"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
+    public void testInvalidConfig() {
+        assertThrows(IllegalArgumentException.class, () ->
+                    DataPrepperConfiguration.fromFile(new File(INVALID_DATA_PREPPER_CONFIG_FILE)));
+    }
+
+    @Test
     public void testInvalidPortConfig() {
-        final DataPrepperConfiguration dataPrepperConfiguration =
-                DataPrepperConfiguration.fromFile(new File(INVALID_PORT_DATA_PREPPER_CONFIG_FILE));
+        assertThrows(IllegalArgumentException.class, () ->
+                DataPrepperConfiguration.fromFile(new File(INVALID_PORT_DATA_PREPPER_CONFIG_FILE)));
     }
 }

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugins/HttpBasicDataPrepperCoreAuthenticationProviderTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugins/HttpBasicDataPrepperCoreAuthenticationProviderTest.java
@@ -1,0 +1,137 @@
+package com.amazon.dataprepper.plugins;
+
+import com.amazon.dataprepper.pipeline.server.HttpBasicAuthenticationConfig;
+import com.sun.net.httpserver.Authenticator;
+import com.sun.net.httpserver.BasicAuthenticator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+class HttpBasicDataPrepperCoreAuthenticationProviderTest {
+
+    private HttpBasicAuthenticationConfig authenticationConfig;
+    private String username;
+    private String password;
+
+    @BeforeEach
+    void setUp() {
+        authenticationConfig = mock(HttpBasicAuthenticationConfig.class);
+
+        username = UUID.randomUUID().toString();
+        password = UUID.randomUUID().toString();
+        when(authenticationConfig.getUsername()).thenReturn(username);
+        when(authenticationConfig.getPassword()).thenReturn(password);
+    }
+
+    private HttpBasicDataPrepperCoreAuthenticationProvider createObjectUnderTest() {
+        return new HttpBasicDataPrepperCoreAuthenticationProvider(authenticationConfig);
+    }
+
+    @Test
+    void constructor_with_null_Config_throws() {
+        authenticationConfig = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void constructor_with_null_username_throws() {
+        reset(authenticationConfig);
+        when(authenticationConfig.getPassword()).thenReturn(password);
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void constructor_with_null_password_throws() {
+        reset(authenticationConfig);
+        when(authenticationConfig.getUsername()).thenReturn(username);
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void getAuthenticator_should_return_Authenticator_with_core_Realm() {
+        final Authenticator authenticator = createObjectUnderTest().getAuthenticator();
+
+        assertThat(authenticator, notNullValue());
+
+        assertThat(authenticator, instanceOf(BasicAuthenticator.class));
+
+        final BasicAuthenticator basicAuthenticator = (BasicAuthenticator) authenticator;
+
+        assertThat(basicAuthenticator.getRealm(), equalTo("core"));
+    }
+
+    @Test
+    void getAuthenticator_should_return_Authenticator_which_returns_true_for_matching_username_and_password() {
+        final Authenticator authenticator = createObjectUnderTest().getAuthenticator();
+
+        assertThat(authenticator, notNullValue());
+
+        assertThat(authenticator, instanceOf(BasicAuthenticator.class));
+
+        final BasicAuthenticator basicAuthenticator = (BasicAuthenticator) authenticator;
+
+        assertThat(basicAuthenticator.checkCredentials(username, password), equalTo(true));
+    }
+
+    @Test
+    void getAuthenticator_should_return_Authenticator_which_returns_false_for_incorrect_username() {
+        final Authenticator authenticator = createObjectUnderTest().getAuthenticator();
+
+        assertThat(authenticator, notNullValue());
+
+        assertThat(authenticator, instanceOf(BasicAuthenticator.class));
+
+        final BasicAuthenticator basicAuthenticator = (BasicAuthenticator) authenticator;
+
+        assertThat(basicAuthenticator.checkCredentials(UUID.randomUUID().toString(), password), equalTo(false));
+    }
+
+    @Test
+    void getAuthenticator_should_return_Authenticator_which_returns_false_for_incorrect_password() {
+        final Authenticator authenticator = createObjectUnderTest().getAuthenticator();
+
+        assertThat(authenticator, notNullValue());
+
+        assertThat(authenticator, instanceOf(BasicAuthenticator.class));
+
+        final BasicAuthenticator basicAuthenticator = (BasicAuthenticator) authenticator;
+
+        assertThat(basicAuthenticator.checkCredentials(username, UUID.randomUUID().toString()), equalTo(false));
+    }
+
+    @Test
+    void getAuthenticator_should_return_Authenticator_which_returns_false_for_null_username() {
+        final Authenticator authenticator = createObjectUnderTest().getAuthenticator();
+
+        assertThat(authenticator, notNullValue());
+
+        assertThat(authenticator, instanceOf(BasicAuthenticator.class));
+
+        final BasicAuthenticator basicAuthenticator = (BasicAuthenticator) authenticator;
+
+        assertThat(basicAuthenticator.checkCredentials(null, password), equalTo(false));
+    }
+
+    @Test
+    void getAuthenticator_should_return_Authenticator_which_returns_false_for_null_password() {
+        final Authenticator authenticator = createObjectUnderTest().getAuthenticator();
+
+        assertThat(authenticator, notNullValue());
+
+        assertThat(authenticator, instanceOf(BasicAuthenticator.class));
+
+        final BasicAuthenticator basicAuthenticator = (BasicAuthenticator) authenticator;
+
+        assertThat(basicAuthenticator.checkCredentials(username, null), equalTo(false));
+    }
+}

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugins/UnauthenticatedDataPrepperCoreAuthenticationProviderTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugins/UnauthenticatedDataPrepperCoreAuthenticationProviderTest.java
@@ -1,0 +1,17 @@
+package com.amazon.dataprepper.plugins;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class UnauthenticatedDataPrepperCoreAuthenticationProviderTest {
+    private UnauthenticatedDataPrepperCoreAuthenticationProvider createObjectUnderTest() {
+        return new UnauthenticatedDataPrepperCoreAuthenticationProvider();
+    }
+
+    @Test
+    void getAuthenticator_returns_null() {
+        assertThat(createObjectUnderTest().getAuthenticator(), nullValue());
+    }
+}

--- a/data-prepper-core/src/test/resources/valid_data_prepper_config_with_basic_authentication.yml
+++ b/data-prepper-core/src/test/resources/valid_data_prepper_config_with_basic_authentication.yml
@@ -1,0 +1,9 @@
+serverPort: 1234
+ssl: true
+keyStoreFilePath: "src/test/resources/test.p12"
+keyStorePassword: "store"
+privateKeyPassword: "key"
+authentication:
+  http_basic:
+    username: testuser
+    password: testpass

--- a/docs/core_apis.md
+++ b/docs/core_apis.md
@@ -30,6 +30,8 @@ The following APIs are available:
 
 You can configure your Data Prepper core APIs through the `data-prepper-config.yaml` file. 
 
+### SSL/TLS Connection
+
 Many of the Getting Started guides in this project disable SSL on the endpoint.
 
 ```yaml
@@ -52,4 +54,27 @@ If you are using a self-signed certificate, you can add the `-k` flag to quickly
 
 ```
 curl -k -X POST https://localhost:4900/shutdown
+```
+
+### Authentication
+
+The Data Prepper Core APIs support HTTP Basic authentication.
+You can set the username and password with the following
+configuration in `data-prepper-config.yaml`:
+
+```
+authentication:
+  http_basic:
+    username: myuser
+    password: mys3cr3t
+```
+
+You can disable authentication of core endpoints using the following
+configuration. Use this with caution because the shutdown API and
+others will be accessible to anybody with network access to
+your Data Prepper instance.
+
+```
+authentication:
+  unauthenticated:
 ```


### PR DESCRIPTION
### Description

This adds pluggable support for authenticating Data Prepper core APIs. It currently uses HTTP Basic authentication only.

This does not include secure-by-default. The solution for that will be to update the default configuration file - not to include constants in code. I will create a follow-on PR for that.
 
### Issues Resolved

#312
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
