### PR TITLE
Fix Java 1.8 compatibility bug by removing Path.of calls

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/SslUtil.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/SslUtil.java
@@ -15,7 +15,7 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.KeyStore;
 
 public class SslUtil {
@@ -27,7 +27,7 @@ public class SslUtil {
 
         try {
             final KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-            keyStore.load(Files.newInputStream(Path.of(keyStoreFilePath)), keyStorePassword.toCharArray());
+            keyStore.load(Files.newInputStream(Paths.get(keyStoreFilePath)), keyStorePassword.toCharArray());
 
             final KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
             keyManagerFactory.init(keyStore, privateKeyPassword.toCharArray());

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/certificate/file/FileCertificateProvider.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/certificate/file/FileCertificateProvider.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Objects;
 
 public class FileCertificateProvider implements CertificateProvider {
@@ -23,11 +24,14 @@ public class FileCertificateProvider implements CertificateProvider {
 
     public Certificate getCertificate() {
         try {
-            final Path certFilePath = Path.of(certificateFilePath);
-            final Path pkFilePath = Path.of(privateKeyFilePath);
+            final Path certFilePath = Paths.get(certificateFilePath);
+            final Path pkFilePath = Paths.get(privateKeyFilePath);
 
-            final String certAsString = Files.readString(certFilePath);
-            final String privateKeyAsString = Files.readString(pkFilePath);
+            final byte[] certFileBytes = Files.readAllBytes(certFilePath);
+            final byte[] pkFileBytes = Files.readAllBytes(pkFilePath);
+
+            final String certAsString = new String(certFileBytes);
+            final String privateKeyAsString = new String(pkFileBytes);
 
             return new Certificate(certAsString, privateKeyAsString);
         } catch (final Exception ex) {

--- a/data-prepper-plugins/http-source/src/main/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
+++ b/data-prepper-plugins/http-source/src/main/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
@@ -17,7 +17,7 @@ import com.google.common.base.Preconditions;
 import io.micrometer.core.instrument.util.StringUtils;
 
 import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class HTTPSourceConfig {
     static final String DEFAULT_LOG_INGEST_URI = "/log/ingest";
@@ -74,7 +74,7 @@ public class HTTPSourceConfig {
     }
 
     private void validateFilePath(final String typeMessage, final String argument, final String argumentName) {
-        if (StringUtils.isEmpty(argument) || !Files.exists(Path.of(argument))) {
+        if (StringUtils.isEmpty(argument) || !Files.exists(Paths.get(argument))) {
             throw new IllegalArgumentException(String.format("%s, %s needs to be a valid file path.", typeMessage, argumentName));
         }
     }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/file/FileCertificateProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/file/FileCertificateProvider.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Objects;
 
 public class FileCertificateProvider implements CertificateProvider {
@@ -20,9 +21,11 @@ public class FileCertificateProvider implements CertificateProvider {
 
     public Certificate getCertificate() {
         try {
-            final Path certFilePath = Path.of(certificateFilePath);
+            final Path certFilePath = Paths.get(certificateFilePath);
 
-            final String certAsString = Files.readString(certFilePath);
+            final byte[] bytes = Files.readAllBytes(certFilePath);
+
+            final String certAsString = new String(bytes);
 
             return new Certificate(certAsString);
         } catch (final Exception ex) {


### PR DESCRIPTION
Signed-off-by: Steven Bayer <smbayer@amazon.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
