### PR TITLE
Added LogstashPluginAttributesMapper for custom mapping

### DIFF
--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AttributesMapperCreator.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AttributesMapperCreator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.logstash.mapping;
+
+import org.opensearch.dataprepper.logstash.exception.LogstashMappingException;
+
+import java.lang.reflect.Constructor;
+
+class AttributesMapperCreator {
+
+    LogstashPluginAttributesMapper createMapperClass(final String attributesMapperClassName) {
+        final Class<?> attributesMapperClass;
+        try {
+            attributesMapperClass = Class.forName(attributesMapperClassName);
+        } catch (final ClassNotFoundException ex) {
+            throw new LogstashMappingException("Unable to find Mapper class with name of " + attributesMapperClassName, ex);
+        }
+
+        if(!LogstashPluginAttributesMapper.class.isAssignableFrom(attributesMapperClass)) {
+            throw new LogstashMappingException("The provided mapping class does not implement " + LogstashPluginAttributesMapper.class);
+        }
+
+        try {
+            final Constructor<?> defaultConstructor = attributesMapperClass.getConstructor();
+            final Object instance = defaultConstructor.newInstance();
+            return  (LogstashPluginAttributesMapper) instance;
+        } catch (final Exception ex) {
+            throw new LogstashMappingException("Unable to create Mapper class with name of " + attributesMapperClassName, ex);
+        }
+    }
+}

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AttributesMapperProvider.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AttributesMapperProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.logstash.mapping;
+
+class AttributesMapperProvider {
+    private final AttributesMapperCreator attributesMapperCreator;
+    private final DefaultLogstashPluginAttributesMapper defaultLogstashPluginAttributesMapper;
+
+    protected AttributesMapperProvider() {
+        attributesMapperCreator = new AttributesMapperCreator();
+        defaultLogstashPluginAttributesMapper = new DefaultLogstashPluginAttributesMapper();
+
+    }
+
+    LogstashPluginAttributesMapper getAttributesMapper(final LogstashMappingModel mappingModel) {
+        final String attributesMapperClassName = mappingModel.getAttributesMapperClass();
+        if(attributesMapperClassName == null) {
+            return defaultLogstashPluginAttributesMapper;
+        }
+
+        return attributesMapperCreator.createMapperClass(attributesMapperClassName);
+    }
+}

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AttributesMapperProvider.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AttributesMapperProvider.java
@@ -9,10 +9,13 @@ class AttributesMapperProvider {
     private final AttributesMapperCreator attributesMapperCreator;
     private final DefaultLogstashPluginAttributesMapper defaultLogstashPluginAttributesMapper;
 
-    protected AttributesMapperProvider() {
-        attributesMapperCreator = new AttributesMapperCreator();
-        defaultLogstashPluginAttributesMapper = new DefaultLogstashPluginAttributesMapper();
+    AttributesMapperProvider() {
+        this(new AttributesMapperCreator());
+    }
 
+    AttributesMapperProvider(final AttributesMapperCreator attributesMapperCreator) {
+        this.attributesMapperCreator = attributesMapperCreator;
+        defaultLogstashPluginAttributesMapper = new DefaultLogstashPluginAttributesMapper();
     }
 
     LogstashPluginAttributesMapper getAttributesMapper(final LogstashMappingModel mappingModel) {

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/DefaultLogstashPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/DefaultLogstashPluginAttributesMapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.logstash.mapping;
+
+import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+class DefaultLogstashPluginAttributesMapper implements LogstashPluginAttributesMapper {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultLogstashPluginAttributesMapper.class);
+
+    @Override
+    public Map<String, Object> mapAttributes(final List<LogstashAttribute> logstashAttributes, final LogstashAttributesMappings logstashAttributesMappings) {
+        final Map<String, Object> pluginSettings = new LinkedHashMap<>(logstashAttributesMappings.getAdditionalAttributes());
+
+        logstashAttributes.forEach(logstashAttribute -> {
+            if (logstashAttributesMappings.getMappedAttributeNames().containsKey(logstashAttribute.getAttributeName())) {
+                pluginSettings.put(
+                        logstashAttributesMappings.getMappedAttributeNames().get(logstashAttribute.getAttributeName()),
+                        logstashAttribute.getAttributeValue().getValue()
+                );
+            }
+            else {
+                LOG.warn("Attribute name {} is not found in mapping file.", logstashAttribute.getAttributeName());
+            }
+        });
+
+        return pluginSettings;
+    }
+}

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/DefaultPluginMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/DefaultPluginMapper.java
@@ -5,12 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.opensearch.dataprepper.logstash.exception.LogstashMappingException;
 import org.opensearch.dataprepper.logstash.model.LogstashPlugin;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -19,8 +16,16 @@ import java.util.Map;
  * @since 1.2
  */
 public class DefaultPluginMapper implements LogstashPluginMapper {
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultPluginMapper.class);
     private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+    private final AttributesMapperProvider attributesMapperProvider;
+
+    public DefaultPluginMapper() {
+        this(new AttributesMapperProvider());
+    }
+
+    DefaultPluginMapper(final AttributesMapperProvider attributesMapperProvider) {
+        this.attributesMapperProvider = attributesMapperProvider;
+    }
 
     @Override
     public PluginModel mapPlugin(LogstashPlugin logstashPlugin) {
@@ -43,19 +48,10 @@ public class DefaultPluginMapper implements LogstashPluginMapper {
         if (logstashMappingModel.getPluginName() == null) {
             throw new LogstashMappingException("The mapping file " + mappingResourceName + " has a null value for 'pluginName'.");
         }
-        Map<String, Object> pluginSettings = new LinkedHashMap<>(logstashMappingModel.getAdditionalAttributes());
 
-        logstashPlugin.getAttributes().forEach(logstashAttribute -> {
-            if (logstashMappingModel.getMappedAttributeNames().containsKey(logstashAttribute.getAttributeName())) {
-                pluginSettings.put(
-                        logstashMappingModel.getMappedAttributeNames().get(logstashAttribute.getAttributeName()),
-                        logstashAttribute.getAttributeValue().getValue()
-                );
-            }
-            else {
-                LOG.warn("Attribute name {} is not found in mapping file.", logstashAttribute.getAttributeName());
-            }
-        });
+        final LogstashPluginAttributesMapper pluginAttributesMapper = attributesMapperProvider.getAttributesMapper(logstashMappingModel);
+
+        final Map<String, Object> pluginSettings = pluginAttributesMapper.mapAttributes(logstashPlugin.getAttributes(), logstashMappingModel);
 
         return new PluginModel(logstashMappingModel.getPluginName(), pluginSettings);
     }

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashAttributesMappings.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashAttributesMappings.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.logstash.mapping;
+
+import java.util.Map;
+
+/**
+ * Represents attribute mappings from Logstash into Data Prepper.
+ *
+ * @since 1.2
+ */
+public interface LogstashAttributesMappings {
+    Map<String, String> getMappedAttributeNames();
+
+    Map<String, Object> getAdditionalAttributes();
+}

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashMappingModel.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashMappingModel.java
@@ -7,15 +7,19 @@ import java.util.Map;
  *
  * @since 1.2
  */
-public class LogstashMappingModel {
+class LogstashMappingModel implements LogstashAttributesMappings {
 
     private String pluginName;
+    private String attributesMapperClass;
     private Map<String, String> mappedAttributeNames;
     private Map<String, Object> additionalAttributes;
 
-    public LogstashMappingModel(final String pluginName, final Map<String, String> mappedAttributeNames,
+    public LogstashMappingModel(final String pluginName,
+                                final String attributesMapperClass,
+                                final Map<String, String> mappedAttributeNames,
                                 final Map<String, Object> additionalAttributes) {
         this.pluginName = pluginName;
+        this.attributesMapperClass = attributesMapperClass;
         this.mappedAttributeNames = mappedAttributeNames;
         this.additionalAttributes = additionalAttributes;
     }
@@ -24,6 +28,10 @@ public class LogstashMappingModel {
 
     public String getPluginName() {
         return pluginName;
+    }
+
+    public String getAttributesMapperClass() {
+        return attributesMapperClass;
     }
 
     public Map<String, String> getMappedAttributeNames() {

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashMappingModel.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashMappingModel.java
@@ -1,4 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.logstash.mapping;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
 
@@ -9,22 +16,17 @@ import java.util.Map;
  */
 class LogstashMappingModel implements LogstashAttributesMappings {
 
+    @JsonProperty
     private String pluginName;
+
+    @JsonProperty
     private String attributesMapperClass;
+
+    @JsonProperty
     private Map<String, String> mappedAttributeNames;
+
+    @JsonProperty
     private Map<String, Object> additionalAttributes;
-
-    public LogstashMappingModel(final String pluginName,
-                                final String attributesMapperClass,
-                                final Map<String, String> mappedAttributeNames,
-                                final Map<String, Object> additionalAttributes) {
-        this.pluginName = pluginName;
-        this.attributesMapperClass = attributesMapperClass;
-        this.mappedAttributeNames = mappedAttributeNames;
-        this.additionalAttributes = additionalAttributes;
-    }
-
-    public LogstashMappingModel() {}
 
     public String getPluginName() {
         return pluginName;

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashPluginAttributesMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.logstash.mapping;
+
+import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An interface for a class which is responsible for mapping attributes
+ * from a Logstash plugin into Data Prepper plugin settings.
+ *
+ * @since 1.2
+ */
+public interface LogstashPluginAttributesMapper {
+    /**
+     * Map all logstashAttributes from a Logstash plugin.
+     *
+     * @param logstashAttributes All the Logstash logstashAttributes for the plugin
+     * @param logstashAttributesMappings The mappings for this Logstash plugin
+     * @return A map of Data Prepper plugin settings.
+     * @since 1.2
+     */
+    Map<String, Object> mapAttributes(List<LogstashAttribute> logstashAttributes, LogstashAttributesMappings logstashAttributesMappings);
+}

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/AttributesMapperCreatorTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/AttributesMapperCreatorTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.logstash.mapping;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.logstash.exception.LogstashMappingException;
+import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AttributesMapperCreatorTest {
+    static class DoesNotImplement {
+    }
+
+    public static class NoDefaultConstructor implements LogstashPluginAttributesMapper {
+        public NoDefaultConstructor(final String ignored) { }
+        @Override
+        public Map<String, Object> mapAttributes(List<LogstashAttribute> logstashAttributes, LogstashAttributesMappings logstashAttributesMappings) {
+            return null;
+        }
+    }
+
+    public static class ThrowingConstructor implements LogstashPluginAttributesMapper {
+        public ThrowingConstructor() {
+            throw new RuntimeException("Intentional exception for testing.");
+        }
+        @Override
+        public Map<String, Object> mapAttributes(List<LogstashAttribute> logstashAttributes, LogstashAttributesMappings logstashAttributesMappings) {
+            return null;
+        }
+    }
+
+    public static class ValidMapper implements LogstashPluginAttributesMapper {
+        @Override
+        public Map<String, Object> mapAttributes(final List<LogstashAttribute> logstashAttributes, final LogstashAttributesMappings logstashAttributesMappings) {
+            return null;
+        }
+    }
+
+    private AttributesMapperCreator createObjectUnderTest() {
+        return new AttributesMapperCreator();
+    }
+
+    @Test
+    void createMapperClass_should_throw_if_class_does_not_exist() {
+        final AttributesMapperCreator objectUnderTest = createObjectUnderTest();
+
+        assertThrows(LogstashMappingException.class,
+                () -> objectUnderTest.createMapperClass("org.opensearch.dataprepper.logstash.DoesNotExist"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            DoesNotImplement.class, NoDefaultConstructor.class, ThrowingConstructor.class
+    })
+    void createMapperClass_should_throw_for_classes_which_cannot_be_constructor(final Class<?> invalidClass) {
+        final AttributesMapperCreator objectUnderTest = createObjectUnderTest();
+
+        assertThrows(LogstashMappingException.class,
+                () -> objectUnderTest.createMapperClass(invalidClass.getName()));
+    }
+
+    @Test
+    void createMapperClass_returns_new_instance() {
+        assertThat(createObjectUnderTest().createMapperClass(ValidMapper.class.getName()),
+            instanceOf(LogstashPluginAttributesMapper.class));
+    }
+}

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/AttributesMapperProviderTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/AttributesMapperProviderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.logstash.mapping;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AttributesMapperProviderTest {
+
+    private AttributesMapperCreator attributesMapperCreator;
+    private LogstashMappingModel logstashMappingModel;
+
+    @BeforeEach
+    void setUp() {
+        attributesMapperCreator = mock(AttributesMapperCreator.class);
+        logstashMappingModel = mock(LogstashMappingModel.class);
+    }
+
+    private AttributesMapperProvider createObjectUnderTest() {
+        return new AttributesMapperProvider(attributesMapperCreator);
+    }
+
+    @Test
+    void getAttributesMapper_should_return_Default_when_model_has_no_AttributesMapperClass() {
+        final LogstashPluginAttributesMapper attributesMapper = createObjectUnderTest().getAttributesMapper(logstashMappingModel);
+
+        assertThat(attributesMapper, notNullValue());
+        assertThat(attributesMapper, instanceOf(DefaultLogstashPluginAttributesMapper.class));
+    }
+
+    @Test
+    void getAttributesMapper_should_return_new_instance_for_AttributesMapperClass() {
+        final String className = UUID.randomUUID().toString();
+        when(logstashMappingModel.getAttributesMapperClass())
+                .thenReturn(className);
+        final LogstashPluginAttributesMapper expectedMapper = mock(LogstashPluginAttributesMapper.class);
+        when(attributesMapperCreator.createMapperClass(className))
+                .thenReturn(expectedMapper);
+
+        assertThat(createObjectUnderTest().getAttributesMapper(logstashMappingModel), equalTo(expectedMapper));
+    }
+}

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/DefaultLogstashPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/DefaultLogstashPluginAttributesMapperTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.logstash.mapping;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
+import org.opensearch.dataprepper.logstash.model.LogstashAttributeValue;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DefaultLogstashPluginAttributesMapperTest {
+    private DefaultLogstashPluginAttributesMapper createObjectUnderTest() {
+        return new DefaultLogstashPluginAttributesMapper();
+    }
+
+    @Test
+    void mapAttributes_sets_mapped_attributes() {
+        final String value = UUID.randomUUID().toString();
+        final String logstashAttributeName = UUID.randomUUID().toString();
+        final LogstashAttribute logstashAttribute = mock(LogstashAttribute.class);
+        final LogstashAttributeValue logstashAttributeValue = mock(LogstashAttributeValue.class);
+        when(logstashAttributeValue.getValue()).thenReturn(value);
+        when(logstashAttribute.getAttributeName()).thenReturn(logstashAttributeName);
+        when(logstashAttribute.getAttributeValue()).thenReturn(logstashAttributeValue);
+
+        final String dataPrepperAttribute = UUID.randomUUID().toString();
+        final LogstashAttributesMappings mappings = mock(LogstashAttributesMappings.class);
+        when(mappings.getMappedAttributeNames()).thenReturn(Collections.singletonMap(logstashAttributeName, dataPrepperAttribute));
+
+        final Map<String, Object> actualPluginSettings =
+                createObjectUnderTest().mapAttributes(Collections.singletonList(logstashAttribute), mappings);
+
+        assertThat(actualPluginSettings, notNullValue());
+        assertThat(actualPluginSettings.size(), equalTo(1));
+        assertThat(actualPluginSettings, hasKey(dataPrepperAttribute));
+        assertThat(actualPluginSettings.get(dataPrepperAttribute), equalTo(value));
+    }
+
+    @Test
+    void mapAttributes_sets_additional_attributes_to_those_values() {
+        final String additionalAttributeName = UUID.randomUUID().toString();
+        final String additionalAttributeValue = UUID.randomUUID().toString();
+        final LogstashAttributesMappings mappings = mock(LogstashAttributesMappings.class);
+        when(mappings.getAdditionalAttributes()).thenReturn(Collections.singletonMap(additionalAttributeName, additionalAttributeValue));
+
+        final Map<String, Object> actualPluginSettings =
+                createObjectUnderTest().mapAttributes(Collections.emptyList(), mappings);
+
+        assertThat(actualPluginSettings, notNullValue());
+        assertThat(actualPluginSettings.size(), equalTo(1));
+        assertThat(actualPluginSettings, hasKey(additionalAttributeName));
+        assertThat(actualPluginSettings.get(additionalAttributeName), equalTo(additionalAttributeValue));
+    }
+}

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/DefaultPluginMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/DefaultPluginMapperTest.java
@@ -6,17 +6,36 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.logstash.exception.LogstashMappingException;
 import org.opensearch.dataprepper.logstash.model.LogstashPlugin;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class DefaultPluginMapperTest {
 
-    private DefaultPluginMapper defaultPluginMapper;
+    private AttributesMapperProvider attributesMapperProvider;
+    private LogstashPluginAttributesMapper logstashPluginAttributesMapper;
 
     @BeforeEach
-    void createObjectUnderTest() {
-        defaultPluginMapper = new DefaultPluginMapper();
+    void setUp() {
+        attributesMapperProvider = mock(AttributesMapperProvider.class);
+
+        logstashPluginAttributesMapper = mock(LogstashPluginAttributesMapper.class);
+        when(attributesMapperProvider.getAttributesMapper(any(LogstashMappingModel.class)))
+                .thenReturn(logstashPluginAttributesMapper);
+
+    }
+
+    DefaultPluginMapper createObjectUnderTest() {
+        return new DefaultPluginMapper(attributesMapperProvider);
     }
 
     @Test
@@ -24,8 +43,9 @@ class DefaultPluginMapperTest {
         LogstashPlugin logstashPlugin = TestDataProvider.invalidMappingResourceNameData();
         String mappingResourceName = logstashPlugin.getPluginName() + ".mapping.yaml";
 
+        final DefaultPluginMapper objectUnderTest = createObjectUnderTest();
         Exception exception = assertThrows(LogstashMappingException.class, () ->
-                defaultPluginMapper.mapPlugin(logstashPlugin));
+                objectUnderTest.mapPlugin(logstashPlugin));
 
         String expectedMessage = "Unable to find mapping resource " + mappingResourceName;
         String actualMessage = exception.getMessage();
@@ -38,8 +58,9 @@ class DefaultPluginMapperTest {
         LogstashPlugin logstashPlugin = TestDataProvider.invalidMappingResourceData();
         String mappingResourceName = logstashPlugin.getPluginName() + ".mapping.yaml";
 
+        final DefaultPluginMapper objectUnderTest = createObjectUnderTest();
         Exception exception = assertThrows(LogstashMappingException.class, () ->
-                defaultPluginMapper.mapPlugin(logstashPlugin));
+                objectUnderTest.mapPlugin(logstashPlugin));
 
         String expectedMessage = "Unable to parse mapping file " + mappingResourceName;
         String actualMessage = exception.getMessage();
@@ -52,8 +73,9 @@ class DefaultPluginMapperTest {
         LogstashPlugin logstashPlugin = TestDataProvider.noPluginNameMappingResourceData();
         String mappingResourceName = logstashPlugin.getPluginName() + ".mapping.yaml";
 
+        final DefaultPluginMapper objectUnderTest = createObjectUnderTest();
         Exception exception = assertThrows(LogstashMappingException.class, () ->
-                defaultPluginMapper.mapPlugin(logstashPlugin));
+                objectUnderTest.mapPlugin(logstashPlugin));
 
         String expectedMessage = "The mapping file " + mappingResourceName + " has a null value for 'pluginName'.";
         String actualMessage = exception.getMessage();
@@ -62,14 +84,29 @@ class DefaultPluginMapperTest {
     }
 
     @Test
-    void mapPlugin_returns_plugin_model_Test() {
-        LogstashPlugin logstashPlugin = TestDataProvider.pluginData();
+    void mapPlugin_should_return_PluginModel_with_correct_pluginName() {
+        final LogstashPlugin logstashPlugin = mock(LogstashPlugin.class);
+        when(logstashPlugin.getPluginName()).thenReturn("amazon_es");
 
-        PluginModel actualPluginModel = defaultPluginMapper.mapPlugin(logstashPlugin);
-        PluginModel expectedPluginModel = TestDataProvider.getSamplePluginModel();
+        final PluginModel pluginModel = createObjectUnderTest().mapPlugin(logstashPlugin);
 
-        assertThat(expectedPluginModel.getPluginName(), equalTo(actualPluginModel.getPluginName()));
-        assertThat(expectedPluginModel.getPluginSettings(), equalTo(actualPluginModel.getPluginSettings()));
+        assertThat(pluginModel, notNullValue());
+        assertThat(pluginModel.getPluginName(), equalTo("opensearch"));
     }
 
+    @Test
+    void mapPlugin_should_return_PluginModel_with_mapped_attributes() {
+        final LogstashPlugin logstashPlugin = mock(LogstashPlugin.class);
+        when(logstashPlugin.getPluginName()).thenReturn("amazon_es");
+
+        final Map<String, Object> mappedPluginSettings = Collections.singletonMap(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        when(logstashPluginAttributesMapper.mapAttributes(anyList(), any(LogstashAttributesMappings.class)))
+                .thenReturn(mappedPluginSettings);
+
+        final PluginModel pluginModel = createObjectUnderTest().mapPlugin(logstashPlugin);
+
+        assertThat(pluginModel, notNullValue());
+        assertThat(pluginModel.getPluginSettings(), notNullValue());
+        assertThat(pluginModel.getPluginSettings(), equalTo(mappedPluginSettings));
+    }
 }

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/LogstashMappingModelTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/LogstashMappingModelTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.logstash.mapping;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class LogstashMappingModelTest {
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper(new YAMLFactory());
+
+    }
+
+    @Test
+    void deserialize_from_JSON_should_have_expected_value() throws IOException {
+
+        final LogstashMappingModel logstashMappingModel = objectMapper.readValue(this.getClass().getResourceAsStream("sample.mapping.yaml"), LogstashMappingModel.class);
+
+        assertThat(logstashMappingModel.getPluginName(), equalTo("samplePlugin"));
+        assertThat(logstashMappingModel.getAttributesMapperClass(), equalTo("org.opensearch.dataprepper.Placeholder"));
+        assertThat(logstashMappingModel.getMappedAttributeNames(), notNullValue());
+        assertThat(logstashMappingModel.getMappedAttributeNames().size(), equalTo(2));
+        assertThat(logstashMappingModel.getMappedAttributeNames().get("valueA"), equalTo("keyA"));
+        assertThat(logstashMappingModel.getMappedAttributeNames().get("valueB"), equalTo("keyB"));
+        assertThat(logstashMappingModel.getAdditionalAttributes(), notNullValue());
+        assertThat(logstashMappingModel.getAdditionalAttributes().size(), equalTo(2));
+        assertThat(logstashMappingModel.getAdditionalAttributes().get("addA"), equalTo(true));
+        assertThat(logstashMappingModel.getAdditionalAttributes().get("addB"), equalTo("staticValueB"));
+    }
+}

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/mapping/sample.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/mapping/sample.mapping.yaml
@@ -1,0 +1,8 @@
+pluginName: samplePlugin
+attributesMapperClass: org.opensearch.dataprepper.Placeholder
+mappedAttributeNames:
+  valueA: keyA
+  valueB: keyB
+additionalAttributes:
+  addA: true
+  addB: staticValueB


### PR DESCRIPTION
### Description

I split the behavior of `DefaultPluginMapper` so that it loads the plugin mapping file and then delegates the attribute mapping to an instance of `LogstashPluginAttributesMapper`. There is a default implementation named `DefaultLogstashPluginAttributesMapper`. But, any plugin can configure the class by setting the `attributesMapperClass` property in the mapping YAML file.

I would like to provide a customizable base class for `LogstashPluginAttributesMapper`, but will do that in a separate PR after this one has been nailed down.
 
### Issues Resolved

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
