### PR TITLE
Add a new metric for OpenSearch Sink plugin: bulkRequestSizeBytes

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -147,6 +147,9 @@ Besides common metrics in [AbstractSink](https://github.com/opensearch-project/d
 - `documentsSuccessFirstAttempt`: measures number of documents successfully sent to ES by bulk requests on first attempt.
 - `documentErrors`: measures number of documents failed to be sent by bulk requests.
 
+### Distribution Summary
+- `bulkRequestSizeBytes`: measures the distribution of bulk request's payload sizes in bytes.
+
 ## Developer Guide
 
 This plugin is compatible with Java 8. See

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -191,6 +191,15 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
                     .add(BulkRetryStrategy.DOCUMENT_ERRORS).toString());
     assertEquals(1, documentErrorsMeasurements.size());
     assertEquals(0.0, documentErrorsMeasurements.get(0).getValue(), 0);
+
+    /**
+     * Metrics: Bulk Request Size in Bytes
+     */
+    final List<Measurement> bulkRequestSizeBytesMetrics = MetricsTestUtil.getMeasurementList(
+            new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                    .add(OpenSearchSink.BULKREQUEST_SIZE_BYTES).toString());
+    assertEquals(1, bulkRequestSizeBytesMetrics.size());
+    assertEquals(2188.0, bulkRequestSizeBytesMetrics.get(0).getValue(), 0);
   }
 
   public void testOutputRawSpanWithDLQ() throws IOException, InterruptedException {
@@ -233,6 +242,15 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
                     .add(BulkRetryStrategy.DOCUMENT_ERRORS).toString());
     assertEquals(1, documentErrorsMeasurements.size());
     assertEquals(1.0, documentErrorsMeasurements.get(0).getValue(), 0);
+
+    /**
+     * Metrics: Bulk Request Size in Bytes
+     */
+    final List<Measurement> bulkRequestSizeBytesMetrics = MetricsTestUtil.getMeasurementList(
+            new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                    .add(OpenSearchSink.BULKREQUEST_SIZE_BYTES).toString());
+    assertEquals(1, bulkRequestSizeBytesMetrics.size());
+    assertEquals(2181.0, bulkRequestSizeBytesMetrics.get(0).getValue(), 0);
   }
 
   public void testInstantiateSinkServiceMapDefault() throws IOException {
@@ -276,6 +294,15 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     assertEquals(3, bulkRequestLatencies.size());
     // COUNT
     Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
+
+    /**
+     * Metrics: Bulk Request Size in Bytes
+     */
+    final List<Measurement> bulkRequestSizeBytesMetrics = MetricsTestUtil.getMeasurementList(
+            new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                    .add(OpenSearchSink.BULKREQUEST_SIZE_BYTES).toString());
+    assertEquals(1, bulkRequestSizeBytesMetrics.size());
+    assertEquals(309.0, bulkRequestSizeBytesMetrics.get(0).getValue(), 0);
 
     // Check restart for index already exists
     sink = new OpenSearchSink(pluginSetting);

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -198,8 +198,10 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     final List<Measurement> bulkRequestSizeBytesMetrics = MetricsTestUtil.getMeasurementList(
             new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                     .add(OpenSearchSink.BULKREQUEST_SIZE_BYTES).toString());
-    assertEquals(1, bulkRequestSizeBytesMetrics.size());
-    assertEquals(2188.0, bulkRequestSizeBytesMetrics.get(0).getValue(), 0);
+    assertEquals(3, bulkRequestSizeBytesMetrics.size());
+    assertEquals(1.0, bulkRequestSizeBytesMetrics.get(0).getValue(), 0);
+    assertEquals(2188.0, bulkRequestSizeBytesMetrics.get(1).getValue(), 0);
+    assertEquals(2188.0, bulkRequestSizeBytesMetrics.get(2).getValue(), 0);
   }
 
   public void testOutputRawSpanWithDLQ() throws IOException, InterruptedException {
@@ -249,8 +251,11 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     final List<Measurement> bulkRequestSizeBytesMetrics = MetricsTestUtil.getMeasurementList(
             new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                     .add(OpenSearchSink.BULKREQUEST_SIZE_BYTES).toString());
-    assertEquals(1, bulkRequestSizeBytesMetrics.size());
-    assertEquals(2181.0, bulkRequestSizeBytesMetrics.get(0).getValue(), 0);
+    assertEquals(3, bulkRequestSizeBytesMetrics.size());
+    assertEquals(1.0, bulkRequestSizeBytesMetrics.get(0).getValue(), 0);
+    assertEquals(2181.0, bulkRequestSizeBytesMetrics.get(1).getValue(), 0);
+    assertEquals(2181.0, bulkRequestSizeBytesMetrics.get(2).getValue(), 0);
+
   }
 
   public void testInstantiateSinkServiceMapDefault() throws IOException {
@@ -301,8 +306,10 @@ public class OpenSearchSinkIT extends OpenSearchRestTestCase {
     final List<Measurement> bulkRequestSizeBytesMetrics = MetricsTestUtil.getMeasurementList(
             new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                     .add(OpenSearchSink.BULKREQUEST_SIZE_BYTES).toString());
-    assertEquals(1, bulkRequestSizeBytesMetrics.size());
-    assertEquals(309.0, bulkRequestSizeBytesMetrics.get(0).getValue(), 0);
+    assertEquals(3, bulkRequestSizeBytesMetrics.size());
+    assertEquals(1.0, bulkRequestSizeBytesMetrics.get(0).getValue(), 0);
+    assertEquals(309.0, bulkRequestSizeBytesMetrics.get(1).getValue(), 0);
+    assertEquals(309.0, bulkRequestSizeBytesMetrics.get(2).getValue(), 0);
 
     // Check restart for index already exists
     sink = new OpenSearchSink(pluginSetting);


### PR DESCRIPTION
Signed-off-by: Han Jiang <jianghan@amazon.com>

### Description
Having the OpenSearch Sink emit a metric, bulkRequestSizeBytes, right before the request sending the batch to OpenSearch.

 
### Issues Resolved
https://github.com/opensearch-project/data-prepper/issues/571

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
