### PR TITLE
Support maps which are not present in the YAML

### DIFF
--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashMappingModel.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashMappingModel.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -26,11 +27,11 @@ class LogstashMappingModel implements LogstashAttributesMappings {
 
     @JsonProperty
     @JsonSetter(nulls = Nulls.AS_EMPTY)
-    private Map<String, String> mappedAttributeNames;
+    private Map<String, String> mappedAttributeNames = new HashMap<>();
 
     @JsonProperty
     @JsonSetter(nulls = Nulls.AS_EMPTY)
-    private Map<String, Object> additionalAttributes;
+    private Map<String, Object> additionalAttributes = new HashMap<>();
 
     public String getPluginName() {
         return pluginName;

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/LogstashMappingModelTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/LogstashMappingModelTest.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 
@@ -42,10 +44,15 @@ class LogstashMappingModelTest {
         assertThat(logstashMappingModel.getAdditionalAttributes().get("addB"), equalTo("staticValueB"));
     }
 
-    @Test
-    void deserialize_from_JSON_with_null_values_has_empty_lists() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "sample-with-nulls.mapping.yaml",
+            "sample-with-empty-maps.mapping.yaml"
+    })
+    void deserialize_from_JSON_with_null_values_has_empty_maps(final String mappingResource) throws IOException {
 
-        final LogstashMappingModel logstashMappingModel = objectMapper.readValue(this.getClass().getResourceAsStream("sample-with-nulls.mapping.yaml"), LogstashMappingModel.class);
+        final LogstashMappingModel logstashMappingModel =
+                objectMapper.readValue(this.getClass().getResourceAsStream(mappingResource), LogstashMappingModel.class);
 
         assertThat(logstashMappingModel.getPluginName(), equalTo("samplePlugin"));
         assertThat(logstashMappingModel.getAttributesMapperClass(), equalTo("org.opensearch.dataprepper.Placeholder"));

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/mapping/sample-with-empty-maps.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/mapping/sample-with-empty-maps.mapping.yaml
@@ -1,0 +1,2 @@
+pluginName: samplePlugin
+attributesMapperClass: org.opensearch.dataprepper.Placeholder


### PR DESCRIPTION
### Description

This is related to #574. Jackson was not setting the value when not present, so the maps were still empty. The previous PR only handled the situation where the maps were explicitly null.
 
### Issues Resolved

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
