### PR TITLE
Fixed a NPE in LogstashVisitor for attributes without value

### DIFF
--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/parser/LogstashVisitor.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/parser/LogstashVisitor.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.LinkedHashMap;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -23,7 +24,7 @@ import java.util.stream.Collectors;
  * @since 1.2
  */
 @SuppressWarnings("rawtypes")
-class LogstashVisitor extends LogstashBaseVisitor {
+public class LogstashVisitor extends LogstashBaseVisitor {
 
     @Override
     public Object visitConfig(final LogstashParser.ConfigContext configContext) {
@@ -65,6 +66,7 @@ class LogstashVisitor extends LogstashBaseVisitor {
         final String pluginName = pluginContext.name().getText();
         final List<LogstashAttribute> logstashAttributeList = pluginContext.attributes().attribute().stream()
                 .map(attribute -> (LogstashAttribute) visitAttribute(attribute))
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
         return LogstashPlugin.builder()
@@ -77,6 +79,9 @@ class LogstashVisitor extends LogstashBaseVisitor {
     public Object visitAttribute(final LogstashParser.AttributeContext attributeContext) {
         LogstashValueType logstashValueType = null;
         Object value = null;
+
+        if(attributeContext.value() == null)
+            return null;
 
         if (attributeContext.value().getChild(0) instanceof LogstashParser.ArrayContext) {
             logstashValueType = LogstashValueType.ARRAY;

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/parser/LogstashVisitorTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/parser/LogstashVisitorTest.java
@@ -4,11 +4,14 @@ import org.antlr.v4.runtime.tree.TerminalNodeImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -186,6 +189,24 @@ class LogstashVisitorTest {
     }
 
     @Test
+    void visit_plugin_with_null_attribute() {
+        given(pluginContextMock.name()).willReturn(nameContextMock);
+        given(nameContextMock.getText()).willReturn(TestDataProvider.RANDOM_STRING_1);
+
+        final LogstashParser.AttributeContext attributeContext = mock(LogstashParser.AttributeContext.class);
+        given(pluginContextMock.attributes()).willReturn(attributesContextMock);
+        when(attributesContextMock.attribute()).thenReturn(Collections.singletonList(attributeContext));
+
+        when(logstashVisitor.visitAttribute(attributeContext))
+                .thenReturn(null);
+
+        final LogstashPlugin actualLogstashPlugin = (LogstashPlugin) logstashVisitor.visitPlugin(pluginContextMock);
+        assertThat(actualLogstashPlugin, notNullValue());
+        assertThat(actualLogstashPlugin.getAttributes(), notNullValue());
+        assertThat(actualLogstashPlugin.getAttributes().size(), equalTo(0));
+    }
+
+    @Test
     void visit_plugin_with_one_array_context_attribute_test() {
         given(pluginContextMock.name()).willReturn(nameContextMock);
         given(nameContextMock.getText()).willReturn(TestDataProvider.RANDOM_STRING_1);
@@ -253,6 +274,12 @@ class LogstashVisitorTest {
             assertThat(actualLogstashPlugin.getAttributes().get(i).getAttributeValue().getAttributeValueType(),
                     equalTo(expectedLogstashPlugin.getAttributes().get(i).getAttributeValue().getAttributeValueType()));
         }
+    }
+
+    @Test
+    void visit_attribute_without_a_value_returns_null() {
+        assertThat(logstashVisitor.visitAttribute(attributeContextMock),
+            nullValue());
     }
 
     @Test


### PR DESCRIPTION
### Description

Some Logstash Configurations are parsing with an `LogstashParser.AttributeContext` without a value. This PR returns a null attribute in such cases and also filters these out.
 
### Issues Resolved

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
