### PR TITLE
Fix issues with extra quotes in Logstash converted YAML files.

### DIFF
--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/parser/LogstashVisitor.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/parser/LogstashVisitor.java
@@ -63,7 +63,7 @@ public class LogstashVisitor extends LogstashBaseVisitor {
 
     @Override
     public Object visitPlugin(final LogstashParser.PluginContext pluginContext) {
-        final String pluginName = pluginContext.name().getText();
+        final String pluginName = normalizeText(pluginContext.name().getText());
         final List<LogstashAttribute> logstashAttributeList = pluginContext.attributes().attribute().stream()
                 .map(attribute -> (LogstashAttribute) visitAttribute(attribute))
                 .filter(Objects::nonNull)
@@ -113,7 +113,7 @@ public class LogstashVisitor extends LogstashBaseVisitor {
                 .build();
 
         return LogstashAttribute.builder()
-                .attributeName(attributeContext.name().getText())
+                .attributeName(normalizeText(attributeContext.name().getText()))
                 .attributeValue(logstashAttributeValue)
                 .build();
     }

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/parser/LogstashVisitor.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/parser/LogstashVisitor.java
@@ -104,7 +104,7 @@ public class LogstashVisitor extends LogstashBaseVisitor {
         }
         else if (attributeContext.value().STRING() != null && attributeContext.value().getText().equals(attributeContext.value().STRING().toString())) {
             logstashValueType = LogstashValueType.STRING;
-            value = attributeContext.value().getText().replaceAll("^\"|\"$|^'|'$", "");
+            value = normalizeText(attributeContext.value().getText());
         }
 
         final LogstashAttributeValue logstashAttributeValue =  LogstashAttributeValue.builder()
@@ -122,6 +122,7 @@ public class LogstashVisitor extends LogstashBaseVisitor {
     public Object visitArray(final LogstashParser.ArrayContext arrayContext) {
         return arrayContext.value().stream()
                 .map(RuleContext::getText)
+                .map(this::normalizeText)
                 .collect(Collectors.toList());
     }
 
@@ -135,7 +136,7 @@ public class LogstashVisitor extends LogstashBaseVisitor {
         final Map<String, Object> hashEntries = new LinkedHashMap<>();
 
         hashentriesContext.hashentry().forEach(hashentryContext -> {
-            final String key = hashentryContext.hashname().getText();
+            final String key = normalizeText(hashentryContext.hashname().getText());
             final Object value = visitHashentry(hashentryContext);
             hashEntries.put(key, value);
         });
@@ -148,6 +149,10 @@ public class LogstashVisitor extends LogstashBaseVisitor {
         if (hashentryContext.value().getChild(0) instanceof LogstashParser.ArrayContext)
             return visitArray(hashentryContext.value().array());
 
-        return hashentryContext.value().getText();
+        return normalizeText(hashentryContext.value().getText());
+    }
+
+    private String normalizeText(final String unNormalizedLogstashText) {
+        return unNormalizedLogstashText.replaceAll("^\"|\"$|^'|'$", "");
     }
 }

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/parser/LogstashVisitorTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/parser/LogstashVisitorTest.java
@@ -280,6 +280,17 @@ class LogstashVisitorTest {
     }
 
     @Test
+    void visit_plugin_with_quoted_pluginName_returns_it_unquoted() {
+        given(pluginContextMock.name()).willReturn(nameContextMock);
+        given(nameContextMock.getText()).willReturn(wrapInQuotes(TestDataProvider.RANDOM_STRING_1));
+        given(pluginContextMock.attributes()).willReturn(attributesContextMock);
+
+        final LogstashPlugin actualLogstashPlugin = (LogstashPlugin) logstashVisitor.visitPlugin(pluginContextMock);
+
+        assertThat(actualLogstashPlugin.getPluginName(), equalTo(TestDataProvider.RANDOM_STRING_1));
+    }
+
+    @Test
     void visit_attribute_without_a_value_returns_null() {
         assertThat(logstashVisitor.visitAttribute(attributeContextMock),
             nullValue());
@@ -408,6 +419,21 @@ class LogstashVisitorTest {
     }
 
     @Test
+    void visitAttribute_with_quoted_attribute_name_returns_unquoted() {
+        given(attributeContextMock.name()).willReturn(nameContextMock);
+        given(nameContextMock.getText()).willReturn(wrapInQuotes(TestDataProvider.RANDOM_STRING_1));
+        given(attributeContextMock.value()).willReturn(valueContextMock);
+        given(valueContextMock.STRING()).willReturn(terminalNodeMock);
+        given(valueContextMock.getText()).willReturn(TestDataProvider.RANDOM_STRING_2);
+        given(valueContextMock.STRING().toString()).willReturn(TestDataProvider.RANDOM_STRING_2);
+
+        final LogstashAttribute actualLogstashAttribute = (LogstashAttribute) logstashVisitor.visitAttribute(attributeContextMock);
+
+        assertThat(actualLogstashAttribute.getAttributeName(),
+                equalTo(TestDataProvider.RANDOM_STRING_1));
+    }
+
+    @Test
     void visit_array_with_empty_array_returns_empty_list_test() {
         given(arrayContextMock.value()).willReturn(Collections.emptyList());
         Object actualList = logstashVisitor.visitArray(arrayContextMock);
@@ -439,7 +465,7 @@ class LogstashVisitorTest {
     }
 
     @Test
-    void visit_array_with_array_of_with_quoted_strings_returns_them_unquoted() {
+    void visitArray_with_with_quoted_strings_returns_them_unquoted() {
         List<LogstashParser.ValueContext> valueContextList = new LinkedList<>(Arrays.asList(arrayValueContextMock1, arrayValueContextMock2));
 
         given(arrayContextMock.value()).willReturn(valueContextList);

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/parser/LogstashVisitorTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/parser/LogstashVisitorTest.java
@@ -73,6 +73,9 @@ class LogstashVisitorTest {
     @Mock
     private LogstashParser.HashnameContext hashnameContextMock = mock(LogstashParser.HashnameContext.class);
 
+    private static String wrapInQuotes(final String inputString) {
+        return "\"" + inputString + "\"";
+    }
 
     @Test
     void visit_config_return_logstash_configuration_object_test() {
@@ -389,8 +392,8 @@ class LogstashVisitorTest {
         given(nameContextMock.getText()).willReturn(TestDataProvider.RANDOM_STRING_1);
         given(attributeContextMock.value()).willReturn(valueContextMock);
         given(valueContextMock.STRING()).willReturn(terminalNodeMock);
-        given(valueContextMock.getText()).willReturn("\"" + TestDataProvider.RANDOM_STRING_2 + "\"");
-        given(valueContextMock.STRING().toString()).willReturn("\"" + TestDataProvider.RANDOM_STRING_2 + "\"");
+        given(valueContextMock.getText()).willReturn(wrapInQuotes(TestDataProvider.RANDOM_STRING_2));
+        given(valueContextMock.STRING().toString()).willReturn(wrapInQuotes(TestDataProvider.RANDOM_STRING_2));
 
         LogstashAttribute actualLogstashAttribute = (LogstashAttribute) logstashVisitor.visitAttribute(attributeContextMock);
         LogstashAttribute expectedLogstashAttribute = TestDataProvider.attributeWithStringTypeValueData();
@@ -436,6 +439,19 @@ class LogstashVisitorTest {
     }
 
     @Test
+    void visit_array_with_array_of_with_quoted_strings_returns_them_unquoted() {
+        List<LogstashParser.ValueContext> valueContextList = new LinkedList<>(Arrays.asList(arrayValueContextMock1, arrayValueContextMock2));
+
+        given(arrayContextMock.value()).willReturn(valueContextList);
+        given(arrayValueContextMock1.getText()).willReturn(wrapInQuotes(TestDataProvider.RANDOM_STRING_1));
+        given(arrayValueContextMock2.getText()).willReturn(wrapInQuotes(TestDataProvider.RANDOM_STRING_2));
+
+        Object actualList = logstashVisitor.visitArray(arrayContextMock);
+
+        assertThat(actualList, equalTo(TestDataProvider.arrayData()));
+    }
+
+    @Test
     void visit_hash_entries_with_string_value_returns_map_of_hash_entries_test() {
         List<LogstashParser.HashentryContext> hashentryContextList = new LinkedList<>(
                 Collections.singletonList(hashentryContextMock));
@@ -445,6 +461,22 @@ class LogstashVisitorTest {
         given(hashnameContextMock.getText()).willReturn(TestDataProvider.RANDOM_STRING_1);
         given(hashentryContextMock.value()).willReturn(valueContextMock);
         given(valueContextMock.getText()).willReturn(TestDataProvider.RANDOM_STRING_2);
+
+        Object actualMap = logstashVisitor.visitHashentries(hashentriesContextMock);
+
+        assertThat(actualMap, equalTo(TestDataProvider.hashEntriesStringData()));
+    }
+
+    @Test
+    void visit_hash_entries_with_quoted_values_returns_unquoted() {
+        List<LogstashParser.HashentryContext> hashentryContextList = new LinkedList<>(
+                Collections.singletonList(hashentryContextMock));
+
+        given(hashentriesContextMock.hashentry()).willReturn(hashentryContextList);
+        given(hashentryContextMock.hashname()).willReturn(hashnameContextMock);
+        given(hashnameContextMock.getText()).willReturn(wrapInQuotes(TestDataProvider.RANDOM_STRING_1));
+        given(hashentryContextMock.value()).willReturn(valueContextMock);
+        given(valueContextMock.getText()).willReturn(wrapInQuotes(TestDataProvider.RANDOM_STRING_2));
 
         Object actualMap = logstashVisitor.visitHashentries(hashentriesContextMock);
 
@@ -476,6 +508,16 @@ class LogstashVisitorTest {
     void visit_hash_entry_with_value_type_string_returns_string_object_test() {
         given(hashentryContextMock.value()).willReturn(valueContextMock);
         given(valueContextMock.getText()).willReturn(TestDataProvider.RANDOM_STRING_2);
+
+        Object actualValue = logstashVisitor.visitHashentry(hashentryContextMock);
+
+        assertThat(actualValue, equalTo(TestDataProvider.hashEntryStringData()));
+    }
+
+    @Test
+    void visit_hash_entry_with_quoted_text_returns_it_unquoted() {
+        given(hashentryContextMock.value()).willReturn(valueContextMock);
+        given(valueContextMock.getText()).willReturn(wrapInQuotes(TestDataProvider.RANDOM_STRING_2));
 
         Object actualValue = logstashVisitor.visitHashentry(hashentryContextMock);
 


### PR DESCRIPTION
### Description

Normalizes strings by removing quotes which should not be present.
 
### Issues Resolved

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
