### PR TITLE
ENH: integrate named captures into grok logstash mapper

### DIFF
--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/GrokNamedCapturesUtil.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/GrokNamedCapturesUtil.java
@@ -4,6 +4,7 @@ package org.opensearch.dataprepper.logstash.mapping;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -49,7 +50,7 @@ class GrokNamedCapturesUtil {
         }
 
         public Map<String, String> getMappedPatternDefinitions() {
-            return mappedPatternDefinitions;
+            return Collections.unmodifiableMap(mappedPatternDefinitions);
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: qchea <qchea@amazon.com>

### Description
This PR enhanced `GrokLogstashPluginAttributesMapper` with named captures by integrating GrokNamedCapturesUtil.
 
### Issues Resolved
#466 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
