### PR TITLE
Added integration tests for the Logstash Configuration Converter

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelinesDataFlowModel.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelinesDataFlowModel.java
@@ -1,14 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.amazon.dataprepper.model.configuration;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
+import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Model for the Pipelines data flow. This has the format of the Data Prepper
+ * pipelines.yaml file.
+ *
+ * @since 1.2
+ */
 public class PipelinesDataFlowModel {
 
     @JsonAnySetter
-    private Map<String, PipelineModel> pipelines;
+    private Map<String, PipelineModel> pipelines = new HashMap<>();
+
+    /**
+     * Jackson will use this constructor.
+     */
+    @JsonCreator
+    @SuppressWarnings("unused")
+    private PipelinesDataFlowModel() { }
 
     public PipelinesDataFlowModel(final Map<String, PipelineModel> pipelines) {
         this.pipelines = pipelines;
@@ -18,5 +38,4 @@ public class PipelinesDataFlowModel {
     public Map<String, PipelineModel> getPipelines() {
         return pipelines;
     }
-
 }

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
@@ -14,9 +15,11 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
 
 class PipelinesDataFlowModelTest {
 
+    private static final String RESOURCE_PATH = "/pipelines_data_flow_serialized.yaml";
     private ObjectMapper objectMapper;
 
     @BeforeEach
@@ -39,11 +42,43 @@ class PipelinesDataFlowModelTest {
 
         final String serializedString = objectMapper.writeValueAsString(pipelinesDataFlowModel);
 
-        InputStream inputStream = this.getClass().getResourceAsStream("/pipelines_data_flow_serialized.yaml");
+        InputStream inputStream = this.getClass().getResourceAsStream(RESOURCE_PATH);
 
         final String expectedYaml = PluginModelTests.convertInputStreamToString(inputStream);
 
         assertThat(serializedString, notNullValue());
         assertThat(serializedString, equalTo(expectedYaml));
+    }
+
+    @Test
+    void deserialize_PipelinesDataFlowModel() throws IOException {
+
+        final InputStream inputStream = this.getClass().getResourceAsStream(RESOURCE_PATH);
+
+        final PipelinesDataFlowModel actualModel = objectMapper.readValue(inputStream, PipelinesDataFlowModel.class);
+
+        final String pipelineName = "test-pipeline";
+
+        assertThat(actualModel, notNullValue());
+        assertThat(actualModel.getPipelines(), notNullValue());
+        assertThat(actualModel.getPipelines().size(), equalTo(1));
+        assertThat(actualModel.getPipelines(), hasKey(pipelineName));
+
+        final PipelineModel pipelineModel = actualModel.getPipelines().get(pipelineName);
+
+        assertThat(pipelineModel, notNullValue());
+
+        assertThat(pipelineModel.getSource(), notNullValue());
+        assertThat(pipelineModel.getSource().getPluginName(), equalTo("testSource"));
+
+        assertThat(pipelineModel.getPreppers(), notNullValue());
+        assertThat(pipelineModel.getPreppers().size(), equalTo(1));
+        assertThat(pipelineModel.getPreppers().get(0), notNullValue());
+        assertThat(pipelineModel.getPreppers().get(0).getPluginName(), equalTo("testPrepper"));
+
+        assertThat(pipelineModel.getSinks(), notNullValue());
+        assertThat(pipelineModel.getSinks().size(), equalTo(1));
+        assertThat(pipelineModel.getSinks().get(0), notNullValue());
+        assertThat(pipelineModel.getSinks().get(0).getPluginName(), equalTo("testSink"));
     }
 }

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/LogstashConfigConverterIT.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/LogstashConfigConverterIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.logstash;
+
+import com.amazon.dataprepper.model.configuration.PipelinesDataFlowModel;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+
+public class LogstashConfigConverterIT {
+
+    private static final String OUTPUT_DIRECTORY = "build/resources/test/org/opensearch/dataprepper/logstash/";
+
+    private LogstashConfigConverter createObjectUnderTest() {
+        return new LogstashConfigConverter();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(LogstashToYamlPathsProviders.class)
+    void convertLogstashConfigurationToPipeline_should_return_converted_file_with_the_expected_YAML(final String configurationPath, final String expectedYamlPath) throws IOException {
+        final String actualPath = createObjectUnderTest().convertLogstashConfigurationToPipeline(configurationPath, OUTPUT_DIRECTORY);
+
+        assertThat(actualPath, notNullValue());
+
+        final String dataPrepperConfigurationString = Files.readString(Path.of(actualPath));
+        final String expectedDataPrepperConfigurationString = Files.readString(Path.of(expectedYamlPath));
+
+        assertThat(dataPrepperConfigurationString, equalTo(expectedDataPrepperConfigurationString));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(LogstashPathsProviders.class)
+    void convertLogstashConfigurationToPipeline_should_return_valid_PipelinesDataFlowModel_with_the_single_known_pipeline(final String configurationPath) throws IOException {
+        final String actualPath = createObjectUnderTest().convertLogstashConfigurationToPipeline(configurationPath, OUTPUT_DIRECTORY);
+
+        assertThat(actualPath, notNullValue());
+
+        final String dataPrepperConfigurationString = Files.readString(Path.of(actualPath));
+
+        assertThat(dataPrepperConfigurationString, notNullValue());
+
+        final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+
+        final PipelinesDataFlowModel pipelinesDataFlowModel = objectMapper.readValue(dataPrepperConfigurationString, PipelinesDataFlowModel.class);
+        assertThat(pipelinesDataFlowModel, notNullValue());
+        assertThat(pipelinesDataFlowModel.getPipelines(), notNullValue());
+        assertThat(pipelinesDataFlowModel.getPipelines().size(), equalTo(1));
+        assertThat(pipelinesDataFlowModel.getPipelines(), hasKey("logstash-converted-pipeline"));
+        assertThat(pipelinesDataFlowModel.getPipelines().get("logstash-converted-pipeline"), notNullValue());
+    }
+
+
+    /**
+     * Provides arguments for a Logstash configuration path. This will include
+     * all Logstash configuration files, whether they have an expected YAML or not.
+     */
+    static class LogstashPathsProviders implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return provideLogstashConfigurationFiles()
+                    .map(Arguments::of);
+        }
+    }
+
+    /**
+     * Provides JUnit5 arguments for Logstash configuration paths along with the
+     * expected YAML path.
+     */
+    static class LogstashToYamlPathsProviders implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return provideLogstashConfigurationFiles()
+                    .filter(logstashPath -> Files.exists(Paths.get(getExpectedFileName(logstashPath))))
+                    .map(logstashPath -> Arguments.of(logstashPath, getExpectedFileName(logstashPath)));
+        }
+
+        private String getExpectedFileName(final String file) {
+            return file.replace(".conf", ".expected.yaml");
+        }
+    }
+
+    private static Stream<String> provideLogstashConfigurationFiles() {
+        final File directoryPath = new File("src/test/resources/org/opensearch/dataprepper/logstash");
+
+        return Arrays.stream(Objects.requireNonNull(directoryPath.listFiles((dir, name) -> name.endsWith(".conf"))))
+                .filter(File::isFile)
+                .map(File::getPath);
+    }
+}

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/LogstashConfigConverterIT.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/LogstashConfigConverterIT.java
@@ -28,6 +28,19 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
 
+/**
+ * Integration tests for the Logstash Configuration Converter.
+ * <p>
+ * These tests use all the <code>.conf</code> files from the
+ * <code>src/test/resources/org/opensearch/dataprepper/logstash</code> directory.
+ * Each file will be tested by converting and then validating that it can deserialize
+ * into a {@link PipelinesDataFlowModel} instance. Additionally, any files with a
+ * matching <code>.expected.yaml</code> file will be compared against that YAML file.
+ * <p>
+ * You can add more test cases by adding both a <code>.conf</code> file and a
+ * <code>.expected.yaml</code> file. If the mapping is non-deterministic, you can forego
+ * adding the <code>.expected.yaml</code> file.
+ */
 public class LogstashConfigConverterIT {
 
     private static final String OUTPUT_DIRECTORY = "build/resources/test/org/opensearch/dataprepper/logstash/";

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/empty.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/empty.conf
@@ -1,0 +1,6 @@
+input {
+}
+filter {
+}
+output {
+}

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/empty.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/empty.expected.yaml
@@ -1,0 +1,4 @@
+logstash-converted-pipeline:
+  source: null
+  prepper: []
+  sink: []

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/http-to-opensearch.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/http-to-opensearch.conf
@@ -1,0 +1,12 @@
+input {
+    http {
+    }
+}
+output {
+    elasticsearch {
+        hosts => ["https://localhost:19000"]
+        user => myuser
+        password => mypassword
+        index => "simple-pipeline"
+    }
+}

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/http-to-opensearch.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/http-to-opensearch.expected.yaml
@@ -1,0 +1,13 @@
+logstash-converted-pipeline:
+  source:
+    http:
+      max_connection_count: 500
+      request_timeout: 10000
+  prepper: []
+  sink:
+    - opensearch:
+        hosts:
+          - "https://localhost:19000"
+        username: "myuser"
+        password: "mypassword"
+        index: "simple-pipeline"

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-multiple-preppers-sinks.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-multiple-preppers-sinks.conf
@@ -1,0 +1,29 @@
+input {
+    http {
+    }
+}
+filter {
+    grok {
+        match => {"log" => "%{COMBINEDAPACHELOG}"}
+    }
+    grok {
+        pattern_definitions => {
+            "CUSTOMYEAR" => "(?>\d\d){1,2}"
+            "CUSTOMMINUTE" => "(?:[0-5][0-9])"
+        }
+        match => {"otherlog" => "%{DATA:message} %{CUSTOMYEAR:year} %{CUSTOMMINUTE:minute}"}
+    }
+}
+output {
+    elasticsearch {
+        hosts => ["https://localhost:9200"]
+        user => admin
+        password => mypassword
+        index => "logingest"
+    }
+    amazon_es {
+        hosts => ["fakedomain.us-east-1.es.amazonaws.com"]
+        region => "us-east-1"
+        index => "logingest"
+    }
+}

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-multiple-preppers-sinks.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-multiple-preppers-sinks.expected.yaml
@@ -1,0 +1,31 @@
+logstash-converted-pipeline:
+  source:
+    http:
+      max_connection_count: 500
+      request_timeout: 10000
+  prepper:
+    - grok:
+        match:
+          log:
+            - "%{COMBINEDAPACHELOG}"
+    - grok:
+        match:
+          otherlog:
+            - "%{DATA:message} %{CUSTOMYEAR:year} %{CUSTOMMINUTE:minute}"
+        pattern_definitions:
+          CUSTOMMINUTE: "(?:[0-5][0-9])"
+          CUSTOMYEAR: "(?>\\d\\d){1,2}"
+  sink:
+    - opensearch:
+        hosts:
+          - "https://localhost:9200"
+        username: "admin"
+        password: "mypassword"
+        index: "logingest"
+    - opensearch:
+        aws_sigv4: true
+        insecure: false
+        hosts:
+          - "fakedomain.us-east-1.es.amazonaws.com"
+        aws_region: "us-east-1"
+        index: "logingest"

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-amazon-opensearch.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-amazon-opensearch.conf
@@ -1,0 +1,16 @@
+input {
+    http {
+    }
+}
+filter {
+    grok {
+        match => {"log" => "%{COMBINEDAPACHELOG}"}
+    }
+}
+output {
+    amazon_es {
+        hosts => ["fakedomain.us-east-1.es.amazonaws.com"]
+        region => "us-east-1"
+        index => "my-index"
+    }
+}

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-amazon-opensearch.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-amazon-opensearch.expected.yaml
@@ -1,0 +1,18 @@
+logstash-converted-pipeline:
+  source:
+    http:
+      max_connection_count: 500
+      request_timeout: 10000
+  prepper:
+    - grok:
+        match:
+          log:
+            - "%{COMBINEDAPACHELOG}"
+  sink:
+    - opensearch:
+        aws_sigv4: true
+        insecure: false
+        hosts:
+          - "fakedomain.us-east-1.es.amazonaws.com"
+        aws_region: "us-east-1"
+        index: "my-index"

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch-named-captures.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch-named-captures.conf
@@ -1,0 +1,18 @@
+input {
+    http {
+    }
+}
+filter {
+    grok {
+        match => {"log" => "%{COMBINEDAPACHELOG}"}
+        match => {"message" => "(?<my_file>[A-Za-z0-9_.-]+java)"}
+    }
+}
+output {
+    elasticsearch {
+        hosts => ["https://localhost:9200"]
+        user => admin
+        password => admin
+        index => "log-ingest"
+    }
+}

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.conf
@@ -1,0 +1,17 @@
+input {
+    http {
+    }
+}
+filter {
+    grok {
+        match => {"log" => "%{COMBINEDAPACHELOG}"}
+    }
+}
+output {
+    elasticsearch {
+        hosts => ["https://localhost:19000"]
+        user => myuser
+        password => mypassword
+        index => "simple-pipeline"
+    }
+}

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.expected.yaml
@@ -1,0 +1,17 @@
+logstash-converted-pipeline:
+  source:
+    http:
+      max_connection_count: 500
+      request_timeout: 10000
+  prepper:
+    - grok:
+        match:
+          log:
+            - "%{COMBINEDAPACHELOG}"
+  sink:
+    - opensearch:
+        hosts:
+          - "https://localhost:19000"
+        username: "myuser"
+        password: "mypassword"
+        index: "simple-pipeline"


### PR DESCRIPTION
### Description

* Added an integration test which converts Logstash configuration files and compares against the PipelineDataFlowModel.
* Added an integration test which converts Logstash configuration files and compares them against expected YAML files.
* Updated the PipelineDataFlowModel to deserialize correctly, and added Javadocs
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
