### PR TITLE
Support unsigned Maven publication. Set groupId to org.opensearch.dataprepper

### DIFF
--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -12,4 +12,4 @@ ext.versionMap = [
 ]
 
 ext.coreProjects = [project(':data-prepper-api'), project(':data-prepper-core'), project('data-prepper-plugins:common')]
-ext.mavenArtifactProjects = [project(':data-prepper-api'), project('data-prepper-plugins:common')]
+ext.mavenArtifactProjects = [project(':data-prepper-api')]

--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//preferably try to main the alphabetical order
+//preferably try to maintain the alphabetical order
 ext.versionMap = [
         junitJupiter : '5.7.2',
         mockito : '3.11.2',
@@ -12,3 +12,4 @@ ext.versionMap = [
 ]
 
 ext.coreProjects = [project(':data-prepper-api'), project(':data-prepper-core'), project('data-prepper-plugins:common')]
+ext.mavenArtifactProjects = [project(':data-prepper-api'), project('data-prepper-plugins:common')]

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 plugins {
     id 'com.diffplug.spotless' version '5.17.0'
 }
@@ -11,7 +12,7 @@ allprojects {
     apply plugin: 'checkstyle'
     apply plugin: 'com.diffplug.spotless'
 
-    group = 'com.amazon'
+    group = 'org.opensearch.dataprepper'
     
     repositories {
         mavenCentral()
@@ -35,6 +36,7 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'maven-publish'
     apply plugin: 'jacoco'
     sourceCompatibility = '1.8'
     spotless {
@@ -91,6 +93,43 @@ configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
         implementation platform('com.fasterxml.jackson:jackson-bom:2.12.5')
         implementation platform('software.amazon.awssdk:bom:2.17.15')
         implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.67')
+    }
+}
+
+configure(mavenArtifactProjects) {
+    java {
+        // TODO: Add once Javadocs are working
+        //withJavadocJar()
+        withSourcesJar()
+    }
+
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                from components.java
+                pom {
+                    name = project.name
+                    description = "Data Prepper project: ${project.name}"
+                    url = 'https://github.com/opensearch-project/data-prepper'
+                    licenses {
+                        license {
+                            name = 'The Apache Software License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            distribution = 'repo'
+                        }
+                    }
+                    developers {
+                        developer {
+                            name = 'OpenSearch'
+                            url = 'https://github.com/opensearch-project'
+                        }
+                    }
+                    scm {
+                        url = 'https://github.com/opensearch-project/data-prepper'
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -98,8 +98,7 @@ configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
 
 configure(mavenArtifactProjects) {
     java {
-        // TODO: Add once Javadocs are working
-        //withJavadocJar()
+        withJavadocJar()
         withSourcesJar()
     }
 

--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -3,15 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-plugins {
-
-}
 dependencies {
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.0'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }
+
 jacocoTestCoverageVerification {
     dependsOn jacocoTestReport
     violationRules {

--- a/docs/plugin_development.md
+++ b/docs/plugin_development.md
@@ -28,3 +28,17 @@ If your plugin requires no arguments, it can use a default constructor which wil
 
 Additionally, the plugin framework can create a plugin using a single parameter constructor with
 a single parameter of type `PluginSetting`. This behavior is deprecated and planned for removal.
+
+## Deploying Maven Artifacts
+
+If you are developing a plugin in another Gradle project your project will depend on at least the `data-prepper-api` project.
+You can deploy this artifact locally so that you can add it as a dependency in your other project.
+
+Run the following command:
+
+```
+./gradlew publishToMavenLocal
+```
+
+The Maven artifacts will then be available in your local Maven repository. In standard environments
+they will be available at `${USER}/.m2/repository/org/opensearch/dataprepper/`.


### PR DESCRIPTION
### Description

* Support unsigned Maven publication
* Configured the Maven POM to meet Sonatype requirements, based on OpenSearch values
* Changed the group Id to `org.opensearch.dataprepper`.
 
### Issues Resolved

Supports #421 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
