### PR TITLE
Fixes javadocs errors and updates deprecated Gradle dependency config…

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
@@ -61,7 +61,7 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
      *
      * @param record          the Record to add
      * @param timeoutInMillis how long to wait before giving up
-     * @throws TimeoutException
+     * @throws TimeoutException Exception thrown when the operation times out
      */
     @Override
     public void write(T record, int timeoutInMillis) throws TimeoutException {
@@ -135,20 +135,20 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
     }
 
     /**
-     * This method should implement the logic for writing to the  buffer
+     * This method should implement the logic for writing to the buffer
      *
      * @param record          Record to write to buffer
      * @param timeoutInMillis Timeout for write operation in millis
-     * @throws TimeoutException
+     * @throws TimeoutException Exception thrown when the operation times out
      */
     public abstract void doWrite(T record, int timeoutInMillis) throws TimeoutException;
 
     /**
-     * This method should implement the logic for writing to the  buffer
+     * This method should implement the logic for writing to the buffer
      *
      * @param records          Collection of records to write to buffer
      * @param timeoutInMillis Timeout for write operation in millis
-     * @throws Exception
+     * @throws Exception Exception thrown when the operation times out
      */
     public abstract void doWriteAll(Collection<T> records, int timeoutInMillis) throws Exception;
 

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/Buffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/Buffer.java
@@ -15,7 +15,6 @@ import java.util.concurrent.TimeoutException;
 /**
  * Buffer queues the records between TI components and acts as a layer between source and prepper/sink. Buffer can
  * be in-memory, disk based or other a standalone implementation.
- * <p>
  */
 public interface Buffer<T extends Record<?>> {
     /**

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/SizeOverflowException.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/SizeOverflowException.java
@@ -8,7 +8,6 @@ package com.amazon.dataprepper.model.buffer;
 /**
  * Thrown to indicate the size of the data to be written into the {@link Buffer} is
  * beyond Buffer's maximum capacity.
- * <p>
  */
 public class SizeOverflowException extends Exception {
     public SizeOverflowException(final String message) {

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PluginSetting.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PluginSetting.java
@@ -133,7 +133,7 @@ public class PluginSetting {
     }
 
     /**
-     * Returns the value of the specified List<String>, or {@code defaultValue} if this settings contains no value for
+     * Returns the value of the specified {@literal List<String>}, or {@code defaultValue} if this settings contains no value for
      * the attribute.
      *
      * @param attribute    name of the attribute
@@ -153,7 +153,7 @@ public class PluginSetting {
     }
 
     /**
-     * Returns the value of the specified Map<String, String> object, or {@code defaultValue} if this settings contains no value for
+     * Returns the value of the specified {@literal Map<String, String> object}, or {@code defaultValue} if this settings contains no value for
      * the attribute.
      *
      * @param attribute    name of the attribute
@@ -179,7 +179,7 @@ public class PluginSetting {
     }
 
     /**
-     * Returns the value of the specified Map<String, List<String>>, or {@code defaultValue} if this settings contains no value for
+     * Returns the value of the specified {@literal Map<String, List<String>>}, or {@code defaultValue} if this settings contains no value for
      * the attribute.
      *
      * @param attribute    name of the attribute

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/Event.java
@@ -13,7 +13,7 @@ import java.util.List;
  * <p>
  * Data Prepper will be migrating away from the original use of {@link com.amazon.dataprepper.model.record.Record}s.
  * Internal interfaces for {@link com.amazon.dataprepper.model.prepper.Prepper}, {@link com.amazon.dataprepper.model.buffer.Buffer},
- * {@link com.amazon.dataprepper.model.sink.Sink}, & {@link com.amazon.dataprepper.model.source.Source}. will be extended to support
+ * {@link com.amazon.dataprepper.model.sink.Sink} and {@link com.amazon.dataprepper.model.source.Source} will be extended to support
  * the new internal model. The use of {@link com.amazon.dataprepper.model.record.Record}s will be deprecated in 2.0.
  * <p>
  * @since 1.2
@@ -44,7 +44,7 @@ public interface Event {
      *
      * @param key the value to retrieve from
      * @param clazz the return type of elements in the list
-     * @return List<T> a list of clazz elements
+     * @return {@literal List<T>} a list of clazz elements
      * @since 1.2
      */
     <T> List<T> getList(String key, Class<T> clazz);

--- a/e2e-test/log/build.gradle
+++ b/e2e-test/log/build.gradle
@@ -150,7 +150,7 @@ task basicLogEndToEndTest(type: Test) {
 
 dependencies {
     implementation "com.github.javafaker:javafaker:1.0.2"
-    integrationTestCompile project(':data-prepper-plugins:opensearch')
+    integrationTestImplementation project(':data-prepper-plugins:opensearch')
     integrationTestImplementation "com.linecorp.armeria:armeria:1.0.0"
     integrationTestImplementation "org.awaitility:awaitility:4.0.3"
     integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${versionMap.opensearchVersion}"

--- a/e2e-test/trace/build.gradle
+++ b/e2e-test/trace/build.gradle
@@ -255,8 +255,8 @@ task serviceMapEndToEndTest(type: Test) {
 }
 
 dependencies {
-    integrationTestCompile project(':data-prepper-plugins:opensearch')
-    integrationTestCompile project(':data-prepper-plugins:otel-trace-group-prepper')
+    integrationTestImplementation project(':data-prepper-plugins:opensearch')
+    integrationTestImplementation project(':data-prepper-plugins:otel-trace-group-prepper')
     integrationTestImplementation "org.awaitility:awaitility:4.0.3"
     integrationTestImplementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
     integrationTestImplementation 'com.google.protobuf:protobuf-java-util:3.13.0'


### PR DESCRIPTION
…uration

Signed-off-by: Shivani Shukla <sshkamz@amazon.com>

### Description
* Fixes all javadocs errors in `data-prepper-plugins:common` and `data-prepper-api` and some warnings
* Updated to `implementation` since `compile` will get deprecated in Gradle 7.0. See [reference](https://docs.gradle.org/6.6.1/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations)
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
