### PR TITLE
Update No-op prepper

### DIFF
--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/NoOpPrepper.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/NoOpPrepper.java
@@ -12,20 +12,21 @@
 package com.amazon.dataprepper.plugins.prepper;
 
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
+import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.record.Record;
 
 import java.util.Collection;
 
 @DataPrepperPlugin(name = "no-op", pluginType = Prepper.class)
-public class NoOpPrepper<InputT extends Record<?>> implements Prepper<InputT, InputT> {
+public class NoOpPrepper implements Prepper<Record<Event>, Record<Event>> {
 
     public NoOpPrepper() {
 
     }
 
     @Override
-    public Collection<InputT> execute(final Collection<InputT> records) {
+    public Collection<Record<Event>> execute(final Collection<Record<Event>> records) {
         return records;
     }
 

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/PrepperFactoryTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/PrepperFactoryTests.java
@@ -43,7 +43,7 @@ public class PrepperFactoryTests {
      */
     @Test
     public void testNewSingletonPrepperClassByNameThatExists() {
-        PrepperFactory.dangerousMethod_setPluginFunction((s, c) -> new NoOpPrepper<>());
+        PrepperFactory.dangerousMethod_setPluginFunction((s, c) -> new NoOpPrepper());
 
         final PluginSetting noOpPrepperConfiguration = new PluginSetting("no-op", new HashMap<>());
         noOpPrepperConfiguration.setPipelineName(TEST_PIPELINE);


### PR DESCRIPTION
### Description
Moves the No-op prepper from using generics to consuming Record<Event>
 
### Issues Resolved
#607 
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
