### PR TITLE
Add maven local to publish repos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,9 @@ configure(mavenArtifactProjects) {
     }
 
     publishing {
+        repositories {
+            mavenLocal()
+        }
         publications {
             maven(MavenPublication) {
                 from components.java


### PR DESCRIPTION
Signed-off-by: Steven Bayer <smbayer@amazon.com>

### Description
Adds support for publishing to maven local with checksum files by running `./gradlew publish`
 
### Issues Resolved
closes #421
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
