### PR TITLE
Consistent OpenSearch, OpenSearch Dashboards, and Amazon OpenSearch Service Usage

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -1,6 +1,6 @@
 # OpenSearch sink
 
-This is the Data Prepper OpenSearch sink plugin that sends records to Elasticsearch cluster via REST client. You can use the sink to send data to Amazon Elasticsearch Service or Opendistro for Elasticsearch.
+This is the Data Prepper OpenSearch sink plugin that sends records to an OpenSearch cluster via REST client. You can use the sink to send data to OpenSearch, Amazon OpenSearch Service, or Opendistro for Elasticsearch.
 
 ## Usages
 
@@ -42,16 +42,16 @@ pipeline:
 
 The OpenSearch sink will reserve `otel-v1-apm-service-map` as index for record ingestion.
 
-### Amazon Elasticsearch Service
+### Amazon OpenSearch Service
 
-The OpenSearch sink can also be configured for Amazon Elasticsearch Service domain. See [security](security.md) for details.
+The OpenSearch sink can also be configured for an Amazon OpenSearch Service domain. See [security](security.md) for details.
 
 ```
 pipeline:
   ...
   sink:
     opensearch:
-      hosts: ["https://your-amazon-elasticssearch-service-endpoint"]
+      hosts: ["https://your-amazon-opensearch-service-endpoint"]
       aws_sigv4: true
       cert: path/to/cert
       insecure: false
@@ -61,16 +61,16 @@ pipeline:
 
 ## Configuration
 
-- `hosts`: A list of IP addresses of elasticsearch nodes.
+- `hosts`: A list of IP addresses of OpenSearch nodes.
 
-- `cert`(optional): CA certificate that is pem encoded. Accepts both .pem or .crt. This enables the client to trust the CA that has signed the certificate that ODFE is using.
+- `cert`(optional): CA certificate that is pem encoded. Accepts both .pem or .crt. This enables the client to trust the CA that has signed the certificate that the OpenSearch cluster is using.
 Default is null.
 
-- `aws_sigv4`: A boolean flag to sign the HTTP request with AWS credentials. Only applies to Amazon Elasticsearch Service. See [security](security.md) for details. Default to `false`.
+- `aws_sigv4`: A boolean flag to sign the HTTP request with AWS credentials. Only applies to Amazon OpenSearch Service. See [security](security.md) for details. Default to `false`.
 
-- `aws_region`: A String represents the region of Amazon Elasticsearch Service domain, e.g. us-west-2. Only applies to Amazon Elasticsearch Service. Defaults to `us-east-1`.
+- `aws_region`: A String represents the region of Amazon OpenSearch Service domain, e.g. us-west-2. Only applies to Amazon OpenSearch Service. Defaults to `us-east-1`.
 
-- `aws_sts_role_arn`: A IAM role arn which the sink plugin will assume to sign request to Amazon Elasticsearch. If not provided the plugin will use the default credentials.
+- `aws_sts_role_arn`: A IAM role arn which the sink plugin will assume to sign request to Amazon OpenSearch Service. If not provided the plugin will use the default credentials.
 
 - `insecure`: A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Default to `false`.
 
@@ -78,9 +78,9 @@ Default is null.
 
 - `connect_timeout`(optional): An integer value indicates the timeout in milliseconds used when requesting a connection from the connection manager. A timeout value of zero is interpreted as an infinite timeout. If this timeout value is either negative or not set, the underlying Apache HttpClient would rely on operating system settings for managing connection timeouts.
 
-- `username`(optional): A String of username used in the [internal users](https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles) of ODFE cluster. Default is null.
+- `username`(optional): A String of username used in the [internal users](https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/) of OpenSearch cluster. Default is null.
 
-- `password`(optional): A String of password used in the [internal users](https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles) of ODFE cluster. Default is null.
+- `password`(optional): A String of password used in the [internal users](https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/) of OpenSearch cluster. Default is null.
 
 - `proxy`(optional): A String of the address of a forward HTTP proxy. The format is like "<host-name-or-ip>:\<port\>". Examples: "example.com:8100", "http://example.com:8100", "112.112.112.112:8100". Note: port number cannot be omitted.
 
@@ -126,7 +126,7 @@ Default value is false. Set it to true for [Service map trace analytics](#servic
 - <a name="index"></a>`index`: A String used as index name for custom data type. Applicable and required only If index_type is explicitly `custom` or defaults to be `custom` while both `trace_analytics_raw` and `trace_analytics_service_map` are set to false.
 
 - <a name="template_file"></a>`template_file`(optional): A json file path to be read as index template for custom data ingestion. The json file content should be the json value of
-`"template"` key in the json content of elasticsearch [Index templates API](https://www.elastic.co/guide/en/elasticsearch/reference/7.8/index-templates.html), 
+`"template"` key in the json content of OpenSearch [Index templates API](https://opensearch.org/docs/latest/opensearch/index-templates/), 
 e.g. [otel-v1-apm-span-index-template.json](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/opensearch/src/main/resources/otel-v1-apm-span-index-template.json)
 
 - `number_of_shards` (optional): The number of primary shards that an index should have on the destination OpenSearch server. This parameter is effective only when `template_file` is either explicitly provided in Sink configuration or built-in. If this parameter is set, it would override the value in index template file. OpenSearch documentation has [more about this parameter](https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/create-index/).

--- a/data-prepper-plugins/opensearch/opensearch_security.md
+++ b/data-prepper-plugins/opensearch/opensearch_security.md
@@ -1,7 +1,7 @@
-## Open Distro For Elasticsearch
+## OpenSearch
 
 
-The OpenSearch sink can send trace data to opendistro-for-elasticsearch (ODFE) cluster by administrative credentials as follows:
+The OpenSearch sink can send trace data to an OpenSearch cluster by administrative credentials as follows:
 
 ```
 sink:
@@ -31,4 +31,4 @@ Note that `indices:admin/template/*` need to be in cluster permissions.
 
 ---------------
 
-With administrative privilege, one can create an internal user, a role and map the user to the role by following the ODFE [instructions](https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/).
+With administrative privilege, one can create an internal user, a role and map the user to the role by following the OpenSearch [Users and roles documentation](https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/).

--- a/data-prepper-plugins/opensearch/security.md
+++ b/data-prepper-plugins/opensearch/security.md
@@ -2,9 +2,9 @@
 
 This document provides more details about the security settings of the sink.
 
-## AWS Elasticsearch Service
+## AWS OpenSearch Service
 
-OpenSearch sink is capable of sending data to Amazon Elasticsearch domain which use Identity and Access Management. The plugin uses the default credential chain. Run `aws configure` using the AWS CLI to set your credentials. 
+OpenSearch sink is capable of sending data to an Amazon OpenSearch Service domain which use Identity and Access Management. The plugin uses the default credential chain. Run `aws configure` using the AWS CLI to set your credentials. 
 
 You should ensure that the credentials you configure have the required permissions. Below is an example Resource based policy, with required set of permissions that is required for the sink to work,
 
@@ -21,7 +21,7 @@ You should ensure that the credentials you configure have the required permissio
       "Resource": [
         "arn:aws:es:us-east-1:<AccountId>:domain/<domain-name>/otel-v1*",
         "arn:aws:es:us-east-1:<AccountId>:domain/<domain-name>/_template/otel-v1*",
-        "arn:aws:es:us-east-1:<AccountId>:domain/<domain-name>/_opendistro/_ism/policies/raw-span-policy",
+        "arn:aws:es:us-east-1:<AccountId>:domain/<domain-name>/_plugins/_ism/policies/raw-span-policy",
         "arn:aws:es:us-east-1:<AccountId>:domain/<domain-name>/_alias/otel-v1*",
         "arn:aws:es:us-east-1:<AccountId>:domain/<domain-name>/_alias/_bulk"
       ]
@@ -38,18 +38,18 @@ You should ensure that the credentials you configure have the required permissio
 }
 ```
 
-Please check this [doc](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-ac.html) to know how to set IAM to your Elasticsearch domain,
+Please check the [Identity and Access Management in Amazon OpenSearch Service documentation](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ac.html) to know how to set IAM to your OpenSearch domain,
 
-### Fine-Grained Access Control (FGAC) in Amazon Elasticsearch Service
+### Fine-Grained Access Control (FGAC) in Amazon OpenSearch Service
 
-The OpenSearch sink creates an [Index State Management (ISM)](https://opendistro.github.io/for-elasticsearch-docs/docs/ism/) policy for Trace Analytics indices but Amazon Elasticsearch Service allows only the `master user` to create an ISM policy. So,
+The OpenSearch sink creates an [Index State Management (ISM)](https://opensearch.org/docs/latest/im-plugin/ism/index/) policy for Trace Analytics indices but Amazon OpenSearch Service allows only the `master user` to create an ISM policy. So,
  
  * If you use IAM for your master user in FGAC domain, configure the sink as below,
 
   ```
   sink:
       opensearch:
-        hosts: ["https://your-fgac-amazon-elasticssearch-service-endpoint"]
+        hosts: ["https://your-fgac-amazon-opensearch-service-endpoint"]
         aws_sigv4: true
   ```
 Run `aws configure` using the AWS CLI to set your credentials to the master IAM user.
@@ -59,7 +59,7 @@ Run `aws configure` using the AWS CLI to set your credentials to the master IAM 
  ```
  sink:
      opensearch:
-       hosts: ["https://your-fgac-amazon-elasticssearch-service-endpoint"]
+       hosts: ["https://your-fgac-amazon-opensearch-service-endpoint"]
        aws_sigv4: false
        username: "master-username"
        password: "master-password"

--- a/data-prepper-plugins/otel-trace-group-prepper/README.md
+++ b/data-prepper-plugins/otel-trace-group-prepper/README.md
@@ -1,11 +1,11 @@
 # OTel Trace Group Prepper
 
 This is a prepper that fills in the missing trace group related fields in the collection of raw span string records output by [otel-trace-raw-prepper](../dataPrepper-plugins/otel-trace-raw-prepper) and then convert them back into a new collection of string records.
-It finds the missing trace group info for a spanId by looking up the relevant fields in its root span stored in opendistro-for-elasticsearch (ODFE) or Amazon Elasticsearch Service backend that the local data-prepper host ingest into.
+It finds the missing trace group info for a spanId by looking up the relevant fields in its root span stored in OpenSearch or Amazon OpenSearch Service backend that the local data-prepper host ingest into.
 
 ## Usages
 
-### Opendistro-for-elasticsearch
+### OpenSearch
 
 ```
 pipeline:
@@ -18,16 +18,16 @@ pipeline:
         password: YOUR_PASSWORD_HERE
 ```
 
-See [odfe_security.md](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/elasticsearch/odfe_security.md) for detailed explanation.
+See [opensearch_security.md](../opensearch/opensearch_security.md) for detailed explanation.
 
-### Amazon Elasticsearch Service
+### Amazon OpenSearch Service
 
 ```
 pipeline:
   ...
   prepper:
     - otel-trace-group-prepper:
-        hosts: ["https://your-amazon-elasticssearch-service-endpoint"]
+        hosts: ["https://your-amazon-opensearch-service-endpoint"]
         aws_sigv4: true
         cert: path/to/cert
         insecure: false
@@ -37,20 +37,20 @@ See [security.md](https://github.com/opensearch-project/data-prepper/blob/main/d
 
 ## Configuration
 
-- `hosts`: A list of IP addresses of elasticsearch nodes.
+- `hosts`: A list of IP addresses of OpenSearch nodes.
 
-- `cert`(optional): CA certificate that is pem encoded. Accepts both .pem or .crt. This enables the client to trust the CA that has signed the certificate that ODFE is using.
+- `cert`(optional): CA certificate that is pem encoded. Accepts both .pem or .crt. This enables the client to trust the CA that has signed the certificate that OpenSearch is using.
 Default is null.
 
-- `aws_sigv4`: A boolean flag to sign the HTTP request with AWS credentials. Only applies to Amazon Elasticsearch Service. See [security](security.md) for details. Default to `false`.
+- `aws_sigv4`: A boolean flag to sign the HTTP request with AWS credentials. Only applies to Amazon OpenSearch Service. See [security](security.md) for details. Default to `false`.
 
-- `aws_region`: A String represents the region of Amazon Elasticsearch Service domain, e.g. us-west-2. Only applies to Amazon Elasticsearch Service. Defaults to `us-east-1`.
+- `aws_region`: A String represents the region of Amazon OpenSearch Service domain, e.g. us-west-2. Only applies to Amazon OpenSearch Service. Defaults to `us-east-1`.
 
 - `insecure`: A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Default to `false`.
 
-- `username`(optional): A String of username used in the [internal users](https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles) of ODFE cluster. Default is null.
+- `username`(optional): A String of username used in the [internal users](https://opensearch.org/docs/latest/security-plugin/access-control/users-roles) of OpenSearch cluster. Default is null.
 
-- `password`(optional): A String of password used in the [internal users](https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles) of ODFE cluster. Default is null.
+- `password`(optional): A String of password used in the [internal users](https://opensearch.org/docs/latest/security-plugin/access-control/users-roles) of OpenSearch cluster. Default is null.
 
 ## Metrics
 

--- a/deployment-template/ec2/README.md
+++ b/deployment-template/ec2/README.md
@@ -1,4 +1,4 @@
 # Deploying with CloudFormation
-This directory contains an [AWS CloudFormation](https://docs.aws.amazon.com/cloudformation/index.html) template which provisions a single Data Prepper instance on an EC2 host. The template's parameters allow you to configure settings such as the EC2 instance type, Amazon Elasticsearch Service endpoint, and which SSH key pair can be used to access the host. 
+This directory contains an [AWS CloudFormation](https://docs.aws.amazon.com/cloudformation/index.html) template which provisions a single Data Prepper instance on an EC2 host. The template's parameters allow you to configure settings such as the EC2 instance type, Amazon OpenSearch Service endpoint, and which SSH key pair can be used to access the host. 
 
 Data Prepper server and pipeline configuration values can be manually adjusted by editing the _Resources_ section of the yaml template.

--- a/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
+++ b/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
@@ -3,25 +3,25 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: "Template to install Data Prepper on a single EC2 instance"
 Parameters:
   AmazonEsEndpoint:
-    Description: Endpoint of the AWS Elasticsearch Service domain (including https://)
+    Description: Endpoint of the Amazon OpenSearch Service domain (including https://)
     Type: String
     AllowedPattern: https:\/\/[a-z0-9-\.]+(es.amazonaws.com)
-    ConstraintDescription: must be a valid Amazon Elasticsearch Service domain endpoint starting with https://
+    ConstraintDescription: must be a valid Amazon OpenSearch Service domain endpoint starting with https://
   AmazonEsRegion:
-    Description: Region of the AWS Elasticsearch Service domain
+    Description: Region of the Amazon OpenSearch Service domain
     Type: String
     AllowedPattern: "[a-z]+-[a-z]+-[0-9]+"
     Default: us-east-1
     ConstraintDescription: must be a valid AWS region (e.g. us-west-2)
   AmazonEsSubnetId:
-    Description: The subnet ID of the AWS Elasticsearch Service domain (Leave blank if the domain is not in a VPC)
+    Description: The subnet ID of the Amazon OpenSearch Service domain (Leave blank if the domain is not in a VPC)
     Type: String
   Username:
-    Description: The username of the AWS Elasticsearch Service domain (Leave blank if the domain is configured with IAM role)
+    Description: The username of the Amazon OpenSearch Service domain (Leave blank if the domain is configured with IAM role)
     Type: String
     Default: ""
   Password:
-    Description: The password of the AWS Elasticsearch Service domain (Leave blank if the domain is configured with IAM role)
+    Description: The password of the Amazon OpenSearch Service domain (Leave blank if the domain is configured with IAM role)
     Type: String
     Default: ""
   DataPrepperVersion:
@@ -31,7 +31,7 @@ Parameters:
     Default: "1.0.0"
     ConstraintDescription: must be a valid release number
   IAMRole:
-    Description: Pre-existing IAM Role to associate with the EC2 instance, to be used for authentication when calling Elasticsearch
+    Description: Pre-existing IAM Role to associate with the EC2 instance, to be used for authentication when calling OpenSearch
       (Leave blank if the domain is configured with HTTP basic authentication in Fine-grained access control)
     Type: String
     AllowedPattern: "^$|[a-zA-Z0-9+=,\\.@\\-_]+"
@@ -67,7 +67,7 @@ Metadata:
         Parameters:
           - IAMRole
       - Label:
-          default: Amazon Elasticsearch Service Domain
+          default: Amazon OpenSearch Service Domain
         Parameters:
           - AmazonEsEndpoint
           - AmazonEsRegion

--- a/deployment-template/k8s/README.md
+++ b/deployment-template/k8s/README.md
@@ -16,7 +16,7 @@ Contains a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configm
 
 #### pipelines.yaml
 This file contains the standard Trace Analytics usecase pipeline configuration. A few adjustments are needed by the user:
-1. Replace the 2 `stdout` sinks with OpenSearch sinks to actually send data to Elasticsearch.
+1. Replace the 2 `stdout` sinks with OpenSearch sinks to actually send data to OpenSearch.
 2. Optionally enable TLS by providing the necessary key files for the `otel_trace_source` and `peer_forwarder` plugins.
 
 #### data-prepper-config.yaml

--- a/docs/dev/trace-analytics-rfc.md
+++ b/docs/dev/trace-analytics-rfc.md
@@ -1,6 +1,6 @@
 # RFC - Trace Analytics
 ## 1. Overview
-Open Distro for Elasticsearch (ODFE) users already store their log data which allows them to access log events in their services. However, with the log data alone, the user can not pinpoint where the error occurred or what caused the poor performance. This means they need another datastore or going into a different codebase to determine the context of the log event. The overall result is that the user has to rely on multiple products, software, log data, and human ingenuity to track down problems with their systems. The goal is to reduce the number of contexts switches a 
+OpenSearch users already store their log data which allows them to access log events in their services. However, with the log data alone, the user can not pinpoint where the error occurred or what caused the poor performance. This means they need another datastore or going into a different codebase to determine the context of the log event. The overall result is that the user has to rely on multiple products, software, log data, and human ingenuity to track down problems with their systems. The goal is to reduce the number of contexts switches a 
 user must do in order to solve a problem in production, we will achieve this through a set of Application Performance Management (APM) features. 
 As the first step, in 2020 we will offer Trace Analytics, which will allow users to store trace information and provide them a holistic view of their
  service under observation.
@@ -8,14 +8,14 @@ As the first step, in 2020 we will offer Trace Analytics, which will allow users
 ## 2. Approach
 The Trace Analytics feature will embrace the Open Telemetry standard and provide the required plugins and adapters to integrate with the ecosystem. 
 Adoption to the OpenTelemetry ecosystem will benefit users of existing tracing standards like Zipkin and OpenTracing to use the Trace Analytics feature.
-To support the trace analytics feature we will build a new service called Data Prepper, which receives trace data from the OpenTelemetry collector, process them to Elasticsearch friendly docs, and stores them in users' elasticsearch cluster. The trace analytics will also provide a Kibana plugin that will provide user-friendly dashboards on the stored trace data. 
+To support the trace analytics feature we will build a new service called Data Prepper, which receives trace data from the OpenTelemetry collector, process them to OpenSearch friendly docs, and stores them in users' OpenSearch cluster. The trace analytics will also provide an OpenSearch Dashboards plugin that will provide user-friendly dashboards on the stored trace data. 
 
 ![Kibana Notebooks Architecture](images/HighLevelDesign.jpg)
 
 
 ## 3. Data Prepper
 
-Data Prepper is an ingestion service which provides users to ingest and transform data before stored in elasticsearch. 
+Data Prepper is an ingestion service which provides users to ingest and transform data before stored in OpenSearch. 
 
 ### 3.1 General Data Prepper design
 
@@ -35,13 +35,13 @@ The source is the input component of a pipeline, it defines the mechanism throug
 The buffer component will act as the layer between the source and sink. The buffer could either be in-memory or disk-based. The default buffer will be in-memory queue bounded by the number of records/size of records.
 
 *Sink:*
-Sink in the output component of the pipeline, it defines the one or more destinations to which a Data Prepper pipeline will publish the records. A sink destination could be either service like elastic search, s3. The sink will have its own configuration options based on the destination type like security, request batching, etc. A sink can be another Data Prepper pipeline, this would provide users the benefit chain multiple Data Prepper pipelines.
+Sink in the output component of the pipeline, it defines the one or more destinations to which a Data Prepper pipeline will publish the records. A sink destination could be either service like OpenSearch, Amazon OpenSearch Service, or S3. The sink will have its own configuration options based on the destination type like security, request batching, etc. A sink can be another Data Prepper pipeline, this would provide users the benefit chain multiple Data Prepper pipelines.
 
 *Prepper:*
 Prepper component of the pipeline, these are intermediary processing units using which users can filter, transform, and enrich the records into the desired format before publishing to the sink. The prepper is an optional component of the pipeline, if not defined the records will be published in the format as defined in the source. You can have more than one prepper and they are executed in the order they are defined in the pipeline spec.
 
 
-Data Prepper will be an ODFE community-driven project, the end goal is to make multiple Source, Sink, and Prepper plugins available.
+Data Prepper will be an OpenSearch community-driven project, the end goal is to make multiple Source, Sink, and Prepper plugins available.
 
 #### 3.1.2 Trace Analytics
 
@@ -60,21 +60,21 @@ mean we will support transport over gRPC, HTTP/Proto and HTTP/JSON. The source w
 ##### Preppers
 
 We are building two preppers for the Trace Analytics feature,
-* *otel-trace-raw-prepper* -  This prepper will be responsible for converting the trace data in [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-proto/tree/master/opentelemetry/proto/trace/v1) to elasticsearch friendly (JSON) docs. These elasticsearch friendly docs will have minimal additional fields like duration which are not part of the original specification. These additional fields are to make the instant kibana dashboards user-friendly.
-* *service-map-prepper* -  This prepper will perform the required preprocessing on the trace data and build metadata to display the service-map kibana dashboards.
+* *otel-trace-raw-prepper* -  This prepper will be responsible for converting the trace data in [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-proto/tree/master/opentelemetry/proto/trace/v1) to OpenSearch friendly (JSON) docs. These OpenSearch friendly docs will have minimal additional fields like duration which are not part of the original specification. These additional fields are to make the instant OpenSearch Dashboards dashboards user-friendly.
+* *service-map-prepper* -  This prepper will perform the required preprocessing on the trace data and build metadata to display the service-map OpenSearch Dashboards dashboards.
 
 
 ##### OpenSearch sink
 
-We will build a generic sink that will write the data to Elasticsearch as the destination. The OpenSearch sink will have configuration options related to elasticsearch cluster like endpoint, SSL/Username, index name, index template, index state management, etc. 
-For the trace analytics feature, the sink will have specific configurations which will make the sink to use indices and index templates specific to the feature. Trace analytics specific Elasticsearch indices are,
+We will build a generic sink that will write the data to OpenSearch as the destination. The OpenSearch sink will have configuration options related to OpenSearch cluster like endpoint, SSL/Username, index name, index template, index state management, etc. 
+For the trace analytics feature, the sink will have specific configurations which will make the sink to use indices and index templates specific to the feature. Trace analytics specific OpenSearch indices are,
                                                                                                                                                                  
 * *apm-trace-raw-v1* -  This index will store the output from otel-trace-raw-prepper. 
 * *apm-service-map-v1* - This index will store the output from the service-map-prepper.
 
-## 4. Kibana
+## 4. OpenSearch Dashboards
 
-These two indices mentioned above will be used by the Kibana plugin to provide the following instant dashboards,
+These two indices mentioned above will be used by the OpenSearch Dashboards plugin to provide the following instant dashboards,
 
 ![Kibana Notebooks Architecture](images/DashboardView.png)
 
@@ -83,7 +83,7 @@ These two indices mentioned above will be used by the Kibana plugin to provide t
 ![Kibana Notebooks Architecture](images/ServiceView.png)
 
 
-NOTE: The above Kibana dashboards are mockup UIs, they are subject to changes.
+NOTE: The above OpenSearch Dashboards dashboards are mockup UIs, they are subject to changes.
 
 
 ## Providing Feedback

--- a/docs/schemas/trace-analytics/readme.md
+++ b/docs/schemas/trace-analytics/readme.md
@@ -1,6 +1,6 @@
 # Trace Analytics Schema Versioning
 
-The purpose of this document is to outline the structure and versioning formats followed by Data Prepper (DP) the Trace Analytics (TA) plugin for Kibana and OpenSearch Dashboards. Each individual schema shall have its own supporting document explaining its structure, fields, and purpose.
+The purpose of this document is to outline the structure and versioning formats followed by Data Prepper (DP) the Trace Analytics (TA) plugin for OpenSearch Dashboards. Each individual schema shall have its own supporting document explaining its structure, fields, and purpose.
 
 ## Tenets
 
@@ -9,7 +9,7 @@ The purpose of this document is to outline the structure and versioning formats 
 3. Index and index template names shall only include the major version (e.g. "otel-v1-apm-span"). The minor version shall be included within the actual schema as a field.
 4. Forward and backward-compatibility promises shall only apply to schemas of the same major version.
 5. A major version increase shall require Data Prepper (writer) artifacts to be made available before Trace Analytics plugin (reader) updates are made available.
-6. A major version increase shall result in a new index template and indexes being created in an Elasticsearch/OpenSearch cluster.
+6. A major version increase shall result in a new index template and indexes being created in an OpenSearch cluster.
 
 ## Versioning Format
 
@@ -100,4 +100,4 @@ To avoid usability downtime of the Trace Analytics plugin, run two versions of D
 Upgrading the Trace Analytics plugin from v1 to v2 will result in no usability downtime, as both plugin versions will have populated indexes to read from. This approach is more complex in that it requires additional Data Prepper instances and results in duplicate data being written (until the old DP instances are shut down).
 
 #### Mitigating data loss
-Upgrading Data Prepper and the Trace Analytics plugin to a new major version schema will result in data written to old indexes being unusable. If users wish to avoid this data loss, the [reindexing APIs](https://opendistro.github.io/for-elasticsearch-docs/docs/elasticsearch/reindex-data/) must be used. Additionally, transforms might required depending on the differences between the two major schema versions.
+Upgrading Data Prepper and the Trace Analytics plugin to a new major version schema will result in data written to old indexes being unusable. If users wish to avoid this data loss, the [reindexing APIs](https://opensearch.org/docs/latest/opensearch/reindex-data/) must be used. Additionally, transforms might required depending on the differences between the two major schema versions.

--- a/examples/dev/k8s/README.md
+++ b/examples/dev/k8s/README.md
@@ -2,7 +2,7 @@
 
 This set of Kubernetes config files recreates the same sample app under the /examples directory, but within a minikube environment.
 * _data-prepper.yaml_ contains a deployment, service, headless service, and configmap required to run Data Prepper with Kubernetes
-* _sample-project-applications.yaml_ contains configuration required to setup the remaining elements of the sample project (Kibana, Elasticsearch, etc.)
+* _sample-project-applications.yaml_ contains configuration required to setup the remaining elements of the sample project (OpenSearch, OpenSearch Dashboards, etc.)
 
 1. Setup kubectl and minikube locally
    1. https://kubernetes.io/docs/tasks/tools/install-kubectl/


### PR DESCRIPTION
### Description

Updated the documentation to use OpenSearch, OpenSearch Dashboard, and Amazon OpenSearch Service.

Some scripts, Docker compose files, and other automation is still not updated to use OpenSearch. For these scenarios, I left the OpenDistro text in place.
 
### Issues Resolved

Resolves #638 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
