### PR TITLE
migrating demo sample application to use opensearch and opensearch da…

### DIFF
--- a/examples/trace-analytics-sample-app/README.md
+++ b/examples/trace-analytics-sample-app/README.md
@@ -41,7 +41,7 @@ The following are the backend services running on different ports:
 
 The following are the database/storage we run on different ports.
 - mysql -> 3306
-- OpenSearch -> 9200,9300
+- opensearch -> 9200,9300
 
 The client makes API calls that produces the APM data that falls into the following trace groups:
 

--- a/examples/trace-analytics-sample-app/README.md
+++ b/examples/trace-analytics-sample-app/README.md
@@ -1,6 +1,6 @@
 # Trace Analytics Sample App
 
-This is a demo that is built to demonstrate the Trace Analytics feature that is supported by Open Distro For Elasticsearch. For the demo we have mock e-commerce app which consists of a group of microservices. This demo uses OpenTelemetry libraries to produce trace data and uses Data Prepper to ingest data into ODFE. 
+This is a demo that is built to demonstrate the Trace Analytics feature that is supported by OpenSearch. For the demo we have mock e-commerce app which consists of a group of microservices. This demo uses OpenTelemetry libraries to produce trace data and uses Data Prepper to ingest data into OpenSearch. 
  
 ## Run
 
@@ -14,8 +14,7 @@ This is a demo that is built to demonstrate the Trace Analytics feature that is 
 docker-compose up -d
 ```
 
-
-* Wait for 5 mins, this is because we spin up multiple python services, elasticsearch and kibana. The DataPrepper will restart till elasticsearch becomes available.
+* Wait for 5 mins, this is because we spin up multiple python services, OpenSearch and OpenSearch Dashboards. The DataPrepper will restart till OpenSearch becomes available.
 
 * Navigate to localhost:8089
 
@@ -42,7 +41,7 @@ The following are the backend services running on different ports:
 
 The following are the database/storage we run on different ports.
 - mysql -> 3306
-- elasticsearch -> 9200,9300
+- OpenSearch -> 9200,9300
 
 The client makes API calls that produces the APM data that falls into the following trace groups:
 
@@ -70,9 +69,3 @@ To run this application together with client:
 ```
 docker-compose up --build -d
 ```
-
-
-
-
-
-

--- a/examples/trace-analytics-sample-app/docker-compose.yml
+++ b/examples/trace-analytics-sample-app/docker-compose.yml
@@ -15,29 +15,37 @@ services:
     networks:
       - my_network
     depends_on:
-      - opendistro-for-elasticsearch
-  opendistro-for-elasticsearch:
+      - opensearch
+  opensearch:
     container_name: node-0.example.com
-    image: amazon/opendistro-for-elasticsearch:1.12.0
-    ports:
-      - '9200:9200'
-      - '9600:9600'
+    image: opensearchproject/opensearch:latest
     environment:
       - discovery.type=single-node
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+        hard: 65536
+    ports:
+      - 9200:9200
+      - 9600:9600 # required for Performance Analyzer
     networks:
       - my_network
-  kibana:
-    build:
-      context: ../..
-      dockerfile: examples/kibana-trace-analytics/Dockerfile
-    container_name: odfe-kibana
+  dashboards:
+    image: opensearchproject/opensearch-dashboards:latest
+    container_name: opensearch-dashboards
     ports:
       - 5601:5601
     expose:
       - "5601"
     environment:
-      ELASTICSEARCH_URL: https://node-0.example.com:9200
-      ELASTICSEARCH_HOSTS: https://node-0.example.com:9200
+      OPENSEARCH_HOSTS: '["https://node-0.example.com:9200"]'
+    depends_on:
+      - opensearch
     networks:
       - my_network
   otel-collector:


### PR DESCRIPTION
…shboards instead of ODFE and kibana

Signed-off-by: Christopher Manning <cmanning09@users.noreply.github.com>

### Description
While preparing for a demo I noticed the use of ODFE and kibana in a sample application. This change migrates those resources to the OpenSearch and OpenSearch Dashboards. I am leveraging existing docker configurations from other
example apps.
 
### Issues
#639
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
