### PR TITLE
reverting pipeline yamls use of processor to prepper.

### DIFF
--- a/examples/config/example-pipelines.yaml
+++ b/examples/config/example-pipelines.yaml
@@ -12,7 +12,7 @@ raw-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - otel_trace_raw_prepper:
   sink:
     - opensearch:
@@ -25,7 +25,7 @@ service-map-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - service_map_stateful:
   sink:
     - opensearch:

--- a/examples/dev/k8s/data-prepper.yaml
+++ b/examples/dev/k8s/data-prepper.yaml
@@ -15,7 +15,7 @@ data:
       source:
         otel_trace_source:
           ssl: false
-      processor:
+      prepper:
         - peer_forwarder:
             discovery_mode: "dns"
             domain_name: "data-prepper-headless"
@@ -29,7 +29,7 @@ data:
       source:
         pipeline:
           name: "entry-pipeline"
-      processor:
+      prepper:
         - otel_trace_raw_prepper:
       sink:
         - opensearch:
@@ -43,7 +43,7 @@ data:
       source:
         pipeline:
           name: "entry-pipeline"
-      processor:
+      prepper:
         - service_map_stateful:
       sink:
         - opensearch:

--- a/examples/dev/trace-analytics-sample-app/resources/pipelines.yaml
+++ b/examples/dev/trace-analytics-sample-app/resources/pipelines.yaml
@@ -5,7 +5,7 @@ entry-pipeline:
       ssl: true
       sslKeyFile: /usr/share/data-prepper/demo-data-prepper.key
       sslKeyCertChainFile: /usr/share/data-prepper/demo-data-prepper.crt
-  processor:
+  prepper:
     - peer_forwarder:
         discovery_mode: "dns"
         domain_name: "prepper-cluster"
@@ -19,7 +19,7 @@ raw-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - otel_trace_raw_prepper:
   sink:
     - opensearch:
@@ -33,7 +33,7 @@ service-map-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - service_map_stateful:
   sink:
     - opensearch:

--- a/examples/trace_analytics.yml
+++ b/examples/trace_analytics.yml
@@ -14,7 +14,7 @@ raw-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - otel_trace_raw_prepper:
   sink:
     - opensearch:
@@ -28,7 +28,7 @@ service-map-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - service_map_stateful:
   sink:
     - opensearch:

--- a/examples/trace_analytics_no_ssl.yml
+++ b/examples/trace_analytics_no_ssl.yml
@@ -12,7 +12,7 @@ raw-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - otel_trace_raw_prepper:
   sink:
     - opensearch:
@@ -26,7 +26,7 @@ service-map-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - service_map_stateful:
   sink:
     - opensearch:


### PR DESCRIPTION
### Description

DP v1.2 is scheduled for release in a week. However a previous change migrated all example pipelines
to use processors. Reverting the change to keep our existing examples working as they are all dependent on
the latest published version of DP. This commit can be reverted once DP v1.2 is released.
 
### Issues
- caused by #655 
- related to #311 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
