### PR TITLE
Corrected the starting version for the Processor renaming to 1.3.0

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,7 +111,7 @@ To do so, add the argument below to the `docker run` command.
 
 ## Deprecated Pipeline Configuration Support
 
-As of DataPrepper 1.2 Prepper plugins were renamed to Processors. The use of the prepper or processor name in pipeline configuration files is still supported. However, the use of both processor and prepper in the same configuration file is **not** supported. Configuration of Processor plugins in pipelines using the Prepper name is deprecated and will be removed in a future release. See the [GitHub issue](https://github.com/opensearch-project/data-prepper/issues/619) for the latest status.
+Starting in DataPrepper 1.3.0, Prepper plugins were renamed to Processors. The use of the prepper or processor name in pipeline configuration files is still supported. However, the use of both processor and prepper in the same configuration file is **not** supported. Configuration of Processor plugins in pipelines using the Prepper name is deprecated and will be removed in a future release. See the [GitHub issue](https://github.com/opensearch-project/data-prepper/issues/619) for the latest status.
 
 Example of deprecated prepper pipeline configuration file (pipelines.yaml):
 ```yaml


### PR DESCRIPTION
### Description

Preppers were renamed to processor starting in version 1.3.0. I have updated the documentation to correctly note this.
 
### Issues Resolved

 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
