### PR TITLE
Refactored event checkKey to use pre-compiled regex pattern. refactored RandomStringSource

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
@@ -268,7 +268,7 @@ public class JacksonEvent implements Event {
     private void checkKey(final String key) {
         checkNotNull(key, "key cannot be null");
         checkArgument(!key.isEmpty(), "key cannot be an empty string");
-        checkArgument((KEY_CHARACTERS_PATTERN.matcher(key).matches()), String.format("key %s must contain only alphanumeric chars with .-_ and must follow JsonPointer (ie. 'field/to/key')", key));
+        checkArgument((KEY_CHARACTERS_PATTERN.matcher(key).matches()), "keys must contain only alphanumeric chars with .-_ and must follow JsonPointer (ie. 'field/to/key')");
     }
 
     private String trimKey(final String key) {

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
@@ -268,7 +268,9 @@ public class JacksonEvent implements Event {
     private void checkKey(final String key) {
         checkNotNull(key, "key cannot be null");
         checkArgument(!key.isEmpty(), "key cannot be an empty string");
-        checkArgument((KEY_CHARACTERS_PATTERN.matcher(key).matches()), "keys must contain only alphanumeric chars with .-_ and must follow JsonPointer (ie. 'field/to/key')");
+        if (!KEY_CHARACTERS_PATTERN.matcher(key).matches()) {
+            throw new IllegalArgumentException("key " + key + " must contain only alphanumeric chars with .-_ and must follow JsonPointer (ie. 'field/to/key')");
+        }
     }
 
     private String trimKey(final String key) {

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -55,6 +56,8 @@ public class JacksonEvent implements Event {
     private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {};
 
     private final EventMetadata eventMetadata;
+
+    private static final Pattern KEY_CHARACTERS_PATTERN = Pattern.compile("^/?((([a-zA-Z][a-zA-Z0-9-_.]+[a-zA-Z0-9])|\\d)/?)+$");
 
     private final JsonNode jsonNode;
 
@@ -265,9 +268,7 @@ public class JacksonEvent implements Event {
     private void checkKey(final String key) {
         checkNotNull(key, "key cannot be null");
         checkArgument(!key.isEmpty(), "key cannot be an empty string");
-        checkArgument(key.matches(
-                        "^/?((([a-zA-Z][a-zA-Z0-9-_.]+[a-zA-Z0-9])|\\d)/?)+$"),
-                String.format("key %s must contain only alphanumeric chars with .-_ and must follow JsonPointer (ie. 'field/to/key')", key));
+        checkArgument((KEY_CHARACTERS_PATTERN.matcher(key).matches()), String.format("key %s must contain only alphanumeric chars with .-_ and must follow JsonPointer (ie. 'field/to/key')", key));
     }
 
     private String trimKey(final String key) {

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/source/RandomStringSource.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/source/RandomStringSource.java
@@ -17,11 +17,15 @@ import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.event.JacksonEvent;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.source.Source;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -34,35 +38,56 @@ public class RandomStringSource implements Source<Record<Event>> {
     static final String EVENT_TYPE = "event";
     private static final Logger LOG = LoggerFactory.getLogger(RandomStringSource.class);
 
+    private ExecutorService executorService;
     private volatile boolean stop = false;
+
+    private void setExecutorService() {
+        if(executorService == null || executorService.isShutdown()) {
+            executorService = Executors.newSingleThreadExecutor(
+                    new ThreadFactoryBuilder().setDaemon(false).setNameFormat("random-source-pool-%d").build()
+            );
+        }
+    }
 
     @Override
     public void start(final Buffer<Record<Event>> buffer) {
-        while (!stop) {
-            try {
-                LOG.info("Writing to buffer");
-                final Record<Event> record = generateRandomStringEventRecord();
-                buffer.write(record, 500);
-                Thread.sleep(500);
-            } catch (final InterruptedException e) {
-                LOG.error("Writing random string to buffer interrupted", e);
-            } catch (final TimeoutException e) {
-                LOG.error("Writing timed out", e);
+        setExecutorService();
+        executorService.execute(() -> {
+            while (!stop) {
+                try {
+                    LOG.info("Writing to buffer");
+                    final Record<Event> record = generateRandomStringEventRecord();
+                    buffer.write(record, 500);
+                    Thread.sleep(500);
+                } catch (final InterruptedException e) {
+                    break;
+                } catch (final TimeoutException e) {
+                    // Do nothing
+                }
             }
-        }
+        });
     }
 
     @Override
     public void stop() {
         stop = true;
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(500, TimeUnit.MILLISECONDS)) {
+                executorService.shutdownNow();
+            }
+        } catch (final InterruptedException ex) {
+            executorService.shutdownNow();
+        }
     }
 
     private Record<Event> generateRandomStringEventRecord() {
-        final Map<String, Object> structuredLine = Map.of(MESSAGE_KEY, UUID.randomUUID().toString());
-        return new Record<>(JacksonEvent
+        final Map<String, String> structuredLine = Map.of(MESSAGE_KEY, UUID.randomUUID().toString());
+        final Event event = JacksonEvent
                 .builder()
                 .withEventType(EVENT_TYPE)
                 .withData(structuredLine)
-                .build());
+                .build();
+        return new Record<>(event);
     }
 }

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/sink/StdOutSinkTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/sink/StdOutSinkTests.java
@@ -15,8 +15,8 @@ package com.amazon.dataprepper.plugins.sink;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.event.JacksonEvent;
 import com.amazon.dataprepper.model.record.Record;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/source/RandomStringSourceTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/source/RandomStringSourceTests.java
@@ -17,13 +17,7 @@ import com.amazon.dataprepper.plugins.buffer.TestBuffer;
 import org.junit.Test;
 
 import java.util.Queue;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -31,22 +25,19 @@ import static org.hamcrest.Matchers.greaterThan;
 public class RandomStringSourceTests {
 
     @Test
-    public void testPutRecord() throws ExecutionException, InterruptedException {
-        final RandomStringSource randomStringSource = new RandomStringSource();
-        final Queue<Record<Event>> bufferQueue = new LinkedBlockingQueue<>();
+    public void testPutRecord() throws InterruptedException {
+        final RandomStringSource randomStringSource =
+                new RandomStringSource();
+        final Queue<Record<Event>> bufferQueue = new ConcurrentLinkedQueue<>();
         final TestBuffer buffer = new TestBuffer(bufferQueue, 1);
-
-        final ExecutorService executorService = Executors.newSingleThreadExecutor();
-        Future<?> task = executorService.submit(() -> randomStringSource.start(buffer));
-
-        try {
-            // this timeout is increased to 3000 to ensure that at least 1 Record has time to be made by the RandomStringSource
-            task.get(3000, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-            assertThat(buffer.size(), greaterThan(0));
-            randomStringSource.stop();
-            assertThat(buffer.size(), greaterThan(0));
-        }
+        //Start source, and sleep for 100 millis
+        randomStringSource.start(buffer);
+        Thread.sleep(1000);
+        //Stop the source, and wait long enough that another message would be sent
+        //if the source was running
+        assertThat(buffer.size(), greaterThan(0));
+        Thread.sleep(1000);
+        randomStringSource.stop();
+        assertThat(buffer.size(), greaterThan(0));
     }
-
 }

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/source/RandomStringSourceTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/source/RandomStringSourceTests.java
@@ -14,31 +14,39 @@ package com.amazon.dataprepper.plugins.source;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.buffer.TestBuffer;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 
 public class RandomStringSourceTests {
 
     @Test
-    public void testPutRecord() throws InterruptedException {
-        final RandomStringSource randomStringSource =
-                new RandomStringSource();
-        final Queue<Record<Event>> bufferQueue = new ConcurrentLinkedQueue<>();
+    public void testPutRecord() throws ExecutionException, InterruptedException {
+        final RandomStringSource randomStringSource = new RandomStringSource();
+        final Queue<Record<Event>> bufferQueue = new LinkedBlockingQueue<>();
         final TestBuffer buffer = new TestBuffer(bufferQueue, 1);
-        //Start source, and sleep for 100 millis
-        randomStringSource.start(buffer);
-        Thread.sleep(500);
-        //Make sure that 1 record is in buffer
-        Assert.assertEquals(1, buffer.size());
-        //Stop the source, and wait long enough that another message would be sent
-        //if the source was running
-        randomStringSource.stop();
-        Thread.sleep(500);
-        //Make sure there is still only 1 record in buffer
-        Assert.assertEquals(1, buffer.size());
+
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        Future<?> task = executorService.submit(() -> randomStringSource.start(buffer));
+
+        try {
+            // this timeout is increased to 3000 to ensure that at least 1 Record has time to be made by the RandomStringSource
+            task.get(3000, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            assertThat(buffer.size(), greaterThan(0));
+            randomStringSource.stop();
+            assertThat(buffer.size(), greaterThan(0));
+        }
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Taylor Gray <33740195+graytaylor0@users.noreply.github.com>

### Description
* The checkKey function of JacksonEvent no longer compiles the regex pattern containing valid key characters. This compilation is now done one time at first instantiation of JacksonEvent.
* Removed String.format from checkKey. This String.format call was actually accounting for .2% of the entire Data Prepper execution (which is more than the grok matching itself), as it is called every time no matter what. We could consider another way to let the user know which key is invalid, but I think we want to put performance first here
* Test for RandomStringSource failed after the Event change, because the test was timing out before it could add a string to the buffer (because it makes an Event, and since it was the first Event the regex pattern was compiled, which is slow. Refactored RandomStringSource to not use ExecutorService, as it was only using it to make testing easier.

Note: Realized this is going to the main branch, and while this is enough for performance testing, it will also need to be done for 1.2 branch.
 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
