### PR TITLE
Create GrokPrepper instance for each worker thread via @SingleThread

### DIFF
--- a/data-prepper-plugins/grok-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepper.java
+++ b/data-prepper-plugins/grok-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepper.java
@@ -13,6 +13,7 @@ package com.amazon.dataprepper.plugins.prepper.grok;
 
 
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
+import com.amazon.dataprepper.model.annotations.SingleThread;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.prepper.AbstractPrepper;
@@ -56,6 +57,7 @@ import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 
+@SingleThread
 @DataPrepperPlugin(name = "grok", pluginType = Prepper.class)
 public class GrokPrepper extends AbstractPrepper<Record<Event>, Record<Event>> {
 


### PR DESCRIPTION
### Description

Each `GrokPrepper` creates a single-thread executor for running code with a timeout (`Executors.newSingleThreadExecutor()`). Multiple `grok` preppers in a pipeline will each get their own instance. However, a single `grok` prepper with multiple worker threads will have each thread share this. This can cause contention when using the `time_out` property.

The PR attempts to remove that contention. It adds the `@SingleThread` annotation to `GrokPrepper`. This instructs Data Prepper Core to create one `GrokPrepper` instance per worker thread. Now, there will be a spare thread per worker.

I believe there is a better long-term solution available since multiple grok preppers could share a single `Executor` per worker thread. However, this is a change to Data Prepper Core and somewhat involved. I'd like to propose it for 1.3.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
