### PR TITLE
Upgrade log4j to 2.15.0

### DIFF
--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -1,4 +1,4 @@
-**  Log4j-core; version 2.14.0 -- https://logging.apache.org/log4j/2.x/
+**  Log4j-core; version 2.15.0 -- https://logging.apache.org/log4j/2.x/
 ** Amazon ION Java; version 1.0.2 -- https://github.com/amzn/ion-java
 ** android annotations; version 4.1.1.4 --
 https://github.com/androidannotations/androidannotations
@@ -38,7 +38,7 @@ https://github.com/jnr/jnr-a64asm/tree/jnr-a64asm-1.0.0
 https://github.com/jnr/jnr-constants/tree/jnr-constants-0.9.15
 ** joda-time; version 2.10.4 -- http://www.joda.org/joda-time/
 ** Kotlin; version 1.4.32 -- https://github.com/JetBrains/kotlin
-** log4j-slf4j-impl; version 2.14.0 -- https://logging.apache.org/log4j/2.x/
+** log4j-slf4j-impl; version 2.15.0 -- https://logging.apache.org/log4j/2.x/
 ** lz4-java; version 1.3.0 -- https://github.com/lz4/lz4-java/tree/1.3.0
 ** MapDB; version 3.0.8 -- http://www.mapdb.org/
 ** micrometer; version 1.6.6 --

--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,9 @@ subprojects {
     sourceCompatibility = '1.8'
     dependencies {
         implementation "com.google.guava:guava:29.0-jre"
-        implementation "org.apache.logging.log4j:log4j-core:2.14.0"
+        implementation "org.apache.logging.log4j:log4j-core:2.15.0"
         implementation "org.slf4j:slf4j-api:1.7.30"
-        implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.14.0"
+        implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.15.0"
         testImplementation("junit:junit:4.13") {
             exclude group: 'org.hamcrest' // workaround for jarHell
         }

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -85,8 +85,8 @@ configurations.all {
         force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.3'
         force 'junit:junit:4.13'
         force "org.slf4j:slf4j-api:1.7.30"
-        force "org.apache.logging.log4j:log4j-api:2.14.1"
-        force "org.apache.logging.log4j:log4j-core:2.14.1"
+        force "org.apache.logging.log4j:log4j-api:2.15.0"
+        force "org.apache.logging.log4j:log4j-core:2.15.0"
     }
 }
 


### PR DESCRIPTION
Signed-off-by: David Powers <ddpowers@amazon.com>

### Description
Upgrades log4j from vulnerable version to protected version
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
