### PR TITLE
[backport 1.2] Add yum update to data prepper to consume all pkg updates

### DIFF
--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -7,6 +7,9 @@ ENV DATA_PREPPER_PATH /usr/share/data-prepper
 ENV ENV_CONFIG_FILEPATH=$CONFIG_FILEPATH
 ENV ENV_PIPELINE_FILEPATH=$PIPELINE_FILEPATH
 
+# Update all packages
+RUN yum update -y && yum clean all
+
 RUN mkdir -p $DATA_PREPPER_PATH
 RUN mkdir -p /var/log/data-prepper
 COPY $JAR_FILE /usr/share/data-prepper/data-prepper.jar


### PR DESCRIPTION
### Description
[backport 1.2] Add yum update to data prepper to consume all pkg updates
 
### Issues Resolved
#716
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
