### PR TITLE
Upgrade log4j to 2.15.0

### DIFF
--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -34,8 +34,8 @@
 ** gRPC; version 1.38.1 -- https://github.com/grpc/grpc
 ** aws-java-sdk-core; version 1.12.43 -- https://aws.amazon.com/sdk-for-java/
 ** guava; version 31.0.1-jre -- https://github.com/google/guava
-** log4j-slf4j-impl; version 2.14.1 -- https://logging.apache.org/log4j/2.x/
-**  Log4j-core; version 2.14.1 -- https://logging.apache.org/log4j/2.x/
+** log4j-slf4j-impl; version 2.15.0 -- https://logging.apache.org/log4j/2.x/
+**  Log4j-core; version 2.15.0 -- https://logging.apache.org/log4j/2.x/
 ** armeria-grpc; version 1.9.2 -- https://github.com/line/armeria
 ** Kotlin; version 1.5.30 -- https://github.com/JetBrains/kotlin
 ** micrometer; version 1.7.2 -- https://github.com/micrometer-metrics/micrometer 

--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,9 @@ subprojects {
     }
     dependencies {
         implementation 'com.google.guava:guava:31.0.1-jre'
-        implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
+        implementation 'org.apache.logging.log4j:log4j-core:2.15.0'
         implementation 'org.slf4j:slf4j-api:1.7.30'
-        implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.1'
+        implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.15.0'
         testImplementation platform("org.junit:junit-bom:${versionMap.junitJupiter}")
         testImplementation 'org.junit.jupiter:junit-jupiter'
         testImplementation 'org.junit.vintage:junit-vintage-engine'

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -91,8 +91,8 @@ configurations.all {
         force 'com.google.guava:guava:31.0.1-jre'
         force 'junit:junit:4.13.2'
         force "org.slf4j:slf4j-api:1.7.32"
-        force "org.apache.logging.log4j:log4j-api:2.14.1"
-        force "org.apache.logging.log4j:log4j-core:2.14.1"
+        force "org.apache.logging.log4j:log4j-api:2.15.0"
+        force "org.apache.logging.log4j:log4j-core:2.15.0"
         force 'commons-beanutils:commons-beanutils:1.9.4'
     }
     // The OpenSearch plugins appear to provide their own version of Mockito


### PR DESCRIPTION
Signed-off-by: David Powers <ddpowers@amazon.com>

### Description
Upgrades log4j from vulnerable version to protected version
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
