### PR TITLE
Added a Gradle constraint to require that log4j-core version 2.15.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,14 @@ subprojects {
                 because 'We want the newest version of httpclient.'
             }
         }
+        constraints {
+            implementation('org.apache.logging.log4j:log4j-core') {
+                version {
+                    require '2.15.0'
+                }
+                because 'Log4j 2.15.0 fixes CVE-2021-44228'
+            }
+        }
     }
 
     configurations.all {


### PR DESCRIPTION
### Description

Additional Gradle constraint to ensure log4j-core 2.15.0. This fixes CVE-2021-44228.
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
