### PR TITLE
Added release notes for Data Prepper 1.1.1 (#724)

### DIFF
--- a/release/release-notes/data-prepper.release-notes-1.1.1.md
+++ b/release/release-notes/data-prepper.release-notes-1.1.1.md
@@ -1,0 +1,7 @@
+## 2021-12-10 Version 1.1.1
+
+---
+
+### Security
+* Fixes [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) by using Apache Log4J 2.15.0. [#718](https://github.com/opensearch-project/data-prepper/pull/718), [#723](https://github.com/opensearch-project/data-prepper/pull/723)
+* Run yum update on Docker images to get all security patches at the time of the Data Prepper Docker build. [#717](https://github.com/opensearch-project/data-prepper/pull/717)


### PR DESCRIPTION
### Description

Adding release notes for Data Prepper 1.1.1. Cherry picks `204d0f91` from the `v1.1.x` branch.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
