### PR TITLE
Updated to log4j-core 2.16.0

### DIFF
--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.micrometer:micrometer-registry-cloudwatch2'
     implementation 'software.amazon.awssdk:cloudwatch'
-    implementation platform('org.apache.logging.log4j:log4j-bom:2.15.0')
+    implementation platform('org.apache.logging.log4j:log4j-bom:2.16.0')
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl'
     testImplementation "org.hamcrest:hamcrest:2.2"

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -95,8 +95,8 @@ configurations.all {
         force 'com.google.guava:guava:31.0.1-jre'
         force 'junit:junit:4.13.2'
         force "org.slf4j:slf4j-api:1.7.32"
-        force 'org.apache.logging.log4j:log4j-api:2.15.0'
-        force 'org.apache.logging.log4j:log4j-core:2.15.0'
+        force 'org.apache.logging.log4j:log4j-api:2.16.0'
+        force 'org.apache.logging.log4j:log4j-core:2.16.0'
         force 'commons-beanutils:commons-beanutils:1.9.4'
     }
     // The OpenSearch plugins appear to provide their own version of Mockito


### PR DESCRIPTION
### Description

Log4j 2.16.0 disables JNDI lookups by default. This will prevent security issues similar to CVE-2021-44228.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
