### PR TITLE
Prepend the version to the S3 key prefix for archives

### DIFF
--- a/release/archives/build.gradle
+++ b/release/archives/build.gradle
@@ -142,7 +142,7 @@ subprojects {
                 dependsOn tarTask.name
                 file file(tarTask.archiveFile.get().asFile.absolutePath)
                 bucketName awsS3Bucket
-                key tarTask.archiveName
+                key "${project.rootProject.version}/${tarTask.archiveName}"
 
                 def m = new ObjectMetadata()
                 m.setCacheControl("no-cache, no-store")
@@ -153,7 +153,7 @@ subprojects {
                 dependsOn zipTask.name
                 file file(zipTask.archiveFile.get().asFile.absolutePath)
                 bucketName awsS3Bucket
-                key zipTask.archiveName
+                key "${project.rootProject.version}/${zipTask.archiveName}"
 
                 def m = new ObjectMetadata()
                 m.setCacheControl("no-cache, no-store")
@@ -164,7 +164,7 @@ subprojects {
                 dependsOn tarWithJDKTask.name
                 file file(tarWithJDKTask.archiveFile.get().asFile.absolutePath)
                 bucketName awsS3Bucket
-                key tarWithJDKTask.archiveName
+                key "${project.rootProject.version}/${tarWithJDKTask.archiveName}"
 
                 def m = new ObjectMetadata()
                 m.setCacheControl("no-cache, no-store")
@@ -175,7 +175,7 @@ subprojects {
                 dependsOn zipWithJDKTask.name
                 file file(zipWithJDKTask.archiveFile.get().asFile.absolutePath)
                 bucketName awsS3Bucket
-                key zipWithJDKTask.archiveName
+                key "${project.rootProject.version}/${zipWithJDKTask.archiveName}"
 
                 def m = new ObjectMetadata()
                 m.setCacheControl("no-cache, no-store")


### PR DESCRIPTION
### Description

Added the version to the key prefix for S3 archives to bring some organization to the S3 bucket.

Below is a screenshot showing the ultimate result in a test S3 bucket:

<img width="1305" alt="key-prefix" src="https://user-images.githubusercontent.com/293424/146261850-8a03102f-c634-4531-ab94-ce5d9ae9fc75.png">

 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
