### PR TITLE
MAINT: file sink to support Event model

### DIFF
--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/sink/FileSink.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/sink/FileSink.java
@@ -16,6 +16,8 @@ import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.sink.Sink;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -28,6 +30,7 @@ import static java.lang.String.format;
 
 @DataPrepperPlugin(name = "file", pluginType = Sink.class)
 public class FileSink implements Sink<Record<Object>> {
+    private static final Logger LOG = LoggerFactory.getLogger(FileSink.class);
     private static final String SAMPLE_FILE_PATH = "src/resources/file-test-sample-output.txt";
 
     public static final String FILE_PATH = "path";
@@ -78,7 +81,7 @@ public class FileSink implements Sink<Record<Object>> {
             writer.write(((Event) object).toJsonString());
             writer.newLine();
         } else {
-            throw new RuntimeException("Invalid record type. FileSink only supports String and Events");
+            LOG.error("Invalid record type. FileSink only supports String and Events");
         }
     }
 

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/sink/FileSink.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/sink/FileSink.java
@@ -78,7 +78,7 @@ public class FileSink implements Sink<Record<Object>> {
             writer.write(((Event) object).toJsonString());
             writer.newLine();
         } else {
-            throw new RuntimeException("Invalid record type. StdOutSink only supports String and Events");
+            throw new RuntimeException("Invalid record type. FileSink only supports String and Events");
         }
     }
 


### PR DESCRIPTION
### Description
This PR modifies FileSink to support Event model while maintaining backward compatibility until we fully migrated all plugins to Event model.
 
### Issues Resolved
Resolves #606 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
