### PR TITLE
MAINT: StringPrepper use Event model

### DIFF
--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/StringPrepper.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/StringPrepper.java
@@ -18,9 +18,17 @@ import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.event.JacksonEvent;
 import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.record.Record;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * An simple String implementation of {@link Prepper} which generates new Records with upper case or lowercase content. The current
@@ -28,6 +36,9 @@ import java.util.Collection;
  */
 @DataPrepperPlugin(name = "string_converter", pluginType = Prepper.class, pluginConfigurationType = StringPrepper.Configuration.class)
 public class StringPrepper implements Prepper<Record<Event>, Record<Event>> {
+    private static Logger LOG = LoggerFactory.getLogger(StringPrepper.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final TypeReference<Map<String, Object>> mapTypeReference = new TypeReference<Map<String, Object>>() {};
 
     public static final String UPPER_CASE = "upper_case";
 
@@ -63,15 +74,32 @@ public class StringPrepper implements Prepper<Record<Event>, Record<Event>> {
         final Collection<Record<Event>> modifiedRecords = new ArrayList<>(records.size());
         for (Record<Event> record : records) {
             final Event recordEvent = record.getData();
-            final String recordData = recordEvent.toJsonString();
-            final String newData = upperCase? recordData.toUpperCase() : recordData.toLowerCase();
-            final Event newRecordEvent = JacksonEvent.builder()
-                    .withEventMetadata(recordEvent.getMetadata())
-                    .withData(newData)
-                    .build();
-            modifiedRecords.add(new Record<>(newRecordEvent));
+            final String eventJson = recordEvent.toJsonString();
+            try {
+                final Map<String, Object> newData = processEventJson(eventJson);
+                final Event newRecordEvent = JacksonEvent.builder()
+                        .withEventMetadata(recordEvent.getMetadata())
+                        .withData(newData)
+                        .build();
+                modifiedRecords.add(new Record<>(newRecordEvent));
+            } catch (JsonProcessingException e) {
+                LOG.error("Unable to process Event data: {}", eventJson, e);
+            }
         }
         return modifiedRecords;
+    }
+
+    private Map<String, Object> processEventJson(final String data) throws JsonProcessingException {
+        final Map<String, Object> dataMap = objectMapper.readValue(data, mapTypeReference);
+        return dataMap.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
+                    final Object val = entry.getValue();
+                    if (val instanceof String) {
+                        return upperCase? ((String) val).toUpperCase() : ((String) val).toLowerCase();
+                    } else {
+                        return val;
+                    }
+                }));
     }
 
     @Override

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/StringPrepper.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/StringPrepper.java
@@ -21,7 +21,6 @@ import com.amazon.dataprepper.model.record.Record;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/StringPrepper.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/StringPrepper.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 public class StringPrepper implements Prepper<Record<Event>, Record<Event>> {
     private static Logger LOG = LoggerFactory.getLogger(StringPrepper.class);
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final TypeReference<Map<String, Object>> mapTypeReference = new TypeReference<Map<String, Object>>() {};
+    private final TypeReference<Map<String, Object>> mapTypeReference = new TypeReference<>() {};
 
     public static final String UPPER_CASE = "upper_case";
 

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/StringPrepper.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/StringPrepper.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 public class StringPrepper implements Prepper<Record<Event>, Record<Event>> {
     private static Logger LOG = LoggerFactory.getLogger(StringPrepper.class);
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final TypeReference<Map<String, Object>> mapTypeReference = new TypeReference<>() {};
+    private final TypeReference<Map<String, Object>> mapTypeReference = new TypeReference<Map<String, Object>>() {};
 
     public static final String UPPER_CASE = "upper_case";
 

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/StringPrepperTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/StringPrepperTests.java
@@ -11,25 +11,41 @@
 
 package com.amazon.dataprepper.plugins.prepper;
 
+import com.amazon.dataprepper.model.event.Event;
+import com.amazon.dataprepper.model.event.JacksonEvent;
 import com.amazon.dataprepper.model.record.Record;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StringPrepperTests {
 
+    private final String TEST_EVENT_TYPE = "test_event_type";
+    private final String UPPERCASE_TEST_KEY = "test_key";
+    private final String LOWERCASE_TEST_KEY = "TEST_KEY";
     private final String UPPERCASE_TEST_STRING = "data_prepper";
     private final String LOWERCASE_TEST_STRING = "STRING_CONVERTER";
-    private final Record<String> TEST_RECORD_1 = new Record<>(UPPERCASE_TEST_STRING);
-    private final Record<String> TEST_RECORD_2 = new Record<>(LOWERCASE_TEST_STRING);
-    private final List<Record<String>> TEST_RECORDS = Arrays.asList(TEST_RECORD_1, TEST_RECORD_2);
+    private final Record<Event> TEST_RECORD_1 = new Record<>(
+            JacksonEvent.builder()
+                    .withEventType(TEST_EVENT_TYPE)
+                    .withData(Map.of(UPPERCASE_TEST_KEY, UPPERCASE_TEST_STRING))
+                    .build()
+    );
+    private final Record<Event> TEST_RECORD_2 = new Record<>(
+            JacksonEvent.builder()
+                    .withEventType(TEST_EVENT_TYPE)
+                    .withData(Map.of(LOWERCASE_TEST_KEY, LOWERCASE_TEST_STRING))
+                    .build()
+    );
+    private final List<Record<Event>> TEST_RECORDS = Arrays.asList(TEST_RECORD_1, TEST_RECORD_2);
     private StringPrepper.Configuration configuration;
 
     @BeforeEach
@@ -45,40 +61,60 @@ public class StringPrepperTests {
     public void testStringPrepperDefault() {
 
         final StringPrepper stringPrepper = createObjectUnderTest();
-        final List<Record<String>> modifiedRecords = (List<Record<String>>) stringPrepper.execute(TEST_RECORDS);
+        final List<Record<Event>> modifiedRecords = (List<Record<Event>>) stringPrepper.execute(TEST_RECORDS);
         stringPrepper.shutdown();
 
-        final List<String> modifiedRecordData = modifiedRecords.stream().map(Record::getData).collect(Collectors.toList());
-        final List<String> expectedRecordData = Arrays.asList(UPPERCASE_TEST_STRING.toUpperCase(), LOWERCASE_TEST_STRING);
+        final List<Event> modifiedRecordEvents = modifiedRecords.stream().map(Record::getData).collect(Collectors.toList());
 
-        assertThat(modifiedRecordData, equalTo(expectedRecordData));
+        assertThat(modifiedRecordEvents.size(), equalTo(2));
+        final Event firstEvent = modifiedRecordEvents.get(0);
+        final Event secondEvent = modifiedRecordEvents.get(1);
+        assertTrue(firstEvent.containsKey(UPPERCASE_TEST_KEY.toUpperCase()));
+        assertThat(firstEvent.getMetadata().getEventType(), equalTo(TEST_EVENT_TYPE));
+        assertThat(firstEvent.get(UPPERCASE_TEST_KEY.toUpperCase(), String.class), equalTo(UPPERCASE_TEST_STRING.toUpperCase()));
+        assertTrue(secondEvent.containsKey(LOWERCASE_TEST_KEY));
+        assertThat(secondEvent.getMetadata().getEventType(), equalTo(TEST_EVENT_TYPE));
+        assertThat(secondEvent.get(LOWERCASE_TEST_KEY, String.class), equalTo(LOWERCASE_TEST_STRING));
     }
 
     @Test
     public void testStringPrepperLowerCase() {
         configuration.setUpperCase(false);
         final StringPrepper stringPrepper = createObjectUnderTest();
-        final List<Record<String>> modifiedRecords = (List<Record<String>>) stringPrepper.execute(TEST_RECORDS);
+        final List<Record<Event>> modifiedRecords = (List<Record<Event>>) stringPrepper.execute(TEST_RECORDS);
         stringPrepper.shutdown();
 
-        final List<String> modifiedRecordData = modifiedRecords.stream().map(Record::getData).collect(Collectors.toList());
-        final List<String> expectedRecordData = Arrays.asList(UPPERCASE_TEST_STRING, LOWERCASE_TEST_STRING.toLowerCase());
+        final List<Event> modifiedRecordEvents = modifiedRecords.stream().map(Record::getData).collect(Collectors.toList());
 
-        assertThat(modifiedRecordData.size(), equalTo(2));
-        assertThat(modifiedRecordData, hasItems(UPPERCASE_TEST_STRING, LOWERCASE_TEST_STRING.toLowerCase()));
+        assertThat(modifiedRecordEvents.size(), equalTo(2));
+        final Event firstEvent = modifiedRecordEvents.get(0);
+        final Event secondEvent = modifiedRecordEvents.get(1);
+        assertTrue(firstEvent.containsKey(UPPERCASE_TEST_KEY));
+        assertThat(firstEvent.getMetadata().getEventType(), equalTo(TEST_EVENT_TYPE));
+        assertThat(firstEvent.get(UPPERCASE_TEST_KEY, String.class), equalTo(UPPERCASE_TEST_STRING));
+        assertTrue(secondEvent.containsKey(LOWERCASE_TEST_KEY.toLowerCase()));
+        assertThat(secondEvent.getMetadata().getEventType(), equalTo(TEST_EVENT_TYPE));
+        assertThat(secondEvent.get(LOWERCASE_TEST_KEY.toLowerCase(), String.class), equalTo(LOWERCASE_TEST_STRING.toLowerCase()));
     }
 
     @Test
     public void testStringPrepperUpperCase() {
         configuration.setUpperCase(true);
         final StringPrepper stringPrepper = createObjectUnderTest();
-        final List<Record<String>> modifiedRecords = (List<Record<String>>) stringPrepper.execute(TEST_RECORDS);
+        final List<Record<Event>> modifiedRecords = (List<Record<Event>>) stringPrepper.execute(TEST_RECORDS);
         stringPrepper.shutdown();
 
-        final List<String> modifiedRecordData = modifiedRecords.stream().map(Record::getData).collect(Collectors.toList());
-        final List<String> expectedRecordData = Arrays.asList(UPPERCASE_TEST_STRING.toUpperCase(), LOWERCASE_TEST_STRING);
+        final List<Event> modifiedRecordEvents = modifiedRecords.stream().map(Record::getData).collect(Collectors.toList());
 
-        assertThat(modifiedRecordData, equalTo(expectedRecordData));
+        assertThat(modifiedRecordEvents.size(), equalTo(2));
+        final Event firstEvent = modifiedRecordEvents.get(0);
+        final Event secondEvent = modifiedRecordEvents.get(1);
+        assertTrue(firstEvent.containsKey(UPPERCASE_TEST_KEY.toUpperCase()));
+        assertThat(firstEvent.getMetadata().getEventType(), equalTo(TEST_EVENT_TYPE));
+        assertThat(firstEvent.get(UPPERCASE_TEST_KEY.toUpperCase(), String.class), equalTo(UPPERCASE_TEST_STRING.toUpperCase()));
+        assertTrue(secondEvent.containsKey(LOWERCASE_TEST_KEY));
+        assertThat(secondEvent.getMetadata().getEventType(), equalTo(TEST_EVENT_TYPE));
+        assertThat(secondEvent.get(LOWERCASE_TEST_KEY, String.class), equalTo(LOWERCASE_TEST_STRING));
     }
 
     @Test

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/StringPrepperTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/StringPrepperTests.java
@@ -29,20 +29,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class StringPrepperTests {
 
     private final String TEST_EVENT_TYPE = "test_event_type";
-    private final String UPPERCASE_TEST_KEY = "test_key";
-    private final String LOWERCASE_TEST_KEY = "TEST_KEY";
+    private final String TEST_KEY = "test_key";
     private final String UPPERCASE_TEST_STRING = "data_prepper";
     private final String LOWERCASE_TEST_STRING = "STRING_CONVERTER";
     private final Record<Event> TEST_RECORD_1 = new Record<>(
             JacksonEvent.builder()
                     .withEventType(TEST_EVENT_TYPE)
-                    .withData(Map.of(UPPERCASE_TEST_KEY, UPPERCASE_TEST_STRING))
+                    .withData(Map.of(TEST_KEY, UPPERCASE_TEST_STRING))
                     .build()
     );
     private final Record<Event> TEST_RECORD_2 = new Record<>(
             JacksonEvent.builder()
                     .withEventType(TEST_EVENT_TYPE)
-                    .withData(Map.of(LOWERCASE_TEST_KEY, LOWERCASE_TEST_STRING))
+                    .withData(Map.of(TEST_KEY, LOWERCASE_TEST_STRING))
                     .build()
     );
     private final List<Record<Event>> TEST_RECORDS = Arrays.asList(TEST_RECORD_1, TEST_RECORD_2);
@@ -69,12 +68,12 @@ public class StringPrepperTests {
         assertThat(modifiedRecordEvents.size(), equalTo(2));
         final Event firstEvent = modifiedRecordEvents.get(0);
         final Event secondEvent = modifiedRecordEvents.get(1);
-        assertTrue(firstEvent.containsKey(UPPERCASE_TEST_KEY.toUpperCase()));
+        assertTrue(firstEvent.containsKey(TEST_KEY));
         assertThat(firstEvent.getMetadata().getEventType(), equalTo(TEST_EVENT_TYPE));
-        assertThat(firstEvent.get(UPPERCASE_TEST_KEY.toUpperCase(), String.class), equalTo(UPPERCASE_TEST_STRING.toUpperCase()));
-        assertTrue(secondEvent.containsKey(LOWERCASE_TEST_KEY));
+        assertThat(firstEvent.get(TEST_KEY, String.class), equalTo(UPPERCASE_TEST_STRING.toUpperCase()));
+        assertTrue(secondEvent.containsKey(TEST_KEY));
         assertThat(secondEvent.getMetadata().getEventType(), equalTo(TEST_EVENT_TYPE));
-        assertThat(secondEvent.get(LOWERCASE_TEST_KEY, String.class), equalTo(LOWERCASE_TEST_STRING));
+        assertThat(secondEvent.get(TEST_KEY, String.class), equalTo(LOWERCASE_TEST_STRING));
     }
 
     @Test
@@ -89,12 +88,12 @@ public class StringPrepperTests {
         assertThat(modifiedRecordEvents.size(), equalTo(2));
         final Event firstEvent = modifiedRecordEvents.get(0);
         final Event secondEvent = modifiedRecordEvents.get(1);
-        assertTrue(firstEvent.containsKey(UPPERCASE_TEST_KEY));
+        assertTrue(firstEvent.containsKey(TEST_KEY));
         assertThat(firstEvent.getMetadata().getEventType(), equalTo(TEST_EVENT_TYPE));
-        assertThat(firstEvent.get(UPPERCASE_TEST_KEY, String.class), equalTo(UPPERCASE_TEST_STRING));
-        assertTrue(secondEvent.containsKey(LOWERCASE_TEST_KEY.toLowerCase()));
+        assertThat(firstEvent.get(TEST_KEY, String.class), equalTo(UPPERCASE_TEST_STRING));
+        assertTrue(secondEvent.containsKey(TEST_KEY));
         assertThat(secondEvent.getMetadata().getEventType(), equalTo(TEST_EVENT_TYPE));
-        assertThat(secondEvent.get(LOWERCASE_TEST_KEY.toLowerCase(), String.class), equalTo(LOWERCASE_TEST_STRING.toLowerCase()));
+        assertThat(secondEvent.get(TEST_KEY, String.class), equalTo(LOWERCASE_TEST_STRING.toLowerCase()));
     }
 
     @Test
@@ -109,12 +108,12 @@ public class StringPrepperTests {
         assertThat(modifiedRecordEvents.size(), equalTo(2));
         final Event firstEvent = modifiedRecordEvents.get(0);
         final Event secondEvent = modifiedRecordEvents.get(1);
-        assertTrue(firstEvent.containsKey(UPPERCASE_TEST_KEY.toUpperCase()));
+        assertTrue(firstEvent.containsKey(TEST_KEY));
         assertThat(firstEvent.getMetadata().getEventType(), equalTo(TEST_EVENT_TYPE));
-        assertThat(firstEvent.get(UPPERCASE_TEST_KEY.toUpperCase(), String.class), equalTo(UPPERCASE_TEST_STRING.toUpperCase()));
-        assertTrue(secondEvent.containsKey(LOWERCASE_TEST_KEY));
+        assertThat(firstEvent.get(TEST_KEY, String.class), equalTo(UPPERCASE_TEST_STRING.toUpperCase()));
+        assertTrue(secondEvent.containsKey(TEST_KEY));
         assertThat(secondEvent.getMetadata().getEventType(), equalTo(TEST_EVENT_TYPE));
-        assertThat(secondEvent.get(LOWERCASE_TEST_KEY, String.class), equalTo(LOWERCASE_TEST_STRING));
+        assertThat(secondEvent.get(TEST_KEY, String.class), equalTo(LOWERCASE_TEST_STRING));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Chen <19492223+chenqi0805@users.noreply.github.com>

### Description
This PR migrates StringPrepper to use Event model.
 
### Issues Resolved
Resolves #608 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
