### PR TITLE
Added opensearch output plugin to converter

### DIFF
--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapper.java
@@ -36,15 +36,24 @@ public abstract class AbstractLogstashPluginAttributesMapper implements Logstash
                 .stream()
                 .filter(logstashAttribute -> !customMappedAttributeNames.contains(logstashAttribute.getAttributeName()))
                 .forEach(logstashAttribute -> {
-            if (mappedAttributeNames.containsKey(logstashAttribute.getAttributeName())) {
-                pluginSettings.put(
-                        mappedAttributeNames.get(logstashAttribute.getAttributeName()),
-                        logstashAttribute.getAttributeValue().getValue()
-                );
-            }
-            else {
-                LOG.warn("Attribute name {} is not found in mapping file.", logstashAttribute.getAttributeName());
-            }
+                    final String logstashAttributeName = logstashAttribute.getAttributeName();
+
+                    if (mappedAttributeNames.containsKey(logstashAttributeName)) {
+                        if (mappedAttributeNames.get(logstashAttributeName).startsWith("!")) {
+                            pluginSettings.put(
+                                    mappedAttributeNames.get(logstashAttributeName).substring(1),
+                                    !(Boolean) logstashAttribute.getAttributeValue().getValue()
+                            );
+                        }
+                        else {
+                            pluginSettings.put(
+                                    mappedAttributeNames.get(logstashAttributeName),
+                                    logstashAttribute.getAttributeValue().getValue());
+                        }
+                    }
+                    else {
+                        LOG.warn("Attribute name {} is not found in mapping file.", logstashAttributeName);
+                    }
         });
 
         if (!customMappedAttributeNames.isEmpty()) {

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/opensearch.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/opensearch.mapping.yaml
@@ -1,0 +1,7 @@
+pluginName: opensearch
+mappedAttributeNames:
+  hosts: hosts
+  user: username
+  password: password
+  index: index
+  ssl_certificate_verification: !insecure

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/DefaultLogstashPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/DefaultLogstashPluginAttributesMapperTest.java
@@ -28,6 +28,7 @@ class DefaultLogstashPluginAttributesMapperTest {
     private String logstashAttributeName;
     private String value;
     private List<LogstashAttribute> logstashAttributes;
+    private LogstashAttributeValue logstashAttributeValue;
     private LogstashAttributesMappings mappings;
 
     @BeforeEach
@@ -35,7 +36,7 @@ class DefaultLogstashPluginAttributesMapperTest {
         value = UUID.randomUUID().toString();
         logstashAttributeName = UUID.randomUUID().toString();
         final LogstashAttribute logstashAttribute = mock(LogstashAttribute.class);
-        final LogstashAttributeValue logstashAttributeValue = mock(LogstashAttributeValue.class);
+        logstashAttributeValue = mock(LogstashAttributeValue.class);
         when(logstashAttributeValue.getValue()).thenReturn(value);
         when(logstashAttribute.getAttributeName()).thenReturn(logstashAttributeName);
         when(logstashAttribute.getAttributeValue()).thenReturn(logstashAttributeValue);
@@ -113,5 +114,21 @@ class DefaultLogstashPluginAttributesMapperTest {
         assertThat(actualPluginSettings.size(), equalTo(1));
         assertThat(actualPluginSettings, hasKey(additionalAttributeName));
         assertThat(actualPluginSettings.get(additionalAttributeName), equalTo(additionalAttributeValue));
+    }
+
+    @Test
+    void mapAttributes_with_negation_expression_negates_boolean_value() {
+        final String dataPrepperAttribute = "!".concat(UUID.randomUUID().toString());
+        boolean value = true;
+
+        when(logstashAttributeValue.getValue()).thenReturn(value);
+        when(mappings.getMappedAttributeNames()).thenReturn(Collections.singletonMap(logstashAttributeName, dataPrepperAttribute));
+
+        final Map<String, Object> actualPluginSettings =
+                createObjectUnderTest().mapAttributes(logstashAttributes, mappings);
+
+        assertThat(actualPluginSettings, notNullValue());
+        assertThat(actualPluginSettings.size(), equalTo(1));
+        assertThat(actualPluginSettings.get(dataPrepperAttribute.substring(1)), equalTo(!value));
     }
 }


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description

- Added OpenSearch output plugin mapping file
- Added an expression in mapping file to support negation of boolean Logstash attribute values

 
### Issues Resolved
Resolves #746 
Resolves #710 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
