### PR TITLE
Added Logstash OpenSearch output plugin mapping to converter

### DIFF
--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapper.java
@@ -36,15 +36,24 @@ public abstract class AbstractLogstashPluginAttributesMapper implements Logstash
                 .stream()
                 .filter(logstashAttribute -> !customMappedAttributeNames.contains(logstashAttribute.getAttributeName()))
                 .forEach(logstashAttribute -> {
-            if (mappedAttributeNames.containsKey(logstashAttribute.getAttributeName())) {
-                pluginSettings.put(
-                        mappedAttributeNames.get(logstashAttribute.getAttributeName()),
-                        logstashAttribute.getAttributeValue().getValue()
-                );
-            }
-            else {
-                LOG.warn("Attribute name {} is not found in mapping file.", logstashAttribute.getAttributeName());
-            }
+                    final String logstashAttributeName = logstashAttribute.getAttributeName();
+
+                    if (mappedAttributeNames.containsKey(logstashAttributeName)) {
+                        if (mappedAttributeNames.get(logstashAttributeName).startsWith("!")) {
+                            pluginSettings.put(
+                                    mappedAttributeNames.get(logstashAttributeName).substring(1),
+                                    !(Boolean) logstashAttribute.getAttributeValue().getValue()
+                            );
+                        }
+                        else {
+                            pluginSettings.put(
+                                    mappedAttributeNames.get(logstashAttributeName),
+                                    logstashAttribute.getAttributeValue().getValue());
+                        }
+                    }
+                    else {
+                        LOG.warn("Attribute name {} is not found in mapping file.", logstashAttributeName);
+                    }
         });
 
         if (!customMappedAttributeNames.isEmpty()) {

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapper.java
@@ -37,18 +37,16 @@ public abstract class AbstractLogstashPluginAttributesMapper implements Logstash
                 .filter(logstashAttribute -> !customMappedAttributeNames.contains(logstashAttribute.getAttributeName()))
                 .forEach(logstashAttribute -> {
                     final String logstashAttributeName = logstashAttribute.getAttributeName();
+                    final String dataPrepperAttributeName = mappedAttributeNames.get(logstashAttributeName);
 
                     if (mappedAttributeNames.containsKey(logstashAttributeName)) {
-                        if (mappedAttributeNames.get(logstashAttributeName).startsWith("!")) {
+                        if (dataPrepperAttributeName.startsWith("!") && logstashAttribute.getAttributeValue().getValue() instanceof Boolean) {
                             pluginSettings.put(
-                                    mappedAttributeNames.get(logstashAttributeName).substring(1),
-                                    !(Boolean) logstashAttribute.getAttributeValue().getValue()
+                                    dataPrepperAttributeName.substring(1), !(Boolean) logstashAttribute.getAttributeValue().getValue()
                             );
                         }
                         else {
-                            pluginSettings.put(
-                                    mappedAttributeNames.get(logstashAttributeName),
-                                    logstashAttribute.getAttributeValue().getValue());
+                            pluginSettings.put(dataPrepperAttributeName, logstashAttribute.getAttributeValue().getValue());
                         }
                     }
                     else {

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/opensearch.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/opensearch.mapping.yaml
@@ -4,4 +4,4 @@ mappedAttributeNames:
   user: username
   password: password
   index: index
-  ssl_certificate_verification: !insecure
+  ssl_certificate_verification: "!insecure"

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/opensearch.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/opensearch.mapping.yaml
@@ -1,0 +1,7 @@
+pluginName: opensearch
+mappedAttributeNames:
+  hosts: hosts
+  user: username
+  password: password
+  index: index
+  ssl_certificate_verification: !insecure

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/DefaultLogstashPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/DefaultLogstashPluginAttributesMapperTest.java
@@ -28,6 +28,7 @@ class DefaultLogstashPluginAttributesMapperTest {
     private String logstashAttributeName;
     private String value;
     private List<LogstashAttribute> logstashAttributes;
+    private LogstashAttributeValue logstashAttributeValue;
     private LogstashAttributesMappings mappings;
 
     @BeforeEach
@@ -35,7 +36,7 @@ class DefaultLogstashPluginAttributesMapperTest {
         value = UUID.randomUUID().toString();
         logstashAttributeName = UUID.randomUUID().toString();
         final LogstashAttribute logstashAttribute = mock(LogstashAttribute.class);
-        final LogstashAttributeValue logstashAttributeValue = mock(LogstashAttributeValue.class);
+        logstashAttributeValue = mock(LogstashAttributeValue.class);
         when(logstashAttributeValue.getValue()).thenReturn(value);
         when(logstashAttribute.getAttributeName()).thenReturn(logstashAttributeName);
         when(logstashAttribute.getAttributeValue()).thenReturn(logstashAttributeValue);
@@ -113,5 +114,21 @@ class DefaultLogstashPluginAttributesMapperTest {
         assertThat(actualPluginSettings.size(), equalTo(1));
         assertThat(actualPluginSettings, hasKey(additionalAttributeName));
         assertThat(actualPluginSettings.get(additionalAttributeName), equalTo(additionalAttributeValue));
+    }
+
+    @Test
+    void mapAttributes_with_negation_expression_negates_boolean_value() {
+        final String dataPrepperAttribute = "!".concat(UUID.randomUUID().toString());
+        boolean value = true;
+
+        when(logstashAttributeValue.getValue()).thenReturn(value);
+        when(mappings.getMappedAttributeNames()).thenReturn(Collections.singletonMap(logstashAttributeName, dataPrepperAttribute));
+
+        final Map<String, Object> actualPluginSettings =
+                createObjectUnderTest().mapAttributes(logstashAttributes, mappings);
+
+        assertThat(actualPluginSettings, notNullValue());
+        assertThat(actualPluginSettings.size(), equalTo(1));
+        assertThat(actualPluginSettings.get(dataPrepperAttribute.substring(1)), equalTo(!value));
     }
 }

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/DefaultLogstashPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/DefaultLogstashPluginAttributesMapperTest.java
@@ -7,6 +7,8 @@ package org.opensearch.dataprepper.logstash.mapping;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
 import org.opensearch.dataprepper.logstash.model.LogstashAttributeValue;
 
@@ -116,19 +118,18 @@ class DefaultLogstashPluginAttributesMapperTest {
         assertThat(actualPluginSettings.get(additionalAttributeName), equalTo(additionalAttributeValue));
     }
 
-    @Test
-    void mapAttributes_with_negation_expression_negates_boolean_value() {
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false } )
+    void mapAttributes_with_negation_expression_negates_boolean_value(boolean inputValue) {
         final String dataPrepperAttribute = "!".concat(UUID.randomUUID().toString());
-        boolean value = true;
 
-        when(logstashAttributeValue.getValue()).thenReturn(value);
+        when(logstashAttributeValue.getValue()).thenReturn(inputValue);
         when(mappings.getMappedAttributeNames()).thenReturn(Collections.singletonMap(logstashAttributeName, dataPrepperAttribute));
 
-        final Map<String, Object> actualPluginSettings =
-                createObjectUnderTest().mapAttributes(logstashAttributes, mappings);
+        final Map<String, Object> actualPluginSettings = createObjectUnderTest().mapAttributes(logstashAttributes, mappings);
 
         assertThat(actualPluginSettings, notNullValue());
         assertThat(actualPluginSettings.size(), equalTo(1));
-        assertThat(actualPluginSettings.get(dataPrepperAttribute.substring(1)), equalTo(!value));
+        assertThat(actualPluginSettings.get(dataPrepperAttribute.substring(1)), equalTo(!inputValue));
     }
 }

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch-insecure.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch-insecure.expected.yaml
@@ -1,0 +1,18 @@
+logstash-converted-pipeline:
+  source:
+    http:
+      max_connection_count: 500
+      request_timeout: 10000
+  processor:
+    - grok:
+        match:
+          log:
+            - "%{COMBINEDAPACHELOG}"
+  sink:
+    - opensearch:
+        hosts:
+          - "fakedomain.us-east-1.es.amazonaws.com"
+        username: "myuser"
+        password: "mypassword"
+        index: "my-index"
+        insecure: true

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch.conf
@@ -1,0 +1,18 @@
+input {
+    http {
+    }
+}
+filter {
+    grok {
+        match => {"log" => "%{COMBINEDAPACHELOG}"}
+    }
+}
+output {
+    opensearch {
+        hosts => ["fakedomain.us-east-1.es.amazonaws.com"]
+        user => myuser
+        password => mypassword
+        index => "my-index"
+        ssl_certificate_verification => true
+    }
+}

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch.expected.yaml
@@ -1,0 +1,18 @@
+logstash-converted-pipeline:
+  source:
+    http:
+      max_connection_count: 500
+      request_timeout: 10000
+  processor:
+    - grok:
+        match:
+          log:
+            - "%{COMBINEDAPACHELOG}"
+  sink:
+    - opensearch:
+        hosts:
+          - "fakedomain.us-east-1.es.amazonaws.com"
+        username: "myuser"
+        password: "mypassword"
+        index: "my-index"
+        insecure: false

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logtstash-opensearch-insecure.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logtstash-opensearch-insecure.conf
@@ -1,0 +1,18 @@
+input {
+    http {
+    }
+}
+filter {
+    grok {
+        match => {"log" => "%{COMBINEDAPACHELOG}"}
+    }
+}
+output {
+    opensearch {
+        hosts => ["fakedomain.us-east-1.es.amazonaws.com"]
+        user => myuser
+        password => mypassword
+        index => "my-index"
+        ssl_certificate_verification => false
+    }
+}


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description

- Added Logstash OpenSearch output plugin mapping to converter
- Added support for negation of boolean Logstash attribute values.

### Issues Resolved
Resolves #710 
Resolves #746 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
