### PR TITLE
Disable lookups

### DIFF
--- a/shared-config/log4j.properties
+++ b/shared-config/log4j.properties
@@ -14,7 +14,7 @@ log4j.rootLogger=WARN, CONSOLE
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.Threshold=INFO
-log4j.appender.CONSOLE.layout.ConversionPattern=%-4r [%t] %-5p %c %x \u2013 %m%n
+log4j.appender.CONSOLE.layout.ConversionPattern=%-4r [%t] %-5p %c %x \u2013 %m{nolookup}%n
 #- size rotation with log cleanup.
 log4j.appender.file=org.apache.log4j.RollingFileAppender
 log4j.appender.file.File=logs/Data-Prepper.log
@@ -23,7 +23,7 @@ log4j.appender.file.MaxBackupIndex=5
 #setting threshold to INFO if the logger level is changed
 log4j.appender.file.Threshold=INFO
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %40C - %m%n
+log4j.appender.file.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %40C - %m{nolookup}%n
 
 #package specific levels
 log4j.logger.com.amazon.dataprepper.pipeline=INFO


### PR DESCRIPTION
### Description
Disable log4j lookups on log message content
log4j documentation: https://logging.apache.org/log4j/2.x/manual/layouts.html

This does not resolve CVE-2021-45046
 
### Issues Resolved
Reduce potential attack surface for log4j based attacks
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
