### PR TITLE
Fix boolean conversion and integer conversion bug for Logstash configuration converter attributes (#766)

### DIFF
--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/parser/ModelConvertingLogstashVisitor.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/parser/ModelConvertingLogstashVisitor.java
@@ -1,20 +1,20 @@
 package org.opensearch.dataprepper.logstash.parser;
 
 import org.antlr.v4.runtime.RuleContext;
-import org.opensearch.dataprepper.logstash.exception.LogstashParsingException;
 import org.opensearch.dataprepper.logstash.LogstashBaseVisitor;
 import org.opensearch.dataprepper.logstash.LogstashParser;
-import org.opensearch.dataprepper.logstash.model.LogstashConfiguration;
-import org.opensearch.dataprepper.logstash.model.LogstashPlugin;
+import org.opensearch.dataprepper.logstash.exception.LogstashParsingException;
 import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
 import org.opensearch.dataprepper.logstash.model.LogstashAttributeValue;
+import org.opensearch.dataprepper.logstash.model.LogstashConfiguration;
+import org.opensearch.dataprepper.logstash.model.LogstashPlugin;
 import org.opensearch.dataprepper.logstash.model.LogstashPluginType;
 import org.opensearch.dataprepper.logstash.model.LogstashValueType;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.LinkedHashMap;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -96,11 +96,22 @@ public class ModelConvertingLogstashVisitor extends LogstashBaseVisitor {
         }
         else if (attributeContext.value().NUMBER() != null && attributeContext.value().getText().equals(attributeContext.value().NUMBER().toString())) {
             logstashValueType = LogstashValueType.NUMBER;
-            value = Double.valueOf(attributeContext.value().getText());
+            try {
+                value = Integer.parseInt(attributeContext.value().getText());
+            } catch (NumberFormatException e) {
+                try {
+                    value = Double.parseDouble(attributeContext.value().getText());
+                } catch (NumberFormatException exception) {
+                    throw new LogstashParsingException("NUMBER types must be either Integer or Double");
+                }
+            }
         }
         else if (attributeContext.value().BAREWORD() != null && attributeContext.value().getText().equals(attributeContext.value().BAREWORD().toString())) {
             logstashValueType = LogstashValueType.BAREWORD;
             value = attributeContext.value().getText();
+            if (value.toString().equals("true") || value.toString().equals("false")) {
+                value = Boolean.parseBoolean(value.toString());
+            }
         }
         else if (attributeContext.value().STRING() != null && attributeContext.value().getText().equals(attributeContext.value().STRING().toString())) {
             logstashValueType = LogstashValueType.STRING;

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/parser/ModelConvertingLogstashVisitorTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/parser/ModelConvertingLogstashVisitorTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.opensearch.dataprepper.logstash.LogstashParser;
@@ -353,16 +355,36 @@ class ModelConvertingLogstashVisitorTest {
     }
 
     @Test
-    void visit_attribute_with_value_type_number_returns_correct_logstash_attribute_test() {
+    void visit_attribute_with_value_type_integer_returns_correct_logstash_attribute_test() {
         given(attributeContextMock.name()).willReturn(nameContextMock);
         given(nameContextMock.getText()).willReturn(TestDataProvider.RANDOM_STRING_1);
         given(attributeContextMock.value()).willReturn(valueContextMock);
         given(valueContextMock.NUMBER()).willReturn(terminalNodeMock);
-        given(valueContextMock.getText()).willReturn(TestDataProvider.RANDOM_VALUE);
-        given(valueContextMock.NUMBER().toString()).willReturn(TestDataProvider.RANDOM_VALUE);
+        given(valueContextMock.getText()).willReturn(TestDataProvider.RANDOM_INTEGER);
+        given(valueContextMock.NUMBER().toString()).willReturn(TestDataProvider.RANDOM_INTEGER);
 
         LogstashAttribute actualLogstashAttribute = (LogstashAttribute) logstashVisitor.visitAttribute(attributeContextMock);
-        LogstashAttribute expectedLogstashAttribute = TestDataProvider.attributeWithNumberTypeValueData();
+        LogstashAttribute expectedLogstashAttribute = TestDataProvider.attributeWithIntegerTypeValueData();
+
+        assertThat(actualLogstashAttribute.getAttributeName(),
+                equalTo(expectedLogstashAttribute.getAttributeName()));
+        assertThat(actualLogstashAttribute.getAttributeValue().getValue(),
+                equalTo(expectedLogstashAttribute.getAttributeValue().getValue()));
+        assertThat(actualLogstashAttribute.getAttributeValue().getAttributeValueType(),
+                equalTo(expectedLogstashAttribute.getAttributeValue().getAttributeValueType()));
+    }
+
+    @Test
+    void visit_attribute_with_value_type_double_returns_correct_logstash_attribute_test() {
+        given(attributeContextMock.name()).willReturn(nameContextMock);
+        given(nameContextMock.getText()).willReturn(TestDataProvider.RANDOM_STRING_1);
+        given(attributeContextMock.value()).willReturn(valueContextMock);
+        given(valueContextMock.NUMBER()).willReturn(terminalNodeMock);
+        given(valueContextMock.getText()).willReturn(TestDataProvider.RANDOM_DOUBLE);
+        given(valueContextMock.NUMBER().toString()).willReturn(TestDataProvider.RANDOM_DOUBLE);
+
+        LogstashAttribute actualLogstashAttribute = (LogstashAttribute) logstashVisitor.visitAttribute(attributeContextMock);
+        LogstashAttribute expectedLogstashAttribute = TestDataProvider.attributeWithDoubleTypeValueData();
 
         assertThat(actualLogstashAttribute.getAttributeName(),
                 equalTo(expectedLogstashAttribute.getAttributeName()));
@@ -384,6 +406,28 @@ class ModelConvertingLogstashVisitorTest {
         LogstashAttribute actualLogstashAttribute = (LogstashAttribute) logstashVisitor.visitAttribute(attributeContextMock);
         LogstashAttribute expectedLogstashAttribute = TestDataProvider.attributeWithBareWordTypeValueData();
 
+
+        assertThat(actualLogstashAttribute.getAttributeName(),
+                equalTo(expectedLogstashAttribute.getAttributeName()));
+        assertThat(actualLogstashAttribute.getAttributeValue().getValue(),
+                equalTo(expectedLogstashAttribute.getAttributeValue().getValue()));
+        assertThat(actualLogstashAttribute.getAttributeValue().getAttributeValueType(),
+                equalTo(expectedLogstashAttribute.getAttributeValue().getAttributeValueType()));
+
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false } )
+    void visit_attribute_with_value_type_bare_word_boolean_returns_correct_logstash_attribute_test(boolean input) {
+        given(attributeContextMock.name()).willReturn(nameContextMock);
+        given(nameContextMock.getText()).willReturn(TestDataProvider.RANDOM_STRING_1);
+        given(attributeContextMock.value()).willReturn(valueContextMock);
+        given(valueContextMock.BAREWORD()).willReturn(terminalNodeMock);
+        given(valueContextMock.getText()).willReturn(String.valueOf(input));
+        given(valueContextMock.BAREWORD().toString()).willReturn(String.valueOf(input));
+
+        LogstashAttribute actualLogstashAttribute = (LogstashAttribute) logstashVisitor.visitAttribute(attributeContextMock);
+        LogstashAttribute expectedLogstashAttribute = TestDataProvider.attributeWithBareWordBooleanTypeValueData(input);
 
         assertThat(actualLogstashAttribute.getAttributeName(),
                 equalTo(expectedLogstashAttribute.getAttributeName()));

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/parser/TestDataProvider.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/parser/TestDataProvider.java
@@ -21,7 +21,8 @@ import java.util.LinkedHashMap;
 class TestDataProvider {
     static final String RANDOM_STRING_1 = UUID.randomUUID().toString();
     static final String RANDOM_STRING_2 = UUID.randomUUID().toString();
-    static final String RANDOM_VALUE = String.valueOf(new Random().nextInt(1000));
+    static final String RANDOM_INTEGER = String.valueOf(new Random().nextInt(1000));
+    static final String RANDOM_DOUBLE = String.valueOf(new Random().nextDouble());
 
     public static LogstashConfiguration configData() {
         List<LogstashPlugin> pluginContextList = new LinkedList<>(Collections.singletonList(pluginWithOneArrayContextAttributeData()));
@@ -82,9 +83,16 @@ class TestDataProvider {
                 .attributeName(TestDataProvider.RANDOM_STRING_1).attributeValue(logstashAttributeValue).build();
     }
 
-    public static LogstashAttribute attributeWithNumberTypeValueData() {
+    public static LogstashAttribute attributeWithIntegerTypeValueData() {
         LogstashAttributeValue logstashAttributeValue = LogstashAttributeValue.builder().
-                attributeValueType(LogstashValueType.NUMBER).value(Double.valueOf(TestDataProvider.RANDOM_VALUE)).build();
+                attributeValueType(LogstashValueType.NUMBER).value(Integer.valueOf(TestDataProvider.RANDOM_INTEGER)).build();
+        return LogstashAttribute.builder()
+                .attributeName(TestDataProvider.RANDOM_STRING_1).attributeValue(logstashAttributeValue).build();
+    }
+
+    public static LogstashAttribute attributeWithDoubleTypeValueData() {
+        LogstashAttributeValue logstashAttributeValue = LogstashAttributeValue.builder().
+                attributeValueType(LogstashValueType.NUMBER).value(Double.valueOf(TestDataProvider.RANDOM_DOUBLE)).build();
         return LogstashAttribute.builder()
                 .attributeName(TestDataProvider.RANDOM_STRING_1).attributeValue(logstashAttributeValue).build();
     }
@@ -92,6 +100,13 @@ class TestDataProvider {
     public static LogstashAttribute attributeWithBareWordTypeValueData() {
         LogstashAttributeValue logstashAttributeValue = LogstashAttributeValue.builder().
                 attributeValueType(LogstashValueType.BAREWORD).value(RANDOM_STRING_2).build();
+        return LogstashAttribute.builder()
+                .attributeName(RANDOM_STRING_1).attributeValue(logstashAttributeValue).build();
+    }
+
+    public static LogstashAttribute attributeWithBareWordBooleanTypeValueData(boolean input) {
+        LogstashAttributeValue logstashAttributeValue = LogstashAttributeValue.builder().
+                attributeValueType(LogstashValueType.BAREWORD).value(input).build();
         return LogstashAttribute.builder()
                 .attributeName(RANDOM_STRING_1).attributeValue(logstashAttributeValue).build();
     }

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.conf
@@ -1,10 +1,14 @@
 input {
     http {
+        port => 3000
+        threads => 10.0
+        ssl => true
     }
 }
 filter {
     grok {
         match => {"log" => "%{COMBINEDAPACHELOG}"}
+        break_on_match => false
     }
 }
 output {

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.expected.yaml
@@ -3,8 +3,12 @@ logstash-converted-pipeline:
     http:
       max_connection_count: 500
       request_timeout: 10000
+      port: 3000
+      thread_count: 10.0
+      ssl: true
   prepper:
     - grok:
+        break_on_match: false
         match:
           log:
             - "%{COMBINEDAPACHELOG}"


### PR DESCRIPTION
Fix boolean conversion and integer conversion bug for Logstash configuration converter attributes

Signed-off-by: Taylor Gray <33740195+graytaylor0@users.noreply.github.com>

### Description
Cherry picked commit from main
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
