### PR TITLE
Add AbstractProcessor constructor that takes a PluginMetrics

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java
@@ -41,6 +41,13 @@ public abstract class AbstractProcessor<InputRecord extends Record<?>, OutputRec
         timeElapsedTimer = pluginMetrics.timer(MetricNames.TIME_ELAPSED);
     }
 
+    public AbstractProcessor(final PluginMetrics pluginMetrics) {
+        this.pluginMetrics = pluginMetrics;
+        recordsInCounter = pluginMetrics.counter(MetricNames.RECORDS_IN);
+        recordsOutCounter = pluginMetrics.counter(MetricNames.RECORDS_OUT);
+        timeElapsedTimer = pluginMetrics.timer(MetricNames.TIME_ELAPSED);
+    }
+
     /**
      * @since 1.2
      * This execute function calls the {@link AbstractProcessor#doExecute(Collection)} function of the implementation,

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java
@@ -41,7 +41,7 @@ public abstract class AbstractProcessor<InputRecord extends Record<?>, OutputRec
         timeElapsedTimer = pluginMetrics.timer(MetricNames.TIME_ELAPSED);
     }
 
-    public AbstractProcessor(final PluginMetrics pluginMetrics) {
+    protected AbstractProcessor(final PluginMetrics pluginMetrics) {
         this.pluginMetrics = pluginMetrics;
         recordsInCounter = pluginMetrics.counter(MetricNames.RECORDS_IN);
         recordsOutCounter = pluginMetrics.counter(MetricNames.RECORDS_OUT);


### PR DESCRIPTION
Signed-off-by: Taylor Gray <33740195+graytaylor0@users.noreply.github.com>

### Description
* This constructor takes a PluginMetrics, and makes AbstractProcessor compatible with `@DataPrepperPluginConstructor` processors that do not use a PluginSetting. It allows for the PluginMetrics passed to the `@DataPrepperPluginConstructor` to be used to create a Processor.
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
