### PR TITLE
MAINT: remove traceGroup keys from required in JacksonSpan

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/JacksonSpan.java
@@ -45,8 +45,8 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
     private static final List<String>
             REQUIRED_NON_EMPTY_KEYS = Arrays.asList(TRACE_ID_KEY, SPAN_ID_KEY, TRACE_STATE_KEY, PARENT_SPAN_ID_KEY, PARENT_SPAN_ID_KEY,
-            NAME_KEY, KIND_KEY, START_TIME_KEY, END_TIME_KEY, TRACE_GROUP_KEY);
-    private static final List<String> REQUIRED_NON_NULL_KEYS = Arrays.asList(DURATION_IN_NANOS_KEY, TRACE_GROUP_FIELDS_KEY);
+            NAME_KEY, KIND_KEY, START_TIME_KEY, END_TIME_KEY);
+    private static final List<String> REQUIRED_NON_NULL_KEYS = Arrays.asList(DURATION_IN_NANOS_KEY);
 
     protected JacksonSpan(final Builder builder) {
         super(builder);

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/JacksonSpanTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/trace/JacksonSpanTest.java
@@ -386,18 +386,6 @@ public class JacksonSpanTest {
     }
 
     @Test
-    public void testBuilder_withoutTraceGroup_throwsNullPointerException() {
-        builder.withTraceGroup(null);
-        assertThrows(NullPointerException.class, builder::build);
-    }
-
-    @Test
-    public void testBuilder_withEmptyTraceGroup_throwsIllegalArgumentException() {
-        builder.withTraceGroup("");
-        assertThrows(IllegalArgumentException.class, builder::build);
-    }
-
-    @Test
     public void testBuilder_allRequiredParameters_createsSpanWithDefaultValues() {
 
         final JacksonSpan span = JacksonSpan.builder()


### PR DESCRIPTION
Signed-off-by: Chen <19492223+chenqi0805@users.noreply.github.com>

### Description
This PR removes traceGroup and traceGroupFields from required in JacksonSpan as they will not always be populated at first place when ExportTraceServiceRequest is converted into our Span model.
 
### Issues Resolved
Contributes to #546 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
