### PR TITLE
Updated to log4j 2.17.1 to fix CVE-2021-44832.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,13 +66,13 @@ subprojects {
             }
             implementation('org.apache.logging.log4j:log4j-core') {
                 version {
-                    require '2.17.0'
+                    require '2.17.1'
                 }
-                because 'Log4j 2.17.0 fixes CVE-2021-44228, CVE-2021-45046, and CVE-2021-45105'
+                because 'Log4j 2.17.1 fixes CVE-2021-44228, CVE-2021-45046, CVE-2021-45105, and CVE-2021-44832'
             }
             implementation('org.apache.logging.log4j:log4j-api') {
                 version {
-                    require '2.17.0'
+                    require '2.17.1'
                 }
                 because 'the build fails if the Log4j API is not update along with log4j-core'
             }

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.micrometer:micrometer-registry-cloudwatch2'
     implementation 'software.amazon.awssdk:cloudwatch'
-    implementation platform('org.apache.logging.log4j:log4j-bom:2.17.0')
+    implementation platform('org.apache.logging.log4j:log4j-bom:2.17.1')
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl'
     testImplementation "org.hamcrest:hamcrest:2.2"

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -95,8 +95,8 @@ configurations.all {
         force 'com.google.guava:guava:31.0.1-jre'
         force 'junit:junit:4.13.2'
         force "org.slf4j:slf4j-api:1.7.32"
-        force 'org.apache.logging.log4j:log4j-api:2.17.0'
-        force 'org.apache.logging.log4j:log4j-core:2.17.0'
+        force 'org.apache.logging.log4j:log4j-api:2.17.1'
+        force 'org.apache.logging.log4j:log4j-core:2.17.1'
         force 'commons-beanutils:commons-beanutils:1.9.4'
     }
     // The OpenSearch plugins appear to provide their own version of Mockito


### PR DESCRIPTION
### Description

Updates to log4j 2.17.1 which fixes [CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832).
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
