### PR TITLE
Assemble the data-prepper-core uber-jar using Zip64

### DIFF
--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 }
 
 jar {
+    zip64 = true
     dependsOn configurations.runtimeClasspath
     manifest {
         attributes('Implementation-Title': project.name,


### PR DESCRIPTION
### Description

In an upcoming PR to support JSR-303/380 validation, I hit this error:

```
Execution failed for task ':data-prepper-core:jar'.
> archive contains more than 65535 entries.

  To build this archive, please enable the zip64 extension.
  See: https://docs.gradle.org/6.6.1/dsl/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:zip64
```

Because data-prepper-core is an uber-jar, it has all the classes necessary in that one jar. This is becoming too many for a normal Zip archive.

This change enables zip 64, which is compatible with Java 7 and above.
 
### Issues Resolved

Resolves #819 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
