### PR TITLE
Add PipelineDescription object to be passed to @DataPrepperPluginConstructor

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelineDescription.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelineDescription.java
@@ -7,15 +7,18 @@ package com.amazon.dataprepper.model.configuration;
 
 /**
  * Model that should be provided to plugins to provide certain details about the pipeline they belong to
+ * @since 1.3
  */
 public interface PipelineDescription {
     /**
      * Returns the name of the pipeline that a plugin belongs to
+     * @since 1.3
      */
     String getPipelineName();
 
     /**
      * Returns the number of process workers the pipeline is using; plugins can utilize this if synchronization between workers is necessary
+     * @since 1.3
      */
     int getNumberOfProcessWorkers();
 }

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelineDescription.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelineDescription.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.model.configuration;
+
+/**
+ * Model that should be provided to plugins to provide certain details about the pipeline they belong to
+ */
+public interface PipelineDescription {
+    /**
+     * Returns the name of the pipeline that a plugin belongs to
+     */
+    String getPipelineName();
+
+    /**
+     * Returns the number of process workers the pipeline is using; plugins can utilize this if synchronization between workers is necessary
+     */
+    int getNumberOfProcessWorkers();
+}

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PluginSetting.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PluginSetting.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class PluginSetting {
+public class PluginSetting implements PipelineDescription {
 
     private static final String UNEXPECTED_ATTRIBUTE_TYPE_MSG = "Unexpected type [%s] for attribute [%s]";
 

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/DefaultPluginFactory.java
@@ -97,6 +97,7 @@ public class DefaultPluginFactory implements PluginFactory {
         return new PluginArgumentsContext.Builder()
                 .withPluginSetting(pluginSetting)
                 .withPluginConfiguration(configuration)
+                .withPipelineDescription(pluginSetting)
                 .withPluginFactory(this)
                 .build();
     }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginArgumentsContext.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginArgumentsContext.java
@@ -6,10 +6,10 @@
 package com.amazon.dataprepper.plugin;
 
 import com.amazon.dataprepper.metrics.PluginMetrics;
+import com.amazon.dataprepper.model.configuration.PipelineDescription;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.plugin.InvalidPluginDefinitionException;
 import com.amazon.dataprepper.model.plugin.PluginFactory;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,6 +37,10 @@ class PluginArgumentsContext {
 
         typedArgumentsSuppliers.put(PluginMetrics.class, () -> PluginMetrics.fromPluginSetting(builder.pluginSetting));
 
+        if (builder.pipelineDescription != null) {
+            typedArgumentsSuppliers.put(PipelineDescription.class, () -> builder.pipelineDescription);
+        }
+
         if(builder.pluginFactory != null)
             typedArgumentsSuppliers.put(PluginFactory.class, () -> builder.pluginFactory);
     }
@@ -60,6 +64,7 @@ class PluginArgumentsContext {
         private Object pluginConfiguration;
         private PluginSetting pluginSetting;
         private PluginFactory pluginFactory;
+        private PipelineDescription pipelineDescription;
 
         Builder withPluginConfiguration(final Object pluginConfiguration) {
             this.pluginConfiguration = pluginConfiguration;
@@ -73,6 +78,11 @@ class PluginArgumentsContext {
 
         Builder withPluginFactory(final PluginFactory pluginFactory) {
             this.pluginFactory = pluginFactory;
+            return this;
+        }
+
+        Builder withPipelineDescription(final PipelineDescription pipelineDescription) {
+            this.pipelineDescription = pipelineDescription;
             return this;
         }
 

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginArgumentsContextTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginArgumentsContextTest.java
@@ -6,6 +6,7 @@
 package com.amazon.dataprepper.plugin;
 
 import com.amazon.dataprepper.metrics.PluginMetrics;
+import com.amazon.dataprepper.model.configuration.PipelineDescription;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.plugin.InvalidPluginDefinitionException;
 import com.amazon.dataprepper.model.plugin.PluginFactory;
@@ -74,6 +75,18 @@ class PluginArgumentsContextTest {
 
         assertThat(objectUnderTest.createArguments(new Class[] { PluginSetting.class, TestPluginConfiguration.class }),
                 equalTo(new Object[] { pluginSetting, testPluginConfiguration }));
+    }
+
+    @Test
+    void createArguments_with_three_classes() {
+        final PluginArgumentsContext objectUnderTest = new PluginArgumentsContext.Builder()
+                .withPluginConfiguration(testPluginConfiguration)
+                .withPluginSetting(pluginSetting)
+                .withPipelineDescription(pluginSetting)
+                .build();
+
+        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class, PluginSetting.class, PipelineDescription.class}),
+                equalTo(new Object[] { testPluginConfiguration, pluginSetting, pluginSetting }));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Taylor Gray <33740195+graytaylor0@users.noreply.github.com>

### Description
* Adds `PipelineDescription` interface to allow passing of pipeline details to the plugins that belong to that pipeline
* Only `PluginSetting` implements this interface. A DefaultPipelineDescription could be created in the future to isolate the PipelineDescription information (i.e. with the configuration settings in `PluginSetting`).
* `PipelineDescription` is now an optional parameter to use with the `@DataPrepperPluginConstructor`
 
### Issues Resolved
closes #771
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
