### PR TITLE
Use Java8's Base64 in ServiceMapRelationship.

### DIFF
--- a/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapRelationship.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapRelationship.java
@@ -11,10 +11,9 @@
 
 package com.amazon.dataprepper.plugins.prepper;
 
-import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
-
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.Objects;
 
 
@@ -25,7 +24,7 @@ public class ServiceMapRelationship {
     /**
      * ThreadLocal object to generate hashes of relationships
      */
-    private static ThreadLocal<MessageDigest> THREAD_LOCAL_MESSAGE_DIGEST = new ThreadLocal<>();
+    private static final ThreadLocal<MessageDigest> THREAD_LOCAL_MESSAGE_DIGEST = new ThreadLocal<>();
 
     /**
      * Service name for the relationship. This corresponds to the source of the relationship
@@ -188,7 +187,7 @@ public class ServiceMapRelationship {
         }
         THREAD_LOCAL_MESSAGE_DIGEST.get().reset();
         THREAD_LOCAL_MESSAGE_DIGEST.get().update(unhashedString().getBytes());
-        return Base64.encode(THREAD_LOCAL_MESSAGE_DIGEST.get().digest());
+        return Base64.getEncoder().encodeToString(THREAD_LOCAL_MESSAGE_DIGEST.get().digest());
     }
 
     /**

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapRelationshipTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapRelationshipTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.prepper;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ServiceMapRelationshipTest {
+    @Test
+    void hash_is_consistent_with_static_known_values() {
+        final String serviceName = "ServiceName";
+        final String kind = "Kind";
+        final String traceGroupName = "TraceGroupName";
+
+        final ServiceMapRelationship objectUnderTest = ServiceMapRelationship.newDestinationRelationship(serviceName, kind, "d1", "r1", traceGroupName);
+
+        assertThat(objectUnderTest.getHashId(), equalTo("r7rZwbptLFxOLPUlg/x2nA=="));
+    }
+}


### PR DESCRIPTION
### Description

Java 8 provides a `Base64` class. I updated `ServiceMapRelationship` to use it.

Additionally, I created a unit test to get the value for static values to ensure it is consistent with the old Base64.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
