### PR TITLE
Fix Javadoc errors and add a Javadoc step to CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,3 +30,5 @@ jobs:
       run: ./gradlew build
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1
+    - name: Generate Javadocs
+      run: ./gradlew javadoc

--- a/data-prepper-plugins/http-source/src/main/java/com/amazon/dataprepper/plugins/source/loghttp/codec/JsonCodec.java
+++ b/data-prepper-plugins/http-source/src/main/java/com/amazon/dataprepper/plugins/source/loghttp/codec/JsonCodec.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * JsonCodec parses the json array format HTTP data into List<{@link String}>.
- * TODO: replace output List<String> with List<InternalModel> type
+ * JsonCodec parses the json array format HTTP data into List&lt;{@link String}&gt;.
+ * TODO: replace output List&lt;String&gt; with List&lt;InternalModel&gt; type
  * <p>
  */
 public class JsonCodec implements Codec<List<String>> {


### PR DESCRIPTION
### Description

Releasing to Maven requires generating Javadocs.

This PR fixes the last Javadoc errors and adds the javadoc step the GitHub workflow to ensure that Javadocs remain stable.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
