### PR TITLE
Updated HTTPSourceConfig to use JSR-380 validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,7 @@ configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
         implementation platform('com.fasterxml.jackson:jackson-bom:2.13.0')
         implementation platform('software.amazon.awssdk:bom:2.17.15')
         implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.67')
+        implementation 'jakarta.validation:jakarta.validation-api:3.0.1'
     }
 }
 

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -19,7 +19,6 @@ dependencies {
     testImplementation project(':data-prepper-plugins:common').sourceSets.test.output
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation "javax.validation:validation-api:2.0.1.Final"
     implementation "org.reflections:reflections:0.10.2"
     implementation 'io.micrometer:micrometer-core'
     implementation 'io.micrometer:micrometer-registry-prometheus'

--- a/data-prepper-plugins/http-source/src/main/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSource.java
+++ b/data-prepper-plugins/http-source/src/main/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSource.java
@@ -50,8 +50,6 @@ public class HTTPSource implements Source<Record<Log>> {
 
     @DataPrepperPluginConstructor
     public HTTPSource(final HTTPSourceConfig sourceConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory) {
-        // TODO: Remove once JSR-303 validation is available.
-        sourceConfig.validate();
         this.sourceConfig = sourceConfig;
         this.pluginMetrics = pluginMetrics;
         certificateProviderFactory = new CertificateProviderFactory(sourceConfig);

--- a/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceConfigTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceConfigTest.java
@@ -11,8 +11,18 @@
 
 package com.amazon.dataprepper.plugins.source.loghttp;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class HTTPSourceConfigTest {
@@ -27,5 +37,83 @@ public class HTTPSourceConfigTest {
         assertEquals(HTTPSourceConfig.DEFAULT_THREAD_COUNT, sourceConfig.getThreadCount());
         assertEquals(HTTPSourceConfig.DEFAULT_MAX_CONNECTION_COUNT, sourceConfig.getMaxConnectionCount());
         assertEquals(HTTPSourceConfig.DEFAULT_MAX_PENDING_REQUESTS, sourceConfig.getMaxPendingRequests());
+    }
+
+    @Nested
+    class Validation {
+        @TempDir
+        File temporaryDirectory;
+        private File file;
+
+        @BeforeEach
+        void setUp() throws IOException {
+            file = new File(temporaryDirectory, UUID.randomUUID().toString());
+            file.createNewFile();
+        }
+
+        @Test
+        void isSslCertificateFileValidation_should_return_true_if_ssl_is_false() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", false);
+
+            assertThat(objectUnderTest.isSslCertificateFileValidation(), equalTo(true));
+        }
+
+        @Test
+        void isSslCertificateFileValidation_should_return_false_if_ssl_is_true_and_sslCertificateFile_is_null() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+
+            assertThat(objectUnderTest.isSslCertificateFileValidation(), equalTo(false));
+        }
+
+        @Test
+        void isSslCertificateFileValidation_should_return_false_if_ssl_is_true_and_sslCertificateFile_is_a_valid_file() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+            reflectivelySetField(objectUnderTest, "sslCertificateFile", file.getAbsolutePath());
+
+            assertThat(objectUnderTest.isSslCertificateFileValidation(), equalTo(true));
+        }
+
+        @Test
+        void isSslKeyFileValidation_should_return_true_if_ssl_is_false() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", false);
+
+            assertThat(objectUnderTest.isSslKeyFileValidation(), equalTo(true));
+        }
+
+        @Test
+        void isSslKeyFileValidation_should_return_true_if_ssl_is_false_and_sslKeyFile_is_null() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+
+            assertThat(objectUnderTest.isSslKeyFileValidation(), equalTo(false));
+        }
+        @Test
+        void isSslKeyFileValidation_should_return_true_if_ssl_is_false_and_sslKeyFile_is_a_valid_file() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+            reflectivelySetField(objectUnderTest, "sslKeyFile", file.getAbsolutePath());
+
+            assertThat(objectUnderTest.isSslKeyFileValidation(), equalTo(true));
+        }
+
+        private void reflectivelySetField(final HTTPSourceConfig httpSourceConfig, final String fieldName, final Object value) throws NoSuchFieldException, IllegalAccessException {
+            final Field field = HTTPSourceConfig.class.getDeclaredField(fieldName);
+            try {
+                field.setAccessible(true);
+                field.set(httpSourceConfig, value);
+            } finally {
+                field.setAccessible(false);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Description

The primary change is updating `HTTPSourceConfig` to use JSR-380 validation instead of using a validate method. Along with this, I added the `jakarta.validation` package to all projects other than `data-prepper-api`.

A second change is that I removed the `javax.validation` dependency from data-prepper-core.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
