### PR TITLE
Add Drop Mapping

### DIFF
--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/drop.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/drop.mapping.yaml
@@ -1,0 +1,1 @@
+pluginName: drop

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/drop.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/drop.mapping.yaml
@@ -1,1 +1,1 @@
-pluginName: drop
+pluginName: drop_events

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.conf
@@ -10,6 +10,7 @@ filter {
         match => {"log" => "%{COMBINEDAPACHELOG}"}
         break_on_match => false
     }
+    drop { }
 }
 output {
     elasticsearch {

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.expected.yaml
@@ -12,6 +12,7 @@ logstash-converted-pipeline:
         match:
           log:
             - "%{COMBINEDAPACHELOG}"
+    - drop_events:
   sink:
     - opensearch:
         hosts:

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.expected.yaml
@@ -12,7 +12,7 @@ logstash-converted-pipeline:
         match:
           log:
             - "%{COMBINEDAPACHELOG}"
-    - drop_events:
+    - drop_events: {}
   sink:
     - opensearch:
         hosts:


### PR DESCRIPTION
Signed-off-by: David Powers <ddpowers@amazon.com>

### Description
Creates a mapping between Logstash's Drop filter and Data Prepper's DropEventProcessor

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
