### PR TITLE
Add Event.getAsMap() function to return the Event as a Map<Object, Object>

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/Event.java
@@ -91,5 +91,5 @@ public interface Event {
      * @return a Map representation of the Event
      * @since 1.3
      */
-    Map<Object, Object> getAsMap();
+    Map<String, Object> toMap();
 }

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/Event.java
@@ -6,6 +6,7 @@
 package com.amazon.dataprepper.model.event;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * All data flowing through Data Prepper will be represented as events. An event is the base representation of data.
@@ -85,4 +86,10 @@ public interface Event {
      * @since 1.2
      */
     boolean isValueAList(String key);
+
+    /**
+     * @return a Map representation of the Event
+     * @since 1.3
+     */
+    Map<Object, Object> getAsMap();
 }

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
@@ -273,8 +273,8 @@ public class JacksonEvent implements Event {
     }
 
     @Override
-    public Map<Object, Object> getAsMap() {
-        return mapper.convertValue(jsonNode, new TypeReference<Map<Object, Object>>() {});
+    public Map<String, Object> toMap() {
+        return mapper.convertValue(jsonNode, MAP_TYPE_REFERENCE);
     }
 
     private String checkAndTrimKey(final String key) {

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
@@ -272,6 +272,11 @@ public class JacksonEvent implements Event {
         return node.isArray();
     }
 
+    @Override
+    public Map<Object, Object> getAsMap() {
+        return mapper.convertValue(jsonNode, new TypeReference<Map<Object, Object>>() {});
+    }
+
     private String checkAndTrimKey(final String key) {
         checkKey(key);
         return trimKey(key);

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/JacksonEventTest.java
@@ -315,7 +315,7 @@ public class JacksonEventTest {
 
     @Test
     public void testGetAsMap_with_EmptyData() {
-        final Map<Object, Object> eventAsMap = event.getAsMap();
+        final Map<String, Object> eventAsMap = event.toMap();
         assertThat(eventAsMap, equalTo(Collections.emptyMap()));
     }
 
@@ -329,7 +329,7 @@ public class JacksonEventTest {
         event.put("list", Arrays.asList(1, 4, 5));
         mapObject.put("list", Arrays.asList(1, 4, 5));
 
-        final Map<Object, Object> eventAsMap = event.getAsMap();
+        final Map<String, Object> eventAsMap = event.toMap();
         assertThat(eventAsMap, equalTo(mapObject));
     }
 

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/JacksonEventTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -310,6 +311,26 @@ public class JacksonEventTest {
         final String result = event.toJsonString();
 
         assertThat(result, is(equalTo(String.format("{\"foo\":\"bar\",\"testObject\":{\"field1\":\"%s\"},\"list\":[1,4,5]}", value))));
+    }
+
+    @Test
+    public void testGetAsMap_with_EmptyData() {
+        final Map<Object, Object> eventAsMap = event.getAsMap();
+        assertThat(eventAsMap, equalTo(Collections.emptyMap()));
+    }
+
+    @Test
+    public void testGetAsMap_withSimpleEvent() {
+        final Map<Object, Object> mapObject = new HashMap<>();
+
+        event.put("foo", "bar");
+        mapObject.put("foo", "bar");
+
+        event.put("list", Arrays.asList(1, 4, 5));
+        mapObject.put("list", Arrays.asList(1, 4, 5));
+
+        final Map<Object, Object> eventAsMap = event.getAsMap();
+        assertThat(eventAsMap, equalTo(mapObject));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Taylor Gray <33740195+graytaylor0@users.noreply.github.com>

### Description
* Adds a function `getAsMap()` to the Event interface
* Implements this function in JacksonEvent and returns the Event as a `Map<Object, Object>` using  ObjectMapper
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
