### PR TITLE
Bring the log-ingest example pipeline back to using prepper. 

### DIFF
--- a/examples/log-ingestion/log_pipeline.yaml
+++ b/examples/log-ingestion/log_pipeline.yaml
@@ -2,7 +2,7 @@ log-pipeline:
   source:
     http:
       ssl: false
-  processor:
+  prepper:
     - grok:
         match:
           log: [ "%{COMMONAPACHELOG}" ]


### PR DESCRIPTION
### Description

Our examples should use `prepper`. They work with both 1.2 and 1.3. Now that 1.2 is out, most users will end up running against that version.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
