### PR TITLE
Fix the build issue with the Gradle License Report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,16 +4,27 @@
  */
 import com.github.jk1.license.render.TextReportRenderer
 
+buildscript {
+    repositories {
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
+    }
+    dependencies {
+        classpath 'com.github.jk1:gradle-license-report:1.17'
+    }
+}
+
 plugins {
     id 'com.diffplug.spotless' version '6.1.0'
-    id 'com.github.jk1.dependency-license-report' version '1.17'
-    id "io.spring.dependency-management" version "1.0.11.RELEASE"
+    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 }
 
 apply from: file("${rootDir}/build-resources.gradle")
 allprojects {
     apply plugin: 'checkstyle'
     apply plugin: 'com.diffplug.spotless'
+    apply plugin: 'com.github.jk1.dependency-license-report'
 
     group = 'org.opensearch.dataprepper'
     


### PR DESCRIPTION
### Description

The Gradle License Report was using the Gradle plugin shorthand syntax. This uses some concepts which still rely on JCenter (for this plugin at least). As a workaround, I am adding the plugin using a more primitive approach. The dependency is now added to the project as a normal Maven dependency which doesn't require JCenter.
 
For reference, this is the GitHub Issue on the Gradle-License-Report project: https://github.com/jk1/Gradle-License-Report/issues/224

### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
