### PR TITLE
Resolve plugins from Maven Central before Gradle Plugins portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,16 +4,37 @@
  */
 import com.github.jk1.license.render.TextReportRenderer
 
+buildscript {
+    repositories {
+        mavenCentral() {
+            metadataSources {
+                mavenPom()
+                ignoreGradleMetadataRedirection()
+            }
+        }
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+            metadataSources {
+                mavenPom()
+                ignoreGradleMetadataRedirection()
+            }
+        }
+    }
+    dependencies {
+        classpath 'com.github.jk1:gradle-license-report:1.17'
+    }
+}
+
 plugins {
     id 'com.diffplug.spotless' version '6.1.0'
-    id 'com.github.jk1.dependency-license-report' version '1.17'
-    id "io.spring.dependency-management" version "1.0.11.RELEASE"
+    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 }
 
 apply from: file("${rootDir}/build-resources.gradle")
 allprojects {
     apply plugin: 'checkstyle'
     apply plugin: 'com.diffplug.spotless'
+    apply plugin: 'com.github.jk1.dependency-license-report'
 
     group = 'org.opensearch.dataprepper'
     

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -1,23 +1,36 @@
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "${versionMap.opensearchVersion}")
-        opensearch_group = "org.opensearch"
+        opensearch_version = System.getProperty('opensearch.version', "${versionMap.opensearchVersion}")
+        opensearch_group = 'org.opensearch'
         distribution = 'oss-zip'
     }
 
     repositories {
-        maven { url 'https://plugins.gradle.org/m2/' }
         mavenCentral()
+        gradlePluginPortal()
     }
 
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
+        constraints {
+            classpath('com.netflix.nebula:nebula-core') {
+                version {
+                    require '3.0.1'
+                }
+                because 'Nebula 3.0.0 is not in Maven Central and any dependency on it will attempt to use JCenter.'
+            }
+        }
     }
 }
 
 plugins {
     id 'java'
 }
+
+repositories {
+    mavenCentral()
+}
+
 apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.build'
 apply plugin: 'opensearch.rest-test'

--- a/e2e-test/build.gradle
+++ b/e2e-test/build.gradle
@@ -6,9 +6,8 @@
 subprojects {
     buildscript {
         repositories {
-            maven {
-                url "https://plugins.gradle.org/m2/"
-            }
+            mavenCentral()
+            gradlePluginPortal()
         }
         dependencies {
             classpath 'com.bmuschko:gradle-docker-plugin:7.0.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = 'opensearch-data-prepper'
 
 if(startParameter.getProjectProperties().containsKey("release")){


### PR DESCRIPTION
### Description

Gradle attempts to resolve plugin dependencies against the Gradle Plugin portal repository by default. This change attempts to resolve against Maven Central first. Then it uses the Gradle Plugin portal.

In addition, it fixes an issue with the Gradle-License-Report plugin where the .module file is being used rather than the POM file.
 
### Issues Resolved

Resolves #858 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
