### PR TITLE
updating maintainers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,6 @@
 | Steven Bayer | [sbayer55](https://github.com/sbayer55) | Amazon |
 | Qi Chen | [chenqi0805](https://github.com/chenqi0805) | Amazon |
 | Taylor Gray | [graytaylor0](https://github.com/graytaylor0) | Amazon |
-| Han Jiang | [jianghancn](https://github.com/jianghancn) | Amazon |
 | Dinu John |  [dinujoh](https://github.com/dinujoh) | Amazon |
 | Christopher Manning | [cmanning09](https://github.com/cmanning09) | Amazon |
 | Asif Sohail Mohammed | [asifsmohammed](https://github.com/asifsmohammed) | Amazon |


### PR DESCRIPTION
Signed-off-by: Christopher Manning <cmanning09@users.noreply.github.com>

### Description
Updating maintainers list to reflect active group.
 
### Issues Resolved
- none
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
