### PR TITLE
adding dependabot configs for all the new processors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,12 +17,37 @@ updates:
     interval: monthly
 
 - package-ecosystem: gradle
+  directory: "/data-prepper-plugins/aggregate-processor"
+  schedule:
+    interval: monthly
+
+- package-ecosystem: gradle
+  directory: "/data-prepper-plugins/armeria-common"
+  schedule:
+    interval: monthly
+
+- package-ecosystem: gradle
   directory: "/data-prepper-plugins/blocking-buffer"
   schedule:
     interval: monthly
 
 - package-ecosystem: gradle
   directory: "/data-prepper-plugins/common"
+  schedule:
+    interval: monthly
+
+- package-ecosystem: gradle
+  directory: "/data-prepper-plugins/drop-events-processor"
+  schedule:
+    interval: monthly
+
+- package-ecosystem: gradle
+  directory: "/data-prepper-plugins/grok-prepper"
+  schedule:
+    interval: monthly
+
+- package-ecosystem: gradle
+  directory: "/data-prepper-plugins/http-source"
   schedule:
     interval: monthly
 


### PR DESCRIPTION
Signed-off-by: Christopher Manning <cmanning09@users.noreply.github.com>

### Description
adding dependabot configs for all the new processors. None of the preppers (processors) release for 1.2 had dependabot configs. Ideally, I would like to simplify this config to capture our dependencies through a wildcard but that feature is not supported at this time: https://github.com/dependabot/dependabot-core/issues/2178
 
### Issues Resolved
none
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
