### PR TITLE
adding treddeni-amazon to maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,5 +9,5 @@
 | Asif Sohail Mohammed | [asifsmohammed](https://github.com/asifsmohammed) | Amazon |
 | David Powers | [dapowers87](https://github.com/dapowers87) | Amazon |
 | Shivani Shukla | [sshivanii](https://github.com/sshivanii) | Amazon |
-| David Venable | [dlvenable](https://github.com/dlvenable) | Amazon |
 | Phill Treddenick | [treddeni-amazon](https://github.com/treddeni-amazon) | Amazon |
+| David Venable | [dlvenable](https://github.com/dlvenable) | Amazon |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,3 +10,4 @@
 | David Powers | [dapowers87](https://github.com/dapowers87) | Amazon |
 | Shivani Shukla | [sshivanii](https://github.com/sshivanii) | Amazon |
 | David Venable | [dlvenable](https://github.com/dlvenable) | Amazon |
+| Phill Treddenick | [treddeni-amazon](https://github.com/treddeni-amazon) | Amazon |


### PR DESCRIPTION
Signed-off-by: Christopher Manning <cmanning09@users.noreply.github.com>

### Description
Adding treddeni-amazon to list of maintainers
 
### Issues Resolved
none
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
