### PR TITLE
Added event timestamp to Jackson log

### DIFF
--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -5,7 +5,8 @@
 
 dependencies {
     implementation 'io.micrometer:micrometer-core'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.0'
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-joda"
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation 'org.hamcrest:hamcrest:2.2'
     implementation "org.apache.commons:commons-lang3:3.12.0"

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +53,8 @@ public class JacksonEvent implements Event {
 
     private static final String SEPARATOR = "/";
 
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = new ObjectMapper()
+            .registerModule(new JodaModule());
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {};
 

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/log/JacksonLog.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/log/JacksonLog.java
@@ -7,6 +7,7 @@ package com.amazon.dataprepper.model.log;
 
 import com.amazon.dataprepper.model.event.EventType;
 import com.amazon.dataprepper.model.event.JacksonEvent;
+import org.joda.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -17,6 +18,7 @@ public class JacksonLog extends JacksonEvent implements Log {
 
     protected JacksonLog(final Builder builder) {
         super(builder);
+        this.put("event_timestamp", LocalDateTime.now());
 
         checkArgument(this.getMetadata().getEventType().equals("LOG"), "eventType must be of type Log");
     }
@@ -46,6 +48,7 @@ public class JacksonLog extends JacksonEvent implements Log {
          * @return a log
          * @since 1.2
          */
+        @Override
         public JacksonLog build() {
             this.withEventType(EventType.LOG.toString());
             return new JacksonLog(this);

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/log/JacksonLogTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/log/JacksonLogTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JacksonLogTest {
 
@@ -48,5 +49,17 @@ public class JacksonLogTest {
 
         assertThat(logBuilder, is(notNullValue()));
         assertThrows(IllegalArgumentException.class, logBuilder::build);
+    }
+
+    @Test
+    public void testBuilder_usesLogEventType_withDefaultTimestamp() {
+        final Log log = JacksonLog.builder()
+                .withEventType("test")
+                .getThis()
+                .build();
+
+        assertThat(log, is(notNullValue()));
+        assertTrue(log.containsKey("event_timestamp"));
+        assertThat(log.getMetadata().getEventType(), is(equalTo("LOG")));
     }
 }


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description

- Added default timestamp to Jackson log which will be defaulted to time when we build the JacksonLog object.
-  Named the field as "event_timestamp". Let me know if there are any other suggestions

### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
