### PR TITLE
Create mapping yaml for KeyValueProcessor. Add in a few more tests

### DIFF
--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/kv.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/kv.mapping.yaml
@@ -1,0 +1,11 @@
+pluginName: key_value
+mappedAttributeNames:
+  source: source
+  target: destination
+  field_split: field_delimiter_regex
+  field_split_pattern: field_delimiter_regex
+  value_split: key_value_delimiter_regex
+  value_split_pattern: key_value_delimiter_regex
+  prefix: prefix
+  remove_char_key: delete_key_regex
+  remove_char_value: delete_value_regex

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/kv.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/kv.mapping.yaml
@@ -3,6 +3,7 @@ mappedAttributeNames:
   target: destination
   field_split: field_split_characters
   field_split_pattern: field_delimiter_regex
+  value_split: value_split_characters
   value_split_pattern: key_value_delimiter_regex
   remove_char_key: delete_key_regex
   remove_char_value: delete_value_regex

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/kv.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/kv.mapping.yaml
@@ -1,6 +1,7 @@
 pluginName: key_value
 mappedAttributeNames:
   target: destination
+  field_split: field_split_characters
   field_split_pattern: field_delimiter_regex
   value_split_pattern: key_value_delimiter_regex
   remove_char_key: delete_key_regex

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/kv.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/kv.mapping.yaml
@@ -1,9 +1,7 @@
 pluginName: key_value
 mappedAttributeNames:
   target: destination
-  field_split: field_delimiter_regex
   field_split_pattern: field_delimiter_regex
-  value_split: key_value_delimiter_regex
   value_split_pattern: key_value_delimiter_regex
   remove_char_key: delete_key_regex
   remove_char_value: delete_value_regex

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/kv.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/kv.mapping.yaml
@@ -1,11 +1,9 @@
 pluginName: key_value
 mappedAttributeNames:
-  source: source
   target: destination
   field_split: field_delimiter_regex
   field_split_pattern: field_delimiter_regex
   value_split: key_value_delimiter_regex
   value_split_pattern: key_value_delimiter_regex
-  prefix: prefix
   remove_char_key: delete_key_regex
   remove_char_value: delete_value_regex

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.conf
@@ -11,6 +11,9 @@ filter {
         break_on_match => false
     }
     drop { }
+    kv {
+        target: "test"
+    }
 }
 output {
     elasticsearch {

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.expected.yaml
@@ -13,6 +13,8 @@ logstash-converted-pipeline:
           log:
             - "%{COMBINEDAPACHELOG}"
     - drop_events: {}
+    - key_value:
+        destination: "test"
   sink:
     - opensearch:
         hosts:

--- a/data-prepper-plugins/key-value-processor/README.md
+++ b/data-prepper-plugins/key-value-processor/README.md
@@ -35,11 +35,16 @@ When run, the processor will parse the message into the following output:
   * Default: `parsed_message`
 * `field_delimiter_regex` - A regex specifying the delimiter between key/value pairs. Special regex characters such as `[` and `]` must be escaped using `\\`.
   * There is no default.
-  * Note: Specifying this field will override any value given in `field_split_characters`
+  * Note: This cannot be defined at the same time as `field_split_characters`
 * `field_split_characters` - A string of characters to split between key/value pairs. Special regex characters such as `[` and `]` must be escaped using `\\`.
   * Default: `&`
+  * Note: This cannot be defined at the same time as `field_delimiter_regex`
 * `key_value_delimiter_regex` - A regex specifying the delimiter between a key and a value. Special regex characters such as `[` and `]` must be escaped using `\\`.
   * Default: `=`
+  * Note: This cannot be defined at the same time as `value_split_characters`
+* `value_split_characters` - A string of characters to split between keys and values. Special regex characters such as `[` and `]` must be escaped using `\\`.
+  * Default: `&`
+  *   * Note: This cannot be defined at the same time as `key_value_delimiter_regex`
 * `non_match_value` - When a key/value cannot be successfully split, the key/value will be placed in the key field and the specified value in the value field.
   * Default: `null`
   * Example: `key1value1&key2=value2` will parse into `{"key1value1": null, "key2": "value2"}`

--- a/data-prepper-plugins/key-value-processor/README.md
+++ b/data-prepper-plugins/key-value-processor/README.md
@@ -33,20 +33,23 @@ When run, the processor will parse the message into the following output:
   * Default: `message`
 * `destination` - The field the parsed source will be output to. This will overwrite any preexisting data for that key.
   * Default: `parsed_message`
-* `field_delimiter_regex` - A regex specifying the delimiter between key/value pairs.
+* `field_delimiter_regex` - A regex specifying the delimiter between key/value pairs. Special regex characters such as `[` and `]` must be escaped using `\\`.
+  * There is no default.
+  * Note: Specifying this field will override any value given in `field_split_characters`
+* `field_split_characters` - A string of characters to split between key/value pairs. Special regex characters such as `[` and `]` must be escaped using `\\`.
   * Default: `&`
-* `key_value_delimiter_regex` - A regex specifying the delimiter between a key and a value.
+* `key_value_delimiter_regex` - A regex specifying the delimiter between a key and a value. Special regex characters such as `[` and `]` must be escaped using `\\`.
   * Default: `=`
 * `non_match_value` - When a key/value cannot be successfully split, the key/value will be placed in the key field and the specified value in the value field.
   * Default: `null`
   * Example: `key1value1&key2=value2` will parse into `{"key1value1": null, "key2": "value2"}`
 * `prefix` - A prefix given to all keys.
   * Default is an empty string
-* `delete_key_regex` - A regex that will be used to delete characters from the key.
+* `delete_key_regex` - A regex that will be used to delete characters from the key. Special regex characters such as `[` and `]` must be escaped using `\\`.
   * There is no default
   * Non-empty string is the only valid value
   * Example: `delete_key_regex` is `"\s"`. `{"key1 =value1"}` will parse into `{"key1": "value1"}`
-* `delete_value_regex` - A regex that will be used to delete characters from the value.
+* `delete_value_regex` - A regex that will be used to delete characters from the value. Special regex characters such as `[` and `]` must be escaped using `\\`.
   * There is no default
   * Cannot be an empty string
   * Example: `delete_value_regex` is `"\s"`. `{"key1=value1 "}` will parse into `{"key1": "value1"}`

--- a/data-prepper-plugins/key-value-processor/src/main/java/com/amazon/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/com/amazon/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -30,7 +30,7 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
 
     private final KeyValueProcessorConfig keyValueProcessorConfig;
 
-    private Pattern fieldDelimiterPattern = null;
+    private final Pattern fieldDelimiterPattern;
     private final Pattern keyValueDelimiterPattern;
 
     @DataPrepperPluginConstructor

--- a/data-prepper-plugins/key-value-processor/src/main/java/com/amazon/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/com/amazon/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -12,7 +12,7 @@ import jakarta.validation.constraints.NotNull;
 public class KeyValueProcessorConfig {
     static final String DEFAULT_SOURCE = "message";
     static final String DEFAULT_DESTINATION = "parsed_message";
-    static final String DEFAULT_FIELD_DELIMITER_REGEX = "&";
+    static final String DEFAULT_FIELD_SPLIT_CHARACTERS = "&";
     static final String DEFAULT_KEY_VALUE_DELIMITER_REGEX = "=";
     static final Object DEFAULT_NON_MATCH_VALUE = null;
     static final String DEFAULT_PREFIX = "";
@@ -26,8 +26,11 @@ public class KeyValueProcessorConfig {
     private String destination = DEFAULT_DESTINATION;
 
     @JsonProperty("field_delimiter_regex")
+    private String fieldDelimiterRegex;
+
+    @JsonProperty("field_split_characters")
     @NotEmpty
-    private String fieldDelimiterRegex = DEFAULT_FIELD_DELIMITER_REGEX;
+    private String fieldSplitCharacters = DEFAULT_FIELD_SPLIT_CHARACTERS;
 
     @JsonProperty("key_value_delimiter_regex")
     @NotEmpty
@@ -57,6 +60,10 @@ public class KeyValueProcessorConfig {
 
     public String getFieldDelimiterRegex() {
         return fieldDelimiterRegex;
+    }
+
+    public String getFieldSplitCharacters() {
+        return fieldSplitCharacters;
     }
 
     public String getKeyValueDelimiterRegex() {

--- a/data-prepper-plugins/key-value-processor/src/main/java/com/amazon/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/com/amazon/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -12,8 +12,8 @@ import jakarta.validation.constraints.NotNull;
 public class KeyValueProcessorConfig {
     static final String DEFAULT_SOURCE = "message";
     static final String DEFAULT_DESTINATION = "parsed_message";
-    static final String DEFAULT_FIELD_SPLIT_CHARACTERS = "&";
-    static final String DEFAULT_KEY_VALUE_DELIMITER_REGEX = "=";
+    public static final String DEFAULT_FIELD_SPLIT_CHARACTERS = "&";
+    public static final String DEFAULT_VALUE_SPLIT_CHARACTERS = "=";
     static final Object DEFAULT_NON_MATCH_VALUE = null;
     static final String DEFAULT_PREFIX = "";
     static final String DEFAULT_DELETE_KEY_REGEX = "";
@@ -33,8 +33,10 @@ public class KeyValueProcessorConfig {
     private String fieldSplitCharacters = DEFAULT_FIELD_SPLIT_CHARACTERS;
 
     @JsonProperty("key_value_delimiter_regex")
-    @NotEmpty
-    private String keyValueDelimiterRegex = DEFAULT_KEY_VALUE_DELIMITER_REGEX;
+    private String keyValueDelimiterRegex;
+
+    @JsonProperty("value_split_characters")
+    private String valueSplitCharacters = DEFAULT_VALUE_SPLIT_CHARACTERS;
 
     @JsonProperty("non_match_value")
     private Object nonMatchValue = DEFAULT_NON_MATCH_VALUE;
@@ -68,6 +70,10 @@ public class KeyValueProcessorConfig {
 
     public String getKeyValueDelimiterRegex() {
         return keyValueDelimiterRegex;
+    }
+
+    public String getValueSplitCharacters() {
+        return valueSplitCharacters;
     }
 
     public Object getNonMatchValue() {

--- a/data-prepper-plugins/key-value-processor/src/test/java/com/amazon/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/com/amazon/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -109,25 +109,29 @@ public class KeyValueProcessorTests {
     @Test
     void testBadKeyValueDelimiterRegexKeyValueProcessor() {
         when(mockConfig.getKeyValueDelimiterRegex()).thenReturn("[");
-        assertThrows(PatternSyntaxException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
+        PatternSyntaxException e = assertThrows(PatternSyntaxException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
+        assertThat(e.getMessage().startsWith("key_value_delimiter"), is(true));
     }
 
     @Test
     void testBadFieldDelimiterRegexKeyValueProcessor() {
         when(mockConfig.getFieldDelimiterRegex()).thenReturn("[");
-        assertThrows(PatternSyntaxException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
+        PatternSyntaxException e = assertThrows(PatternSyntaxException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
+        assertThat(e.getMessage().startsWith("field_delimiter"), is(true));
     }
 
     @Test
     void testBadDeleteKeyRegexKeyValueProcessor() {
         when(mockConfig.getDeleteKeyRegex()).thenReturn("[");
-        assertThrows(PatternSyntaxException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
+        PatternSyntaxException e = assertThrows(PatternSyntaxException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
+        assertThat(e.getMessage().startsWith("delete_key_regex"), is(true));
     }
 
     @Test
     void testBadDeleteValueRegexKeyValueProcessor() {
         when(mockConfig.getDeleteValueRegex()).thenReturn("[");
-        assertThrows(PatternSyntaxException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
+        PatternSyntaxException e = assertThrows(PatternSyntaxException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
+        assertThat(e.getMessage().startsWith("delete_value_regex"), is(true));
     }
 
     @Test

--- a/data-prepper-plugins/key-value-processor/src/test/java/com/amazon/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/com/amazon/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -104,6 +104,20 @@ public class KeyValueProcessorTests {
     }
 
     @Test
+    void testBothKeyValuesDefinedErrorKeyValueProcessor() {
+        when(mockConfig.getKeyValueDelimiterRegex()).thenReturn(":\\+*:");
+
+        assertThrows(IllegalArgumentException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
+    }
+
+    @Test
+    void testBothFieldsDefinedErrorKeyValueProcessor() {
+        when(mockConfig.getFieldDelimiterRegex()).thenReturn(":\\+*:");
+
+        assertThrows(IllegalArgumentException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
+    }
+
+    @Test
     void testSingleRegexKvDelimiterKvToObjectKeyValueProcessor() {
         when(mockConfig.getKeyValueDelimiterRegex()).thenReturn(":\\+*:");
         when(mockConfig.getValueSplitCharacters()).thenReturn(null);

--- a/data-prepper-plugins/key-value-processor/src/test/java/com/amazon/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/com/amazon/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -9,6 +9,7 @@ import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.event.JacksonEvent;
 import com.amazon.dataprepper.model.record.Record;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -139,7 +140,7 @@ public class KeyValueProcessorTests {
         when(mockConfig.getValueSplitCharacters()).thenReturn(null);
 
         PatternSyntaxException e = assertThrows(PatternSyntaxException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
-        assertThat(e.getMessage().startsWith("key_value_delimiter"), is(true));
+        assertThat(e.getMessage(), CoreMatchers.startsWith("key_value_delimiter"));
     }
 
     @Test
@@ -148,21 +149,21 @@ public class KeyValueProcessorTests {
         when(mockConfig.getFieldSplitCharacters()).thenReturn(null);
 
         PatternSyntaxException e = assertThrows(PatternSyntaxException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
-        assertThat(e.getMessage().startsWith("field_delimiter"), is(true));
+        assertThat(e.getMessage(), CoreMatchers.startsWith("field_delimiter"));
     }
 
     @Test
     void testBadDeleteKeyRegexKeyValueProcessor() {
         when(mockConfig.getDeleteKeyRegex()).thenReturn("[");
         PatternSyntaxException e = assertThrows(PatternSyntaxException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
-        assertThat(e.getMessage().startsWith("delete_key_regex"), is(true));
+        assertThat(e.getMessage(), CoreMatchers.startsWith("delete_key_regex"));
     }
 
     @Test
     void testBadDeleteValueRegexKeyValueProcessor() {
         when(mockConfig.getDeleteValueRegex()).thenReturn("[");
         PatternSyntaxException e = assertThrows(PatternSyntaxException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
-        assertThat(e.getMessage().startsWith("delete_value_regex"), is(true));
+        assertThat(e.getMessage(), CoreMatchers.startsWith("delete_value_regex"));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: David Powers <ddpowers@amazon.com>

### Description
Adds logstash conversion support for KeyValueProcessor as well as a few new tests
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
