### PR TITLE
Moved DataPrepper to core package

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepperExecute.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepperExecute.java
@@ -5,6 +5,7 @@
 
 package com.amazon.dataprepper;
 
+import com.amazon.dataprepper.core.DataPrepper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/core/DataPrepper.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/core/DataPrepper.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazon.dataprepper;
+package com.amazon.dataprepper.core;
 
 import com.amazon.dataprepper.model.plugin.PluginFactory;
 import com.amazon.dataprepper.parser.PipelineParser;

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/MetricRegistryType.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/MetricRegistryType.java
@@ -13,7 +13,7 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 
 import java.util.Arrays;
 
-import static com.amazon.dataprepper.DataPrepper.getServiceNameForMetrics;
+import static com.amazon.dataprepper.core.DataPrepper.getServiceNameForMetrics;
 import static com.amazon.dataprepper.metrics.MetricNames.SERVICE_NAME;
 import static java.lang.String.format;
 

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
@@ -5,7 +5,7 @@
 
 package com.amazon.dataprepper.pipeline.server;
 
-import com.amazon.dataprepper.DataPrepper;
+import com.amazon.dataprepper.core.DataPrepper;
 import com.amazon.dataprepper.model.configuration.PluginModel;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.plugin.PluginFactory;

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/ListPipelinesHandler.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/ListPipelinesHandler.java
@@ -5,17 +5,18 @@
 
 package com.amazon.dataprepper.pipeline.server;
 
-import com.amazon.dataprepper.DataPrepper;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
+import com.amazon.dataprepper.core.DataPrepper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * HttpHandler to handle requests for listing pipelines running on the data prepper instance

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/ShutdownHandler.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/ShutdownHandler.java
@@ -5,13 +5,14 @@
 
 package com.amazon.dataprepper.pipeline.server;
 
-import com.amazon.dataprepper.DataPrepper;
-import java.io.IOException;
-import java.net.HttpURLConnection;
+import com.amazon.dataprepper.core.DataPrepper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
 
 /**
  * HttpHandler to handle requests to shut down the data prepper instance

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/core/DataPrepperTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/core/DataPrepperTests.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazon.dataprepper;
+package com.amazon.dataprepper.core;
 
 import com.amazon.dataprepper.model.plugin.PluginFactory;
 import com.amazon.dataprepper.parser.PipelineParser;

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/server/DataPrepperServerTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/server/DataPrepperServerTest.java
@@ -5,8 +5,8 @@
 
 package com.amazon.dataprepper.server;
 
-import com.amazon.dataprepper.DataPrepper;
 import com.amazon.dataprepper.TestDataProvider;
+import com.amazon.dataprepper.core.DataPrepper;
 import com.amazon.dataprepper.model.plugin.PluginFactory;
 import com.amazon.dataprepper.parser.model.DataPrepperConfiguration;
 import com.amazon.dataprepper.pipeline.server.DataPrepperCoreAuthenticationProvider;


### PR DESCRIPTION
Signed-off-by: Steven Bayer <smbayer@amazon.com>

### Description
Move DataPrepper class to a core package. Part of large refactoring to moving all core classes to a new core package
 
### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
