### PR TITLE
Updated the plugin framework to use dependency injection for internal class

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/DefaultPluginFactory.java
@@ -32,19 +32,6 @@ public class DefaultPluginFactory implements PluginFactory {
     private final PluginConfigurationConverter pluginConfigurationConverter;
 
     @Inject
-    public DefaultPluginFactory() {
-        this(new PluginProviderLoader(), new PluginCreator(), new PluginConfigurationConverter());
-        // TODO: Remove this along with the removal of com.amazon.dataprepper.plugins.PluginFactory
-        com.amazon.dataprepper.plugins.PluginFactory.dangerousMethod_setPluginFunction(
-                ((pluginSetting, aClass) -> pluginCreator.newPluginInstance(aClass, getConstructionContext(pluginSetting, aClass), pluginSetting.getName()))
-        );
-    }
-
-    /**
-     * For testing only.
-     * TODO: Correct the constructors once we have dependency injection.
-     */
-    @Deprecated
     DefaultPluginFactory(
             final PluginProviderLoader pluginProviderLoader,
             final PluginCreator pluginCreator,
@@ -59,6 +46,11 @@ public class DefaultPluginFactory implements PluginFactory {
             throw new RuntimeException("Data Prepper requires at least one PluginProvider. " +
                     "Your Data Prepper configuration may be missing the com.amazon.dataprepper.plugin.PluginProvider file.");
         }
+
+        // TODO: Remove this along with the removal of com.amazon.dataprepper.plugins.PluginFactory
+        com.amazon.dataprepper.plugins.PluginFactory.dangerousMethod_setPluginFunction(
+                ((pluginSetting, aClass) -> pluginCreator.newPluginInstance(aClass, getConstructionContext(pluginSetting, aClass), pluginSetting.getName()))
+        );
     }
 
     @Override

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginApplicationContext.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginApplicationContext.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugin;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Application context for internal plugin framework beans.
+ */
+@Configuration
+class PluginApplicationContext {
+    @Bean
+    Validator validator() {
+        final ValidatorFactory validationFactory = Validation.buildDefaultValidatorFactory();
+        return validationFactory.getValidator();
+    }
+}

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginConfigurationConverter.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginConfigurationConverter.java
@@ -11,10 +11,9 @@ import com.amazon.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import jakarta.validation.ConstraintViolation;
-import jakarta.validation.Validation;
 import jakarta.validation.Validator;
-import jakarta.validation.ValidatorFactory;
 
+import javax.inject.Named;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -23,15 +22,15 @@ import java.util.stream.Collectors;
  * Converts and validates a plugin configuration. This class is responsible for taking a {@link PluginSetting}
  * and converting it to the plugin model type which should be denoted by {@link DataPrepperPlugin#pluginConfigurationType()}
  */
+@Named
 class PluginConfigurationConverter {
     private final ObjectMapper objectMapper;
     private final Validator validator;
 
-    PluginConfigurationConverter() {
+    PluginConfigurationConverter(final Validator validator) {
         this.objectMapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 
-        final ValidatorFactory validationFactory = Validation.buildDefaultValidatorFactory();
-        validator = validationFactory.getValidator();
+        this.validator = validator;
     }
 
     /**

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginCreator.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginCreator.java
@@ -12,6 +12,7 @@ import com.amazon.dataprepper.model.plugin.PluginInvocationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Named;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
@@ -20,6 +21,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Named
 class PluginCreator {
     private static final Logger LOG = LoggerFactory.getLogger(PluginCreator.class);
 

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginProviderLoader.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginProviderLoader.java
@@ -8,12 +8,14 @@ package com.amazon.dataprepper.plugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Named;
 import java.util.Collection;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+@Named
 class PluginProviderLoader {
     private static final Logger LOG = LoggerFactory.getLogger(PluginProviderLoader.class);
     private final ServiceLoader<PluginProvider> serviceLoader;

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/PipelineParserTests.java
@@ -10,6 +10,7 @@ import com.amazon.dataprepper.pipeline.Pipeline;
 import com.amazon.dataprepper.plugin.DefaultPluginFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.util.Map;
 
@@ -34,7 +35,10 @@ class PipelineParserTests {
 
     @BeforeEach
     void setUp() {
-        pluginFactory = new DefaultPluginFactory();
+        final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.scan(DefaultPluginFactory.class.getPackage().getName());
+        context.refresh();
+        pluginFactory = context.getBean(DefaultPluginFactory.class);
     }
 
     @Test

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/DefaultPluginFactoryIT.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/DefaultPluginFactoryIT.java
@@ -10,6 +10,7 @@ import com.amazon.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import com.amazon.dataprepper.plugins.TestPlugin;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +38,11 @@ class DefaultPluginFactoryIT {
     }
 
     private DefaultPluginFactory createObjectUnderTest() {
-        return new DefaultPluginFactory();
+        final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.scan(DefaultPluginFactory.class.getPackage().getName());
+        context.refresh();
+
+        return context.getBean(DefaultPluginFactory.class);
     }
 
     @Test

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginConfigurationConverterTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginConfigurationConverterTest.java
@@ -9,12 +9,9 @@ import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Path;
-import jakarta.validation.Validation;
 import jakarta.validation.Validator;
-import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 
 import java.util.Collections;
 import java.util.UUID;
@@ -30,7 +27,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 
 class PluginConfigurationConverterTest {
     private PluginSetting pluginSetting;
@@ -53,14 +49,7 @@ class PluginConfigurationConverterTest {
     }
 
     private PluginConfigurationConverter createObjectUnderTest() {
-        final ValidatorFactory validatorFactory = mock(ValidatorFactory.class);
-        given(validatorFactory.getValidator()).willReturn(validator);
-
-        try(final MockedStatic<Validation> validationMockedStatic = mockStatic(Validation.class)) {
-            validationMockedStatic.when(Validation::buildDefaultValidatorFactory)
-                    .thenReturn(validatorFactory);
-            return new PluginConfigurationConverter();
-        }
+        return new PluginConfigurationConverter(validator);
     }
 
     @Test


### PR DESCRIPTION
### Description

This change adds dependency injection to the plugin framework's internal objects. In addition, the integration test for the plugins uses the application context for building the whole object.

I recommended starting by reviewing the `DefaultPluginFactory` changes. Most everything flows from that.

### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
