### PR TITLE
Refactored by creating AggregateActionInput and GroupState interfaces, and class DefaultGroupState

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateAction.java
@@ -7,7 +7,6 @@ package com.amazon.dataprepper.plugins.processor.aggregate;
 
 import com.amazon.dataprepper.model.event.Event;
 
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -19,24 +18,26 @@ public interface AggregateAction {
      * Handles an event as part of aggregation.
      *
      * @param event The current event
-     * @param groupState A map for AggregationActions to maintain user-defined state for a group. The same map is provided for all events in a single group. This map is non-null.
+     * @param aggregateActionInput An implementation of {@link com.amazon.dataprepper.plugins.processor.aggregate.AggregateActionInput}.
+     *                             This AggregateActionInput exposes the {@link com.amazon.dataprepper.plugins.processor.aggregate.GroupState}
+     *                             that is shared between all events in a single group. This GroupState is non-null.
      * @return An {@link com.amazon.dataprepper.plugins.processor.aggregate.AggregateActionResponse} with an Event that will either
      * be processed immediately, or is empty if the Event should be removed from processing
      * @since 1.3
      */
-    default AggregateActionResponse handleEvent(final Event event, final Map<Object, Object> groupState) {
+    default AggregateActionResponse handleEvent(final Event event, final AggregateActionInput aggregateActionInput) {
         return AggregateActionResponse.fromEvent(event);
     }
 
     /**
      * Concludes a group of Events
      *
-     * @param groupState The groupState map from previous calls to handleEvent
+     * @param aggregateActionInput The {@link com.amazon.dataprepper.plugins.processor.aggregate.AggregateActionInput} from previous calls to handleEvent
      * @return The final Event to return. Return empty if the aggregate processor
      * should not pass an event
      * @since 1.3
      */
-    default Optional<Event> concludeGroup(final Map<Object, Object> groupState) {
+    default Optional<Event> concludeGroup(final AggregateActionInput aggregateActionInput) {
         return Optional.empty();
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateActionInput.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateActionInput.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.processor.aggregate;
+
+/**
+ * Implementing classes are able to be passed to the functions of {@link com.amazon.dataprepper.plugins.processor.aggregate.AggregateAction}
+ * @since 1.3
+ */
+public interface AggregateActionInput {
+
+    /**
+     * @return An implementation of {@link com.amazon.dataprepper.plugins.processor.aggregate.GroupState}
+     * @since 1.3
+     */
+    GroupState getGroupState();
+}

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroup.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroup.java
@@ -5,17 +5,14 @@
 
 package com.amazon.dataprepper.plugins.processor.aggregate;
 
-import java.util.HashMap;
-import java.util.Map;
-
-public class AggregateGroup {
-    private final Map<Object, Object> groupState = new HashMap<>();
+class AggregateGroup implements AggregateActionInput {
+    private final GroupState groupState;
 
     AggregateGroup() {
-
+        this.groupState = new DefaultGroupState();
     }
 
-    public Map<Object, Object> getGroupState() {
+    public GroupState getGroupState() {
         return groupState;
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -58,7 +58,7 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
             final AggregateIdentificationKeysHasher.IdentificationHash identificationKeysHash = aggregateIdentificationKeysHasher.createIdentificationKeyHashFromEvent(event);
             final AggregateGroup aggregateGroupForEvent = aggregateGroupManager.getAggregateGroup(identificationKeysHash);
 
-            final AggregateActionResponse handleEventResponse = aggregateAction.handleEvent(event, aggregateGroupForEvent.getGroupState());
+            final AggregateActionResponse handleEventResponse = aggregateAction.handleEvent(event, aggregateGroupForEvent);
 
             final Event aggregateActionResponseEvent = handleEventResponse.getEvent();
 

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/DefaultGroupState.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/DefaultGroupState.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.processor.aggregate;
+
+import java.util.HashMap;
+
+/**
+ * The primary implementation of {@link com.amazon.dataprepper.plugins.processor.aggregate.GroupState}
+ * @since 1.3
+ */
+class DefaultGroupState extends HashMap<Object, Object> implements GroupState {
+
+}

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/GroupState.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/GroupState.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.processor.aggregate;
+
+import java.util.Map;
+
+/**
+ * Implementing classes will be shared between all Events that belong to this GroupState.
+ * @see com.amazon.dataprepper.plugins.processor.aggregate.DefaultGroupState
+ * @since 1.3
+ */
+public interface GroupState extends Map<Object, Object> {
+
+}

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/actions/CombineAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/actions/CombineAggregateAction.java
@@ -8,9 +8,10 @@ package com.amazon.dataprepper.plugins.processor.aggregate.actions;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.event.JacksonEvent;
 import com.amazon.dataprepper.plugins.processor.aggregate.AggregateAction;
+import com.amazon.dataprepper.plugins.processor.aggregate.AggregateActionInput;
 import com.amazon.dataprepper.plugins.processor.aggregate.AggregateActionResponse;
+import com.amazon.dataprepper.plugins.processor.aggregate.GroupState;
 
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -23,16 +24,18 @@ public class CombineAggregateAction implements AggregateAction {
     static final String EVENT_TYPE = "event";
 
     @Override
-    public AggregateActionResponse handleEvent(final Event event, final Map<Object, Object> groupState) {
+    public AggregateActionResponse handleEvent(final Event event, final AggregateActionInput aggregateActionInput) {
+        final GroupState groupState = aggregateActionInput.getGroupState();
         groupState.putAll(event.toMap());
         return AggregateActionResponse.nullEventResponse();
     }
 
     @Override
-    public Optional<Event> concludeGroup(final Map<Object, Object> groupState) {
+    public Optional<Event> concludeGroup(final AggregateActionInput aggregateActionInput) {
+
         final Event event = JacksonEvent.builder()
                 .withEventType(EVENT_TYPE)
-                .withData(groupState)
+                .withData(aggregateActionInput.getGroupState())
                 .build();
 
         return Optional.of(event);

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/actions/RemoveDuplicatesAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/actions/RemoveDuplicatesAggregateAction.java
@@ -8,9 +8,9 @@ package com.amazon.dataprepper.plugins.processor.aggregate.actions;
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.plugins.processor.aggregate.AggregateAction;
+import com.amazon.dataprepper.plugins.processor.aggregate.AggregateActionInput;
 import com.amazon.dataprepper.plugins.processor.aggregate.AggregateActionResponse;
-
-import java.util.Map;
+import com.amazon.dataprepper.plugins.processor.aggregate.GroupState;
 
 /**
  * An AggregateAction that will pass down the first Event of a groupState immediately for processing, and then ignore Events
@@ -22,7 +22,8 @@ public class RemoveDuplicatesAggregateAction implements AggregateAction {
     static final String GROUP_STATE_HAS_EVENT = "GROUP_STATE_HAS_EVENT";
 
     @Override
-    public AggregateActionResponse handleEvent(final Event event, final Map<Object, Object> groupState) {
+    public AggregateActionResponse handleEvent(final Event event, final AggregateActionInput aggregateActionInput) {
+        final GroupState groupState = aggregateActionInput.getGroupState();
         if (groupState.size() == 0) {
             groupState.put(GROUP_STATE_HAS_EVENT, true);
             return AggregateActionResponse.fromEvent(event);

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateActionTestUtils.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateActionTestUtils.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.processor.aggregate;
+
+import java.util.HashMap;
+
+public class AggregateActionTestUtils {
+    public static class TestAggregateActionInput implements AggregateActionInput {
+        private final GroupState groupState;
+
+        public TestAggregateActionInput() {
+            this.groupState = new AggregateActionTestUtils.TestGroupState();
+        }
+
+        @Override
+        public GroupState getGroupState() {
+            return groupState;
+        }
+    }
+
+    public static class TestGroupState extends HashMap<Object, Object> implements GroupState {
+
+    }
+}

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -85,8 +85,7 @@ public class AggregateProcessorTest {
         when(aggregateIdentificationKeysHasher.createIdentificationKeyHashFromEvent(event))
                 .thenReturn(identificationHash);
         when(aggregateGroupManager.getAggregateGroup(identificationHash)).thenReturn(aggregateGroup);
-        when(aggregateGroup.getGroupState()).thenReturn(Collections.emptyMap());
-        when(aggregateAction.handleEvent(eq(event), eq(Collections.emptyMap()))).thenReturn(aggregateActionResponse);
+        when(aggregateAction.handleEvent(event, aggregateGroup)).thenReturn(aggregateActionResponse);
     }
 
     private AggregateProcessor createObjectUnderTest() {


### PR DESCRIPTION
Signed-off-by: Taylor Gray <33740195+graytaylor0@users.noreply.github.com>

### Description
* Creates an interface `AggregateActionInput`, which is passed to the `AggregateAction` functions `handleEvent` and `concludeGroup`. This will give the option to provide more than just a `GroupState` to `AggregateAction` creators if the need arises. `AggregateActionInput` is implemented by `AggregateGroup`. The implemented methods are public for use in AggregateActions. Methods of `AggregateGroup` that will not be exposed to AggregateActions will be made package private.
* Creates an interface `GroupState`, which is exposed by the `AggregateActionInput.getGroupState()` method. This interface extends `Map<Object, Object>`, so as to not lock in `AggregateActions` to a single `Map` type.
* Creates a class `DefaultGroupState` that implements `GroupState` and extends `HashMap<Object, Object>`. This allows for more advanced functionality to be provided to AggregateActions if the need arises.
 
### Issues Resolved
Closes #942
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
