### PR TITLE
Support loading plugins from multiple packages.

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/ClasspathPluginProvider.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/ClasspathPluginProvider.java
@@ -7,6 +7,7 @@ package com.amazon.dataprepper.plugin;
 
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import org.reflections.Reflections;
+import org.reflections.util.ConfigurationBuilder;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,12 +22,13 @@ import java.util.Set;
  */
 public class ClasspathPluginProvider implements PluginProvider {
 
-    private static final String DEFAULT_PLUGINS_CLASSPATH = "com.amazon.dataprepper.plugins";
     private final Reflections reflections;
     private Map<String, Map<Class<?>, Class<?>>> nameToSupportedTypeToPluginType;
 
     public ClasspathPluginProvider() {
-        this(new Reflections(DEFAULT_PLUGINS_CLASSPATH));
+        this(new Reflections(new ConfigurationBuilder()
+                .forPackages(new PluginPackagesSupplier().get()))
+        );
     }
 
     /**

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginPackagesSupplier.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginPackagesSupplier.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugin;
+
+import com.google.common.collect.Iterators;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * Supplies packages to scan for plugins.
+ */
+class PluginPackagesSupplier implements Supplier<String[]> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PluginPackagesSupplier.class);
+    private static final String DEFAULT_PLUGINS_CLASSPATH = "com.amazon.dataprepper.plugins";
+
+    PluginPackagesSupplier() {
+    }
+
+    Iterator<URL> loadResources() throws IOException {
+        final Enumeration<URL> resourcesEnumeration = getClass().getClassLoader().getResources("META-INF/data-prepper.plugins.properties");
+        return Iterators.forEnumeration(resourcesEnumeration);
+    }
+
+    @Override
+    public String[] get() {
+
+        final Set<String> packageNames = getUniquePackageNames();
+
+        final String[] packageNamesArray = packageNames.toArray(new String[0]);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Using packages for plugins: {}", String.join(",", packageNamesArray));
+        }
+
+        return packageNamesArray;
+    }
+
+    private Set<String> getUniquePackageNames() {
+        Set<String> packageNames;
+        try {
+            final Iterator<URL> pluginResources = loadResources();
+            packageNames = readResources(pluginResources);
+        } catch (final IOException ex) {
+            LOG.warn("Unable to load data-prepper.plugins.properties file. Reverting to default plugin package.");
+            packageNames = Collections.singleton(DEFAULT_PLUGINS_CLASSPATH);
+        }
+        return packageNames;
+    }
+
+    private Set<String> readResources(final Iterator<URL> pluginResources) {
+        final Set<String> packageNames = new HashSet<>();
+        while (pluginResources.hasNext()) {
+
+            final URL pluginPropertiesUrl = pluginResources.next();
+
+            final Properties pluginProperties = new Properties();
+            final InputStream pluginPropertiesInputStream;
+            try {
+                pluginPropertiesInputStream = pluginPropertiesUrl.openStream();
+                pluginProperties.load(pluginPropertiesInputStream);
+            } catch (final IOException ex) {
+                LOG.warn("Unable to load properties from resource. url={}", pluginPropertiesUrl, ex);
+            }
+
+            final String packagesRawString = pluginProperties.getProperty("org.opensearch.dataprepper.plugin.packages");
+
+            final String[] currentPackageNames = packagesRawString.split(",");
+
+            packageNames.addAll(Arrays.asList(currentPackageNames));
+        }
+
+        if(packageNames.isEmpty()) {
+            packageNames.add(DEFAULT_PLUGINS_CLASSPATH);
+        }
+
+        return packageNames;
+    }
+}

--- a/data-prepper-core/src/main/resources/META-INF/data-prepper.plugins.properties
+++ b/data-prepper-core/src/main/resources/META-INF/data-prepper.plugins.properties
@@ -1,0 +1,6 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+
+org.opensearch.dataprepper.plugin.packages=com.amazon.dataprepper.plugins

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginPackagesSupplierTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginPackagesSupplierTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugin;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+class PluginPackagesSupplierTest {
+
+    private static final String PROPERTIES_PREFIX = "org.opensearch.dataprepper.plugin.packages=";
+    private static final String DEFAULT_PACKAGE_NAME = "com.amazon.dataprepper.plugins";
+
+    private PluginPackagesSupplier createObjectUnderTest() {
+        final PluginPackagesSupplier object = new PluginPackagesSupplier();
+        return spy(object);
+    }
+
+    @Test
+    void get_returns_default_package_if_getResources_throws_exception() throws IOException {
+        final PluginPackagesSupplier objectUnderTest = createObjectUnderTest();
+
+        when(objectUnderTest.loadResources()).thenThrow(IOException.class);
+
+        final String[] actualPackages = objectUnderTest.get();
+        assertThat(actualPackages, notNullValue());
+
+        assertThat(actualPackages.length, equalTo(1));
+        assertThat(actualPackages[0], equalTo(DEFAULT_PACKAGE_NAME));
+    }
+
+    @Test
+    void get_returns_default_package_if_no_resources_are_found() throws IOException {
+        final PluginPackagesSupplier objectUnderTest = createObjectUnderTest();
+
+        when(objectUnderTest.loadResources()).thenReturn(Collections.emptyIterator());
+
+        final String[] actualPackages = objectUnderTest.get();
+        assertThat(actualPackages, notNullValue());
+
+        assertThat(actualPackages.length, equalTo(1));
+        assertThat(actualPackages[0], equalTo(DEFAULT_PACKAGE_NAME));
+    }
+
+    @Test
+    void get_returns_packages_from_all_resources() throws IOException {
+        final PluginPackagesSupplier objectUnderTest = createObjectUnderTest();
+
+        final Set<String> packageNames = IntStream.range(0, 3)
+                .mapToObj(i -> randomPackageName())
+                .collect(Collectors.toSet());
+
+        final Iterator<URL> iterator = packageNames.stream()
+                .map(packageName -> PROPERTIES_PREFIX + packageName)
+                .map(propertyLine -> new ByteArrayInputStream(propertyLine.getBytes()))
+                .map(PluginPackagesSupplierTest::createMockedUrl)
+                .iterator();
+
+        when(objectUnderTest.loadResources()).thenReturn(iterator);
+
+        final String[] actualPackages = objectUnderTest.get();
+        assertThat(actualPackages, notNullValue());
+
+        assertThat(actualPackages.length, equalTo(packageNames.size()));
+
+        final Set<String> actualPackagesList = new HashSet<>(Arrays.asList(actualPackages));
+
+        assertThat(actualPackagesList, equalTo(packageNames));
+    }
+
+    @Test
+    void get_returns_multiple_packages_from_resources_files_with_comma_delimited_list() throws IOException {
+        final PluginPackagesSupplier objectUnderTest = createObjectUnderTest();
+
+        final Set<String> packageNames = IntStream.range(0, 3)
+                .mapToObj(i -> randomPackageName())
+                .collect(Collectors.toSet());
+
+        final String propertyLine = PROPERTIES_PREFIX + String.join(",", packageNames);
+        final InputStream inputStream = new ByteArrayInputStream(propertyLine.getBytes());
+        final URL resourceUrl = createMockedUrl(inputStream);
+
+        final Iterator<URL> iterator = Collections.singleton(resourceUrl).iterator();
+
+        when(objectUnderTest.loadResources()).thenReturn(iterator);
+
+        final String[] actualPackages = objectUnderTest.get();
+        assertThat(actualPackages, notNullValue());
+
+        assertThat(actualPackages.length, equalTo(packageNames.size()));
+
+        final Set<String> actualPackagesList = new HashSet<>(Arrays.asList(actualPackages));
+
+        assertThat(actualPackagesList, equalTo(packageNames));
+    }
+
+    private String randomPackageName() {
+        return UUID.randomUUID().toString().replace("-", ".");
+    }
+
+    private static URL createMockedUrl(final InputStream inputStream) {
+        final URL resourceUrl = mock(URL.class);
+        try {
+            when(resourceUrl.openStream()).thenReturn(inputStream);
+        } catch (final IOException ex) {
+            throw new RuntimeException(ex);
+        }
+        return resourceUrl;
+    }
+}

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginPackagesSupplierTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginPackagesSupplierTest.java
@@ -64,6 +64,43 @@ class PluginPackagesSupplierTest {
     }
 
     @Test
+    void get_returns_default_package_if_resources_have_no_plugin_packages_defined() throws IOException {
+        final PluginPackagesSupplier objectUnderTest = createObjectUnderTest();
+
+        final Iterator<URL> iteratorOfEmptyFiles = IntStream.range(0, 3)
+                .mapToObj(propertyLine -> new ByteArrayInputStream(new byte[]{}))
+                .map(PluginPackagesSupplierTest::createMockedUrl)
+                .iterator();
+
+        when(objectUnderTest.loadResources()).thenReturn(iteratorOfEmptyFiles);
+
+        final String[] actualPackages = objectUnderTest.get();
+        assertThat(actualPackages, notNullValue());
+
+        assertThat(actualPackages.length, equalTo(1));
+        assertThat(actualPackages[0], equalTo(DEFAULT_PACKAGE_NAME));
+    }
+
+    @Test
+    void get_returns_default_package_if_resources_have_empty_plugin_packages_defined() throws IOException {
+        final PluginPackagesSupplier objectUnderTest = createObjectUnderTest();
+
+        final Iterator<URL> iterator = IntStream.range(0, 3)
+                .mapToObj(packageName -> PROPERTIES_PREFIX)
+                .map(propertyLine -> new ByteArrayInputStream(propertyLine.getBytes()))
+                .map(PluginPackagesSupplierTest::createMockedUrl)
+                .iterator();
+
+        when(objectUnderTest.loadResources()).thenReturn(iterator);
+
+        final String[] actualPackages = objectUnderTest.get();
+        assertThat(actualPackages, notNullValue());
+
+        assertThat(actualPackages.length, equalTo(1));
+        assertThat(actualPackages[0], equalTo(DEFAULT_PACKAGE_NAME));
+    }
+
+    @Test
     void get_returns_packages_from_all_resources() throws IOException {
         final PluginPackagesSupplier objectUnderTest = createObjectUnderTest();
 


### PR DESCRIPTION
### Description

This PR allows Data Prepper to support plugins in packages other than `com.amazon.dataprepper.plugins`.

Data Prepper reads all resources (files embedded in jars) of `META-INF/data-prepper.plugins.properties`. It then looks for a property `org.opensearch.dataprepper.plugin.packages` from each one. The value of this property is a comma-delimited list of packages.

Data Prepper will scan all of these packages for plugins.

Note that because of the uber-jar, Data Prepper can only have one file for all packages. However, plugin authors can create their own jar files with this file. As long as it is on the classpath, their custom plugin will be available.

It may be worthwhile to move some plugins in future PRs.
 
### Issues Resolved

#379 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
