### PR TITLE
[BUG] Fixed some failing unit tests on Windows

### DIFF
--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
@@ -64,8 +64,8 @@ public class AbstractBufferTest {
         Assert.assertTrue(
                 MetricsTestUtil.isBetween(
                         MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
-                        0.4,
-                        0.7));
+                        0.45,
+                        0.65));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
@@ -64,8 +64,8 @@ public class AbstractBufferTest {
         Assert.assertTrue(
                 MetricsTestUtil.isBetween(
                         MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
-                        0.5,
-                        0.6));
+                        0.4,
+                        0.7));
     }
 
     @Test
@@ -91,8 +91,8 @@ public class AbstractBufferTest {
         Assert.assertTrue(
                 MetricsTestUtil.isBetween(
                         MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
-                        0.1,
-                        0.2));
+                        0.05,
+                        0.25));
     }
 
     @Test
@@ -129,8 +129,8 @@ public class AbstractBufferTest {
         Assert.assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(readTimeMeasurements, Statistic.COUNT).getValue(), 0);
         Assert.assertTrue(MetricsTestUtil.isBetween(
                 MetricsTestUtil.getMeasurementFromList(readTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
-                0.1,
-                0.2));
+                0.05,
+                0.25));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
@@ -31,6 +31,7 @@ class PipelinesDataFlowModelTest {
     void setup() {
         objectMapper = new ObjectMapper(YAMLFactory.builder()
                 .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+                .enable(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS)
                 .build());
     }
 

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PluginModelTests.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PluginModelTests.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
@@ -64,7 +65,7 @@ public class PluginModelTests {
     public final void testSerialization_empty_plugin_to_YAML() throws JsonGenerationException, JsonMappingException, IOException {
         final PluginModel pluginModel = new PluginModel("customPlugin", new HashMap<>());
 
-        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS));
 
         final String serialized = mapper.writeValueAsString(pluginModel);
 
@@ -78,7 +79,7 @@ public class PluginModelTests {
     public final void testUsingCustomSerializerWithPluginSettings_noExceptions() throws JsonGenerationException, JsonMappingException, IOException {
         final PluginModel pluginModel = new PluginModel("customPlugin", validPluginSettings());
 
-        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS));
 
         final String serialized = mapper.writeValueAsString(pluginModel);
 

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/DefaultEventMetadataTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/DefaultEventMetadataTest.java
@@ -83,7 +83,7 @@ public class DefaultEventMetadataTest {
     @Test
     public void testBuild_withoutTimeReceived() {
 
-        final Instant before = Instant.ofEpochMilli(Instant.now().toEpochMilli() - 1);
+        final Instant before = Instant.now().minusSeconds(1);
 
         EventMetadata result = DefaultEventMetadata.builder()
                 .withEventType(testEventType)
@@ -93,7 +93,7 @@ public class DefaultEventMetadataTest {
         final Instant timeReceived = result.getTimeReceived();
         assertThat(timeReceived, notNullValue());
         assertThat(timeReceived, is(greaterThan(before)));
-        assertThat(timeReceived, is(lessThan(Instant.ofEpochMilli(Instant.now().toEpochMilli() + 1))));
+        assertThat(timeReceived, is(lessThan(Instant.now().plusSeconds(1))));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/DefaultEventMetadataTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/DefaultEventMetadataTest.java
@@ -83,7 +83,7 @@ public class DefaultEventMetadataTest {
     @Test
     public void testBuild_withoutTimeReceived() {
 
-        final Instant before = Instant.now();
+        final Instant before = Instant.ofEpochMilli(Instant.now().toEpochMilli() - 1);
 
         EventMetadata result = DefaultEventMetadata.builder()
                 .withEventType(testEventType)
@@ -93,7 +93,7 @@ public class DefaultEventMetadataTest {
         final Instant timeReceived = result.getTimeReceived();
         assertThat(timeReceived, notNullValue());
         assertThat(timeReceived, is(greaterThan(before)));
-        assertThat(timeReceived, is(lessThan(Instant.now())));
+        assertThat(timeReceived, is(lessThan(Instant.ofEpochMilli(Instant.now().toEpochMilli() + 1))));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/DefaultEventMetadataTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/DefaultEventMetadataTest.java
@@ -20,8 +20,8 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.emptyOrNullString;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DefaultEventMetadataTest {
@@ -83,7 +83,7 @@ public class DefaultEventMetadataTest {
     @Test
     public void testBuild_withoutTimeReceived() {
 
-        final Instant before = Instant.now().minusSeconds(1);
+        final Instant before = Instant.now();
 
         EventMetadata result = DefaultEventMetadata.builder()
                 .withEventType(testEventType)
@@ -92,8 +92,8 @@ public class DefaultEventMetadataTest {
         assertThat(result, notNullValue());
         final Instant timeReceived = result.getTimeReceived();
         assertThat(timeReceived, notNullValue());
-        assertThat(timeReceived, is(greaterThan(before)));
-        assertThat(timeReceived, is(lessThan(Instant.now().plusSeconds(1))));
+        assertThat(timeReceived, is(greaterThanOrEqualTo(before)));
+        assertThat(timeReceived, is(lessThanOrEqualTo(Instant.now())));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/JacksonEventTest.java
@@ -385,7 +385,7 @@ public class JacksonEventTest {
     @Test
     public void testBuild_withAllMetadataFields() {
 
-        final Instant now = Instant.now();
+        final Instant now = Instant.now().minusSeconds(1);
         final Map<String, Object> testAttributes = new HashMap<>();
         testAttributes.put(UUID.randomUUID().toString(), UUID.randomUUID());
         testAttributes.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
@@ -403,7 +403,7 @@ public class JacksonEventTest {
                 .build();
 
         assertThat(event.getMetadata().getAttributes(), is(not(equalTo(testAttributes))));
-        assertThat(event.getMetadata().getTimeReceived(), equalTo(now));
+        assertThat(event.getMetadata().getTimeReceived(), is(not(equalTo(now))));
         assertThat(event.getMetadata().getEventType(), is(equalTo(emEventType)));
     }
 

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/JacksonEventTest.java
@@ -403,7 +403,7 @@ public class JacksonEventTest {
                 .build();
 
         assertThat(event.getMetadata().getAttributes(), is(not(equalTo(testAttributes))));
-        assertThat(event.getMetadata().getTimeReceived(), is(not(equalTo(now))));
+        assertThat(event.getMetadata().getTimeReceived(), equalTo(now));
         assertThat(event.getMetadata().getEventType(), is(equalTo(emEventType)));
     }
 

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/config/DataPrepperArgsTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/config/DataPrepperArgsTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.io.File;
+import java.nio.file.Paths;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
@@ -67,7 +67,7 @@ class DataPrepperArgsTest {
     public void testGivenLogstashConfigPathThenPipelineConfigCreated() {
         final DataPrepperArgs args = new DataPrepperArgs(LOGSTASH_PIPELINE_FILE_PATH, DP_CONFIG_YAML_FILE_PATH);
 
-        final String configFileEnding = String.format("src%stest%sresources%slogstash-filter.yaml", File.separator, File.separator, File.separator);
+        final String configFileEnding = Paths.get("src", "test", "resources", "logstash-filter.yaml").toString();
 
         assertThat(args, is(notNullValue()));
         assertThat(

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/config/DataPrepperArgsTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/config/DataPrepperArgsTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.File;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
@@ -65,10 +67,12 @@ class DataPrepperArgsTest {
     public void testGivenLogstashConfigPathThenPipelineConfigCreated() {
         final DataPrepperArgs args = new DataPrepperArgs(LOGSTASH_PIPELINE_FILE_PATH, DP_CONFIG_YAML_FILE_PATH);
 
+        final String configFileEnding = String.format("src%stest%sresources%slogstash-filter.yaml", File.separator, File.separator, File.separator);
+
         assertThat(args, is(notNullValue()));
         assertThat(
                 args.getPipelineConfigFileLocation(),
-                endsWith("src/test/resources/logstash-filter.yaml"));
+                endsWith(configFileEnding));
         assertThat(args.getDataPrepperConfigFileLocation(), is(DP_CONFIG_YAML_FILE_PATH));
     }
 

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/LogstashConfigConverter.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/LogstashConfigConverter.java
@@ -51,6 +51,7 @@ public class LogstashConfigConverter {
         ObjectMapper mapper = new ObjectMapper(YAMLFactory.builder()
                 .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
                 .enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR)
+                .enable(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS)
                 .disable(YAMLGenerator.Feature.SPLIT_LINES)
                 .enable(YAMLGenerator.Feature.LITERAL_BLOCK_STYLE)
                 .build());

--- a/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
@@ -47,6 +47,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -88,7 +89,6 @@ class HTTPSourceTest {
     private final String TEST_PIPELINE_NAME = "test_pipeline";
     private final String TEST_SSL_CERTIFICATE_FILE = getClass().getClassLoader().getResource("test_cert.crt").getFile();
     private final String TEST_SSL_KEY_FILE = getClass().getClassLoader().getResource("test_decrypted_key.key").getFile();
-
     @Mock
     private ServerBuilder serverBuilder;
 

--- a/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
@@ -47,7 +47,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -89,6 +88,7 @@ class HTTPSourceTest {
     private final String TEST_PIPELINE_NAME = "test_pipeline";
     private final String TEST_SSL_CERTIFICATE_FILE = getClass().getClassLoader().getResource("test_cert.crt").getFile();
     private final String TEST_SSL_KEY_FILE = getClass().getClassLoader().getResource("test_decrypted_key.key").getFile();
+
     @Mock
     private ServerBuilder serverBuilder;
 


### PR DESCRIPTION
### Description
There are a handful of unit tests that fail when running on Windows. This PR fixes some of them. The reasons for failing tests include:

1. Instant comparison is too strict and varies based on CPU
2. YAMLGenerator needs to enable `USE_PLATFORM_LINE_BREAKS`  to not always default to Unix `\n` (Windows standard is `\r\n`
3. Test paths are created with `/`, while windows uses `\`
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
