### PR TITLE
Added concludeGroup logic to AggregateProcessor, added AggregateActionSynchronizer class to synchronize groupConcluding and eventHandling

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.processor.aggregate;
+
+import com.amazon.dataprepper.model.event.Event;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+
+class AggregateActionSynchronizer {
+    private final AggregateAction aggregateAction;
+    private final AggregateGroupManager aggregateGroupManager;
+
+    private static final Logger LOG = LoggerFactory.getLogger(AggregateActionSynchronizer.class);
+
+    private AggregateActionSynchronizer(final AggregateAction aggregateAction, final AggregateGroupManager aggregateGroupManager) {
+        this.aggregateAction = aggregateAction;
+        this.aggregateGroupManager = aggregateGroupManager;
+    }
+
+    Optional<Event> concludeGroup(final AggregateIdentificationKeysHasher.IdentificationHash hash, final AggregateGroup aggregateGroup) {
+        final Lock concludeGroupLock = aggregateGroup.getConcludeGroupLock();
+        final Lock handleEventForGroupLock = aggregateGroup.getHandleEventForGroupLock();
+
+        Optional<Event> concludeGroupEvent = Optional.empty();
+        if (concludeGroupLock.tryLock()) {
+            try {
+                handleEventForGroupLock.lock();
+                concludeGroupEvent = aggregateAction.concludeGroup(aggregateGroup);
+                aggregateGroupManager.removeGroupWithHash(hash, aggregateGroup);
+                aggregateGroup.resetGroupStart();
+                aggregateGroup.clearGroupState();
+            } catch (Exception e) {
+                LOG.debug("Error while concluding group: ", e);
+            } finally{
+                handleEventForGroupLock.unlock();
+                concludeGroupLock.unlock();
+            }
+        }
+        return concludeGroupEvent;
+    }
+
+    AggregateActionResponse handleEventForGroup(final Event event, final AggregateIdentificationKeysHasher.IdentificationHash hash, final AggregateGroup aggregateGroup) {
+        final Lock concludeGroupLock = aggregateGroup.getConcludeGroupLock();
+        final Lock handleEventForGroupLock = aggregateGroup.getHandleEventForGroupLock();
+
+        concludeGroupLock.lock();
+        concludeGroupLock.unlock();
+
+        AggregateActionResponse handleEventResponse;
+        try {
+            handleEventForGroupLock.lock();
+            handleEventResponse = aggregateAction.handleEvent(event, aggregateGroup);
+            aggregateGroupManager.putGroupWithHash(hash, aggregateGroup);
+        } catch (final Exception e) {
+            LOG.debug("Error while handling event, event will be processed by remainder of the pipeline: ", e);
+            handleEventResponse = new AggregateActionResponse(event);
+        } finally{
+            handleEventForGroupLock.unlock();
+        }
+
+        return handleEventResponse;
+    }
+
+    static class AggregateActionSynchronizerProvider {
+        public AggregateActionSynchronizer provide(final AggregateAction aggregateAction, final AggregateGroupManager aggregateGroupManager) {
+            return new AggregateActionSynchronizer(aggregateAction, aggregateGroupManager);
+        }
+    }
+}

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroup.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroup.java
@@ -5,14 +5,45 @@
 
 package com.amazon.dataprepper.plugins.processor.aggregate;
 
+import java.time.Instant;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 class AggregateGroup implements AggregateActionInput {
     private final GroupState groupState;
+    private Instant groupStart;
+    private final Lock concludeGroupLock;
+    private final Lock handleEventForGroupLock;
+
 
     AggregateGroup() {
         this.groupState = new DefaultGroupState();
+        this.groupStart = Instant.now();
+        this.concludeGroupLock = new ReentrantLock();
+        this.handleEventForGroupLock = new ReentrantLock();
     }
 
     public GroupState getGroupState() {
         return groupState;
+    }
+
+    Instant getGroupStart() {
+        return groupStart;
+    }
+
+    Lock getConcludeGroupLock() {
+        return concludeGroupLock;
+    }
+
+    Lock getHandleEventForGroupLock() {
+        return handleEventForGroupLock;
+    }
+
+    void resetGroupStart() {
+        this.groupStart = Instant.now();
+    }
+
+    void clearGroupState() {
+        groupState.clear();
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroup.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroup.java
@@ -39,11 +39,8 @@ class AggregateGroup implements AggregateActionInput {
         return handleEventForGroupLock;
     }
 
-    void resetGroupStart() {
-        this.groupStart = Instant.now();
-    }
-
-    void clearGroupState() {
+    void resetGroup() {
+        groupStart = Instant.now();
         groupState.clear();
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
@@ -5,27 +5,53 @@
 
 package com.amazon.dataprepper.plugins.processor.aggregate;
 
-import java.util.Map;
-
 import com.google.common.collect.Maps;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 class AggregateGroupManager {
 
-    private final Map<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> allGroupStates = Maps.newConcurrentMap();
+    private final Map<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> allGroups = Maps.newConcurrentMap();
+    private final int windowDuration;
 
-    AggregateGroupManager() {
-
+    AggregateGroupManager(final int windowDuration) {
+        this.windowDuration = windowDuration;
     }
 
     AggregateGroup getAggregateGroup(final AggregateIdentificationKeysHasher.IdentificationHash identificationHash) {
-        final AggregateGroup aggregateGroup = allGroupStates.get(identificationHash);
+        final AggregateGroup aggregateGroup = allGroups.get(identificationHash);
 
         if (aggregateGroup != null) {
             return aggregateGroup;
         }
 
         final AggregateGroup newAggregateGroup = new AggregateGroup();
-        allGroupStates.put(identificationHash, newAggregateGroup);
+        allGroups.put(identificationHash, newAggregateGroup);
         return newAggregateGroup;
+    }
+
+    List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> getGroupsToConclude() {
+        final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> groupsToConclude = new ArrayList<>();
+        for (final Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> groupEntry : allGroups.entrySet()) {
+            if (shouldConcludeGroup(groupEntry.getValue())) {
+                groupsToConclude.add(groupEntry);
+            }
+        }
+        return groupsToConclude;
+    }
+
+    private boolean shouldConcludeGroup(final AggregateGroup aggregateGroup) {
+        return (Instant.now().toEpochMilli() - aggregateGroup.getGroupStart().toEpochMilli()) >= windowDuration * 1000L;
+    }
+
+    void removeGroupWithHash(final AggregateIdentificationKeysHasher.IdentificationHash hash, final AggregateGroup group) {
+        allGroups.remove(hash, group);
+    }
+
+    void putGroupWithHash(final AggregateIdentificationKeysHasher.IdentificationHash hash, final AggregateGroup group) {
+        allGroups.put(hash, group);
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateIdentificationKeysHasher.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateIdentificationKeysHasher.java
@@ -10,6 +10,7 @@ import com.amazon.dataprepper.model.event.Event;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 class AggregateIdentificationKeysHasher {
     private final List<String> identificationKeys;
@@ -33,13 +34,16 @@ class AggregateIdentificationKeysHasher {
         }
 
         @Override
-        public boolean equals(Object other) {
-            return this.hash.equals(other);
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            IdentificationHash that = (IdentificationHash) o;
+            return Objects.equals(hash, that.hash);
         }
 
         @Override
         public int hashCode() {
-            return hash.hashCode();
+            return Objects.hash(hash);
         }
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -44,7 +44,7 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
         this.aggregateProcessorConfig = aggregateProcessorConfig;
         this.aggregateGroupManager = aggregateGroupManager;
         this.aggregateIdentificationKeysHasher = aggregateIdentificationKeysHasher;
-        AggregateAction aggregateAction = loadAggregateAction(pluginFactory);
+        final AggregateAction aggregateAction = loadAggregateAction(pluginFactory);
         this.aggregateActionSynchronizer = aggregateActionSynchronizerProvider.provide(aggregateAction, aggregateGroupManager);
     }
 

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizerTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.processor.aggregate;
+
+import com.amazon.dataprepper.model.event.Event;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AggregateActionSynchronizerTest {
+
+    @Mock
+    private AggregateAction aggregateAction;
+
+    @Mock
+    private AggregateGroupManager aggregateGroupManager;
+
+    @Mock
+    private AggregateGroup aggregateGroup;
+
+    @Mock
+    private AggregateIdentificationKeysHasher.IdentificationHash identificationHash;
+
+    @Mock
+    private AggregateActionResponse aggregateActionResponse;
+
+    @Mock
+    private Lock concludeGroupLock;
+
+    @Mock
+    private Lock handleEventForGroupLock;
+
+    @Mock
+    private Event event;
+
+    @BeforeEach
+    void setup() {
+        lenient().doNothing().when(handleEventForGroupLock).lock();
+        lenient().doNothing().when(handleEventForGroupLock).unlock();
+        lenient().doNothing().when(concludeGroupLock).unlock();
+        lenient().doNothing().when(aggregateGroup).clearGroupState();
+        lenient().doNothing().when(aggregateGroup).resetGroupStart();
+        lenient().doNothing().when(aggregateGroupManager).putGroupWithHash(identificationHash, aggregateGroup);
+        lenient().doNothing().when(aggregateGroupManager).removeGroupWithHash(identificationHash, aggregateGroup);
+        when(aggregateGroup.getConcludeGroupLock()).thenReturn(concludeGroupLock);
+        when(aggregateGroup.getHandleEventForGroupLock()).thenReturn(handleEventForGroupLock);
+    }
+
+    private AggregateActionSynchronizer createObjectUnderTest() {
+        final AggregateActionSynchronizer.AggregateActionSynchronizerProvider aggregateActionSynchronizerProvider = new AggregateActionSynchronizer.AggregateActionSynchronizerProvider();
+        return aggregateActionSynchronizerProvider.provide(aggregateAction, aggregateGroupManager);
+    }
+
+    @Test
+    void concludeGroup_with_tryLock_false_returns_empty_optional() {
+        final AggregateActionSynchronizer objectUnderTest = createObjectUnderTest();
+        when(concludeGroupLock.tryLock()).thenReturn(false);
+
+        final Optional<Event> concludeGroupEvent = objectUnderTest.concludeGroup(identificationHash, aggregateGroup);
+
+        verifyNoInteractions(handleEventForGroupLock);
+        verifyNoInteractions(aggregateAction);
+        verifyNoInteractions(aggregateGroupManager);
+        verify(aggregateGroup, times(0)).resetGroupStart();
+        verify(aggregateGroup, times(0)).clearGroupState();
+        verify(concludeGroupLock, times(0)).unlock();
+
+        assertThat(concludeGroupEvent, equalTo(Optional.empty()));
+    }
+
+    @Test
+    void concludeGroup_with_tryLock_true_calls_expected_functions_and_returns_correct_event() {
+        final AggregateActionSynchronizer objectUnderTest = createObjectUnderTest();
+        when(concludeGroupLock.tryLock()).thenReturn(true);
+        lenient().when(aggregateAction.concludeGroup(aggregateGroup)).thenReturn(Optional.of(event));
+
+        final Optional<Event> concludeGroupEvent = objectUnderTest.concludeGroup(identificationHash, aggregateGroup);
+
+        verify(handleEventForGroupLock).lock();
+        verify(handleEventForGroupLock).unlock();
+        verify(aggregateGroup).resetGroupStart();
+        verify(aggregateGroup).clearGroupState();
+        verify(aggregateGroupManager).removeGroupWithHash(identificationHash, aggregateGroup);
+        verify(aggregateAction).concludeGroup(aggregateGroup);
+        verify(concludeGroupLock).unlock();
+
+        assertThat(concludeGroupEvent.isPresent(), equalTo(true));
+        assertThat(concludeGroupEvent.get(), equalTo(event));
+    }
+
+    @Test
+    void locks_are_unlocked_and_empty_optional_returned_when_aggregateAction_concludeGroup_throws_exception() {
+        final AggregateActionSynchronizer objectUnderTest = createObjectUnderTest();
+        when(concludeGroupLock.tryLock()).thenReturn(true);
+        lenient().when(aggregateAction.concludeGroup(aggregateGroup)).thenThrow(RuntimeException.class);
+
+        final Optional<Event> concludeGroupEvent = objectUnderTest.concludeGroup(identificationHash, aggregateGroup);
+
+        verify(handleEventForGroupLock).unlock();
+        verify(concludeGroupLock).unlock();
+
+        assertThat(concludeGroupEvent, equalTo(Optional.empty()));
+    }
+
+    @Test
+    void handleEventForGroup_calls_expected_functions_and_returns_correct_AggregateActionResponse() {
+        final AggregateActionSynchronizer objectUnderTest = createObjectUnderTest();
+        lenient().when(aggregateAction.handleEvent(event, aggregateGroup)).thenReturn(aggregateActionResponse);
+
+        final AggregateActionResponse handleEventResponse = objectUnderTest.handleEventForGroup(event, identificationHash, aggregateGroup);
+
+        verify(concludeGroupLock).lock();
+        verify(concludeGroupLock).unlock();
+        verify(handleEventForGroupLock).lock();
+        verify(handleEventForGroupLock).unlock();
+        verify(aggregateGroupManager).putGroupWithHash(identificationHash, aggregateGroup);
+        verify(aggregateAction).handleEvent(event, aggregateGroup);
+
+        assertThat(handleEventResponse, equalTo(aggregateActionResponse));
+    }
+
+    @Test
+    void locks_are_unlocked_and_event_returned_when_aggregateAction_handleEvent_throws_exception() {
+        final AggregateActionSynchronizer objectUnderTest = createObjectUnderTest();
+        lenient().when(aggregateAction.handleEvent(event, aggregateGroup)).thenThrow(RuntimeException.class);
+
+        final AggregateActionResponse handleEventResponse = objectUnderTest.handleEventForGroup(event, identificationHash, aggregateGroup);
+
+        verify(handleEventForGroupLock).unlock();
+
+        assertThat(handleEventResponse, notNullValue());
+        assertThat(handleEventResponse.getEvent(), equalTo(event));
+    }
+
+}

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
@@ -8,22 +8,28 @@ package com.amazon.dataprepper.plugins.processor.aggregate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class AggregateGroupManagerTest {
 
     private AggregateGroupManager aggregateGroupManager;
 
     private AggregateIdentificationKeysHasher.IdentificationHash identificationHash;
+
+    private static final int TEST_WINDOW_DURATION = 10;
 
     @BeforeEach
     void setup() {
@@ -34,11 +40,11 @@ public class AggregateGroupManagerTest {
     }
 
     private AggregateGroupManager createObjectUnderTest() {
-        return new AggregateGroupManager();
+        return new AggregateGroupManager(TEST_WINDOW_DURATION);
     }
 
     @Test
-    void getGroupState_with_non_existing_group_state_creates_and_returns_new_group_state_and_adds_to_allGroupStates() {
+    void getGroup_with_non_existing_group_state_creates_and_returns_new_group_and_adds_to_allGroups() {
         aggregateGroupManager = createObjectUnderTest();
 
         final AggregateGroup emptyAggregateGroup = aggregateGroupManager.getAggregateGroup(identificationHash);
@@ -55,10 +61,50 @@ public class AggregateGroupManagerTest {
         aggregateGroupManager = createObjectUnderTest();
 
         final AggregateGroup firstAggregateGroup = aggregateGroupManager.getAggregateGroup(identificationHash);
-        firstAggregateGroup.getGroupState().put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        final GroupState groupState = firstAggregateGroup.getGroupState();
+        groupState.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
         final AggregateGroup secondAggregateGroup = aggregateGroupManager.getAggregateGroup(identificationHash);
         assertThat(secondAggregateGroup, equalTo(firstAggregateGroup));
+        assertThat(secondAggregateGroup.getGroupState(), equalTo(groupState));
 
+    }
+
+    @Test
+    void putGroupWithHash_overwrites_old_group() {
+        aggregateGroupManager = createObjectUnderTest();
+
+        final AggregateGroup expectedOldGroup = mock(AggregateGroup.class);
+        aggregateGroupManager.putGroupWithHash(identificationHash, expectedOldGroup);
+        final AggregateGroup oldGroup = aggregateGroupManager.getAggregateGroup(identificationHash);
+        assertThat(oldGroup, equalTo(expectedOldGroup));
+
+        final AggregateGroup expectedNewGroup = mock(AggregateGroup.class);
+        aggregateGroupManager.putGroupWithHash(identificationHash, expectedNewGroup);
+        final AggregateGroup newGroup = aggregateGroupManager.getAggregateGroup(identificationHash);
+        assertThat(newGroup, equalTo(expectedNewGroup));
+    }
+
+    @Test
+    void getGroupsToConclude_returns_correct_group() {
+        aggregateGroupManager = createObjectUnderTest();
+
+        final AggregateGroup groupToConclude = mock(AggregateGroup.class);
+        final AggregateIdentificationKeysHasher.IdentificationHash hashForGroupToConclude = mock(AggregateIdentificationKeysHasher.IdentificationHash.class);
+        when(groupToConclude.getGroupStart()).thenReturn(Instant.ofEpochMilli(Instant.now().toEpochMilli() - (TEST_WINDOW_DURATION * 1000L)));
+
+        final AggregateGroup groupToNotConclude = mock(AggregateGroup.class);
+        final AggregateIdentificationKeysHasher.IdentificationHash hashForGroupToNotConclude = mock(AggregateIdentificationKeysHasher.IdentificationHash.class);
+        when(groupToNotConclude.getGroupStart()).thenReturn(Instant.ofEpochMilli(Instant.now().toEpochMilli() + (TEST_WINDOW_DURATION * 1000L)));
+
+        aggregateGroupManager.putGroupWithHash(hashForGroupToConclude, groupToConclude);
+        aggregateGroupManager.putGroupWithHash(hashForGroupToNotConclude, groupToNotConclude);
+
+        final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> groupsToConclude = aggregateGroupManager.getGroupsToConclude();
+
+        assertThat(groupsToConclude.size(), equalTo(1));
+        assertThat(groupsToConclude.get(0), notNullValue());
+        assertThat(groupsToConclude.get(0).getKey(), equalTo(hashForGroupToConclude));
+        assertThat(groupsToConclude.get(0).getValue(), equalTo(groupToConclude));
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
@@ -91,11 +91,11 @@ public class AggregateGroupManagerTest {
 
         final AggregateGroup groupToConclude = mock(AggregateGroup.class);
         final AggregateIdentificationKeysHasher.IdentificationHash hashForGroupToConclude = mock(AggregateIdentificationKeysHasher.IdentificationHash.class);
-        when(groupToConclude.getGroupStart()).thenReturn(Instant.ofEpochMilli(Instant.now().toEpochMilli() - (TEST_WINDOW_DURATION * 1000L)));
+        when(groupToConclude.getGroupStart()).thenReturn(Instant.now().minusSeconds(TEST_WINDOW_DURATION));
 
         final AggregateGroup groupToNotConclude = mock(AggregateGroup.class);
         final AggregateIdentificationKeysHasher.IdentificationHash hashForGroupToNotConclude = mock(AggregateIdentificationKeysHasher.IdentificationHash.class);
-        when(groupToNotConclude.getGroupStart()).thenReturn(Instant.ofEpochMilli(Instant.now().toEpochMilli() + (TEST_WINDOW_DURATION * 1000L)));
+        when(groupToNotConclude.getGroupStart()).thenReturn(Instant.now().plusSeconds(TEST_WINDOW_DURATION));
 
         aggregateGroupManager.putGroupWithHash(hashForGroupToConclude, groupToConclude);
         aggregateGroupManager.putGroupWithHash(hashForGroupToNotConclude, groupToNotConclude);

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -29,7 +30,7 @@ public class AggregateGroupManagerTest {
 
     private AggregateIdentificationKeysHasher.IdentificationHash identificationHash;
 
-    private static final int TEST_WINDOW_DURATION = 10;
+    private static final int TEST_WINDOW_DURATION = new Random().nextInt(10) + 10;
 
     @BeforeEach
     void setup() {

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.processor.aggregate;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class AggregateGroupTest {
+
+    @Test
+    void clearingGroupState_after_getting_group_state_clears_group_state() {
+        final AggregateGroup aggregateGroup = new AggregateGroup();
+
+        final GroupState groupState = aggregateGroup.getGroupState();
+        groupState.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+        aggregateGroup.clearGroupState();
+
+        assertThat(groupState, equalTo(Collections.emptyMap()));
+    }
+}

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupTest.java
@@ -16,13 +16,13 @@ import static org.hamcrest.Matchers.equalTo;
 public class AggregateGroupTest {
 
     @Test
-    void clearingGroupState_after_getting_group_state_clears_group_state() {
+    void resetGroup_after_getting_group_state_clears_group_state() {
         final AggregateGroup aggregateGroup = new AggregateGroup();
 
         final GroupState groupState = aggregateGroup.getGroupState();
         groupState.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
-        aggregateGroup.clearGroupState();
+        aggregateGroup.resetGroup();
 
         assertThat(groupState, equalTo(Collections.emptyMap()));
     }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateIdentificationKeysHasherTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateIdentificationKeysHasherTest.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class AggregateIdentificationKeysHasherTest {
@@ -36,13 +38,13 @@ public class AggregateIdentificationKeysHasherTest {
     }
 
     @Test
-    void createIdentificationKeyHashFromEvent_returns_expected_Map() {
+    void createIdentificationKeyHashFromEvent_returns_expected_IdentficationHash() {
         aggregateIdentificationKeysHasher = createObjectUnderTest();
         final Map<Object, Object> eventMap = new HashMap<>();
         eventMap.put("firstIdentificationKey", UUID.randomUUID().toString());
         eventMap.put("secondIdentificationKey", UUID.randomUUID().toString());
 
-        final Map<Object, Object> expectedResult = new HashMap<>(eventMap);
+        final AggregateIdentificationKeysHasher.IdentificationHash expectedResult = new AggregateIdentificationKeysHasher.IdentificationHash(new HashMap<>(eventMap));
 
         eventMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
@@ -61,8 +63,10 @@ public class AggregateIdentificationKeysHasherTest {
         final Map<Object, Object> eventMap = new HashMap<>();
         eventMap.put("firstIdentificationKey", UUID.randomUUID().toString());
 
-        final Map<Object, Object> expectedResult = new HashMap<>(eventMap);
-        expectedResult.put("secondIdentificationKey", null);
+        final Map<Object, Object> mapForExpectedHash = new HashMap<>(eventMap);
+        mapForExpectedHash.put("secondIdentificationKey", null);
+
+        final AggregateIdentificationKeysHasher.IdentificationHash expectedResult = new AggregateIdentificationKeysHasher.IdentificationHash(mapForExpectedHash);
 
         eventMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
@@ -73,5 +77,51 @@ public class AggregateIdentificationKeysHasherTest {
 
         final AggregateIdentificationKeysHasher.IdentificationHash result = aggregateIdentificationKeysHasher.createIdentificationKeyHashFromEvent(event);
         assertThat(result, equalTo(expectedResult));
+    }
+
+    @Test
+    void identical_identification_hashes_but_different_objects_are_considered_equal() {
+        aggregateIdentificationKeysHasher = createObjectUnderTest();
+        final Map<Object, Object> eventMap = new HashMap<>();
+        eventMap.put("firstIdentificationKey", UUID.randomUUID().toString());
+        eventMap.put("secondIdentificationKey", UUID.randomUUID().toString());
+        eventMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+        event = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(eventMap)
+                .build();
+
+        final AggregateIdentificationKeysHasher.IdentificationHash result = aggregateIdentificationKeysHasher.createIdentificationKeyHashFromEvent(event);
+        final AggregateIdentificationKeysHasher.IdentificationHash secondResult = aggregateIdentificationKeysHasher.createIdentificationKeyHashFromEvent(event);
+
+        assertThat(result, equalTo(secondResult));
+    }
+
+    @Test
+    void different_identification_hashes_are_not_considered_equal() {
+        aggregateIdentificationKeysHasher = createObjectUnderTest();
+        final Map<Object, Object> eventMap = new HashMap<>();
+        eventMap.put("firstIdentificationKey", UUID.randomUUID().toString());
+        eventMap.put("secondIdentificationKey", UUID.randomUUID().toString());
+        eventMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+        final Map<Object, Object> secondEventMap = new HashMap<>(eventMap);
+        secondEventMap.remove("firstIdentificationKey");
+
+        event = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(eventMap)
+                .build();
+
+        final Event secondEvent = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(secondEventMap)
+                .build();
+
+        final AggregateIdentificationKeysHasher.IdentificationHash result = aggregateIdentificationKeysHasher.createIdentificationKeyHashFromEvent(event);
+        final AggregateIdentificationKeysHasher.IdentificationHash secondResult = aggregateIdentificationKeysHasher.createIdentificationKeyHashFromEvent(secondEvent);
+
+        assertThat(result, is(not(equalTo(secondResult))));
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorConfigTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorConfigTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -18,10 +18,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -59,6 +61,12 @@ public class AggregateProcessorTest {
     private AggregateGroupManager aggregateGroupManager;
 
     @Mock
+    private AggregateActionSynchronizer.AggregateActionSynchronizerProvider aggregateActionSynchronizerProvider;
+
+    @Mock
+    private AggregateActionSynchronizer aggregateActionSynchronizer;
+
+    @Mock
     private AggregateGroup aggregateGroup;
 
     @Mock
@@ -85,16 +93,19 @@ public class AggregateProcessorTest {
         when(aggregateIdentificationKeysHasher.createIdentificationKeyHashFromEvent(event))
                 .thenReturn(identificationHash);
         when(aggregateGroupManager.getAggregateGroup(identificationHash)).thenReturn(aggregateGroup);
-        when(aggregateAction.handleEvent(event, aggregateGroup)).thenReturn(aggregateActionResponse);
+
+        when(aggregateActionSynchronizerProvider.provide(aggregateAction, aggregateGroupManager)).thenReturn(aggregateActionSynchronizer);
+        when(aggregateActionSynchronizer.handleEventForGroup(event, identificationHash, aggregateGroup)).thenReturn(aggregateActionResponse);
     }
 
     private AggregateProcessor createObjectUnderTest() {
-        return new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, aggregateGroupManager, aggregateIdentificationKeysHasher);
+        return new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, aggregateGroupManager, aggregateIdentificationKeysHasher, aggregateActionSynchronizerProvider);
     }
 
     @Test
     void handleEvent_returning_with_no_event_does_not_add_event_to_records_out() {
         final AggregateProcessor objectUnderTest = createObjectUnderTest();
+        when(aggregateGroupManager.getGroupsToConclude()).thenReturn(Collections.emptyList());
         when(aggregateActionResponse.getEvent()).thenReturn(null);
 
         final List<Record<Event>> recordsOut = (List<Record<Event>>)objectUnderTest.doExecute(Collections.singletonList(new Record<>(event)));
@@ -105,7 +116,39 @@ public class AggregateProcessorTest {
     @Test
     void handleEvent_returning_with_event_adds_event_to_records_out() {
         final AggregateProcessor objectUnderTest = createObjectUnderTest();
+        when(aggregateGroupManager.getGroupsToConclude()).thenReturn(Collections.emptyList());
         when(aggregateActionResponse.getEvent()).thenReturn(event);
+
+        final List<Record<Event>> recordsOut = (List<Record<Event>>)objectUnderTest.doExecute(Collections.singletonList(new Record<>(event)));
+
+        assertThat(recordsOut.size(), equalTo(1));
+        assertThat(recordsOut.get(0), notNullValue());
+        assertThat(recordsOut.get(0).getData(), equalTo(event));
+    }
+
+    @Test
+    void concludeGroup_returning_with_no_event_does_not_add_event_to_records_out() {
+        final AggregateProcessor objectUnderTest = createObjectUnderTest();
+
+        final Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> groupEntry = new AbstractMap.SimpleEntry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>(identificationHash, aggregateGroup);
+                when(aggregateGroupManager.getGroupsToConclude()).thenReturn(Collections.singletonList(groupEntry));
+        when(aggregateActionResponse.getEvent()).thenReturn(null);
+        when(aggregateActionSynchronizer.concludeGroup(identificationHash, aggregateGroup)).thenReturn(Optional.empty());
+
+        final List<Record<Event>> recordsOut = (List<Record<Event>>)objectUnderTest.doExecute(Collections.singletonList(new Record<>(event)));
+
+        assertThat(recordsOut.size(), equalTo(0));
+
+    }
+
+    @Test
+    void concludeGroup_returning_with_event_adds_event_to_records_out() {
+        final AggregateProcessor objectUnderTest = createObjectUnderTest();
+
+        final Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> groupEntry = new AbstractMap.SimpleEntry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>(identificationHash, aggregateGroup);
+        when(aggregateGroupManager.getGroupsToConclude()).thenReturn(Collections.singletonList(groupEntry));
+        when(aggregateActionResponse.getEvent()).thenReturn(null);
+        when(aggregateActionSynchronizer.concludeGroup(identificationHash, aggregateGroup)).thenReturn(Optional.of(event));
 
         final List<Record<Event>> recordsOut = (List<Record<Event>>)objectUnderTest.doExecute(Collections.singletonList(new Record<>(event)));
 


### PR DESCRIPTION

Signed-off-by: Taylor Gray <tylgry@amazon.com>

### Description
* Adds logic of concluding a group to the `AggregateProcessor`. It will get the groups to conclude from the `AggregateGroupManager` and call `AggregateActionSynchronizer.concludeGroup()` on each of these.
* The `AggregateActionSynchronizer` class keeps threads from modifying the same `AggregateGroup` at the same time, and wraps the `AggregateAction` function calls for the `AggregateProcessor`. 
 
### Issues Resolved
Closes #938 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
