### PR TITLE
docker run command fixed. correct docker image and network

### DIFF
--- a/examples/log-ingestion/log_ingestion_demo_guide.md
+++ b/examples/log-ingestion/log_ingestion_demo_guide.md
@@ -45,11 +45,11 @@ process them with the [Grok Prepper](../../data-prepper-plugins/grok-prepper) by
 and send the processed logs to a local [OpenSearch sink](../../data-prepper-plugins/opensearch) to an index named `apache_logs`.
 
 
-3. Run the Data Prepper docker image with the `log_pipeline.yaml` from step 2 passed in. This command attaches the Data Prepper Docker image to the Docker network `log-ingestion_opensearch_net` so that 
+3. Run the Data Prepper docker image with the `log_pipeline.yaml` from step 2 passed in. This command attaches the Data Prepper Docker image to the Docker network `data-prepper-example_opensearch-net` so that 
 FluentBit is able to send logs to the http source of Data Prepper.
 
 ```
-docker run --name data-prepper -v /full/path/to/log_pipeline.yaml:/usr/share/data-prepper/pipelines.yaml --network "log-ingestion_opensearch-net" opensearch-data-prepper:latest
+docker run --name data-prepper -v /full/path/to/log_pipeline.yaml:/usr/share/data-prepper/pipelines.yaml --network "data-prepper-example_opensearch-net" opensearchproject/data-prepper:latest
 ```
 
 If Data Prepper is running correctly, you should see something similar to the following line as the latest output in your terminal.


### PR DESCRIPTION
Signed-off-by: Jonas Schubert schubert.jonas@web.de

### Description

- used docker image used in the docker run command did not match the previously downloaded one
- network `log-ingestion_opensearch_net` was not created, so I corrected it to the one which was created at my system

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
