### PR TITLE
Change CombineAggregateAction name to PutAllAggregateAction

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/actions/PutAllAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/actions/PutAllAggregateAction.java
@@ -5,6 +5,7 @@
 
 package com.amazon.dataprepper.plugins.processor.aggregate.actions;
 
+import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.event.JacksonEvent;
 import com.amazon.dataprepper.plugins.processor.aggregate.AggregateAction;
@@ -20,7 +21,8 @@ import java.util.Optional;
  * most recently handled Event.
  * @since 1.3
  */
-public class CombineAggregateAction implements AggregateAction {
+@DataPrepperPlugin(name = "put_all", pluginType = AggregateAction.class)
+public class PutAllAggregateAction implements AggregateAction {
     static final String EVENT_TYPE = "event";
 
     @Override

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/actions/PutAllAggregateActionTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/actions/PutAllAggregateActionTest.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class CombineAggregateActionTest {
+public class PutAllAggregateActionTest {
     private AggregateAction combineAggregateAction;
     private List<Event> events;
     private List<Map<String, Object>> eventMaps;
@@ -55,8 +55,8 @@ public class CombineAggregateActionTest {
                 .build();
     }
 
-    private CombineAggregateAction createObjectUnderTest() {
-        return new CombineAggregateAction();
+    private PutAllAggregateAction createObjectUnderTest() {
+        return new PutAllAggregateAction();
     }
 
     @Test
@@ -97,7 +97,7 @@ public class CombineAggregateActionTest {
 
         final Optional<Event> result = combineAggregateAction.concludeGroup(aggregateActionInput);
         assertThat(result.isPresent(), equalTo(true));
-        assertThat(result.get().getMetadata().getEventType(), equalTo(CombineAggregateAction.EVENT_TYPE));
+        assertThat(result.get().getMetadata().getEventType(), equalTo(PutAllAggregateAction.EVENT_TYPE));
         assertThat(result.get().toMap(), equalTo(groupState));
     }
 }


### PR DESCRIPTION
Signed-off-by: graytaylor0 <tylgry@amazon.com>

### Description
* Change the name of the `CombineAggregateAction` to `PutAllAggregateAction`. This name more accurately reflects what the AggregateAction is doing, and will make it easier to distinguish AggregateActions as new ones are created. For example, another action named `append` could be created in the future that deals with key conflicts by appending a value rather than just putting or overwriting like the `put_all` action does. See #855 for more context.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
