### PR TITLE
Updated Jackson to 2.13.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ subprojects {
 
 configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
     dependencies {
-        implementation platform('com.fasterxml.jackson:jackson-bom:2.13.0')
+        implementation platform('com.fasterxml.jackson:jackson-bom:2.13.1')
         implementation platform('software.amazon.awssdk:bom:2.17.15')
         implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.67')
         implementation 'jakarta.validation:jakarta.validation-api:3.0.1'

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -85,12 +85,13 @@ compileJava.options.warnings = false
 configurations.all {
     resolutionStrategy {
         force 'com.amazonaws:aws-java-sdk-core:1.12.67'
-        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0'
-        force 'com.fasterxml.jackson.core:jackson-annotations:2.13.0'
-        force 'com.fasterxml.jackson.core:jackson-databind:2.13.0'
+        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.1'
+        force 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
+        force 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
         force 'com.fasterxml.jackson.core:jackson-core:2.13.1'
-        force 'com.fasterxml.jackson:jackson-bom:2.13.0'
-        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.0'
+        force 'com.fasterxml.jackson:jackson-bom:2.13.1'
+        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.1'
+        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.1'
         force 'commons-codec:commons-codec:1.15'
         force 'commons-logging:commons-logging:1.2'
         force 'org.apache.httpcomponents:httpclient:4.5.13'
@@ -98,7 +99,6 @@ configurations.all {
         force "org.hdrhistogram:HdrHistogram:2.1.12"
         force 'joda-time:joda-time:2.10.13'
         force 'org.yaml:snakeyaml:1.29'
-        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.0'
         force 'com.google.guava:guava:31.0.1-jre'
         force 'junit:junit:4.13.2'
         force "org.slf4j:slf4j-api:1.7.32"

--- a/performance-test/build.gradle
+++ b/performance-test/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.13.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 }


### PR DESCRIPTION
### Description

Update Jackson to 2.13.1 in the BOM file.
Force Jackson 2.13.1 in the opensearch build
Removed unnecessary version specification in performance-test project
 
### Issues Resolved

Resolves #991
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
