### PR TITLE
Updated Gson to 2.8.9 and protobuf-java-util to 3.19.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,12 @@ subprojects {
                 }
                 because 'the build fails if the Log4j API is not update along with log4j-core'
             }
+            implementation('com.google.code.gson:gson') {
+                version {
+                    require '2.8.9'
+                }
+                because 'Fixes WS-2021-0419 DoS vulnerability'
+            }
         }
         constraints {
             implementation('io.netty:netty-tcnative-boringssl-static') {

--- a/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'commons-codec:commons-codec:1.15'
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
-    implementation 'com.google.protobuf:protobuf-java-util:3.19.3'
+    implementation 'com.google.protobuf:protobuf-java-util:3.19.4'
     implementation "com.linecorp.armeria:armeria:1.9.2"
     implementation "com.linecorp.armeria:armeria-grpc:1.9.2"
     implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation "commons-io:commons-io:2.11.0"
     implementation 'com.amazonaws:aws-java-sdk-s3'
     implementation 'com.amazonaws:aws-java-sdk-acm'
-    implementation 'com.google.protobuf:protobuf-java-util:3.19.1'
+    implementation 'com.google.protobuf:protobuf-java-util:3.19.4'
     implementation "com.linecorp.armeria:armeria:1.9.2"
     implementation "com.linecorp.armeria:armeria-grpc:1.9.2"
     implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/e2e-test/trace/build.gradle
+++ b/e2e-test/trace/build.gradle
@@ -264,7 +264,7 @@ dependencies {
     integrationTestImplementation project(':data-prepper-plugins:otel-trace-group-prepper')
     integrationTestImplementation "org.awaitility:awaitility:4.0.3"
     integrationTestImplementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
-    integrationTestImplementation 'com.google.protobuf:protobuf-java-util:3.13.0'
+    integrationTestImplementation 'com.google.protobuf:protobuf-java-util:3.19.4'
     integrationTestImplementation "com.linecorp.armeria:armeria:1.0.0"
     integrationTestImplementation "com.linecorp.armeria:armeria-grpc:1.0.0"
     integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${versionMap.opensearchVersion}"


### PR DESCRIPTION
### Description

Require that `gson` version 2.8.9 or higher be used.

The `gson` dependency is a transitive dependency of `protobuf-java-util`, so I also updated all occurrences to the latest version of 3.19.4.
 
### Issues Resolved

Resolves #989
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
