### PR TITLE
Fixed issue where Spring was unable to find the PrometheusMeterRegistry Bean

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/config/MetricsConfig.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/config/MetricsConfig.java
@@ -86,7 +86,7 @@ public class MetricsConfig {
     }
 
     @Bean
-    public MeterRegistry prometheusMeterRegistry(final DataPrepperConfiguration dataPrepperConfiguration) {
+    public PrometheusMeterRegistry prometheusMeterRegistry(final DataPrepperConfiguration dataPrepperConfiguration) {
         if (dataPrepperConfiguration.getMetricRegistryTypes().contains(MetricRegistryType.Prometheus)) {
             final PrometheusMeterRegistry meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
             configureMetricRegistry(meterRegistry);


### PR DESCRIPTION
Signed-off-by: graytaylor0 <tylgry@amazon.com>

### Description
* The Data Prepper Server was unable to find the PrometheusMeterRegistry Bean, which resulted in the metrics core api endpoints being unavailable.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
