### PR TITLE
Added metrics for the Aggregate Processor

### DIFF
--- a/data-prepper-plugins/aggregate-processor/README.md
+++ b/data-prepper-plugins/aggregate-processor/README.md
@@ -1,0 +1,35 @@
+# Aggregate Processor
+
+TODO
+
+## Metrics
+
+Apart from common metrics in [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java), the Aggregate Processor introduces the following custom metrics.
+
+**Counter**
+
+* `actionHandleEventsForwarded`: The number of Events that have been returned from the `handleEvent` call to the [action]() configured
+
+
+* `actionHandleEventsDropped`: The number of Events that have not been returned from the `handleEvent` call to the [action]() configured.
+
+
+* `actionHandleEventsProcessingErrors`: The number of calls made to `handleEvent` for the [action]() configured that resulted in an error.
+
+
+* `actionConcludeGroupEventsForwarded`: The number of Events that have been returned from the `concludeGroup` call to the [action]() configured.
+
+
+* `actionConcludeGroupEventsDropped`: The number of Events that have not been returned from the `condludeGroup` call to the [action]() configured.
+
+
+* `actionConcludeGroupEventsProcessingErrors`: The number of calls made to `concludeGroup` for the [action]() configured that resulted in an error.
+
+**Gauge**
+
+* `currentAggregateGroups`: The current number of groups. This gauge decreases when groups are concluded, and increases when an Event triggers the creation of a new group.
+
+## Developer Guide
+This plugin is compatible with Java 14. See
+- [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md)
+- [monitoring](https://github.com/opensearch-project/data-prepper/blob/main/docs/readme/monitoring.md)

--- a/data-prepper-plugins/aggregate-processor/build.gradle
+++ b/data-prepper-plugins/aggregate-processor/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'io.micrometer:micrometer-core'
     testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
 }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
@@ -48,4 +48,8 @@ class AggregateGroupManager {
     void putGroupWithHash(final AggregateIdentificationKeysHasher.IdentificationHash hash, final AggregateGroup group) {
         allGroups.put(hash, group);
     }
+
+    long getAllGroupsSize() {
+        return allGroups.size();
+    }
 }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -90,6 +90,8 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
             }
         }
 
+        int handleEventsForwarded = 0;
+        int handleEventsDropped = 0;
         for (final Record<Event> record : records) {
             final Event event = record.getData();
             final AggregateIdentificationKeysHasher.IdentificationHash identificationKeysHash = aggregateIdentificationKeysHasher.createIdentificationKeyHashFromEvent(event);
@@ -101,11 +103,14 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
 
             if (aggregateActionResponseEvent != null) {
                 recordsOut.add(new Record<>(aggregateActionResponseEvent, record.getMetadata()));
-                actionHandleEventsForwardedCounter.increment();
+                handleEventsForwarded++;
             } else {
-                actionHandleEventsDroppedCounter.increment();
+                handleEventsDropped++;
             }
         }
+
+        actionHandleEventsForwardedCounter.increment(handleEventsForwarded);
+        actionHandleEventsDroppedCounter.increment(handleEventsDropped);
         return recordsOut;
     }
 

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
@@ -6,20 +6,16 @@
 package com.amazon.dataprepper.plugins.processor.aggregate;
 
 import com.amazon.dataprepper.model.configuration.PluginModel;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
-import java.io.File;
 import java.util.List;
 
 public class AggregateProcessorConfig {
 
     static int DEFAULT_WINDOW_DURATION = 180;
-    static String DEFAULT_DB_PATH = "data/aggregate";
 
     @JsonProperty("identification_keys")
     @NotEmpty
@@ -29,16 +25,9 @@ public class AggregateProcessorConfig {
     @Min(0)
     private int windowDuration = DEFAULT_WINDOW_DURATION;
 
-    @JsonProperty("db_path")
-    @NotEmpty
-    private String dbPath = DEFAULT_DB_PATH;
-
     @JsonProperty("action")
     @NotNull
     private PluginModel aggregateAction;
-
-    @JsonIgnore
-    private File dbFile;
 
     public List<String> getIdentificationKeys() {
         return identificationKeys;
@@ -48,16 +37,6 @@ public class AggregateProcessorConfig {
         return windowDuration;
     }
 
-    public String getDbPath() {
-        return dbPath;
-    }
-
     public PluginModel getAggregateAction() { return aggregateAction; }
-
-    @AssertTrue(message = "db_path is not a valid file path")
-    boolean isDbPathValid() {
-        dbFile = new File(dbPath);
-        return dbFile.exists() || dbFile.mkdirs();
-    }
 
 }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorConfigTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorConfigTest.java
@@ -5,15 +5,7 @@
 
 package com.amazon.dataprepper.plugins.processor.aggregate;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,38 +16,5 @@ public class AggregateProcessorConfigTest {
         final AggregateProcessorConfig aggregateConfig = new AggregateProcessorConfig();
 
         assertThat(aggregateConfig.getWindowDuration(), equalTo(AggregateProcessorConfig.DEFAULT_WINDOW_DURATION));
-        assertThat(aggregateConfig.getDbPath(), equalTo(AggregateProcessorConfig.DEFAULT_DB_PATH));
-        assertThat(aggregateConfig.isDbPathValid(), equalTo(true));
-    }
-
-    @Nested
-    class Validation {
-
-        @TempDir
-        File temporaryDirectory;
-        private File file;
-
-        @BeforeEach
-        void setUp() throws IOException {
-            file = new File(temporaryDirectory, UUID.randomUUID().toString());
-            file.createNewFile();
-        }
-
-        @Test
-        void isDbPathValid_should_return_true_for_existing_file() throws NoSuchFieldException, IllegalAccessException {
-            final AggregateProcessorConfig aggregateConfig = new AggregateProcessorConfig();
-            reflectivelySetField(aggregateConfig, "dbPath", file.getAbsolutePath());
-            assertThat(aggregateConfig.isDbPathValid(), equalTo(true));
-        }
-    }
-
-    private void reflectivelySetField(final AggregateProcessorConfig aggregateProcessorConfig, final String fieldName, final Object value) throws NoSuchFieldException, IllegalAccessException {
-        final Field field = AggregateProcessorConfig.class.getDeclaredField(fieldName);
-        try {
-            field.setAccessible(true);
-            field.set(aggregateProcessorConfig, value);
-        } finally {
-            field.setAccessible(false);
-        }
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -78,13 +78,13 @@ public class AggregateProcessorTest {
     private PluginMetrics pluginMetrics;
 
     @Mock
-    private Counter actionHandleEventsForwardedCounter;
+    private Counter actionHandleEventsOutCounter;
 
     @Mock
     private Counter actionHandleEventsDroppedCounter;
 
     @Mock
-    private Counter actionConcludeGroupEventsForwardedCounter;
+    private Counter actionConcludeGroupEventsOutCounter;
 
     @Mock
     private Counter actionConcludeGroupEventsDroppedCounter;
@@ -123,9 +123,9 @@ public class AggregateProcessorTest {
         when(aggregateActionSynchronizerProvider.provide(aggregateAction, aggregateGroupManager, pluginMetrics)).thenReturn(aggregateActionSynchronizer);
         when(aggregateActionSynchronizer.handleEventForGroup(event, identificationHash, aggregateGroup)).thenReturn(aggregateActionResponse);
 
-        when(pluginMetrics.counter(AggregateProcessor.ACTION_HANDLE_EVENTS_FORWARDED)).thenReturn(actionHandleEventsForwardedCounter);
+        when(pluginMetrics.counter(AggregateProcessor.ACTION_HANDLE_EVENTS_OUT)).thenReturn(actionHandleEventsOutCounter);
         when(pluginMetrics.counter(AggregateProcessor.ACTION_HANDLE_EVENTS_DROPPED)).thenReturn(actionHandleEventsDroppedCounter);
-        when(pluginMetrics.counter(AggregateProcessor.ACTION_CONCLUDE_GROUP_EVENTS_FORWARDED)).thenReturn(actionConcludeGroupEventsForwardedCounter);
+        when(pluginMetrics.counter(AggregateProcessor.ACTION_CONCLUDE_GROUP_EVENTS_OUT)).thenReturn(actionConcludeGroupEventsOutCounter);
         when(pluginMetrics.counter(AggregateProcessor.ACTION_CONCLUDE_GROUP_EVENTS_DROPPED)).thenReturn(actionConcludeGroupEventsDroppedCounter);
 
         when(pluginMetrics.counter(MetricNames.RECORDS_IN)).thenReturn(recordsIn);
@@ -148,9 +148,9 @@ public class AggregateProcessorTest {
         assertThat(recordsOut.size(), equalTo(0));
 
         verify(actionHandleEventsDroppedCounter).increment(1);
-        verify(actionHandleEventsForwardedCounter).increment(0);
+        verify(actionHandleEventsOutCounter).increment(0);
         verifyNoInteractions(actionConcludeGroupEventsDroppedCounter);
-        verifyNoInteractions(actionConcludeGroupEventsForwardedCounter);
+        verifyNoInteractions(actionConcludeGroupEventsOutCounter);
     }
 
     @Test
@@ -165,10 +165,10 @@ public class AggregateProcessorTest {
         assertThat(recordsOut.get(0), notNullValue());
         assertThat(recordsOut.get(0).getData(), equalTo(event));
 
-        verify(actionHandleEventsForwardedCounter).increment(1);
+        verify(actionHandleEventsOutCounter).increment(1);
         verify(actionHandleEventsDroppedCounter).increment(0);
         verifyNoInteractions(actionConcludeGroupEventsDroppedCounter);
-        verifyNoInteractions(actionConcludeGroupEventsForwardedCounter);
+        verifyNoInteractions(actionConcludeGroupEventsOutCounter);
     }
 
     @Test
@@ -186,8 +186,8 @@ public class AggregateProcessorTest {
 
         verify(actionConcludeGroupEventsDroppedCounter).increment();
         verify(actionHandleEventsDroppedCounter).increment(1);
-        verify(actionHandleEventsForwardedCounter).increment(0);
-        verifyNoInteractions(actionConcludeGroupEventsForwardedCounter);
+        verify(actionHandleEventsOutCounter).increment(0);
+        verifyNoInteractions(actionConcludeGroupEventsOutCounter);
 
     }
 
@@ -206,9 +206,9 @@ public class AggregateProcessorTest {
         assertThat(recordsOut.get(0), notNullValue());
         assertThat(recordsOut.get(0).getData(), equalTo(event));
 
-        verify(actionConcludeGroupEventsForwardedCounter).increment();
+        verify(actionConcludeGroupEventsOutCounter).increment();
         verify(actionHandleEventsDroppedCounter).increment(1);
-        verify(actionHandleEventsForwardedCounter).increment(0);
+        verify(actionHandleEventsOutCounter).increment(0);
         verifyNoInteractions(actionConcludeGroupEventsDroppedCounter);
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -147,9 +147,8 @@ public class AggregateProcessorTest {
 
         assertThat(recordsOut.size(), equalTo(0));
 
-        verify(actionHandleEventsDroppedCounter).increment();
-
-        verifyNoInteractions(actionHandleEventsForwardedCounter);
+        verify(actionHandleEventsDroppedCounter).increment(1);
+        verify(actionHandleEventsForwardedCounter).increment(0);
         verifyNoInteractions(actionConcludeGroupEventsDroppedCounter);
         verifyNoInteractions(actionConcludeGroupEventsForwardedCounter);
     }
@@ -166,9 +165,8 @@ public class AggregateProcessorTest {
         assertThat(recordsOut.get(0), notNullValue());
         assertThat(recordsOut.get(0).getData(), equalTo(event));
 
-        verify(actionHandleEventsForwardedCounter).increment();
-
-        verifyNoInteractions(actionHandleEventsDroppedCounter);
+        verify(actionHandleEventsForwardedCounter).increment(1);
+        verify(actionHandleEventsDroppedCounter).increment(0);
         verifyNoInteractions(actionConcludeGroupEventsDroppedCounter);
         verifyNoInteractions(actionConcludeGroupEventsForwardedCounter);
     }
@@ -187,9 +185,8 @@ public class AggregateProcessorTest {
         assertThat(recordsOut.size(), equalTo(0));
 
         verify(actionConcludeGroupEventsDroppedCounter).increment();
-        verify(actionHandleEventsDroppedCounter).increment();
-
-        verifyNoInteractions(actionHandleEventsForwardedCounter);
+        verify(actionHandleEventsDroppedCounter).increment(1);
+        verify(actionHandleEventsForwardedCounter).increment(0);
         verifyNoInteractions(actionConcludeGroupEventsForwardedCounter);
 
     }
@@ -210,9 +207,8 @@ public class AggregateProcessorTest {
         assertThat(recordsOut.get(0).getData(), equalTo(event));
 
         verify(actionConcludeGroupEventsForwardedCounter).increment();
-        verify(actionHandleEventsDroppedCounter).increment();
-
-        verifyNoInteractions(actionHandleEventsForwardedCounter);
+        verify(actionHandleEventsDroppedCounter).increment(1);
+        verify(actionHandleEventsForwardedCounter).increment(0);
         verifyNoInteractions(actionConcludeGroupEventsDroppedCounter);
     }
 }


### PR DESCRIPTION
Signed-off-by: graytaylor0 <tylgry@amazon.com>

### Description
Introduces the following metrics to the Aggregate Processor:

**Counter**

* `actionHandleEventsOut`: The number of Events that have been returned from the `handleEvent` call to the [action]() configured


* `actionHandleEventsDropped`: The number of Events that have not been returned from the `handleEvent` call to the [action]() configured.


* `actionHandleEventsProcessingErrors`: The number of calls made to `handleEvent` for the [action]() configured that resulted in an error.


* `actionConcludeGroupEventsOut`: The number of Events that have been returned from the `concludeGroup` call to the [action]() configured.


* `actionConcludeGroupEventsDropped`: The number of Events that have not been returned from the `condludeGroup` call to the [action]() configured.


* `actionConcludeGroupEventsProcessingErrors`: The number of calls made to `concludeGroup` for the [action]() configured that resulted in an error.

**Gauge**

* `currentAggregateGroups`: The current number of groups. This gauge decreases when groups are concluded, and increases when an Event triggers the creation of a new group.
 

One metric that has value to the user that has not been added here is `currentAggregateGroupsMemoryUsage`, which would show how much memory is being used to store the aggregate processor state. This was not added because it requires an `InstrumentationAgent` with a generic `getObjectSize(Object)` function, which is more overhead than is wanted just for a single metric. Alternative solutions to add this are welcome. (How else can the memory usage of a java `Map` be collected?)
### Issues Resolved
Closes #1004
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
