### PR TITLE
Initial GitHub Action to build all artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Build Release Artifacts
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 14
+    - name: Checkout Data-Prepper
+      uses: actions/checkout@v2
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build
+      run: ./gradlew build
+    - name: Archives
+      run: ./gradlew :release:archives:linux:linuxTar -Prelease
+    - name: Docker
+      run: ./gradlew :release:docker:docker -Prelease


### PR DESCRIPTION
### Description

This PR adds a new GitHub Action for building all artifacts. This PR currently performs the release builds and keeps all artifacts locally. It is a starting point for further work.

This action requires a user manually start it. It is not triggered automatically.
 
### Issues Resolved

This is only part of #977.
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
