### PR TITLE
Add documentation for the AggregateProcessor, change window_duration to group_duration

### DIFF
--- a/data-prepper-plugins/aggregate-processor/README.md
+++ b/data-prepper-plugins/aggregate-processor/README.md
@@ -1,6 +1,6 @@
 # Aggregate Processor
 
-This stateful processor groups Events together based on the values of the [identification_keys](#identification_keys) provided, and performs a configurable [action](#action) on each group.
+This stateful processor groups Events together based on the values of the [identification_keys](#identification_keys) provided, and performs a configurable [action](#action) on each group. You can use existing actions, or you can create your own actions as Java code to perform custom aggregations.
 It is a great way to reduce unnecessary log volume and create aggregated logs over time.
 
 ## Usage
@@ -92,34 +92,7 @@ public interface AggregateAction {
 ```
 
 The `AggregateActionInput` that is passed to the functions of the interface contains a method `getGroupState()`, which returns a `GroupState` Object that can be operated on like a java `Map`. 
-Here is an example of an `AggregateAction` implementation for [put_all](#put_all):
-
-```
-@DataPrepperPlugin(name = "put_all", pluginType = AggregateAction.class)
-public class PutAllAggregateAction implements AggregateAction {
-    static final String EVENT_TYPE = "event";
-
-    // This function drops the Event that is passed to it after merging it into the group state.
-    @Override
-    public AggregateActionResponse handleEvent(final Event event, final AggregateActionInput aggregateActionInput) {
-        final GroupState groupState = aggregateActionInput.getGroupState();
-        groupState.putAll(event.toMap());
-        return AggregateActionResponse.nullEventResponse();
-    }
-
-    // This function returns the aggregated group state as a single Event.
-    @Override
-    public Optional<Event> concludeGroup(final AggregateActionInput aggregateActionInput) {
-
-        final Event event = JacksonEvent.builder()
-                .withEventType(EVENT_TYPE)
-                .withData(aggregateActionInput.getGroupState())
-                .build();
-
-        return Optional.of(event);
-    }
-}
-```
+For actual examples, take a closer look at the code for some existing AggregateActions [here](src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/actions).
 
 ## State
 

--- a/data-prepper-plugins/aggregate-processor/README.md
+++ b/data-prepper-plugins/aggregate-processor/README.md
@@ -132,22 +132,22 @@ Apart from common metrics in [AbstractProcessor](https://github.com/opensearch-p
 
 **Counter**
 
-* `actionHandleEventsOut`: The number of Events that have been returned from the `handleEvent` call to the [action]() configured
+* `actionHandleEventsOut`: The number of Events that have been returned from the `handleEvent` call to the [action](#action) configured
 
 
-* `actionHandleEventsDropped`: The number of Events that have not been returned from the `handleEvent` call to the [action]() configured.
+* `actionHandleEventsDropped`: The number of Events that have not been returned from the `handleEvent` call to the [action](#action) configured.
 
 
-* `actionHandleEventsProcessingErrors`: The number of calls made to `handleEvent` for the [action]() configured that resulted in an error.
+* `actionHandleEventsProcessingErrors`: The number of calls made to `handleEvent` for the [action](#action) configured that resulted in an error.
 
 
-* `actionConcludeGroupEventsOut`: The number of Events that have been returned from the `concludeGroup` call to the [action]() configured.
+* `actionConcludeGroupEventsOut`: The number of Events that have been returned from the `concludeGroup` call to the [action](#action) configured.
 
 
-* `actionConcludeGroupEventsDropped`: The number of Events that have not been returned from the `condludeGroup` call to the [action]() configured.
+* `actionConcludeGroupEventsDropped`: The number of Events that have not been returned from the `condludeGroup` call to the [action](#action) configured.
 
 
-* `actionConcludeGroupEventsProcessingErrors`: The number of calls made to `concludeGroup` for the [action]() configured that resulted in an error.
+* `actionConcludeGroupEventsProcessingErrors`: The number of calls made to `concludeGroup` for the [action](#action) configured that resulted in an error.
 
 **Gauge**
 

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
@@ -16,10 +16,10 @@ import java.util.Map;
 class AggregateGroupManager {
 
     private final Map<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> allGroups = Maps.newConcurrentMap();
-    private final Duration windowDuration;
+    private final Duration groupDuration;
 
-    AggregateGroupManager(final int windowDuration) {
-        this.windowDuration = Duration.ofSeconds(windowDuration);
+    AggregateGroupManager(final int groupDuration) {
+        this.groupDuration = Duration.ofSeconds(groupDuration);
     }
 
     AggregateGroup getAggregateGroup(final AggregateIdentificationKeysHasher.IdentificationHash identificationHash) {
@@ -37,7 +37,7 @@ class AggregateGroupManager {
     }
 
     private boolean shouldConcludeGroup(final AggregateGroup aggregateGroup) {
-        return Duration.between(aggregateGroup.getGroupStart(), Instant.now()).compareTo(windowDuration) >= 0;
+        return Duration.between(aggregateGroup.getGroupStart(), Instant.now()).compareTo(groupDuration) >= 0;
     }
 
     void closeGroup(final AggregateIdentificationKeysHasher.IdentificationHash hash, final AggregateGroup group) {

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -47,7 +47,7 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
 
     @DataPrepperPluginConstructor
     public AggregateProcessor(final AggregateProcessorConfig aggregateProcessorConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory) {
-        this(aggregateProcessorConfig, pluginMetrics, pluginFactory, new AggregateGroupManager(aggregateProcessorConfig.getWindowDuration()),
+        this(aggregateProcessorConfig, pluginMetrics, pluginFactory, new AggregateGroupManager(aggregateProcessorConfig.getGroupDuration()),
                 new AggregateIdentificationKeysHasher(aggregateProcessorConfig.getIdentificationKeys()), new AggregateActionSynchronizer.AggregateActionSynchronizerProvider());
     }
     public AggregateProcessor(final AggregateProcessorConfig aggregateProcessorConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory, final AggregateGroupManager aggregateGroupManager,

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
@@ -15,15 +15,15 @@ import java.util.List;
 
 public class AggregateProcessorConfig {
 
-    static int DEFAULT_WINDOW_DURATION = 180;
+    static int DEFAULT_GROUP_DURATION = 180;
 
     @JsonProperty("identification_keys")
     @NotEmpty
     private List<String> identificationKeys;
 
-    @JsonProperty("window_duration")
+    @JsonProperty("group_duration")
     @Min(0)
-    private int windowDuration = DEFAULT_WINDOW_DURATION;
+    private int groupDuration = DEFAULT_GROUP_DURATION;
 
     @JsonProperty("action")
     @NotNull
@@ -33,8 +33,8 @@ public class AggregateProcessorConfig {
         return identificationKeys;
     }
 
-    public int getWindowDuration() {
-        return windowDuration;
+    public int getGroupDuration() {
+        return groupDuration;
     }
 
     public PluginModel getAggregateAction() { return aggregateAction; }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
@@ -30,7 +30,7 @@ public class AggregateGroupManagerTest {
 
     private AggregateIdentificationKeysHasher.IdentificationHash identificationHash;
 
-    private static final int TEST_WINDOW_DURATION = new Random().nextInt(10) + 10;
+    private static final int TEST_GROUP_DURATION = new Random().nextInt(10) + 10;
 
     @BeforeEach
     void setup() {
@@ -41,7 +41,7 @@ public class AggregateGroupManagerTest {
     }
 
     private AggregateGroupManager createObjectUnderTest() {
-        return new AggregateGroupManager(TEST_WINDOW_DURATION);
+        return new AggregateGroupManager(TEST_GROUP_DURATION);
     }
 
     @Test
@@ -92,11 +92,11 @@ public class AggregateGroupManagerTest {
 
         final AggregateGroup groupToConclude = mock(AggregateGroup.class);
         final AggregateIdentificationKeysHasher.IdentificationHash hashForGroupToConclude = mock(AggregateIdentificationKeysHasher.IdentificationHash.class);
-        when(groupToConclude.getGroupStart()).thenReturn(Instant.now().minusSeconds(TEST_WINDOW_DURATION));
+        when(groupToConclude.getGroupStart()).thenReturn(Instant.now().minusSeconds(TEST_GROUP_DURATION));
 
         final AggregateGroup groupToNotConclude = mock(AggregateGroup.class);
         final AggregateIdentificationKeysHasher.IdentificationHash hashForGroupToNotConclude = mock(AggregateIdentificationKeysHasher.IdentificationHash.class);
-        when(groupToNotConclude.getGroupStart()).thenReturn(Instant.now().plusSeconds(TEST_WINDOW_DURATION));
+        when(groupToNotConclude.getGroupStart()).thenReturn(Instant.now().plusSeconds(TEST_GROUP_DURATION));
 
         aggregateGroupManager.putGroupWithHash(hashForGroupToConclude, groupToConclude);
         aggregateGroupManager.putGroupWithHash(hashForGroupToNotConclude, groupToNotConclude);

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorConfigTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorConfigTest.java
@@ -15,6 +15,6 @@ public class AggregateProcessorConfigTest {
     public void testDefault() {
         final AggregateProcessorConfig aggregateConfig = new AggregateProcessorConfig();
 
-        assertThat(aggregateConfig.getWindowDuration(), equalTo(AggregateProcessorConfig.DEFAULT_WINDOW_DURATION));
+        assertThat(aggregateConfig.getGroupDuration(), equalTo(AggregateProcessorConfig.DEFAULT_GROUP_DURATION));
     }
 }


### PR DESCRIPTION
Signed-off-by: graytaylor0 <tylgry@amazon.com>

### Description
* Add README documentation for `AggregateProcessor`
* Rename `window_duration` configuration option to `group_duration`, as the `AggregateProcessor` does not have windows, but groups.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
