### PR TITLE
Remove Gradle permissions change for GitHub Actions workflows.

### DIFF
--- a/.github/workflows/data-prepper-log-analytics-basic-grok-e2e-tests.yml
+++ b/.github/workflows/data-prepper-log-analytics-basic-grok-e2e-tests.yml
@@ -24,7 +24,5 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Run basic grok end-to-end tests with Gradle
         run: ./gradlew :e2e-test:log:basicLogEndToEndTest

--- a/.github/workflows/data-prepper-performance-test-compile-check.yml
+++ b/.github/workflows/data-prepper-performance-test-compile-check.yml
@@ -24,7 +24,5 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Build performance tests with Gradle
         run: ./gradlew :performance-test:compileGatlingJava

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-compatibility-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-compatibility-e2e-tests.yml
@@ -24,7 +24,5 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: Checkout Data-Prepper
       uses: actions/checkout@v2
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
     - name: Run raw-span compatibility end-to-end tests with Gradle
       run: ./gradlew :e2e-test:trace:rawSpanCompatibilityEndToEndTest

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
@@ -24,7 +24,5 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Run raw-span end-to-end tests with Gradle
         run: ./gradlew :e2e-test:trace:rawSpanEndToEndTest

--- a/.github/workflows/data-prepper-trace-analytics-service-map-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-service-map-e2e-tests.yml
@@ -24,7 +24,5 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Run service-map end-to-end tests with Gradle
         run: ./gradlew :e2e-test:trace:serviceMapEndToEndTest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,8 +24,6 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: Checkout Data-Prepper
       uses: actions/checkout@v2
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
     - name: Upload Coverage Report

--- a/.github/workflows/opensearch-sink-odfe-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-odfe-integration-tests.yml
@@ -25,8 +25,6 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Run ODFE docker
         run: |
           docker pull amazon/opendistro-for-elasticsearch:${{ matrix.odfe }}

--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -21,8 +21,6 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Run OpenSearch docker
         run: |
           docker pull opensearchproject/opensearch:${{ matrix.opensearch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ jobs:
         java-version: 14
     - name: Checkout Data-Prepper
       uses: actions/checkout@v2
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
     - name: Build
       run: ./gradlew build
     - name: Archives


### PR DESCRIPTION
### Description

The `./gradlew` file is already executable and GitHub Actions run without this step.
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
