### PR TITLE
ENH: remove string format in JacksonSpan.Builder::validateParameters

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/JacksonSpan.java
@@ -435,18 +435,18 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         private void validateParameters() {
             REQUIRED_KEYS.forEach(key -> {
-                checkState(data.containsKey(key), String.format("%s need to be assigned", key));
+                checkState(data.containsKey(key), key + " need to be assigned");
             });
 
             REQUIRED_NON_EMPTY_KEYS.forEach(key -> {
                 final String value = (String) data.get(key);
-                checkNotNull(value, String.format("%s cannot be null", key));
-                checkArgument(!value.isEmpty(),  String.format("%s cannot be an empty string", key));
+                checkNotNull(value, key + " cannot be null");
+                checkArgument(!value.isEmpty(),  key + " cannot be an empty string");
             });
 
             REQUIRED_NON_NULL_KEYS.forEach(key -> {
                 final Object value = data.get(key);
-                checkNotNull(value, String.format("%s cannot be null", key));
+                checkNotNull(value, key + " cannot be null");
             });
         }
 


### PR DESCRIPTION
Signed-off-by: Chen <19492223+chenqi0805@users.noreply.github.com>

### Description
String.format turns out to suck up most of the time spent on JacksonSpan.Builder::validateParameters which also takes a non-trivial portion in OTelTraceRawPrepper::processSpan:

* Before:
![OTelTraceRawPrepper-processSpan](https://user-images.githubusercontent.com/19492223/154139553-ef4f7381-bdf8-42bd-92c7-d1cbd2cdebcc.png)
* After:
![OTelTraceRawPrepper-processSpan-remove-string-format](https://user-images.githubusercontent.com/19492223/154139572-84817435-7d83-44ae-adf7-59e3ad9f2ba7.png)

 
### Issues Resolved
Contributes to #939 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
