### PR TITLE
MAINT: stdout print any object

### DIFF
--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/sink/StdOutSink.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/sink/StdOutSink.java
@@ -41,12 +41,10 @@ public class StdOutSink implements Sink<Record<Object>> {
     // Temporary function to support both trace and log ingestion pipelines.
     // TODO: This function should be removed with the completion of: https://github.com/opensearch-project/data-prepper/issues/546
     private void checkTypeAndPrintObject(final Object object) {
-        if (object instanceof String) {
-            System.out.println(object);
-        } else if (object instanceof Event) {
+        if (object instanceof Event) {
             System.out.println(((Event) object).toJsonString());
         } else {
-            throw new RuntimeException("Invalid record type. StdOutSink only supports String and Events");
+            System.out.println(object);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Chen <19492223+chenqi0805@users.noreply.github.com>

### Description
This is for the convenience of benchmarking trace ingestion (e.g. ExportTraceServiceRequest can be directly printed). 
 
### Issues Resolved
Contributes to #546 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
