### PR TITLE
OpenSearch Index DateTime Pattern conversion

### DIFF
--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapper.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.logstash.mapping;
 
-import org.opensearch.dataprepper.logstash.exception.LogstashConfigurationException;
 import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
 
 import java.util.Collections;
@@ -31,16 +30,14 @@ class OpenSearchPluginAttributesMapper extends AbstractLogstashPluginAttributesM
     @Override
     protected void mapCustomAttributes(final List<LogstashAttribute> logstashAttributes, final LogstashAttributesMappings logstashAttributesMappings, final Map<String, Object> pluginSettings) {
 
-        final LogstashAttribute logstashIndexAttribute = logstashAttributes.stream()
+        logstashAttributes.stream()
                 .filter(a -> a.getAttributeName().equals(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME))
+                .map(logstashIndexAttribute -> findAndMatchDateTimePattern(logstashIndexAttribute))
                 .findFirst()
-                .orElseThrow(() -> new LogstashConfigurationException("Index attribute not found"));
-
-        final String convertedIndexPatternValue = findAndMatchDateTimePattern(logstashIndexAttribute);
-
-        pluginSettings.put(logstashAttributesMappings.getMappedAttributeNames().get(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME),
-                convertedIndexPatternValue);
-
+                .ifPresent(convertedIndexAttributeValue -> {
+                    pluginSettings.put(logstashAttributesMappings.getMappedAttributeNames().get(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME),
+                            convertedIndexAttributeValue);
+                });
     }
 
     @Override

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapper.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.logstash.mapping;
+
+import org.opensearch.dataprepper.logstash.exception.LogstashConfigurationException;
+import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class OpenSearchPluginAttributesMapper extends AbstractLogstashPluginAttributesMapper {
+    protected static final String LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME = "index";
+    protected static final String REGEX_EXTRACTING_DATETIME_PATTERN = "%\\{(.*?)\\}";
+
+    @Override
+    protected void mapCustomAttributes(List<LogstashAttribute> logstashAttributes, LogstashAttributesMappings logstashAttributesMappings, Map<String, Object> pluginSettings) {
+
+        final LogstashAttribute logstashIndexAttribute = logstashAttributes.stream()
+                .filter(a -> a.getAttributeName().equals(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME))
+                .findFirst()
+                .orElseThrow(() -> new LogstashConfigurationException("Index attribute not found"));
+
+        final String convertedIndexPatternValue = convertIndexDateTimePattern(logstashIndexAttribute);
+
+        pluginSettings.put(logstashAttributesMappings.getMappedAttributeNames().get(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME),
+                convertedIndexPatternValue);
+
+    }
+
+    @Override
+    protected HashSet<String> getCustomMappedAttributeNames() {
+        return new HashSet<>(Collections.singletonList(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME));
+    }
+
+    private String convertIndexDateTimePattern(LogstashAttribute logstashAttribute) {
+
+        final String logstashIndexAttributeValue = logstashAttribute.getAttributeValue().getValue().toString();
+        final Pattern pattern = Pattern.compile(REGEX_EXTRACTING_DATETIME_PATTERN);
+        final Matcher dateTimePatternMatcher = pattern.matcher(logstashIndexAttributeValue);
+
+        final StringBuilder updatedDateTimePattern = new StringBuilder();
+        String updatedIndexAttributeValue = "";
+
+        if (dateTimePatternMatcher.find()) {
+            final String dateTimePattern = dateTimePatternMatcher.group(0);
+
+            for (char character: dateTimePattern.toCharArray()) {
+                if (character == '+') {
+                    continue;
+                } else if (character == 'y') {
+                    updatedDateTimePattern.append('u');
+                } else if (character == 'Y') {
+                    updatedDateTimePattern.append('y');
+                } else if (character == 'x') {
+                    updatedDateTimePattern.append('Y');
+                } else {
+                    updatedDateTimePattern.append(character);
+                }
+            }
+            updatedIndexAttributeValue = logstashIndexAttributeValue.replace(dateTimePattern, updatedDateTimePattern);
+        }
+        return updatedIndexAttributeValue;
+    }
+}

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/amazon_es.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/amazon_es.mapping.yaml
@@ -1,4 +1,5 @@
 pluginName: opensearch
+attributesMapperClass: org.opensearch.dataprepper.logstash.mapping.OpenSearchPluginAttributesMapper
 mappedAttributeNames:
   hosts: hosts
   index: index

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/elasticsearch.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/elasticsearch.mapping.yaml
@@ -1,4 +1,5 @@
 pluginName: opensearch
+attributesMapperClass: org.opensearch.dataprepper.logstash.mapping.OpenSearchPluginAttributesMapper
 mappedAttributeNames:
   hosts: hosts
   cacert: cert

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/opensearch.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/opensearch.mapping.yaml
@@ -1,4 +1,5 @@
 pluginName: opensearch
+attributesMapperClass: org.opensearch.dataprepper.logstash.mapping.OpenSearchPluginAttributesMapper
 mappedAttributeNames:
   hosts: hosts
   user: username

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
@@ -52,7 +52,12 @@ class OpenSearchPluginAttributesMapperTest {
     @Test
     void convert_emptyString_indexAttribute_to_return_pluginSettings_with_no_index_key() {
 
-        final LogstashAttribute logstashAttribute = createLogstashIndexAttribute("");
+        final LogstashAttribute logstashAttribute = mock(LogstashAttribute.class);
+        final LogstashAttributeValue logstashAttributeValue = mock(LogstashAttributeValue.class);
+        when(logstashAttribute.getAttributeName()).thenReturn("");
+        when(logstashAttribute.getAttributeValue()).thenReturn(logstashAttributeValue);
+        when(logstashAttributeValue.getAttributeValueType()).thenReturn(LogstashValueType.STRING);
+        when(logstashAttributeValue.getValue()).thenReturn("");
 
         final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
         when(logstashAttributesMappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
@@ -60,7 +65,7 @@ class OpenSearchPluginAttributesMapperTest {
         final Map<String, Object> pluginSettings = createObjectUnderTest()
                 .mapAttributes(Collections.singletonList(logstashAttribute), logstashAttributesMappings);
 
-        assertThat(pluginSettings.size(), equalTo(1));
+        assertThat(pluginSettings.size(), equalTo(0));
         assertThat(pluginSettings, not(hasKey(DATA_PREPPER_OPENSEARCH_INDEX_ATTRIBUTE)));
     }
 

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
@@ -5,20 +5,12 @@
 
 package org.opensearch.dataprepper.logstash.mapping;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasKey;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.opensearch.dataprepper.logstash.mapping.OpenSearchPluginAttributesMapper.LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME;
-
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.junit.jupiter.params.provider.Arguments;
-
 import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
 import org.opensearch.dataprepper.logstash.model.LogstashAttributeValue;
 import org.opensearch.dataprepper.logstash.model.LogstashValueType;
@@ -27,12 +19,42 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.logstash.mapping.OpenSearchPluginAttributesMapper.LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME;
+
 class OpenSearchPluginAttributesMapperTest {
 
     private static final String DATA_PREPPER_OPENSEARCH_INDEX_ATTRIBUTE = "index";
 
     private OpenSearchPluginAttributesMapper createObjectUnderTest() {
         return new OpenSearchPluginAttributesMapper();
+    }
+
+    @Test
+    void convert_missing_indexAttribute_to_return_empty_pluginSettings() {
+
+        final LogstashAttribute logstashAttribute = mock(LogstashAttribute.class);
+        final LogstashAttributeValue logstashAttributeValue = mock(LogstashAttributeValue.class);
+
+        when(logstashAttribute.getAttributeName()).thenReturn("");
+        when(logstashAttribute.getAttributeValue()).thenReturn(logstashAttributeValue);
+        when(logstashAttributeValue.getAttributeValueType()).thenReturn(LogstashValueType.STRING);
+        when(logstashAttributeValue.getValue()).thenReturn("");
+
+        final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
+        when(logstashAttributesMappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
+
+        final Map<String, Object> pluginSettings = createObjectUnderTest()
+                .mapAttributes(Collections.singletonList(logstashAttribute), logstashAttributesMappings);
+
+        assertThat(pluginSettings.size(), equalTo(0));
+        assertThat(pluginSettings, not(hasKey(DATA_PREPPER_OPENSEARCH_INDEX_ATTRIBUTE)));
     }
 
     @ParameterizedTest

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
@@ -100,14 +100,14 @@ class OpenSearchPluginAttributesMapperTest {
         }
     }
 
-    private LogstashAttribute createLogstashIndexAttribute(final String index) {
+    private LogstashAttribute createLogstashIndexAttribute(final String indexAttributeValue) {
         final LogstashAttribute logstashAttribute = mock(LogstashAttribute.class);
         final LogstashAttributeValue logstashAttributeValue = mock(LogstashAttributeValue.class);
 
         when(logstashAttribute.getAttributeName()).thenReturn(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME);
         when(logstashAttribute.getAttributeValue()).thenReturn(logstashAttributeValue);
         when(logstashAttributeValue.getAttributeValueType()).thenReturn(LogstashValueType.STRING);
-        when(logstashAttributeValue.getValue()).thenReturn(index);
+        when(logstashAttributeValue.getValue()).thenReturn(indexAttributeValue);
 
         return logstashAttribute;
     }

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
@@ -17,6 +17,7 @@ import org.opensearch.dataprepper.logstash.model.LogstashValueType;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -54,10 +55,10 @@ class OpenSearchPluginAttributesMapperTest {
 
         final LogstashAttribute logstashAttribute = mock(LogstashAttribute.class);
         final LogstashAttributeValue logstashAttributeValue = mock(LogstashAttributeValue.class);
-        when(logstashAttribute.getAttributeName()).thenReturn("");
+        when(logstashAttribute.getAttributeName()).thenReturn(UUID.randomUUID().toString());
         when(logstashAttribute.getAttributeValue()).thenReturn(logstashAttributeValue);
         when(logstashAttributeValue.getAttributeValueType()).thenReturn(LogstashValueType.STRING);
-        when(logstashAttributeValue.getValue()).thenReturn("");
+        when(logstashAttributeValue.getValue()).thenReturn(UUID.randomUUID().toString());
 
         final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
         when(logstashAttributesMappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.logstash.mapping;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.logstash.mapping.OpenSearchPluginAttributesMapper.LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
+import org.opensearch.dataprepper.logstash.model.LogstashAttributeValue;
+import org.opensearch.dataprepper.logstash.model.LogstashValueType;
+
+import java.util.Collections;
+import java.util.Map;
+
+class OpenSearchPluginAttributesMapperTest {
+
+    private OpenSearchPluginAttributesMapper createObjectUnderTest() {
+        return new OpenSearchPluginAttributesMapper();
+    }
+
+    @Test
+    void convert_logstash_index_date_time_pattern() {
+        final String dataPrepperIndexAttribute = "index";
+        final String value = "my-application-index";
+
+        final LogstashAttribute logstashAttribute = mock(LogstashAttribute.class);
+        final LogstashAttributeValue logstashAttributeValue = mock(LogstashAttributeValue.class);
+        when(logstashAttributeValue.getValue()).thenReturn(value);
+        when(logstashAttribute.getAttributeName()).thenReturn("index");
+        when(logstashAttribute.getAttributeValue()).thenReturn(logstashAttributeValue);
+
+        final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
+        when(logstashAttributesMappings.getMappedAttributeNames()).thenReturn(Collections.singletonMap(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME, dataPrepperIndexAttribute));
+
+
+        final Map<String, Object> pluginSettings =
+                createObjectUnderTest().mapAttributes(Collections.singletonList(logstashAttribute), logstashAttributesMappings);
+
+        assertThat(pluginSettings, notNullValue());
+        assertThat(pluginSettings.size(), equalTo(1));
+        assertThat(pluginSettings, hasKey(dataPrepperIndexAttribute));
+    }
+
+    @Test
+    void convert_logstashIndexPattern_joda_year_to_dataPrepperIndexPattern_java_year() {
+
+        final LogstashAttribute logstashAttribute = createIndexAttributeValue("logstash-%{+yyyy.MM.dd}");
+
+        final String dataPrepperIndexAttribute = "index";
+        final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
+        when(logstashAttributesMappings.getMappedAttributeNames()).thenReturn(Collections.singletonMap(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME, dataPrepperIndexAttribute));
+
+        final Map<String, Object> pluginSettings =
+                createObjectUnderTest().mapAttributes(Collections.singletonList(logstashAttribute), logstashAttributesMappings);
+
+        final String expectedIndexPattern = "logstash-%{uuuu.MM.dd}";
+
+        assertThat(pluginSettings, notNullValue());
+        assertThat(pluginSettings, hasKey(dataPrepperIndexAttribute));
+        assertThat(pluginSettings.get(dataPrepperIndexAttribute), equalTo(expectedIndexPattern));
+    }
+
+    @Test
+    void convert_logstashIndexPattern_joda_yearOfEra_to_dataPrepperIndexPattern_java_yearOfEra() {
+
+        final LogstashAttribute logstashAttribute = createIndexAttributeValue("logstash-index-%{+YYYY.MM.dd}");
+
+        final String dataPrepperIndexAttribute = "index";
+        final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
+        when(logstashAttributesMappings.getMappedAttributeNames()).thenReturn(Collections.singletonMap(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME, dataPrepperIndexAttribute));
+
+        final Map<String, Object> pluginSettings =
+                createObjectUnderTest().mapAttributes(Collections.singletonList(logstashAttribute), logstashAttributesMappings);
+
+        final String expectedIndexPattern = "logstash-index-%{yyyy.MM.dd}";
+
+        assertThat(pluginSettings, notNullValue());
+        assertThat(pluginSettings, hasKey(dataPrepperIndexAttribute));
+        assertThat(pluginSettings.get(dataPrepperIndexAttribute), equalTo(expectedIndexPattern));
+    }
+
+    @Test
+    void convert_logstashIndexPattern_joda_weekyear_to_dataPrepperIndexPattern_java_weekyear() {
+
+        final LogstashAttribute logstashAttribute = createIndexAttributeValue("logstash-%{+xxxx.ww}");
+
+        final String dataPrepperIndexAttribute = "index";
+        final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
+        when(logstashAttributesMappings.getMappedAttributeNames()).thenReturn(Collections.singletonMap(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME, dataPrepperIndexAttribute));
+
+        final Map<String, Object> pluginSettings =
+                createObjectUnderTest().mapAttributes(Collections.singletonList(logstashAttribute), logstashAttributesMappings);
+
+        final String expectedIndexPattern = "logstash-%{YYYY.ww}";
+
+        assertThat(pluginSettings, notNullValue());
+        assertThat(pluginSettings, hasKey(dataPrepperIndexAttribute));
+        assertThat(pluginSettings.get(dataPrepperIndexAttribute), equalTo(expectedIndexPattern));
+    }
+
+    @Test
+    void convert_logstashIndexPattern_time_to_dataPrepperIndexPattern_java_time() {
+
+        final LogstashAttribute logstashAttribute = createIndexAttributeValue("my-index-name-%{+YYYY.MM.dd.HH}");
+
+        final String dataPrepperIndexAttribute = "index";
+        final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
+        when(logstashAttributesMappings.getMappedAttributeNames()).thenReturn(Collections.singletonMap(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME, dataPrepperIndexAttribute));
+
+        final Map<String, Object> pluginSettings =
+                createObjectUnderTest().mapAttributes(Collections.singletonList(logstashAttribute), logstashAttributesMappings);
+
+        final String expectedIndexPattern = "my-index-name-%{yyyy.MM.dd.HH}";
+
+        assertThat(pluginSettings, notNullValue());
+        assertThat(pluginSettings, hasKey(dataPrepperIndexAttribute));
+        assertThat(pluginSettings.get(dataPrepperIndexAttribute), equalTo(expectedIndexPattern));
+    }
+
+
+    private LogstashAttribute createIndexAttributeValue(final String index) {
+        final LogstashAttribute logstashAttribute = mock(LogstashAttribute.class);
+        final LogstashAttributeValue logstashAttributeValue = mock(LogstashAttributeValue.class);
+
+        when(logstashAttribute.getAttributeName()).thenReturn(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME);
+        when(logstashAttribute.getAttributeValue()).thenReturn(logstashAttributeValue);
+        when(logstashAttributeValue.getAttributeValueType()).thenReturn(LogstashValueType.STRING);
+        when(logstashAttributeValue.getValue()).thenReturn(index);
+
+        return logstashAttribute;
+    }
+}

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
@@ -39,13 +39,20 @@ class OpenSearchPluginAttributesMapperTest {
     @Test
     void convert_missing_indexAttribute_to_return_empty_pluginSettings() {
 
-        final LogstashAttribute logstashAttribute = mock(LogstashAttribute.class);
-        final LogstashAttributeValue logstashAttributeValue = mock(LogstashAttributeValue.class);
+        final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
+        when(logstashAttributesMappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
 
-        when(logstashAttribute.getAttributeName()).thenReturn("");
-        when(logstashAttribute.getAttributeValue()).thenReturn(logstashAttributeValue);
-        when(logstashAttributeValue.getAttributeValueType()).thenReturn(LogstashValueType.STRING);
-        when(logstashAttributeValue.getValue()).thenReturn("");
+        final Map<String, Object> pluginSettings = createObjectUnderTest()
+                .mapAttributes(Collections.emptyList(), logstashAttributesMappings);
+
+        assertThat(pluginSettings.size(), equalTo(0));
+        assertThat(pluginSettings, not(hasKey(DATA_PREPPER_OPENSEARCH_INDEX_ATTRIBUTE)));
+    }
+
+    @Test
+    void convert_emptyString_indexAttribute_to_return_pluginSettings_with_no_index_key() {
+
+        final LogstashAttribute logstashAttribute = createLogstashIndexAttribute("");
 
         final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
         when(logstashAttributesMappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
@@ -53,7 +60,7 @@ class OpenSearchPluginAttributesMapperTest {
         final Map<String, Object> pluginSettings = createObjectUnderTest()
                 .mapAttributes(Collections.singletonList(logstashAttribute), logstashAttributesMappings);
 
-        assertThat(pluginSettings.size(), equalTo(0));
+        assertThat(pluginSettings.size(), equalTo(1));
         assertThat(pluginSettings, not(hasKey(DATA_PREPPER_OPENSEARCH_INDEX_ATTRIBUTE)));
     }
 

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch.expected.yaml
@@ -14,5 +14,5 @@ logstash-converted-pipeline:
           - "fakedomain.us-east-1.es.amazonaws.com"
         username: "myuser"
         password: "mypassword"
-        index: "my-index"
         insecure: false
+        index: "my-index"


### PR DESCRIPTION
### Description
* Adds a custom AttributeMapper to converts `year`, `year-of-era`, `week-year` patterns in index from [Joda](https://www.joda.org/joda-time/key_format.html) to [Java-time](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html):
* Removes `+` from DateTime patterns in Logstash config
* Adds test cases

 
### Issues Resolved
Resolves #854 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
