### PR TITLE
Added metrics and destination timezone configuration option.

### DIFF
--- a/data-prepper-plugins/date-processor/build.gradle
+++ b/data-prepper-plugins/date-processor/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-test-common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'io.micrometer:micrometer-core'
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/data-prepper-plugins/date-processor/src/main/java/com/amazon/dataprepper/plugins/processor/date/DateProcessor.java
+++ b/data-prepper-plugins/date-processor/src/main/java/com/amazon/dataprepper/plugins/processor/date/DateProcessor.java
@@ -12,12 +12,12 @@ import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.processor.AbstractProcessor;
 import com.amazon.dataprepper.model.processor.Processor;
 import com.amazon.dataprepper.model.record.Record;
+import io.micrometer.core.instrument.Counter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -29,17 +29,25 @@ import java.util.stream.Collectors;
 @DataPrepperPlugin(name = "date", pluginType = Processor.class, pluginConfigurationType = DateProcessorConfig.class)
 public class DateProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
     private static final Logger LOG = LoggerFactory.getLogger(DateProcessor.class);
-    private static final ZoneId OUTPUT_TIMEZONE = ZoneId.systemDefault();
-    private static final String OUTPUT_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+    static final String OUTPUT_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+
+    static final String DATE_PROCESSING_MATCH_SUCCESS = "dateProcessingMatchSuccess";
+    static final String DATE_PROCESSING_MATCH_FAILURE = "dateProcessingMatchFailure";
 
     private String keyToParse;
     private List<DateTimeFormatter> dateTimeFormatters;
     private final DateProcessorConfig dateProcessorConfig;
 
+    private final Counter dateProcessingMatchSuccessCounter;
+    private final Counter dateProcessingMatchFailureCounter;
+
     @DataPrepperPluginConstructor
     protected DateProcessor(PluginMetrics pluginMetrics, final DateProcessorConfig dateProcessorConfig) {
         super(pluginMetrics);
         this.dateProcessorConfig = dateProcessorConfig;
+
+        dateProcessingMatchSuccessCounter = pluginMetrics.counter(DATE_PROCESSING_MATCH_SUCCESS);
+        dateProcessingMatchFailureCounter = pluginMetrics.counter(DATE_PROCESSING_MATCH_FAILURE);
 
         if (dateProcessorConfig.getMatch() != null)
             extractKeyAndFormatters();
@@ -53,13 +61,22 @@ public class DateProcessor extends AbstractProcessor<Record<Event>, Record<Event
             if (Boolean.TRUE.equals(dateProcessorConfig.getFromTimeReceived()))
                 zonedDateTime =  getDateTimeFromTimeReceived(record);
 
-            else if (keyToParse != null && !keyToParse.isEmpty())
+            else if (keyToParse != null && !keyToParse.isEmpty()) {
                 zonedDateTime = getDateTimeFromMatch(record);
+                populateDateProcessorMetrics(zonedDateTime);
+            }
 
             if (zonedDateTime != null)
                 record.getData().put(dateProcessorConfig.getDestination(), zonedDateTime);
         }
         return records;
+    }
+
+    private void populateDateProcessorMetrics(final String zonedDateTime) {
+        if (zonedDateTime != null)
+            dateProcessingMatchSuccessCounter.increment();
+        else
+            dateProcessingMatchFailureCounter.increment();
     }
 
     private void extractKeyAndFormatters() {
@@ -70,7 +87,7 @@ public class DateProcessor extends AbstractProcessor<Record<Event>, Record<Event
     }
 
     private DateTimeFormatter getSourceFormatter(final String pattern) {
-        final LocalDate localDateForDefaultValues = LocalDate.now(dateProcessorConfig.getZonedId());
+        final LocalDate localDateForDefaultValues = LocalDate.now(dateProcessorConfig.getSourceZoneId());
 
         return new DateTimeFormatterBuilder()
                 .appendPattern(pattern)
@@ -81,16 +98,16 @@ public class DateProcessor extends AbstractProcessor<Record<Event>, Record<Event
                 .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
                 .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
                 .toFormatter(dateProcessorConfig.getSourceLocale())
-                .withZone(dateProcessorConfig.getZonedId());
+                .withZone(dateProcessorConfig.getSourceZoneId());
     }
 
     private String getDateTimeFromTimeReceived(final Record<Event> record) {
         final Instant timeReceived = record.getData().getMetadata().getTimeReceived();
-        return timeReceived.atZone(OUTPUT_TIMEZONE).format(getOutputFormatter());
+        return timeReceived.atZone(dateProcessorConfig.getDestinationZoneId()).format(getOutputFormatter());
     }
 
     private String getDateTimeFromMatch(final Record<Event> record) {
-        String sourceTimestamp = getSourceTimestamp(record);
+        final String sourceTimestamp = getSourceTimestamp(record);
         if (sourceTimestamp == null)
             return null;
 
@@ -109,7 +126,7 @@ public class DateProcessor extends AbstractProcessor<Record<Event>, Record<Event
     private String getFormattedDateTimeString(final String sourceTimestamp) {
         for (DateTimeFormatter formatter : dateTimeFormatters) {
             try {
-                return ZonedDateTime.parse(sourceTimestamp, formatter).format(getOutputFormatter().withZone(OUTPUT_TIMEZONE));
+                return ZonedDateTime.parse(sourceTimestamp, formatter).format(getOutputFormatter().withZone(dateProcessorConfig.getDestinationZoneId()));
             } catch (Exception ignored) {
 
             }

--- a/data-prepper-plugins/date-processor/src/main/java/com/amazon/dataprepper/plugins/processor/date/DateProcessor.java
+++ b/data-prepper-plugins/date-processor/src/main/java/com/amazon/dataprepper/plugins/processor/date/DateProcessor.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 @DataPrepperPlugin(name = "date", pluginType = Processor.class, pluginConfigurationType = DateProcessorConfig.class)
 public class DateProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
     private static final Logger LOG = LoggerFactory.getLogger(DateProcessor.class);
-    static final String OUTPUT_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+    private static final String OUTPUT_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
     static final String DATE_PROCESSING_MATCH_SUCCESS = "dateProcessingMatchSuccess";
     static final String DATE_PROCESSING_MATCH_FAILURE = "dateProcessingMatchFailure";

--- a/data-prepper-plugins/date-processor/src/main/java/com/amazon/dataprepper/plugins/processor/date/DateProcessorConfig.java
+++ b/data-prepper-plugins/date-processor/src/main/java/com/amazon/dataprepper/plugins/processor/date/DateProcessorConfig.java
@@ -16,7 +16,8 @@ import java.util.Locale;
 public class DateProcessorConfig {
     static final Boolean DEFAULT_FROM_TIME_RECEIVED = false;
     static final String DEFAULT_DESTINATION = "@timestamp";
-    static final String DEFAULT_TIMEZONE = "UTC";
+    static final String DEFAULT_SOURCE_TIMEZONE = ZoneId.systemDefault().toString();
+    static final String DEFAULT_DESTINATION_TIMEZONE = ZoneId.systemDefault().toString();
 
     public static class DateMatch {
         @JsonProperty("key")
@@ -42,14 +43,20 @@ public class DateProcessorConfig {
     @JsonProperty("destination")
     private String destination = DEFAULT_DESTINATION;
 
-    @JsonProperty("timezone")
-    private String timezone = DEFAULT_TIMEZONE;
+    @JsonProperty("source_timezone")
+    private String sourceTimezone = DEFAULT_SOURCE_TIMEZONE;
+
+    @JsonProperty("destination_timezone")
+    private String destinationTimezone = DEFAULT_DESTINATION_TIMEZONE;
 
     @JsonProperty("locale")
     private String locale;
 
     @JsonIgnore
-    private ZoneId zoneId;
+    private ZoneId sourceZoneId;
+
+    @JsonIgnore
+    private ZoneId destinationZoneId;
 
     @JsonIgnore
     private Locale sourceLocale;
@@ -66,15 +73,19 @@ public class DateProcessorConfig {
         return destination;
     }
 
-    public ZoneId getZonedId() {
-        return zoneId;
+    public ZoneId getSourceZoneId() {
+        return sourceZoneId;
+    }
+
+    public ZoneId getDestinationZoneId() {
+        return destinationZoneId;
     }
 
     public Locale getSourceLocale() {
         return sourceLocale;
     }
 
-    private ZoneId buildZoneId(String timezone) {
+    private ZoneId buildZoneId(final String timezone) {
         try {
             return ZoneId.of(timezone);
         } catch (Exception e) {
@@ -82,7 +93,7 @@ public class DateProcessorConfig {
         }
     }
 
-    private Locale buildLocale(String locale) {
+    private Locale buildLocale(final String locale) {
         Locale currentLocale;
         if (locale == null || locale.equalsIgnoreCase("ROOT")) {
             return Locale.ROOT;
@@ -133,10 +144,20 @@ public class DateProcessorConfig {
         return true;
     }
 
-    @AssertTrue(message = "Invalid timezone provided.")
-    boolean isTimezoneValid() {
+    @AssertTrue(message = "Invalid source_timezone provided.")
+    boolean isSourceTimezoneValid() {
         try {
-            zoneId = buildZoneId(timezone);
+            sourceZoneId = buildZoneId(sourceTimezone);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @AssertTrue(message = "Invalid destination_timezone provided.")
+    boolean isDestinationTimezoneValid() {
+        try {
+            destinationZoneId = buildZoneId(destinationTimezone);
             return true;
         } catch (Exception e) {
             return false;

--- a/data-prepper-plugins/date-processor/src/test/java/com/amazon/dataprepper/plugins/processor/date/DateProcessorConfigTest.java
+++ b/data-prepper-plugins/date-processor/src/test/java/com/amazon/dataprepper/plugins/processor/date/DateProcessorConfigTest.java
@@ -123,18 +123,26 @@ class DateProcessorConfigTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"America/New_York", "America/Los_Angeles", "Australia/Adelaide", "Japan"})
-        void isTimezoneValid_should_return_true_if_timezone_is_valid(String timezone) throws NoSuchFieldException, IllegalAccessException {
+        void isSourceTimezoneValid_should_return_true_if_timezone_is_valid(String timezone) throws NoSuchFieldException, IllegalAccessException {
 
-            reflectivelySetField(dateProcessorConfig, "timezone", timezone);
-            assertThat(dateProcessorConfig.isTimezoneValid(), equalTo(true));
+            reflectivelySetField(dateProcessorConfig, "sourceTimezone", timezone);
+            assertThat(dateProcessorConfig.isSourceTimezoneValid(), equalTo(true));
         }
 
         @ParameterizedTest
         @ValueSource(strings = {"invalidZone", "randomZone"})
-        void isTimezoneValid_should_return_false_if_timezone_is_invalid(String timezone) throws NoSuchFieldException, IllegalAccessException {
+        void isSourceTimezoneValid_should_return_false_if_timezone_is_invalid(String timezone) throws NoSuchFieldException, IllegalAccessException {
 
-            reflectivelySetField(dateProcessorConfig, "timezone", timezone);
-            assertThat(dateProcessorConfig.isTimezoneValid(), equalTo(false));
+            reflectivelySetField(dateProcessorConfig, "sourceTimezone", timezone);
+            assertThat(dateProcessorConfig.isSourceTimezoneValid(), equalTo(false));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"America/New_York", "America/Los_Angeles", "Australia/Adelaide", "Japan"})
+        void isTimezoneValid_should_return_true_if_timezone_is_valid(String timezone) throws NoSuchFieldException, IllegalAccessException {
+
+            reflectivelySetField(dateProcessorConfig, "destinationTimezone", timezone);
+            assertThat(dateProcessorConfig.isDestinationTimezoneValid(), equalTo(true));
         }
 
         @ParameterizedTest
@@ -142,7 +150,7 @@ class DateProcessorConfigTest {
         void isLocaleValid_should_return_true_if_locale_is_valid(String locale) throws NoSuchFieldException, IllegalAccessException {
 
             reflectivelySetField(dateProcessorConfig, "locale", locale);
-            assertThat(dateProcessorConfig.isTimezoneValid(), equalTo(true));
+            assertThat(dateProcessorConfig.isSourceTimezoneValid(), equalTo(true));
         }
 
         @ParameterizedTest

--- a/data-prepper-plugins/date-processor/src/test/java/com/amazon/dataprepper/plugins/processor/date/DateProcessorTests.java
+++ b/data-prepper-plugins/date-processor/src/test/java/com/amazon/dataprepper/plugins/processor/date/DateProcessorTests.java
@@ -11,6 +11,7 @@ import com.amazon.dataprepper.model.event.JacksonEvent;
 import com.amazon.dataprepper.model.record.Record;
 import io.micrometer.core.instrument.Counter;
 import org.apache.commons.lang3.LocaleUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -79,6 +80,11 @@ class DateProcessorTests {
         expectedDateTime = LocalDateTime.now();
     }
 
+    @AfterEach
+    void cleanup() {
+        verifyNoMoreInteractions(dateProcessingMatchSuccessCounter, dateProcessingMatchFailureCounter);
+    }
+
     private DateProcessor createObjectUnderTest() {
         return new DateProcessor(pluginMetrics, mockDateProcessorConfig);
     }
@@ -104,7 +110,6 @@ class DateProcessorTests {
         ZonedDateTime actualZonedDateTime = processedRecords.get(0).getData().get(TIMESTAMP_KEY, ZonedDateTime.class);
 
         Assertions.assertEquals(0, actualZonedDateTime.toInstant().compareTo(expectedInstant.truncatedTo(ChronoUnit.MILLIS)));
-        verifyNoInteractions(dateProcessingMatchSuccessCounter, dateProcessingMatchFailureCounter);
     }
 
     @Test
@@ -130,7 +135,6 @@ class DateProcessorTests {
         ZonedDateTime actualZonedDateTime = processedRecords.get(0).getData().get(destination, ZonedDateTime.class);
 
         Assertions.assertEquals(0, actualZonedDateTime.toInstant().compareTo(expectedInstant.truncatedTo(ChronoUnit.MILLIS)));
-        verifyNoInteractions(dateProcessingMatchSuccessCounter, dateProcessingMatchFailureCounter);
     }
 
     @Test
@@ -155,7 +159,6 @@ class DateProcessorTests {
 
         assertTimestampsAreEqual(processedRecords.get(0), mockDateProcessorConfig.getSourceZoneId(), TIMESTAMP_KEY);
         verify(dateProcessingMatchSuccessCounter, times(1)).increment();
-        verifyNoInteractions(dateProcessingMatchFailureCounter);
     }
 
     @Test
@@ -181,7 +184,6 @@ class DateProcessorTests {
 
         assertTimestampsAreEqual(processedRecords.get(0), mockDateProcessorConfig.getSourceZoneId(), destination);
         verify(dateProcessingMatchSuccessCounter, times(1)).increment();
-        verifyNoInteractions(dateProcessingMatchFailureCounter);
     }
 
     @Test
@@ -209,7 +211,6 @@ class DateProcessorTests {
 
         Assertions.assertTrue(actualZonedDateTime.isEqual(expectedZonedDateTime));
         verify(dateProcessingMatchSuccessCounter, times(1)).increment();
-        verifyNoInteractions(dateProcessingMatchFailureCounter);
     }
 
     @Test
@@ -232,7 +233,6 @@ class DateProcessorTests {
 
         Assertions.assertFalse(processedRecords.get(0).getData().containsKey(TIMESTAMP_KEY));
         verify(dateProcessingMatchFailureCounter, times(1)).increment();
-        verifyNoInteractions(dateProcessingMatchSuccessCounter);
     }
 
     @ParameterizedTest
@@ -257,7 +257,6 @@ class DateProcessorTests {
 
         assertTimestampsAreEqual(processedRecords.get(0), mockDateProcessorConfig.getSourceZoneId(), TIMESTAMP_KEY);
         verify(dateProcessingMatchSuccessCounter, times(1)).increment();
-        verifyNoInteractions(dateProcessingMatchFailureCounter);
     }
 
     @ParameterizedTest
@@ -282,7 +281,6 @@ class DateProcessorTests {
 
         assertTimestampsAreEqual(processedRecords.get(0), mockDateProcessorConfig.getSourceZoneId(), TIMESTAMP_KEY);
         verify(dateProcessingMatchSuccessCounter, times(1)).increment();
-        verifyNoInteractions(dateProcessingMatchFailureCounter);
     }
 
     @ParameterizedTest
@@ -307,7 +305,6 @@ class DateProcessorTests {
 
         assertTimestampsAreEqual(processedRecords.get(0), mockDateProcessorConfig.getSourceZoneId(), TIMESTAMP_KEY);
         verify(dateProcessingMatchSuccessCounter, times(1)).increment();
-        verifyNoInteractions(dateProcessingMatchFailureCounter);
     }
 
     static Record<Event> buildRecordWithEvent(final Map<String, Object> data) {


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description

- Added `dateProcessingMatchSuccessCounter` and `dateProcessingMatchFailureCounter` metrics
- Added a new configuration option `destination_timezone`which let's user define the timezone of output that'll be stored in event data.
- Updated the default source timezone to be system default instead of `UTC`.
 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
