### PR TITLE
Publish to Maven as part of the release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,11 @@ jobs:
         java-version: 14
     - name: Checkout Data-Prepper
       uses: actions/checkout@v2
-    - name: Build
+    - name: Build Jar Files
       run: ./gradlew build
-    - name: Archives
-      run: ./gradlew :release:archives:linux:linuxTar -Prelease
-    - name: Docker
+    - name: Build Archives
+      run: ./gradlew :release:archives:buildArchives -Prelease
+    - name: Build Docker Image
       run: ./gradlew :release:docker:docker -Prelease
+    - name: Build Maven Artifacts
+      run: ./gradlew publish


### PR DESCRIPTION
### Description

This commit adds the following changes to the nascent GitHub Actions release build:

* Adds a new step to publish to Maven (local only, as with the Archives and Docker steps)
* Improved the step names
* Build all archive files. Now that macOS is no longer part of the Gradle build, this only builds Linux as it should.
 
### Issues Resolved

Part of #977
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
