### PR TITLE
ENH: fill in traceGroup fields in otel-trace-raw-prepper

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/JacksonSpan.java
@@ -28,6 +28,8 @@ import static com.google.common.base.Preconditions.checkState;
  */
 public class JacksonSpan extends JacksonEvent implements Span {
 
+    public static final String TRACE_GROUP_KEY = "traceGroup";
+    public static final String TRACE_GROUP_FIELDS_KEY = "traceGroupFields";
     private static final String TRACE_ID_KEY = "traceId";
     private static final String SPAN_ID_KEY = "spanId";
     private static final String TRACE_STATE_KEY = "traceState";
@@ -43,9 +45,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
     private static final String LINKS_KEY = "links";
     private static final String DROPPED_LINKS_COUNT_KEY = "droppedLinksCount";
     private static final String SERVICE_NAME_KEY = "serviceName";
-    private static final String TRACE_GROUP_KEY = "traceGroup";
     private static final String DURATION_IN_NANOS_KEY = "durationInNanos";
-    private static final String TRACE_GROUP_FIELDS_KEY = "traceGroupFields";
 
     private static final List<String> REQUIRED_KEYS = Arrays.asList(TRACE_GROUP_KEY);
     private static final List<String>

--- a/data-prepper-plugins/otel-trace-group-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltracegroup/OTelTraceGroupPrepper.java
+++ b/data-prepper-plugins/otel-trace-group-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltracegroup/OTelTraceGroupPrepper.java
@@ -104,10 +104,8 @@ public class OTelTraceGroupPrepper extends AbstractPrepper<Record<Span>, Record<
             final TraceGroup traceGroup = traceIdToTraceGroup.get(traceId);
             if (traceGroup != null) {
                 try {
-                    final JacksonSpan newSpan = JacksonSpan.builder().fromSpan(span)
-                            .withTraceGroup(traceGroup.getTraceGroup())
-                            .withTraceGroupFields(traceGroup.getTraceGroupFields()).build();
-                    recordsOut.add(new Record<>(newSpan, record.getMetadata()));
+                    fillInTraceGroupInfo(span, traceGroup);
+                    recordsOut.add(record);
                     recordsOutFixedTraceGroupCounter.increment();
                 } catch (Exception e) {
                     recordsOut.add(record);
@@ -123,6 +121,11 @@ public class OTelTraceGroupPrepper extends AbstractPrepper<Record<Span>, Record<
         }
 
         return recordsOut;
+    }
+
+    private void fillInTraceGroupInfo(final Span span, final TraceGroup traceGroup) {
+        span.put(JacksonSpan.TRACE_GROUP_KEY, traceGroup.getTraceGroup());
+        span.put(JacksonSpan.TRACE_GROUP_FIELDS_KEY, traceGroup.getTraceGroupFields());
     }
 
     private Map<String, TraceGroup> searchTraceGroupByTraceIds(final Collection<String> traceIds) {

--- a/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OTelTraceRawPrepper.java
+++ b/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OTelTraceRawPrepper.java
@@ -128,11 +128,8 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<Span>, Record<Sp
         final SpanSet spanSet = traceIdSpanSetMap.get(parentSpanTraceId);
         if (spanSet != null) {
             for (final Span span : spanSet.getSpans()) {
-                final Span newSpan = JacksonSpan.builder().fromSpan(span)
-                        .withTraceGroup(traceGroup.getTraceGroup())
-                        .withTraceGroupFields(traceGroup.getTraceGroupFields())
-                        .build();
-                recordsToFlush.add(newSpan);
+                fillInTraceGroupInfo(span, traceGroup);
+                recordsToFlush.add(span);
             }
 
             traceIdSpanSetMap.remove(parentSpanTraceId);
@@ -153,11 +150,8 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<Span>, Record<Sp
         final TraceGroup traceGroup = traceIdTraceGroupCache.getIfPresent(childSpanTraceId);
 
         if (traceGroup != null) {
-            final Span newChildSpan = JacksonSpan.builder().fromSpan(childSpan)
-                    .withTraceGroup(traceGroup.getTraceGroup())
-                    .withTraceGroupFields(traceGroup.getTraceGroupFields())
-                    .build();
-            return Optional.of(newChildSpan);
+            fillInTraceGroupInfo(childSpan, traceGroup);
+            return Optional.of(childSpan);
         } else {
             traceIdSpanSetMap.compute(childSpanTraceId, (traceId, spanSet) -> {
                 if (spanSet == null) {
@@ -199,11 +193,8 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<Span>, Record<Sp
                             final Set<Span> spans = spanSet.getSpans();
                             if (traceGroup != null) {
                                 spans.forEach(span -> {
-                                    final Span newSpan = JacksonSpan.builder().fromSpan(span)
-                                            .withTraceGroup(traceGroup.getTraceGroup())
-                                            .withTraceGroupFields(traceGroup.getTraceGroupFields())
-                                            .build();
-                                    recordsToFlush.add(newSpan);
+                                    fillInTraceGroupInfo(span, traceGroup);
+                                    recordsToFlush.add(span);
                                 });
                             } else {
                                 spans.forEach(span -> {
@@ -225,6 +216,11 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<Span>, Record<Sp
         }
 
         return recordsToFlush;
+    }
+
+    private void fillInTraceGroupInfo(final Span span, final TraceGroup traceGroup) {
+        span.put(JacksonSpan.TRACE_GROUP_KEY, traceGroup.getTraceGroup());
+        span.put(JacksonSpan.TRACE_GROUP_FIELDS_KEY, traceGroup.getTraceGroupFields());
     }
 
     private boolean shouldGarbageCollect() {

--- a/data-prepper-plugins/otel-trace-raw-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OTelTraceRawPrepperTest.java
+++ b/data-prepper-plugins/otel-trace-raw-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OTelTraceRawPrepperTest.java
@@ -61,33 +61,19 @@ public class OTelTraceRawPrepperTest {
     private static final String TEST_TRACE_GROUP_2_CHILD_SPAN_1_JSON_FILE = "trace-group-2-child-span-1.json";
     private static final String TEST_TRACE_GROUP_2_CHILD_SPAN_2_JSON_FILE = "trace-group-2-child-span-2.json";
 
-    private static final Span TEST_TRACE_GROUP_1_ROOT_SPAN = buildSpanFromJsonFile(TEST_TRACE_GROUP_1_ROOT_SPAN_JSON_FILE);
-    private static final Span TEST_TRACE_GROUP_1_CHILD_SPAN_1 = buildSpanFromJsonFile(TEST_TRACE_GROUP_1_CHILD_SPAN_1_JSON_FILE);
-    private static final Span TEST_TRACE_GROUP_1_CHILD_SPAN_2 = buildSpanFromJsonFile(TEST_TRACE_GROUP_1_CHILD_SPAN_2_JSON_FILE);
-    private static final Span TEST_TRACE_GROUP_2_ROOT_SPAN = buildSpanFromJsonFile(TEST_TRACE_GROUP_2_ROOT_SPAN_JSON_FILE);
-    private static final Span TEST_TRACE_GROUP_2_CHILD_SPAN_1 = buildSpanFromJsonFile(TEST_TRACE_GROUP_2_CHILD_SPAN_1_JSON_FILE);
-    private static final Span TEST_TRACE_GROUP_2_CHILD_SPAN_2 = buildSpanFromJsonFile(TEST_TRACE_GROUP_2_CHILD_SPAN_2_JSON_FILE);
+    private Span TEST_TRACE_GROUP_1_ROOT_SPAN;
+    private Span TEST_TRACE_GROUP_1_CHILD_SPAN_1;
+    private Span TEST_TRACE_GROUP_1_CHILD_SPAN_2;
+    private Span TEST_TRACE_GROUP_2_ROOT_SPAN;
+    private Span TEST_TRACE_GROUP_2_CHILD_SPAN_1;
+    private Span TEST_TRACE_GROUP_2_CHILD_SPAN_2;
 
-    private static final List<Record<Span>> TEST_ONE_FULL_TRACE_GROUP_RECORDS = Stream.of(
-            TEST_TRACE_GROUP_1_ROOT_SPAN, TEST_TRACE_GROUP_1_CHILD_SPAN_1, TEST_TRACE_GROUP_1_CHILD_SPAN_2)
-            .map(Record::new).collect(Collectors.toList());
-    private static final List<Record<Span>> TEST_ONE_TRACE_GROUP_MISSING_ROOT_RECORDS = Stream.of(
-                    TEST_TRACE_GROUP_2_CHILD_SPAN_1, TEST_TRACE_GROUP_2_CHILD_SPAN_2)
-            .map(Record::new).collect(Collectors.toList());
-    private static final List<Record<Span>> TEST_TWO_FULL_TRACE_GROUP_RECORDS = Stream.of(
-                    TEST_TRACE_GROUP_1_ROOT_SPAN, TEST_TRACE_GROUP_1_CHILD_SPAN_1, TEST_TRACE_GROUP_1_CHILD_SPAN_2,
-                    TEST_TRACE_GROUP_2_ROOT_SPAN, TEST_TRACE_GROUP_2_CHILD_SPAN_1, TEST_TRACE_GROUP_2_CHILD_SPAN_2)
-            .map(Record::new).collect(Collectors.toList());
-    private static final List<Record<Span>> TEST_TWO_TRACE_GROUP_INTERLEAVED_PART_1_RECORDS = Stream.of(
-                    TEST_TRACE_GROUP_1_ROOT_SPAN, TEST_TRACE_GROUP_2_CHILD_SPAN_1, TEST_TRACE_GROUP_2_CHILD_SPAN_2)
-            .map(Record::new).collect(Collectors.toList());
-    private static final List<Record<Span>> TEST_TWO_TRACE_GROUP_INTERLEAVED_PART_2_RECORDS = Stream.of(
-                    TEST_TRACE_GROUP_2_ROOT_SPAN, TEST_TRACE_GROUP_1_CHILD_SPAN_1, TEST_TRACE_GROUP_1_CHILD_SPAN_2)
-            .map(Record::new).collect(Collectors.toList());
-    private static final List<Record<Span>> TEST_TWO_TRACE_GROUP_MISSING_ROOT_RECORDS = Stream.of(
-                    TEST_TRACE_GROUP_1_CHILD_SPAN_1, TEST_TRACE_GROUP_1_CHILD_SPAN_2,
-                    TEST_TRACE_GROUP_2_CHILD_SPAN_1, TEST_TRACE_GROUP_2_CHILD_SPAN_2)
-            .map(Record::new).collect(Collectors.toList());
+    private List<Record<Span>> TEST_ONE_FULL_TRACE_GROUP_RECORDS;
+    private List<Record<Span>> TEST_ONE_TRACE_GROUP_MISSING_ROOT_RECORDS;
+    private List<Record<Span>> TEST_TWO_FULL_TRACE_GROUP_RECORDS;
+    private List<Record<Span>> TEST_TWO_TRACE_GROUP_INTERLEAVED_PART_1_RECORDS;
+    private List<Record<Span>> TEST_TWO_TRACE_GROUP_INTERLEAVED_PART_2_RECORDS;
+    private List<Record<Span>> TEST_TWO_TRACE_GROUP_MISSING_ROOT_RECORDS;
 
     PluginSetting pluginSetting;
     public OTelTraceRawPrepper oTelTraceRawPrepper;
@@ -95,6 +81,33 @@ public class OTelTraceRawPrepperTest {
 
     @Before
     public void setup() {
+        TEST_TRACE_GROUP_1_ROOT_SPAN = buildSpanFromJsonFile(TEST_TRACE_GROUP_1_ROOT_SPAN_JSON_FILE);
+        TEST_TRACE_GROUP_1_CHILD_SPAN_1 = buildSpanFromJsonFile(TEST_TRACE_GROUP_1_CHILD_SPAN_1_JSON_FILE);
+        TEST_TRACE_GROUP_1_CHILD_SPAN_2 = buildSpanFromJsonFile(TEST_TRACE_GROUP_1_CHILD_SPAN_2_JSON_FILE);
+        TEST_TRACE_GROUP_2_ROOT_SPAN = buildSpanFromJsonFile(TEST_TRACE_GROUP_2_ROOT_SPAN_JSON_FILE);
+        TEST_TRACE_GROUP_2_CHILD_SPAN_1 = buildSpanFromJsonFile(TEST_TRACE_GROUP_2_CHILD_SPAN_1_JSON_FILE);
+        TEST_TRACE_GROUP_2_CHILD_SPAN_2 = buildSpanFromJsonFile(TEST_TRACE_GROUP_2_CHILD_SPAN_2_JSON_FILE);
+        TEST_ONE_FULL_TRACE_GROUP_RECORDS = Stream.of(
+                        TEST_TRACE_GROUP_1_ROOT_SPAN, TEST_TRACE_GROUP_1_CHILD_SPAN_1, TEST_TRACE_GROUP_1_CHILD_SPAN_2)
+                .map(Record::new).collect(Collectors.toList());
+        TEST_ONE_TRACE_GROUP_MISSING_ROOT_RECORDS = Stream.of(
+                        TEST_TRACE_GROUP_2_CHILD_SPAN_1, TEST_TRACE_GROUP_2_CHILD_SPAN_2)
+                .map(Record::new).collect(Collectors.toList());
+        TEST_TWO_FULL_TRACE_GROUP_RECORDS = Stream.of(
+                        TEST_TRACE_GROUP_1_ROOT_SPAN, TEST_TRACE_GROUP_1_CHILD_SPAN_1, TEST_TRACE_GROUP_1_CHILD_SPAN_2,
+                        TEST_TRACE_GROUP_2_ROOT_SPAN, TEST_TRACE_GROUP_2_CHILD_SPAN_1, TEST_TRACE_GROUP_2_CHILD_SPAN_2)
+                .map(Record::new).collect(Collectors.toList());
+        TEST_TWO_TRACE_GROUP_INTERLEAVED_PART_1_RECORDS = Stream.of(
+                        TEST_TRACE_GROUP_1_ROOT_SPAN, TEST_TRACE_GROUP_2_CHILD_SPAN_1, TEST_TRACE_GROUP_2_CHILD_SPAN_2)
+                .map(Record::new).collect(Collectors.toList());
+        TEST_TWO_TRACE_GROUP_INTERLEAVED_PART_2_RECORDS = Stream.of(
+                        TEST_TRACE_GROUP_2_ROOT_SPAN, TEST_TRACE_GROUP_1_CHILD_SPAN_1, TEST_TRACE_GROUP_1_CHILD_SPAN_2)
+                .map(Record::new).collect(Collectors.toList());
+        TEST_TWO_TRACE_GROUP_MISSING_ROOT_RECORDS = Stream.of(
+                        TEST_TRACE_GROUP_1_CHILD_SPAN_1, TEST_TRACE_GROUP_1_CHILD_SPAN_2,
+                        TEST_TRACE_GROUP_2_CHILD_SPAN_1, TEST_TRACE_GROUP_2_CHILD_SPAN_2)
+                .map(Record::new).collect(Collectors.toList());
+
         MetricsTestUtil.initMetrics();
         pluginSetting = new PluginSetting(
                 "OTelTrace",


### PR DESCRIPTION
Signed-off-by: Chen <19492223+chenqi0805@users.noreply.github.com>

### Description
This PR enhances the performance of otel-trace-raw-prepper by updating traceGroup related attributes in the input data instead of building new spans.

Before this change:
![Screen Shot 2022-02-18 at 2 55 48 PM](https://user-images.githubusercontent.com/19492223/154760104-fa414898-c8d6-438a-8d8b-af332de6ebfe.png)

after this change:
![Screen Shot 2022-02-18 at 2 56 12 PM](https://user-images.githubusercontent.com/19492223/154760138-0c1bba83-609b-4148-8a61-26144385a6b2.png)



 
### Issues Resolved
Contributes to #546 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
