### PR TITLE
ENH: refactor checkAndSetDefaultValues into JacksonSpan.Builder

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/JacksonSpan.java
@@ -56,8 +56,6 @@ public class JacksonSpan extends JacksonEvent implements Span {
         super(builder);
 
         checkArgument(this.getMetadata().getEventType().equals("TRACE"), "eventType must be of type Trace");
-
-        checkAndSetDefaultValues();
     }
 
     @Override
@@ -148,32 +146,6 @@ public class JacksonSpan extends JacksonEvent implements Span {
     @Override
     public String getServiceName() {
         return this.get(SERVICE_NAME_KEY, String.class);
-    }
-
-    private void checkAndSetDefaultValues() {
-        if (this.getAttributes() == null ) {
-            this.put(ATTRIBUTES_KEY, new HashMap<>());
-        }
-
-        if (this.getDroppedAttributesCount() == null) {
-            this.put(DROPPED_ATTRIBUTES_COUNT_KEY, 0);
-        }
-
-        if (this.getLinks() == null) {
-            this.put(LINKS_KEY, new LinkedList<>());
-        }
-
-        if (this.getDroppedLinksCount() == null) {
-            this.put(DROPPED_LINKS_COUNT_KEY, 0);
-        }
-
-        if (this.getEvents() == null) {
-            this.put(EVENTS_KEY, new LinkedList<>());
-        }
-
-        if (this.getDroppedEventsCount() == null) {
-            this.put(DROPPED_EVENTS_COUNT_KEY, 0);
-        }
     }
 
     public static Builder builder() {
@@ -428,6 +400,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
          */
         public JacksonSpan build() {
             validateParameters();
+            checkAndSetDefaultValues();
             this.withData(data);
             this.withEventType(EventType.TRACE.toString());
             return new JacksonSpan(this);
@@ -448,6 +421,15 @@ public class JacksonSpan extends JacksonEvent implements Span {
                 final Object value = data.get(key);
                 checkNotNull(value, key + " cannot be null");
             });
+        }
+
+        private void checkAndSetDefaultValues() {
+            data.computeIfAbsent(ATTRIBUTES_KEY, k -> new HashMap<>());
+            data.putIfAbsent(DROPPED_ATTRIBUTES_COUNT_KEY, 0);
+            data.computeIfAbsent(LINKS_KEY, k -> new LinkedList<>());
+            data.putIfAbsent(DROPPED_LINKS_COUNT_KEY, 0);
+            data.computeIfAbsent(EVENTS_KEY, k -> new LinkedList<>());
+            data.putIfAbsent(DROPPED_EVENTS_COUNT_KEY, 0);
         }
 
     }

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/event/JacksonEventTest.java
@@ -174,6 +174,11 @@ public class JacksonEventTest {
     }
 
     @Test
+    public void testGetList_Missing() {
+        assertThat(event.getList("missingKey", Object.class), is(nullValue()));
+    }
+
+    @Test
     public void testGet_withEmptyEvent() {
         final String key = "foo/bar";
 


### PR DESCRIPTION
Signed-off-by: Chen <19492223+chenqi0805@users.noreply.github.com>

### Description
* As synced with @cmanning09 offline, this PR refactors checkAndSetDefaultValues from JacksonSpan into JacksonSpan.Builder in order to avoid get calls with JsonPointers which is time consuming in the JacksonSpan constructor:

![Screen Shot 2022-02-18 at 3 27 55 PM](https://user-images.githubusercontent.com/19492223/154763780-5be880b0-b08d-4392-bd83-c51de214330b.png)

* Also added a test case on JacksonEvent as the coverage is a little shy.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
