### PR TITLE
Added SimpleExpressionMatcher

### DIFF
--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/ContextMatcher.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/ContextMatcher.java
@@ -43,6 +43,20 @@ import static org.hamcrest.core.IsEqual.equalTo;
  * </p>
  */
 public class ContextMatcher extends DiagnosingMatcher<ParseTree> {
+    public static void describeContextTo(final ParseTree ctx, final Description mismatch) {
+        if (ctx != null) {
+            final StringBuilder context = new StringBuilder(ctx.getText());
+            ParseTree parent = ctx.getParent();
+
+            while (parent != null) {
+                context.insert(0, parent.getText() + " -> ");
+                parent = parent.getParent();
+            }
+
+            mismatch.appendText("\n\t\t" + context + "\n\t\t");
+        }
+    }
+
     /**
      * @since 1.3
      * <p>Shortcut for constructor matching Hamcrest standard.</p>

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/ContextMatcher.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/ContextMatcher.java
@@ -43,10 +43,10 @@ import static org.hamcrest.core.IsEqual.equalTo;
  * </p>
  */
 public class ContextMatcher extends DiagnosingMatcher<ParseTree> {
-    public static void describeContextTo(final ParseTree ctx, final Description mismatch) {
-        if (ctx != null) {
-            final StringBuilder context = new StringBuilder(ctx.getText());
-            ParseTree parent = ctx.getParent();
+    public static void describeContextTo(final ParseTree parseTree, final Description mismatch) {
+        if (parseTree != null) {
+            final StringBuilder context = new StringBuilder(parseTree.getText());
+            ParseTree parent = parseTree.getParent();
 
             while (parent != null) {
                 context.insert(0, parent.getText() + " -> ");
@@ -96,14 +96,14 @@ public class ContextMatcher extends DiagnosingMatcher<ParseTree> {
      * @since 1.3
      * Asserts number of children equal to the number of childMatchers and, in order each child matches the
      * corresponding matcher.
-     * @param ctx ParseTree branch to get children from
+     * @param parseTree ParseTree branch to get children from
      * @param mismatch Description used for printing Hamcrest mismatch messages
      * @return true if all assertions pass
      */
-    private boolean matchChildren(final ParseTree ctx, final Description mismatch) {
-        if (listSizeMatcher.matches(ctx.getChildCount())) {
+    private boolean matchChildren(final ParseTree parseTree, final Description mismatch) {
+        if (listSizeMatcher.matches(parseTree.getChildCount())) {
             for (int i = 0; i < childrenMatchers.length; i++) {
-                final ParseTree child = ctx.getChild(i);
+                final ParseTree child = parseTree.getChild(i);
                 final DiagnosingMatcher<? extends ParseTree> matcher = childrenMatchers[i];
 
                 if (!matcher.matches(child)) {
@@ -120,7 +120,7 @@ public class ContextMatcher extends DiagnosingMatcher<ParseTree> {
         else {
             mismatch.appendDescriptionOf(listSizeMatcher)
                     .appendText(" ");
-            listSizeMatcher.describeMismatch(ctx.getChildCount(), mismatch);
+            listSizeMatcher.describeMismatch(parseTree.getChildCount(), mismatch);
             failedAssertion = listSizeMatcher;
             return false;
         }
@@ -135,8 +135,8 @@ public class ContextMatcher extends DiagnosingMatcher<ParseTree> {
      */
     public boolean matches(final Object item, final Description mismatch) {
         if (isParserRuleContextType.matches(item)) {
-            final ParseTree ctx = (ParseTree) item;
-            return matchChildren(ctx, mismatch);
+            final ParseTree parseTree = (ParseTree) item;
+            return matchChildren(parseTree, mismatch);
         }
         else {
             mismatch.appendDescriptionOf(isParserRuleContextType)

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/RuleClassOrderedList.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/RuleClassOrderedList.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression.util;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * RuleClassOrderedList calculates the position of an objects class or super class in an orders list of classes.
+ */
+public class RuleClassOrderedList {
+    private final List<Class<? extends ParseTree>> orderedRules = new ArrayList<>();
+
+    @SafeVarargs
+    public RuleClassOrderedList(final Class<? extends ParseTree> ... rules) {
+        Collections.addAll(orderedRules, rules);
+    }
+
+    /**
+     * Calculates the first index of a class item is an instance of.
+     * @param item object that should be an instance of any class within {@link RuleClassOrderedList#orderedRules}
+     * @return the index of the class or -1
+     */
+    public int indexOf(@Nullable final ParseTree item) {
+        for (int x = 0; x < orderedRules.size(); x++) {
+            if (orderedRules.get(x).isInstance(item)) {
+                return x;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Checks if {@link RuleClassOrderedList#indexOf(ParseTree)} of first is immediately followed by the index of second.
+     * @param first object that should be an instance of any class within {@link RuleClassOrderedList#orderedRules}
+     * @param second object that should be an instance of the class following first in {@link RuleClassOrderedList#orderedRules}
+     * @return if the indices are sequential
+     */
+    public boolean isSequentialRules(@Nullable final ParseTree first, @Nullable final ParseTree second) {
+        final int firstIndex = indexOf(first);
+        if (firstIndex < 0 || firstIndex >= orderedRules.size() - 1) {
+            return false;
+        }
+        else {
+            return orderedRules.get(firstIndex + 1).isInstance(second);
+        }
+    }
+
+    /**
+     * Checks if item is an instance of the last class in {@link RuleClassOrderedList#orderedRules}
+     * @param item object to check
+     * @return if instanceof last rule class
+     */
+    public boolean isInstanceOfLast(final ParseTree item) {
+        final int lastIndex = orderedRules.size() - 1;
+        return orderedRules.get(lastIndex).isInstance(item);
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/RuleClassOrderedListTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/RuleClassOrderedListTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression.util;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+class RuleClassOrderedListTest {
+
+    private RuleClassOrderedList ruleClassOrderedList;
+
+    private abstract static class A implements ParseTree {}
+    private abstract static class A1 extends A {}
+    private abstract static class B implements ParseTree {}
+    private abstract static class C implements ParseTree {}
+
+    @BeforeEach
+    void beforeEach() {
+        ruleClassOrderedList = new RuleClassOrderedList(A.class, B.class, C.class);
+    }
+
+    private static Stream<Arguments> provideParseTreesAndIndices() {
+        return Stream.of(
+                Arguments.of(mock(A.class), 0),
+                Arguments.of(mock(A1.class), 0),
+                Arguments.of(mock(B.class), 1),
+                Arguments.of(mock(C.class), 2)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParseTreesAndIndices")
+    void indexOf(final ParseTree parseTree, final Integer index) {
+        assertThat(ruleClassOrderedList.indexOf(parseTree), is(index));
+    }
+
+    private static Stream<Arguments> provideSequentialParseTrees() {
+        return Stream.of(
+                Arguments.of(mock(A.class), mock(B.class), true),
+                Arguments.of(mock(A1.class), mock(B.class), true),
+                Arguments.of(mock(A.class), mock(A1.class), false),
+                Arguments.of(mock(B.class), mock(C.class), true),
+                Arguments.of(mock(C.class), mock(B.class), false),
+                Arguments.of(mock(B.class), mock(B.class), false)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSequentialParseTrees")
+    void isSequentialRules(final ParseTree first, final ParseTree second, final boolean isSequential) {
+        assertThat(ruleClassOrderedList.isSequentialRules(first, second), is(isSequential));
+    }
+
+    @Test
+    void isInstanceOfLastGivenInstanceOfLast() {
+        assertThat(ruleClassOrderedList.isInstanceOfLast(mock(C.class)), is(true));
+    }
+
+    @Test
+    void isInstanceOfLastGivenNotInstanceOfLast() {
+        assertThat(ruleClassOrderedList.isInstanceOfLast(mock(B.class)), is(false));
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/SimpleExpressionMatcher.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/SimpleExpressionMatcher.java
@@ -19,7 +19,7 @@ import static org.opensearch.dataprepper.expression.util.ContextMatcher.describe
  * Base class for Matcher that asserts a unary tree ending in a node that matches {@link SimpleExpressionMatcher#lastNodeClass}
  */
 abstract class SimpleExpressionMatcher extends DiagnosingMatcher<ParseTree> {
-    private static final Matcher<Integer> childCountMatcher = is(1);
+    private static final Matcher<Integer> singleChildMatcher = is(1);
 
     protected final List<Class<? extends ParseTree>> validRuleOrder;
     protected final Class<? extends ParseTree> lastNodeClass;
@@ -75,7 +75,7 @@ abstract class SimpleExpressionMatcher extends DiagnosingMatcher<ParseTree> {
                 return false;
             }
         }
-        else if (childCountMatcher.matches(item.getChildCount())) {
+        else if (singleChildMatcher.matches(item.getChildCount())) {
             final ParseTree child = item.getChild(0);
             if (!isValidRuleOrder(item, child, mismatch)) {
                 describeTo(mismatch);

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/SimpleExpressionMatcher.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/SimpleExpressionMatcher.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression.util;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.hamcrest.Description;
+import org.hamcrest.DiagnosingMatcher;
+import org.hamcrest.Matcher;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.opensearch.dataprepper.expression.util.ContextMatcher.describeContextTo;
+
+/**
+ * Base class for Matcher that asserts a unary tree ending in a node that matches {@link SimpleExpressionMatcher#lastNodeClass}
+ */
+abstract class SimpleExpressionMatcher extends DiagnosingMatcher<ParseTree> {
+    private static final Matcher<Integer> childCountMatcher = is(1);
+
+    protected final List<Class<? extends ParseTree>> validRuleOrder;
+    protected final Class<? extends ParseTree> lastNodeClass;
+
+    protected SimpleExpressionMatcher(final List<Class<? extends ParseTree>> validRuleOrder) {
+        this.validRuleOrder = validRuleOrder;
+        this.lastNodeClass = validRuleOrder.get(validRuleOrder.size() - 1);
+    }
+
+    private int getRuleIndex(final ParseTree item) {
+        for (int x = 0; x < validRuleOrder.size(); x++) {
+            if (validRuleOrder.get(x).isInstance(item)) {
+                return x;
+            }
+        }
+        return -1;
+    }
+
+    private boolean isValidRuleOrder(final ParseTree current, final ParseTree next, final Description mismatchDescription) {
+        final int index = getRuleIndex(current);
+        if (index < 0 || index >= validRuleOrder.size() - 1) {
+            mismatchDescription.appendText(current.getClass() + " is not a valid context ");
+            return false;
+        }
+        else {
+            if (validRuleOrder.get(index + 1).isInstance(next)) {
+                return true;
+            }
+            else {
+                mismatchDescription.appendText(current.getClass() + " -> " + next.getClass() + " not valid rule order");
+                describeContextTo(current, mismatchDescription);
+                return false;
+            }
+        }
+    }
+
+    /**
+     * Called when {@link SimpleExpressionMatcher#matchesParseTree(ParseTree, Description)} finds a node matching
+     * {@link SimpleExpressionMatcher#lastNodeClass}
+     * @param item matching node
+     * @param mismatchDescription description to append failed assertion context.
+     * @return if this matcher matches
+     */
+    protected abstract boolean baseCase(final ParseTree item, final Description mismatchDescription);
+
+    private boolean matchesParseTree(final ParseTree item, final Description mismatch) {
+        if (lastNodeClass.isInstance(item)) {
+            if (baseCase(item, mismatch)) {
+                return true;
+            }
+            else {
+                describeContextTo(item, mismatch);
+                return false;
+            }
+        }
+        else if (childCountMatcher.matches(item.getChildCount())) {
+            final ParseTree child = item.getChild(0);
+            if (!isValidRuleOrder(item, child, mismatch)) {
+                describeTo(mismatch);
+                return false;
+            }
+            return isValidRuleOrder(item, child, mismatch) && matchesParseTree(child, mismatch);
+        }
+        else {
+            mismatch.appendText("Unexpected terminal node " + item.getText());
+            if (item.getParent() != null) {
+                mismatch.appendText(", child of parent node " + item.getParent().getText());
+            }
+            return false;
+        }
+    }
+
+    @Override
+    protected boolean matches(final Object item, final Description mismatchDescription) {
+        if (item instanceof ParseTree) {
+            return matchesParseTree((ParseTree) item, mismatchDescription);
+        }
+        else {
+            return false;
+        }
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/SimpleExpressionMatcher.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/SimpleExpressionMatcher.java
@@ -10,92 +10,117 @@ import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
 import org.hamcrest.Matcher;
 
-import java.util.List;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.opensearch.dataprepper.expression.util.ContextMatcher.describeContextTo;
 
 /**
- * Base class for Matcher that asserts a unary tree ending in a node that matches {@link SimpleExpressionMatcher#lastNodeClass}
+ * Base class for Matcher that asserts a unary tree ending in a node that matches
+ * {@link RuleClassOrderedList#isInstanceOfLast(ParseTree)}
  */
 abstract class SimpleExpressionMatcher extends DiagnosingMatcher<ParseTree> {
     private static final Matcher<Integer> singleChildMatcher = is(1);
 
-    protected final List<Class<? extends ParseTree>> validRuleOrder;
-    protected final Class<? extends ParseTree> lastNodeClass;
+    protected final RuleClassOrderedList validRuleOrder;
 
-    protected SimpleExpressionMatcher(final List<Class<? extends ParseTree>> validRuleOrder) {
+    protected SimpleExpressionMatcher(final RuleClassOrderedList validRuleOrder) {
         this.validRuleOrder = validRuleOrder;
-        this.lastNodeClass = validRuleOrder.get(validRuleOrder.size() - 1);
-    }
-
-    private int getRuleIndex(final ParseTree item) {
-        for (int x = 0; x < validRuleOrder.size(); x++) {
-            if (validRuleOrder.get(x).isInstance(item)) {
-                return x;
-            }
-        }
-        return -1;
-    }
-
-    private boolean isValidRuleOrder(final ParseTree current, final ParseTree next, final Description mismatchDescription) {
-        final int index = getRuleIndex(current);
-        if (index < 0 || index >= validRuleOrder.size() - 1) {
-            mismatchDescription.appendText(current.getClass() + " is not a valid context ");
-            return false;
-        }
-        else {
-            if (validRuleOrder.get(index + 1).isInstance(next)) {
-                return true;
-            }
-            else {
-                mismatchDescription.appendText(current.getClass() + " -> " + next.getClass() + " not valid rule order");
-                describeContextTo(current, mismatchDescription);
-                return false;
-            }
-        }
     }
 
     /**
      * Called when {@link SimpleExpressionMatcher#matchesParseTree(ParseTree, Description)} finds a node matching
-     * {@link SimpleExpressionMatcher#lastNodeClass}
+     * {@link RuleClassOrderedList#isInstanceOfLast(ParseTree)}
+     *
      * @param item matching node
-     * @param mismatchDescription description to append failed assertion context.
+     * @param mismatch description to append failed assertion context.
      * @return if this matcher matches
      */
-    protected abstract boolean baseCase(final ParseTree item, final Description mismatchDescription);
+    protected abstract boolean baseCase(final ParseTree item, final Description mismatch);
 
-    private boolean matchesParseTree(final ParseTree item, final Description mismatch) {
-        if (lastNodeClass.isInstance(item)) {
-            if (baseCase(item, mismatch)) {
-                return true;
-            }
-            else {
-                describeContextTo(item, mismatch);
-                return false;
-            }
-        }
-        else if (singleChildMatcher.matches(item.getChildCount())) {
-            final ParseTree child = item.getChild(0);
-            if (!isValidRuleOrder(item, child, mismatch)) {
-                describeTo(mismatch);
-                return false;
-            }
-            return isValidRuleOrder(item, child, mismatch) && matchesParseTree(child, mismatch);
+    /**
+     * Wrapper method for {@link SimpleExpressionMatcher#baseCase(ParseTree, Description)} to ensure a mismatch
+     * description is added.
+     *
+     * @param item ParseTree to match
+     * @param mismatch description of matcher
+     * @return if item matches the expected value
+     */
+    private boolean matchesBaseCase(final ParseTree item, final Description mismatch) {
+        if (baseCase(item, mismatch)) {
+            return true;
         }
         else {
-            mismatch.appendText("Unexpected terminal node " + item.getText());
-            if (item.getParent() != null) {
-                mismatch.appendText(", child of parent node " + item.getParent().getText());
-            }
+            describeContextTo(item, mismatch);
             return false;
         }
     }
 
+    /**
+     * <p>
+     *     Checks if item has one child and that item's class and item's child's class are sequential in
+     *     {@link SimpleExpressionMatcher#validRuleOrder}. Then recursively starts matching item's child.
+     * </p>
+     * <p>
+     *     Valid Rule Order:<br>
+     *     A -> B -> C
+     * </p>
+     * <p>
+     *     True if <pre>item.getClass() == <? extends A> && item.getChild(0).getClass() == <? extends B></pre>
+     * </p>
+     *
+     * @param item ParseTree to match
+     * @param mismatch description of matcher
+     * @return if item matches the expected value
+     */
+    private boolean matchesChildren(final ParseTree item, final Description mismatch) {
+        if (singleChildMatcher.matches(item.getChildCount())) {
+            final ParseTree child = item.getChild(0);
+
+            if (validRuleOrder.isSequentialRules(item, child)) {
+                return matchesParseTree(child, mismatch);
+            }
+            else {
+                mismatch.appendText(item.getClass() + " -> " + child.getClass() + " not valid rule order");
+                describeContextTo(item, mismatch);
+                return false;
+            }
+        }
+        else {
+            singleChildMatcher.describeMismatch(item.getChildCount(), mismatch);
+            describeContextTo(item, mismatch);
+            return false;
+        }
+    }
+
+    /**
+     * Checks if item is the last rule in {@link SimpleExpressionMatcher#validRuleOrder}. If yes, trigger base case,
+     * otherwise match the nodes children.
+     *
+     * @param item ParseTree to match
+     * @param mismatch description of matcher
+     * @return if item matches the expected value
+     */
+    private boolean matchesParseTree(final ParseTree item, final Description mismatch) {
+        if (validRuleOrder.isInstanceOfLast(item)) {
+            return matchesBaseCase(item, mismatch);
+        }
+        else {
+            return matchesChildren(item, mismatch);
+        }
+    }
+
+    /**
+     * Verifies item is a ParseTree, then starts matching logic
+     *
+     * @see SimpleExpressionMatcher#matchesParseTree(ParseTree, Description)
+     *
+     * @param item parse tree to match against
+     * @param mismatch description of matcher
+     * @return if item matches the expected value
+     */
     @Override
-    protected boolean matches(final Object item, final Description mismatchDescription) {
+    protected boolean matches(final Object item, final Description mismatch) {
         if (item instanceof ParseTree) {
-            return matchesParseTree((ParseTree) item, mismatchDescription);
+            return matchesParseTree((ParseTree) item, mismatch);
         }
         else {
             return false;


### PR DESCRIPTION
Signed-off-by: Steven Bayer <smbayer@amazon.com>

### Description
SimpleExpressionMatcher as an abstract base matcher for creating grammar matcher classes
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
