### PR TITLE
Update fromMessage API in data-prepper-common Sources

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/event/JacksonEvent.java
@@ -83,7 +83,7 @@ public class JacksonEvent implements Event {
         this.jsonNode = getInitialJsonNode(builder.data);
     }
 
-    static Event fromMessage(String message) {
+    public static Event fromMessage(String message) {
         return JacksonEvent.builder()
                 .withEventType(EVENT_TYPE)
                 .withData(Collections.singletonMap(MESSAGE_KEY, message))

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/source/RandomStringSource.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/source/RandomStringSource.java
@@ -15,7 +15,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -28,8 +27,6 @@ import java.util.concurrent.TimeoutException;
 @DataPrepperPlugin(name = "random", pluginType = Source.class)
 public class RandomStringSource implements Source<Record<Event>> {
 
-    static final String MESSAGE_KEY = "message";
-    static final String EVENT_TYPE = "event";
     private static final Logger LOG = LoggerFactory.getLogger(RandomStringSource.class);
 
     private ExecutorService executorService;
@@ -76,12 +73,7 @@ public class RandomStringSource implements Source<Record<Event>> {
     }
 
     private Record<Event> generateRandomStringEventRecord() {
-        final Map<String, String> structuredLine = Map.of(MESSAGE_KEY, UUID.randomUUID().toString());
-        final Event event = JacksonEvent
-                .builder()
-                .withEventType(EVENT_TYPE)
-                .withData(structuredLine)
-                .build();
+        final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
         return new Record<>(event);
     }
 }

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/source/StdInSource.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/source/StdInSource.java
@@ -15,7 +15,6 @@ import com.amazon.dataprepper.model.source.Source;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
 import java.util.Scanner;
 import java.util.concurrent.TimeoutException;
 
@@ -28,8 +27,6 @@ import static java.lang.String.format;
  */
 @DataPrepperPlugin(name = "stdin", pluginType = Source.class)
 public class StdInSource implements Source<Record<Event>> {
-    static final String MESSAGE_KEY = "message";
-    static final String EVENT_TYPE = "event";
     private static final Logger LOG = LoggerFactory.getLogger(StdInSource.class);
     private static final String ATTRIBUTE_TIMEOUT = "write_timeout";
     private static final int WRITE_TIMEOUT = 5_000;
@@ -82,11 +79,7 @@ public class StdInSource implements Source<Record<Event>> {
     }
 
     private Record<Event> convertLineIntoEventRecord(final String line) {
-        final Map<String, String> structuredLine = Map.of(MESSAGE_KEY, line);
-        return new Record<>(JacksonEvent
-                .builder()
-                .withEventType(EVENT_TYPE)
-                .withData(structuredLine)
-                .build());
+        final Event event = JacksonEvent.fromMessage(line);
+        return new Record<>(event);
     }
 }

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/source/StdInSourceTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/source/StdInSourceTests.java
@@ -22,7 +22,6 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 
-import static com.amazon.dataprepper.plugins.source.StdInSource.MESSAGE_KEY;
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -105,7 +104,7 @@ public class StdInSourceTests {
         final Collection<Record<Event>> recordsFromBuffer = readResult.getKey();
         assertThat(recordsFromBuffer.size(), is(equalTo(1)));
         recordsFromBuffer.forEach(actualRecord -> assertThat(
-                actualRecord.getData().get(MESSAGE_KEY, String.class), is(equalTo(READ_CONTENT))));
+                actualRecord.getData().get("message", String.class), is(equalTo(READ_CONTENT))));
     }
 
     @Test


### PR DESCRIPTION
### Description
* Changes access modifier of `fromMessage` API to public to leverage in `Sources`
* Updates usage in `RandomStringSource` and `StdInSource`
 
### Issues Resolved
Resolves #646 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
