### PR TITLE
Added ErrorListener

### DIFF
--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/ErrorListener.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/ErrorListener.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression.util;
+
+import org.antlr.v4.runtime.ANTLRErrorListener;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.atn.ATNConfigSet;
+import org.antlr.v4.runtime.dfa.DFA;
+import org.antlr.v4.runtime.tree.ErrorNode;
+import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionBaseListener;
+
+import java.util.BitSet;
+
+/**
+ * ErrorListener implements all ANTLR listeners to track if any error event occurred during any phase of parsing
+ */
+public class ErrorListener extends DataPrepperExpressionBaseListener implements ANTLRErrorListener {
+    private boolean errorFound = false;
+    private boolean warningFound = false;
+
+    public boolean isErrorFound() {
+        return errorFound;
+    }
+
+    public boolean isWarningFound() {
+        return warningFound;
+    }
+
+    @Override
+    public void syntaxError(
+            final Recognizer<?, ?> recognizer,
+            final Object offendingSymbol,
+            final int line,
+            final int charPositionInLine,
+            final String msg,
+            final RecognitionException e
+    ) {
+        errorFound = true;
+    }
+
+    @Override
+    public void reportAmbiguity(
+            final Parser recognizer,
+            final DFA dfa,
+            final int startIndex,
+            final int stopIndex,
+            final boolean exact,
+            final BitSet ambigAlts,
+            final ATNConfigSet configs
+    ) {
+        warningFound = true;
+    }
+
+    @Override
+    public void reportAttemptingFullContext(
+            final Parser recognizer,
+            final DFA dfa,
+            final int startIndex,
+            final int stopIndex,
+            final BitSet conflictingAlts,
+            final ATNConfigSet configs
+    ) {
+        warningFound = true;
+    }
+
+    @Override
+    public void reportContextSensitivity(
+            final Parser recognizer,
+            final DFA dfa,
+            final int startIndex,
+            final int stopIndex,
+            final int prediction,
+            final ATNConfigSet configs
+    ) {
+        warningFound = true;
+    }
+
+    @Override
+    public void visitErrorNode(final ErrorNode node) {
+        super.visitErrorNode(node);
+        errorFound = true;
+    }
+
+    @Override
+    public void enterEveryRule(final ParserRuleContext ctx) {
+        super.enterEveryRule(ctx);
+        if (ctx.exception != null) {
+            errorFound = true;
+        }
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/ErrorListenerTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/ErrorListenerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression.util;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ErrorListenerTest {
+    private ErrorListener errorListener;
+
+    @BeforeEach
+    void beforeEach() {
+        errorListener = new ErrorListener();
+    }
+
+    @Test
+    void testSyntaxError() {
+        errorListener.syntaxError(null, null, 0, 0, null, null);
+        assertThat(errorListener.isWarningFound(), is(false));
+        assertThat(errorListener.isErrorFound(), is(true));
+    }
+
+    @Test
+    void testReportAmbiguity() {
+        errorListener.reportAmbiguity(null, null, 0, 0, false, null, null);
+        assertThat(errorListener.isWarningFound(), is(true));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+
+    @Test
+    void testReportAttemptingFullContext() {
+        errorListener.reportAttemptingFullContext(null, null, 0, 0, null, null);
+        assertThat(errorListener.isWarningFound(), is(true));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+
+    @Test
+    void testReportContextSensitivity() {
+        errorListener.reportContextSensitivity(null, null, 0, 0, 0, null);
+        assertThat(errorListener.isWarningFound(), is(true));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+
+    @Test
+    void testVisitErrorNode() {
+        errorListener.visitErrorNode(null);
+        assertThat(errorListener.isWarningFound(), is(false));
+        assertThat(errorListener.isErrorFound(), is(true));
+    }
+
+    @Test
+    void testEnterEveryRule() {
+        final ParserRuleContext context = mock(ParserRuleContext.class);
+        context.exception = mock(RecognitionException.class);
+        errorListener.enterEveryRule(context);
+        assertThat(errorListener.isWarningFound(), is(false));
+        assertThat(errorListener.isErrorFound(), is(true));
+    }
+}


### PR DESCRIPTION
Signed-off-by: Steven Bayer <smbayer@amazon.com>

### Description
Added error lsitener, an implementation of ANTLRErrorListener and DataPrepperExpressionListener that tracks if any error events have been published
 
### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
