### PR TITLE
Fix: added missing configuration in kv yaml mapping

### DIFF
--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/kv.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/kv.mapping.yaml
@@ -1,5 +1,6 @@
 pluginName: key_value
 mappedAttributeNames:
+  source: source
   target: destination
   field_split: field_split_characters
   field_split_pattern: field_delimiter_regex

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.conf
@@ -12,6 +12,7 @@ filter {
     }
     drop { }
     kv {
+        source => "message"
         target => "test"
     }
     mutate {

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-opensearch.expected.yaml
@@ -14,6 +14,7 @@ logstash-converted-pipeline:
             - "%{COMBINEDAPACHELOG}"
     - drop_events: {}
     - key_value:
+        source: "message"
         destination: "test"
     - rename_keys:
         entries:


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
Added `source` to mapping file
 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
