### PR TITLE
Added LiteralMatcher

### DIFF
--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/LiteralMatcher.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/LiteralMatcher.java
@@ -15,7 +15,7 @@ import static org.opensearch.dataprepper.expression.util.ContextMatcher.hasConte
 import static org.opensearch.dataprepper.expression.util.TerminalNodeMatcher.isTerminalNode;
 
 public class LiteralMatcher extends SimpleExpressionMatcher {
-    private final Matcher<ParseTree> literalMatcher = hasContext(DataPrepperExpressionParser.LiteralContext.class, isTerminalNode());
+    private static final Matcher<ParseTree> LITERAL_MATCHER = hasContext(DataPrepperExpressionParser.LiteralContext.class, isTerminalNode());
 
     //region valid rule order
     private static final RuleClassOrderedList VALID_LITERAL_RULE_ORDER = new RuleClassOrderedList(
@@ -45,12 +45,13 @@ public class LiteralMatcher extends SimpleExpressionMatcher {
         return new LiteralMatcher(VALID_LITERAL_RULE_ORDER);
     }
 
+    @Override
     protected boolean baseCase(final ParseTree item, final Description mismatchDescription) {
-        if (literalMatcher.matches(item)) {
+        if (LITERAL_MATCHER.matches(item)) {
             return true;
         }
         else {
-            literalMatcher.describeTo(mismatchDescription);
+            LITERAL_MATCHER.describeTo(mismatchDescription);
             mismatchDescription.appendText("\n\t\texpected LiteralContext but found " + item);
             return false;
         }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/LiteralMatcher.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/LiteralMatcher.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression.util;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.hamcrest.Description;
+import org.hamcrest.DiagnosingMatcher;
+import org.hamcrest.Matcher;
+import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
+
+import static org.opensearch.dataprepper.expression.util.ContextMatcher.hasContext;
+import static org.opensearch.dataprepper.expression.util.TerminalNodeMatcher.isTerminalNode;
+
+public class LiteralMatcher extends SimpleExpressionMatcher {
+    private final Matcher<ParseTree> literalMatcher = hasContext(DataPrepperExpressionParser.LiteralContext.class, isTerminalNode());
+
+    //region valid rule order
+    private static final RuleClassOrderedList VALID_LITERAL_RULE_ORDER = new RuleClassOrderedList(
+            DataPrepperExpressionParser.ExpressionContext.class,
+            DataPrepperExpressionParser.ConditionalExpressionContext.class,
+            DataPrepperExpressionParser.EqualityOperatorExpressionContext.class,
+            DataPrepperExpressionParser.RegexOperatorExpressionContext.class,
+            DataPrepperExpressionParser.RelationalOperatorExpressionContext.class,
+            DataPrepperExpressionParser.SetOperatorExpressionContext.class,
+            DataPrepperExpressionParser.UnaryOperatorExpressionContext.class,
+            DataPrepperExpressionParser.PrimaryContext.class,
+            DataPrepperExpressionParser.LiteralContext.class
+    );
+    //endregion
+
+    protected LiteralMatcher(final RuleClassOrderedList validRuleOrder) {
+        super(validRuleOrder);
+    }
+
+    /**
+     * Creates a matcher to check if a nodes is a unary tree with all nodes in a valid order that ends in a terminal node
+     * @return DiagnosingMatcher
+     *
+     * @see TerminalNodeMatcher#isTerminalNode()
+     */
+    public static DiagnosingMatcher<ParseTree> isUnaryTree() {
+        return new LiteralMatcher(VALID_LITERAL_RULE_ORDER);
+    }
+
+    protected boolean baseCase(final ParseTree item, final Description mismatchDescription) {
+        if (literalMatcher.matches(item)) {
+            return true;
+        }
+        else {
+            literalMatcher.describeTo(mismatchDescription);
+            mismatchDescription.appendText("\n\t\texpected LiteralContext but found " + item);
+            return false;
+        }
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendText("Expected LiteralContext");
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/LiteralMatcherTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/LiteralMatcherTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression.util;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.hamcrest.DiagnosingMatcher;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.opensearch.dataprepper.expression.util.LiteralMatcher.isUnaryTree;
+
+class LiteralMatcherTest {
+
+    @Test
+    void baseCase() {
+        final DiagnosingMatcher<ParseTree> isUnaryTree = isUnaryTree();
+        final ParseTree primary = mock(DataPrepperExpressionParser.PrimaryContext.class, "PrimaryContext");
+        final ParseTree literal = mock(DataPrepperExpressionParser.LiteralContext.class, "JsonPointerContext");
+        final ParseTree terminal = mock(TerminalNode.class, "TerminalNode");
+
+        doReturn(1).when(primary).getChildCount();
+        doReturn(1).when(literal).getChildCount();
+        doReturn(literal).when(primary).getChild(eq(0));
+        doReturn(terminal).when(literal).getChild(eq(0));
+
+        assertTrue(isUnaryTree.matches(primary));
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Steven Bayer <smbayer@amazon.com>

### Description
Added LiteralMatcher
 
### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
