### PR TITLE
Added standard duration string deserializer for Data Prepper plugin, refactored the AggregateProcessor group_duration to use this deserializer

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginConfigurationConverter.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginConfigurationConverter.java
@@ -10,10 +10,12 @@ import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 
 import javax.inject.Named;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -28,7 +30,12 @@ class PluginConfigurationConverter {
     private final Validator validator;
 
     PluginConfigurationConverter(final Validator validator) {
-        this.objectMapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+        final SimpleModule simpleModule = new SimpleModule();
+        simpleModule.addDeserializer(Duration.class, new PluginDurationDeserializer());
+
+        this.objectMapper = new ObjectMapper()
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .registerModule(simpleModule);
 
         this.validator = validator;
     }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginDurationDeserializer.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginDurationDeserializer.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
  * Whitespace is ignored and leading zeroes are not allowed.
  * @since 1.3
  */
-public class PluginDurationDeserializer extends StdDeserializer<Duration> {
+class PluginDurationDeserializer extends StdDeserializer<Duration> {
 
     private static final String SIMPLE_DURATION_REGEX = "^([1-9]\\d*)(s|ms)$";
     private static final Pattern SIMPLE_DURATION_PATTERN = Pattern.compile(SIMPLE_DURATION_REGEX);
@@ -39,6 +39,9 @@ public class PluginDurationDeserializer extends StdDeserializer<Duration> {
             duration = Duration.parse(durationString);
         } catch (final DateTimeParseException e) {
             duration = parseSimpleDuration(durationString);
+            if (duration == null) {
+                throw new IllegalArgumentException("Durations must use either ISO 8601 notation or simple notations for seconds (60s) or milliseconds (100ms). Whitespace is ignored.");
+            }
         }
 
         return duration;
@@ -48,7 +51,7 @@ public class PluginDurationDeserializer extends StdDeserializer<Duration> {
         final String durationStringNoSpaces = durationString.replaceAll("\\s", "");
         final Matcher matcher = SIMPLE_DURATION_PATTERN.matcher(durationStringNoSpaces);
         if (!matcher.find()) {
-            throw new IllegalArgumentException("Durations must use either ISO 8601 notation or simple notations for seconds (60s) or milliseconds (100ms). Whitespace is ignored.");
+           return null;
         }
 
         final long durationNumber = Long.parseLong(matcher.group(1));
@@ -64,6 +67,6 @@ public class PluginDurationDeserializer extends StdDeserializer<Duration> {
             case "ms":
                 return Duration.ofMillis(durationNumber);
         }
-        throw new IllegalArgumentException("Simple notation duration only supports seconds (s) and milliseconds (ms).");
+        return null;
     }
 }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginDurationDeserializer.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginDurationDeserializer.java
@@ -1,0 +1,69 @@
+package com.amazon.dataprepper.plugin;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This deserializer is used for all plugin configurations that use a {@link Duration} type that is mapped to by Jackson in the {@link PluginConfigurationConverter}.
+ * It supports ISO 8601 notation ("PT20.345S", "PT15M", etc.) and simple durations for
+ * seconds (60s) and milliseconds (100ms). It does not support combining the units for simple durations ("60s 100ms" is not allowed).
+ * Whitespace is ignored and leading zeroes are not allowed.
+ * @since 1.3
+ */
+public class PluginDurationDeserializer extends StdDeserializer<Duration> {
+
+    private static final String SIMPLE_DURATION_REGEX = "^([1-9]\\d*)(s|ms)$";
+    private static final Pattern SIMPLE_DURATION_PATTERN = Pattern.compile(SIMPLE_DURATION_REGEX);
+
+    public PluginDurationDeserializer() {
+        this(null);
+    }
+    protected PluginDurationDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public Duration deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        final String durationString = p.getValueAsString();
+
+        Duration duration;
+
+        try {
+            duration = Duration.parse(durationString);
+        } catch (final DateTimeParseException e) {
+            duration = parseSimpleDuration(durationString);
+        }
+
+        return duration;
+    }
+
+    private Duration parseSimpleDuration(final String durationString) throws IllegalArgumentException {
+        final String durationStringNoSpaces = durationString.replaceAll("\\s", "");
+        final Matcher matcher = SIMPLE_DURATION_PATTERN.matcher(durationStringNoSpaces);
+        if (!matcher.find()) {
+            throw new IllegalArgumentException("Durations must use either ISO 8601 notation or simple notations for seconds (60s) or milliseconds (100ms). Whitespace is ignored.");
+        }
+
+        final long durationNumber = Long.parseLong(matcher.group(1));
+        final String durationUnit = matcher.group(2);
+
+        return getDurationFromUnitAndNumber(durationNumber, durationUnit);
+    }
+
+    private Duration getDurationFromUnitAndNumber(final long durationNumber, final String durationUnit) {
+        switch (durationUnit) {
+            case "s":
+                return Duration.ofSeconds(durationNumber);
+            case "ms":
+                return Duration.ofMillis(durationNumber);
+        }
+        throw new IllegalArgumentException("Simple notation duration only supports seconds (s) and milliseconds (ms).");
+    }
+}

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginDurationDeserializerTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginDurationDeserializerTest.java
@@ -1,0 +1,56 @@
+package com.amazon.dataprepper.plugin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PluginDurationDeserializerTest {
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setup() {
+        final SimpleModule simpleModule = new SimpleModule();
+        simpleModule.addDeserializer(Duration.class, new PluginDurationDeserializer());
+
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(simpleModule);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"6s1s", "60ms 100s", "20.345s", "0s", "-1s", "06s", "100m", "100sm", "100"})
+    void invalidDurationStringsThrowIllegalArgumentException(String durationString) {
+        assertThrows(IllegalArgumentException.class, () -> objectMapper.convertValue(durationString, Duration.class));
+    }
+
+    @Test
+    void ISO_8601_duration_string_returns_correct_duration() {
+        final String durationString = "PT15M";
+        final Duration result = objectMapper.convertValue(durationString, Duration.class);
+        assertThat(result, equalTo(Duration.ofMinutes(15)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"60s", "60000ms", "60 s", "60000 ms", "  60  s "})
+    void simple_duration_strings_of_60_seconds_return_correct_duration(String durationString) {
+        final Duration result = objectMapper.convertValue(durationString, Duration.class);
+
+        assertThat(result, equalTo(Duration.ofSeconds(60)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"5s", "5000ms", "5 s", "5000 ms", "  5  s "})
+    void simple_duration_strings_of_5_seconds_return_correct_duration(String durationString) {
+        final Duration result = objectMapper.convertValue(durationString, Duration.class);
+
+        assertThat(result, equalTo(Duration.ofSeconds(5)));
+    }
+}

--- a/data-prepper-plugins/aggregate-processor/README.md
+++ b/data-prepper-plugins/aggregate-processor/README.md
@@ -39,7 +39,7 @@ While not necessary, a great way to set up the Aggregate Processor [identificati
     * [remove_duplicates](#remove_duplicates)
     * [put_all](#put_all)
 ### <a name="group_duration"></a>
-* `group_duration` (Optional): The amount of time, in seconds, that a group should exist before it is concluded automatically. Default value is `180`.
+* `group_duration` (Optional): A `String` that represents the amount of time that a group should exist before it is concluded automatically. Supports ISO_8601 notation Strings ("PT20.345S", "PT15M", etc.) as well as simple notation Strings for seconds ("60s") and milliseconds ("1500ms"). Default value is `180s`.
 
 ## Available Aggregate Actions
 

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
@@ -18,8 +18,8 @@ class AggregateGroupManager {
     private final Map<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> allGroups = Maps.newConcurrentMap();
     private final Duration groupDuration;
 
-    AggregateGroupManager(final int groupDuration) {
-        this.groupDuration = Duration.ofSeconds(groupDuration);
+    AggregateGroupManager(final Duration groupDuration) {
+        this.groupDuration = groupDuration;
     }
 
     AggregateGroup getAggregateGroup(final AggregateIdentificationKeysHasher.IdentificationHash identificationHash) {

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
@@ -7,23 +7,22 @@ package com.amazon.dataprepper.plugins.processor.aggregate;
 
 import com.amazon.dataprepper.model.configuration.PluginModel;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.Duration;
 import java.util.List;
 
 public class AggregateProcessorConfig {
 
-    static int DEFAULT_GROUP_DURATION = 180;
+    static int DEFAULT_GROUP_DURATION_SECONDS = 180;
 
     @JsonProperty("identification_keys")
     @NotEmpty
     private List<String> identificationKeys;
 
     @JsonProperty("group_duration")
-    @Min(0)
-    private int groupDuration = DEFAULT_GROUP_DURATION;
+    private Duration groupDuration = Duration.ofSeconds(DEFAULT_GROUP_DURATION_SECONDS);
 
     @JsonProperty("action")
     @NotNull
@@ -33,7 +32,7 @@ public class AggregateProcessorConfig {
         return identificationKeys;
     }
 
-    public int getGroupDuration() {
+    public Duration getGroupDuration() {
         return groupDuration;
     }
 

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
@@ -8,6 +8,7 @@ package com.amazon.dataprepper.plugins.processor.aggregate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,7 +31,7 @@ public class AggregateGroupManagerTest {
 
     private AggregateIdentificationKeysHasher.IdentificationHash identificationHash;
 
-    private static final int TEST_GROUP_DURATION = new Random().nextInt(10) + 10;
+    private static final Duration TEST_GROUP_DURATION = Duration.ofSeconds(new Random().nextInt(10) + 10);
 
     @BeforeEach
     void setup() {
@@ -92,11 +93,11 @@ public class AggregateGroupManagerTest {
 
         final AggregateGroup groupToConclude = mock(AggregateGroup.class);
         final AggregateIdentificationKeysHasher.IdentificationHash hashForGroupToConclude = mock(AggregateIdentificationKeysHasher.IdentificationHash.class);
-        when(groupToConclude.getGroupStart()).thenReturn(Instant.now().minusSeconds(TEST_GROUP_DURATION));
+        when(groupToConclude.getGroupStart()).thenReturn(Instant.now().minusSeconds(TEST_GROUP_DURATION.getSeconds()));
 
         final AggregateGroup groupToNotConclude = mock(AggregateGroup.class);
         final AggregateIdentificationKeysHasher.IdentificationHash hashForGroupToNotConclude = mock(AggregateIdentificationKeysHasher.IdentificationHash.class);
-        when(groupToNotConclude.getGroupStart()).thenReturn(Instant.now().plusSeconds(TEST_GROUP_DURATION));
+        when(groupToNotConclude.getGroupStart()).thenReturn(Instant.now().plusSeconds(TEST_GROUP_DURATION.getSeconds()));
 
         aggregateGroupManager.putGroupWithHash(hashForGroupToConclude, groupToConclude);
         aggregateGroupManager.putGroupWithHash(hashForGroupToNotConclude, groupToNotConclude);

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorConfigTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorConfigTest.java
@@ -7,6 +7,8 @@ package com.amazon.dataprepper.plugins.processor.aggregate;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -15,6 +17,6 @@ public class AggregateProcessorConfigTest {
     public void testDefault() {
         final AggregateProcessorConfig aggregateConfig = new AggregateProcessorConfig();
 
-        assertThat(aggregateConfig.getGroupDuration(), equalTo(AggregateProcessorConfig.DEFAULT_GROUP_DURATION));
+        assertThat(aggregateConfig.getGroupDuration(), equalTo(Duration.ofSeconds(AggregateProcessorConfig.DEFAULT_GROUP_DURATION_SECONDS)));
     }
 }


### PR DESCRIPTION
Signed-off-by: graytaylor0 <tylgry@amazon.com>

### Description
* A Duration deserializer has been added to the `PluginConfigurationConverter` `ObjectMapper`. 
* This deserializer supports strings in ISO_8601 notation, as well as a simple notation for durations with seconds or milliseconds
* The `group_duration` option in the `AggregateProcessor` now uses this deserializer.
 
### Issues Resolved
closes #1079 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
