### PR TITLE
Support default values for attributes

### DIFF
--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapper.java
@@ -33,6 +33,7 @@ public abstract class AbstractLogstashPluginAttributesMapper implements Logstash
         Objects.requireNonNull(logstashAttributesMappings);
         Objects.requireNonNull(logstashAttributesMappings.getMappedAttributeNames());
         Objects.requireNonNull(logstashAttributesMappings.getAdditionalAttributes());
+        Objects.requireNonNull(logstashAttributesMappings.getDefaultSettings());
 
         final Map<String, Object> pluginSettings = new LinkedHashMap<>(logstashAttributesMappings.getAdditionalAttributes());
         final Map<String, String> mappedAttributeNames = logstashAttributesMappings.getMappedAttributeNames();

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapper.java
@@ -11,12 +11,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
-import java.util.Objects;
 import java.util.List;
 import java.util.Map;
-import java.util.LinkedHashMap;
-import java.util.HashSet;
+import java.util.Objects;
 
 /**
  * An abstract class which is responsible for mapping basic attributes
@@ -37,6 +37,7 @@ public abstract class AbstractLogstashPluginAttributesMapper implements Logstash
 
         final Map<String, Object> pluginSettings = new LinkedHashMap<>(logstashAttributesMappings.getAdditionalAttributes());
         final Map<String, String> mappedAttributeNames = logstashAttributesMappings.getMappedAttributeNames();
+        final Map<String, Object> defaultSettings = logstashAttributesMappings.getDefaultSettings();
 
         Collection<String> customMappedAttributeNames = getCustomMappedAttributeNames();
 
@@ -53,6 +54,9 @@ public abstract class AbstractLogstashPluginAttributesMapper implements Logstash
                                     dataPrepperAttributeName.substring(1), !(Boolean) logstashAttribute.getAttributeValue().getValue()
                             );
                         }
+                        else if(defaultSettings.containsKey(logstashAttributeName)) {
+                            pluginSettings.put(dataPrepperAttributeName, defaultSettings.get(dataPrepperAttributeName));
+                        }
                         else {
                             pluginSettings.put(dataPrepperAttributeName, logstashAttribute.getAttributeValue().getValue());
                         }
@@ -60,7 +64,7 @@ public abstract class AbstractLogstashPluginAttributesMapper implements Logstash
                     else {
                         LOG.warn("Attribute name {} is not found in mapping file.", logstashAttributeName);
                     }
-        });
+                });
 
         if (!customMappedAttributeNames.isEmpty()) {
             mapCustomAttributes(logstashAttributes, logstashAttributesMappings, pluginSettings);
@@ -75,10 +79,9 @@ public abstract class AbstractLogstashPluginAttributesMapper implements Logstash
     /**
      * Map custom logstashAttributes from a Logstash plugin.
      *
-     * @param logstashAttributes All the Logstash logstashAttributes for the plugin
+     * @param logstashAttributes         All the Logstash logstashAttributes for the plugin
      * @param logstashAttributesMappings The mappings for this Logstash plugin
-     * @param pluginSettings A map of Data Prepper basic plugin settings.
-     *
+     * @param pluginSettings             A map of Data Prepper basic plugin settings.
      * @since 1.2
      */
     protected abstract void mapCustomAttributes(List<LogstashAttribute> logstashAttributes, LogstashAttributesMappings logstashAttributesMappings, Map<String, Object> pluginSettings);

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapper.java
@@ -54,9 +54,6 @@ public abstract class AbstractLogstashPluginAttributesMapper implements Logstash
                                     dataPrepperAttributeName.substring(1), !(Boolean) logstashAttribute.getAttributeValue().getValue()
                             );
                         }
-                        else if(defaultSettings.containsKey(logstashAttributeName)) {
-                            pluginSettings.put(dataPrepperAttributeName, defaultSettings.get(dataPrepperAttributeName));
-                        }
                         else {
                             pluginSettings.put(dataPrepperAttributeName, logstashAttribute.getAttributeValue().getValue());
                         }
@@ -65,6 +62,12 @@ public abstract class AbstractLogstashPluginAttributesMapper implements Logstash
                         LOG.warn("Attribute name {} is not found in mapping file.", logstashAttributeName);
                     }
                 });
+
+        for(Map.Entry<String, Object> defaultSetting: defaultSettings.entrySet()) {
+            if(!pluginSettings.containsKey(defaultSetting.getKey())) {
+                pluginSettings.put(defaultSetting.getKey(), defaultSetting.getValue());
+            }
+        }
 
         if (!customMappedAttributeNames.isEmpty()) {
             mapCustomAttributes(logstashAttributes, logstashAttributesMappings, pluginSettings);

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashAttributesMappings.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashAttributesMappings.java
@@ -42,4 +42,14 @@ public interface LogstashAttributesMappings {
      * @since 1.3
      */
     String getPluginName();
+
+    /**
+     * A map of default settings of Data Prepper attributes.
+     * <p>
+     * This should not return null and should return empty if not defined.
+     *
+     * @return A Map
+     * @since 1.3
+     */
+    Map<String, Object> getDefaultSettings();
 }

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashMappingModel.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashMappingModel.java
@@ -36,6 +36,10 @@ class LogstashMappingModel implements LogstashAttributesMappings {
     @JsonSetter(nulls = Nulls.AS_EMPTY)
     private Map<String, Object> additionalAttributes = new HashMap<>();
 
+    @JsonProperty
+    @JsonSetter
+    private Map<String, Object> defaultSettings = new HashMap<>();
+
     public String getPluginName() {
         return pluginName;
     }
@@ -55,4 +59,6 @@ class LogstashMappingModel implements LogstashAttributesMappings {
     public String getCustomPluginMapperClass() {
         return customPluginMapperClass;
     }
+
+    public Map<String, Object> getDefaultSettings() { return defaultSettings; }
 }

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashMappingModel.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashMappingModel.java
@@ -37,7 +37,7 @@ class LogstashMappingModel implements LogstashAttributesMappings {
     private Map<String, Object> additionalAttributes = new HashMap<>();
 
     @JsonProperty
-    @JsonSetter
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     private Map<String, Object> defaultSettings = new HashMap<>();
 
     public String getPluginName() {
@@ -60,5 +60,7 @@ class LogstashMappingModel implements LogstashAttributesMappings {
         return customPluginMapperClass;
     }
 
-    public Map<String, Object> getDefaultSettings() { return defaultSettings; }
+    public Map<String, Object> getDefaultSettings() {
+        return defaultSettings;
+    }
 }

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapper.java
@@ -31,16 +31,12 @@ class OpenSearchPluginAttributesMapper extends AbstractLogstashPluginAttributesM
     @Override
     protected void mapCustomAttributes(final List<LogstashAttribute> logstashAttributes, final LogstashAttributesMappings logstashAttributesMappings, final Map<String, Object> pluginSettings) {
 
-        Optional<String> convertedIndexAttributeValue = logstashAttributes.stream()
+        final Optional<String> convertedIndexAttributeValue = logstashAttributes.stream()
                 .filter(a -> a.getAttributeName().equals(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME))
                 .map(this::findAndMatchDateTimePattern)
                 .findFirst();
 
-        if (convertedIndexAttributeValue.isPresent()) {
-            pluginSettings.put(logstashAttributesMappings.getMappedAttributeNames().get(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME), convertedIndexAttributeValue.get());
-        } else {
-            pluginSettings.put(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME, logstashAttributesMappings.getDefaultSettings().get(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME));
-        }
+        convertedIndexAttributeValue.ifPresent(s -> pluginSettings.put(logstashAttributesMappings.getMappedAttributeNames().get(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME), s));
     }
 
     @Override

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapper.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -30,14 +31,16 @@ class OpenSearchPluginAttributesMapper extends AbstractLogstashPluginAttributesM
     @Override
     protected void mapCustomAttributes(final List<LogstashAttribute> logstashAttributes, final LogstashAttributesMappings logstashAttributesMappings, final Map<String, Object> pluginSettings) {
 
-        logstashAttributes.stream()
+        Optional<String> convertedIndexAttributeValue = logstashAttributes.stream()
                 .filter(a -> a.getAttributeName().equals(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME))
-                .map(logstashIndexAttribute -> findAndMatchDateTimePattern(logstashIndexAttribute))
-                .findFirst()
-                .ifPresent(convertedIndexAttributeValue -> {
-                    pluginSettings.put(logstashAttributesMappings.getMappedAttributeNames().get(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME),
-                            convertedIndexAttributeValue);
-                });
+                .map(this::findAndMatchDateTimePattern)
+                .findFirst();
+
+        if (convertedIndexAttributeValue.isPresent()) {
+            pluginSettings.put(logstashAttributesMappings.getMappedAttributeNames().get(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME), convertedIndexAttributeValue.get());
+        } else {
+            pluginSettings.put(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME, logstashAttributesMappings.getDefaultSettings().get(LOGSTASH_OPENSEARCH_INDEX_ATTRIBUTE_NAME));
+        }
     }
 
     @Override

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/amazon_es.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/amazon_es.mapping.yaml
@@ -7,3 +7,5 @@ mappedAttributeNames:
 additionalAttributes:
   aws_sigv4: true
   insecure: false
+defaultSettings:
+  index: "logstash-%{yyyy.MM.dd}"

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/elasticsearch.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/elasticsearch.mapping.yaml
@@ -7,3 +7,5 @@ mappedAttributeNames:
   password: password
   index: index
   proxy: proxy
+defaultSettings:
+  index: "logstash-%{uuuu.MM.dd}"

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/opensearch.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/opensearch.mapping.yaml
@@ -6,3 +6,5 @@ mappedAttributeNames:
   password: password
   index: index
   ssl_certificate_verification: "!insecure"
+defaultSettings:
+  index: "logstash-%{uuuu.MM.dd}"

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapperTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
+import org.opensearch.dataprepper.logstash.model.LogstashAttributeValue;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -19,7 +20,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -42,42 +47,111 @@ class AbstractLogstashPluginAttributesMapperTest {
         defaultSettings = mappings.getDefaultSettings();
     }
 
+
+    private AbstractLogstashPluginAttributesMapper createObjectUnderTest() {
+        return Mockito.spy(AbstractLogstashPluginAttributesMapper.class);
+    }
+
     @Test
     void mapAttributes_with_no_custom_attributes_does_not_invoke_mapCustomAttributes_Test() {
-        AbstractLogstashPluginAttributesMapper abstractLogstashPluginAttributesMapper = Mockito
-                .spy(AbstractLogstashPluginAttributesMapper.class);
+        final AbstractLogstashPluginAttributesMapper objectUnderTest = createObjectUnderTest();
 
-        when(abstractLogstashPluginAttributesMapper.getCustomMappedAttributeNames()).thenReturn(new HashSet<>());
+        when(objectUnderTest.getCustomMappedAttributeNames()).thenReturn(new HashSet<>());
 
-        List<PluginModel> pluginModels = abstractLogstashPluginAttributesMapper.mapAttributes(logstashAttributes, mappings);
-        verify(abstractLogstashPluginAttributesMapper, never()).mapCustomAttributes(
+        List<PluginModel> pluginModels = objectUnderTest.mapAttributes(logstashAttributes, mappings);
+        verify(objectUnderTest, never()).mapCustomAttributes(
                 logstashAttributes, mappings, pluginModels.get(0).getPluginSettings());
     }
 
     @Test
     void mapAttributes_with_custom_attributes_invokes_mapCustomAttributes_Test() {
-        AbstractLogstashPluginAttributesMapper abstractLogstashPluginAttributesMapper = Mockito
-                .spy(AbstractLogstashPluginAttributesMapper.class);
+        final AbstractLogstashPluginAttributesMapper objectUnderTest = createObjectUnderTest();
 
-        when(abstractLogstashPluginAttributesMapper.getCustomMappedAttributeNames())
+        when(objectUnderTest.getCustomMappedAttributeNames())
                 .thenReturn(new HashSet<>(Collections.singletonList("customAttribute")));
 
-        List<PluginModel> pluginModels = abstractLogstashPluginAttributesMapper.mapAttributes(logstashAttributes, mappings);
-        verify(abstractLogstashPluginAttributesMapper).mapCustomAttributes(logstashAttributes, mappings, pluginModels.get(0).getPluginSettings());
+        List<PluginModel> pluginModels = objectUnderTest.mapAttributes(logstashAttributes, mappings);
+        verify(objectUnderTest).mapCustomAttributes(logstashAttributes, mappings, pluginModels.get(0).getPluginSettings());
     }
 
     @Test
-    void mapAttributes_with_default_settings_Test() {
-        AbstractLogstashPluginAttributesMapper abstractLogstashPluginAttributesMapper = Mockito
-                .spy(AbstractLogstashPluginAttributesMapper.class);
+    void mapAttributes_with_defaults_should_set_the_default_when_it_is_not_in_the_actual_attributes() {
+        final AbstractLogstashPluginAttributesMapper objectUnderTest = createObjectUnderTest();
         final String defaultSettingAttributeName = UUID.randomUUID().toString();
         final String defaultSettingAttributeValue = UUID.randomUUID().toString();
         when(mappings.getDefaultSettings()).thenReturn(Collections.singletonMap(defaultSettingAttributeName, defaultSettingAttributeValue));
+        when(mappings.getMappedAttributeNames()).thenReturn(Collections.singletonMap(defaultSettingAttributeName, defaultSettingAttributeName));
 
-        List<PluginModel> pluginModels = abstractLogstashPluginAttributesMapper.mapAttributes(Collections.emptyList(), mappings);
+        List<PluginModel> pluginModels = objectUnderTest.mapAttributes(Collections.emptyList(), mappings);
 
         assertThat(pluginModels, Matchers.notNullValue());
         assertThat(pluginModels.size(), Matchers.equalTo(1));
-        assertThat(pluginModels.get(0), Matchers.notNullValue());
+        final PluginModel actualPluginModel = pluginModels.get(0);
+        assertThat(actualPluginModel, Matchers.notNullValue());
+
+        assertThat(actualPluginModel.getPluginSettings(), Matchers.notNullValue());
+        assertThat(actualPluginModel.getPluginSettings(), hasKey(defaultSettingAttributeName));
+        assertThat(actualPluginModel.getPluginSettings().get(defaultSettingAttributeName), equalTo(defaultSettingAttributeValue));
     }
+
+    @Test
+    void mapAttributes_with_defaults_should_use_the_actual_value_from_the_attribute_when_it_is_present() {
+        final String defaultSettingName = UUID.randomUUID().toString();
+        final String defaultSettingValue = UUID.randomUUID().toString();
+        final String attributeValue = UUID.randomUUID().toString();
+
+        when(mappings.getDefaultSettings()).thenReturn(Collections.singletonMap(defaultSettingName, defaultSettingValue));
+        when(mappings.getMappedAttributeNames()).thenReturn(Collections.singletonMap(defaultSettingName, defaultSettingName));
+
+        final LogstashAttribute logstashAttribute = mock(LogstashAttribute.class);
+        when(logstashAttribute.getAttributeName()).thenReturn(defaultSettingName);
+        final LogstashAttributeValue logstashAttributeValue = mock(LogstashAttributeValue.class);
+        when(logstashAttribute.getAttributeValue()).thenReturn(logstashAttributeValue);
+        when(logstashAttributeValue.getValue()).thenReturn(attributeValue);
+
+        final List<LogstashAttribute> logstashAttributes = Collections.singletonList(logstashAttribute);
+
+        final List<PluginModel> pluginModels = createObjectUnderTest().mapAttributes(logstashAttributes, mappings);
+
+        assertThat(pluginModels, notNullValue());
+        assertThat(pluginModels.size(), equalTo(1));
+        final PluginModel actualPluginModel = pluginModels.get(0);
+        assertThat(actualPluginModel, notNullValue());
+
+        assertThat(actualPluginModel.getPluginSettings(), notNullValue());
+        assertThat(actualPluginModel.getPluginSettings(), hasKey(defaultSettingName));
+        assertThat(actualPluginModel.getPluginSettings().get(defaultSettingName), equalTo(attributeValue));
+    }
+
+    @Test
+    void mapAttributes_with_defaults_should_set_the_default_attribute_name_when_different_from_logstash_attribute_name() {
+        final String defaultSettingName = UUID.randomUUID().toString();
+        final String defaultSettingValue = UUID.randomUUID().toString();
+        final String attributeName = UUID.randomUUID().toString();
+        final String attributeValue = UUID.randomUUID().toString();
+
+        when(mappings.getDefaultSettings()).thenReturn(Collections.singletonMap(defaultSettingName, defaultSettingValue));
+        when(mappings.getMappedAttributeNames()).thenReturn(Collections.singletonMap(attributeName, defaultSettingName));
+
+        final LogstashAttribute logstashAttribute = mock(LogstashAttribute.class);
+        when(logstashAttribute.getAttributeName()).thenReturn(attributeName);
+        final LogstashAttributeValue logstashAttributeValue = mock(LogstashAttributeValue.class);
+        when(logstashAttribute.getAttributeValue()).thenReturn(logstashAttributeValue);
+        when(logstashAttributeValue.getValue()).thenReturn(attributeValue);
+
+        final List<LogstashAttribute> logstashAttributes = Collections.singletonList(logstashAttribute);
+
+        final List<PluginModel> pluginModels = createObjectUnderTest().mapAttributes(logstashAttributes, mappings);
+
+        assertThat(pluginModels, notNullValue());
+        assertThat(pluginModels.size(), equalTo(1));
+        final PluginModel actualPluginModel = pluginModels.get(0);
+        assertThat(actualPluginModel, notNullValue());
+
+        assertThat(actualPluginModel.getPluginSettings(), notNullValue());
+        assertThat(actualPluginModel.getPluginSettings(), hasKey(defaultSettingName));
+        assertThat(actualPluginModel.getPluginSettings(), not(hasKey(attributeName)));
+        assertThat(actualPluginModel.getPluginSettings().get(defaultSettingName), equalTo(attributeValue));
+    }
+
 }

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapperTest.java
@@ -6,27 +6,31 @@
 package org.opensearch.dataprepper.logstash.mapping;
 
 import com.amazon.dataprepper.model.configuration.PluginModel;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.LinkedHashMap;
-import java.util.HashSet;
+import java.util.UUID;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class AbstractLogstashPluginAttributesMapperTest {
 
     private List<LogstashAttribute> logstashAttributes;
     private LogstashAttributesMappings mappings;
     private Map<String, Object> pluginSettings;
+    private Map<String, Object> defaultSettings;
 
     @BeforeEach
     void setUp() {
@@ -35,6 +39,7 @@ class AbstractLogstashPluginAttributesMapperTest {
         logstashAttributes = Collections.singletonList(logstashAttribute);
         mappings = mock(LogstashAttributesMappings.class);
         pluginSettings = new LinkedHashMap<>(mappings.getAdditionalAttributes());
+        defaultSettings = mappings.getDefaultSettings();
     }
 
     @Test
@@ -49,7 +54,6 @@ class AbstractLogstashPluginAttributesMapperTest {
                 logstashAttributes, mappings, pluginModels.get(0).getPluginSettings());
     }
 
-
     @Test
     void mapAttributes_with_custom_attributes_invokes_mapCustomAttributes_Test() {
         AbstractLogstashPluginAttributesMapper abstractLogstashPluginAttributesMapper = Mockito
@@ -62,4 +66,18 @@ class AbstractLogstashPluginAttributesMapperTest {
         verify(abstractLogstashPluginAttributesMapper).mapCustomAttributes(logstashAttributes, mappings, pluginModels.get(0).getPluginSettings());
     }
 
+    @Test
+    void mapAttributes_with_default_settings_Test() {
+        AbstractLogstashPluginAttributesMapper abstractLogstashPluginAttributesMapper = Mockito
+                .spy(AbstractLogstashPluginAttributesMapper.class);
+        final String defaultSettingAttributeName = UUID.randomUUID().toString();
+        final String defaultSettingAttributeValue = UUID.randomUUID().toString();
+        when(mappings.getDefaultSettings()).thenReturn(Collections.singletonMap(defaultSettingAttributeName, defaultSettingAttributeValue));
+
+        List<PluginModel> pluginModels = abstractLogstashPluginAttributesMapper.mapAttributes(Collections.emptyList(), mappings);
+
+        assertThat(pluginModels, Matchers.notNullValue());
+        assertThat(pluginModels.size(), Matchers.equalTo(1));
+        assertThat(pluginModels.get(0), Matchers.notNullValue());
+    }
 }

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
@@ -7,7 +7,6 @@ package org.opensearch.dataprepper.logstash.mapping;
 
 import com.amazon.dataprepper.model.configuration.PluginModel;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -35,23 +34,6 @@ class OpenSearchPluginAttributesMapperTest {
 
     private OpenSearchPluginAttributesMapper createObjectUnderTest() {
         return new OpenSearchPluginAttributesMapper();
-    }
-
-    @Test
-    void convert_no_explicit_indexAttribute_to_return_indexAttribute_with_defaultSettings() {
-
-        final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
-        when(logstashAttributesMappings.getDefaultSettings()).thenReturn(Collections.singletonMap("index", "logstash-%{uuuu.MM.dd}"));
-
-        final List<PluginModel> actualPluginModel = createObjectUnderTest()
-                .mapAttributes(Collections.emptyList(), logstashAttributesMappings);
-
-        assertThat(actualPluginModel, Matchers.notNullValue());
-        assertThat(actualPluginModel.size(), Matchers.equalTo(1));
-        assertThat(actualPluginModel.get(0), Matchers.notNullValue());
-
-        assertThat(actualPluginModel.get(0).getPluginSettings().size(), equalTo(0));
-        assertThat(actualPluginModel.get(0).getPluginSettings(), (hasKey(DATA_PREPPER_OPENSEARCH_INDEX_ATTRIBUTE)));
     }
 
     @ParameterizedTest

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.logstash.mapping;
 
 import com.amazon.dataprepper.model.configuration.PluginModel;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -18,9 +19,11 @@ import org.opensearch.dataprepper.logstash.model.LogstashValueType;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
@@ -35,6 +38,49 @@ class OpenSearchPluginAttributesMapperTest {
     private OpenSearchPluginAttributesMapper createObjectUnderTest() {
         return new OpenSearchPluginAttributesMapper();
     }
+
+    @Test
+    void convert_missing_indexAttribute_to_return_empty_pluginSettings() {
+
+        final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
+        when(logstashAttributesMappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
+
+        final List<PluginModel> actualPluginModel = createObjectUnderTest()
+                .mapAttributes(Collections.emptyList(), logstashAttributesMappings);
+
+        assertThat(actualPluginModel, Matchers.notNullValue());
+        assertThat(actualPluginModel.size(), Matchers.equalTo(1));
+        assertThat(actualPluginModel.get(0), Matchers.notNullValue());
+
+        assertThat(actualPluginModel.get(0).getPluginSettings().size(), equalTo(0));
+        assertThat(actualPluginModel.get(0).getPluginSettings(), not(hasKey(DATA_PREPPER_OPENSEARCH_INDEX_ATTRIBUTE)));
+    }
+
+    @Test
+    void convert_emptyString_indexAttribute_to_return_pluginSettings_with_no_index_key() {
+
+        final LogstashAttribute logstashAttribute = mock(LogstashAttribute.class);
+        final LogstashAttributeValue logstashAttributeValue = mock(LogstashAttributeValue.class);
+        when(logstashAttribute.getAttributeName()).thenReturn(UUID.randomUUID().toString());
+        when(logstashAttribute.getAttributeValue()).thenReturn(logstashAttributeValue);
+        when(logstashAttributeValue.getAttributeValueType()).thenReturn(LogstashValueType.STRING);
+        when(logstashAttributeValue.getValue()).thenReturn(UUID.randomUUID().toString());
+
+        final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
+        when(logstashAttributesMappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
+
+        final List<PluginModel> actualPluginModel = createObjectUnderTest()
+                .mapAttributes(Collections.singletonList(logstashAttribute), logstashAttributesMappings);
+
+        assertThat(actualPluginModel, Matchers.notNullValue());
+        assertThat(actualPluginModel.size(), Matchers.equalTo(1));
+        assertThat(actualPluginModel.get(0), Matchers.notNullValue());
+
+        assertThat(actualPluginModel.get(0).getPluginSettings().size(), equalTo(0));
+        assertThat(actualPluginModel.get(0).getPluginSettings(), not(hasKey(DATA_PREPPER_OPENSEARCH_INDEX_ATTRIBUTE)));
+    }
+
+
 
     @ParameterizedTest
     @ArgumentsSource(JodaToJava8IndicesArgumentsProvider.class)

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/OpenSearchPluginAttributesMapperTest.java
@@ -19,11 +19,9 @@ import org.opensearch.dataprepper.logstash.model.LogstashValueType;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
@@ -40,10 +38,10 @@ class OpenSearchPluginAttributesMapperTest {
     }
 
     @Test
-    void convert_missing_indexAttribute_to_return_empty_pluginSettings() {
+    void convert_no_explicit_indexAttribute_to_return_indexAttribute_with_defaultSettings() {
 
         final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
-        when(logstashAttributesMappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
+        when(logstashAttributesMappings.getDefaultSettings()).thenReturn(Collections.singletonMap("index", "logstash-%{uuuu.MM.dd}"));
 
         final List<PluginModel> actualPluginModel = createObjectUnderTest()
                 .mapAttributes(Collections.emptyList(), logstashAttributesMappings);
@@ -53,31 +51,7 @@ class OpenSearchPluginAttributesMapperTest {
         assertThat(actualPluginModel.get(0), Matchers.notNullValue());
 
         assertThat(actualPluginModel.get(0).getPluginSettings().size(), equalTo(0));
-        assertThat(actualPluginModel.get(0).getPluginSettings(), not(hasKey(DATA_PREPPER_OPENSEARCH_INDEX_ATTRIBUTE)));
-    }
-
-    @Test
-    void convert_emptyString_indexAttribute_to_return_pluginSettings_with_no_index_key() {
-
-        final LogstashAttribute logstashAttribute = mock(LogstashAttribute.class);
-        final LogstashAttributeValue logstashAttributeValue = mock(LogstashAttributeValue.class);
-        when(logstashAttribute.getAttributeName()).thenReturn(UUID.randomUUID().toString());
-        when(logstashAttribute.getAttributeValue()).thenReturn(logstashAttributeValue);
-        when(logstashAttributeValue.getAttributeValueType()).thenReturn(LogstashValueType.STRING);
-        when(logstashAttributeValue.getValue()).thenReturn(UUID.randomUUID().toString());
-
-        final LogstashAttributesMappings logstashAttributesMappings = mock(LogstashAttributesMappings.class);
-        when(logstashAttributesMappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
-
-        final List<PluginModel> actualPluginModel = createObjectUnderTest()
-                .mapAttributes(Collections.singletonList(logstashAttribute), logstashAttributesMappings);
-
-        assertThat(actualPluginModel, Matchers.notNullValue());
-        assertThat(actualPluginModel.size(), Matchers.equalTo(1));
-        assertThat(actualPluginModel.get(0), Matchers.notNullValue());
-
-        assertThat(actualPluginModel.get(0).getPluginSettings().size(), equalTo(0));
-        assertThat(actualPluginModel.get(0).getPluginSettings(), not(hasKey(DATA_PREPPER_OPENSEARCH_INDEX_ATTRIBUTE)));
+        assertThat(actualPluginModel.get(0).getPluginSettings(), (hasKey(DATA_PREPPER_OPENSEARCH_INDEX_ATTRIBUTE)));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Description
 Adds `defaultSettings` property to the Logstash Mapping YAML files setting the default Data Prepper attribute values.
 
### Issues Resolved
Resolves #1080 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
