### PR TITLE
Added ParseTreeTest

### DIFF
--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeTest.java
@@ -190,7 +190,7 @@ public class ParseTreeTest extends GrammarTest {
     @Test
     void testValidJsonPointerCharacterSet() {
         final ParserRuleContext expression = parseExpression(
-                "/ABCDEFGHIJKLMNOPQRSTUVWXYZ/ambcdefghijklmnopqrstuvwxyz/0123456789/_");
+                "/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/0123456789/_");
         assertThat(expression, isExpression(isJsonPointerUnaryTree()));
         assertThat(errorListener.isErrorFound(), is(false));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeTest.java
@@ -1,0 +1,197 @@
+package org.opensearch.dataprepper.expression;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.hamcrest.DiagnosingMatcher;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.expression.util.GrammarTest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.dataprepper.expression.util.ContextMatcher.hasContext;
+import static org.opensearch.dataprepper.expression.util.ContextMatcher.isExpression;
+import static org.opensearch.dataprepper.expression.util.ContextMatcher.isOperator;
+import static org.opensearch.dataprepper.expression.util.ContextMatcherFactory.isParseTree;
+import static org.opensearch.dataprepper.expression.util.JsonPointerMatcher.isJsonPointerUnaryTree;
+import static org.opensearch.dataprepper.expression.util.LiteralMatcher.isUnaryTree;
+
+public class ParseTreeTest extends GrammarTest {
+
+    @Test
+    void testEqualityExpression() {
+        final ParserRuleContext expression = parseExpression("5==5");
+
+        final DiagnosingMatcher<ParseTree> equalityExpression = isParseTree(
+                CONDITIONAL_EXPRESSION,
+                EQUALITY_OPERATOR_EXPRESSION
+        ).withChildrenMatching(isUnaryTree(), isOperator(EQUALITY_OPERATOR), isUnaryTree());
+
+        assertThat(expression, isExpression(equalityExpression));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+
+    @Test
+    void testGivenOperandIsNotStringWhenEvaluateThenErrorPresent() {
+        parseExpression("(true) =~ \"Hello?\"");
+
+        assertThat(errorListener.isErrorFound(), is(true));
+    }
+
+    @Test
+    void testEquality() {
+        final ParserRuleContext expression = parseExpression("true==false");
+
+        final DiagnosingMatcher<ParseTree> equalityExpression = isParseTree(
+                CONDITIONAL_EXPRESSION,
+                EQUALITY_OPERATOR_EXPRESSION
+        ).withChildrenMatching(isUnaryTree(), isOperator(EQUALITY_OPERATOR), isUnaryTree());
+
+        assertThat(expression, isExpression(equalityExpression));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+
+    @Test
+    void testConditionalExpression() {
+        final ParserRuleContext expression = parseExpression("false and true");
+
+        assertThat(expression, isExpression(hasContext(
+                CONDITIONAL_EXPRESSION,
+                isUnaryTree(),
+                isOperator(CONDITIONAL_OPERATOR),
+                isUnaryTree()
+        )));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+
+    @Test
+    void testMultipleConditionExpressions() {
+        final ParserRuleContext expression = parseExpression("false and true or true");
+        assertThat(expression, isExpression(hasContext(
+                CONDITIONAL_EXPRESSION,
+                hasContext(
+                        CONDITIONAL_EXPRESSION,
+                        isUnaryTree(),
+                        isOperator(CONDITIONAL_OPERATOR),
+                        isUnaryTree()
+                ),
+                isOperator(CONDITIONAL_OPERATOR),
+                isUnaryTree()
+        )));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+
+    @Test
+    void testJsonPointer() {
+        final ParserRuleContext expression = parseExpression("/a/b/c == true");
+
+        assertThat(expression, isExpression(isParseTree(
+                        CONDITIONAL_EXPRESSION,
+                        EQUALITY_OPERATOR_EXPRESSION
+                ).withChildrenMatching(
+                        isJsonPointerUnaryTree(),
+                        isOperator(EQUALITY_OPERATOR),
+                        isUnaryTree()
+                )
+        ));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+
+    @Test
+    void testSimpleString() {
+        final ParserRuleContext expression = parseExpression("\"Hello World\" == 42");
+
+        assertThat(expression, isExpression(isParseTree(
+                CONDITIONAL_EXPRESSION,
+                EQUALITY_OPERATOR_EXPRESSION
+        ).withChildrenMatching(
+                isUnaryTree(),
+                isOperator(EQUALITY_OPERATOR),
+                isUnaryTree()
+        )));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+
+    @Test
+    void testStringEscapeCharacters() {
+        final ParserRuleContext expression = parseExpression("\"Hello \\\"World\\\"\" == 42");
+
+        assertThat(expression, isExpression(isParseTree(
+                CONDITIONAL_EXPRESSION,
+                EQUALITY_OPERATOR_EXPRESSION
+        ).withChildrenMatching(
+                isUnaryTree(),
+                isOperator(EQUALITY_OPERATOR),
+                isUnaryTree()
+        )));
+        assertThat(errorListener.isErrorFound(), is(false));
+
+    }
+
+    @Test
+    void testJsonPointerEscapeCharacters() {
+        final ParserRuleContext expression = parseExpression("\"/a b/\\\"c~d\\\"/\\/\"");
+        assertThat(expression, isExpression(isJsonPointerUnaryTree()));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+
+    @Test
+    void testRelationalExpression() {
+        final ParserRuleContext expression = parseExpression("1 < 2");
+
+        assertThat(expression, isExpression(isParseTree(
+                CONDITIONAL_EXPRESSION,
+                EQUALITY_OPERATOR_EXPRESSION,
+                REGEX_OPERATOR_EXPRESSION,
+                RELATIONAL_OPERATOR_EXPRESSION
+        ).withChildrenMatching(
+                isUnaryTree(),
+                isOperator(RELATIONAL_OPERATOR),
+                isUnaryTree()
+        )));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+
+    @Test
+    void testNestedConditionalExpression() {
+        final ParserRuleContext expression = parseExpression("1 < 2 or 3 <= 4 or 5 > 6 or 7 >= 8");
+
+        final DiagnosingMatcher<ParseTree> relationalOperatorExpression = isParseTree(
+                EQUALITY_OPERATOR_EXPRESSION,
+                REGEX_OPERATOR_EXPRESSION,
+                RELATIONAL_OPERATOR_EXPRESSION
+        ).withChildrenMatching(
+                isUnaryTree(),
+                isOperator(RELATIONAL_OPERATOR),
+                isUnaryTree()
+        );
+        final DiagnosingMatcher<ParseTree> firstConditional = hasContext(
+                CONDITIONAL_EXPRESSION,
+                hasContext(CONDITIONAL_EXPRESSION, relationalOperatorExpression),
+                isOperator(CONDITIONAL_OPERATOR),
+                relationalOperatorExpression
+        );
+        final DiagnosingMatcher<ParseTree> secondConditional = hasContext(
+                CONDITIONAL_EXPRESSION,
+                firstConditional,
+                isOperator(CONDITIONAL_OPERATOR),
+                relationalOperatorExpression
+        );
+        final DiagnosingMatcher<ParseTree> thirdConditional = hasContext(
+                CONDITIONAL_EXPRESSION,
+                secondConditional,
+                isOperator(CONDITIONAL_OPERATOR),
+                relationalOperatorExpression
+        );
+
+        assertThat(expression, isExpression(thirdConditional));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+
+    @Test
+    void testValidJsonPointerCharacterSet() {
+        final ParserRuleContext expression = parseExpression(
+                "/ABCDEFGHIJKLMNOPQRSTUVWXYZ/ambcdefghijklmnopqrstuvwxyz/0123456789/_");
+        assertThat(expression, isExpression(isJsonPointerUnaryTree()));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParserTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParserTest.java
@@ -136,4 +136,15 @@ public class ParserTest extends GrammarTest {
     void testValidOptionalSpaceOperators(final String expression) {
         assertThatIsValid(expression);
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "falkse and true",
+            "true an true",
+            "2 is in {2}",
+            "2 in {2,,}"
+    })
+    void testTypo(final String expression) {
+        assertThatHasParseError(expression);
+    }
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParserTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParserTest.java
@@ -5,41 +5,15 @@
 
 package org.opensearch.dataprepper.expression;
 
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CodePointCharStream;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionLexer;
-import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
-import org.opensearch.dataprepper.expression.util.ErrorListener;
+import org.opensearch.dataprepper.expression.util.GrammarTest;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ParserTest {
-
-    private ErrorListener errorListener;
-
-    private void parseExpression(final String expression) {
-        errorListener = new ErrorListener();
-
-        final CodePointCharStream stream = CharStreams.fromString(expression);
-        final DataPrepperExpressionLexer lexer = new DataPrepperExpressionLexer(stream);
-        lexer.addErrorListener(errorListener);
-
-        final CommonTokenStream tokenStream = new CommonTokenStream(lexer);
-        final DataPrepperExpressionParser parser = new DataPrepperExpressionParser(tokenStream);
-        parser.addErrorListener(errorListener);
-
-        final ParserRuleContext context = parser.expression();
-
-        final ParseTreeWalker walker = new ParseTreeWalker();
-        walker.walk(errorListener, context);
-    }
+public class ParserTest extends GrammarTest {
 
     private void assertThatIsValid(final String expression) {
         parseExpression(expression);

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/ContextMatcher.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/ContextMatcher.java
@@ -9,12 +9,14 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
 import org.hamcrest.Matcher;
+import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import javax.annotation.Nullable;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.opensearch.dataprepper.expression.util.TerminalNodeMatcher.isTerminalNode;
 
 /**
  * @since 1.3
@@ -55,6 +57,34 @@ public class ContextMatcher extends DiagnosingMatcher<ParseTree> {
 
             mismatch.appendText("\n\t\t" + context + "\n\t\t");
         }
+    }
+
+    /**
+     * Creates matcher to check if tree is <b>operatorType</b> with a single child of type TerminalNode
+     * @param operatorType class type of operator to assert
+     * @return DiagnosingMatcher
+     */
+    public static DiagnosingMatcher<ParseTree> isOperator(final Class<? extends ParseTree> operatorType) {
+        return hasContext(operatorType, isTerminalNode());
+    }
+
+    /**
+     * @since 1.3
+     *
+     * <p>Creates a matcher to check for standard ParseTree root.</p>
+     * <pre>
+     * Expression<br>
+     * ├─ {lhs}<br>
+     * ├─ &lt;EOF&gt;<br>
+     * </pre>
+     *
+     * @param lhs matcher to use for the first child of the Expression node
+     * @return DiagnosingMatcher
+     *
+     * @see ContextMatcher#hasContext(Class, DiagnosingMatcher[])
+     */
+    public static DiagnosingMatcher<ParseTree> isExpression(final DiagnosingMatcher<ParseTree> lhs) {
+        return hasContext(DataPrepperExpressionParser.ExpressionContext.class, lhs, isTerminalNode());
     }
 
     /**

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/GrammarTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/GrammarTest.java
@@ -1,0 +1,46 @@
+package org.opensearch.dataprepper.expression.util;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CodePointCharStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionLexer;
+import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
+
+public abstract class GrammarTest {
+    //region ParseTree child classes
+    protected static final Class<? extends ParseTree> CONDITIONAL_EXPRESSION = DataPrepperExpressionParser.ConditionalExpressionContext.class;
+    protected static final Class<? extends ParseTree> CONDITIONAL_OPERATOR = DataPrepperExpressionParser.ConditionalOperatorContext.class;
+    protected static final Class<? extends ParseTree> EQUALITY_OPERATOR_EXPRESSION =
+            DataPrepperExpressionParser.EqualityOperatorExpressionContext.class;
+    protected static final Class<? extends ParseTree> EQUALITY_OPERATOR = DataPrepperExpressionParser.EqualityOperatorContext.class;
+    protected static final Class<? extends ParseTree> REGEX_OPERATOR_EXPRESSION =
+            DataPrepperExpressionParser.RegexOperatorExpressionContext.class;
+    protected static final Class<? extends ParseTree> RELATIONAL_OPERATOR_EXPRESSION =
+            DataPrepperExpressionParser.RelationalOperatorExpressionContext.class;
+    protected static final Class<? extends ParseTree> RELATIONAL_OPERATOR = DataPrepperExpressionParser.RelationalOperatorContext.class;
+    //endregion
+
+    protected ErrorListener errorListener;
+
+    protected ParserRuleContext parseExpression(final String expression) {
+        errorListener = new ErrorListener();
+
+        final CodePointCharStream stream = CharStreams.fromString(expression);
+        final DataPrepperExpressionLexer lexer = new DataPrepperExpressionLexer(stream);
+        lexer.addErrorListener(errorListener);
+
+        final CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+        final DataPrepperExpressionParser parser = new DataPrepperExpressionParser(tokenStream);
+        parser.addErrorListener(errorListener);
+
+        final ParserRuleContext context = parser.expression();
+
+        final ParseTreeWalker walker = new ParseTreeWalker();
+        walker.walk(errorListener, context);
+
+        return context;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Steven Bayer <smbayer@amazon.com>

### Description
Adds Data Prepper Expression parsers tests that assert full expression parsing
 
### Issues Resolved
Missing test coverage
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
