### PR TITLE
MAINT: reduce getAttributes calls

### DIFF
--- a/data-prepper-plugins/otel-proto-common/src/main/java/com/amazon/dataprepper/plugins/otel/codec/OTelProtoCodec.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/com/amazon/dataprepper/plugins/otel/codec/OTelProtoCodec.java
@@ -288,12 +288,13 @@ public class OTelProtoCodec {
 
         public ResourceSpans convertToResourceSpans(final Span span) throws UnsupportedEncodingException, DecoderException {
             final ResourceSpans.Builder rsBuilder = ResourceSpans.newBuilder();
-            final Resource resource = constructResource(span.getServiceName(), span.getAttributes());
+            final Map<String, Object> allAttributes = span.getAttributes();
+            final Resource resource = constructResource(span.getServiceName(), allAttributes);
             rsBuilder.setResource(resource);
             final InstrumentationLibrarySpans.Builder instrumentationLibrarySpansBuilder = InstrumentationLibrarySpans.newBuilder();
-            final InstrumentationLibrary instrumentationLibrary = constructInstrumentationLibrary(span.getAttributes());
+            final InstrumentationLibrary instrumentationLibrary = constructInstrumentationLibrary(allAttributes);
             instrumentationLibrarySpansBuilder.setInstrumentationLibrary(instrumentationLibrary);
-            final io.opentelemetry.proto.trace.v1.Span otelProtoSpan = constructSpan(span);
+            final io.opentelemetry.proto.trace.v1.Span otelProtoSpan = constructSpan(span, allAttributes);
             instrumentationLibrarySpansBuilder.addSpans(otelProtoSpan);
             rsBuilder.addInstrumentationLibrarySpans(instrumentationLibrarySpansBuilder);
             return rsBuilder.build();
@@ -409,7 +410,8 @@ public class OTelProtoCodec {
             return builder.build();
         }
 
-        protected io.opentelemetry.proto.trace.v1.Span constructSpan(final Span span) throws DecoderException, UnsupportedEncodingException {
+        protected io.opentelemetry.proto.trace.v1.Span constructSpan(final Span span, final Map<String, Object> allAttributes)
+                throws DecoderException, UnsupportedEncodingException {
             io.opentelemetry.proto.trace.v1.Span.Builder builder = io.opentelemetry.proto.trace.v1.Span.newBuilder()
                     .setSpanId(ByteString.copyFrom(Hex.decodeHex(span.getSpanId())))
                     .setParentSpanId(ByteString.copyFrom(Hex.decodeHex(span.getParentSpanId())))
@@ -422,7 +424,6 @@ public class OTelProtoCodec {
                     .setDroppedAttributesCount(span.getDroppedAttributesCount())
                     .setDroppedEventsCount(span.getDroppedEventsCount())
                     .setDroppedLinksCount(span.getDroppedLinksCount());
-            final Map<String, Object> allAttributes = span.getAttributes();
             builder
                     .setStatus(constructSpanStatus(allAttributes))
                     .addAllAttributes(getSpanAttributes(allAttributes))


### PR DESCRIPTION
Signed-off-by: Chen <19492223+chenqi0805@users.noreply.github.com>

### Description
Minor improvement on repeated span.getAttributes call that introduces jsonNode overhead.
 
### Issues Resolved
Contributes to #546 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
