### PR TITLE
Staging resources CDK: Include CloudFront distribution and release IAM role

### DIFF
--- a/release/staging-resources-cdk/README.md
+++ b/release/staging-resources-cdk/README.md
@@ -1,7 +1,72 @@
 # Data Prepper Staging Resources CDK
 
 This project provides a CDK stack for deploying Data Prepper resources to a staging environment.
+This creates an AWS environment suitable for hosting Data Prepper artifacts.
 
-**This project is current a work-in-progress.**
+*You probably don't need to use this sub-project. It is intended for releasing Data Prepper.
+If you do want to distribute your own Data Prepper releases, read on.*
 
-*TODO: Complete this documentation*
+
+## Build & Test
+
+### Build Prerequisites
+
+You must install CDK and Node.js first.
+
+
+### Build
+
+You must ruan all the following commands from the `release/staging/resources-cdk` directory. 
+
+The first time you use the CDK, run:
+
+```
+npm install
+```
+
+### Testing
+
+You can run the following command to run the CDK tests.
+
+```
+npm run test
+```
+
+If you have made code changes, please run the linter to verify that your code is correctly formatted.
+
+```
+npm run lint
+```
+
+## Deployment
+
+### AWS Prerequisites
+
+You must have an AWS account and administrator permissions to this account.
+
+Additionally, you must create your own S3 bucket. This stack expects that the bucket exists.
+
+### Deploy Steps
+
+The following CDK commands all require defining context. The context variables are:
+
+* `archivesBucketName` - The name of the S3 bucket you will use to deploy. This bucket must be in the same region as your stack.
+* `dataPrepperOrganization` - The name of the GitHub organization which has the `data-prepper` repository. This allows you to create staging environments for forks. The default value is `opensearch-project`.
+
+Deploy the GitHub access stack:
+
+```
+cdk deploy GitHubAccessStack --context archivesBucketName={s3-bucket-name} --context dataPrepperOrganization={data-prepper-organization-name}
+```
+
+Deploy the stack with the actual staging resources:
+
+```
+cdk deploy StagingResourcesStack --context archivesBucketName={s3-bucket-name} --context dataPrepperOrganization={data-prepper-organization-name}
+```
+
+Deploy the stack which gives GitHub Actions permissions to deploy to the staging resources.
+
+```
+cdk deploy GitHubActionsReleaseAccessStack --context archivesBucketName={s3-bucket-name} --context dataPrepperOrganization={data-prepper-organization-name}
+```

--- a/release/staging-resources-cdk/README.md
+++ b/release/staging-resources-cdk/README.md
@@ -16,7 +16,7 @@ You must install CDK and Node.js first.
 
 ### Build
 
-You must ruan all the following commands from the `release/staging/resources-cdk` directory. 
+You must run all the following commands from the `release/staging/resources-cdk` directory. 
 
 The first time you use the CDK, run:
 

--- a/release/staging-resources-cdk/bin/staging-resources-cdk.ts
+++ b/release/staging-resources-cdk/bin/staging-resources-cdk.ts
@@ -9,14 +9,21 @@ import 'source-map-support/register';
 import {App} from 'aws-cdk-lib';
 import {GitHubAccessStack} from '../lib/GitHubAccessStack';
 import {StagingResourcesStack} from '../lib/StagingResourcesStack';
+import {GitHubActionsReleaseAccessStack} from '../lib/GitHubActionsReleaseAccessStack';
 
 
 const app = new App();
 
-new GitHubAccessStack(app, 'GitHubAccessStack', {
+const gitHubAccessStack = new GitHubAccessStack(app, 'GitHubAccessStack', {
   stackName: 'GitHubAccess'
 });
 
-new StagingResourcesStack(app, 'StagingResourcesStack', {
+const stagingResourcesStack = new StagingResourcesStack(app, 'StagingResourcesStack', {
   stackName: 'StagingResources'
+});
+
+new GitHubActionsReleaseAccessStack(app, 'GitHubActionsReleaseAccessStack', {
+  stackName: 'GitHubActionsReleaseAccess',
+  gitHubOidcProvider: gitHubAccessStack.gitHubOidcProvider,
+  ecrRepository: stagingResourcesStack.dataPrepperEcrRepository
 });

--- a/release/staging-resources-cdk/lib/GitHubActionsReleaseAccessStack.ts
+++ b/release/staging-resources-cdk/lib/GitHubActionsReleaseAccessStack.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Stack, StackProps} from 'aws-cdk-lib';
+import {Construct} from 'constructs';
+import {
+  ManagedPolicy,
+  PolicyStatement,
+  Effect,
+  OpenIdConnectPrincipal,
+  Role,
+  OpenIdConnectProvider
+} from 'aws-cdk-lib/aws-iam'
+import {CfnPublicRepository} from 'aws-cdk-lib/aws-ecr';
+
+const DEFAULT_ORGANIZATION = 'opensearch-project'
+
+export interface GitHubActionsReleaseAccessStackProps extends StackProps {
+  readonly ecrRepository: CfnPublicRepository;
+  readonly gitHubOidcProvider: OpenIdConnectProvider
+}
+
+/**
+ * Creates the IAM role which GitHub will assume. This role will have all the
+ * necessary permissions to deploy artifacts.
+ */
+export class GitHubActionsReleaseAccessStack extends Stack {
+
+  constructor(scope: Construct, id: string, props: GitHubActionsReleaseAccessStackProps) {
+    super(scope, id, props);
+
+    const archivesBucketName: string = scope.node.tryGetContext('archivesBucketName');
+
+    const dataPrepperOrganization: string = scope.node.tryGetContext('dataPrepperOrganization') || DEFAULT_ORGANIZATION;
+
+    const gitHubPrincipal = new OpenIdConnectPrincipal(props.gitHubOidcProvider, {
+      'ForAllValues:StringEquals': {
+        'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
+        'token.actions.githubusercontent.com:sub': `repo:${dataPrepperOrganization}/data-prepper:ref:refs/heads/main`
+      },
+    });
+
+    const gitHubActionsReleaseRole = new Role(this, 'GitHubActionsStagingRole', {
+      roleName: 'GitHubActionsRelease',
+      assumedBy: gitHubPrincipal
+    });
+
+
+    const ecrPublicAuthorizationPolicy = new ManagedPolicy(this, 'ECRPublicAuthorization', {
+      managedPolicyName: 'ECRPublicAuthorization',
+      statements: [
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: [
+            'ecr-public:GetAuthorizationToken',
+            'sts:GetServiceBearerToken'
+          ],
+          resources: ['*'],
+        })
+      ]
+    });
+
+    const ecrPushPolicy = new ManagedPolicy(this, 'ECRPushPolicy', {
+      managedPolicyName: 'DataPrepperECRPush',
+      statements: [
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: [
+            'ecr-public:InitiateLayerUpload',
+            'ecr-public:UploadLayerPart',
+            'ecr-public:PutImage',
+            'ecr-public:CompleteLayerUpload',
+            'ecr-public:BatchCheckLayerAvailability'
+          ],
+          resources: [
+            props.ecrRepository.attrArn
+          ],
+        })
+      ]
+    });
+
+    const archivesPushPolicy = new ManagedPolicy(this, 'ArchivesPushPolicy', {
+      managedPolicyName: 'DataPrepperArchivesPush',
+      statements: [
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: [
+            's3:PutObject',
+            's3:GetObject'
+          ],
+          resources: [`arn:aws:s3:::${archivesBucketName}/*`],
+        }),
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: [
+            's3:ListBucket'
+          ],
+          resources: [`arn:aws:s3:::${archivesBucketName}`],
+        }),
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: [
+            's3:GetBucketLocation'
+          ],
+          resources: [`arn:aws:s3:::${archivesBucketName}`],
+        })
+      ]
+    });
+
+    gitHubActionsReleaseRole.addManagedPolicy(ecrPublicAuthorizationPolicy);
+    gitHubActionsReleaseRole.addManagedPolicy(ecrPushPolicy);
+    gitHubActionsReleaseRole.addManagedPolicy(archivesPushPolicy);
+  }
+}

--- a/release/staging-resources-cdk/lib/StagingResourcesStack.ts
+++ b/release/staging-resources-cdk/lib/StagingResourcesStack.ts
@@ -3,10 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Stack, StackProps} from 'aws-cdk-lib';
+import {CfnOutput, Stack, StackProps} from 'aws-cdk-lib';
 import {Construct} from 'constructs';
 import {CfnPublicRepository} from 'aws-cdk-lib/aws-ecr'
+import {CloudFrontWebDistribution, OriginAccessIdentity} from 'aws-cdk-lib/aws-cloudfront';
+import {Bucket, BucketPolicy} from 'aws-cdk-lib/aws-s3';
+import {PolicyStatement} from 'aws-cdk-lib/aws-iam';
 
+/**
+ * This stack creates the resources necessary for the staging environment used
+ * in the Data Prepper release process. It excludes related IAM resources.
+ */
 export class StagingResourcesStack extends Stack {
   readonly dataPrepperEcrRepository: CfnPublicRepository;
 
@@ -15,6 +22,52 @@ export class StagingResourcesStack extends Stack {
 
     this.dataPrepperEcrRepository = new CfnPublicRepository(this, 'DataPrepperECRRepository', {
       repositoryName: 'data-prepper'
+    });
+
+    const archivesBucketName: string = scope.node.tryGetContext('archivesBucketName');
+
+    const archivesBucket = Bucket.fromBucketName(this, 'StagingBucket', archivesBucketName);
+    const originAccessIdentity = new OriginAccessIdentity(this, 'StagingOriginAccessIdentity');
+
+    const cloudFrontDistribution = new CloudFrontWebDistribution(this, 'StagingCloudFrontDistribution', {
+      originConfigs: [
+        {
+          s3OriginSource: {
+            s3BucketSource: archivesBucket,
+            originAccessIdentity: originAccessIdentity
+          },
+          behaviors: [
+            {
+              isDefaultBehavior: true
+            }
+          ]
+        }
+      ]
+    });
+
+    const policyStatement = new PolicyStatement({
+      actions: [
+        's3:GetObject'
+      ],
+      resources: [
+        archivesBucket.arnForObjects('*')
+      ],
+      principals: [
+        originAccessIdentity.grantPrincipal
+      ]
+    });
+    const bucketPolicy = new BucketPolicy(this, 'StagingDistributionOriginAccess', {
+      bucket: archivesBucket
+    });
+    bucketPolicy.document.addStatements(policyStatement);
+
+
+    new CfnOutput(this, 'StagingDomainName', {
+      value: cloudFrontDistribution.distributionDomainName
+    });
+
+    new CfnOutput(this, 'StagingCloudFrontDistributionId', {
+      value: cloudFrontDistribution.distributionId
     });
   }
 }

--- a/release/staging-resources-cdk/test/GitHubActionsReleaseAccessStack.test.ts
+++ b/release/staging-resources-cdk/test/GitHubActionsReleaseAccessStack.test.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {App, Stack} from 'aws-cdk-lib';
+import {Match, Template} from 'aws-cdk-lib/assertions';
+import {GitHubActionsReleaseAccessStack} from '../lib/GitHubActionsReleaseAccessStack';
+import {OpenIdConnectProvider} from 'aws-cdk-lib/aws-iam';
+import {CfnPublicRepository} from 'aws-cdk-lib/aws-ecr';
+
+
+let app: App;
+
+beforeEach(() => {
+  app = new App({
+    context: {
+      archivesBucketName: 'test-s3-bucket-name'
+    }
+  });
+});
+
+function createOidcProvider(): OpenIdConnectProvider {
+  const stack = new Stack(app, 'OidcStack');
+  return new OpenIdConnectProvider(stack, 'TestOidcProvider', {
+    url: 'https://aws.amazon.com/example'
+  });
+}
+
+function createEcrRepository(): CfnPublicRepository {
+  const stack = new Stack(app, 'EcrRepositoryStack');
+  return new CfnPublicRepository(stack, 'TestECRRepository', {
+    repositoryName: 'sample-repository'
+  });
+}
+
+function createStackUnderTest() {
+  return new GitHubActionsReleaseAccessStack(app, 'StackUnderTest', {
+    gitHubOidcProvider: createOidcProvider(),
+    ecrRepository: createEcrRepository()
+  });
+}
+
+test('Creates Role with the correct assume role if no organization is supplied', () => {
+  const stackUnderTest = createStackUnderTest();
+
+  const template = Template.fromStack(stackUnderTest);
+
+  template.hasResourceProperties('AWS::IAM::Role', {
+    RoleName: 'GitHubActionsRelease',
+    AssumeRolePolicyDocument: {
+      Statement: [
+        {
+          Action: 'sts:AssumeRoleWithWebIdentity',
+          Condition: {
+            'ForAllValues:StringEquals': {
+              'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
+              'token.actions.githubusercontent.com:sub': 'repo:opensearch-project/data-prepper:ref:refs/heads/main'
+            }
+          },
+          Effect: 'Allow',
+          Principal: {
+            Federated: {
+              'Fn::ImportValue': Match.anyValue()
+            }
+          }
+        }
+      ]
+    }
+  });
+});
+
+test('Creates Role with the correct assume role when the organization is provided', () => {
+
+  app = new App({
+    context: {
+      'dataPrepperOrganization': 'test-organization'
+    }
+  });
+
+  const stackUnderTest = createStackUnderTest();
+
+  const template = Template.fromStack(stackUnderTest);
+
+  template.hasResourceProperties('AWS::IAM::Role', {
+    RoleName: 'GitHubActionsRelease',
+    AssumeRolePolicyDocument: {
+      Statement: [
+        {
+          Action: 'sts:AssumeRoleWithWebIdentity',
+          Condition: {
+            'ForAllValues:StringEquals': {
+              'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
+              'token.actions.githubusercontent.com:sub': 'repo:test-organization/data-prepper:ref:refs/heads/main'
+            }
+          },
+          Effect: 'Allow',
+          Principal: {
+            Federated: {
+              'Fn::ImportValue': Match.anyValue()
+            }
+          }
+        }
+      ]
+    }
+  });
+});
+
+test('Creates Managed Policy with permissions to authenticate with ECR Public', () => {
+
+  const stackUnderTest = createStackUnderTest();
+
+  const template = Template.fromStack(stackUnderTest);
+
+  template.hasResourceProperties('AWS::IAM::ManagedPolicy', {
+    ManagedPolicyName: 'ECRPublicAuthorization',
+    PolicyDocument: {
+      Statement: [
+        {
+          Action: [
+            'ecr-public:GetAuthorizationToken',
+            'sts:GetServiceBearerToken'
+          ],
+          Effect: 'Allow',
+          Resource: '*'
+        }
+      ]
+    }
+  });
+});
+
+test('Creates Managed Policy with permissions to push to the S3 bucket', () => {
+
+  const stackUnderTest = createStackUnderTest();
+
+  const template = Template.fromStack(stackUnderTest);
+
+  template.hasResourceProperties('AWS::IAM::ManagedPolicy', {
+    ManagedPolicyName: 'DataPrepperArchivesPush',
+    PolicyDocument: {
+      Statement: [
+        {
+          Action: [
+            's3:PutObject',
+            's3:GetObject'
+          ],
+          Effect: 'Allow',
+          Resource: 'arn:aws:s3:::test-s3-bucket-name/*'
+        },
+        {
+          Action: 's3:ListBucket',
+          Effect: 'Allow',
+          Resource: 'arn:aws:s3:::test-s3-bucket-name'
+        },
+        {
+          Action: 's3:GetBucketLocation',
+          Effect: 'Allow',
+          Resource: 'arn:aws:s3:::test-s3-bucket-name'
+        }
+      ]
+    }
+  });
+});
+
+test('Creates Managed Policy with permissions to push to the ECR repository', () => {
+
+  const gitHubOidcProvider = createOidcProvider();
+
+  const stackUnderTest = new GitHubActionsReleaseAccessStack(app, 'StackUnderTest', {
+    gitHubOidcProvider: gitHubOidcProvider,
+    ecrRepository: createEcrRepository()
+  });
+
+  const template = Template.fromStack(stackUnderTest);
+
+  template.hasResourceProperties('AWS::IAM::ManagedPolicy', {
+    ManagedPolicyName: 'DataPrepperECRPush',
+    PolicyDocument: {
+      Statement: [
+        {
+          Action: [
+            'ecr-public:InitiateLayerUpload',
+            'ecr-public:UploadLayerPart',
+            'ecr-public:PutImage',
+            'ecr-public:CompleteLayerUpload',
+            'ecr-public:BatchCheckLayerAvailability'
+          ],
+          Effect: 'Allow',
+          Resource: {
+            'Fn::ImportValue': Match.anyValue()
+          }
+        }
+      ]
+    }
+  });
+});

--- a/release/staging-resources-cdk/test/StagingResourcesStack.test.ts
+++ b/release/staging-resources-cdk/test/StagingResourcesStack.test.ts
@@ -4,12 +4,21 @@
  */
 
 import {App} from 'aws-cdk-lib';
-import {Template} from 'aws-cdk-lib/assertions';
+import {Capture, Match, Template} from 'aws-cdk-lib/assertions';
 import {StagingResourcesStack} from '../lib/StagingResourcesStack';
 
-test('Creates an ECR Public Repository for Data Prepper', () => {
-  const app = new App();
 
+let app: App;
+
+beforeEach(() => {
+  app = new App({
+    context: {
+      archivesBucketName: 'test-s3-bucket-name'
+    }
+  });
+});
+
+test('Creates an ECR Public Repository for Data Prepper', () => {
   const stackUnderTest = new StagingResourcesStack(app, 'TestStack');
 
   const template = Template.fromStack(stackUnderTest);
@@ -17,4 +26,59 @@ test('Creates an ECR Public Repository for Data Prepper', () => {
   template.hasResourceProperties('AWS::ECR::PublicRepository', {
     RepositoryName: 'data-prepper'
   });
+});
+
+test('Creates a CloudFront distribution with the bucket as the origin', () => {
+  const stackUnderTest = new StagingResourcesStack(app, 'TestStack');
+
+  const template = Template.fromStack(stackUnderTest);
+
+  const domainNameCapture = new Capture();
+  template.hasResourceProperties('AWS::CloudFront::Distribution', {
+    DistributionConfig: {
+      Origins: [
+        {
+          DomainName: domainNameCapture,
+          S3OriginConfig: Match.anyValue()
+        }
+      ]
+    }
+  });
+
+  const domainNameJson = JSON.stringify(domainNameCapture.asObject());
+  expect(domainNameJson).toContain('test-s3-bucket-name')
+});
+
+test('Creates a CloudFront Origin Access Identity', () => {
+  const stackUnderTest = new StagingResourcesStack(app, 'TestStack');
+
+  const template = Template.fromStack(stackUnderTest);
+
+  template.hasResourceProperties('AWS::CloudFront::CloudFrontOriginAccessIdentity', {});
+});
+
+test('Creates an S3 Bucket policy granting access to the CloudFront Origin Access Identity', () => {
+  const stackUnderTest = new StagingResourcesStack(app, 'TestStack');
+
+  const template = Template.fromStack(stackUnderTest);
+
+  const bucketObjectsCapture = new Capture();
+  template.hasResourceProperties('AWS::S3::BucketPolicy', {
+    Bucket: 'test-s3-bucket-name',
+    PolicyDocument: {
+      Statement: [
+        {
+          Action: 's3:GetObject',
+          Effect: 'Allow',
+          Principal: {
+            CanonicalUser: Match.anyValue()
+          },
+          Resource: bucketObjectsCapture
+        }
+      ]
+    }
+  });
+
+  const allBucketsJson = JSON.stringify(bucketObjectsCapture.asObject());
+  expect(allBucketsJson).toContain('test-s3-bucket-name/*')
 });


### PR DESCRIPTION
### Description

Updated the staging resources CDK with a CloudFront distribution and the IAM role for GitHub Actions to assume to perform the release process. This includes the necessary S3 bucket policy for the CloudFront origin access identity. Updated the README.md with instructions on build and deployment.

 
### Issues Resolved

Part of #977
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
