### PR TITLE
Upload release archive files to a unique key path per build

### DIFF
--- a/release/archives/build.gradle
+++ b/release/archives/build.gradle
@@ -26,7 +26,8 @@ subprojects {
 
     ext {
         archiveToTar = this.&archiveToTar
-        awsS3Bucket = project.hasProperty("bucket") ? project.getProperty("bucket") : awsResources.get('default_bucket')
+        awsS3Bucket = project.hasProperty('bucket') ? project.getProperty('bucket') : awsResources.get('default_bucket')
+        buildNumber = project.hasProperty('buildNumber') ? project.getProperty('buildNumber') : 'development'
     }
 
     def supportedArchitectures = architectures.get(it.name) as String[]
@@ -128,6 +129,7 @@ subprojects {
             def tarWithJDKTask = tasks.getByName("${platformWithArchitecture}WithJDKDistTar")
             def zipTask = tasks.getByName("${platformWithArchitecture}DistZip")
             def zipWithJDKTask = tasks.getByName("${platformWithArchitecture}WithJDKDistZip")
+            def destinationKeyPath = "${project.rootProject.version}/${project.buildNumber}/archive"
 
             tasks.getByName("${platformWithArchitecture}WithJDKDistTar").dependsOn("download${it}JDK")
             tasks.getByName("${platformWithArchitecture}WithJDKDistZip").dependsOn("download${it}JDK")
@@ -136,10 +138,10 @@ subprojects {
                 dependsOn tarTask.name
                 file file(tarTask.archiveFile.get().asFile.absolutePath)
                 bucketName awsS3Bucket
-                key "${project.rootProject.version}/${tarTask.archiveName}"
+                key "${destinationKeyPath}/${tarTask.archiveName}"
 
                 def m = new ObjectMetadata()
-                m.setCacheControl("no-cache, no-store")
+                m.setCacheControl('no-cache, no-store')
                 objectMetadata = m
             }
 
@@ -147,10 +149,10 @@ subprojects {
                 dependsOn zipTask.name
                 file file(zipTask.archiveFile.get().asFile.absolutePath)
                 bucketName awsS3Bucket
-                key "${project.rootProject.version}/${zipTask.archiveName}"
+                key "${destinationKeyPath}/${zipTask.archiveName}"
 
                 def m = new ObjectMetadata()
-                m.setCacheControl("no-cache, no-store")
+                m.setCacheControl('no-cache, no-store')
                 objectMetadata = m
             }
 
@@ -158,10 +160,10 @@ subprojects {
                 dependsOn tarWithJDKTask.name
                 file file(tarWithJDKTask.archiveFile.get().asFile.absolutePath)
                 bucketName awsS3Bucket
-                key "${project.rootProject.version}/${tarWithJDKTask.archiveName}"
+                key "${destinationKeyPath}/${tarWithJDKTask.archiveName}"
 
                 def m = new ObjectMetadata()
-                m.setCacheControl("no-cache, no-store")
+                m.setCacheControl('no-cache, no-store')
                 objectMetadata = m
             }
 
@@ -169,10 +171,10 @@ subprojects {
                 dependsOn zipWithJDKTask.name
                 file file(zipWithJDKTask.archiveFile.get().asFile.absolutePath)
                 bucketName awsS3Bucket
-                key "${project.rootProject.version}/${zipWithJDKTask.archiveName}"
+                key "${destinationKeyPath}/${zipWithJDKTask.archiveName}"
 
                 def m = new ObjectMetadata()
-                m.setCacheControl("no-cache, no-store")
+                m.setCacheControl('no-cache, no-store')
                 objectMetadata = m
             }
         }


### PR DESCRIPTION
### Description

Changes the release archive S3 path to include the build number.

This yields paths like the following:

```
/
  {version}/
    {buildNumber}/
      archive/
        opensearch-data-prepper-1.3.0-linux-x64.tar.gz
        opensearch-data-prepper-jdk-1.3.0-linux-x64.tar.gz
```

### Issues Resolved

Part of #977
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
