### PR TITLE
Renamed CompositeException

### DIFF
--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCompositeException.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCompositeException.java
@@ -15,12 +15,12 @@ import java.util.stream.Collectors;
  * <p>
  * Exception thrown by {@link ParseTreeParser} if ANTLR parse emits error events.
  */
-public class CompositeException extends RuntimeException {
+public class ParseTreeCompositeException extends RuntimeException {
     private static final String SEPARATOR = System.getProperty("line.separator");
 
     private final Set<Throwable> exceptions;
 
-    public CompositeException(final List<Throwable> exceptions) {
+    public ParseTreeCompositeException(final List<Throwable> exceptions) {
         if (exceptions.isEmpty()) {
             throw new IllegalArgumentException("exceptions is empty");
         }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeParser.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeParser.java
@@ -52,9 +52,9 @@ class ParseTreeParser implements Parser<ParseTree> {
      *
      * @param expression String to be parsed
      * @return ParseTree data structure containing a hierarchy of the tokens found while parsing.
-     * @throws CompositeException thrown when ANTLR parser creates an exception event
+     * @throws ParseTreeCompositeException thrown when ANTLR parser creates an exception event
      */
-    private ParseTree createParseTree(final String expression) throws CompositeException {
+    private ParseTree createParseTree(final String expression) throws ParseTreeCompositeException {
         errorListener.resetErrors();
 
         final IntStream input = CharStreams.fromString(expression);
@@ -66,7 +66,7 @@ class ParseTreeParser implements Parser<ParseTree> {
         final ParseTree parseTree = parser.expression();
 
         if (errorListener.isErrorFound()) {
-            throw new CompositeException(errorListener.getExceptions());
+            throw new ParseTreeCompositeException(errorListener.getExceptions());
         }
         else {
             return parseTree;
@@ -81,10 +81,10 @@ class ParseTreeParser implements Parser<ParseTree> {
      *
      * @param expression String to be parsed
      * @return ParseTree data structure containing a hierarchy of the tokens found while parsing.
-     * @throws CompositeException thrown when ANTLR parser creates an exception event
+     * @throws ParseTreeCompositeException thrown when ANTLR parser creates an exception event
      */
     @Override
-    public ParseTree parse(final String expression) throws CompositeException {
+    public ParseTree parse(final String expression) throws ParseTreeCompositeException {
         if (cache.containsKey(expression)) {
             return cache.get(expression);
         }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/Parser.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/Parser.java
@@ -8,5 +8,5 @@ interface Parser<T> {
      * @param expression String to be parsed
      * @return Object representing a parsed expression
      */
-    T parse(final String expression) throws CompositeException;
+    T parse(final String expression) throws ParseTreeCompositeException;
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCompositeExceptionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCompositeExceptionTest.java
@@ -16,38 +16,38 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
-class CompositeExceptionTest {
+class ParseTreeCompositeExceptionTest {
 
     @Test
     void testNoCausesThrows() {
-        assertThrows(NullPointerException.class, () -> new CompositeException(null));
+        assertThrows(NullPointerException.class, () -> new ParseTreeCompositeException(null));
     }
 
     @Test
     void testEmptyListThrows() {
-        assertThrows(IllegalArgumentException.class, () -> new CompositeException(Collections.emptyList()));
+        assertThrows(IllegalArgumentException.class, () -> new ParseTreeCompositeException(Collections.emptyList()));
     }
 
     @Test
     void testGivenSingleExceptionThenExceptionIsCause() {
         final RuntimeException mock = mock(RuntimeException.class);
-        final CompositeException compositeException = new CompositeException(Arrays.asList(mock));
+        final ParseTreeCompositeException parseTreeCompositeException = new ParseTreeCompositeException(Arrays.asList(mock));
 
-        assertThat(compositeException.getCause(), is(mock));
+        assertThat(parseTreeCompositeException.getCause(), is(mock));
     }
 
     @Test
-    void testMultipleExceptionsPrinted() throws CompositeException {
-        final CompositeException compositeException = new CompositeException(Arrays.asList(
+    void testMultipleExceptionsPrinted() throws ParseTreeCompositeException {
+        final ParseTreeCompositeException parseTreeCompositeException = new ParseTreeCompositeException(Arrays.asList(
                 new RuntimeException("Error"),
                 new RuntimeException("Error 2"),
                 new RuntimeException("Error 3"),
                 null
         ));
 
-        assertThat(compositeException.getCause() instanceof ExceptionOverview, is(true));
+        assertThat(parseTreeCompositeException.getCause() instanceof ExceptionOverview, is(true));
 
-        final String message = compositeException.getCause().getMessage();
+        final String message = parseTreeCompositeException.getCause().getMessage();
         assertThat(message, containsString("Multiple exceptions (4)"));
         assertThat(message, containsString("|-- java.lang.RuntimeException: Error 3"));
         assertThat(message, containsString("|-- java.lang.RuntimeException: Error 2"));

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeParserTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeParserTest.java
@@ -61,7 +61,7 @@ class ParseTreeParserTest {
     }
 
     @Test
-    void testValidStatement() throws CompositeException {
+    void testValidStatement() throws ParseTreeCompositeException {
         final ParseTree expected = mock(DataPrepperExpressionParser.ExpressionContext.class);
         doReturn(expected).when(parser).expression();
 
@@ -72,7 +72,7 @@ class ParseTreeParserTest {
     }
 
     @Test
-    void testCacheGivenMultipleExpressionCalls() throws CompositeException {
+    void testCacheGivenMultipleExpressionCalls() throws ParseTreeCompositeException {
         final ParseTree expected = mock(DataPrepperExpressionParser.ExpressionContext.class);
         doReturn(expected).when(parser).expression();
 
@@ -94,11 +94,11 @@ class ParseTreeParserTest {
         doReturn(Collections.singletonList(recognitionException)).when(errorListener).getExceptions();
         doReturn(true).when(errorListener).isErrorFound();
 
-        assertThrows(CompositeException.class, () -> parseTreeParser.parse("Error should throw"));
+        assertThrows(ParseTreeCompositeException.class, () -> parseTreeParser.parse("Error should throw"));
     }
 
     @Test
-    void testResetErrorsIsCalled() throws CompositeException {
+    void testResetErrorsIsCalled() throws ParseTreeCompositeException {
         final ParseTree expected = mock(DataPrepperExpressionParser.ExpressionContext.class);
         doReturn(expected).when(parser).expression();
 


### PR DESCRIPTION
Signed-off-by: Steven Bayer <smbayer@amazon.com>

### Description
Renamed CompositeException to ParseTreeCompositeException
 
### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
