### PR TITLE
Updated Gradle projects to use the dependency string notation

### DIFF
--- a/data-prepper-plugins/mapdb-prepper-state/build.gradle
+++ b/data-prepper-plugins/mapdb-prepper-state/build.gradle
@@ -7,9 +7,6 @@ plugins {
     id 'java'
 }
 
-group 'com.amazon'
-version '0.1-beta'
-
 sourceCompatibility = 1.8
 
 repositories {
@@ -19,13 +16,13 @@ repositories {
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')
-    implementation group: 'org.mapdb', name: 'mapdb', version: '3.0.8'
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.6.10'
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-common', version: '1.6.10'
+    implementation 'org.mapdb:mapdb:3.0.8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.10'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-common:1.6.10'
 
     testImplementation project(':data-prepper-plugins:common').sourceSets.test.output
-    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation "org.hamcrest:hamcrest:2.2"
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
@@ -14,15 +14,15 @@ dependencies {
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
     implementation 'com.google.protobuf:protobuf-java-util:3.19.4'
-    implementation "com.linecorp.armeria:armeria:1.9.2"
-    implementation "com.linecorp.armeria:armeria-grpc:1.9.2"
+    implementation 'com.linecorp.armeria:armeria:1.9.2'
+    implementation 'com.linecorp.armeria:armeria-grpc:1.9.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    implementation 'com.google.guava:guava:31.0.1-jre'
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
-    testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "org.awaitility:awaitility:4.1.1"
+    testImplementation 'org.hamcrest:hamcrest:2.2'
+    testImplementation 'org.awaitility:awaitility:4.1.1'
 }
 
 jacocoTestCoverageVerification {


### PR DESCRIPTION
### Description

Updated Gradle projects to use the string notation for dependencies. This helps with quick find all commands and is consistent across projects.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
