### PR TITLE
Netty 4.1.74, which fixes CVE-2021-43797.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,8 +121,8 @@ subprojects {
     configurations.all {
         resolutionStrategy.eachDependency { def details ->
             if (details.requested.group == 'io.netty' && !details.requested.name.startsWith('netty-tcnative')) {
-                details.useVersion '4.1.68.Final'
-                details.because 'Fixes CVE-2021-37136 and CVE-2021-37137. See https://netty.io/news/2021/09/09/4-1-68-Final.html'
+                details.useVersion '4.1.74.Final'
+                details.because 'Fixes CVE-2021-43797, CVE-2021-37136 and CVE-2021-37137. See https://netty.io/news/2021/09/09/4-1-68-Final.html'
             }
         }
     }


### PR DESCRIPTION
### Description

Updated Netty to 4.1.74, the current latest on the 4.1 series. It includes a fix for CVE-2021-43797.
 
### Issues Resolved

Resolves #995
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
