### PR TITLE
Use Hibernate's ParameterMessageInterpolator

### DIFF
--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-cloudwatch2'
     implementation 'software.amazon.awssdk:cloudwatch'
     implementation 'org.hibernate.validator:hibernate-validator:7.0.2.Final'
-    implementation 'org.glassfish:jakarta.el:4.0.2'
     implementation platform('org.apache.logging.log4j:log4j-bom:2.17.1')
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl'

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginApplicationContext.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginApplicationContext.java
@@ -8,6 +8,7 @@ package com.amazon.dataprepper.plugin;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -18,7 +19,10 @@ import org.springframework.context.annotation.Configuration;
 class PluginApplicationContext {
     @Bean
     Validator validator() {
-        final ValidatorFactory validationFactory = Validation.buildDefaultValidatorFactory();
+        final ValidatorFactory validationFactory = Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(new ParameterMessageInterpolator())
+                .buildValidatorFactory();
         return validationFactory.getValidator();
     }
 }


### PR DESCRIPTION
### Description

Using Hibernate's ParameterMessageInterpolator allows us to remove the Jakara EL library and its licenses.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
