### PR TITLE
Verify against OpenSearch 1.2.4 during the CI integration tests.

### DIFF
--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         java: [14]
-        opensearch: [1.0.1, 1.1.0]
+        opensearch: [1.0.1, 1.1.0, 1.2.4]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### Description

Adds a verification workflow against OpenSearch 1.2.4. These run in parallel, so the GitHub Actions should not be any slower.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
