### PR TITLE
Fix not bug

### DIFF
--- a/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
+++ b/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
@@ -88,7 +88,8 @@ setInitializer
     ;
 
 unaryNotOperatorExpression
-    : unaryOperator conditionalExpression
+    : unaryOperator parenthesesExpression
+    | unaryOperator primary
     ;
 
 unaryOperator

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/GrammarTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/GrammarTest.java
@@ -33,6 +33,10 @@ public abstract class GrammarTest {
             DataPrepperExpressionParser.SetOperatorExpressionContext.class;
     protected static final Class<? extends ParseTree> UNARY_OPERATOR_EXPRESSION =
             DataPrepperExpressionParser.UnaryOperatorExpressionContext.class;
+    protected static final Class<? extends ParseTree> UNARY_NOT_OPERATOR_EXPRESSION =
+            DataPrepperExpressionParser.UnaryNotOperatorExpressionContext.class;
+    protected static final Class<? extends ParseTree> UNARY_OPERATOR =
+            DataPrepperExpressionParser.UnaryOperatorContext.class;
     protected static final Class<? extends ParseTree> PARENTHESES_EXPRESSION = DataPrepperExpressionParser.ParenthesesExpressionContext.class;
     //endregion
 


### PR DESCRIPTION
Signed-off-by: Steven Bayer <smbayer@amazon.com>

### Description
Update the types the not operator will accept.
```
unaryNotOperatorExpression
    : unaryOperator parenthesesExpression
    | unaryOperator primary
    ;
```
 
### Issues Resolved
Previously not operator accepted any conditional statement. The order of operations parsed did not match the order defined in #1005 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
