### PR TITLE
Updated the release build to push the Docker image and upload archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Build Release Artifacts
 on:
   workflow_dispatch:
 
+permissions:
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,11 +17,36 @@ jobs:
         java-version: 14
     - name: Checkout Data-Prepper
       uses: actions/checkout@v2
+    - name: Get Version
+      run:  grep '^version=' gradle.properties >> $GITHUB_ENV
     - name: Build Jar Files
       run: ./gradlew build
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: ${{ secrets.RELEASE_IAM_ROLE }}
+        aws-region: us-east-1
+
     - name: Build Archives
       run: ./gradlew :release:archives:buildArchives -Prelease
-    - name: Build Docker Image
-      run: ./gradlew :release:docker:docker -Prelease
+    - name: Upload Archives to Archives Bucket
+      run: ./gradlew :release:archives:uploadArchives -Prelease -Pregion=us-east-1 -Pbucket=${{ secrets.ARCHIVES_BUCKET_NAME }} -Pprofile=default -PbuildNumber=${{ github.run_number }}
+
     - name: Build Maven Artifacts
       run: ./gradlew publish
+
+
+    - name: Build Docker Image
+      run: ./gradlew :release:docker:docker -Prelease
+    - name: Log into Amazon ECR Public
+      id: login-ecr
+      uses: docker/login-action@v1
+      with:
+        registry: public.ecr.aws
+      env:
+        AWS_REGION: us-east-1
+    - name: Push Image to Staging ECR
+      run: |
+        docker tag opensearch-data-prepper:${{ env.version }} ${{ secrets.ECR_REPOSITORY_URL }}:${{ env.version }}-${{ github.run_number }}
+        docker push ${{ secrets.ECR_REPOSITORY_URL }}:${{ env.version }}-${{ github.run_number }}


### PR DESCRIPTION
### Description

This updates the new "Build Release Artifacts" job to also:
* Upload archive files (tar.gz) to a staging S3 bucket
* Push the Docker image to the staging ECR repository
 
### Issues Resolved

Resolves #1149 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
