### PR TITLE
ENH: rule index in operators and OperatorProvider

### DIFF
--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/AndOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/AndOperator.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import javax.inject.Named;
@@ -13,17 +14,17 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 @Named
 class AndOperator implements Operator<Boolean> {
-    private static final Integer SYMBOL = DataPrepperExpressionParser.AND;
+    private static final int SYMBOL = DataPrepperExpressionParser.AND;
     private static final String DISPLAY_NAME = DataPrepperExpressionParser.VOCABULARY
             .getDisplayName(DataPrepperExpressionParser.AND);
 
     @Override
-    public Integer getRuleIndex() {
-        return DataPrepperExpressionParser.RULE_conditionalOperator;
+    public boolean shouldEvaluate(final ParserRuleContext ctx) {
+        return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_conditionalExpression;
     }
 
     @Override
-    public Integer getSymbol() {
+    public int getSymbol() {
         return SYMBOL;
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/AndOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/AndOperator.java
@@ -18,6 +18,11 @@ class AndOperator implements Operator<Boolean> {
             .getDisplayName(DataPrepperExpressionParser.AND);
 
     @Override
+    public Integer getRuleIndex() {
+        return DataPrepperExpressionParser.RULE_conditionalOperator;
+    }
+
+    @Override
     public Integer getSymbol() {
         return SYMBOL;
     }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/AndOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/AndOperator.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.dataprepper.expression;
 
-import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import javax.inject.Named;
@@ -19,7 +19,7 @@ class AndOperator implements Operator<Boolean> {
             .getDisplayName(DataPrepperExpressionParser.AND);
 
     @Override
-    public boolean shouldEvaluate(final ParserRuleContext ctx) {
+    public boolean shouldEvaluate(final RuleContext ctx) {
         return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_conditionalExpression;
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericEqualOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericEqualOperator.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import java.util.function.BiPredicate;
@@ -12,23 +13,23 @@ import java.util.function.BiPredicate;
 import static com.google.common.base.Preconditions.checkArgument;
 
 public class GenericEqualOperator implements Operator<Boolean> {
-    private final Integer symbol;
+    private final int symbol;
     private final String displayName;
     private final BiPredicate<Object, Object> operation;
 
-    public GenericEqualOperator(final Integer symbol, BiPredicate<Object, Object> operation) {
+    public GenericEqualOperator(final int symbol, BiPredicate<Object, Object> operation) {
         this.symbol = symbol;
         displayName = DataPrepperExpressionParser.VOCABULARY.getDisplayName(symbol);
         this.operation = operation;
     }
 
     @Override
-    public Integer getRuleIndex() {
-        return DataPrepperExpressionParser.RULE_equalityOperator;
+    public boolean shouldEvaluate(final ParserRuleContext ctx) {
+        return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_equalityOperatorExpression;
     }
 
     @Override
-    public Integer getSymbol() {
+    public int getSymbol() {
         return symbol;
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericEqualOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericEqualOperator.java
@@ -23,6 +23,11 @@ public class GenericEqualOperator implements Operator<Boolean> {
     }
 
     @Override
+    public Integer getRuleIndex() {
+        return DataPrepperExpressionParser.RULE_equalityOperator;
+    }
+
+    @Override
     public Integer getSymbol() {
         return symbol;
     }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericEqualOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericEqualOperator.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.dataprepper.expression;
 
-import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import java.util.function.BiPredicate;
@@ -24,7 +24,7 @@ public class GenericEqualOperator implements Operator<Boolean> {
     }
 
     @Override
-    public boolean shouldEvaluate(final ParserRuleContext ctx) {
+    public boolean shouldEvaluate(final RuleContext ctx) {
         return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_equalityOperatorExpression;
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericInSetOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericInSetOperator.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.dataprepper.expression;
 
-import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import java.util.Set;
@@ -25,7 +25,7 @@ public class GenericInSetOperator implements Operator<Boolean> {
     }
 
     @Override
-    public boolean shouldEvaluate(final ParserRuleContext ctx) {
+    public boolean shouldEvaluate(final RuleContext ctx) {
         return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_setOperatorExpression;
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericInSetOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericInSetOperator.java
@@ -24,6 +24,11 @@ public class GenericInSetOperator implements Operator<Boolean> {
     }
 
     @Override
+    public Integer getRuleIndex() {
+        return DataPrepperExpressionParser.RULE_setOperator;
+    }
+
+    @Override
     public Integer getSymbol() {
         return symbol;
     }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericInSetOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericInSetOperator.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import java.util.Set;
@@ -13,23 +14,23 @@ import java.util.function.BiPredicate;
 import static com.google.common.base.Preconditions.checkArgument;
 
 public class GenericInSetOperator implements Operator<Boolean> {
-    private final Integer symbol;
+    private final int symbol;
     private final String displayName;
     private final BiPredicate<Object, Object> operation;
 
-    public GenericInSetOperator(final Integer symbol, BiPredicate<Object, Object> operation) {
+    public GenericInSetOperator(final int symbol, BiPredicate<Object, Object> operation) {
         this.symbol = symbol;
         displayName = DataPrepperExpressionParser.VOCABULARY.getDisplayName(symbol);
         this.operation = operation;
     }
 
     @Override
-    public Integer getRuleIndex() {
-        return DataPrepperExpressionParser.RULE_setOperator;
+    public boolean shouldEvaluate(final ParserRuleContext ctx) {
+        return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_setOperatorExpression;
     }
 
     @Override
-    public Integer getSymbol() {
+    public int getSymbol() {
         return symbol;
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericRegexMatchOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericRegexMatchOperator.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import java.util.function.BiPredicate;
@@ -13,23 +14,23 @@ import java.util.regex.PatternSyntaxException;
 import static com.google.common.base.Preconditions.checkArgument;
 
 public class GenericRegexMatchOperator implements Operator<Boolean> {
-    private final Integer symbol;
+    private final int symbol;
     private final String displayName;
     private final BiPredicate<Object, Object> operation;
 
-    public GenericRegexMatchOperator(final Integer symbol, BiPredicate<Object, Object> operation) {
+    public GenericRegexMatchOperator(final int symbol, BiPredicate<Object, Object> operation) {
         this.symbol = symbol;
         displayName = DataPrepperExpressionParser.VOCABULARY.getDisplayName(symbol);
         this.operation = operation;
     }
 
     @Override
-    public Integer getRuleIndex() {
-        return DataPrepperExpressionParser.RULE_regexEqualityOperator;
+    public boolean shouldEvaluate(final ParserRuleContext ctx) {
+        return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_regexOperatorExpression;
     }
 
     @Override
-    public Integer getSymbol() {
+    public int getSymbol() {
         return symbol;
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericRegexMatchOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericRegexMatchOperator.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.dataprepper.expression;
 
-import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import java.util.function.BiPredicate;
@@ -25,7 +25,7 @@ public class GenericRegexMatchOperator implements Operator<Boolean> {
     }
 
     @Override
-    public boolean shouldEvaluate(final ParserRuleContext ctx) {
+    public boolean shouldEvaluate(final RuleContext ctx) {
         return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_regexOperatorExpression;
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericRegexMatchOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericRegexMatchOperator.java
@@ -24,6 +24,11 @@ public class GenericRegexMatchOperator implements Operator<Boolean> {
     }
 
     @Override
+    public Integer getRuleIndex() {
+        return DataPrepperExpressionParser.RULE_regexEqualityOperator;
+    }
+
+    @Override
     public Integer getSymbol() {
         return symbol;
     }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NotOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NotOperator.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.dataprepper.expression;
 
-import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import javax.inject.Named;
@@ -19,7 +19,7 @@ class NotOperator implements Operator<Boolean> {
             .getDisplayName(DataPrepperExpressionParser.NOT);
 
     @Override
-    public boolean shouldEvaluate(final ParserRuleContext ctx) {
+    public boolean shouldEvaluate(final RuleContext ctx) {
         return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_unaryNotOperatorExpression;
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NotOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NotOperator.java
@@ -18,6 +18,11 @@ class NotOperator implements Operator<Boolean> {
             .getDisplayName(DataPrepperExpressionParser.NOT);
 
     @Override
+    public Integer getRuleIndex() {
+        return DataPrepperExpressionParser.RULE_unaryOperator;
+    }
+
+    @Override
     public Integer getSymbol() {
         return SYMBOL;
     }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NotOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NotOperator.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import javax.inject.Named;
@@ -13,17 +14,17 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 @Named
 class NotOperator implements Operator<Boolean> {
-    private static final Integer SYMBOL = DataPrepperExpressionParser.NOT;
+    private static final int SYMBOL = DataPrepperExpressionParser.NOT;
     private static final String DISPLAY_NAME = DataPrepperExpressionParser.VOCABULARY
             .getDisplayName(DataPrepperExpressionParser.NOT);
 
     @Override
-    public Integer getRuleIndex() {
-        return DataPrepperExpressionParser.RULE_unaryOperator;
+    public boolean shouldEvaluate(final ParserRuleContext ctx) {
+        return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_unaryNotOperatorExpression;
     }
 
     @Override
-    public Integer getSymbol() {
+    public int getSymbol() {
         return SYMBOL;
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NumericCompareOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NumericCompareOperator.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import java.util.Map;
@@ -13,11 +14,11 @@ import java.util.function.BiFunction;
 import static com.google.common.base.Preconditions.checkArgument;
 
 public class NumericCompareOperator implements Operator<Boolean> {
-    private final Integer symbol;
+    private final int symbol;
     private final String displayName;
     private final Map<Class<? extends Number>, Map<Class<? extends Number>, BiFunction<Object, Object, Boolean>>> operandsToOperationMap;
 
-    public NumericCompareOperator(final Integer symbol,
+    public NumericCompareOperator(final int symbol,
             final Map<Class<? extends Number>, Map<Class<? extends Number>, BiFunction<Object, Object, Boolean>>> operandsToOperationMap) {
         this.symbol = symbol;
         displayName = DataPrepperExpressionParser.VOCABULARY.getDisplayName(symbol);
@@ -26,12 +27,12 @@ public class NumericCompareOperator implements Operator<Boolean> {
 
 
     @Override
-    public Integer getRuleIndex() {
-        return DataPrepperExpressionParser.RULE_relationalOperator;
+    public boolean shouldEvaluate(final ParserRuleContext ctx) {
+        return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_relationalOperatorExpression;
     }
 
     @Override
-    public Integer getSymbol() {
+    public int getSymbol() {
         return symbol;
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NumericCompareOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NumericCompareOperator.java
@@ -17,12 +17,17 @@ public class NumericCompareOperator implements Operator<Boolean> {
     private final String displayName;
     private final Map<Class<? extends Number>, Map<Class<? extends Number>, BiFunction<Object, Object, Boolean>>> operandsToOperationMap;
 
-    public NumericCompareOperator(
-            final Integer symbol,
+    public NumericCompareOperator(final Integer symbol,
             final Map<Class<? extends Number>, Map<Class<? extends Number>, BiFunction<Object, Object, Boolean>>> operandsToOperationMap) {
         this.symbol = symbol;
         displayName = DataPrepperExpressionParser.VOCABULARY.getDisplayName(symbol);
         this.operandsToOperationMap = operandsToOperationMap;
+    }
+
+
+    @Override
+    public Integer getRuleIndex() {
+        return DataPrepperExpressionParser.RULE_relationalOperator;
     }
 
     @Override

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NumericCompareOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NumericCompareOperator.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.dataprepper.expression;
 
-import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import java.util.Map;
@@ -27,7 +27,7 @@ public class NumericCompareOperator implements Operator<Boolean> {
 
 
     @Override
-    public boolean shouldEvaluate(final ParserRuleContext ctx) {
+    public boolean shouldEvaluate(final RuleContext ctx) {
         return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_relationalOperatorExpression;
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/Operator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/Operator.java
@@ -5,10 +5,10 @@
 
 package org.opensearch.dataprepper.expression;
 
-import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RuleContext;
 
 interface Operator<T> {
-    boolean shouldEvaluate(final ParserRuleContext ctx);
+    boolean shouldEvaluate(final RuleContext ctx);
 
     int getSymbol();
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/Operator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/Operator.java
@@ -6,6 +6,8 @@
 package org.opensearch.dataprepper.expression;
 
 interface Operator<T> {
+    Integer getRuleIndex();
+
     Integer getSymbol();
 
     /**

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/Operator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/Operator.java
@@ -5,10 +5,12 @@
 
 package org.opensearch.dataprepper.expression;
 
-interface Operator<T> {
-    Integer getRuleIndex();
+import org.antlr.v4.runtime.ParserRuleContext;
 
-    Integer getSymbol();
+interface Operator<T> {
+    boolean shouldEvaluate(final ParserRuleContext ctx);
+
+    int getSymbol();
 
     /**
      * @since 1.3

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/OperatorProvider.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/OperatorProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Named
+class OperatorProvider {
+    private final Map<Integer, Operator<?>> symbolToOperators;
+
+    @Inject
+    public OperatorProvider(final List<Operator<?>> operators) {
+        symbolToOperators = new HashMap<>();
+        for (final Operator<?> operator : operators) {
+            symbolToOperators.put(operator.getSymbol(), operator);
+        }
+    }
+
+    public Operator<?> getOperator(final Integer symbol) {
+        final Operator<?> operator = symbolToOperators.get(symbol);
+        if (operator == null) {
+            throw new UnsupportedOperationException("Unsupported operator symbol index: " + symbol);
+        }
+        return operator;
+    }
+}

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/OperatorProvider.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/OperatorProvider.java
@@ -10,6 +10,9 @@ import javax.inject.Named;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 @Named
 class OperatorProvider {
@@ -17,13 +20,15 @@ class OperatorProvider {
 
     @Inject
     public OperatorProvider(final List<Operator<?>> operators) {
+        checkArgument(Objects.nonNull(operators) && operators.stream().allMatch(Objects::nonNull),
+                "Input operators should not contain null.");
         symbolToOperators = new HashMap<>();
         for (final Operator<?> operator : operators) {
             symbolToOperators.put(operator.getSymbol(), operator);
         }
     }
 
-    public Operator<?> getOperator(final Integer symbol) {
+    public Operator<?> getOperator(final int symbol) {
         final Operator<?> operator = symbolToOperators.get(symbol);
         if (operator == null) {
             throw new UnsupportedOperationException("Unsupported operator symbol index: " + symbol);

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/OrOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/OrOperator.java
@@ -18,6 +18,11 @@ class OrOperator implements Operator<Boolean> {
             .getDisplayName(DataPrepperExpressionParser.OR);
 
     @Override
+    public Integer getRuleIndex() {
+        return DataPrepperExpressionParser.RULE_conditionalOperator;
+    }
+
+    @Override
     public Integer getSymbol() {
         return SYMBOL;
     }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/OrOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/OrOperator.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import javax.inject.Named;
@@ -13,17 +14,17 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 @Named
 class OrOperator implements Operator<Boolean> {
-    private static final Integer SYMBOL = DataPrepperExpressionParser.OR;
+    private static final int SYMBOL = DataPrepperExpressionParser.OR;
     private static final String DISPLAY_NAME = DataPrepperExpressionParser.VOCABULARY
             .getDisplayName(DataPrepperExpressionParser.OR);
 
     @Override
-    public Integer getRuleIndex() {
-        return DataPrepperExpressionParser.RULE_conditionalOperator;
+    public boolean shouldEvaluate(final ParserRuleContext ctx) {
+        return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_conditionalExpression;
     }
 
     @Override
-    public Integer getSymbol() {
+    public int getSymbol() {
         return SYMBOL;
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/OrOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/OrOperator.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.dataprepper.expression;
 
-import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RuleContext;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import javax.inject.Named;
@@ -19,7 +19,7 @@ class OrOperator implements Operator<Boolean> {
             .getDisplayName(DataPrepperExpressionParser.OR);
 
     @Override
-    public boolean shouldEvaluate(final ParserRuleContext ctx) {
+    public boolean shouldEvaluate(final RuleContext ctx) {
         return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_conditionalExpression;
     }
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/AndOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/AndOperatorTest.java
@@ -16,6 +16,11 @@ class AndOperatorTest {
     final AndOperator objectUnderTest = new AndOperator();
 
     @Test
+    void testGetRuleIndex() {
+        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_conditionalOperator));
+    }
+
+    @Test
     void testGetSymbol() {
         assertThat(objectUnderTest.getSymbol(), is(DataPrepperExpressionParser.AND));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/AndOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/AndOperatorTest.java
@@ -5,19 +5,31 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class AndOperatorTest {
     final AndOperator objectUnderTest = new AndOperator();
 
+    @Mock
+    private ParserRuleContext ctx;
+
     @Test
-    void testGetRuleIndex() {
-        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_conditionalOperator));
+    void testShouldEvaluate() {
+        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_conditionalExpression);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(true));
+        when(ctx.getRuleIndex()).thenReturn(-1);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(false));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/EqualOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/EqualOperatorTest.java
@@ -17,6 +17,11 @@ class EqualOperatorTest {
     final GenericEqualOperator objectUnderTest = new OperatorFactory().equalOperator();
 
     @Test
+    void testGetRuleIndex() {
+        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_equalityOperator));
+    }
+
+    @Test
     void testGetSymbol() {
         assertThat(objectUnderTest.getSymbol(), is(DataPrepperExpressionParser.EQUAL));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/EqualOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/EqualOperatorTest.java
@@ -5,20 +5,32 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 import org.opensearch.dataprepper.expression.util.TestObject;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class EqualOperatorTest {
     final GenericEqualOperator objectUnderTest = new OperatorFactory().equalOperator();
 
+    @Mock
+    private ParserRuleContext ctx;
+
     @Test
-    void testGetRuleIndex() {
-        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_equalityOperator));
+    void testShouldEvaluate() {
+        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_equalityOperatorExpression);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(true));
+        when(ctx.getRuleIndex()).thenReturn(-1);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(false));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GreaterThanOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GreaterThanOperatorTest.java
@@ -16,6 +16,11 @@ class GreaterThanOperatorTest {
     final Operator<Boolean> objectUnderTest = new OperatorFactory().greaterThanOperator();
 
     @Test
+    void testGetRuleIndex() {
+        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_relationalOperator));
+    }
+
+    @Test
     void testGetSymbol() {
         assertThat(objectUnderTest.getSymbol(), is(DataPrepperExpressionParser.GT));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GreaterThanOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GreaterThanOperatorTest.java
@@ -5,19 +5,31 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class GreaterThanOperatorTest {
     final Operator<Boolean> objectUnderTest = new OperatorFactory().greaterThanOperator();
 
+    @Mock
+    private ParserRuleContext ctx;
+
     @Test
-    void testGetRuleIndex() {
-        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_relationalOperator));
+    void testShouldEvaluate() {
+        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_relationalOperatorExpression);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(true));
+        when(ctx.getRuleIndex()).thenReturn(-1);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(false));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GreaterThanOrEqualOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GreaterThanOrEqualOperatorTest.java
@@ -16,6 +16,11 @@ class GreaterThanOrEqualOperatorTest {
     final Operator<Boolean> objectUnderTest = new OperatorFactory().greaterThanOrEqualOperator();
 
     @Test
+    void testGetRuleIndex() {
+        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_relationalOperator));
+    }
+
+    @Test
     void testGetSymbol() {
         assertThat(objectUnderTest.getSymbol(), is(DataPrepperExpressionParser.GTE));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GreaterThanOrEqualOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GreaterThanOrEqualOperatorTest.java
@@ -5,19 +5,31 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class GreaterThanOrEqualOperatorTest {
     final Operator<Boolean> objectUnderTest = new OperatorFactory().greaterThanOrEqualOperator();
 
+    @Mock
+    private ParserRuleContext ctx;
+
     @Test
-    void testGetRuleIndex() {
-        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_relationalOperator));
+    void testShouldEvaluate() {
+        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_relationalOperatorExpression);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(true));
+        when(ctx.getRuleIndex()).thenReturn(-1);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(false));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/InSetOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/InSetOperatorTest.java
@@ -19,6 +19,11 @@ class InSetOperatorTest {
     final GenericInSetOperator objectUnderTest = new OperatorFactory().inSetOperator();
 
     @Test
+    void testGetRuleIndex() {
+        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_setOperator));
+    }
+
+    @Test
     void testGetSymbol() {
         assertThat(objectUnderTest.getSymbol(), is(DataPrepperExpressionParser.IN_SET));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/InSetOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/InSetOperatorTest.java
@@ -5,7 +5,11 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import java.util.Collections;
@@ -14,13 +18,21 @@ import java.util.Set;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class InSetOperatorTest {
     final GenericInSetOperator objectUnderTest = new OperatorFactory().inSetOperator();
 
+    @Mock
+    private ParserRuleContext ctx;
+
     @Test
-    void testGetRuleIndex() {
-        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_setOperator));
+    void testShouldEvaluate() {
+        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_setOperatorExpression);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(true));
+        when(ctx.getRuleIndex()).thenReturn(-1);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(false));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/LessThanOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/LessThanOperatorTest.java
@@ -16,6 +16,11 @@ class LessThanOperatorTest {
     final Operator<Boolean> objectUnderTest = new OperatorFactory().lessThanOperator();
 
     @Test
+    void testGetRuleIndex() {
+        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_relationalOperator));
+    }
+
+    @Test
     void testGetSymbol() {
         assertThat(objectUnderTest.getSymbol(), is(DataPrepperExpressionParser.LT));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/LessThanOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/LessThanOperatorTest.java
@@ -5,19 +5,31 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class LessThanOperatorTest {
     final Operator<Boolean> objectUnderTest = new OperatorFactory().lessThanOperator();
 
+    @Mock
+    private ParserRuleContext ctx;
+
     @Test
-    void testGetRuleIndex() {
-        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_relationalOperator));
+    void testShouldEvaluate() {
+        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_relationalOperatorExpression);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(true));
+        when(ctx.getRuleIndex()).thenReturn(-1);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(false));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/LessThanOrEqualOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/LessThanOrEqualOperatorTest.java
@@ -5,19 +5,31 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class LessThanOrEqualOperatorTest {
     final Operator<Boolean> objectUnderTest = new OperatorFactory().lessThanOrEqualOperator();
 
+    @Mock
+    private ParserRuleContext ctx;
+
     @Test
-    void testGetRuleIndex() {
-        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_relationalOperator));
+    void testShouldEvaluate() {
+        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_relationalOperatorExpression);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(true));
+        when(ctx.getRuleIndex()).thenReturn(-1);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(false));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/LessThanOrEqualOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/LessThanOrEqualOperatorTest.java
@@ -16,6 +16,11 @@ class LessThanOrEqualOperatorTest {
     final Operator<Boolean> objectUnderTest = new OperatorFactory().lessThanOrEqualOperator();
 
     @Test
+    void testGetRuleIndex() {
+        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_relationalOperator));
+    }
+
+    @Test
     void testGetSymbol() {
         assertThat(objectUnderTest.getSymbol(), is(DataPrepperExpressionParser.LTE));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NotEqualOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NotEqualOperatorTest.java
@@ -5,20 +5,32 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 import org.opensearch.dataprepper.expression.util.TestObject;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class NotEqualOperatorTest {
     final GenericEqualOperator objectUnderTest = new OperatorFactory().notEqualOperator();
 
+    @Mock
+    private ParserRuleContext ctx;
+
     @Test
-    void testGetRuleIndex() {
-        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_equalityOperator));
+    void testShouldEvaluate() {
+        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_equalityOperatorExpression);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(true));
+        when(ctx.getRuleIndex()).thenReturn(-1);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(false));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NotEqualOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NotEqualOperatorTest.java
@@ -17,6 +17,11 @@ class NotEqualOperatorTest {
     final GenericEqualOperator objectUnderTest = new OperatorFactory().notEqualOperator();
 
     @Test
+    void testGetRuleIndex() {
+        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_equalityOperator));
+    }
+
+    @Test
     void testGetSymbol() {
         assertThat(objectUnderTest.getSymbol(), is(DataPrepperExpressionParser.NOT_EQUAL));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NotInSetOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NotInSetOperatorTest.java
@@ -5,7 +5,11 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import java.util.Collections;
@@ -14,13 +18,21 @@ import java.util.Set;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class NotInSetOperatorTest {
     final GenericInSetOperator objectUnderTest = new OperatorFactory().notInSetOperator();
 
+    @Mock
+    private ParserRuleContext ctx;
+
     @Test
-    void testGetRuleIndex() {
-        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_setOperator));
+    void testShouldEvaluate() {
+        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_setOperatorExpression);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(true));
+        when(ctx.getRuleIndex()).thenReturn(-1);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(false));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NotInSetOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NotInSetOperatorTest.java
@@ -19,6 +19,11 @@ class NotInSetOperatorTest {
     final GenericInSetOperator objectUnderTest = new OperatorFactory().notInSetOperator();
 
     @Test
+    void testGetRuleIndex() {
+        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_setOperator));
+    }
+
+    @Test
     void testGetSymbol() {
         assertThat(objectUnderTest.getSymbol(), is(DataPrepperExpressionParser.NOT_IN_SET));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NotOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NotOperatorTest.java
@@ -16,6 +16,11 @@ class NotOperatorTest {
     final NotOperator objectUnderTest = new NotOperator();
 
     @Test
+    void testGetRuleIndex() {
+        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_unaryOperator));
+    }
+
+    @Test
     void testGetSymbol() {
         assertThat(objectUnderTest.getSymbol(), is(DataPrepperExpressionParser.NOT));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NotOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NotOperatorTest.java
@@ -5,19 +5,31 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class NotOperatorTest {
     final NotOperator objectUnderTest = new NotOperator();
 
+    @Mock
+    private ParserRuleContext ctx;
+
     @Test
-    void testGetRuleIndex() {
-        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_unaryOperator));
+    void testShouldEvaluate() {
+        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_unaryNotOperatorExpression);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(true));
+        when(ctx.getRuleIndex()).thenReturn(-1);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(false));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/OperatorProviderTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/OperatorProviderTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -17,26 +18,42 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class OperatorProviderTest {
 
     @Mock
-    Operator<Boolean> testOperator;
+    private Operator<?> testOperator;
 
     OperatorProvider objectUnderTest;
 
     @Test
-    void testGetExistingOperator() {
+    void testIllegalArgumentsInConstructor() {
+        assertThrows(IllegalArgumentException.class, () -> new OperatorProvider(null));
         final int testSymbol = 100;
-        when(testOperator.getSymbol()).thenReturn(testSymbol);
-        final List<Operator<?>> testOperators = Collections.singletonList(testOperator);
+        final List<Operator<?>> operatorsWithNull = Arrays.asList(testOperator, null);
+        assertThrows(IllegalArgumentException.class, () -> new OperatorProvider(operatorsWithNull));
+    }
+
+    @Test
+    void testGetExistingOperator() {
+        final int testSymbol1 = 100;
+        when(testOperator.getSymbol()).thenReturn(testSymbol1);
+        final int testSymbol2 = 200;
+        final Operator<?> testOperator2 = mock(Operator.class);
+        when(testOperator2.getSymbol()).thenReturn(testSymbol2);
+        final List<Operator<?>> testOperators = Arrays.asList(testOperator, testOperator2);
 
         objectUnderTest = new OperatorProvider(testOperators);
-        final Operator<?> retrievedOperator =  objectUnderTest.getOperator(testSymbol);
-        assertThat(retrievedOperator, notNullValue());
-        assertThat(retrievedOperator.getSymbol(), equalTo(testSymbol));
+        final Operator<?> retrievedOperator1 =  objectUnderTest.getOperator(testSymbol1);
+        assertThat(retrievedOperator1, notNullValue());
+        assertThat(retrievedOperator1.getSymbol(), equalTo(testSymbol1));
+        objectUnderTest = new OperatorProvider(testOperators);
+        final Operator<?> retrievedOperator2 =  objectUnderTest.getOperator(testSymbol2);
+        assertThat(retrievedOperator2, notNullValue());
+        assertThat(retrievedOperator2.getSymbol(), equalTo(testSymbol2));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/OperatorProviderTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/OperatorProviderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OperatorProviderTest {
+
+    @Mock
+    Operator<Boolean> testOperator;
+
+    OperatorProvider objectUnderTest;
+
+    @Test
+    void testGetExistingOperator() {
+        final int testSymbol = 100;
+        when(testOperator.getSymbol()).thenReturn(testSymbol);
+        final List<Operator<?>> testOperators = Collections.singletonList(testOperator);
+
+        objectUnderTest = new OperatorProvider(testOperators);
+        final Operator<?> retrievedOperator =  objectUnderTest.getOperator(testSymbol);
+        assertThat(retrievedOperator, notNullValue());
+        assertThat(retrievedOperator.getSymbol(), equalTo(testSymbol));
+    }
+
+    @Test
+    void testGetNonExistingOperator() {
+        objectUnderTest = new OperatorProvider(Collections.emptyList());
+        assertThrows(UnsupportedOperationException.class, () -> objectUnderTest.getOperator(100));
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/OrOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/OrOperatorTest.java
@@ -16,6 +16,11 @@ class OrOperatorTest {
     final OrOperator objectUnderTest = new OrOperator();
 
     @Test
+    void testGetRuleIndex() {
+        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_conditionalOperator));
+    }
+
+    @Test
     void testGetSymbol() {
         assertThat(objectUnderTest.getSymbol(), is(DataPrepperExpressionParser.OR));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/OrOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/OrOperatorTest.java
@@ -5,19 +5,31 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class OrOperatorTest {
     final OrOperator objectUnderTest = new OrOperator();
 
+    @Mock
+    private ParserRuleContext ctx;
+
     @Test
-    void testGetRuleIndex() {
-        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_conditionalOperator));
+    void testShouldEvaluate() {
+        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_conditionalExpression);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(true));
+        when(ctx.getRuleIndex()).thenReturn(-1);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(false));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/RegexEqualOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/RegexEqualOperatorTest.java
@@ -5,19 +5,31 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class RegexEqualOperatorTest {
     final GenericRegexMatchOperator objectUnderTest = new OperatorFactory().regexEqualOperator();
 
+    @Mock
+    private ParserRuleContext ctx;
+
     @Test
-    void testGetRuleIndex() {
-        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_regexEqualityOperator));
+    void testShouldEvaluate() {
+        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_regexOperatorExpression);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(true));
+        when(ctx.getRuleIndex()).thenReturn(-1);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(false));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/RegexEqualOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/RegexEqualOperatorTest.java
@@ -16,6 +16,11 @@ class RegexEqualOperatorTest {
     final GenericRegexMatchOperator objectUnderTest = new OperatorFactory().regexEqualOperator();
 
     @Test
+    void testGetRuleIndex() {
+        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_regexEqualityOperator));
+    }
+
+    @Test
     void testGetSymbol() {
         assertThat(objectUnderTest.getSymbol(), is(DataPrepperExpressionParser.MATCH_REGEX_PATTERN));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/RegexNotEqualOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/RegexNotEqualOperatorTest.java
@@ -5,19 +5,31 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class RegexNotEqualOperatorTest {
     final GenericRegexMatchOperator objectUnderTest = new OperatorFactory().regexNotEqualOperator();
 
+    @Mock
+    private ParserRuleContext ctx;
+
     @Test
-    void testGetRuleIndex() {
-        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_regexEqualityOperator));
+    void testShouldEvaluate() {
+        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_regexOperatorExpression);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(true));
+        when(ctx.getRuleIndex()).thenReturn(-1);
+        assertThat(objectUnderTest.shouldEvaluate(ctx), is(false));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/RegexNotEqualOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/RegexNotEqualOperatorTest.java
@@ -16,6 +16,11 @@ class RegexNotEqualOperatorTest {
     final GenericRegexMatchOperator objectUnderTest = new OperatorFactory().regexNotEqualOperator();
 
     @Test
+    void testGetRuleIndex() {
+        assertThat(objectUnderTest.getRuleIndex(), is(DataPrepperExpressionParser.RULE_regexEqualityOperator));
+    }
+
+    @Test
     void testGetSymbol() {
         assertThat(objectUnderTest.getSymbol(), is(DataPrepperExpressionParser.NOT_MATCH_REGEX_PATTERN));
     }


### PR DESCRIPTION
### Description
As a breakdown of #1145 , this PR 
* adds rule index into Operator interface
* adds OperatorProvider to encapsulate the lookup and retrieval of operator.

They will be used in ParseTreeEvaluatorListener.
 
### Issues Resolved
Contributes to #1003 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
