### PR TITLE
Reintroduce `WithKeysConfig`

### DIFF
--- a/data-prepper-plugins/mutate-string-processors/src/main/java/com/amazon/dataprepper/plugins/processor/mutatestring/LowercaseStringProcessor.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/com/amazon/dataprepper/plugins/processor/mutatestring/LowercaseStringProcessor.java
@@ -16,10 +16,10 @@ import java.util.Locale;
  * This processor takes in a key and changes its value to a lowercase string. If the value is not a string,
  * no action is performed.
  */
-@DataPrepperPlugin(name = "lowercase_string", pluginType = Processor.class, pluginConfigurationType = StringProcessorConfig.class)
+@DataPrepperPlugin(name = "lowercase_string", pluginType = Processor.class, pluginConfigurationType = WithKeysConfig.class)
 public class LowercaseStringProcessor extends AbstractStringProcessor<String> {
     @DataPrepperPluginConstructor
-    public LowercaseStringProcessor(final PluginMetrics pluginMetrics, final StringProcessorConfig<String> config) {
+    public LowercaseStringProcessor(final PluginMetrics pluginMetrics, final WithKeysConfig config) {
         super(pluginMetrics, config);
     }
 

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/com/amazon/dataprepper/plugins/processor/mutatestring/TrimStringProcessor.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/com/amazon/dataprepper/plugins/processor/mutatestring/TrimStringProcessor.java
@@ -15,10 +15,10 @@ import com.amazon.dataprepper.model.processor.Processor;
  * This processor takes in a key and changes its value to a string with the leading and trailing spaces trimmed.
  * If the value is not a string, no action is performed.
  */
-@DataPrepperPlugin(name = "trim_string", pluginType = Processor.class, pluginConfigurationType = StringProcessorConfig.class)
+@DataPrepperPlugin(name = "trim_string", pluginType = Processor.class, pluginConfigurationType = WithKeysConfig.class)
 public class TrimStringProcessor extends AbstractStringProcessor<String> {
     @DataPrepperPluginConstructor
-    public TrimStringProcessor(final PluginMetrics pluginMetrics, final StringProcessorConfig<String> config) {
+    public TrimStringProcessor(final PluginMetrics pluginMetrics, final WithKeysConfig config) {
         super(pluginMetrics, config);
     }
 

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/com/amazon/dataprepper/plugins/processor/mutatestring/UppercaseStringProcessor.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/com/amazon/dataprepper/plugins/processor/mutatestring/UppercaseStringProcessor.java
@@ -16,10 +16,10 @@ import java.util.Locale;
  * This processor takes in a key and changes its value to an uppercase string. If the value is not a string,
  * no action is performed.
  */
-@DataPrepperPlugin(name = "uppercase_string", pluginType = Processor.class, pluginConfigurationType = StringProcessorConfig.class)
+@DataPrepperPlugin(name = "uppercase_string", pluginType = Processor.class, pluginConfigurationType = WithKeysConfig.class)
 public class UppercaseStringProcessor extends AbstractStringProcessor<String> {
     @DataPrepperPluginConstructor
-    public UppercaseStringProcessor(final PluginMetrics pluginMetrics, final StringProcessorConfig<String> config) {
+    public UppercaseStringProcessor(final PluginMetrics pluginMetrics, final WithKeysConfig config) {
         super(pluginMetrics, config);
     }
 

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/com/amazon/dataprepper/plugins/processor/mutatestring/WithKeysConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/com/amazon/dataprepper/plugins/processor/mutatestring/WithKeysConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.processor.mutatestring;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jdk.nashorn.internal.ir.annotations.Ignore;
+
+import java.util.List;
+
+public class WithKeysConfig implements StringProcessorConfig<String> {
+
+    @NotNull
+    @NotEmpty
+    @JsonProperty("with_keys")
+    private List<String> withKeys;
+
+    @Override
+    public List<String> getIterativeConfig() {
+        return withKeys;
+    }
+
+    public List<String> getWithKeys() {
+        return withKeys;
+    }
+}

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/com/amazon/dataprepper/plugins/processor/mutatestring/WithKeysConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/com/amazon/dataprepper/plugins/processor/mutatestring/WithKeysConfig.java
@@ -8,7 +8,6 @@ package com.amazon.dataprepper.plugins.processor.mutatestring;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jdk.nashorn.internal.ir.annotations.Ignore;
 
 import java.util.List;
 

--- a/data-prepper-plugins/mutate-string-processors/src/test/java/com/amazon/dataprepper/plugins/processor/mutatestring/LowercaseStringProcessorTests.java
+++ b/data-prepper-plugins/mutate-string-processors/src/test/java/com/amazon/dataprepper/plugins/processor/mutatestring/LowercaseStringProcessorTests.java
@@ -33,7 +33,7 @@ public class LowercaseStringProcessorTests {
     private PluginMetrics pluginMetrics;
 
     @Mock
-    private StringProcessorConfig<String> config;
+    private WithKeysConfig config;
 
     @BeforeEach
     public void setup() {

--- a/data-prepper-plugins/mutate-string-processors/src/test/java/com/amazon/dataprepper/plugins/processor/mutatestring/TrimStringProcessorTests.java
+++ b/data-prepper-plugins/mutate-string-processors/src/test/java/com/amazon/dataprepper/plugins/processor/mutatestring/TrimStringProcessorTests.java
@@ -33,7 +33,7 @@ public class TrimStringProcessorTests {
     private PluginMetrics pluginMetrics;
 
     @Mock
-    private StringProcessorConfig<String> config;
+    private WithKeysConfig config;
 
     @BeforeEach
     public void setup() {

--- a/data-prepper-plugins/mutate-string-processors/src/test/java/com/amazon/dataprepper/plugins/processor/mutatestring/UppercaseStringProcessorTests.java
+++ b/data-prepper-plugins/mutate-string-processors/src/test/java/com/amazon/dataprepper/plugins/processor/mutatestring/UppercaseStringProcessorTests.java
@@ -33,7 +33,7 @@ public class UppercaseStringProcessorTests {
     private PluginMetrics pluginMetrics;
 
     @Mock
-    private StringProcessorConfig<String> config;
+    private WithKeysConfig config;
 
     @BeforeEach
     public void setup() {


### PR DESCRIPTION
Signed-off-by: David Powers <ddpowers@amazon.com>

### Description
I recently took out WithKeysConfig. That was a mistake. This PR reintroduces it.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
