### PR TITLE
When core

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/ContextManager.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/ContextManager.java
@@ -8,7 +8,6 @@ package com.amazon.dataprepper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.env.SimpleCommandLinePropertySource;
 
 /**
@@ -39,7 +38,8 @@ class ContextManager {
         LOG.trace("Reading args");
         final SimpleCommandLinePropertySource commandLinePropertySource = new SimpleCommandLinePropertySource(args);
 
-        final GenericApplicationContext publicApplicationContext = new GenericApplicationContext();
+        final AnnotationConfigApplicationContext publicApplicationContext = new AnnotationConfigApplicationContext();
+        publicApplicationContext.scan("org.opensearch.dataprepper.expression");
         publicApplicationContext.refresh();
 
         coreApplicationContext = new AnnotationConfigApplicationContext();

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginArgumentsContext.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginArgumentsContext.java
@@ -66,23 +66,32 @@ class PluginArgumentsContext {
         if(typedArgumentsSuppliers.containsKey(parameterType)) {
             return typedArgumentsSuppliers.get(parameterType);
         }
+        else if (beanFactory != null) {
+            return createBeanSupplier(parameterType, beanFactory);
+        }
         else {
-            return createBeanSupplier(parameterType);
+            throw new InvalidPluginDefinitionException(UNABLE_TO_CREATE_PLUGIN_PARAMETER + parameterType);
         }
     }
 
-    private Supplier<Object> createBeanSupplier(final Class<?> parameterType) {
-        if (beanFactory == null) {
-            throw new InvalidPluginDefinitionException(UNABLE_TO_CREATE_PLUGIN_PARAMETER + parameterType);
-        }
-        else {
+    /**
+     * @since 1.3
+     *
+     * Create a supplier to return a bean of type <pre>parameterType</pre> if one is available in <pre>beanFactory</pre>
+     *
+     * @param parameterType type of bean requested
+     * @param beanFactory bean source the generated supplier will use
+     * @return supplier of object type bean
+     * @throws InvalidPluginDefinitionException if no bean is available from beanFactory
+     */
+    private <T> Supplier<T> createBeanSupplier(final Class<? extends T> parameterType, final BeanFactory beanFactory) {
+        return () -> {
             try {
-                final Object bean = beanFactory.getBean(parameterType);
-                return () -> bean;
+                return beanFactory.getBean(parameterType);
             } catch (final BeansException e) {
                 throw new InvalidPluginDefinitionException(UNABLE_TO_CREATE_PLUGIN_PARAMETER + parameterType, e);
             }
-        }
+        };
     }
 
     static class Builder {

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginArgumentsContextTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginArgumentsContextTest.java
@@ -15,13 +15,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
@@ -72,6 +76,22 @@ class PluginArgumentsContextTest {
 
         assertThat(objectUnderTest.createArguments(new Class[] { Object.class }),
                 equalTo(new Object[] {mock}));
+    }
+
+    @Test
+    void createArguments_given_bean_not_available_with_single_class_using_bean_factory() {
+        doThrow(mock(BeansException.class)).when(beanFactory).getBean((Class<Object>) any());
+
+        final PluginArgumentsContext objectUnderTest = new PluginArgumentsContext.Builder()
+                .withPluginSetting(pluginSetting)
+                .withBeanFactory(beanFactory)
+                .build();
+
+        final InvalidPluginDefinitionException throwable = assertThrows(
+                InvalidPluginDefinitionException.class,
+                () -> objectUnderTest.createArguments(new Class[]{Object.class})
+        );
+        assertTrue(throwable.getCause() instanceof BeansException);
     }
 
     @Test

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeParser.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeParser.java
@@ -27,7 +27,7 @@ import java.util.Map;
 @Named
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 class ParseTreeParser implements Parser<ParseTree> {
-    private static final String MISSING_LISTENER_MESSAGE =
+    private static final String MISSING_PARSER_ERROR_LISTENER_MESSAGE =
             "Expected DataPrepperExpressionParser to have error listener of type ParserErrorListener but none were found.";
     private final Map<String, ParseTree> cache = new HashMap<>();
     private final ParserErrorListener errorListener;
@@ -41,7 +41,7 @@ class ParseTreeParser implements Parser<ParseTree> {
                 .stream()
                 .filter(errorListener -> errorListener instanceof ParserErrorListener)
                 .findFirst()
-                .orElseThrow(() -> new IllegalStateException(MISSING_LISTENER_MESSAGE));
+                .orElseThrow(() -> new IllegalStateException(MISSING_PARSER_ERROR_LISTENER_MESSAGE));
 
         final TokenSource tokenSource = parser.getTokenStream().getTokenSource();
         if (tokenSource instanceof Lexer) {

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeParserConfiguration.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeParserConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CodePointCharStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionLexer;
+import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Scope;
+
+import javax.inject.Named;
+
+@Named
+class ParseTreeParserConfiguration {
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public DataPrepperExpressionParser dataPrepperExpressionParser() {
+        final ParserErrorListener errorListener = new ParserErrorListener();
+
+        final CodePointCharStream stream = CharStreams.fromString("");
+        final DataPrepperExpressionLexer lexer = new DataPrepperExpressionLexer(stream);
+        lexer.addErrorListener(errorListener);
+
+        final CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+        final DataPrepperExpressionParser parser = new DataPrepperExpressionParser(tokenStream);
+        parser.addErrorListener(errorListener);
+
+        return parser;
+    }
+}

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParserErrorListener.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParserErrorListener.java
@@ -11,7 +11,6 @@ import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.atn.ATNConfigSet;
 import org.antlr.v4.runtime.dfa.DFA;
-import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -24,10 +23,6 @@ import java.util.List;
  */
 class ParserErrorListener implements ANTLRErrorListener {
     private final List<Throwable> exceptions = new ArrayList<>();
-
-    public ParserErrorListener(final DataPrepperExpressionParser parser) {
-        parser.addErrorListener(this);
-    }
 
     /**
      * @since 1.3

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeParserConfigurationTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeParserConfigurationTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
+
+import static org.hamcrest.CoreMatchers.isA;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ParseTreeParserConfigurationTest {
+
+    @Test
+    void testDataPrepperExpressionParser() {
+        final ParseTreeParserConfiguration parseTreeParserConfiguration = new ParseTreeParserConfiguration();
+
+        final DataPrepperExpressionParser dataPrepperExpressionParser = parseTreeParserConfiguration.dataPrepperExpressionParser();
+
+        assertThat(dataPrepperExpressionParser, isA(DataPrepperExpressionParser.class));
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeParserTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeParserTest.java
@@ -48,16 +48,18 @@ class ParseTreeParserTest {
     void beforeEach() {
         doReturn(tokenStream).when(parser).getTokenStream();
         doReturn(lexer).when(tokenStream).getTokenSource();
+        doReturn(Collections.singletonList(errorListener)).when(parser).getErrorListeners();
 
-        parseTreeParser = new ParseTreeParser(parser, errorListener);
+        parseTreeParser = new ParseTreeParser(parser);
     }
 
     @Test
     void testMissingLexer() {
         final DataPrepperExpressionParser mockParser = mock(DataPrepperExpressionParser.class);
         doReturn(mock(TokenStream.class)).when(mockParser).getTokenStream();
+        doReturn(Collections.singletonList(errorListener)).when(mockParser).getErrorListeners();
 
-        assertThrows(ClassCastException.class, () -> new ParseTreeParser(mockParser, null));
+        assertThrows(ClassCastException.class, () -> new ParseTreeParser(mockParser));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeParserTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeParserTest.java
@@ -63,6 +63,13 @@ class ParseTreeParserTest {
     }
 
     @Test
+    void testMissingListener() {
+        final DataPrepperExpressionParser mockParser = mock(DataPrepperExpressionParser.class);
+
+        assertThrows(IllegalStateException.class, () -> new ParseTreeParser(mockParser));
+    }
+
+    @Test
     void testValidStatement() throws ParseTreeCompositeException {
         final ParseTree expected = mock(DataPrepperExpressionParser.ExpressionContext.class);
         doReturn(expected).when(parser).expression();


### PR DESCRIPTION
### Description
Added `org.opensearch.dataprepper.expression` to public context
Added DI support for `DataPrepperExpressionParser`
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
