### PR TITLE
Added data-prepper-expression to test coverage report

### DIFF
--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -15,6 +15,6 @@ ext.coreProjects = [
         project(':data-prepper-api'),
         project(':data-prepper-core'),
         project('data-prepper-plugins:common'),
-        project('data-prepper-expression:common')
+        project('data-prepper-expression')
 ]
 ext.mavenArtifactProjects = [project(':data-prepper-api')]

--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -11,5 +11,10 @@ ext.versionMap = [
         opensearchVersion : '1.1.0'
 ]
 
-ext.coreProjects = [project(':data-prepper-api'), project(':data-prepper-core'), project('data-prepper-plugins:common')]
+ext.coreProjects = [
+        project(':data-prepper-api'),
+        project(':data-prepper-core'),
+        project('data-prepper-plugins:common'),
+        project('data-prepper-expression:common')
+]
 ext.mavenArtifactProjects = [project(':data-prepper-api')]

--- a/data-prepper-expression/build.gradle
+++ b/data-prepper-expression/build.gradle
@@ -37,5 +37,12 @@ jacocoTestCoverageVerification {
             }
         }
     }
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    "org/opensearch/dataprepper/expression/antlr/**"
+            ])
+        }))
+    }
 }
 

--- a/data-prepper-expression/build.gradle
+++ b/data-prepper-expression/build.gradle
@@ -8,6 +8,10 @@ plugins {
     id 'idea'
 }
 
+ext {
+    antlrGeneratedPackageDirectory = "org/opensearch/dataprepper/expression/antlr/"
+}
+
 dependencies {
     antlr 'org.antlr:antlr4:4.9.2'
     implementation project(':data-prepper-api')
@@ -25,7 +29,7 @@ dependencies {
 }
 
 generateGrammarSource {
-    outputDirectory = new File('build/generated-src/antlr/main/org/opensearch/dataprepper/expression/antlr/')
+    outputDirectory = new File("build/generated-src/antlr/main/${antlrGeneratedPackageDirectory}")
 }
 
 jacocoTestCoverageVerification {
@@ -39,9 +43,7 @@ jacocoTestCoverageVerification {
     }
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: [
-                    "org/opensearch/dataprepper/expression/antlr/**"
-            ])
+            fileTree(dir: it, exclude: ["${antlrGeneratedPackageDirectory}/**"])
         }))
     }
 }

--- a/data-prepper-expression/build.gradle
+++ b/data-prepper-expression/build.gradle
@@ -5,7 +5,6 @@
 
 plugins {
     id 'antlr'
-    id 'java'
     id 'idea'
 }
 
@@ -29,6 +28,14 @@ generateGrammarSource {
     outputDirectory = new File('build/generated-src/antlr/main/org/opensearch/dataprepper/expression/antlr/')
 }
 
-test {
-    useJUnitPlatform()
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule { //in addition to core projects rule - this one checks for 100% code coverage for this project
+            limit {
+                minimum = 1.0 //keep this at 100%
+            }
+        }
+    }
 }
+


### PR DESCRIPTION
Signed-off-by: Steven Bayer <smbayer@amazon.com>

### Description
Added data-prepper-expression to test coverage report
 
### Issues Resolved
Missing test coverage report
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
