### PR TITLE
Add drop_events.drop_when documentation

### DIFF
--- a/data-prepper-plugins/drop-events-processor/README.md
+++ b/data-prepper-plugins/drop-events-processor/README.md
@@ -24,6 +24,10 @@ Create the following file named `logs_json.log` and replace the `path` in the fi
 
 When run, the processor will filter out and drop all messages.
 
+## Conditional Drop Events
+The `when` parameter can be used to drop selected events. The `when` parameter takes a single String expression. See
+[Data Prepper Expression syntax](../../docs/expression_syntax) for a complete list of features supported by a Data Prepper Expression.
+
 ## Developer Guide
 This plugin is compatible with Java 14. See
 - [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md)

--- a/data-prepper-plugins/drop-events-processor/README.md
+++ b/data-prepper-plugins/drop-events-processor/README.md
@@ -6,7 +6,8 @@ This is a processor that drops all messages that are passed into it.
 ### Starting in Data Prepper v1.3.0
 * Added support for new configurations options `drop_when` and `handle_failed_events`. See [Configuration Options](#Configuration-Options).
 
-Upgrade information can be found at [how to upgrade from a pre-release version to 1.3.0](#upgrade-to-1.3.0).
+Upgrade information can be found at 
+[how to upgrade from a pre-release version to 1.3.0](#How-to-upgrade-from-a-pre-release-version-to-130).
 
 
 ## Basic Usage
@@ -63,7 +64,6 @@ This plugin is compatible with Java 14. See
 
 ## How To Upgrade Guides
 
-<a name="upgrade-to-1.3.0"></a>
 ### How to upgrade from a pre-release version to 1.3.0
 
 When upgrading only adding `drop_when: true` is required for compatability with Data Prepper 1.3.0. After adding `drop_when: true`

--- a/data-prepper-plugins/drop-events-processor/README.md
+++ b/data-prepper-plugins/drop-events-processor/README.md
@@ -1,6 +1,14 @@
 # Drop Events Processor
 This is a processor that drops all messages that are passed into it.
 
+## Changes
+
+### Starting in Data Prepper v1.3.0
+* Added support for new configurations options `drop_when` and `handle_failed_events`. See [Configuration Options](#Configuration-Options).
+
+Upgrade information can be found at [how to upgrade from a pre-release version to 1.3.0](#upgrade-to-1.3.0).
+
+
 ## Basic Usage
 To get started, create the following `pipeline.yaml`.
 ```yaml
@@ -12,11 +20,13 @@ drop-pipeline:
       format: "json"
   processor:
     - drop_events:
+        drop_when: true
   sink:
     - stdout:
 ```
 
-Create the following file named `logs_json.log` and replace the `path` in the file source of your `pipeline.yaml` with the path of this file.
+Create the following file named `logs_json.log` and replace the `path` in the file source of your `pipeline.yaml` with the path of this 
+file.
 
 ```
 {"message": "127.0.0.1 198.126.12 [10/Oct/2000:13:55:36 -0700] 200"}
@@ -24,11 +34,52 @@ Create the following file named `logs_json.log` and replace the `path` in the fi
 
 When run, the processor will filter out and drop all messages.
 
+## Configuration Options
+
+### `drop_when`
+**Required**
+
+Accepts a Data Prepper Expression String following the [Data Prepper Expression syntax](../../docs/expression_syntax). Configuring 
+`drop_events` processor with `drop_when: true` will drop all events received.
+
+### `handle_failed_events`
+**Optional**
+
+While evaluating an event if an exception occurs `handle_failed_events` specifies how the exception will be handled
+    * `drop` **Default** - The event will be dropped and a warning will be logged.
+    * `drop_silently` - The event will be dropped without warning.
+    * `skip` - The event will not be dropped and a warning will be logged.
+    * `skip_silently` - The event will not be dropped without warning.
+
+
 ## Conditional Drop Events
-The `when` parameter can be used to drop selected events. The `when` parameter takes a single String expression. See
+The `drop_when` parameter can be used to drop selected events. The `drop_when` parameter takes a single String expression. See
 [Data Prepper Expression syntax](../../docs/expression_syntax) for a complete list of features supported by a Data Prepper Expression.
 
 ## Developer Guide
 This plugin is compatible with Java 14. See
 - [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md)
 - [monitoring](https://github.com/opensearch-project/data-prepper/blob/main/docs/monitoring.md)
+
+## How To Upgrade Guides
+
+<a name="upgrade-to-1.3.0"></a>
+### How to upgrade from a pre-release version to 1.3.0
+
+When upgrading only adding `drop_when: true` is required for compatability with Data Prepper 1.3.0. After adding `drop_when: true`
+upgraded configurations will function exactly as before the updated.
+
+Pre-release pipeline configuration:
+```yaml
+my-pipeline:
+  processor:
+    - drop_events:
+```
+
+Data Prepper 1.3.0 compliant configuration:
+```yaml
+my-pipeline:
+  processor:
+    - drop_events:
+      drop_when: true
+```

--- a/data-prepper-plugins/drop-events-processor/README.md
+++ b/data-prepper-plugins/drop-events-processor/README.md
@@ -1,15 +1,6 @@
 # Drop Events Processor
 This is a processor that drops all messages that are passed into it.
 
-## Changes
-
-### Starting in Data Prepper v1.3.0
-* Added support for new configurations options `drop_when` and `handle_failed_events`. See [Configuration Options](#Configuration-Options).
-
-Upgrade information can be found at 
-[how to upgrade from a pre-release version to 1.3.0](#How-to-upgrade-from-a-pre-release-version-to-130).
-
-
 ## Basic Usage
 To get started, create the following `pipeline.yaml`.
 ```yaml
@@ -61,25 +52,3 @@ The `drop_when` parameter can be used to drop selected events. The `drop_when` p
 This plugin is compatible with Java 14. See
 - [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md)
 - [monitoring](https://github.com/opensearch-project/data-prepper/blob/main/docs/monitoring.md)
-
-## How To Upgrade Guides
-
-### How to upgrade from a pre-release version to 1.3.0
-
-When upgrading only adding `drop_when: true` is required for compatability with Data Prepper 1.3.0. After adding `drop_when: true`
-upgraded configurations will function exactly as before the updated.
-
-Pre-release pipeline configuration:
-```yaml
-my-pipeline:
-  processor:
-    - drop_events:
-```
-
-Data Prepper 1.3.0 compliant configuration:
-```yaml
-my-pipeline:
-  processor:
-    - drop_events:
-      drop_when: true
-```

--- a/docs/expression_syntax.md
+++ b/docs/expression_syntax.md
@@ -1,35 +1,30 @@
-**Is your feature request related to a problem? Please describe.**
-As part of a larger feature (#522) to support complex condition statements in data prepper there is a need to define a syntax for conditional statements. A conditional statement is a String that is evaluated at runtime and may reference fields within a record.
-
-**Describe the solution you'd like**
-_Terms used throught this document are defined in the Definitions section_
-
 ## Supported Operators
 In order of evaluation priority. _(top to bottom, left to right)_
 
-| Operator             | Description              | Data Prepper Version |
-|----------------------|--------------------------|----------------------|
-| `{}`                 | Set Initializer          | 1.4.0                |
-| `()`                 | Priority Expression      | 1.3.0                |
-| `not`                | Not Operator             | 1.3.0                |
-| `in`, `not in`       | Set Operators            | 1.4.0                |
-| `<`, `<=`, `>`, `>=` | Relational Operators     | 1.3.0                |
-| `=~`, `!~`           | Regex Equality Operators | 2.0.0                |
-| `==`, `!=`           | Equality Operators       | 1.3.0                |
-| `and`, `or`          | Conditional Expression   | 1.3.0                |
-| `,`                  | Set Value Delimiter      | 1.4.0                |
+| Level | Operator             | Description                                           | Associativity |
+|-------|----------------------|-------------------------------------------------------|---------------|
+| 5     | `()`                 | Priority Expression                                   | left-to-right |
+| 4     | `not`, `+`, `-`      | Unary Logical NOT<br>Unary Positive<br>Unary negative | right-to-left |
+| 3     | `<`, `<=`, `>`, `>=` | Relational Operators                                  | left-to-right |
+| 2     | `==`, `!=`           | Equality Operators                                    | left-to-right |
+| 1     | `and`, `or`          | Conditional Expression                                | left-to-right |
 
 ## Reserved for possible future functionality
 Reserved symbol set: `^`, `*`, `/`, `%`, `+`, `-`, `xor`, `=`, `+=`, `-=`, `*=`, `/=`, `%=`, `++`, `--`, `${<text>}`
 
-## Set Initialiser
+## Set Initializer
 Defines a set or term and/or expressions.
 
 Examples
 ```
-{1, 2, 3}
-{"a", "b", "c"}
-{/people/0/name, /status_code}
+# Http Status Codes
+{200, 201, 202}
+
+# Http respone payloads
+{"Created", "Accepted"}
+
+# Handle multiple event types with different keys
+{/request_payload, /request_message}
 ```
 
 ## Priority Expression
@@ -39,21 +34,6 @@ expression or value, empty parentheses are not supported.
 Examples
 ```
 /is_cool == (/name == "Steven")
-```
-
-## Set Operators
-Tests if a value is in/not in a set. Note, the right-hand side operand must be a set.
-
-Syntax
-```
-<Expression> in <Set>
-<Expression> not in <Set>
-```
-
-Examples
-```
-/status_code in {200, 202}
-/status_code not in {400, 404, 500}
 ```
 
 ## Relational Operators
@@ -70,21 +50,6 @@ Syntax
 Examples
 ```
 /status_code >= 200 and /status_code < 300
-```
-
-## Regex Equality Operators
-Used to test if a String value matches/does not match a Regular Expression. Note, the left-hand side operand must be a string or Json Pointer that resolves to a String. The right hand side operand must be a String that contains a regular expression or a Json Pointer that resolves to a String that contains a regular expression.
-
-Syntax
-```
-<String | Json Pointer> =~ <Regex String | Json Pointer>
-<String | Json Pointer> !~ <Regex String | Json Pointer>
-```
-
-Examples
-```
-/string_property =~ "^[A-Za-z\s]*$"
-"Hello!" !~ /event/regex_matcher
 ```
 
 ## Equality Operators
@@ -137,7 +102,8 @@ Expression String resulting in a return value. Note, an _Expression String_ is n
 The highest level component of the Expression String.
 
 ### Expression
-A generic component that contains a _Primary_ or an _Operator_. Expressions may contain expressions. An expressions imminent children can contains 0-1 _Operators_.
+A generic component that contains a _Primary_ or an _Operator_. Expressions may contain expressions. An expressions imminent children can 
+contains 0-1 _Operators_.
 
 ### Primary
 
@@ -149,7 +115,10 @@ A generic component that contains a _Primary_ or an _Operator_. Expressions may 
 Hard coded token that identifies the operation use in an _Expression_.
 
 ### Json Pointer
-A Literal used to reference a value within the Event provided as context for the _Expression String_. Json Pointers are identified by a leading `/` containing alpha numeric character or underscores, delimited by `/`. Json Pointers can use an extended character set if wrapped in double quotes (`"`) using the escape character `\`. Note, Json Pointer require `~` and `/` that should be used as part of the path and not a delimiter to be escaped.
+A Literal used to reference a value within the Event provided as context for the _Expression String_. Json Pointers are identified by a 
+leading `/` containing alphanumeric character or underscores, delimited by `/`. Json Pointers can use an extended character set if wrapped 
+in double quotes (`"`) using the escape character `\`. Note, Json Pointer require `~` and `/` that should be used as part of the path and 
+not a delimiter to be escaped.
 
 - `~0` representing `~`
 - `~1` representing `/`

--- a/docs/expression_syntax.md
+++ b/docs/expression_syntax.md
@@ -2,7 +2,7 @@
 As part of a larger feature (#522) to support complex condition statements in data prepper there is a need to define a syntax for conditional statements. A conditional statement is a String that is evaluated at runtime and may reference fields within a record.
 
 **Describe the solution you'd like**
-_Terms used throughout this document are defined in the Definitions section_
+_Terms used throught this document are defined in the Definitions section_
 
 ## Supported Operators
 In order of evaluation priority. _(top to bottom, left to right)_
@@ -11,17 +11,18 @@ In order of evaluation priority. _(top to bottom, left to right)_
 |----------------------|--------------------------|----------------------|
 | `{}`                 | Set Initializer          | 1.4.0                |
 | `()`                 | Priority Expression      | 1.3.0                |
+| `not`                | Not Operator             | 1.3.0                |
 | `in`, `not in`       | Set Operators            | 1.4.0                |
 | `<`, `<=`, `>`, `>=` | Relational Operators     | 1.3.0                |
 | `=~`, `!~`           | Regex Equality Operators | 2.0.0                |
 | `==`, `!=`           | Equality Operators       | 1.3.0                |
-| `and`, `or`, `not`   | Conditional Expression   | 1.3.0                |
+| `and`, `or`          | Conditional Expression   | 1.3.0                |
 | `,`                  | Set Value Delimiter      | 1.4.0                |
 
 ## Reserved for possible future functionality
 Reserved symbol set: `^`, `*`, `/`, `%`, `+`, `-`, `xor`, `=`, `+=`, `-=`, `*=`, `/=`, `%=`, `++`, `--`, `${<text>}`
 
-## Set Initializer
+## Set Initialiser
 Defines a set or term and/or expressions.
 
 Examples

--- a/docs/expression_syntax.md
+++ b/docs/expression_syntax.md
@@ -1,0 +1,194 @@
+**Is your feature request related to a problem? Please describe.**
+As part of a larger feature (#522) to support complex condition statements in data prepper there is a need to define a syntax for conditional statements. A conditional statement is a String that is evaluated at runtime and may reference fields within a record.
+
+**Describe the solution you'd like**
+_Terms used throughout this document are defined in the Definitions section_
+
+## Supported Operators
+In order of evaluation priority. _(top to bottom, left to right)_
+
+| Operator             | Description              | Data Prepper Version |
+|----------------------|--------------------------|----------------------|
+| `{}`                 | Set Initializer          | 1.4.0                |
+| `()`                 | Priority Expression      | 1.3.0                |
+| `in`, `not in`       | Set Operators            | 1.4.0                |
+| `<`, `<=`, `>`, `>=` | Relational Operators     | 1.3.0                |
+| `=~`, `!~`           | Regex Equality Operators | 2.0.0                |
+| `==`, `!=`           | Equality Operators       | 1.3.0                |
+| `and`, `or`, `not`   | Conditional Expression   | 1.3.0                |
+| `,`                  | Set Value Delimiter      | 1.4.0                |
+
+## Reserved for possible future functionality
+Reserved symbol set: `^`, `*`, `/`, `%`, `+`, `-`, `xor`, `=`, `+=`, `-=`, `*=`, `/=`, `%=`, `++`, `--`, `${<text>}`
+
+## Set Initializer
+Defines a set or term and/or expressions.
+
+Examples
+```
+{1, 2, 3}
+{"a", "b", "c"}
+{/people/0/name, /status_code}
+```
+
+## Priority Expression
+Identifies an expression that will be evaluated at the highest priority level. Priority expression must contain an
+expression or value, empty parentheses are not supported.
+
+Examples
+```
+/is_cool == (/name == "Steven")
+```
+
+## Set Operators
+Tests if a value is in/not in a set. Note, the right-hand side operand must be a set.
+
+Syntax
+```
+<Expression> in <Set>
+<Expression> not in <Set>
+```
+
+Examples
+```
+/status_code in {200, 202}
+/status_code not in {400, 404, 500}
+```
+
+## Relational Operators
+Tests the relationship of two numeric values. Note, the operands must be a number or Json Pointer that will resolve to a number.
+
+Syntax
+```
+<Number | Json Pointer> < <Number | Json Pointer>
+<Number | Json Pointer> <= <Number | Json Pointer>
+<Number | Json Pointer> > <Number | Json Pointer>
+<Number | Json Pointer> >= <Number | Json Pointer>
+```
+
+Examples
+```
+/status_code >= 200 and /status_code < 300
+```
+
+## Regex Equality Operators
+Used to test if a String value matches/does not match a Regular Expression. Note, the left-hand side operand must be a string or Json Pointer that resolves to a String. The right hand side operand must be a String that contains a regular expression or a Json Pointer that resolves to a String that contains a regular expression.
+
+Syntax
+```
+<String | Json Pointer> =~ <Regex String | Json Pointer>
+<String | Json Pointer> !~ <Regex String | Json Pointer>
+```
+
+Examples
+```
+/string_property =~ "^[A-Za-z\s]*$"
+"Hello!" !~ /event/regex_matcher
+```
+
+## Equality Operators
+Used to test if two value are/are not equivalent.
+
+Syntax
+```
+<Any> == <Any>
+<Any> != <Any>
+```
+
+Examples
+```
+/is_cool == true
+3.14 != /status_code
+{1, 2} == /event/set_property
+```
+
+## Conditional Expression
+Used to chain together multiple expressions and/or values.
+
+Syntax
+```
+<Any> and <Any>
+<Any> or <Any>
+not <Any>
+```
+
+Examples
+```
+/status_code == 200 and /message == "Hello world"
+/status_code == 200 or /status_code == 202
+not /status_code in {200, 202}
+```
+
+# Definitions
+### Literal
+A fundamental value that has no children.
+- Float _(Supports values from 3.40282347 x 10^38 to 1.40239846 x 10^-45)_
+- Integer _(Supports values from -2147483648 to 2147483647)_
+- Boolean _(Supports true or false)_
+- Json Pointer _(See Json Pointer section for details)_
+- String _(Supports Valid Java String characters)_
+
+### Expression String
+The String that will be parsed for evaluation. Expression String is the highest level of a Data Prepper Expression. Only supports one
+Expression String resulting in a return value. Note, an _Expression String_ is not the same as an _Expression_.
+
+### Statement
+The highest level component of the Expression String.
+
+### Expression
+A generic component that contains a _Primary_ or an _Operator_. Expressions may contain expressions. An expressions imminent children can contains 0-1 _Operators_.
+
+### Primary
+
+- _Set_
+- _Priority Expression_
+- _Literal_
+
+### Operator
+Hard coded token that identifies the operation use in an _Expression_.
+
+### Json Pointer
+A Literal used to reference a value within the Event provided as context for the _Expression String_. Json Pointers are identified by a leading `/` containing alpha numeric character or underscores, delimited by `/`. Json Pointers can use an extended character set if wrapped in double quotes (`"`) using the escape character `\`. Note, Json Pointer require `~` and `/` that should be used as part of the path and not a delimiter to be escaped.
+
+- `~0` representing `~`
+- `~1` representing `/`
+
+Shorthand Syntax (Regex, `\w` = `[A-Za-z_]`)
+```
+/\w+(/\w+)*
+```
+
+Shorthand Example
+```
+/Hello/World/0
+```
+
+Escaped Syntax
+```
+"/<Valid String Characters | Escaped Character>(/<Valid String Characters | Escaped Character>)*"
+```
+
+Escaped Example
+```
+# Path
+# { "Hello - 'world/" : [{ "\"JsonPointer\"": true }] }
+"/Hello - 'world\//0/\"JsonPointer\""
+```
+
+## White Space
+### Operators
+White space is **optional** surrounding Relational Operators, Regex Equality Operators, Equality Operators and commas.
+White space is **required** surrounding Set Initializers, Priority Expressions, Set Operators, and Conditional Expressions.
+
+### Reference Table
+
+| Operator             | Description              | White Space Required | ✅ Valid Examples                                               | ❌ Invalid Examples                    |
+|----------------------|--------------------------|----------------------|----------------------------------------------------------------|---------------------------------------|
+| `{}`                 | Set Initializer          | Yes                  | `/status in {200}`                                             | `/status in{200}`                     |
+| `()`                 | Priority Expression      | Yes                  | `/a==(/b==200)`<br>`/a in ({200})`                             | `/status in({200})`                   |
+| `in`, `not in`       | Set Operators            | Yes                  | `/a in {200}`<br>`/a not in {400}`                             | `/a in{200, 202}`<br>`/a not in{400}` |
+| `<`, `<=`, `>`, `>=` | Relational Operators     | No                   | `/status < 300`<br>`/status>=300`                              |                                       |
+| `=~`, `!~`           | Regex Equality Operators | No                   | `/msg =~ "^\w*$"`<br>`/msg=~"^\w*$"`                           |                                       |
+| `==`, `!=`           | Equality Operators       | No                   | `/status == 200`<br>`/status_code==200`                        |                                       |
+| `and`, `or`, `not`   | Conditional Operators    | Yes                  | `/a<300 and /b>200`                                            | `/b<300and/b>200`                     |
+| `,`                  | Set Value Delimiter      | No                   | `/a in {200, 202}`<br>`/a in {200,202}`<br>`/a in {200 , 202}` | `/a in {200,}`                        |


### PR DESCRIPTION
### Description
Updated `drop_events` readme to include `drop_when` and `handle_failed_events` options
Added documentation on Data Prepper Expression syntax.
 
### Check List
- [x] New functionality has been documented.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
