### PR TITLE
Negative value support with unary subtract operator

### DIFF
--- a/data-prepper-expression/build.gradle
+++ b/data-prepper-expression/build.gradle
@@ -38,7 +38,7 @@ jacocoTestCoverageVerification {
     violationRules {
         rule { //in addition to core projects rule - this one checks for 100% code coverage for this project
             limit {
-                minimum = 0.8 //keep this at 100%
+                minimum = 1.0 //keep this at 100%
             }
         }
     }

--- a/data-prepper-expression/build.gradle
+++ b/data-prepper-expression/build.gradle
@@ -48,4 +48,3 @@ jacocoTestCoverageVerification {
         }))
     }
 }
-

--- a/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
+++ b/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
@@ -69,9 +69,8 @@ setOperator
 unaryOperatorExpression
     : primary
     | setInitializer
-    | regexPattern
     | parenthesesExpression
-    | unaryNotOperatorExpression
+    | unaryOperator (primary | unaryOperatorExpression)
     ;
 
 parenthesesExpression
@@ -87,13 +86,11 @@ setInitializer
     : LBRACE primary (SET_DELIMITER primary)* RBRACE
     ;
 
-unaryNotOperatorExpression
-    : unaryOperator parenthesesExpression
-    | unaryOperator primary
-    ;
 
 unaryOperator
     : NOT
+    | SUBTRACT
+    | ADD
     ;
 
 primary
@@ -240,6 +237,8 @@ NOT_IN_SET : SPACE 'not in' SPACE;
 AND : SPACE 'and' SPACE;
 OR : SPACE 'or' SPACE;
 NOT : 'not' SPACE;
+ADD : '+';
+SUBTRACT : '-';
 LPAREN : '(';
 RPAREN : ')';
 LBRACE : '{';

--- a/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
+++ b/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
@@ -90,7 +90,6 @@ setInitializer
 unaryOperator
     : NOT
     | SUBTRACT
-    | ADD
     ;
 
 primary
@@ -237,7 +236,6 @@ NOT_IN_SET : SPACE 'not in' SPACE;
 AND : SPACE 'and' SPACE;
 OR : SPACE 'or' SPACE;
 NOT : 'not' SPACE;
-ADD : '+';
 SUBTRACT : '-';
 LPAREN : '(';
 RPAREN : ')';

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NotOperator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/NotOperator.java
@@ -20,7 +20,7 @@ class NotOperator implements Operator<Boolean> {
 
     @Override
     public boolean shouldEvaluate(final RuleContext ctx) {
-        return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_unaryNotOperatorExpression;
+        return ctx.getRuleIndex() == DataPrepperExpressionParser.RULE_unaryOperatorExpression;
     }
 
     @Override

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GrammarLexerTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GrammarLexerTest.java
@@ -165,6 +165,16 @@ public class GrammarLexerTest {
     }
 
     @Test
+    void testTokenADD() {
+        assertToken("+", DataPrepperExpressionLexer.ADD);
+    }
+
+    @Test
+    void testTokenSUBTRACT() {
+        assertToken("-", DataPrepperExpressionLexer.SUBTRACT);
+    }
+
+    @Test
     void testSpaceInsignificant() {
         final String statement = " ";
         final List<? extends Token> tokens = getTokens(statement);

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GrammarLexerTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GrammarLexerTest.java
@@ -165,11 +165,6 @@ public class GrammarLexerTest {
     }
 
     @Test
-    void testTokenADD() {
-        assertToken("+", DataPrepperExpressionLexer.ADD);
-    }
-
-    @Test
     void testTokenSUBTRACT() {
         assertToken("-", DataPrepperExpressionLexer.SUBTRACT);
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NotOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/NotOperatorTest.java
@@ -26,7 +26,7 @@ class NotOperatorTest {
 
     @Test
     void testShouldEvaluate() {
-        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_unaryNotOperatorExpression);
+        when(ctx.getRuleIndex()).thenReturn(DataPrepperExpressionParser.RULE_unaryOperatorExpression);
         assertThat(objectUnderTest.shouldEvaluate(ctx), is(true));
         when(ctx.getRuleIndex()).thenReturn(-1);
         assertThat(objectUnderTest.shouldEvaluate(ctx), is(false));

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
@@ -86,6 +86,18 @@ class ParseTreeCoercionServiceTest {
     }
 
     @Test
+    void testCoerceTerminalNodeBooleanType() throws ExpressionCoercionException {
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.Boolean);
+        final Boolean testBoolean = new Random().nextBoolean();
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn(String.valueOf(testBoolean));
+        final Event testEvent = createTestEvent(new HashMap<>());
+        final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
+        assertThat(result, instanceOf(Boolean.class));
+        assertThat(result, equalTo(testBoolean));
+    }
+
+    @Test
     void testCoerceTerminalNodeJsonPointerType() throws ExpressionCoercionException {
         final String testKey1 = "key1";
         final String testKey2 = "key2";

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCompositeExceptionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCompositeExceptionTest.java
@@ -65,9 +65,8 @@ class ParseTreeCompositeExceptionTest {
 
         assertThat(parseTreeCompositeException.getCause() instanceof ExceptionOverview, is(true));
         final String message = parseTreeCompositeException.getCause().getMessage();
-        assertThat(message, is("Multiple exceptions (2)\n" +
-                "|-- java.lang.RuntimeException: Error2" +
-                "|-- java.lang.RuntimeException: Error1"
-        ));
+        assertThat(message, containsString("Multiple exceptions (2)"));
+        assertThat(message, containsString("|-- java.lang.RuntimeException: Error2"));
+        assertThat(message, containsString("|-- java.lang.RuntimeException: Error1"));
     }
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCompositeExceptionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCompositeExceptionTest.java
@@ -31,7 +31,7 @@ class ParseTreeCompositeExceptionTest {
     @Test
     void testGivenSingleExceptionThenExceptionIsCause() {
         final RuntimeException mock = mock(RuntimeException.class);
-        final ParseTreeCompositeException parseTreeCompositeException = new ParseTreeCompositeException(Arrays.asList(mock));
+        final ParseTreeCompositeException parseTreeCompositeException = new ParseTreeCompositeException(Collections.singletonList(mock));
 
         assertThat(parseTreeCompositeException.getCause(), is(mock));
     }
@@ -57,13 +57,17 @@ class ParseTreeCompositeExceptionTest {
 
     @Test
     void testExceptionWithoutStackTrace() {
-        final Throwable cause = new Throwable();
-        final ParseTreeCompositeException parseTreeCompositeException =
-                new ParseTreeCompositeException(Collections.singletonList(cause));
+        final RuntimeException error1 = new RuntimeException("Error1");
+        error1.setStackTrace(new StackTraceElement[0]);
+        final RuntimeException error2 = new RuntimeException("Error2");
+        error2.setStackTrace(new StackTraceElement[0]);
+        final ParseTreeCompositeException parseTreeCompositeException = new ParseTreeCompositeException(Arrays.asList(error1, error2));
 
         assertThat(parseTreeCompositeException.getCause() instanceof ExceptionOverview, is(true));
         final String message = parseTreeCompositeException.getCause().getMessage();
-        //TODO: Fix test
-        assertThat(message, is("Hello?"));
+        assertThat(message, is("Multiple exceptions (2)\n" +
+                "|-- java.lang.RuntimeException: Error2" +
+                "|-- java.lang.RuntimeException: Error1"
+        ));
     }
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCompositeExceptionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCompositeExceptionTest.java
@@ -54,4 +54,16 @@ class ParseTreeCompositeExceptionTest {
         assertThat(message, containsString("|-- java.lang.RuntimeException: Error"));
         assertThat(message, containsString("|-- java.lang.NullPointerException: Throwable was null!"));
     }
+
+    @Test
+    void testExceptionWithoutStackTrace() {
+        final Throwable cause = new Throwable();
+        final ParseTreeCompositeException parseTreeCompositeException =
+                new ParseTreeCompositeException(Collections.singletonList(cause));
+
+        assertThat(parseTreeCompositeException.getCause() instanceof ExceptionOverview, is(true));
+        final String message = parseTreeCompositeException.getCause().getMessage();
+        //TODO: Fix test
+        assertThat(message, is("Hello?"));
+    }
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeExpressionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeExpressionTest.java
@@ -336,8 +336,7 @@ public class ParseTreeExpressionTest extends GrammarTest {
                 REGEX_OPERATOR_EXPRESSION,
                 RELATIONAL_OPERATOR_EXPRESSION,
                 SET_OPERATOR_EXPRESSION,
-                UNARY_OPERATOR_EXPRESSION,
-                UNARY_NOT_OPERATOR_EXPRESSION
+                UNARY_OPERATOR_EXPRESSION
         ).withChildrenMatching(
                 isOperator(UNARY_OPERATOR),
                 isUnaryTree()
@@ -370,8 +369,7 @@ public class ParseTreeExpressionTest extends GrammarTest {
                 REGEX_OPERATOR_EXPRESSION,
                 RELATIONAL_OPERATOR_EXPRESSION,
                 SET_OPERATOR_EXPRESSION,
-                UNARY_OPERATOR_EXPRESSION,
-                UNARY_NOT_OPERATOR_EXPRESSION
+                UNARY_OPERATOR_EXPRESSION
         ).withChildrenMatching(isOperator(UNARY_OPERATOR), parenthesesExpression);
 
         assertThat(expression, isExpression(not));

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeTest.java
@@ -11,6 +11,8 @@ import org.hamcrest.DiagnosingMatcher;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.expression.util.GrammarTest;
 
+import java.util.function.Function;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.dataprepper.expression.util.ContextMatcher.hasContext;
@@ -197,6 +199,37 @@ public class ParseTreeTest extends GrammarTest {
         final ParserRuleContext expression = parseExpression(
                 "/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/0123456789/_");
         assertThat(expression, isExpression(isJsonPointerUnaryTree()));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+
+    @Test
+    void testSubtractOperator() {
+        final ParserRuleContext expression = parseExpression("/status_code == --200");
+
+        final DiagnosingMatcher<ParseTree> lhs = isJsonPointerUnaryTree();
+        final Function<DiagnosingMatcher<ParseTree>, DiagnosingMatcher<ParseTree>> isNegative =
+                rhs -> hasContext(UNARY_OPERATOR_EXPRESSION, isOperator(UNARY_OPERATOR), rhs);
+        final DiagnosingMatcher<ParseTree> doubleNegative200 = isNegative.apply(isNegative.apply(isUnaryTree()));
+
+        final DiagnosingMatcher<ParseTree> rhs = isParseTree(
+                REGEX_OPERATOR_EXPRESSION,
+                RELATIONAL_OPERATOR_EXPRESSION,
+                SET_OPERATOR_EXPRESSION
+        ).withChildrenMatching(
+                doubleNegative200
+        );
+
+        final DiagnosingMatcher<ParseTree> equalsExpression = isParseTree(
+                CONDITIONAL_EXPRESSION,
+                EQUALITY_OPERATOR_EXPRESSION
+        ).withChildrenMatching(
+                lhs,
+                isOperator(EQUALITY_OPERATOR),
+                rhs
+        );
+
+
+        assertThat(expression, isExpression(equalsExpression));
         assertThat(errorListener.isErrorFound(), is(false));
     }
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeTest.java
@@ -204,12 +204,12 @@ public class ParseTreeTest extends GrammarTest {
 
     @Test
     void testSubtractOperator() {
-        final ParserRuleContext expression = parseExpression("/status_code == --200");
+        final ParserRuleContext expression = parseExpression("/status_code == -200");
 
         final DiagnosingMatcher<ParseTree> lhs = isJsonPointerUnaryTree();
         final Function<DiagnosingMatcher<ParseTree>, DiagnosingMatcher<ParseTree>> isNegative =
                 rhs -> hasContext(UNARY_OPERATOR_EXPRESSION, isOperator(UNARY_OPERATOR), rhs);
-        final DiagnosingMatcher<ParseTree> doubleNegative200 = isNegative.apply(isNegative.apply(isUnaryTree()));
+        final DiagnosingMatcher<ParseTree> doubleNegative200 = isNegative.apply(isUnaryTree());
 
         final DiagnosingMatcher<ParseTree> rhs = isParseTree(
                 REGEX_OPERATOR_EXPRESSION,

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParserTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParserTest.java
@@ -145,8 +145,7 @@ public class ParserTest extends GrammarTest {
             "not (true)",
             "-5",
             "-3.14",
-            "-(5)",
-            "--10",
+            "-(5)"
     })
     void testValidUnaryOperators(final String expression) {
         assertThatIsValid(expression);

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParserTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParserTest.java
@@ -139,6 +139,21 @@ public class ParserTest extends GrammarTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
+            "not false",
+            "not not false",
+            "not /status_code",
+            "not (true)",
+            "-5",
+            "-3.14",
+            "-(5)",
+            "--10",
+    })
+    void testValidUnaryOperators(final String expression) {
+        assertThatIsValid(expression);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
             "falkse and true",
             "true an true",
             "2 is in {2}",

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/GrammarTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/GrammarTest.java
@@ -24,8 +24,6 @@ public abstract class GrammarTest {
     protected static final Class<? extends ParseTree> EQUALITY_OPERATOR = DataPrepperExpressionParser.EqualityOperatorContext.class;
     protected static final Class<? extends ParseTree> REGEX_OPERATOR_EXPRESSION =
             DataPrepperExpressionParser.RegexOperatorExpressionContext.class;
-    protected static final Class<? extends ParseTree> REGEX_EQUALITY_OPERATOR =
-            DataPrepperExpressionParser.RegexEqualityOperatorContext.class;
     protected static final Class<? extends ParseTree> RELATIONAL_OPERATOR_EXPRESSION =
             DataPrepperExpressionParser.RelationalOperatorExpressionContext.class;
     protected static final Class<? extends ParseTree> RELATIONAL_OPERATOR = DataPrepperExpressionParser.RelationalOperatorContext.class;

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/GrammarTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/GrammarTest.java
@@ -16,8 +16,8 @@ import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 public abstract class GrammarTest {
     //region ParseTree child classes
-    protected static final Class<? extends ParseTree> EXPRESSION = DataPrepperExpressionParser.ExpressionContext.class;
-    protected static final Class<? extends ParseTree> CONDITIONAL_EXPRESSION = DataPrepperExpressionParser.ConditionalExpressionContext.class;
+    protected static final Class<? extends ParseTree> CONDITIONAL_EXPRESSION =
+            DataPrepperExpressionParser.ConditionalExpressionContext.class;
     protected static final Class<? extends ParseTree> CONDITIONAL_OPERATOR = DataPrepperExpressionParser.ConditionalOperatorContext.class;
     protected static final Class<? extends ParseTree> EQUALITY_OPERATOR_EXPRESSION =
             DataPrepperExpressionParser.EqualityOperatorExpressionContext.class;
@@ -33,11 +33,10 @@ public abstract class GrammarTest {
             DataPrepperExpressionParser.SetOperatorExpressionContext.class;
     protected static final Class<? extends ParseTree> UNARY_OPERATOR_EXPRESSION =
             DataPrepperExpressionParser.UnaryOperatorExpressionContext.class;
-    protected static final Class<? extends ParseTree> UNARY_NOT_OPERATOR_EXPRESSION =
-            DataPrepperExpressionParser.UnaryNotOperatorExpressionContext.class;
     protected static final Class<? extends ParseTree> UNARY_OPERATOR =
             DataPrepperExpressionParser.UnaryOperatorContext.class;
-    protected static final Class<? extends ParseTree> PARENTHESES_EXPRESSION = DataPrepperExpressionParser.ParenthesesExpressionContext.class;
+    protected static final Class<? extends ParseTree> PARENTHESES_EXPRESSION =
+            DataPrepperExpressionParser.ParenthesesExpressionContext.class;
     //endregion
 
     protected ErrorListener errorListener;


### PR DESCRIPTION
Signed-off-by: Steven Bayer <smbayer@amazon.com>

### Description
Added subtract unary operator to support negative values. Ex: `-5` or `-/status_code`
 
### Issues Resolved
Missing support for negative numbers
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
