### PR TITLE
Release GitHub Actions workflow to perform Docker smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build Release Artifacts
+name: Release Artifacts
 
 on:
   workflow_dispatch:
@@ -36,7 +36,6 @@ jobs:
     - name: Build Maven Artifacts
       run: ./gradlew publish
 
-
     - name: Build Docker Image
       run: ./gradlew :release:docker:docker -Prelease
     - name: Log into Amazon ECR Public
@@ -50,3 +49,18 @@ jobs:
       run: |
         docker tag opensearch-data-prepper:${{ env.version }} ${{ secrets.ECR_REPOSITORY_URL }}:${{ env.version }}-${{ github.run_number }}
         docker push ${{ secrets.ECR_REPOSITORY_URL }}:${{ env.version }}-${{ github.run_number }}
+
+  validate:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout Data-Prepper
+        uses: actions/checkout@v2
+      - name: Get Version
+        run:  grep '^version=' gradle.properties >> $GITHUB_ENV
+
+      - name: Smoke Test Docker Image
+        run: |
+          docker pull ${{ secrets.ECR_REPOSITORY_URL }}:${{ env.version }}-${{ github.run_number }}
+          ./release/smoke-tests/run-smoke-tests.sh -v ${{ env.version }}-${{ github.run_number }} -i ${{ secrets.ECR_REPOSITORY_URL }}


### PR DESCRIPTION
### Description

Two changes to the GitHub Actions release workflow:

* Renamed to "Release Artifacts" to shorten name and make it stand out in the Actions list
* Run a new job (on a different worker) which runs a smoke test of the Docker image built in the release process.

You can see how this build worked in my fork: https://github.com/dlvenable/data-prepper/actions/runs/1965528744
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
