### PR TITLE
FIX: coercion on json pointer values

### DIFF
--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/LiteralTypeConversionsConfiguration.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/LiteralTypeConversionsConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.springframework.context.annotation.Bean;
+
+import javax.inject.Named;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Named
+class LiteralTypeConversionsConfiguration {
+    @Bean
+    public Map<Class<? extends Serializable>, Function<Object, Object>> literalTypeConversions() {
+        return new HashMap<Class<? extends Serializable>, Function<Object, Object>>() {{
+            put(String.class, Function.identity());
+            put(Boolean.class, Function.identity());
+            put(Integer.class, Function.identity());
+            put(Float.class, Function.identity());
+            put(Double.class, o -> ((Double) o).floatValue());
+        }};
+    }
+}

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -11,9 +11,7 @@ import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 
 import javax.inject.Named;
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -12,7 +12,6 @@ import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
@@ -102,7 +102,8 @@ class ParseTreeCoercionServiceTest {
         final String testKey1 = "key1";
         final String testKey2 = "key2";
         final String testJsonPointerKey = String.format("/%s/%s", testKey1, testKey2);
-        final Event testEvent = createTestEvent(Map.of(testKey1, Map.of(testKey2, testValue)));
+        final Event testEvent = testValue == null ? createTestEvent(new HashMap<>()) :
+                createTestEvent(Map.of(testKey1, Map.of(testKey2, testValue)));
         when(token.getType()).thenReturn(DataPrepperExpressionParser.JsonPointer);
         when(terminalNode.getSymbol()).thenReturn(token);
         when(terminalNode.getText()).thenReturn(testJsonPointerKey);
@@ -148,7 +149,8 @@ class ParseTreeCoercionServiceTest {
     void testCoerceTerminalNodeEscapeJsonPointerTypeSupportedValues(final Object testValue) {
         final String testKey = "testKey";
         final String testEscapeJsonPointerKey = String.format("\"/%s\"", testKey);
-        final Event testEvent = createTestEvent(Map.of(testKey, testValue));
+        final Event testEvent = testValue == null ? createTestEvent(new HashMap<>()) :
+                createTestEvent(Map.of(testKey, testValue));
         when(token.getType()).thenReturn(DataPrepperExpressionParser.EscapedJsonPointer);
         when(terminalNode.getSymbol()).thenReturn(token);
         when(terminalNode.getText()).thenReturn(testEscapeJsonPointerKey);
@@ -227,14 +229,12 @@ class ParseTreeCoercionServiceTest {
                 Arguments.of(true),
                 Arguments.of("test value"),
                 Arguments.of(1.1f),
-                Arguments.of(1.1)
+                Arguments.of(1.1),
+                Arguments.of((Object) null)
         );
     }
 
     private static Stream<Arguments> provideUnSupportedJsonPointerValues() {
-        return Stream.of(
-                Arguments.of(Long.MAX_VALUE),
-                Arguments.of((Object) null)
-        );
+        return Stream.of(Arguments.of(Long.MAX_VALUE));
     }
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
@@ -46,7 +46,10 @@ class ParseTreeCoercionServiceTest {
     @Mock
     private Token token;
 
-    private final ParseTreeCoercionService objectUnderTest = new ParseTreeCoercionService();
+    private final LiteralTypeConversionsConfiguration literalTypeConversionsConfiguration =
+            new LiteralTypeConversionsConfiguration();
+    private final ParseTreeCoercionService objectUnderTest = new ParseTreeCoercionService(
+            literalTypeConversionsConfiguration.literalTypeConversions());
 
     @Test
     void testCoerceTerminalNodeStringType() {

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListenerTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListenerTest.java
@@ -115,24 +115,13 @@ class ParseTreeEvaluatorListenerTest {
     }
 
     @Test
-    void testSimpleEqualityOperatorExpressionWithJsonPointerTypeExistingKey() {
+    void testSimpleEqualityOperatorExpressionWithJsonPointerType() {
         final String testKey = "testKey";
         final Integer testValue = random.nextInt(1000);
         final Map<String, Integer> data = Map.of(testKey, testValue);
         final Event testEvent = createTestEvent(data);
         final String equalStatement = String.format("/%s == %d", testKey, testValue);
         final String notEqualStatement = String.format("/%s != %d", testKey, testValue + 1);
-        assertThat(evaluateStatementOnEvent(equalStatement, testEvent), is(true));
-        assertThat(evaluateStatementOnEvent(notEqualStatement, testEvent), is(true));
-    }
-
-    @Test
-    void testSimpleEqualityOperatorExpressionWithJsonPointerTypeMissingKey() {
-        final String testMissingKey1 = "missingKey1";
-        final String testMissingKey2 = "missingKey2";
-        final String equalStatement = String.format("/%s == /%s", testMissingKey1, testMissingKey2);
-        final String notEqualStatement = String.format("/%s != 1", testMissingKey1);
-        final Event testEvent = createTestEvent(new HashMap<>());
         assertThat(evaluateStatementOnEvent(equalStatement, testEvent), is(true));
         assertThat(evaluateStatementOnEvent(notEqualStatement, testEvent), is(true));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListenerTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListenerTest.java
@@ -30,7 +30,9 @@ class ParseTreeEvaluatorListenerTest {
     private final ParseTreeWalker walker = new ParseTreeWalker();
     private final ParseTreeParser parseTreeParser = constructParseTreeParser();
     private final OperatorFactory operatorFactory = new OperatorFactory();
-    private final ParseTreeCoercionService coercionService = new ParseTreeCoercionService();
+    private final LiteralTypeConversionsConfiguration literalTypeConversionsConfiguration = new LiteralTypeConversionsConfiguration();
+    private final ParseTreeCoercionService coercionService = new ParseTreeCoercionService(
+            literalTypeConversionsConfiguration.literalTypeConversions());
     private final List<Operator<?>> operators = Arrays.asList(
             new AndOperator(), new OrOperator(),
             operatorFactory.inSetOperator(), operatorFactory.notInSetOperator(),


### PR DESCRIPTION
Signed-off-by: Chen <19492223+chenqi0805@users.noreply.github.com>

### Description
This PR fixes coercion on corner cases in jsonpointer value, especially
* Double value -> convert to float
* non literal value -> exception
 
### Issues Resolved
Resolves #1003 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
