### PR TITLE
Upload Maven artifacts as part of Release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,19 @@ jobs:
 
     - name: Build Archives
       run: ./gradlew :release:archives:buildArchives -Prelease
-    - name: Upload Archives to Archives Bucket
-      run: ./gradlew :release:archives:uploadArchives -Prelease -Pregion=us-east-1 -Pbucket=${{ secrets.ARCHIVES_BUCKET_NAME }} -Pprofile=default -PbuildNumber=${{ github.run_number }}
 
     - name: Build Maven Artifacts
       run: ./gradlew publish
 
     - name: Build Docker Image
       run: ./gradlew :release:docker:docker -Prelease
+
+    - name: Upload Archives to Archives Bucket
+      run: ./gradlew :release:archives:uploadArchives -Prelease -Pregion=us-east-1 -Pbucket=${{ secrets.ARCHIVES_BUCKET_NAME }} -Pprofile=default -PbuildNumber=${{ github.run_number }}
+
+    - name: Upload Maven Artifacts to Archives Bucket
+      run: ./gradlew :release:maven:uploadArtifacts -Prelease -Pregion=us-east-1 -Pbucket=${{ secrets.ARCHIVES_BUCKET_NAME }} -Pprofile=default -PbuildNumber=${{ github.run_number }}
+
     - name: Log into Amazon ECR Public
       id: login-ecr
       uses: docker/login-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ allprojects {
     apply plugin: 'com.github.jk1.dependency-license-report'
 
     group = 'org.opensearch.dataprepper'
+
+    ext {
+        mavenPublicationRootFile = file("${rootProject.buildDir}/m2")
+    }
     
     repositories {
         mavenCentral()
@@ -155,7 +159,9 @@ configure(mavenArtifactProjects) {
 
     publishing {
         repositories {
-            mavenLocal()
+            maven {
+                url "file://${mavenPublicationRootFile.absolutePath}"
+            }
         }
         publications {
             maven(MavenPublication) {
@@ -224,4 +230,8 @@ task generateThirdPartyReport(type: Copy) {
     include 'THIRD-PARTY-NOTICES.txt'
     rename 'THIRD-PARTY-NOTICES.txt', 'THIRD-PARTY'
     generateThirdPartyReport.dependsOn(generateLicenseReport)
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/release/archives/build.gradle
+++ b/release/archives/build.gradle
@@ -4,8 +4,7 @@
  */
 
 plugins {
-    id "de.undercouch.download" version "4.1.2" apply false
-    id "jp.classmethod.aws.s3" version "0.41" apply false
+    id 'de.undercouch.download' version '4.1.2' apply false
 }
 
 import com.amazonaws.services.s3.model.ObjectMetadata
@@ -15,7 +14,6 @@ import jp.classmethod.aws.gradle.s3.CreateBucketTask
 subprojects {
     apply plugin: 'de.undercouch.download'
     apply plugin: 'distribution'
-    apply plugin: 'jp.classmethod.aws.s3'
 
     dependencies {
         /* required to resolve below issue with aws sdk
@@ -26,8 +24,6 @@ subprojects {
 
     ext {
         archiveToTar = this.&archiveToTar
-        awsS3Bucket = project.hasProperty('bucket') ? project.getProperty('bucket') : awsResources.get('default_bucket')
-        buildNumber = project.hasProperty('buildNumber') ? project.getProperty('buildNumber') : 'development'
     }
 
     def supportedArchitectures = architectures.get(it.name) as String[]
@@ -97,11 +93,6 @@ subprojects {
         }
     }
 
-    aws {
-        profileName = project.hasProperty("profile") ? project.getProperty("profile") : awsResources.get('default_profile')
-        region = project.hasProperty("region") ? project.getProperty("region") : awsResources.get('default_region')
-    }
-
     task createBucket(type: CreateBucketTask) {
         bucketName awsS3Bucket
         ifNotExists true
@@ -111,7 +102,7 @@ subprojects {
             def platformWithArchitecture = "${platform}${it}"
             def tarTask = tasks.getByName("${platformWithArchitecture}DistTar")
             def tarWithJDKTask = tasks.getByName("${platformWithArchitecture}WithJDKDistTar")
-            def destinationKeyPath = "${project.rootProject.version}/${project.buildNumber}/archive"
+            def destinationKeyPath = "${archiveRootKey}/archive"
 
             tasks.getByName("${platformWithArchitecture}WithJDKDistTar").dependsOn("download${it}JDK")
 

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -3,9 +3,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-apply from: file("build-resources.gradle")
+plugins {
+    id 'jp.classmethod.aws.s3' version '0.41' apply false
+}
+
+apply from: file('build-resources.gradle')
 
 allprojects {
+    apply plugin: 'jp.classmethod.aws.s3'
+
+    ext {
+        awsS3Bucket = project.hasProperty('bucket') ? project.getProperty('bucket') : awsResources.get('default_bucket')
+        buildNumber = project.hasProperty('buildNumber') ? project.getProperty('buildNumber') : 'development'
+        archiveRootKey = "${project.rootProject.version}/${project.buildNumber}"
+    }
+
+    aws {
+        profileName = project.hasProperty('profile') ? project.getProperty('profile') : awsResources.get('default_profile')
+        region = project.hasProperty('region') ? project.getProperty('region') : awsResources.get('default_region')
+    }
+
     dependencies {
         implementation project(':data-prepper-core')
     }

--- a/release/maven/build.gradle
+++ b/release/maven/build.gradle
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import com.amazonaws.services.s3.model.ObjectMetadata
+import jp.classmethod.aws.gradle.s3.BulkUploadTask
+
+dependencies {
+    /* required to resolve below issue with aws sdk
+      JAXB is unavailable. Will fallback to SDK implementation which may be less performant
+     */
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+}
+
+tasks.create(name: 'uploadMavenArtifactsToS3', type: BulkUploadTask) {
+    dependsOn ':release:releasePrerequisites'
+    source = fileTree(dir: mavenPublicationRootFile)
+    bucketName = awsS3Bucket
+    prefix = "${archiveRootKey}/maven/"
+
+    metadataProvider = { bucketName, key, file ->
+        def metadata = new ObjectMetadata()
+        metadata.setCacheControl('no-cache, no-store')
+        return metadata
+    }
+}
+
+task uploadArtifacts {
+    dependsOn 'uploadMavenArtifactsToS3'
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,11 +12,12 @@ pluginManagement {
 
 rootProject.name = 'opensearch-data-prepper'
 
-if(startParameter.getProjectProperties().containsKey("release")){
+if(startParameter.getProjectProperties().containsKey('release')){
     include 'release'
     include 'release:docker'
     include 'release:archives'
     include 'release:archives:linux'
+    include 'release:maven'
 }
 include 'data-prepper-api'
 include 'data-prepper-plugins'


### PR DESCRIPTION
### Description

The goal of this PR is to upload Maven artifacts to the staging S3 bucket and make them available for download.

* Created a Gradle task (and project) for uploading Maven artifacts
* Changed the Maven publish task to use a local build directory (to keep artifacts clean from other Maven artifacts)
* Fixed the root `clean` task which was not deleting the `build/` directory
* Updated the Release GitHub Action to upload Maven artifacts
* Moved all uploading GitHub Actions steps to occur after all the local build parts
* Refactored the archives Gradle project to share some common conventions with the new Maven project
 
### Issues Resolved

Resolves #1180
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
