### PR TITLE
FIX: temporarily allow output generic object type

### DIFF
--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/sink/FileSink.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/sink/FileSink.java
@@ -68,14 +68,12 @@ public class FileSink implements Sink<Record<Object>> {
     // Temporary function to support both trace and log ingestion pipelines.
     // TODO: This function should be removed with the completion of: https://github.com/opensearch-project/data-prepper/issues/546
     private void checkTypeAndWriteObject(final Object object, final BufferedWriter writer) throws IOException {
-        if (object instanceof String) {
-            writer.write((String) object);
-            writer.newLine();
-        } else if (object instanceof Event) {
+        if (object instanceof Event) {
             writer.write(((Event) object).toJsonString());
             writer.newLine();
         } else {
-            LOG.error("Invalid record type. FileSink only supports String and Events");
+            writer.write(object.toString());
+            writer.newLine();
         }
     }
 

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/sink/StdOutSink.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/sink/StdOutSink.java
@@ -41,12 +41,10 @@ public class StdOutSink implements Sink<Record<Object>> {
     // Temporary function to support both trace and log ingestion pipelines.
     // TODO: This function should be removed with the completion of: https://github.com/opensearch-project/data-prepper/issues/546
     private void checkTypeAndPrintObject(final Object object) {
-        if (object instanceof String) {
-            System.out.println(object);
-        } else if (object instanceof Event) {
+        if (object instanceof Event) {
             System.out.println(((Event) object).toJsonString());
         } else {
-            throw new RuntimeException("Invalid record type. StdOutSink only supports String and Events");
+            System.out.println(object);
         }
     }
 

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/sink/FileSinkTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/sink/FileSinkTests.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,6 +79,18 @@ public class FileSinkTests {
         Assert.assertTrue(outputData.contains(TEST_DATA_2));
     }
 
+    // TODO: remove with the completion of: https://github.com/opensearch-project/data-prepper/issues/546
+    @Test
+    public void testValidFilePathCustomTypeRecord() throws IOException {
+        final FileSink fileSink = new FileSink(completePluginSettingForFileSink(TEST_OUTPUT_FILE.getPath()));
+        final TestObject testObject = new TestObject();
+        fileSink.output(Collections.singleton(new Record<>(testObject)));
+        fileSink.shutdown();
+
+        final String outputData = readDocFromFile(TEST_OUTPUT_FILE);
+        Assert.assertTrue(outputData.contains(testObject.toString()));
+    }
+
     @Test
     public void testValidFilePath() throws IOException {
         final FileSink fileSink = new FileSink(completePluginSettingForFileSink(TEST_OUTPUT_FILE.getPath()));
@@ -101,5 +114,9 @@ public class FileSinkTests {
             bufferedReader.lines().forEach(jsonBuilder::append);
         }
         return jsonBuilder.toString();
+    }
+
+    private static class TestObject {
+
     }
 }

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/sink/StdOutSinkTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/sink/StdOutSinkTests.java
@@ -56,9 +56,14 @@ public class StdOutSinkTests {
         stdOutSink.shutdown();
     }
 
+    // TODO: remove with the completion of: https://github.com/opensearch-project/data-prepper/issues/546
     @Test
-    public void testSinkWithString() {
+    public void testSinkWithCustomType() {
         final StdOutSink stdOutSink = new StdOutSink(new PluginSetting(PLUGIN_NAME, new HashMap<>()));
-        stdOutSink.output(Collections.singletonList(new Record<Object>(UUID.randomUUID().toString())));
+        stdOutSink.output(Collections.singletonList(new Record<Object>(new TestObject())));
+    }
+
+    private static class TestObject {
+
     }
 }


### PR DESCRIPTION
Signed-off-by: Chen <19492223+chenqi0805@users.noreply.github.com>

### Description
This is a temporary fix on #1075 since we cannot get permanent fix #546 merged in for the upcoming release.
 
### Issues Resolved
Resolves #1075 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
