### PR TITLE
Force snakeyaml to version 1.29

### DIFF
--- a/e2e-test/log/build.gradle
+++ b/e2e-test/log/build.gradle
@@ -6,11 +6,12 @@ apply plugin: DockerRemoteApiPlugin
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import com.bmuschko.gradle.docker.DockerRemoteApiPlugin
 import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
+import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
 import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
 import com.bmuschko.gradle.docker.tasks.container.DockerStopContainer
-import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile
@@ -159,4 +160,10 @@ dependencies {
     integrationTestImplementation "com.linecorp.armeria:armeria:1.0.0"
     integrationTestImplementation "org.awaitility:awaitility:4.1.1"
     integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${versionMap.opensearchVersion}"
+}
+
+configurations.all {
+    resolutionStrategy {
+        force 'org.yaml:snakeyaml:1.29'
+    }
 }


### PR DESCRIPTION
Signed-off-by: Steven Bayer <smbayer@amazon.com>

### Description
Force snakeyaml to version 1.29
 
### Issues Resolved
`:e2e-test:log:basicLogEndToEndTest` failing

```
* What went wrong:
Execution failed for task ':e2e-test:log:basicLogEndToEndTest'.
> Could not resolve all files for configuration ':e2e-test:log:integrationTestRuntimeClasspath'.
   > Could not find snakeyaml-1.30-android.jar (org.yaml:snakeyaml:1.30).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/org/yaml/snakeyaml/1.30/snakeyaml-1.30-android.jar
```
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
