### PR TITLE
FIX: remove extra quotes in string literal

### DIFF
--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -34,7 +34,8 @@ class ParseTreeCoercionService {
             case DataPrepperExpressionParser.JsonPointer:
                 return resolveJsonPointerValue(nodeStringValue, event);
             case DataPrepperExpressionParser.String:
-                return nodeStringValue;
+                final String nodeStringValueWithQuotesStripped = nodeStringValue.substring(1, nodeStringValue.length() - 1);
+                return nodeStringValueWithQuotesStripped;
             case DataPrepperExpressionParser.Integer:
                 return Integer.valueOf(nodeStringValue);
             case DataPrepperExpressionParser.Float:

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ConditionalExpressionEvaluatorIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ConditionalExpressionEvaluatorIT.java
@@ -96,7 +96,8 @@ class ConditionalExpressionEvaluatorIT {
                 Arguments.of(
                         escapedJsonPointer(ALL_JACKSON_EVENT_GET_SUPPORTED_CHARACTERS) + " == true",
                         complexEvent(ALL_JACKSON_EVENT_GET_SUPPORTED_CHARACTERS, true),
-                        true)
+                        true),
+                Arguments.of("/response == \"OK\"", event("{\"response\": \"OK\"}"), true)
         );
     }
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
@@ -55,8 +55,9 @@ class ParseTreeCoercionServiceTest {
     void testCoerceTerminalNodeStringType() {
         when(token.getType()).thenReturn(DataPrepperExpressionParser.String);
         final String testString = "test string";
+        final String testNodeStringValue = String.format("\"%s\"", testString);
         when(terminalNode.getSymbol()).thenReturn(token);
-        when(terminalNode.getText()).thenReturn(testString);
+        when(terminalNode.getText()).thenReturn(testNodeStringValue);
         final Event testEvent = createTestEvent(new HashMap<>());
         final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
         assertThat(result, instanceOf(String.class));

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListenerTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListenerTest.java
@@ -86,7 +86,8 @@ class ParseTreeEvaluatorListenerTest {
 
     @Test
     void testSinglePrimaryExpression() {
-        final String testSingleStringStatement = "\"test string\"";
+        final String testStringValue = "test string";
+        final String testSingleStringStatement = String.format("\"%s\"", testStringValue);
         final Integer testInteger = random.nextInt(1000);
         final String testSingleIntegerStatement = String.format("%d", testInteger);
         final Float testFloat = random.nextFloat();
@@ -99,7 +100,7 @@ class ParseTreeEvaluatorListenerTest {
         final String testSingleJsonPointerStatement = String.format("/%s", testKey);
         final String testSingleEscapeJsonPointerStatement = String.format("\"/%s\"", testKey);
 
-        assertThat(evaluateStatementOnEvent(testSingleStringStatement, testEvent), equalTo(testSingleStringStatement));
+        assertThat(evaluateStatementOnEvent(testSingleStringStatement, testEvent), equalTo(testStringValue));
         assertThat(evaluateStatementOnEvent(testSingleIntegerStatement, testEvent), equalTo(testInteger));
         assertThat(evaluateStatementOnEvent(testSingleFloatStatement, testEvent), equalTo(testFloat));
         assertThat(evaluateStatementOnEvent(testSingleBooleanStatement, testEvent), equalTo(true));


### PR DESCRIPTION
Signed-off-by: Chen <19492223+chenqi0805@users.noreply.github.com>

### Description
This PR fixes the extra quote introduced by antlr grammar in string literal value when doing expression evaluation.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
