### PR TITLE
Fix incorrect key-value documentation

### DIFF
--- a/data-prepper-plugins/key-value-processor/README.md
+++ b/data-prepper-plugins/key-value-processor/README.md
@@ -40,10 +40,10 @@ When run, the processor will parse the message into the following output:
   * Default: `&`
   * Note: This cannot be defined at the same time as `field_delimiter_regex`
 * `key_value_delimiter_regex` - A regex specifying the delimiter between a key and a value. Special regex characters such as `[` and `]` must be escaped using `\\`.
-  * Default: `=`
+  * There is no default.
   * Note: This cannot be defined at the same time as `value_split_characters`
 * `value_split_characters` - A string of characters to split between keys and values. Special regex characters such as `[` and `]` must be escaped using `\\`.
-  * Default: `&`
+  * Default: `=`
   *   * Note: This cannot be defined at the same time as `key_value_delimiter_regex`
 * `non_match_value` - When a key/value cannot be successfully split, the key/value will be placed in the key field and the specified value in the value field.
   * Default: `null`


### PR DESCRIPTION
Signed-off-by: Taylor Gray <tylgry@amazon.com>

### Description
* key-value documentation is incorrect in the default values for `key_value_delimiter_regex` and `value_split_characters`
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
