### PR TITLE
Fix bug where a group can be concluded twice in the Aggregate Processor

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
@@ -56,10 +56,13 @@ class AggregateActionSynchronizer {
         Optional<Event> concludeGroupEvent = Optional.empty();
         if (concludeGroupLock.tryLock()) {
             handleEventForGroupLock.lock();
+
             try {
-                LOG.debug("Start critical section in concludeGroup");
-                concludeGroupEvent = aggregateAction.concludeGroup(aggregateGroup);
-                aggregateGroupManager.closeGroup(hash, aggregateGroup);
+                if (aggregateGroup.shouldConcludeGroup(aggregateGroupManager.getGroupDuration())) {
+                    LOG.debug("Start critical section in concludeGroup");
+                    concludeGroupEvent = aggregateAction.concludeGroup(aggregateGroup);
+                    aggregateGroupManager.closeGroup(hash, aggregateGroup);
+                }
             } catch (final Exception e) {
                 LOG.debug("Error while concluding group: ", e);
                 actionConcludeGroupEventsProcessingErrors.increment();

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroup.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroup.java
@@ -5,6 +5,7 @@
 
 package com.amazon.dataprepper.plugins.processor.aggregate;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -37,6 +38,10 @@ class AggregateGroup implements AggregateActionInput {
 
     Lock getHandleEventForGroupLock() {
         return handleEventForGroupLock;
+    }
+
+    boolean shouldConcludeGroup(final Duration groupDuration) {
+        return Duration.between(groupStart, Instant.now()).compareTo(groupDuration) >= 0;
     }
 
     void resetGroup() {

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
@@ -8,7 +8,6 @@ package com.amazon.dataprepper.plugins.processor.aggregate;
 import com.google.common.collect.Maps;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -29,15 +28,11 @@ class AggregateGroupManager {
     List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> getGroupsToConclude() {
         final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> groupsToConclude = new ArrayList<>();
         for (final Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> groupEntry : allGroups.entrySet()) {
-            if (shouldConcludeGroup(groupEntry.getValue())) {
+            if (groupEntry.getValue().shouldConcludeGroup(groupDuration)) {
                 groupsToConclude.add(groupEntry);
             }
         }
         return groupsToConclude;
-    }
-
-    private boolean shouldConcludeGroup(final AggregateGroup aggregateGroup) {
-        return Duration.between(aggregateGroup.getGroupStart(), Instant.now()).compareTo(groupDuration) >= 0;
     }
 
     void closeGroup(final AggregateIdentificationKeysHasher.IdentificationHash hash, final AggregateGroup group) {
@@ -51,5 +46,9 @@ class AggregateGroupManager {
 
     long getAllGroupsSize() {
         return allGroups.size();
+    }
+
+    Duration getGroupDuration() {
+        return this.groupDuration;
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -78,7 +78,6 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
         final List<Record<Event>> recordsOut = new LinkedList<>();
 
         final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> groupsToConclude = aggregateGroupManager.getGroupsToConclude();
-
         for (final Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> groupEntry : groupsToConclude) {
             final Optional<Event> concludeGroupEvent = aggregateActionSynchronizer.concludeGroup(groupEntry.getKey(), groupEntry.getValue());
 

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -92,12 +91,12 @@ public class AggregateGroupManagerTest {
         aggregateGroupManager = createObjectUnderTest();
 
         final AggregateGroup groupToConclude = mock(AggregateGroup.class);
+        when(groupToConclude.shouldConcludeGroup(TEST_GROUP_DURATION)).thenReturn(true);
         final AggregateIdentificationKeysHasher.IdentificationHash hashForGroupToConclude = mock(AggregateIdentificationKeysHasher.IdentificationHash.class);
-        when(groupToConclude.getGroupStart()).thenReturn(Instant.now().minusSeconds(TEST_GROUP_DURATION.getSeconds()));
 
         final AggregateGroup groupToNotConclude = mock(AggregateGroup.class);
+        when(groupToNotConclude.shouldConcludeGroup(TEST_GROUP_DURATION)).thenReturn(false);
         final AggregateIdentificationKeysHasher.IdentificationHash hashForGroupToNotConclude = mock(AggregateIdentificationKeysHasher.IdentificationHash.class);
-        when(groupToNotConclude.getGroupStart()).thenReturn(Instant.now().plusSeconds(TEST_GROUP_DURATION.getSeconds()));
 
         aggregateGroupManager.putGroupWithHash(hashForGroupToConclude, groupToConclude);
         aggregateGroupManager.putGroupWithHash(hashForGroupToNotConclude, groupToNotConclude);

--- a/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
@@ -13,7 +13,6 @@ import com.amazon.dataprepper.model.event.JacksonEvent;
 import com.amazon.dataprepper.model.plugin.PluginFactory;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.processor.aggregate.actions.RemoveDuplicatesAggregateAction;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,7 +50,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class AggregateProcessorIT {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final int NUM_EVENTS_PER_BATCH = 200;
     private static final int NUM_UNIQUE_EVENTS_PER_BATCH = 8;
     private static final int NUM_THREADS = 100;


### PR DESCRIPTION
Signed-off-by: Taylor Gray <tylgry@amazon.com>

### Description
* This fixes a bug where a thread is able to grab a concluded group right before another thread concludes that group, then the thread that concludes the group unlocks the `concludeGroupLock`, so the group is concluded twice

 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
