### PR TITLE
Add an integration test which tests against OpenSearch 1.3.0.

### DIFF
--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         java: [14]
-        opensearch: [1.0.1, 1.1.0, 1.2.4]
+        opensearch: [1.0.1, 1.1.0, 1.2.4, 1.3.0]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### Description

Added OpenSearch 1.3.0 to the list of OpenSearch versions Data Prepper tests against.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
