### PR TITLE
MAINT: migrate service map stateful to accept both Event and ExportTraceServiceRequest as record data type

### DIFF
--- a/data-prepper-benchmarks/service-map-stateful-benchmarks/src/jmh/java/com/amazon/dataprepper/benchmarks/prepper/ServiceMapStatefulPrepperBenchmarks.java
+++ b/data-prepper-benchmarks/service-map-stateful-benchmarks/src/jmh/java/com/amazon/dataprepper/benchmarks/prepper/ServiceMapStatefulPrepperBenchmarks.java
@@ -43,7 +43,7 @@ public class ServiceMapStatefulPrepperBenchmarks {
     private static final Random RANDOM = new Random();
     private static final List<String> serviceNames = Arrays.asList("FRONTEND", "BACKEND", "PAYMENT", "CHECKOUT", "DATABASE");
     private static final List<String> traceGroups = Arrays.asList("tg1", "tg2", "tg3", "tg4", "tg5", "tg6", "tg7", "tg8", "tg9");
-    private List<Record<ExportTraceServiceRequest>> batch;
+    private List<Record<Object>> batch;
 
     @Param(value = "100")
     private int batchSize;

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation project(':data-prepper-plugins:common')
     implementation project(':data-prepper-plugins:mapdb-prepper-state')
     testImplementation project(':data-prepper-api').sourceSets.test.output
+    implementation 'commons-codec:commons-codec:1.15'
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"

--- a/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/OTelHelper.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/OTelHelper.java
@@ -10,6 +10,7 @@ import io.opentelemetry.proto.trace.v1.Span;
 
 import java.util.Optional;
 
+// TODO: remove in 2.0
 public class OTelHelper {
 
     static final String SERVICE_NAME_KEY = "service.name";

--- a/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
@@ -8,14 +8,18 @@ package com.amazon.dataprepper.plugins.prepper;
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.annotations.SingleThread;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
+import com.amazon.dataprepper.model.event.Event;
+import com.amazon.dataprepper.model.event.JacksonEvent;
 import com.amazon.dataprepper.model.prepper.AbstractPrepper;
 import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.model.trace.Span;
 import com.amazon.dataprepper.plugins.prepper.state.MapDbPrepperState;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.SignedBytes;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import org.apache.commons.codec.binary.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @SingleThread
 @DataPrepperPlugin(name = "service_map_stateful", pluginType = Prepper.class)
-public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTraceServiceRequest>, Record<String>> {
+public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<Object>, Record<Event>> {
 
     public static final String SPANS_DB_SIZE = "spansDbSize";
     public static final String TRACE_GROUP_DB_SIZE = "traceGroupDbSize";
@@ -42,7 +46,7 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
     private static final Logger LOG = LoggerFactory.getLogger(ServiceMapStatefulPrepper.class);
     private static final String EMPTY_SUFFIX = "-empty";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final Collection<Record<String>> EMPTY_COLLECTION = Collections.emptySet();
+    private static final Collection<Record<Event>> EMPTY_COLLECTION = Collections.emptySet();
     private static final Integer TO_MILLIS = 1_000;
 
     // TODO: This should not be tracked in this class, move it up to the creator
@@ -121,10 +125,30 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
      * added to the service map index. Otherwise, returns an empty set.
      */
     @Override
-    public Collection<Record<String>> doExecute(Collection<Record<ExportTraceServiceRequest>> records) {
-        final Collection<Record<String>> relationships = windowDurationHasPassed() ? evaluateEdges() : EMPTY_COLLECTION;
+    public Collection<Record<Event>> doExecute(Collection<Record<Object>> records) {
+        final Collection<Record<Event>> relationships = windowDurationHasPassed() ? evaluateEdges() : EMPTY_COLLECTION;
         final Map<byte[], ServiceMapStateData> batchStateData = new TreeMap<>(SignedBytes.lexicographicalComparator());
-        records.forEach(i -> i.getData().getResourceSpansList().forEach(resourceSpans -> {
+        records.forEach(i -> {
+            final Object recordData = i.getData();
+            if (recordData instanceof ExportTraceServiceRequest) {
+                processExportTraceServiceRequest((ExportTraceServiceRequest) recordData, batchStateData);
+            } else if (recordData instanceof Span) {
+                processSpan((Span) recordData, batchStateData);
+            } else {
+                throw new RuntimeException("Unsupported record data type: " + recordData.getClass());
+            }
+        });
+        try {
+            currentWindow.putAll(batchStateData);
+        } catch (RuntimeException e) {
+            LOG.error("Caught exception trying to put batch state data", e);
+        }
+        return relationships;
+    }
+
+    private void processExportTraceServiceRequest(
+            final ExportTraceServiceRequest exportTraceServiceRequest, final Map<byte[], ServiceMapStateData> batchStateData) {
+        exportTraceServiceRequest.getResourceSpansList().forEach(resourceSpans -> {
             OTelHelper.getServiceName(resourceSpans.getResource()).ifPresent(serviceName -> resourceSpans.getInstrumentationLibrarySpansList().forEach(
                     instrumentationLibrarySpans -> {
                         instrumentationLibrarySpans.getSpansList().forEach(
@@ -155,24 +179,46 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
                                 });
                     }
             ));
-        }));
-        try {
-            currentWindow.putAll(batchStateData);
-        } catch (RuntimeException e) {
-            LOG.error("Caught exception trying to put batch state data", e);
+        });
+    }
+
+    private void processSpan(final Span span, final Map<byte[], ServiceMapStateData> batchStateData) {
+        if (span.getServiceName() != null) {
+            final String serviceName = span.getServiceName();
+            final String spanId = span.getSpanId();
+            final String traceId = span.getTraceId();
+            final String parentSpanId = span.getParentSpanId();
+            try {
+                batchStateData.put(
+                        Hex.decodeHex(spanId),
+                        new ServiceMapStateData(
+                                serviceName,
+                                parentSpanId.isEmpty()? null : Hex.decodeHex(parentSpanId),
+                                Hex.decodeHex(traceId),
+                                span.getKind(),
+                                span.getName()));
+            } catch (Exception e) {
+                LOG.error("Caught exception trying to put service map state data into batch", e);
+            }
+            if (parentSpanId.isEmpty()) {
+                try {
+                    currentTraceGroupWindow.put(Hex.decodeHex(traceId), span.getName());
+                } catch (Exception e) {
+                    LOG.error("Caught exception trying to put trace group name", e);
+                }
+            }
         }
-        return relationships;
     }
 
     /**
      * This function parses the current and previous windows to find the edges, and rotates the window state objects.
      *
-     * @return Set of Record<String> containing json representation of ServiceMapRelationships found
+     * @return Set of Record<Event> containing json representation of ServiceMapRelationships found
      */
-    private Collection<Record<String>> evaluateEdges() {
+    private Collection<Record<Event>> evaluateEdges() {
         LOG.info("Evaluating service map edges");
         try {
-            final Collection<Record<String>> serviceDependencyRecords = new HashSet<>();
+            final Collection<Record<Event>> serviceDependencyRecords = new HashSet<>();
 
             serviceDependencyRecords.addAll(iteratePrepperState(previousWindow));
             serviceDependencyRecords.addAll(iteratePrepperState(currentWindow));
@@ -194,8 +240,8 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
         }
     }
 
-    private Collection<Record<String>> iteratePrepperState(final MapDbPrepperState<ServiceMapStateData> prepperState) {
-        final Collection<Record<String>> serviceDependencyRecords = new HashSet<>();
+    private Collection<Record<Event>> iteratePrepperState(final MapDbPrepperState<ServiceMapStateData> prepperState) {
+        final Collection<Record<Event>> serviceDependencyRecords = new HashSet<>();
 
         if (prepperState.getAll() != null && !prepperState.getAll().isEmpty()) {
             prepperState.getIterator(preppersCreated.get(), thisPrepperId).forEachRemaining(entry -> {
@@ -223,28 +269,29 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
                         child.spanKind, child.serviceName, child.name, traceGroupName);
 
 
-                // check if relationshipState has it
-                if (!RELATIONSHIP_STATE.contains(destinationRelationship)) {
-                    try {
-                        serviceDependencyRecords.add(new Record<>(OBJECT_MAPPER.writeValueAsString(destinationRelationship)));
-                        RELATIONSHIP_STATE.add(destinationRelationship);
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-
-                if (!RELATIONSHIP_STATE.contains(targetRelationship)) {
-                    try {
-                        serviceDependencyRecords.add(new Record<>(OBJECT_MAPPER.writeValueAsString(targetRelationship)));
-                        RELATIONSHIP_STATE.add(targetRelationship);
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                }
+                // check if relationshipState has the above
+                addServiceMapRelationship(serviceDependencyRecords, destinationRelationship);
+                addServiceMapRelationship(serviceDependencyRecords, targetRelationship);
             });
         }
 
         return serviceDependencyRecords;
+    }
+
+    private void addServiceMapRelationship(
+            final Collection<Record<Event>> serviceDependencyRecords, final ServiceMapRelationship serviceMapRelationship) {
+        if (!RELATIONSHIP_STATE.contains(serviceMapRelationship)) {
+            try {
+                final Event destinationRelationshipEvent = JacksonEvent.builder()
+                        .withEventType("event")
+                        .withData(serviceMapRelationship)
+                        .build();
+                serviceDependencyRecords.add(new Record<>(destinationRelationshipEvent));
+                RELATIONSHIP_STATE.add(serviceMapRelationship);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     /**

--- a/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
@@ -130,6 +130,7 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<Object>, R
         final Map<byte[], ServiceMapStateData> batchStateData = new TreeMap<>(SignedBytes.lexicographicalComparator());
         records.forEach(i -> {
             final Object recordData = i.getData();
+            // TODO: remove support for ExportTraceServiceRequest in 2.0
             if (recordData instanceof ExportTraceServiceRequest) {
                 processExportTraceServiceRequest((ExportTraceServiceRequest) recordData, batchStateData);
             } else if (recordData instanceof Span) {

--- a/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
@@ -10,8 +10,8 @@ import com.amazon.dataprepper.model.annotations.SingleThread;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.event.JacksonEvent;
-import com.amazon.dataprepper.model.prepper.AbstractPrepper;
-import com.amazon.dataprepper.model.prepper.Prepper;
+import com.amazon.dataprepper.model.processor.AbstractProcessor;
+import com.amazon.dataprepper.model.processor.Processor;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.trace.Span;
 import com.amazon.dataprepper.plugins.prepper.state.MapDbPrepperState;
@@ -37,8 +37,8 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @SingleThread
-@DataPrepperPlugin(name = "service_map_stateful", pluginType = Prepper.class)
-public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<Object>, Record<Event>> {
+@DataPrepperPlugin(name = "service_map_stateful", pluginType = Processor.class)
+public class ServiceMapStatefulPrepper extends AbstractProcessor<Record<Object>, Record<Event>> {
 
     public static final String SPANS_DB_SIZE = "spansDbSize";
     public static final String TRACE_GROUP_DB_SIZE = "traceGroupDbSize";

--- a/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
@@ -45,6 +45,7 @@ public class ServiceMapStatefulPrepper extends AbstractProcessor<Record<Object>,
 
     private static final Logger LOG = LoggerFactory.getLogger(ServiceMapStatefulPrepper.class);
     private static final String EMPTY_SUFFIX = "-empty";
+    private static final String EVENT_TYPE = "event";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Collection<Record<Event>> EMPTY_COLLECTION = Collections.emptySet();
     private static final Integer TO_MILLIS = 1_000;
@@ -284,7 +285,7 @@ public class ServiceMapStatefulPrepper extends AbstractProcessor<Record<Object>,
         if (!RELATIONSHIP_STATE.contains(serviceMapRelationship)) {
             try {
                 final Event destinationRelationshipEvent = JacksonEvent.builder()
-                        .withEventType("event")
+                        .withEventType(EVENT_TYPE)
                         .withData(serviceMapRelationship)
                         .build();
                 serviceDependencyRecords.add(new Record<>(destinationRelationshipEvent));

--- a/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
@@ -330,11 +330,6 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<Object>, R
         currentTraceGroupWindow.delete();
     }
 
-    // TODO: Temp code, complex instance creation logic should be moved to a separate class
-    static void resetStaticCounters() {
-        preppersCreated.set(0);
-    }
-
 
     /**
      * Rotate windows for prepper state

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepperTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepperTest.java
@@ -9,9 +9,11 @@ import com.amazon.dataprepper.metrics.MetricNames;
 import com.amazon.dataprepper.metrics.MetricsTestUtil;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.model.trace.Span;
+import com.google.common.collect.Sets;
 import io.micrometer.core.instrument.Measurement;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
-import io.opentelemetry.proto.trace.v1.Span;
+import org.apache.commons.codec.binary.Hex;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -20,6 +22,7 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Arrays;
@@ -32,6 +35,7 @@ import java.util.StringJoiner;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertFalse;
@@ -55,9 +59,39 @@ public class ServiceMapStatefulPrepperTest {
     }};
 
     @Before
-    public void setup() {
-        ServiceMapStatefulPrepper.resetStaticCounters();
+    public void setup() throws NoSuchFieldException, IllegalAccessException {
+        resetServiceMapStatefulPrepperStatic();
         MetricsTestUtil.initMetrics();
+    }
+
+    public void resetServiceMapStatefulPrepperStatic() throws NoSuchFieldException, IllegalAccessException {
+        reflectivelySetField(ServiceMapStatefulPrepper.class, "RELATIONSHIP_STATE", Sets.newConcurrentHashSet());
+        reflectivelySetField(ServiceMapStatefulPrepper.class, "preppersCreated", new AtomicInteger(0));
+        reflectivelySetField(ServiceMapStatefulPrepper.class, "previousTimestamp", 0);
+        reflectivelySetField(ServiceMapStatefulPrepper.class, "windowDurationMillis", 0);
+        reflectivelySetField(ServiceMapStatefulPrepper.class, "dbPath", null);
+        reflectivelySetField(ServiceMapStatefulPrepper.class, "currentWindow", null);
+        reflectivelySetField(ServiceMapStatefulPrepper.class, "previousWindow", null);
+        reflectivelySetField(ServiceMapStatefulPrepper.class, "currentTraceGroupWindow", null);
+        reflectivelySetField(ServiceMapStatefulPrepper.class, "previousTraceGroupWindow", null);
+        reflectivelySetField(ServiceMapStatefulPrepper.class, "allThreadsCyclicBarrier", null);
+    }
+
+    private void reflectivelySetField(final Class<?> clazz, final String fieldName, final Object value) throws NoSuchFieldException, IllegalAccessException {
+        final Field field = clazz.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        final Object fieldValue = field.get(clazz);
+        try {
+            if (fieldValue instanceof Set) {
+                ((Set) fieldValue).clear();
+            } else if (fieldValue instanceof AtomicInteger) {
+                ((AtomicInteger) fieldValue).set(0);
+            } else {
+                field.set(clazz, value);
+            }
+        } finally {
+            field.setAccessible(false);
+        }
     }
 
     /**
@@ -90,8 +124,9 @@ public class ServiceMapStatefulPrepperTest {
         final ServiceMapStatefulPrepper serviceMapStatefulPrepper = new ServiceMapStatefulPrepper(pluginSetting);
     }
 
+    // TODO: remove in 2.0
     @Test
-    public void testTraceGroups() throws Exception {
+    public void testTraceGroupsWithExportTraceServiceRequestRecordData() throws Exception {
         final Clock clock = Mockito.mock(Clock.class);
         Mockito.when(clock.millis()).thenReturn(1L);
         Mockito.when(clock.instant()).thenReturn(Instant.now());
@@ -107,30 +142,30 @@ public class ServiceMapStatefulPrepperTest {
         final String traceGroup1 = "reset_password";
         final String traceGroup2 = "checkout";
 
-        final ResourceSpans frontendSpans1 = ServiceMapTestUtils.getResourceSpans(FRONTEND_SERVICE, traceGroup1, rootSpanId1, null, traceId1, Span.SpanKind.SPAN_KIND_CLIENT);
-        final ResourceSpans authenticationSpansServer = ServiceMapTestUtils.getResourceSpans(AUTHENTICATION_SERVICE, "reset", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(frontendSpans1), traceId1, Span.SpanKind.SPAN_KIND_SERVER);
-        final ResourceSpans authenticationSpansClient = ServiceMapTestUtils.getResourceSpans(AUTHENTICATION_SERVICE, "reset", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(authenticationSpansServer), traceId1, Span.SpanKind.SPAN_KIND_CLIENT);
-        final ResourceSpans passwordDbSpans = ServiceMapTestUtils.getResourceSpans(PASSWORD_DATABASE, "update", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(authenticationSpansClient), traceId1, Span.SpanKind.SPAN_KIND_SERVER);
+        final ResourceSpans frontendSpans1 = ServiceMapTestUtils.getResourceSpans(FRONTEND_SERVICE, traceGroup1, rootSpanId1, null, traceId1, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+        final ResourceSpans authenticationSpansServer = ServiceMapTestUtils.getResourceSpans(AUTHENTICATION_SERVICE, "reset", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(frontendSpans1), traceId1, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER);
+        final ResourceSpans authenticationSpansClient = ServiceMapTestUtils.getResourceSpans(AUTHENTICATION_SERVICE, "reset", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(authenticationSpansServer), traceId1, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+        final ResourceSpans passwordDbSpans = ServiceMapTestUtils.getResourceSpans(PASSWORD_DATABASE, "update", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(authenticationSpansClient), traceId1, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER);
 
-        final ResourceSpans frontendSpans2 = ServiceMapTestUtils.getResourceSpans(FRONTEND_SERVICE, traceGroup2, rootSpanId2, null, traceId2, Span.SpanKind.SPAN_KIND_CLIENT);
-        final ResourceSpans checkoutSpansServer = ServiceMapTestUtils.getResourceSpans(CHECKOUT_SERVICE, "checkout", ServiceMapTestUtils.getRandomBytes(8), rootSpanId2, traceId2, Span.SpanKind.SPAN_KIND_SERVER);
-        final ResourceSpans checkoutSpansClient = ServiceMapTestUtils.getResourceSpans(CHECKOUT_SERVICE, "checkout", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(checkoutSpansServer), traceId2, Span.SpanKind.SPAN_KIND_CLIENT);
-        final ResourceSpans cartSpans = ServiceMapTestUtils.getResourceSpans(CART_SERVICE, "get_items", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(checkoutSpansClient), traceId2, Span.SpanKind.SPAN_KIND_SERVER);
-        final ResourceSpans paymentSpans = ServiceMapTestUtils.getResourceSpans(PAYMENT_SERVICE, "charge", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(checkoutSpansClient), traceId2, Span.SpanKind.SPAN_KIND_SERVER);
+        final ResourceSpans frontendSpans2 = ServiceMapTestUtils.getResourceSpans(FRONTEND_SERVICE, traceGroup2, rootSpanId2, null, traceId2, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+        final ResourceSpans checkoutSpansServer = ServiceMapTestUtils.getResourceSpans(CHECKOUT_SERVICE, "checkout", ServiceMapTestUtils.getRandomBytes(8), rootSpanId2, traceId2, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER);
+        final ResourceSpans checkoutSpansClient = ServiceMapTestUtils.getResourceSpans(CHECKOUT_SERVICE, "checkout", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(checkoutSpansServer), traceId2, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+        final ResourceSpans cartSpans = ServiceMapTestUtils.getResourceSpans(CART_SERVICE, "get_items", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(checkoutSpansClient), traceId2, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER);
+        final ResourceSpans paymentSpans = ServiceMapTestUtils.getResourceSpans(PAYMENT_SERVICE, "charge", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(checkoutSpansClient), traceId2, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER);
 
 
         //Expected relationships
-        final ServiceMapRelationship frontendAuth = ServiceMapRelationship.newDestinationRelationship(FRONTEND_SERVICE, Span.SpanKind.SPAN_KIND_CLIENT.name(), AUTHENTICATION_SERVICE, "reset", traceGroup1);
-        final ServiceMapRelationship authPassword = ServiceMapRelationship.newDestinationRelationship(AUTHENTICATION_SERVICE, Span.SpanKind.SPAN_KIND_CLIENT.name(), PASSWORD_DATABASE, "update", traceGroup1);
-        final ServiceMapRelationship frontendCheckout = ServiceMapRelationship.newDestinationRelationship(FRONTEND_SERVICE, Span.SpanKind.SPAN_KIND_CLIENT.name(), CHECKOUT_SERVICE, "checkout", traceGroup2);
-        final ServiceMapRelationship checkoutCart = ServiceMapRelationship.newDestinationRelationship(CHECKOUT_SERVICE, Span.SpanKind.SPAN_KIND_CLIENT.name(), CART_SERVICE, "get_items", traceGroup2);
-        final ServiceMapRelationship checkoutPayment = ServiceMapRelationship.newDestinationRelationship(CHECKOUT_SERVICE, Span.SpanKind.SPAN_KIND_CLIENT.name(), PAYMENT_SERVICE, "charge", traceGroup2);
+        final ServiceMapRelationship frontendAuth = ServiceMapRelationship.newDestinationRelationship(FRONTEND_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT.name(), AUTHENTICATION_SERVICE, "reset", traceGroup1);
+        final ServiceMapRelationship authPassword = ServiceMapRelationship.newDestinationRelationship(AUTHENTICATION_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT.name(), PASSWORD_DATABASE, "update", traceGroup1);
+        final ServiceMapRelationship frontendCheckout = ServiceMapRelationship.newDestinationRelationship(FRONTEND_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT.name(), CHECKOUT_SERVICE, "checkout", traceGroup2);
+        final ServiceMapRelationship checkoutCart = ServiceMapRelationship.newDestinationRelationship(CHECKOUT_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT.name(), CART_SERVICE, "get_items", traceGroup2);
+        final ServiceMapRelationship checkoutPayment = ServiceMapRelationship.newDestinationRelationship(CHECKOUT_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT.name(), PAYMENT_SERVICE, "charge", traceGroup2);
 
-        final ServiceMapRelationship checkoutTarget = ServiceMapRelationship.newTargetRelationship(CHECKOUT_SERVICE, Span.SpanKind.SPAN_KIND_SERVER.name(), CHECKOUT_SERVICE, "checkout", traceGroup2);
-        final ServiceMapRelationship authTarget = ServiceMapRelationship.newTargetRelationship(AUTHENTICATION_SERVICE, Span.SpanKind.SPAN_KIND_SERVER.name(), AUTHENTICATION_SERVICE, "reset", traceGroup1);
-        final ServiceMapRelationship passwordTarget = ServiceMapRelationship.newTargetRelationship(PASSWORD_DATABASE, Span.SpanKind.SPAN_KIND_SERVER.name(), PASSWORD_DATABASE, "update", traceGroup1);
-        final ServiceMapRelationship paymentTarget = ServiceMapRelationship.newTargetRelationship(PAYMENT_SERVICE, Span.SpanKind.SPAN_KIND_SERVER.name(), PAYMENT_SERVICE, "charge", traceGroup2);
-        final ServiceMapRelationship cartTarget = ServiceMapRelationship.newTargetRelationship(CART_SERVICE, Span.SpanKind.SPAN_KIND_SERVER.name(), CART_SERVICE, "get_items", traceGroup2);
+        final ServiceMapRelationship checkoutTarget = ServiceMapRelationship.newTargetRelationship(CHECKOUT_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER.name(), CHECKOUT_SERVICE, "checkout", traceGroup2);
+        final ServiceMapRelationship authTarget = ServiceMapRelationship.newTargetRelationship(AUTHENTICATION_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER.name(), AUTHENTICATION_SERVICE, "reset", traceGroup1);
+        final ServiceMapRelationship passwordTarget = ServiceMapRelationship.newTargetRelationship(PASSWORD_DATABASE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER.name(), PASSWORD_DATABASE, "update", traceGroup1);
+        final ServiceMapRelationship paymentTarget = ServiceMapRelationship.newTargetRelationship(PAYMENT_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER.name(), PAYMENT_SERVICE, "charge", traceGroup2);
+        final ServiceMapRelationship cartTarget = ServiceMapRelationship.newTargetRelationship(CART_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER.name(), CART_SERVICE, "get_items", traceGroup2);
 
         final Set<ServiceMapRelationship> relationshipsFound = new HashSet<>();
 
@@ -209,8 +244,8 @@ public class ServiceMapStatefulPrepperTest {
         //Make sure that future relationships that are equivalent are caught by cache
         final byte[] rootSpanId3 = ServiceMapTestUtils.getRandomBytes(8);
         final byte[] traceId3 = ServiceMapTestUtils.getRandomBytes(16);
-        final ResourceSpans frontendSpans3 = ServiceMapTestUtils.getResourceSpans(FRONTEND_SERVICE, traceGroup1, rootSpanId3, rootSpanId3, traceId3, Span.SpanKind.SPAN_KIND_CLIENT);
-        final ResourceSpans authenticationSpansServer2 = ServiceMapTestUtils.getResourceSpans(AUTHENTICATION_SERVICE, "reset", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(frontendSpans3), traceId3, Span.SpanKind.SPAN_KIND_SERVER);
+        final ResourceSpans frontendSpans3 = ServiceMapTestUtils.getResourceSpans(FRONTEND_SERVICE, traceGroup1, rootSpanId3, rootSpanId3, traceId3, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+        final ResourceSpans authenticationSpansServer2 = ServiceMapTestUtils.getResourceSpans(AUTHENTICATION_SERVICE, "reset", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(frontendSpans3), traceId3, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER);
 
         when(clock.millis()).thenReturn(450L);
         Future<Set<ServiceMapRelationship>> r7 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful1,
@@ -226,10 +261,186 @@ public class ServiceMapStatefulPrepperTest {
         assertTrue(r9.get().isEmpty());
         assertTrue(r10.get().isEmpty());
         serviceMapStateful1.shutdown();
+        serviceMapStateful2.shutdown();
     }
 
     @Test
-    public void testPrepareForShutdown() throws Exception {
+    public void testTraceGroupsWithEventRecordData() throws Exception {
+        final Clock clock = Mockito.mock(Clock.class);
+        Mockito.when(clock.millis()).thenReturn(1L);
+        Mockito.when(clock.instant()).thenReturn(Instant.now());
+        ExecutorService threadpool = Executors.newCachedThreadPool();
+        final File path = new File(ServiceMapPrepperConfig.DEFAULT_DB_PATH);
+        final ServiceMapStatefulPrepper serviceMapStateful1 = new ServiceMapStatefulPrepper(100, path, clock, 2, PLUGIN_SETTING);
+        final ServiceMapStatefulPrepper serviceMapStateful2 = new ServiceMapStatefulPrepper(100, path, clock, 2, PLUGIN_SETTING);
+
+        final byte[] rootSpanId1Bytes = ServiceMapTestUtils.getRandomBytes(8);
+        final byte[] rootSpanId2Bytes = ServiceMapTestUtils.getRandomBytes(8);
+        final byte[] traceId1Bytes = ServiceMapTestUtils.getRandomBytes(16);
+        final byte[] traceId2Bytes = ServiceMapTestUtils.getRandomBytes(16);
+        final String rootSpanId1 = Hex.encodeHexString(rootSpanId1Bytes);
+        final String rootSpanId2 = Hex.encodeHexString(rootSpanId2Bytes);
+        final String traceId1 = Hex.encodeHexString(traceId1Bytes);
+        final String traceId2 = Hex.encodeHexString(traceId2Bytes);
+
+        final String traceGroup1 = "reset_password";
+        final String traceGroup2 = "checkout";
+
+        final Span frontendSpans1 = ServiceMapTestUtils.getSpan(FRONTEND_SERVICE, traceGroup1, rootSpanId1,
+                "", traceId1, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+        final Span authenticationSpansServer = ServiceMapTestUtils.getSpan(AUTHENTICATION_SERVICE, "reset",
+                Hex.encodeHexString(ServiceMapTestUtils.getRandomBytes(8)), frontendSpans1.getSpanId(), traceId1,
+                io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER);
+        final Span authenticationSpansClient = ServiceMapTestUtils.getSpan(AUTHENTICATION_SERVICE, "reset",
+                Hex.encodeHexString(ServiceMapTestUtils.getRandomBytes(8)), authenticationSpansServer.getSpanId(), traceId1,
+                io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+        final Span passwordDbSpans = ServiceMapTestUtils.getSpan(PASSWORD_DATABASE, "update",
+                Hex.encodeHexString(ServiceMapTestUtils.getRandomBytes(8)), authenticationSpansClient.getSpanId(), traceId1,
+                io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER);
+
+        final Span frontendSpans2 = ServiceMapTestUtils.getSpan(FRONTEND_SERVICE, traceGroup2, rootSpanId2,
+                "", traceId2, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+        final Span checkoutSpansServer = ServiceMapTestUtils.getSpan(CHECKOUT_SERVICE, "checkout",
+                Hex.encodeHexString(ServiceMapTestUtils.getRandomBytes(8)), rootSpanId2, traceId2,
+                io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER);
+        final Span checkoutSpansClient = ServiceMapTestUtils.getSpan(CHECKOUT_SERVICE, "checkout",
+                Hex.encodeHexString(ServiceMapTestUtils.getRandomBytes(8)), checkoutSpansServer.getSpanId(), traceId2,
+                io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+        final Span cartSpans = ServiceMapTestUtils.getSpan(CART_SERVICE, "get_items",
+                Hex.encodeHexString(ServiceMapTestUtils.getRandomBytes(8)), checkoutSpansClient.getSpanId(), traceId2,
+                io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER);
+        final Span paymentSpans = ServiceMapTestUtils.getSpan(PAYMENT_SERVICE, "charge",
+                Hex.encodeHexString(ServiceMapTestUtils.getRandomBytes(8)), checkoutSpansClient.getSpanId(), traceId2,
+                io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER);
+
+
+        //Expected relationships
+        final ServiceMapRelationship frontendAuth = ServiceMapRelationship.newDestinationRelationship(
+                FRONTEND_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT.name(), AUTHENTICATION_SERVICE, "reset", traceGroup1);
+        final ServiceMapRelationship authPassword = ServiceMapRelationship.newDestinationRelationship(
+                AUTHENTICATION_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT.name(), PASSWORD_DATABASE, "update", traceGroup1);
+        final ServiceMapRelationship frontendCheckout = ServiceMapRelationship.newDestinationRelationship(
+                FRONTEND_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT.name(), CHECKOUT_SERVICE, "checkout", traceGroup2);
+        final ServiceMapRelationship checkoutCart = ServiceMapRelationship.newDestinationRelationship(
+                CHECKOUT_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT.name(), CART_SERVICE, "get_items", traceGroup2);
+        final ServiceMapRelationship checkoutPayment = ServiceMapRelationship.newDestinationRelationship(
+                CHECKOUT_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT.name(), PAYMENT_SERVICE, "charge", traceGroup2);
+
+        final ServiceMapRelationship checkoutTarget = ServiceMapRelationship.newTargetRelationship(
+                CHECKOUT_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER.name(), CHECKOUT_SERVICE, "checkout", traceGroup2);
+        final ServiceMapRelationship authTarget = ServiceMapRelationship.newTargetRelationship(
+                AUTHENTICATION_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER.name(), AUTHENTICATION_SERVICE, "reset", traceGroup1);
+        final ServiceMapRelationship passwordTarget = ServiceMapRelationship.newTargetRelationship(
+                PASSWORD_DATABASE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER.name(), PASSWORD_DATABASE, "update", traceGroup1);
+        final ServiceMapRelationship paymentTarget = ServiceMapRelationship.newTargetRelationship(
+                PAYMENT_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER.name(), PAYMENT_SERVICE, "charge", traceGroup2);
+        final ServiceMapRelationship cartTarget = ServiceMapRelationship.newTargetRelationship(
+                CART_SERVICE, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER.name(), CART_SERVICE, "get_items", traceGroup2);
+
+        final Set<ServiceMapRelationship> relationshipsFound = new HashSet<>();
+
+        //First batch
+        Mockito.when(clock.millis()).thenReturn(110L);
+        Future<Set<ServiceMapRelationship>> r1 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful1,
+                Arrays.asList(new Record<>(frontendSpans1), new Record<>(checkoutSpansServer)));
+        Future<Set<ServiceMapRelationship>> r2 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful2,
+                Arrays.asList(new Record<>(frontendSpans2), new Record<>(checkoutSpansClient)));
+        relationshipsFound.addAll(r1.get());
+        relationshipsFound.addAll(r2.get());
+
+        //Shouldn't find any relationships
+        Assert.assertEquals(0, relationshipsFound.size());
+
+        //Second batch
+        Mockito.when(clock.millis()).thenReturn(220L);
+        Future<Set<ServiceMapRelationship>> r3 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful1,
+                Arrays.asList(new Record<>(authenticationSpansServer), new Record<>(authenticationSpansClient), new Record<>(cartSpans)));
+        Future<Set<ServiceMapRelationship>> r4 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful2,
+                Arrays.asList(new Record<>(passwordDbSpans), new Record<>(paymentSpans)));
+        relationshipsFound.addAll(r3.get());
+        relationshipsFound.addAll(r4.get());
+
+        //Should find the frontend->checkout relationship indicated in the first batch
+        Assert.assertEquals(2, relationshipsFound.size());
+        assertTrue(relationshipsFound.containsAll(Arrays.asList(
+                frontendCheckout,
+                checkoutTarget
+        )));
+
+        //Third batch
+        Mockito.when(clock.millis()).thenReturn(340L);
+        Future<Set<ServiceMapRelationship>> r5 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful1, Arrays.asList());
+        Future<Set<ServiceMapRelationship>> r6 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful2, Arrays.asList());
+        relationshipsFound.addAll(r5.get());
+        relationshipsFound.addAll(r6.get());
+
+        //Should find the rest of the relationships
+        Assert.assertEquals(10, relationshipsFound.size());
+        assertTrue(relationshipsFound.containsAll(Arrays.asList(
+                frontendAuth,
+                authTarget,
+                authPassword,
+                passwordTarget,
+                checkoutCart,
+                cartTarget,
+                checkoutPayment,
+                paymentTarget
+        )));
+
+        // Extra validation
+        final List<ServiceMapSourceDest> expectedSourceDests = Arrays.asList(
+                new ServiceMapSourceDest(FRONTEND_SERVICE, AUTHENTICATION_SERVICE),
+                new ServiceMapSourceDest(AUTHENTICATION_SERVICE, PASSWORD_DATABASE),
+                new ServiceMapSourceDest(FRONTEND_SERVICE, CHECKOUT_SERVICE),
+                new ServiceMapSourceDest(CHECKOUT_SERVICE, CART_SERVICE),
+                new ServiceMapSourceDest(CHECKOUT_SERVICE, PAYMENT_SERVICE)
+        );
+
+        assertTrue(evaluateEdges(relationshipsFound).containsAll(expectedSourceDests));
+
+        // Verify gauges
+        final List<Measurement> spansDbSizeMeasurement = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add("testPipelineName").add("testServiceMapPrepper")
+                        .add(ServiceMapStatefulPrepper.SPANS_DB_SIZE).toString());
+        Assert.assertEquals(1, spansDbSizeMeasurement.size());
+
+        final List<Measurement> traceGroupDbSizeMeasurement = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add("testPipelineName").add("testServiceMapPrepper")
+                        .add(ServiceMapStatefulPrepper.TRACE_GROUP_DB_SIZE).toString());
+        Assert.assertEquals(1, traceGroupDbSizeMeasurement.size());
+
+
+        //Make sure that future relationships that are equivalent are caught by cache
+        final byte[] rootSpanId3Bytes = ServiceMapTestUtils.getRandomBytes(8);
+        final byte[] traceId3Bytes = ServiceMapTestUtils.getRandomBytes(16);
+        final String rootSpanId3 = Hex.encodeHexString(rootSpanId3Bytes);
+        final String traceId3 = Hex.encodeHexString(traceId3Bytes);
+        final Span frontendSpans3 = ServiceMapTestUtils.getSpan(
+                FRONTEND_SERVICE, traceGroup1, rootSpanId3, rootSpanId3, traceId3, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+        final Span authenticationSpansServer2 = ServiceMapTestUtils.getSpan(
+                AUTHENTICATION_SERVICE, "reset", Hex.encodeHexString(ServiceMapTestUtils.getRandomBytes(8)),
+                frontendSpans3.getSpanId(), traceId3, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER);
+
+        when(clock.millis()).thenReturn(450L);
+        Future<Set<ServiceMapRelationship>> r7 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful1,
+                Collections.singletonList(new Record<>(frontendSpans3)));
+        Future<Set<ServiceMapRelationship>> r8 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful2,
+                Collections.singletonList(new Record<>(authenticationSpansServer2)));
+        assertTrue(r7.get().isEmpty());
+        assertTrue(r8.get().isEmpty());
+
+        when(clock.millis()).thenReturn(560L);
+        Future<Set<ServiceMapRelationship>> r9 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful1, Arrays.asList());
+        Future<Set<ServiceMapRelationship>> r10 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful2, Arrays.asList());
+        assertTrue(r9.get().isEmpty());
+        assertTrue(r10.get().isEmpty());
+        serviceMapStateful1.shutdown();
+        serviceMapStateful2.shutdown();
+    }
+
+    // TODO: remove in 2.0
+    @Test
+    public void testPrepareForShutdownWithExportTraceServiceRequestRecordData() throws Exception {
         final File path = new File(ServiceMapPrepperConfig.DEFAULT_DB_PATH);
         final ServiceMapStatefulPrepper serviceMapStateful = new ServiceMapStatefulPrepper(100, path, Clock.systemUTC(), 1, PLUGIN_SETTING);
 
@@ -237,10 +448,39 @@ public class ServiceMapStatefulPrepperTest {
         final byte[] traceId1 = ServiceMapTestUtils.getRandomBytes(16);
         final String traceGroup1 = "reset_password";
 
-        final ResourceSpans frontendSpans1 = ServiceMapTestUtils.getResourceSpans(FRONTEND_SERVICE, traceGroup1, rootSpanId1, null, traceId1, Span.SpanKind.SPAN_KIND_CLIENT);
-        final ResourceSpans authenticationSpansServer = ServiceMapTestUtils.getResourceSpans(AUTHENTICATION_SERVICE, "reset", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(frontendSpans1), traceId1, Span.SpanKind.SPAN_KIND_SERVER);
+        final ResourceSpans frontendSpans1 = ServiceMapTestUtils.getResourceSpans(FRONTEND_SERVICE, traceGroup1, rootSpanId1, null, traceId1, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+        final ResourceSpans authenticationSpansServer = ServiceMapTestUtils.getResourceSpans(AUTHENTICATION_SERVICE, "reset", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(frontendSpans1), traceId1, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER);
 
         serviceMapStateful.execute(Collections.singletonList(new Record<>(ServiceMapTestUtils.getExportTraceServiceRequest(frontendSpans1, authenticationSpansServer))));
+
+        assertFalse(serviceMapStateful.isReadyForShutdown());
+
+        serviceMapStateful.prepareForShutdown();
+        serviceMapStateful.execute(Collections.emptyList());
+
+        assertTrue(serviceMapStateful.isReadyForShutdown());
+
+        serviceMapStateful.shutdown();
+    }
+
+    @Test
+    public void testPrepareForShutdownWithEventRecordData() {
+        final File path = new File(ServiceMapPrepperConfig.DEFAULT_DB_PATH);
+        final ServiceMapStatefulPrepper serviceMapStateful = new ServiceMapStatefulPrepper(100, path, Clock.systemUTC(), 1, PLUGIN_SETTING);
+
+        final byte[] rootSpanId1Bytes = ServiceMapTestUtils.getRandomBytes(8);
+        final byte[] traceId1Bytes = ServiceMapTestUtils.getRandomBytes(16);
+        final String rootSpanId1 = Hex.encodeHexString(rootSpanId1Bytes);
+        final String traceId1 = Hex.encodeHexString(traceId1Bytes);
+        final String traceGroup1 = "reset_password";
+
+        final Span frontendSpans1 = ServiceMapTestUtils.getSpan(
+                FRONTEND_SERVICE, traceGroup1, rootSpanId1, "", traceId1, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+        final Span authenticationSpansServer = ServiceMapTestUtils.getSpan(
+                AUTHENTICATION_SERVICE, "reset", Hex.encodeHexString(ServiceMapTestUtils.getRandomBytes(8)),
+                frontendSpans1.getSpanId(), traceId1, io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER);
+
+        serviceMapStateful.execute(Arrays.asList(new Record<>(frontendSpans1), new Record<>(authenticationSpansServer)));
 
         assertFalse(serviceMapStateful.isReadyForShutdown());
 

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepperTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepperTest.java
@@ -70,6 +70,7 @@ public class ServiceMapStatefulPrepperTest {
         reflectivelySetField(ServiceMapStatefulPrepper.class, "previousTimestamp", 0);
         reflectivelySetField(ServiceMapStatefulPrepper.class, "windowDurationMillis", 0);
         reflectivelySetField(ServiceMapStatefulPrepper.class, "dbPath", null);
+        reflectivelySetField(ServiceMapStatefulPrepper.class, "clock", null);
         reflectivelySetField(ServiceMapStatefulPrepper.class, "currentWindow", null);
         reflectivelySetField(ServiceMapStatefulPrepper.class, "previousWindow", null);
         reflectivelySetField(ServiceMapStatefulPrepper.class, "currentTraceGroupWindow", null);

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapTestUtils.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapTestUtils.java
@@ -43,13 +43,13 @@ public class ServiceMapTestUtils {
     }
 
     public static Future<Set<ServiceMapRelationship>> startExecuteAsync(ExecutorService threadpool, ServiceMapStatefulPrepper prepper,
-                                                                 Collection<Record<ExportTraceServiceRequest>> records) {
+                                                                 Collection<Record<Object>> records) {
         return threadpool.submit(() -> {
             return prepper.execute(records)
                     .stream()
                     .map(record -> {
                         try {
-                            return OBJECT_MAPPER.readValue(record.getData(), ServiceMapRelationship.class);
+                            return OBJECT_MAPPER.readValue(record.getData().toJsonString(), ServiceMapRelationship.class);
                         } catch (JsonProcessingException e) {
                             throw new RuntimeException(e);
                         }

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapTestUtils.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapTestUtils.java
@@ -20,11 +20,11 @@ import io.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 
 import java.io.UnsupportedEncodingException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Random;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
@@ -115,7 +115,8 @@ public class ServiceMapTestUtils {
      */
     public static Span getSpan(final String serviceName, final String spanName, final String
             spanId, final String parentId, final String traceId, final io.opentelemetry.proto.trace.v1.Span.SpanKind spanKind) {
-        final String endTime = UUID.randomUUID().toString();
+        final Instant endInstant = Instant.now();
+        final String endTime = endInstant.toString();
         final JacksonSpan.Builder builder = JacksonSpan.builder()
                 .withSpanId(spanId)
                 .withTraceId(traceId)
@@ -124,7 +125,7 @@ public class ServiceMapTestUtils {
                 .withName(spanName)
                 .withServiceName(serviceName)
                 .withKind(spanKind.name())
-                .withStartTime(UUID.randomUUID().toString())
+                .withStartTime(endInstant.minusMillis(1000).toString())
                 .withEndTime(endTime)
                 .withTraceGroup(parentId.isEmpty()? null : spanName)
                 .withDurationInNanos(500L);

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapTestUtils.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapTestUtils.java
@@ -6,6 +6,9 @@
 package com.amazon.dataprepper.plugins.prepper;
 
 import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.model.trace.DefaultTraceGroupFields;
+import com.amazon.dataprepper.model.trace.JacksonSpan;
+import com.amazon.dataprepper.model.trace.Span;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
@@ -15,13 +18,13 @@ import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.resource.v1.Resource;
 import io.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
-import io.opentelemetry.proto.trace.v1.Span;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
@@ -68,7 +71,7 @@ public class ServiceMapTestUtils {
      * @throws UnsupportedEncodingException
      */
     public static ResourceSpans getResourceSpans(final String serviceName, final String spanName, final byte[]
-            spanId, final byte[] parentId, final byte[] traceId, final Span.SpanKind spanKind) throws UnsupportedEncodingException {
+            spanId, final byte[] parentId, final byte[] traceId, final io.opentelemetry.proto.trace.v1.Span.SpanKind spanKind) throws UnsupportedEncodingException {
         final ByteString parentSpanId = parentId != null ? ByteString.copyFrom(parentId) : ByteString.EMPTY;
         return ResourceSpans.newBuilder()
                 .setResource(
@@ -82,7 +85,7 @@ public class ServiceMapTestUtils {
                         0,
                         InstrumentationLibrarySpans.newBuilder()
                                 .addSpans(
-                                        Span.newBuilder()
+                                        io.opentelemetry.proto.trace.v1.Span.newBuilder()
                                                 .setName(spanName)
                                                 .setKind(spanKind)
                                                 .setSpanId(ByteString.copyFrom(spanId))
@@ -99,6 +102,45 @@ public class ServiceMapTestUtils {
         return ExportTraceServiceRequest.newBuilder()
                 .addAllResourceSpans(Arrays.asList(spans))
                 .build();
+    }
+
+    /**
+     * Creates a {@link com.amazon.dataprepper.model.trace.Span} object with the given parameters
+     * @param serviceName Resource name for the ResourceSpans object
+     * @param spanName Span name for the single span in the ResourceSpans object
+     * @param spanId Span id for the single span in the ResourceSpans object
+     * @param parentId Parent id for the single span in the ResourceSpans object
+     * @param spanKind Span kind for the single span in the ResourceSpans object
+     * @return {@link com.amazon.dataprepper.model.trace.Span} object with a single span constructed according to the parameters
+     */
+    public static Span getSpan(final String serviceName, final String spanName, final String
+            spanId, final String parentId, final String traceId, final io.opentelemetry.proto.trace.v1.Span.SpanKind spanKind) {
+        final String endTime = UUID.randomUUID().toString();
+        final JacksonSpan.Builder builder = JacksonSpan.builder()
+                .withSpanId(spanId)
+                .withTraceId(traceId)
+                .withTraceState("")
+                .withParentSpanId(parentId)
+                .withName(spanName)
+                .withServiceName(serviceName)
+                .withKind(spanKind.name())
+                .withStartTime(UUID.randomUUID().toString())
+                .withEndTime(endTime)
+                .withTraceGroup(parentId.isEmpty()? null : spanName)
+                .withDurationInNanos(500L);
+        if (parentId.isEmpty()) {
+            builder.withTraceGroupFields(
+                    DefaultTraceGroupFields.builder()
+                            .withStatusCode(1)
+                            .withDurationInNanos(500L)
+                            .withEndTime(endTime)
+                            .build()
+            );
+        } else {
+            builder.withTraceGroupFields(
+                    DefaultTraceGroupFields.builder().build());
+        }
+        return builder.build();
     }
 
 }

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapTestUtils.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapTestUtils.java
@@ -30,7 +30,8 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 public class ServiceMapTestUtils {
-
+    private static final long TEST_DURATION_IN_NANOS = 1000;
+    private static final int TEST_STATUS_CODE = 1;
     private static final Random RANDOM = new Random();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -125,15 +126,15 @@ public class ServiceMapTestUtils {
                 .withName(spanName)
                 .withServiceName(serviceName)
                 .withKind(spanKind.name())
-                .withStartTime(endInstant.minusMillis(1000).toString())
+                .withStartTime(endInstant.minusNanos(TEST_DURATION_IN_NANOS).toString())
                 .withEndTime(endTime)
                 .withTraceGroup(parentId.isEmpty()? null : spanName)
-                .withDurationInNanos(500L);
+                .withDurationInNanos(TEST_DURATION_IN_NANOS);
         if (parentId.isEmpty()) {
             builder.withTraceGroupFields(
                     DefaultTraceGroupFields.builder()
-                            .withStatusCode(1)
-                            .withDurationInNanos(500L)
+                            .withStatusCode(TEST_STATUS_CODE)
+                            .withDurationInNanos(TEST_DURATION_IN_NANOS)
                             .withEndTime(endTime)
                             .build()
             );


### PR DESCRIPTION
### Description
This PR "merges" the change from service-map-stateful in https://github.com/opensearch-project/data-prepper/tree/maint/546-migrate-trace-analytics-to-event-model into main branch with the following adaption:

* ServiceMapStatefulPrepper extends the AbstractProcessor interface
* ServiceMapStatefulPrepper input record data type supports either ExportTraceServiceRequest or Event
* ServiceMapStatefulPrepperTests::testTraceGroups splits into testTraceGroupsWithEventRecordData() and testTraceGroupsWithExportTraceServiceRequestRecordData() with the caveat that the latter will be removed in 2.0
* ServiceMapStatefulPrepperTests::testPrepareForShutdown splits into testPrepareForShutdownWithEventRecordData() and testPrepareForShutdownWithExportTraceServiceRequestRecordData() with the caveat that the latter will be removed in 2.0
 
### Issues Resolved
Contributes to #1158 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
