### PR TITLE
MAINT: peer forwarder from trace event migration branch

### DIFF
--- a/data-prepper-plugins/peer-forwarder/build.gradle
+++ b/data-prepper-plugins/peer-forwarder/build.gradle
@@ -16,6 +16,7 @@ repositories {
 
 dependencies {
     implementation project(':data-prepper-api')
+    implementation project(':data-prepper-plugins:otel-proto-common')
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
     implementation "com.linecorp.armeria:armeria:1.9.2"

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarder.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarder.java
@@ -105,6 +105,8 @@ public class PeerForwarder extends AbstractProcessor<Record<Object>, Record<Obje
                 exportTraceServiceRequests.add((ExportTraceServiceRequest) recordData);
             } else if (recordData instanceof Span) {
                 spans.add((Span) recordData);
+            } else {
+                throw new RuntimeException("Unsupported record data type: " + recordData.getClass());
             }
         });
         final List<ExportTraceServiceRequest> requestsToProcessLocally = executeExportTraceServiceRequests(exportTraceServiceRequests);

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarder.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarder.java
@@ -101,6 +101,7 @@ public class PeerForwarder extends AbstractProcessor<Record<Object>, Record<Obje
         final List<ExportTraceServiceRequest> exportTraceServiceRequests = new ArrayList<>();
         records.forEach(record -> {
             final Object recordData = record.getData();
+            // TODO: remove support for ExportTraceServiceRequest in 2.0
             if (recordData instanceof ExportTraceServiceRequest) {
                 exportTraceServiceRequests.add((ExportTraceServiceRequest) recordData);
             } else if (recordData instanceof Span) {

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarder.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarder.java
@@ -7,18 +7,22 @@ package com.amazon.dataprepper.plugins.prepper.peerforwarder;
 
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
-import com.amazon.dataprepper.model.prepper.AbstractPrepper;
-import com.amazon.dataprepper.model.prepper.Prepper;
+import com.amazon.dataprepper.model.processor.AbstractProcessor;
+import com.amazon.dataprepper.model.processor.Processor;
 import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.model.trace.Span;
+import com.amazon.dataprepper.plugins.otel.codec.OTelProtoCodec;
 import com.amazon.dataprepper.plugins.prepper.peerforwarder.discovery.StaticPeerListProvider;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import org.apache.commons.codec.DecoderException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
@@ -33,9 +37,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-@DataPrepperPlugin(name = "peer_forwarder", pluginType = Prepper.class)
-public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequest>, Record<ExportTraceServiceRequest>> {
+@DataPrepperPlugin(name = "peer_forwarder", pluginType = Processor.class)
+public class PeerForwarder extends AbstractProcessor<Record<Object>, Record<Object>> {
     public static final String REQUESTS = "requests";
     public static final String LATENCY = "latency";
     public static final String ERRORS = "errors";
@@ -47,6 +53,7 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
 
     private static final Logger LOG = LoggerFactory.getLogger(PeerForwarder.class);
 
+    private final OTelProtoCodec.OTelProtoEncoder oTelProtoEncoder;
     private final HashRing hashRing;
     private final PeerClientPool peerClientPool;
     private final int maxNumSpansPerRequest;
@@ -58,10 +65,12 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
     private final ExecutorService executorService;
 
     public PeerForwarder(final PluginSetting pluginSetting,
+                         final OTelProtoCodec.OTelProtoEncoder oTelProtoEncoder,
                          final PeerClientPool peerClientPool,
                          final HashRing hashRing,
                          final int maxNumSpansPerRequest) {
         super(pluginSetting);
+        this.oTelProtoEncoder = oTelProtoEncoder;
         this.peerClientPool = peerClientPool;
         this.hashRing = hashRing;
         this.maxNumSpansPerRequest = maxNumSpansPerRequest;
@@ -79,6 +88,7 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
     public PeerForwarder(final PluginSetting pluginSetting, final PeerForwarderConfig peerForwarderConfig) {
         this(
                 pluginSetting,
+                new OTelProtoCodec.OTelProtoEncoder(),
                 peerForwarderConfig.getPeerClientPool(),
                 peerForwarderConfig.getHashRing(),
                 peerForwarderConfig.getMaxNumSpansPerRequest()
@@ -86,12 +96,28 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
     }
 
     @Override
-    public List<Record<ExportTraceServiceRequest>> doExecute(final Collection<Record<ExportTraceServiceRequest>> records) {
+    public List<Record<Object>> doExecute(final Collection<Record<Object>> records) {
+        final List<Span> spans = new ArrayList<>();
+        final List<ExportTraceServiceRequest> exportTraceServiceRequests = new ArrayList<>();
+        records.forEach(record -> {
+            final Object recordData = record.getData();
+            if (recordData instanceof ExportTraceServiceRequest) {
+                exportTraceServiceRequests.add((ExportTraceServiceRequest) recordData);
+            } else if (recordData instanceof Span) {
+                spans.add((Span) recordData);
+            }
+        });
+        final List<ExportTraceServiceRequest> requestsToProcessLocally = executeExportTraceServiceRequests(exportTraceServiceRequests);
+        final List<Span> spansToProcessLocally = executeSpans(spans);
+        return Stream.concat(requestsToProcessLocally.stream(), spansToProcessLocally.stream()).map(Record::new).collect(Collectors.toList());
+    }
+
+    private List<ExportTraceServiceRequest> executeExportTraceServiceRequests(final List<ExportTraceServiceRequest> requests) {
         final Map<String, List<ResourceSpans>> groupedRS = new HashMap<>();
 
         // Group ResourceSpans by consistent hashing of traceId
-        for (final Record<ExportTraceServiceRequest> record : records) {
-            for (final ResourceSpans rs : record.getData().getResourceSpansList()) {
+        for (final ExportTraceServiceRequest request : requests) {
+            for (final ResourceSpans rs : request.getResourceSpansList()) {
                 final List<Map.Entry<String, ResourceSpans>> rsBatch = PeerForwarderUtils.splitByTrace(rs);
                 for (final Map.Entry<String, ResourceSpans> entry : rsBatch) {
                     final String traceId = entry.getKey();
@@ -102,8 +128,8 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
             }
         }
 
-        final List<Record<ExportTraceServiceRequest>> recordsToProcessLocally = new ArrayList<>();
-        final List<CompletableFuture<Record>> forwardedRequestFutures = new ArrayList<>();
+        final List<ExportTraceServiceRequest> requestsToProcessLocally = new ArrayList<>();
+        final List<CompletableFuture<ExportTraceServiceRequest>> forwardedRequestFutures = new ArrayList<>();
 
         for (final Map.Entry<String, List<ResourceSpans>> entry : groupedRS.entrySet()) {
             final TraceServiceGrpc.TraceServiceBlockingStub client = getClient(entry.getKey());
@@ -116,7 +142,7 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
                 if (currSpansCount >= maxNumSpansPerRequest) {
                     final ExportTraceServiceRequest currRequest = currRequestBuilder.build();
                     if (isLocalClient(client)) {
-                        recordsToProcessLocally.add(new Record<>(currRequest));
+                        requestsToProcessLocally.add(currRequest);
                     } else {
                         forwardedRequestFutures.add(processRequest(client, currRequest));
                     }
@@ -130,25 +156,90 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
             if (currSpansCount > 0) {
                 final ExportTraceServiceRequest currRequest = currRequestBuilder.build();
                 if (client == null) {
-                    recordsToProcessLocally.add(new Record<>(currRequest));
+                    requestsToProcessLocally.add(currRequest);
                 } else {
                     forwardedRequestFutures.add(processRequest(client, currRequest));
                 }
             }
         }
 
-        for (final CompletableFuture<Record> future : forwardedRequestFutures) {
+        for (final CompletableFuture<ExportTraceServiceRequest> future : forwardedRequestFutures) {
             try {
-                final Record record = future.get();
-                if (record != null) {
-                    recordsToProcessLocally.add(record);
+                final ExportTraceServiceRequest request = future.get();
+                if (request != null) {
+                    requestsToProcessLocally.add(request);
                 }
             } catch (InterruptedException | ExecutionException e) {
                 LOG.error("Problem with asynchronous peer forwarding", e);
             }
         }
 
-        return recordsToProcessLocally;
+        return requestsToProcessLocally;
+    }
+
+    private List<Span> executeSpans(final List<Span> spans) {
+        final Map<String, List<Span>> spansByTraceId = PeerForwarderUtils.splitByTrace(spans);
+        // Group ResourceSpans by consistent hashing of traceId
+        final Map<String, List<Span>> spansByEndPoint = new HashMap<>();
+        for (final Map.Entry<String, List<Span>> entry: spansByTraceId.entrySet()) {
+            final String traceId = entry.getKey();
+            final String dataPrepperIp = hashRing.getServerIp(traceId).orElse(StaticPeerListProvider.LOCAL_ENDPOINT);
+            spansByEndPoint.computeIfAbsent(dataPrepperIp, x -> new ArrayList<>()).addAll(entry.getValue());
+        }
+
+        final List<Span> spansToProcessLocally = new ArrayList<>();
+        final Map<CompletableFuture<ExportTraceServiceRequest>, List<Span>> forwardedRequestFuturesToSpans = new HashMap<>();
+
+        for (final Map.Entry<String, List<Span>> entry : spansByEndPoint.entrySet()) {
+            final TraceServiceGrpc.TraceServiceBlockingStub client = getClient(entry.getKey());
+            if (isLocalClient(client)) {
+                spansToProcessLocally.addAll(entry.getValue());
+                continue;
+            }
+
+            // Create ExportTraceRequest for storing single batch of spans
+            ExportTraceServiceRequest.Builder currRequestBuilder = ExportTraceServiceRequest.newBuilder();
+            List<Span> currBatchSpans = new ArrayList<>();
+            for (final Span span : entry.getValue()) {
+                try {
+                    final ResourceSpans rs = oTelProtoEncoder.convertToResourceSpans(span);
+                    currRequestBuilder.addResourceSpans(rs);
+                    currBatchSpans.add(span);
+                } catch (UnsupportedEncodingException | DecoderException e) {
+                    LOG.error("failed to encode span with spanId: {} into opentelemetry-protobuf, span will be processed locally.",
+                            span.getSpanId(), e);
+                    spansToProcessLocally.add(span);
+                }
+                if (currBatchSpans.size() >= maxNumSpansPerRequest) {
+                    final ExportTraceServiceRequest currRequest = currRequestBuilder.build();
+                    forwardedRequestFuturesToSpans.put(processRequest(client, currRequest), currBatchSpans);
+                    currRequestBuilder = ExportTraceServiceRequest.newBuilder();
+                    currBatchSpans = new ArrayList<>();
+                }
+            }
+            // Dealing with the last batch request
+            if (currBatchSpans.size() > 0) {
+                final ExportTraceServiceRequest currRequest = currRequestBuilder.build();
+                forwardedRequestFuturesToSpans.put(processRequest(client, currRequest), currBatchSpans);
+            }
+        }
+
+        for (final Map.Entry<CompletableFuture<ExportTraceServiceRequest>, List<Span>> entry : forwardedRequestFuturesToSpans.entrySet()) {
+            try {
+                final CompletableFuture<ExportTraceServiceRequest> future = entry.getKey();
+                final ExportTraceServiceRequest request = future.get();
+                if (request != null) {
+                    final List<Span> spansFailedToForward = entry.getValue();
+                    spansToProcessLocally.addAll(spansFailedToForward);
+                }
+            } catch (InterruptedException | ExecutionException e) {
+                LOG.error("Problem with asynchronous peer forwarding, current batch of spans will be processed locally.", e);
+                final List<Span> spansFailedToForward = entry.getValue();
+                spansToProcessLocally.addAll(spansFailedToForward);
+            }
+        }
+
+        return spansToProcessLocally;
     }
 
     /**
@@ -156,7 +247,7 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
      * the request succeeds, otherwise the payload will contain the failed ExportTraceServiceRequest to
      * be processed locally.
      */
-    private CompletableFuture<Record> processRequest(final TraceServiceGrpc.TraceServiceBlockingStub client,
+    private CompletableFuture<ExportTraceServiceRequest> processRequest(final TraceServiceGrpc.TraceServiceBlockingStub client,
                                                      final ExportTraceServiceRequest request) {
         final String peerIp = client.getChannel().authority();
         final Timer forwardRequestTimer = forwardRequestTimers.computeIfAbsent(
@@ -166,7 +257,7 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
         final Counter forwardRequestErrorCounter = forwardRequestErrorCounters.computeIfAbsent(
                 peerIp, ip -> pluginMetrics.counterWithTags(ERRORS, DESTINATION, ip));
 
-        final CompletableFuture<Record> callFuture = CompletableFuture.supplyAsync(() ->
+        final CompletableFuture<ExportTraceServiceRequest> callFuture = CompletableFuture.supplyAsync(() ->
         {
             forwardedRequestCounter.increment();
             try {
@@ -175,7 +266,7 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
             } catch (Exception e) {
                 LOG.error("Failed to forward request to address: {}", peerIp, e);
                 forwardRequestErrorCounter.increment();
-                return new Record<>(request);
+                return request;
             }
         }, executorService);
 

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderUtils.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderUtils.java
@@ -5,16 +5,18 @@
 
 package com.amazon.dataprepper.plugins.prepper.peerforwarder;
 
+import com.amazon.dataprepper.model.trace.Span;
 import com.linecorp.armeria.internal.shaded.bouncycastle.util.encoders.Hex;
 import io.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
-import io.opentelemetry.proto.trace.v1.Span;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public final class PeerForwarderUtils {
     public static int getResourceSpansSize(final ResourceSpans rs) {
@@ -25,7 +27,7 @@ public final class PeerForwarderUtils {
         final List<Map.Entry<String, ResourceSpans>> result = new ArrayList<>();
         for (final InstrumentationLibrarySpans ils: rs.getInstrumentationLibrarySpansList()) {
             final Map<String, ResourceSpans.Builder> batches = new HashMap<>();
-            for (final Span span: ils.getSpansList()) {
+            for (final io.opentelemetry.proto.trace.v1.Span span: ils.getSpansList()) {
                 final String sTraceId = Hex.toHexString(span.getTraceId().toByteArray());
                 if (!batches.containsKey(sTraceId)) {
                     final ResourceSpans.Builder newRSBuilder = ResourceSpans.newBuilder()
@@ -42,5 +44,9 @@ public final class PeerForwarderUtils {
         }
 
         return result;
+    }
+
+    public static Map<String, List<Span>> splitByTrace(final Collection<Span> spans) {
+        return spans.stream().collect(Collectors.groupingBy(Span::getTraceId));
     }
 }

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderTest.java
@@ -9,6 +9,10 @@ import com.amazon.dataprepper.metrics.MetricNames;
 import com.amazon.dataprepper.metrics.MetricsTestUtil;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.model.trace.DefaultTraceGroupFields;
+import com.amazon.dataprepper.model.trace.JacksonSpan;
+import com.amazon.dataprepper.model.trace.Span;
+import com.amazon.dataprepper.plugins.otel.codec.OTelProtoCodec;
 import com.google.protobuf.ByteString;
 import io.grpc.Channel;
 import io.micrometer.core.instrument.Measurement;
@@ -18,17 +22,20 @@ import io.opentelemetry.proto.common.v1.InstrumentationLibrary;
 import io.opentelemetry.proto.resource.v1.Resource;
 import io.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
-import io.opentelemetry.proto.trace.v1.Span;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,37 +43,78 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static com.amazon.dataprepper.plugins.otel.codec.OTelProtoCodec.convertUnixNanosToISO8601;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PeerForwarderTest {
     private static final String TEST_PIPELINE_NAME = "testPipeline";
     private static final String LOCAL_IP = "127.0.0.1";
-    private static final Span SPAN_1 = Span.newBuilder()
+    private static final io.opentelemetry.proto.trace.v1.Span OTLP_SPAN_1 = io.opentelemetry.proto.trace.v1.Span.newBuilder()
             .setTraceId(ByteString.copyFromUtf8("traceIdA")).setSpanId(ByteString.copyFromUtf8("spanId1")).build();
-    private static final Span SPAN_2 = Span.newBuilder()
+    private static final io.opentelemetry.proto.trace.v1.Span OTLP_SPAN_2 = io.opentelemetry.proto.trace.v1.Span.newBuilder()
             .setTraceId(ByteString.copyFromUtf8("traceIdA")).setSpanId(ByteString.copyFromUtf8("spanId2")).build();
-    private static final Span SPAN_3 = Span.newBuilder()
+    private static final io.opentelemetry.proto.trace.v1.Span OTLP_SPAN_3 = io.opentelemetry.proto.trace.v1.Span.newBuilder()
             .setTraceId(ByteString.copyFromUtf8("traceIdA")).setSpanId(ByteString.copyFromUtf8("spanId3")).build();
-    private static final Span SPAN_4 = Span.newBuilder()
+    private static final io.opentelemetry.proto.trace.v1.Span OTLP_SPAN_4 = io.opentelemetry.proto.trace.v1.Span.newBuilder()
             .setTraceId(ByteString.copyFromUtf8("traceIdB")).setSpanId(ByteString.copyFromUtf8("spanId4")).build();
-    private static final Span SPAN_5 = Span.newBuilder()
+    private static final io.opentelemetry.proto.trace.v1.Span OTLP_SPAN_5 = io.opentelemetry.proto.trace.v1.Span.newBuilder()
             .setTraceId(ByteString.copyFromUtf8("traceIdB")).setSpanId(ByteString.copyFromUtf8("spanId5")).build();
-    private static final Span SPAN_6 = Span.newBuilder()
+    private static final io.opentelemetry.proto.trace.v1.Span OTLP_SPAN_6 = io.opentelemetry.proto.trace.v1.Span.newBuilder()
             .setTraceId(ByteString.copyFromUtf8("traceIdB")).setSpanId(ByteString.copyFromUtf8("spanId6")).build();
 
-    private static final ExportTraceServiceRequest REQUEST_1 = generateRequest(SPAN_1, SPAN_2, SPAN_4);
-    private static final ExportTraceServiceRequest REQUEST_2 = generateRequest(SPAN_3, SPAN_5, SPAN_6);
-    private static final ExportTraceServiceRequest REQUEST_3 = generateRequest(SPAN_1, SPAN_2, SPAN_3);
-    private static final ExportTraceServiceRequest REQUEST_4 = generateRequest(SPAN_4, SPAN_5, SPAN_6);
+    private static final ExportTraceServiceRequest REQUEST_1 = generateRequest(OTLP_SPAN_1, OTLP_SPAN_2, OTLP_SPAN_4);
+    private static final ExportTraceServiceRequest REQUEST_2 = generateRequest(OTLP_SPAN_3, OTLP_SPAN_5, OTLP_SPAN_6);
+    private static final ExportTraceServiceRequest REQUEST_3 = generateRequest(OTLP_SPAN_1, OTLP_SPAN_2, OTLP_SPAN_3);
+    private static final ExportTraceServiceRequest REQUEST_4 = generateRequest(OTLP_SPAN_4, OTLP_SPAN_5, OTLP_SPAN_6);
+
+    private static final String TEST_TRACE_ID_1 = "b1";
+    private static final String TEST_TRACE_ID_2 = "b2";
+    private static final String TEST_SERVICE_A = "serviceA";
+    private static final String TEST_SERVICE_B = "serviceB";
+    private static final String TEST_SPAN_ID_1 = "d1";
+    private static final String TEST_SPAN_ID_2 = "d2";
+    private static final String TEST_SPAN_ID_3 = "d3";
+    private static final String TEST_SPAN_ID_4 = "d4";
+    private static final String TEST_SPAN_ID_5 = "d5";
+    private static final String TEST_SPAN_ID_6 = "d6";
+    private static final Span SPAN_1 = getSpan(TEST_TRACE_ID_1, TEST_SPAN_ID_1, "", TEST_SERVICE_A, "spanName1",
+            io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+    private static final Span SPAN_2 = getSpan(TEST_TRACE_ID_1, TEST_SPAN_ID_2, "", TEST_SERVICE_A, "spanName2",
+            io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+    private static final Span SPAN_3 = getSpan(TEST_TRACE_ID_1, TEST_SPAN_ID_3, "", TEST_SERVICE_A, "spanName3",
+            io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+    private static final Span SPAN_4 = getSpan(TEST_TRACE_ID_2, TEST_SPAN_ID_4, "", TEST_SERVICE_B, "spanName4",
+            io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+    private static final Span SPAN_5 = getSpan(TEST_TRACE_ID_2, TEST_SPAN_ID_5, "", TEST_SERVICE_B, "spanName5",
+            io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+    private static final Span SPAN_6 = getSpan(TEST_TRACE_ID_2, TEST_SPAN_ID_6, "", TEST_SERVICE_B, "spanName6",
+            io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT);
+
+    private static final List<Span> TEST_SPANS_ALL = Arrays.asList(SPAN_1, SPAN_2, SPAN_3, SPAN_4, SPAN_5, SPAN_6);
+    private static final List<Span> TEST_SPANS_A = Arrays.asList(SPAN_1, SPAN_2, SPAN_3);
+    private static final List<Span> TEST_SPANS_B = Arrays.asList(SPAN_4, SPAN_5, SPAN_6);
 
     private MockedStatic<PeerClientPool> peerClientPoolClassMock;
+
+    @Mock
+    private OTelProtoCodec.OTelProtoEncoder oTelProtoEncoder;
 
     @Mock
     private PeerClientPool peerClientPool;
@@ -74,9 +122,12 @@ public class PeerForwarderTest {
     @Mock
     private TraceServiceGrpc.TraceServiceBlockingStub client;
 
+    @Mock
+    private CompletableFuture<ExportTraceServiceRequest> completableFuture;
+
     @Before
     public void setUp() {
-        peerClientPoolClassMock = Mockito.mockStatic(PeerClientPool.class);
+        peerClientPoolClassMock = mockStatic(PeerClientPool.class);
         peerClientPoolClassMock.when(PeerClientPool::getInstance).thenReturn(peerClientPool);
     }
 
@@ -86,7 +137,7 @@ public class PeerForwarderTest {
         peerClientPoolClassMock.close();
     }
 
-    private static ExportTraceServiceRequest generateRequest(final Span... spans) {
+    private static ExportTraceServiceRequest generateRequest(final io.opentelemetry.proto.trace.v1.Span... spans) {
         return ExportTraceServiceRequest.newBuilder()
                 .addResourceSpans(ResourceSpans.newBuilder()
                         .setResource(Resource.newBuilder().build())
@@ -97,15 +148,63 @@ public class PeerForwarderTest {
                         .build()).build();
     }
 
-    private static ResourceSpans generateResourceSpans(final Span... spans) {
+    private static ResourceSpans generateResourceSpans(final io.opentelemetry.proto.trace.v1.Span... spans) {
         return ResourceSpans.newBuilder().setResource(Resource.newBuilder().build()).addInstrumentationLibrarySpans(
                 InstrumentationLibrarySpans.newBuilder()
                         .setInstrumentationLibrary(InstrumentationLibrary.newBuilder().build())
                         .addAllSpans(Arrays.asList(spans))).build();
     }
 
+    public static Span getSpan(final String traceId, final String spanId, final String parentId,
+                               final String serviceName, final String spanName, final io.opentelemetry.proto.trace.v1.Span.SpanKind spanKind) {
+        final long startTimeNanos = System.nanoTime();
+        final long endTimeNanos = System.nanoTime();
+        final String endTime = UUID.randomUUID().toString();
+        JacksonSpan.Builder builder = JacksonSpan.builder()
+                .withSpanId(spanId)
+                .withTraceId(traceId)
+                .withTraceState("")
+                .withParentSpanId(parentId)
+                .withName(spanName)
+                .withServiceName(serviceName)
+                .withKind(spanKind.name())
+                .withStartTime(convertUnixNanosToISO8601(startTimeNanos))
+                .withEndTime(convertUnixNanosToISO8601(endTimeNanos))
+                .withTraceGroup(parentId.isEmpty()? null : spanName)
+                .withDurationInNanos(endTimeNanos - startTimeNanos);
+        if (parentId.isEmpty()) {
+            builder.withTraceGroupFields(
+                    DefaultTraceGroupFields.builder()
+                            .withStatusCode(1)
+                            .withDurationInNanos(500L)
+                            .withEndTime(endTime)
+                            .build()
+            );
+        } else {
+            builder.withTraceGroupFields(
+                    DefaultTraceGroupFields.builder().build());
+        }
+        return builder.build();
+    }
+
+    private String extractServiceName(final ResourceSpans resourceSpans) {
+        return resourceSpans.getResource().getAttributesList().stream().filter(kv -> kv.getKey().equals("service.name"))
+                .findFirst().get().getValue().getStringValue();
+    }
+
+    private void reflectivelySetEncoder(final PeerForwarder peerForwarder, final OTelProtoCodec.OTelProtoEncoder encoder)
+            throws NoSuchFieldException, IllegalAccessException {
+        final Field field = PeerForwarder.class.getDeclaredField("oTelProtoEncoder");
+        try {
+            field.setAccessible(true);
+            field.set(peerForwarder, encoder);
+        } finally {
+            field.setAccessible(false);
+        }
+    }
+
     @Test
-    public void testLocalIpOnly() {
+    public void testLocalIpOnlyWithExportTraceServiceRequestRecordData() {
         final PeerForwarder testPeerForwarder = generatePeerForwarder(Collections.singletonList(LOCAL_IP), 2);
         final List<Record<Object>> exportedRecords =
                 testPeerForwarder.doExecute(Arrays.asList(new Record<>(REQUEST_1), new Record<>(REQUEST_2)));
@@ -117,17 +216,29 @@ public class PeerForwarderTest {
             exportedResourceSpans.addAll(((ExportTraceServiceRequest) recordData).getResourceSpansList());
         }
         final List<ResourceSpans> expectedResourceSpans = Arrays.asList(
-                generateResourceSpans(SPAN_1, SPAN_2),
-                generateResourceSpans(SPAN_3),
-                generateResourceSpans(SPAN_4),
-                generateResourceSpans(SPAN_5, SPAN_6)
+                generateResourceSpans(OTLP_SPAN_1, OTLP_SPAN_2),
+                generateResourceSpans(OTLP_SPAN_3),
+                generateResourceSpans(OTLP_SPAN_4),
+                generateResourceSpans(OTLP_SPAN_5, OTLP_SPAN_6)
         );
         assertTrue(exportedResourceSpans.containsAll(expectedResourceSpans));
         assertTrue(expectedResourceSpans.containsAll(exportedResourceSpans));
     }
 
     @Test
-    public void testSingleRemoteIpBothLocalAndForwardedRequest() {
+    public void testLocalIpOnlyWithEventRecordData() {
+        final PeerForwarder testPeerForwarder = generatePeerForwarder(Collections.singletonList(LOCAL_IP), 2);
+        final List<Span> inputSpans = Arrays.asList(SPAN_1, SPAN_2, SPAN_4, SPAN_5);
+        final List<Record<Object>> exportedRecords = testPeerForwarder.doExecute(
+                inputSpans.stream().map(span -> new Record<Object>(span)).collect(Collectors.toList()));
+        assertEquals(4, exportedRecords.size());
+        final List<Span> exportedSpans = exportedRecords.stream().map(record -> (Span) record.getData()).collect(Collectors.toList());
+        assertTrue(exportedSpans.containsAll(inputSpans));
+        assertTrue(inputSpans.containsAll(exportedSpans));
+    }
+
+    @Test
+    public void testSingleRemoteIpBothLocalAndForwardedRequestWithExportTraceServiceRequestRecordData() {
         final List<String> testIps = generateTestIps(2);
         final Channel channel = mock(Channel.class);
         final String peerIp = testIps.get(1);
@@ -149,19 +260,19 @@ public class PeerForwarderTest {
                 .doExecute(Arrays.asList(new Record<>(REQUEST_1), new Record<>(REQUEST_2)));
 
         final List<ResourceSpans> expectedLocalResourceSpans = Arrays.asList(
-                generateResourceSpans(SPAN_1, SPAN_2),
-                generateResourceSpans(SPAN_3)
+                generateResourceSpans(OTLP_SPAN_1, OTLP_SPAN_2),
+                generateResourceSpans(OTLP_SPAN_3)
         );
         final List<ResourceSpans> expectedForwardedResourceSpans = Arrays.asList(
-                generateResourceSpans(SPAN_5, SPAN_6),
-                generateResourceSpans(SPAN_4)
+                generateResourceSpans(OTLP_SPAN_5, OTLP_SPAN_6),
+                generateResourceSpans(OTLP_SPAN_4)
         );
-        Assert.assertEquals(1, exportedRecords.size());
+        assertEquals(1, exportedRecords.size());
         final ExportTraceServiceRequest localRequest = (ExportTraceServiceRequest) exportedRecords.get(0).getData();
         final List<ResourceSpans> localResourceSpans = localRequest.getResourceSpansList();
         assertTrue(localResourceSpans.containsAll(expectedLocalResourceSpans));
         assertTrue(expectedLocalResourceSpans.containsAll(localResourceSpans));
-        Assert.assertEquals(1, requestsByIp.get(peerIp).size());
+        assertEquals(1, requestsByIp.get(peerIp).size());
         final ExportTraceServiceRequest forwardedRequest = requestsByIp.get(peerIp).get(0);
         final List<ResourceSpans> forwardedResourceSpans = forwardedRequest.getResourceSpansList();
         assertTrue(forwardedResourceSpans.containsAll(expectedForwardedResourceSpans));
@@ -169,7 +280,48 @@ public class PeerForwarderTest {
     }
 
     @Test
-    public void testSingleRemoteIpLocalRequestOnly() throws Exception {
+    public void testSingleRemoteIpBothLocalAndForwardedRequestWithEventRecordData() throws DecoderException {
+        final List<String> testIps = generateTestIps(2);
+        final Channel channel = mock(Channel.class);
+        final String peerIp = testIps.get(1);
+        when(channel.authority()).thenReturn(String.format("%s:21890", peerIp));
+        when(peerClientPool.getClient(peerIp)).thenReturn(client);
+        when(client.getChannel()).thenReturn(channel);
+        final Map<String, List<ExportTraceServiceRequest>> requestsByIp = testIps.stream()
+                .collect(Collectors.toMap(ip-> ip, ip-> new ArrayList<>()));
+        doAnswer(invocation -> {
+            final ExportTraceServiceRequest exportTraceServiceRequest = invocation.getArgument(0);
+            requestsByIp.get(peerIp).add(exportTraceServiceRequest);
+            return null;
+        }).when(client).export(any(ExportTraceServiceRequest.class));
+
+        MetricsTestUtil.initMetrics();
+        final PeerForwarder testPeerForwarder = generatePeerForwarder(testIps, 3);
+
+        final List<Record<Object>> exportedRecords = testPeerForwarder
+                .doExecute(TEST_SPANS_ALL.stream().map(span -> new Record<Object>(span)).collect(Collectors.toList()));
+
+        final List<Span> expectedLocalSpans = Arrays.asList(SPAN_1, SPAN_2, SPAN_3);
+        Assert.assertEquals(3, exportedRecords.size());
+        final List<Span> localSpans = exportedRecords.stream().map(record -> (Span) record.getData()).collect(Collectors.toList());
+        assertTrue(localSpans.containsAll(expectedLocalSpans));
+        assertTrue(expectedLocalSpans.containsAll(localSpans));
+        Assert.assertEquals(1, requestsByIp.get(peerIp).size());
+        final ExportTraceServiceRequest forwardedRequest = requestsByIp.get(peerIp).get(0);
+        final List<ResourceSpans> forwardedResourceSpans = forwardedRequest.getResourceSpansList();
+        assertEquals(3, forwardedResourceSpans.size());
+        forwardedResourceSpans.forEach(rs -> {
+            assertEquals(TEST_SERVICE_B, extractServiceName(rs));
+            assertEquals(1, rs.getInstrumentationLibrarySpansCount());
+            final InstrumentationLibrarySpans ils = rs.getInstrumentationLibrarySpans(0);
+            assertEquals(1, ils.getSpansCount());
+            final io.opentelemetry.proto.trace.v1.Span sp = ils.getSpans(0);
+            assertEquals(TEST_TRACE_ID_2, Hex.encodeHexString(sp.getTraceId().toByteArray()));
+        });
+    }
+
+    @Test
+    public void testSingleRemoteIpLocalRequestOnlyWithExportTraceServiceRequestRecordData() throws Exception {
         final List<String> testIps = generateTestIps(2);
         final PeerForwarder testPeerForwarder = generatePeerForwarder(testIps, 3);
 
@@ -177,8 +329,8 @@ public class PeerForwarderTest {
                 .doExecute(Collections.singletonList(new Record<>(REQUEST_3)));
 
         final List<ResourceSpans> expectedLocalResourceSpans = Collections.singletonList(
-                generateResourceSpans(SPAN_1, SPAN_2, SPAN_3));
-        Assert.assertEquals(1, exportedRecords.size());
+                generateResourceSpans(OTLP_SPAN_1, OTLP_SPAN_2, OTLP_SPAN_3));
+        assertEquals(1, exportedRecords.size());
         final ExportTraceServiceRequest localRequest = (ExportTraceServiceRequest) exportedRecords.get(0).getData();
         final List<ResourceSpans> localResourceSpans = localRequest.getResourceSpansList();
         assertTrue(localResourceSpans.containsAll(expectedLocalResourceSpans));
@@ -186,7 +338,21 @@ public class PeerForwarderTest {
     }
 
     @Test
-    public void testSingleRemoteIpForwardedRequestOnly() throws Exception {
+    public void testSingleRemoteIpLocalRequestOnlyWithEventRecordData() throws Exception {
+        final List<String> testIps = generateTestIps(2);
+        final PeerForwarder testPeerForwarder = generatePeerForwarder(testIps, 3);
+
+        final List<Record<Object>> exportedRecords = testPeerForwarder
+                .doExecute(TEST_SPANS_A.stream().map(span -> new Record<Object>(span)).collect(Collectors.toList()));
+
+        Assert.assertEquals(3, exportedRecords.size());
+        final List<Span> localSpans = exportedRecords.stream().map(record -> (Span) record.getData()).collect(Collectors.toList());
+        assertTrue(localSpans.containsAll(TEST_SPANS_A));
+        assertTrue(TEST_SPANS_A.containsAll(localSpans));
+    }
+
+    @Test
+    public void testSingleRemoteIpForwardedRequestOnlyWithExportTraceServiceRequestRecordData() throws Exception {
         final List<String> testIps = generateTestIps(2);
         final Channel channel = mock(Channel.class);
         final String peerIp = testIps.get(1);
@@ -209,12 +375,72 @@ public class PeerForwarderTest {
                 .doExecute(Collections.singletonList(new Record<>(REQUEST_4)));
 
         final List<ResourceSpans> expectedForwardedResourceSpans = Collections.singletonList(
-                generateResourceSpans(SPAN_4, SPAN_5, SPAN_6));
-        Assert.assertEquals(1, requestsByIp.get(peerIp).size());
+                generateResourceSpans(OTLP_SPAN_4, OTLP_SPAN_5, OTLP_SPAN_6));
+        assertEquals(1, requestsByIp.get(peerIp).size());
         final ExportTraceServiceRequest forwardedRequest = requestsByIp.get(peerIp).get(0);
         final List<ResourceSpans> forwardedResourceSpans = forwardedRequest.getResourceSpansList();
         assertTrue(forwardedResourceSpans.containsAll(expectedForwardedResourceSpans));
         assertTrue(expectedForwardedResourceSpans.containsAll(forwardedResourceSpans));
+        assertEquals(0, exportedRecords.size());
+
+        // Verify metrics
+        final List<Measurement> forwardRequestErrorMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(TEST_PIPELINE_NAME).add("peer_forwarder")
+                        .add(PeerForwarder.ERRORS).toString());
+        assertEquals(1, forwardRequestErrorMeasurements.size());
+        assertEquals(0.0, forwardRequestErrorMeasurements.get(0).getValue(), 0);
+        final List<Measurement> forwardRequestSuccessMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(TEST_PIPELINE_NAME).add("peer_forwarder")
+                        .add(PeerForwarder.REQUESTS).toString());
+        assertEquals(1, forwardRequestSuccessMeasurements.size());
+        assertEquals(1.0, forwardRequestSuccessMeasurements.get(0).getValue(), 0);
+        final List<Measurement> forwardRequestLatencyMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(TEST_PIPELINE_NAME).add("peer_forwarder")
+                        .add(PeerForwarder.LATENCY).toString());
+        assertEquals(3, forwardRequestLatencyMeasurements.size());
+        // COUNT
+        assertEquals(1.0, forwardRequestLatencyMeasurements.get(0).getValue(), 0);
+        // TOTAL_TIME
+        assertTrue(forwardRequestLatencyMeasurements.get(1).getValue() > 0.0);
+        // MAX
+        assertTrue(forwardRequestLatencyMeasurements.get(2).getValue() > 0.0);
+    }
+
+    @Test
+    public void testSingleRemoteIpForwardedRequestOnlyWithEventRecordData() throws Exception {
+        final List<String> testIps = generateTestIps(2);
+        final Channel channel = mock(Channel.class);
+        final String peerIp = testIps.get(1);
+        final String fullPeerIp = String.format("%s:21890", peerIp);
+        when(channel.authority()).thenReturn(fullPeerIp);
+        when(peerClientPool.getClient(peerIp)).thenReturn(client);
+        when(client.getChannel()).thenReturn(channel);
+        final Map<String, List<ExportTraceServiceRequest>> requestsByIp = testIps.stream()
+                .collect(Collectors.toMap(ip-> ip, ip-> new ArrayList<>()));
+        doAnswer(invocation -> {
+            final ExportTraceServiceRequest exportTraceServiceRequest = invocation.getArgument(0);
+            requestsByIp.get(peerIp).add(exportTraceServiceRequest);
+            return null;
+        }).when(client).export(any(ExportTraceServiceRequest.class));
+
+        MetricsTestUtil.initMetrics();
+        final PeerForwarder testPeerForwarder = generatePeerForwarder(testIps, 3);
+
+        final List<Record<Object>> exportedRecords = testPeerForwarder
+                .doExecute(TEST_SPANS_B.stream().map(span -> new Record<Object>(span)).collect(Collectors.toList()));
+
+        Assert.assertEquals(1, requestsByIp.get(peerIp).size());
+        final ExportTraceServiceRequest forwardedRequest = requestsByIp.get(peerIp).get(0);
+        final List<ResourceSpans> forwardedResourceSpans = forwardedRequest.getResourceSpansList();
+        assertEquals(3, forwardedResourceSpans.size());
+        forwardedResourceSpans.forEach(rs -> {
+            assertEquals(TEST_SERVICE_B, extractServiceName(rs));
+            assertEquals(1, rs.getInstrumentationLibrarySpansCount());
+            final InstrumentationLibrarySpans ils = rs.getInstrumentationLibrarySpans(0);
+            assertEquals(1, ils.getSpansCount());
+            final io.opentelemetry.proto.trace.v1.Span sp = ils.getSpans(0);
+            assertEquals(TEST_TRACE_ID_2, Hex.encodeHexString(sp.getTraceId().toByteArray()));
+        });
         Assert.assertEquals(0, exportedRecords.size());
 
         // Verify metrics
@@ -241,7 +467,7 @@ public class PeerForwarderTest {
     }
 
     @Test
-    public void testSingleRemoteIpForwardRequestError() {
+    public void testSingleRemoteIpForwardRequestClientErrorWithExportTraceServiceRequestRecordData() {
         final List<String> testIps = generateTestIps(2);
         final Channel channel = mock(Channel.class);
         final String peerIp = testIps.get(1);
@@ -258,12 +484,57 @@ public class PeerForwarderTest {
                 .doExecute(Collections.singletonList(new Record<>(REQUEST_4)));
 
         final List<ResourceSpans> expectedLocalResourceSpans = Collections.singletonList(
-                generateResourceSpans(SPAN_4, SPAN_5, SPAN_6));
-        Assert.assertEquals(1, exportedRecords.size());
+                generateResourceSpans(OTLP_SPAN_4, OTLP_SPAN_5, OTLP_SPAN_6));
+        assertEquals(1, exportedRecords.size());
         final ExportTraceServiceRequest exportedRequest = (ExportTraceServiceRequest) exportedRecords.get(0).getData();
         final List<ResourceSpans> forwardedResourceSpans = exportedRequest.getResourceSpansList();
         assertTrue(forwardedResourceSpans.containsAll(expectedLocalResourceSpans));
         assertTrue(expectedLocalResourceSpans.containsAll(forwardedResourceSpans));
+
+        // Verify metrics
+        final List<Measurement> forwardRequestErrorMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(TEST_PIPELINE_NAME).add("peer_forwarder")
+                        .add(PeerForwarder.ERRORS).toString());
+        assertEquals(1, forwardRequestErrorMeasurements.size());
+        assertEquals(1.0, forwardRequestErrorMeasurements.get(0).getValue(), 0);
+        final List<Measurement> forwardRequestSuccessMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(TEST_PIPELINE_NAME).add("peer_forwarder")
+                        .add(PeerForwarder.REQUESTS).toString());
+        assertEquals(1, forwardRequestSuccessMeasurements.size());
+        assertEquals(1.0, forwardRequestSuccessMeasurements.get(0).getValue(), 0);
+        final List<Measurement> forwardRequestLatencyMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(TEST_PIPELINE_NAME).add("peer_forwarder")
+                        .add(PeerForwarder.LATENCY).toString());
+        assertEquals(3, forwardRequestLatencyMeasurements.size());
+        // COUNT
+        assertEquals(1.0, forwardRequestLatencyMeasurements.get(0).getValue(), 0);
+        // TOTAL_TIME
+        assertTrue(forwardRequestLatencyMeasurements.get(1).getValue() > 0.0);
+        // MAX
+        assertTrue(forwardRequestLatencyMeasurements.get(2).getValue() > 0.0);
+    }
+
+    @Test
+    public void testSingleRemoteIpForwardRequestClientErrorWithEventRecordData() {
+        final List<String> testIps = generateTestIps(2);
+        final Channel channel = mock(Channel.class);
+        final String peerIp = testIps.get(1);
+        final String fullPeerIp = String.format("%s:21890", peerIp);
+        when(channel.authority()).thenReturn(fullPeerIp);
+        when(peerClientPool.getClient(peerIp)).thenReturn(client);
+        when(client.export(any(ExportTraceServiceRequest.class))).thenThrow(new RuntimeException());
+        when(client.getChannel()).thenReturn(channel);
+
+        MetricsTestUtil.initMetrics();
+        final PeerForwarder testPeerForwarder = generatePeerForwarder(testIps, 3);
+
+        final List<Record<Object>> exportedRecords = testPeerForwarder
+                .doExecute(TEST_SPANS_B.stream().map(span -> new Record<Object>(span)).collect(Collectors.toList()));
+
+        Assert.assertEquals(3, exportedRecords.size());
+        final List<Span> exportedSpans = exportedRecords.stream().map(record -> (Span) record.getData()).collect(Collectors.toList());
+        assertTrue(exportedSpans.containsAll(TEST_SPANS_B));
+        assertTrue(TEST_SPANS_B.containsAll(exportedSpans));
 
         // Verify metrics
         final List<Measurement> forwardRequestErrorMeasurements = MetricsTestUtil.getMeasurementList(
@@ -286,6 +557,57 @@ public class PeerForwarderTest {
         assertTrue(forwardRequestLatencyMeasurements.get(1).getValue() > 0.0);
         // MAX
         assertTrue(forwardRequestLatencyMeasurements.get(2).getValue() > 0.0);
+    }
+
+    @Test
+    public void testSingleRemoteIpForwardRequestFutureError() throws ExecutionException, InterruptedException {
+        try (final MockedStatic<CompletableFuture> completableFutureMockedStatic = mockStatic(CompletableFuture.class)) {
+            completableFutureMockedStatic.when(() -> CompletableFuture.supplyAsync(
+                            ArgumentMatchers.<Supplier<ExportTraceServiceRequest>>any(), any(ExecutorService.class)))
+                    .thenReturn(completableFuture);
+            when(completableFuture.get()).thenThrow(new InterruptedException());
+            final List<String> testIps = generateTestIps(2);
+            final Channel channel = mock(Channel.class);
+            final String peerIp = testIps.get(1);
+            final String fullPeerIp = String.format("%s:21890", peerIp);
+            when(channel.authority()).thenReturn(fullPeerIp);
+            when(peerClientPool.getClient(peerIp)).thenReturn(client);
+            when(client.getChannel()).thenReturn(channel);
+
+            MetricsTestUtil.initMetrics();
+            final PeerForwarder testPeerForwarder = generatePeerForwarder(testIps, 3);
+
+            final List<Record<Object>> exportedRecords = testPeerForwarder
+                    .doExecute(TEST_SPANS_B.stream().map(span -> new Record<Object>(span)).collect(Collectors.toList()));
+
+            verify(completableFuture, times(1)).get();
+            Assert.assertEquals(3, exportedRecords.size());
+            final List<Span> exportedSpans = exportedRecords.stream().map(record -> (Span) record.getData()).collect(Collectors.toList());
+            assertTrue(exportedSpans.containsAll(TEST_SPANS_B));
+            assertTrue(TEST_SPANS_B.containsAll(exportedSpans));
+        }
+    }
+
+    @Test
+    public void testSingleRemoteIpForwardRequestEncodeError() throws NoSuchFieldException, IllegalAccessException,
+            DecoderException, UnsupportedEncodingException {
+        final List<String> testIps = generateTestIps(2);
+        final String peerIp = testIps.get(1);
+        when(peerClientPool.getClient(peerIp)).thenReturn(client);
+
+        MetricsTestUtil.initMetrics();
+        final PeerForwarder testPeerForwarder = generatePeerForwarder(testIps, 3);
+        when(oTelProtoEncoder.convertToResourceSpans(any(Span.class))).thenThrow(new DecoderException());
+        reflectivelySetEncoder(testPeerForwarder, oTelProtoEncoder);
+
+        final List<Record<Object>> exportedRecords = testPeerForwarder
+                .doExecute(TEST_SPANS_B.stream().map(span -> new Record<Object>(span)).collect(Collectors.toList()));
+
+        verifyNoInteractions(client);
+        Assert.assertEquals(3, exportedRecords.size());
+        final List<Span> exportedSpans = exportedRecords.stream().map(record -> (Span) record.getData()).collect(Collectors.toList());
+        assertTrue(exportedSpans.containsAll(TEST_SPANS_B));
+        assertTrue(TEST_SPANS_B.containsAll(exportedSpans));
     }
 
     @Test

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderTest.java
@@ -107,12 +107,14 @@ public class PeerForwarderTest {
     @Test
     public void testLocalIpOnly() {
         final PeerForwarder testPeerForwarder = generatePeerForwarder(Collections.singletonList(LOCAL_IP), 2);
-        final List<Record<ExportTraceServiceRequest>> exportedRecords =
+        final List<Record<Object>> exportedRecords =
                 testPeerForwarder.doExecute(Arrays.asList(new Record<>(REQUEST_1), new Record<>(REQUEST_2)));
         assertTrue(exportedRecords.size() >= 3);
         final List<ResourceSpans> exportedResourceSpans = new ArrayList<>();
-        for (final Record<ExportTraceServiceRequest> record: exportedRecords) {
-            exportedResourceSpans.addAll(record.getData().getResourceSpansList());
+        for (final Record<Object> record: exportedRecords) {
+            final Object recordData = record.getData();
+            assertTrue(recordData instanceof ExportTraceServiceRequest);
+            exportedResourceSpans.addAll(((ExportTraceServiceRequest) recordData).getResourceSpansList());
         }
         final List<ResourceSpans> expectedResourceSpans = Arrays.asList(
                 generateResourceSpans(SPAN_1, SPAN_2),
@@ -143,7 +145,7 @@ public class PeerForwarderTest {
         MetricsTestUtil.initMetrics();
         final PeerForwarder testPeerForwarder = generatePeerForwarder(testIps, 3);
 
-        final List<Record<ExportTraceServiceRequest>> exportedRecords = testPeerForwarder
+        final List<Record<Object>> exportedRecords = testPeerForwarder
                 .doExecute(Arrays.asList(new Record<>(REQUEST_1), new Record<>(REQUEST_2)));
 
         final List<ResourceSpans> expectedLocalResourceSpans = Arrays.asList(
@@ -155,7 +157,7 @@ public class PeerForwarderTest {
                 generateResourceSpans(SPAN_4)
         );
         Assert.assertEquals(1, exportedRecords.size());
-        final ExportTraceServiceRequest localRequest = exportedRecords.get(0).getData();
+        final ExportTraceServiceRequest localRequest = (ExportTraceServiceRequest) exportedRecords.get(0).getData();
         final List<ResourceSpans> localResourceSpans = localRequest.getResourceSpansList();
         assertTrue(localResourceSpans.containsAll(expectedLocalResourceSpans));
         assertTrue(expectedLocalResourceSpans.containsAll(localResourceSpans));
@@ -171,13 +173,13 @@ public class PeerForwarderTest {
         final List<String> testIps = generateTestIps(2);
         final PeerForwarder testPeerForwarder = generatePeerForwarder(testIps, 3);
 
-        final List<Record<ExportTraceServiceRequest>> exportedRecords = testPeerForwarder
+        final List<Record<Object>> exportedRecords = testPeerForwarder
                 .doExecute(Collections.singletonList(new Record<>(REQUEST_3)));
 
         final List<ResourceSpans> expectedLocalResourceSpans = Collections.singletonList(
                 generateResourceSpans(SPAN_1, SPAN_2, SPAN_3));
         Assert.assertEquals(1, exportedRecords.size());
-        final ExportTraceServiceRequest localRequest = exportedRecords.get(0).getData();
+        final ExportTraceServiceRequest localRequest = (ExportTraceServiceRequest) exportedRecords.get(0).getData();
         final List<ResourceSpans> localResourceSpans = localRequest.getResourceSpansList();
         assertTrue(localResourceSpans.containsAll(expectedLocalResourceSpans));
         assertTrue(expectedLocalResourceSpans.containsAll(localResourceSpans));
@@ -203,7 +205,7 @@ public class PeerForwarderTest {
         MetricsTestUtil.initMetrics();
         final PeerForwarder testPeerForwarder = generatePeerForwarder(testIps, 3);
 
-        final List<Record<ExportTraceServiceRequest>> exportedRecords = testPeerForwarder
+        final List<Record<Object>> exportedRecords = testPeerForwarder
                 .doExecute(Collections.singletonList(new Record<>(REQUEST_4)));
 
         final List<ResourceSpans> expectedForwardedResourceSpans = Collections.singletonList(
@@ -252,13 +254,13 @@ public class PeerForwarderTest {
         MetricsTestUtil.initMetrics();
         final PeerForwarder testPeerForwarder = generatePeerForwarder(testIps, 3);
 
-        final List<Record<ExportTraceServiceRequest>> exportedRecords = testPeerForwarder
+        final List<Record<Object>> exportedRecords = testPeerForwarder
                 .doExecute(Collections.singletonList(new Record<>(REQUEST_4)));
 
         final List<ResourceSpans> expectedLocalResourceSpans = Collections.singletonList(
                 generateResourceSpans(SPAN_4, SPAN_5, SPAN_6));
         Assert.assertEquals(1, exportedRecords.size());
-        final ExportTraceServiceRequest exportedRequest = exportedRecords.get(0).getData();
+        final ExportTraceServiceRequest exportedRequest = (ExportTraceServiceRequest) exportedRecords.get(0).getData();
         final List<ResourceSpans> forwardedResourceSpans = exportedRequest.getResourceSpansList();
         assertTrue(forwardedResourceSpans.containsAll(expectedLocalResourceSpans));
         assertTrue(expectedLocalResourceSpans.containsAll(forwardedResourceSpans));

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderTest.java
@@ -203,6 +203,7 @@ public class PeerForwarderTest {
         }
     }
 
+    // TODO: remove in 2.0
     @Test
     public void testLocalIpOnlyWithExportTraceServiceRequestRecordData() {
         final PeerForwarder testPeerForwarder = generatePeerForwarder(Collections.singletonList(LOCAL_IP), 2);
@@ -237,6 +238,7 @@ public class PeerForwarderTest {
         assertTrue(inputSpans.containsAll(exportedSpans));
     }
 
+    // TODO: remove in 2.0
     @Test
     public void testSingleRemoteIpBothLocalAndForwardedRequestWithExportTraceServiceRequestRecordData() {
         final List<String> testIps = generateTestIps(2);
@@ -320,6 +322,7 @@ public class PeerForwarderTest {
         });
     }
 
+    // TODO: remove in 2.0
     @Test
     public void testSingleRemoteIpLocalRequestOnlyWithExportTraceServiceRequestRecordData() throws Exception {
         final List<String> testIps = generateTestIps(2);
@@ -351,6 +354,7 @@ public class PeerForwarderTest {
         assertTrue(TEST_SPANS_A.containsAll(localSpans));
     }
 
+    // TODO: remove in 2.0
     @Test
     public void testSingleRemoteIpForwardedRequestOnlyWithExportTraceServiceRequestRecordData() throws Exception {
         final List<String> testIps = generateTestIps(2);
@@ -466,6 +470,7 @@ public class PeerForwarderTest {
         assertTrue(forwardRequestLatencyMeasurements.get(2).getValue() > 0.0);
     }
 
+    // TODO: remove in 2.0
     @Test
     public void testSingleRemoteIpForwardRequestClientErrorWithExportTraceServiceRequestRecordData() {
         final List<String> testIps = generateTestIps(2);


### PR DESCRIPTION
### Description
This PR "merges" peer-forwarder from https://github.com/opensearch-project/data-prepper/tree/maint/546-migrate-trace-analytics-to-event-model with the following adjustment:

* change the peer-forwarder interface to AbstractProcessor<Record<Object>, Record<Object>>
* input and output record data types are the same but can be either ExportTraceServiceRequest or Event. 
* make sure test cases cover both record data type.
 
### Issues Resolved
Contributes to #1158 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
