### PR TITLE
MAINT: adjust otel-trace-source from trace event migration branch

### DIFF
--- a/data-prepper-plugins/otel-trace-source/README.md
+++ b/data-prepper-plugins/otel-trace-source/README.md
@@ -20,6 +20,9 @@ source:
 * thread_count(Optional) => the number of threads to keep in the ScheduledThreadPool. Default is `200`.
 * max_connection_count(Optional) => the maximum allowed number of open connections. Default is `500`. 
 * authentication(Optional) => An authentication configuration. By default, this runs an unauthenticated server. See below for more information.
+* record_type(Optional) => A string represents the supported record data type that will be written into the buffer plugin. Its value takes either `otlp` or `event`. Default is `otlp`.
+  * `otlp`: otel-trace-source will write each incoming ExportTraceServiceRequest as record data type into the buffer.
+  * `event`: otel-trace-source will decode each incoming ExportTraceServiceRequest into collection of Data Prepper internal spans serving as buffer items. To achieve better performance in this mode, it is recommended to set the buffer capacity proportional to the estimated number of spans in the incoming request payload. 
 
 ### Authentication Configurations
 

--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(':data-prepper-plugins:common')
     implementation project(':data-prepper-plugins:blocking-buffer')
     implementation project(':data-prepper-plugins:armeria-common')
+    implementation project(':data-prepper-plugins:otel-proto-common')
     implementation 'commons-codec:commons-codec:1.15'
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
@@ -7,46 +7,89 @@ package com.amazon.dataprepper.plugins.source.oteltrace;
 
 import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.buffer.Buffer;
+import com.amazon.dataprepper.model.buffer.SizeOverflowException;
 import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.model.trace.Span;
+import com.amazon.dataprepper.plugins.otel.codec.OTelProtoCodec;
 import io.grpc.Context;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Timer;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 public class OTelTraceGrpcService extends TraceServiceGrpc.TraceServiceImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(OTelTraceGrpcService.class);
 
     public static final String REQUEST_TIMEOUTS = "requestTimeouts";
     public static final String REQUESTS_RECEIVED = "requestsReceived";
+    public static final String BAD_REQUESTS = "badRequests";
+    public static final String REQUESTS_TOO_LARGE = "requestsTooLarge";
+    public static final String INTERNAL_SERVER_ERROR = "internalServerError";
+    public static final String SUCCESS_REQUESTS = "successRequests";
+    public static final String PAYLOAD_SIZE = "payloadSize";
+    public static final String REQUEST_PROCESS_DURATION = "requestProcessDuration";
 
     private final int bufferWriteTimeoutInMillis;
-    private final Buffer<Record<ExportTraceServiceRequest>> buffer;
+    private final RecordType recordType;
+    private final OTelProtoCodec.OTelProtoDecoder oTelProtoDecoder;
+    private final Buffer<Record<Object>> buffer;
 
     private final Counter requestTimeoutCounter;
     private final Counter requestsReceivedCounter;
+    private final Counter successRequestsCounter;
+    private final Counter badRequestsCounter;
+    private final Counter requestsTooLargeCounter;
+    private final Counter internalServerErrorCounter;
+    private final DistributionSummary payloadSizeSummary;
+    private final Timer requestProcessDuration;
 
 
     public OTelTraceGrpcService(int bufferWriteTimeoutInMillis,
-                                Buffer<Record<ExportTraceServiceRequest>> buffer,
+                                final RecordType recordType,
+                                final OTelProtoCodec.OTelProtoDecoder oTelProtoDecoder,
+                                final Buffer<Record<Object>> buffer,
                                 final PluginMetrics pluginMetrics) {
         this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
+        this.recordType = recordType;
         this.buffer = buffer;
+        this.oTelProtoDecoder = oTelProtoDecoder;
 
         requestTimeoutCounter = pluginMetrics.counter(REQUEST_TIMEOUTS);
         requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED);
+        badRequestsCounter = pluginMetrics.counter(BAD_REQUESTS);
+        requestsTooLargeCounter = pluginMetrics.counter(REQUESTS_TOO_LARGE);
+        internalServerErrorCounter = pluginMetrics.counter(INTERNAL_SERVER_ERROR);
+        successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS);
+        payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE);
+        requestProcessDuration = pluginMetrics.timer(REQUEST_PROCESS_DURATION);
     }
 
 
     @Override
     public void export(ExportTraceServiceRequest request, StreamObserver<ExportTraceServiceResponse> responseObserver) {
+        if (recordType.equals(RecordType.otlp)) {
+            requestProcessDuration.record(() -> processRequestWithoutDecoding(request, responseObserver));
+        } else {
+            requestProcessDuration.record(() -> processRequest(request, responseObserver));
+        }
+    }
+
+    // TODO: remove in 2.0
+    private void processRequestWithoutDecoding(
+            final ExportTraceServiceRequest request, final StreamObserver<ExportTraceServiceResponse> responseObserver) {
         requestsReceivedCounter.increment();
+        payloadSizeSummary.record(request.getSerializedSize());
 
         if (Context.current().isCancelled()) {
             requestTimeoutCounter.increment();
@@ -64,6 +107,56 @@ public class OTelTraceGrpcService extends TraceServiceGrpc.TraceServiceImplBase 
             responseObserver
                     .onError(Status.RESOURCE_EXHAUSTED.withDescription("Buffer is full, request timed out.")
                             .asException());
+        }
+    }
+
+    private void processRequest(
+            final ExportTraceServiceRequest request, final StreamObserver<ExportTraceServiceResponse> responseObserver) {
+        requestsReceivedCounter.increment();
+        payloadSizeSummary.record(request.getSerializedSize());
+
+        if (Context.current().isCancelled()) {
+            requestTimeoutCounter.increment();
+            responseObserver.onError(Status.CANCELLED.withDescription("Cancelled by client").asRuntimeException());
+            return;
+        }
+
+        Collection<Span> spans;
+
+        try {
+            spans = oTelProtoDecoder.parseExportTraceServiceRequest(request);
+        } catch (Exception e) {
+            LOG.error("Failed to parse the request content [{}] due to:", request, e);
+            badRequestsCounter.increment();
+            responseObserver.onError(Status.INVALID_ARGUMENT.withDescription(e.getMessage()).asException());
+            return;
+        }
+
+        final List<Record<Object>> records = spans.stream().map(span -> new Record<Object>(span)).collect(Collectors.toList());
+
+        try {
+            buffer.writeAll(records, bufferWriteTimeoutInMillis);
+            successRequestsCounter.increment();
+            responseObserver.onNext(ExportTraceServiceResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.error("Failed to write the request content [{}] due to:", request, e);
+            if (e instanceof TimeoutException) {
+                requestTimeoutCounter.increment();
+                responseObserver
+                        .onError(Status.RESOURCE_EXHAUSTED.withDescription(e.getMessage())
+                                .asException());
+            } else if (e instanceof SizeOverflowException) {
+                requestsTooLargeCounter.increment();
+                responseObserver
+                        .onError(Status.RESOURCE_EXHAUSTED.withDescription(e.getMessage())
+                                .asException());
+            } else {
+                internalServerErrorCounter.increment();
+                responseObserver
+                        .onError(Status.INTERNAL.withDescription(e.getMessage())
+                                .asException());
+            }
         }
     }
 }

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
@@ -78,7 +78,7 @@ public class OTelTraceGrpcService extends TraceServiceGrpc.TraceServiceImplBase 
 
     @Override
     public void export(ExportTraceServiceRequest request, StreamObserver<ExportTraceServiceResponse> responseObserver) {
-        if (recordType.equals(RecordType.otlp)) {
+        if (recordType == RecordType.OTLP) {
             requestProcessDuration.record(() -> processRequestWithoutDecoding(request, responseObserver));
         } else {
             requestProcessDuration.record(() -> processRequest(request, responseObserver));

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
@@ -58,7 +58,6 @@ public class OTelTraceSource implements Source<Record<Object>> {
     // accessible only in the same package for unit test
     OTelTraceSource(final OTelTraceSourceConfig oTelTraceSourceConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory, final CertificateProviderFactory certificateProviderFactory) {
         oTelTraceSourceConfig.validateAndInitializeCertAndKeyFileInS3();
-        oTelTraceSourceConfig.validateRecordType();
         this.oTelTraceSourceConfig = oTelTraceSourceConfig;
         this.pluginMetrics = pluginMetrics;
         this.certificateProviderFactory = certificateProviderFactory;
@@ -75,7 +74,7 @@ public class OTelTraceSource implements Source<Record<Object>> {
 
             final OTelTraceGrpcService oTelTraceGrpcService = new OTelTraceGrpcService(
                     oTelTraceSourceConfig.getRequestTimeoutInMillis(),
-                    RecordType.valueOf(oTelTraceSourceConfig.getRecordType()),
+                    oTelTraceSourceConfig.getRecordType(),
                     new OTelProtoCodec.OTelProtoDecoder(),
                     buffer,
                     pluginMetrics

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
@@ -38,7 +38,7 @@ public class OTelTraceSourceConfig {
     static final boolean DEFAULT_PROTO_REFLECTION_SERVICE = false;
     static final boolean DEFAULT_USE_ACM_CERT_FOR_SSL = false;
     static final int DEFAULT_ACM_CERT_ISSUE_TIME_OUT_MILLIS = 120000;
-    static final String DEFAULT_RECORD_TYPE = RecordType.otlp.name();
+    static final RecordType DEFAULT_RECORD_TYPE = RecordType.OTLP;
     private static final String S3_PREFIX = "s3://";
 
     @JsonProperty(REQUEST_TIMEOUT)
@@ -92,7 +92,7 @@ public class OTelTraceSourceConfig {
     private PluginModel authentication;
 
     @JsonProperty(RECORD_TYPE)
-    private String recordType = DEFAULT_RECORD_TYPE;
+    private RecordType recordType = DEFAULT_RECORD_TYPE;
 
     public void validateAndInitializeCertAndKeyFileInS3() {
         boolean certAndKeyFileInS3 = false;
@@ -107,10 +107,6 @@ public class OTelTraceSourceConfig {
             }
         }
         sslCertAndKeyFileInS3 = certAndKeyFileInS3;
-    }
-
-    public void validateRecordType() {
-        checkArgument(RecordType.contains(recordType), "Unsupported record type: " + recordType);
     }
 
     private void validateSSLArgument(final String sslTypeMessage, final String argument, final String argumentName) {
@@ -195,7 +191,7 @@ public class OTelTraceSourceConfig {
 
     public PluginModel getAuthentication() { return authentication; }
 
-    public String getRecordType() {
+    public RecordType getRecordType() {
         return recordType;
     }
 }

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
@@ -9,8 +9,6 @@ import com.amazon.dataprepper.model.configuration.PluginModel;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.StringUtils;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 public class OTelTraceSourceConfig {
     static final String REQUEST_TIMEOUT = "request_timeout";
     static final String PORT = "port";

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
@@ -38,7 +38,7 @@ public class OTelTraceSourceConfig {
     static final boolean DEFAULT_PROTO_REFLECTION_SERVICE = false;
     static final boolean DEFAULT_USE_ACM_CERT_FOR_SSL = false;
     static final int DEFAULT_ACM_CERT_ISSUE_TIME_OUT_MILLIS = 120000;
-    static final String DEFAULT_RECORD_TYPE = RecordType.event.name();
+    static final String DEFAULT_RECORD_TYPE = RecordType.otlp.name();
     private static final String S3_PREFIX = "s3://";
 
     @JsonProperty(REQUEST_TIMEOUT)

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
@@ -9,6 +9,8 @@ import com.amazon.dataprepper.model.configuration.PluginModel;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.StringUtils;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class OTelTraceSourceConfig {
     static final String REQUEST_TIMEOUT = "request_timeout";
     static final String PORT = "port";
@@ -25,6 +27,7 @@ public class OTelTraceSourceConfig {
     static final String THREAD_COUNT = "thread_count";
     static final String MAX_CONNECTION_COUNT = "max_connection_count";
     static final String ENABLE_UNFRAMED_REQUESTS = "unframed_requests";
+    static final String RECORD_TYPE = "record_type";
     static final int DEFAULT_REQUEST_TIMEOUT_MS = 10000;
     static final int DEFAULT_PORT = 21890;
     static final int DEFAULT_THREAD_COUNT = 200;
@@ -35,6 +38,7 @@ public class OTelTraceSourceConfig {
     static final boolean DEFAULT_PROTO_REFLECTION_SERVICE = false;
     static final boolean DEFAULT_USE_ACM_CERT_FOR_SSL = false;
     static final int DEFAULT_ACM_CERT_ISSUE_TIME_OUT_MILLIS = 120000;
+    static final String DEFAULT_RECORD_TYPE = RecordType.event.name();
     private static final String S3_PREFIX = "s3://";
 
     @JsonProperty(REQUEST_TIMEOUT)
@@ -87,6 +91,9 @@ public class OTelTraceSourceConfig {
     @JsonProperty("authentication")
     private PluginModel authentication;
 
+    @JsonProperty(RECORD_TYPE)
+    private String recordType = DEFAULT_RECORD_TYPE;
+
     public void validateAndInitializeCertAndKeyFileInS3() {
         boolean certAndKeyFileInS3 = false;
         if (useAcmCertForSSL) {
@@ -100,6 +107,10 @@ public class OTelTraceSourceConfig {
             }
         }
         sslCertAndKeyFileInS3 = certAndKeyFileInS3;
+    }
+
+    public void validateRecordType() {
+        checkArgument(RecordType.contains(recordType), "Unsupported record type: " + recordType);
     }
 
     private void validateSSLArgument(final String sslTypeMessage, final String argument, final String argumentName) {
@@ -183,4 +194,8 @@ public class OTelTraceSourceConfig {
     }
 
     public PluginModel getAuthentication() { return authentication; }
+
+    public String getRecordType() {
+        return recordType;
+    }
 }

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/RecordType.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/RecordType.java
@@ -5,7 +5,6 @@
 
 package com.amazon.dataprepper.plugins.source.oteltrace;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Arrays;

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/RecordType.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/RecordType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.oteltrace;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An enum to represent the record data types supported in {@link OTelTraceSource}.
+ * @since 1.4
+ * TODO: remove in 2.0
+ */
+enum RecordType {
+    otlp,
+    event;
+
+    private static final Map<String, RecordType> NAMES_MAP = new HashMap<>();
+
+    static {
+        Arrays.stream(RecordType.values()).forEach(recordType -> NAMES_MAP.put(recordType.name(), recordType));
+    }
+
+    public static boolean contains(final String name) {
+        return NAMES_MAP.containsKey(name);
+    }
+}

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/RecordType.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/RecordType.java
@@ -37,8 +37,4 @@ enum RecordType {
     public String toString() {
         return this.name;
     }
-
-    public static boolean contains(final String name) {
-        return NAMES_MAP.containsKey(name);
-    }
 }

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/RecordType.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/RecordType.java
@@ -5,6 +5,9 @@
 
 package com.amazon.dataprepper.plugins.source.oteltrace;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -15,13 +18,25 @@ import java.util.Map;
  * TODO: remove in 2.0
  */
 enum RecordType {
-    otlp,
-    event;
+    @JsonProperty("otlp")
+    OTLP("otlp"),
+    @JsonProperty("event")
+    EVENT("event");
 
     private static final Map<String, RecordType> NAMES_MAP = new HashMap<>();
 
     static {
         Arrays.stream(RecordType.values()).forEach(recordType -> NAMES_MAP.put(recordType.name(), recordType));
+    }
+
+    private final String name;
+
+    RecordType(final String name) {
+        this.name = name;
+    }
+
+    public String toString() {
+        return this.name;
     }
 
     public static boolean contains(final String name) {

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceGrpcServiceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceGrpcServiceTest.java
@@ -7,29 +7,43 @@ package com.amazon.dataprepper.plugins.source.oteltrace;
 
 import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.buffer.Buffer;
+import com.amazon.dataprepper.model.buffer.SizeOverflowException;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.model.trace.Span;
+import com.amazon.dataprepper.plugins.otel.codec.OTelProtoCodec;
+import com.google.protobuf.ByteString;
+import io.grpc.Status;
+import io.grpc.StatusException;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Timer;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
-import io.opentelemetry.proto.trace.v1.Span;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -39,14 +53,26 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class OTelTraceGrpcServiceTest {
+    private static final io.opentelemetry.proto.trace.v1.Span TEST_SPAN = io.opentelemetry.proto.trace.v1.Span.newBuilder()
+            .setTraceId(ByteString.copyFromUtf8("TEST_TRACE_ID"))
+            .setSpanId(ByteString.copyFromUtf8("TEST_SPAN_ID"))
+            .setName("TEST_NAME")
+            .setKind(io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_SERVER)
+            .setStartTimeUnixNano(100)
+            .setEndTimeUnixNano(101)
+            .setTraceState("SUCCESS").build();
     private static final ExportTraceServiceRequest SUCCESS_REQUEST = ExportTraceServiceRequest.newBuilder()
             .addResourceSpans(ResourceSpans.newBuilder()
-                    .addInstrumentationLibrarySpans(InstrumentationLibrarySpans.newBuilder()
-                            .addSpans(Span.newBuilder().setTraceState("SUCCESS").build())).build()).build();
+                    .addInstrumentationLibrarySpans(InstrumentationLibrarySpans.newBuilder().addSpans(TEST_SPAN)).build())
+            .build();
 
     private static PluginSetting pluginSetting;
     private final int bufferWriteTimeoutInMillis = 100000;
 
+    @Mock
+    OTelProtoCodec.OTelProtoDecoder mockOTelProtoDecoder;
+    @Mock
+    PluginMetrics mockPluginMetrics;
     @Mock
     Counter requestsReceivedCounter;
     @Mock
@@ -55,28 +81,55 @@ public class OTelTraceGrpcServiceTest {
     StreamObserver responseObserver;
     @Mock
     Buffer buffer;
+    @Mock
+    Counter successRequestsCounter;
+    @Mock
+    Counter badRequestsCounter;
+    @Mock
+    Counter requestsTooLargeCounter;
+    @Mock
+    Counter internalServerErrorCounter;
+    @Mock
+    DistributionSummary payloadSizeSummary;
+    @Mock
+    Timer requestProcessDuration;
 
     @Captor
     ArgumentCaptor<Record> recordCaptor;
 
-    private OTelTraceGrpcService sut;
+    @Captor
+    ArgumentCaptor<Collection<Record<Span>>> recordsCaptor;
+
+    @Captor
+    ArgumentCaptor<StatusException> statusExceptionArgumentCaptor;
+
+    private OTelTraceGrpcService objectUnderTest;
 
     @BeforeEach
     public void setup() {
         pluginSetting = new PluginSetting("OTelTraceGrpcService", Collections.EMPTY_MAP);
         pluginSetting.setPipelineName("pipeline");
 
-        PluginMetrics mockPluginMetrics = mock(PluginMetrics.class);
+        mockPluginMetrics = mock(PluginMetrics.class);
 
         when(mockPluginMetrics.counter(OTelTraceGrpcService.REQUESTS_RECEIVED)).thenReturn(requestsReceivedCounter);
         when(mockPluginMetrics.counter(OTelTraceGrpcService.REQUEST_TIMEOUTS)).thenReturn(timeoutCounter);
-
-        sut = new OTelTraceGrpcService(bufferWriteTimeoutInMillis, buffer, mockPluginMetrics);
+        when(mockPluginMetrics.counter(OTelTraceGrpcService.BAD_REQUESTS)).thenReturn(badRequestsCounter);
+        when(mockPluginMetrics.counter(OTelTraceGrpcService.REQUESTS_TOO_LARGE)).thenReturn(requestsTooLargeCounter);
+        when(mockPluginMetrics.counter(OTelTraceGrpcService.INTERNAL_SERVER_ERROR)).thenReturn(internalServerErrorCounter);
+        when(mockPluginMetrics.counter(OTelTraceGrpcService.SUCCESS_REQUESTS)).thenReturn(successRequestsCounter);
+        when(mockPluginMetrics.summary(OTelTraceGrpcService.PAYLOAD_SIZE)).thenReturn(payloadSizeSummary);
+        when(mockPluginMetrics.timer(OTelTraceGrpcService.REQUEST_PROCESS_DURATION)).thenReturn(requestProcessDuration);
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return null;
+        }).when(requestProcessDuration).record(ArgumentMatchers.<Runnable>any());
     }
 
     @Test
-    public void export_Success_responseObserverOnCompleted() throws Exception {
-        sut.export(SUCCESS_REQUEST, responseObserver);
+    public void export_Success_responseObserverOnCompleted_withOTLPRecordType() throws Exception {
+        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.otlp);
+        objectUnderTest.export(SUCCESS_REQUEST, responseObserver);
 
         verify(buffer, times(1)).write(recordCaptor.capture(), anyInt());
         verify(responseObserver, times(1)).onNext(ExportTraceServiceResponse.newBuilder().build());
@@ -89,15 +142,152 @@ public class OTelTraceGrpcServiceTest {
     }
 
     @Test
-    public void export_BufferTimeout_responseObserverOnError() throws Exception {
+    public void export_Success_responseObserverOnCompleted_withEventRecordType() throws Exception {
+        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.event);
+        objectUnderTest.export(SUCCESS_REQUEST, responseObserver);
+
+        verify(buffer, times(1)).writeAll(recordsCaptor.capture(), anyInt());
+        verify(responseObserver, times(1)).onNext(ExportTraceServiceResponse.newBuilder().build());
+        verify(responseObserver, times(1)).onCompleted();
+        verify(requestsReceivedCounter, times(1)).increment();
+        verify(successRequestsCounter, times(1)).increment();
+        verifyNoInteractions(badRequestsCounter);
+        verifyNoInteractions(requestsTooLargeCounter);
+        verifyNoInteractions(timeoutCounter);
+        final ArgumentCaptor<Double> payloadLengthCaptor = ArgumentCaptor.forClass(Double.class);
+        verify(payloadSizeSummary, times(1)).record(payloadLengthCaptor.capture());
+        assertThat(payloadLengthCaptor.getValue().intValue(), equalTo(SUCCESS_REQUEST.getSerializedSize()));
+        verify(requestProcessDuration, times(1)).record(ArgumentMatchers.<Runnable>any());
+
+        final List<Record<Span>> capturedRecords = (List<Record<Span>>) recordsCaptor.getValue();
+        assertThat(capturedRecords.size(), equalTo(1));
+        assertThat(capturedRecords.get(0).getData().getTraceState(), equalTo("SUCCESS"));
+    }
+
+    @Test
+    public void export_BufferTimeout_responseObserverOnError_withOTLPRecordType() throws Exception {
+        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.otlp);
         doThrow(new TimeoutException()).when(buffer).write(any(Record.class), anyInt());
 
-        sut.export(SUCCESS_REQUEST, responseObserver);
+        objectUnderTest.export(SUCCESS_REQUEST, responseObserver);
 
         verify(buffer, times(1)).write(any(Record.class), anyInt());
         verify(responseObserver, times(0)).onNext(any());
         verify(responseObserver, times(0)).onCompleted();
+        verify(responseObserver, times(1)).onError(statusExceptionArgumentCaptor.capture());
         verify(timeoutCounter, times(1)).increment();
         verify(requestsReceivedCounter, times(1)).increment();
+        verifyNoInteractions(successRequestsCounter);
+        verifyNoInteractions(badRequestsCounter);
+        verifyNoInteractions(requestsTooLargeCounter);
+        final ArgumentCaptor<Double> payloadLengthCaptor = ArgumentCaptor.forClass(Double.class);
+        verify(payloadSizeSummary, times(1)).record(payloadLengthCaptor.capture());
+        assertThat(payloadLengthCaptor.getValue().intValue(), equalTo(SUCCESS_REQUEST.getSerializedSize()));
+        verify(requestProcessDuration, times(1)).record(ArgumentMatchers.<Runnable>any());
+        StatusException capturedStatusException = statusExceptionArgumentCaptor.getValue();
+        assertThat(capturedStatusException.getStatus().getCode(), equalTo(Status.RESOURCE_EXHAUSTED.getCode()));
+    }
+
+    @Test
+    public void export_BufferTimeout_responseObserverOnError_withEventRecordType() throws Exception {
+        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.event);
+        doThrow(new TimeoutException()).when(buffer).writeAll(any(Collection.class), anyInt());
+
+        objectUnderTest.export(SUCCESS_REQUEST, responseObserver);
+
+        verify(buffer, times(1)).writeAll(any(Collection.class), anyInt());
+        verify(responseObserver, times(0)).onNext(any());
+        verify(responseObserver, times(0)).onCompleted();
+        verify(responseObserver, times(1)).onError(statusExceptionArgumentCaptor.capture());
+        verify(timeoutCounter, times(1)).increment();
+        verify(requestsReceivedCounter, times(1)).increment();
+        verifyNoInteractions(successRequestsCounter);
+        verifyNoInteractions(badRequestsCounter);
+        verifyNoInteractions(requestsTooLargeCounter);
+        final ArgumentCaptor<Double> payloadLengthCaptor = ArgumentCaptor.forClass(Double.class);
+        verify(payloadSizeSummary, times(1)).record(payloadLengthCaptor.capture());
+        assertThat(payloadLengthCaptor.getValue().intValue(), equalTo(SUCCESS_REQUEST.getSerializedSize()));
+        verify(requestProcessDuration, times(1)).record(ArgumentMatchers.<Runnable>any());
+        StatusException capturedStatusException = statusExceptionArgumentCaptor.getValue();
+        assertThat(capturedStatusException.getStatus().getCode(), equalTo(Status.RESOURCE_EXHAUSTED.getCode()));
+    }
+
+    @Test
+    public void export_BadRequest_responseObserverOnError() throws Exception {
+        final String testMessage = "test message";
+        final RuntimeException testException = new RuntimeException(testMessage);
+        when(mockOTelProtoDecoder.parseExportTraceServiceRequest(any())).thenThrow(testException);
+        objectUnderTest = generateOTelTraceGrpcService(mockOTelProtoDecoder, RecordType.event);
+        objectUnderTest.export(SUCCESS_REQUEST, responseObserver);
+
+        verifyNoInteractions(buffer);
+        verify(responseObserver, times(0)).onNext(ExportTraceServiceResponse.newBuilder().build());
+        verify(responseObserver, times(0)).onCompleted();
+        verify(responseObserver, times(1)).onError(statusExceptionArgumentCaptor.capture());
+        verify(requestsReceivedCounter, times(1)).increment();
+        verify(badRequestsCounter, times(1)).increment();
+        verifyNoInteractions(successRequestsCounter);
+        verifyNoInteractions(requestsTooLargeCounter);
+        verifyNoInteractions(timeoutCounter);
+        final ArgumentCaptor<Double> payloadLengthCaptor = ArgumentCaptor.forClass(Double.class);
+        verify(payloadSizeSummary, times(1)).record(payloadLengthCaptor.capture());
+        assertThat(payloadLengthCaptor.getValue().intValue(), equalTo(SUCCESS_REQUEST.getSerializedSize()));
+        verify(requestProcessDuration, times(1)).record(ArgumentMatchers.<Runnable>any());
+
+        StatusException capturedStatusException = statusExceptionArgumentCaptor.getValue();
+        assertThat(capturedStatusException.getStatus().getCode(), equalTo(Status.INVALID_ARGUMENT.getCode()));
+    }
+
+    @Test
+    public void export_RequestTooLarge_responseObserverOnError() throws Exception {
+        final String testMessage = "test message";
+        doThrow(new SizeOverflowException(testMessage)).when(buffer).writeAll(any(Collection.class), anyInt());
+        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.event);
+        objectUnderTest.export(SUCCESS_REQUEST, responseObserver);
+
+        verify(buffer, times(1)).writeAll(any(Collection.class), anyInt());
+        verify(responseObserver, times(0)).onNext(any());
+        verify(responseObserver, times(0)).onCompleted();
+        verify(responseObserver, times(1)).onError(statusExceptionArgumentCaptor.capture());
+        verify(requestsReceivedCounter, times(1)).increment();
+        verify(requestsTooLargeCounter, times(1)).increment();
+        verifyNoInteractions(timeoutCounter);
+        verifyNoInteractions(successRequestsCounter);
+        verifyNoInteractions(badRequestsCounter);
+        final ArgumentCaptor<Double> payloadLengthCaptor = ArgumentCaptor.forClass(Double.class);
+        verify(payloadSizeSummary, times(1)).record(payloadLengthCaptor.capture());
+        assertThat(payloadLengthCaptor.getValue().intValue(), equalTo(SUCCESS_REQUEST.getSerializedSize()));
+        verify(requestProcessDuration, times(1)).record(ArgumentMatchers.<Runnable>any());
+        StatusException capturedStatusException = statusExceptionArgumentCaptor.getValue();
+        assertThat(capturedStatusException.getStatus().getCode(), equalTo(Status.RESOURCE_EXHAUSTED.getCode()));
+    }
+
+    @Test
+    public void export_BufferInternalException_responseObserverOnError() throws Exception {
+        final String testMessage = "test message";
+        doThrow(new IOException(testMessage)).when(buffer).writeAll(any(Collection.class), anyInt());
+        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.event);
+        objectUnderTest.export(SUCCESS_REQUEST, responseObserver);
+
+        verify(buffer, times(1)).writeAll(any(Collection.class), anyInt());
+        verify(responseObserver, times(0)).onNext(any());
+        verify(responseObserver, times(0)).onCompleted();
+        verify(responseObserver, times(1)).onError(statusExceptionArgumentCaptor.capture());
+        verify(requestsReceivedCounter, times(1)).increment();
+        verifyNoInteractions(requestsTooLargeCounter);
+        verifyNoInteractions(timeoutCounter);
+        verifyNoInteractions(successRequestsCounter);
+        verifyNoInteractions(badRequestsCounter);
+        final ArgumentCaptor<Double> payloadLengthCaptor = ArgumentCaptor.forClass(Double.class);
+        verify(payloadSizeSummary, times(1)).record(payloadLengthCaptor.capture());
+        assertThat(payloadLengthCaptor.getValue().intValue(), equalTo(SUCCESS_REQUEST.getSerializedSize()));
+        verify(requestProcessDuration, times(1)).record(ArgumentMatchers.<Runnable>any());
+        StatusException capturedStatusException = statusExceptionArgumentCaptor.getValue();
+        assertThat(capturedStatusException.getStatus().getCode(), equalTo(Status.INTERNAL.getCode()));
+    }
+
+    private OTelTraceGrpcService generateOTelTraceGrpcService(final OTelProtoCodec.OTelProtoDecoder decoder, final RecordType recordType) {
+        return new OTelTraceGrpcService(
+                bufferWriteTimeoutInMillis, recordType, decoder, buffer, mockPluginMetrics);
     }
 }

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceGrpcServiceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceGrpcServiceTest.java
@@ -128,7 +128,7 @@ public class OTelTraceGrpcServiceTest {
 
     @Test
     public void export_Success_responseObserverOnCompleted_withOTLPRecordType() throws Exception {
-        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.otlp);
+        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.OTLP);
         objectUnderTest.export(SUCCESS_REQUEST, responseObserver);
 
         verify(buffer, times(1)).write(recordCaptor.capture(), anyInt());
@@ -143,7 +143,7 @@ public class OTelTraceGrpcServiceTest {
 
     @Test
     public void export_Success_responseObserverOnCompleted_withEventRecordType() throws Exception {
-        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.event);
+        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.EVENT);
         objectUnderTest.export(SUCCESS_REQUEST, responseObserver);
 
         verify(buffer, times(1)).writeAll(recordsCaptor.capture(), anyInt());
@@ -166,7 +166,7 @@ public class OTelTraceGrpcServiceTest {
 
     @Test
     public void export_BufferTimeout_responseObserverOnError_withOTLPRecordType() throws Exception {
-        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.otlp);
+        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.OTLP);
         doThrow(new TimeoutException()).when(buffer).write(any(Record.class), anyInt());
 
         objectUnderTest.export(SUCCESS_REQUEST, responseObserver);
@@ -190,7 +190,7 @@ public class OTelTraceGrpcServiceTest {
 
     @Test
     public void export_BufferTimeout_responseObserverOnError_withEventRecordType() throws Exception {
-        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.event);
+        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.EVENT);
         doThrow(new TimeoutException()).when(buffer).writeAll(any(Collection.class), anyInt());
 
         objectUnderTest.export(SUCCESS_REQUEST, responseObserver);
@@ -217,7 +217,7 @@ public class OTelTraceGrpcServiceTest {
         final String testMessage = "test message";
         final RuntimeException testException = new RuntimeException(testMessage);
         when(mockOTelProtoDecoder.parseExportTraceServiceRequest(any())).thenThrow(testException);
-        objectUnderTest = generateOTelTraceGrpcService(mockOTelProtoDecoder, RecordType.event);
+        objectUnderTest = generateOTelTraceGrpcService(mockOTelProtoDecoder, RecordType.EVENT);
         objectUnderTest.export(SUCCESS_REQUEST, responseObserver);
 
         verifyNoInteractions(buffer);
@@ -242,7 +242,7 @@ public class OTelTraceGrpcServiceTest {
     public void export_RequestTooLarge_responseObserverOnError() throws Exception {
         final String testMessage = "test message";
         doThrow(new SizeOverflowException(testMessage)).when(buffer).writeAll(any(Collection.class), anyInt());
-        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.event);
+        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.EVENT);
         objectUnderTest.export(SUCCESS_REQUEST, responseObserver);
 
         verify(buffer, times(1)).writeAll(any(Collection.class), anyInt());
@@ -266,7 +266,7 @@ public class OTelTraceGrpcServiceTest {
     public void export_BufferInternalException_responseObserverOnError() throws Exception {
         final String testMessage = "test message";
         doThrow(new IOException(testMessage)).when(buffer).writeAll(any(Collection.class), anyInt());
-        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.event);
+        objectUnderTest = generateOTelTraceGrpcService(new OTelProtoCodec.OTelProtoDecoder(), RecordType.EVENT);
         objectUnderTest.export(SUCCESS_REQUEST, responseObserver);
 
         verify(buffer, times(1)).writeAll(any(Collection.class), anyInt());

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -170,7 +170,7 @@ public class OTelTraceSourceTest {
     }
 
     private static Stream<Arguments> recordTypeArguments() {
-        return Stream.of(Arguments.of(RecordType.otlp.name()), Arguments.of(RecordType.event.name()));
+        return Stream.of(Arguments.of(RecordType.OTLP.toString()), Arguments.of(RecordType.EVENT.toString()));
     }
 
     @BeforeEach
@@ -189,7 +189,7 @@ public class OTelTraceSourceTest {
         final GrpcAuthenticationProvider authenticationProvider = mock(GrpcBasicAuthenticationProvider.class);
         when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))
                 .thenReturn(authenticationProvider);
-        configureObjectUnderTest(RecordType.event.name());
+        configureObjectUnderTest(RecordType.EVENT.toString());
         buffer = getBuffer();
     }
 

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
@@ -70,7 +70,7 @@ public class OtelTraceSourceConfigTests {
                 true,
                 TEST_KEY_CERT,
                 TEST_KEY,
-                RecordType.otlp.name(),
+                RecordType.OTLP.toString(),
                 TEST_THREAD_COUNT,
                 TEST_MAX_CONNECTION_COUNT);
 
@@ -103,7 +103,7 @@ public class OtelTraceSourceConfigTests {
                 true,
                 TEST_KEY_CERT_S3,
                 TEST_KEY_S3,
-                RecordType.otlp.name(),
+                RecordType.OTLP.toString(),
                 TEST_THREAD_COUNT,
                 TEST_MAX_CONNECTION_COUNT);
 
@@ -135,7 +135,7 @@ public class OtelTraceSourceConfigTests {
                 false,
                 true, null,
                 TEST_KEY,
-                RecordType.otlp.name(),
+                RecordType.OTLP.toString(),
                 DEFAULT_THREAD_COUNT,
                 DEFAULT_MAX_CONNECTION_COUNT);
 
@@ -158,7 +158,7 @@ public class OtelTraceSourceConfigTests {
                 true,
                 "",
                 TEST_KEY,
-                RecordType.otlp.name(),
+                RecordType.OTLP.toString(),
                 DEFAULT_THREAD_COUNT,
                 DEFAULT_MAX_CONNECTION_COUNT);
 
@@ -181,7 +181,7 @@ public class OtelTraceSourceConfigTests {
                 true,
                 TEST_KEY_CERT,
                 "",
-                RecordType.otlp.name(),
+                RecordType.OTLP.toString(),
                 DEFAULT_THREAD_COUNT,
                 DEFAULT_MAX_CONNECTION_COUNT);
 
@@ -208,7 +208,7 @@ public class OtelTraceSourceConfigTests {
                 TEST_MAX_CONNECTION_COUNT);
 
         final OTelTraceSourceConfig otelTraceSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelTraceSourceConfig.class);
-        otelTraceSourceConfig.validateRecordType();
+        assertEquals(recordType, otelTraceSourceConfig.getRecordType().toString());
     }
 
     @Test
@@ -227,8 +227,7 @@ public class OtelTraceSourceConfigTests {
                 TEST_THREAD_COUNT,
                 TEST_MAX_CONNECTION_COUNT);
 
-        final OTelTraceSourceConfig otelTraceSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelTraceSourceConfig.class);
-        assertThrows(IllegalArgumentException.class, otelTraceSourceConfig::validateRecordType);
+        assertThrows(IllegalArgumentException.class, () -> OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelTraceSourceConfig.class));
     }
 
     private PluginSetting completePluginSettingForOtelTraceSource(final int requestTimeoutInMillis,

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
@@ -9,7 +9,6 @@ import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.HashMap;

--- a/research/zipkin-opensearch-to-otel/src/main/java/com/amazon/dataprepper/research/zipkin/ZipkinOpenSearchToOtel.java
+++ b/research/zipkin-opensearch-to-otel/src/main/java/com/amazon/dataprepper/research/zipkin/ZipkinOpenSearchToOtel.java
@@ -90,7 +90,7 @@ public class ZipkinOpenSearchToOtel {
         oTelTraceSource.stop();
     }
 
-    private static BlockingBuffer<Record<ExportTraceServiceRequest>> getBuffer() {
+    private static BlockingBuffer<Record<Object>> getBuffer() {
         final HashMap<String, Object> integerHashMap = new HashMap<>();
         integerHashMap.put("buffer_size", 5);
         return new BlockingBuffer<>(new PluginSetting("blocking_buffer", integerHashMap));


### PR DESCRIPTION
### Description
This PR "merges" otel-trace-source from https://github.com/opensearch-project/data-prepper/tree/maint/546-migrate-trace-analytics-to-event-model with the following adjustment:

* expose `record_type` as an additional otel-trace-source config parameter
* accepts either ExportTraceServiceRequest or Event as record data type in the buffer.
* make sure test cases cover both record data type.
 
### Issues Resolved
Contributes to #1158 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
