### PR TITLE
Fix confusion in Log Ingestion Demo Guide where Docker prepends folder to network name

### DIFF
--- a/examples/log-ingestion/log_ingestion_demo_guide.md
+++ b/examples/log-ingestion/log_ingestion_demo_guide.md
@@ -29,7 +29,7 @@ FluentBit is tailing to collect logs from.
 4. Now that you understand a bit more about how FluentBit and OpenSearch are set up, run them with:
 
 ```
-docker-compose up -d
+docker-compose --project-name data-prepper up
 ```
 
 ### Data Prepper Setup
@@ -49,7 +49,7 @@ and send the processed logs to a local [OpenSearch sink](../../data-prepper-plug
 FluentBit is able to send logs to the http source of Data Prepper.
 
 ```
-docker run --name data-prepper -v /full/path/to/log_pipeline.yaml:/usr/share/data-prepper/pipelines.yaml --network "log-ingestion_opensearch-net" opensearch-data-prepper:latest
+docker run --name data-prepper -v /full/path/to/log_pipeline.yaml:/usr/share/data-prepper/pipelines.yaml --network "data-prepper_opensearch-net" opensearchproject/data-prepper:latest
 ```
 
 If Data Prepper is running correctly, you should see something similar to the following line as the latest output in your terminal.


### PR DESCRIPTION
Signed-off-by: Taylor Gray <tylgry@amazon.com>

### Description
* Fix confusion in Log Ingestion Demo Guide where Docker prepends folder to network name; add `--project-name` flag to docker-compose command for OpenSearch and FluentBit
 
### Issues Resolved
#981 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
