### PR TITLE
MAINT: add custom metrics in otel-trace-source README

### DIFF
--- a/data-prepper-plugins/otel-trace-source/README.md
+++ b/data-prepper-plugins/otel-trace-source/README.md
@@ -93,6 +93,17 @@ curl -k -H 'Content-Type: application/json; charset=utf-8'  -d '{"resourceSpans"
 ### Counter
 - `requestTimeouts`: measures total number of requests that time out.
 - `requestsReceived`: measures total number of requests received by otel trace source.
+- `successRequests`: measures total number of requests successfully processed by otel trace source plugin.
+- `badRequests`: measures total number of requests with invalid format processed by otel trace source plugin.
+- `requestTimeouts`: measures total number of requests that time out.
+- `requestsTooLarge`: measures total number of requests of which the number of spans in the content is larger than the buffer capacity.
+- `internalServerError`: measures total number of requests processed by otel trace source with custom exception type.
+
+### Timer
+- `requestProcessDuration`: measures latency of requests processed by otel trace source plugin in seconds.
+
+### Distribution Summary
+- `payloadSize`: measures the distribution of incoming requests payload sizes in bytes.
 
 ## Developer Guide
 This plugin is compatible with Java 8. See 

--- a/data-prepper-plugins/otel-trace-source/README.md
+++ b/data-prepper-plugins/otel-trace-source/README.md
@@ -95,7 +95,6 @@ curl -k -H 'Content-Type: application/json; charset=utf-8'  -d '{"resourceSpans"
 - `requestsReceived`: measures total number of requests received by otel trace source.
 - `successRequests`: measures total number of requests successfully processed by otel trace source plugin.
 - `badRequests`: measures total number of requests with invalid format processed by otel trace source plugin.
-- `requestTimeouts`: measures total number of requests that time out.
 - `requestsTooLarge`: measures total number of requests of which the number of spans in the content is larger than the buffer capacity.
 - `internalServerError`: measures total number of requests processed by otel trace source with custom exception type.
 


### PR DESCRIPTION
Signed-off-by: Qi Chen <19492223+chenqi0805@users.noreply.github.com>

### Description
This PR adds the custom metrics introduced in #1241 into README of otel_trace_source
 
### Issues Resolved
#1158 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
