### PR TITLE
Bump spring versions to mitigate CVE-2022-22965 in example app.

### DIFF
--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -30,13 +30,13 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl'
     implementation 'javax.inject:javax.inject:1'
-    implementation('org.springframework:spring-core:5.3.16') {
+    implementation('org.springframework:spring-core:5.3.18') {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
-    implementation('org.springframework:spring-context:5.3.16') {
+    implementation('org.springframework:spring-context:5.3.18') {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
-    testImplementation 'org.springframework:spring-test:5.3.16'
+    testImplementation 'org.springframework:spring-test:5.3.18'
     testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
 }

--- a/examples/trace-analytics-sample-app/sample-app/analytics-service/build.gradle
+++ b/examples/trace-analytics-sample-app/sample-app/analytics-service/build.gradle
@@ -5,7 +5,7 @@
 
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.3.1.RELEASE'
+    id 'org.springframework.boot' version '2.6.6.RELEASE'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 }
 


### PR DESCRIPTION


Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
The update to trace-analytics-sample-app mitigates the CVE.
Data-prepper-core is also updated, but this is not currently exploitable as this package does not meet the requirements
https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement#am-i-impacted.
 
### Issues Resolved
related https://github.com/opensearch-project/OpenSearch/issues/2699
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
