### PR TITLE
Removed the OpenSearch build-tools Gradle plugin from the OpenSearch plugin

### DIFF
--- a/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
@@ -32,5 +32,5 @@ jobs:
           sleep 90
       - name: Run Open Distro tests
         run: |
-          ./gradlew :data-prepper-plugins:opensearch:test --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchTests.testOpenSearchConnection" -Dos.host=https://localhost:9200 -Dos.user=admin -Dos.password=admin
-          ./gradlew :data-prepper-plugins:opensearch:integTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchSinkIT" -Dos=true -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Duser=admin -Dpassword=admin
+          ./gradlew :data-prepper-plugins:opensearch:integrationTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchIT" -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=admin
+          ./gradlew :data-prepper-plugins:opensearch:integrationTest -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=admin -Dtests.opensearch.bundle=true

--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -28,5 +28,5 @@ jobs:
           sleep 90
       - name: Run OpenSearch tests
         run: |
-          ./gradlew :data-prepper-plugins:opensearch:test --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchTests.testOpenSearchConnection" -Dos.host=https://localhost:9200 -Dos.user=admin -Dos.password=admin
-          ./gradlew :data-prepper-plugins:opensearch:integTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchSinkIT" -Dos=true -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Duser=admin -Dpassword=admin
+          ./gradlew :data-prepper-plugins:opensearch:integrationTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchIT" -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=admin
+          ./gradlew :data-prepper-plugins:opensearch:integrationTest -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=admin -Dtests.opensearch.bundle=true

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -6,7 +6,6 @@
 buildscript {
     ext {
         opensearchVersion = System.getProperty('opensearch.version', "${versionMap.opensearchVersion}")
-        distribution = 'oss-zip'
     }
 
     repositories {
@@ -15,7 +14,6 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.opensearch.gradle:build-tools:${opensearchVersion}"
         constraints {
             classpath('com.netflix.nebula:nebula-core') {
                 version {
@@ -35,20 +33,10 @@ repositories {
     mavenCentral()
 }
 
-apply plugin: 'opensearch.testclusters'
-apply plugin: 'opensearch.build'
-apply plugin: 'opensearch.rest-test'
-
-// To pass OpenSearch plugin check
-ext {
-    licenseFile = rootProject.file('LICENSE')
-    noticeFile = rootProject.file('NOTICE')
-}
-
 dependencies {
-    api project(':data-prepper-api')
+    implementation project(':data-prepper-api')
     testImplementation project(':data-prepper-api').sourceSets.test.output
-    api project(':data-prepper-plugins:common')
+    implementation project(':data-prepper-plugins:common')
     implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearchVersion}"
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
@@ -63,10 +51,6 @@ dependencies {
     implementation 'software.amazon.awssdk:url-connection-client:2.17.15'
     implementation 'software.amazon.awssdk:arns:2.17.15'
     implementation 'io.micrometer:micrometer-core:1.7.5'
-    // The OpenSearch build-tools plugin appears to be preventing Gradle's platform
-    // support from working correctly, so we have to specify the JUnit versions here.
-    testImplementation "org.junit.jupiter:junit-jupiter:${versionMap.junitJupiter}"
-    testImplementation "org.junit.vintage:junit-vintage-engine:${versionMap.junitJupiter}"
     testImplementation('junit:junit:4.13.2') {
         exclude group:'org.hamcrest' // workaround for jarHell
     }
@@ -77,64 +61,39 @@ dependencies {
     testImplementation 'net.bytebuddy:byte-buddy-agent:1.11.20'
 }
 
-// Workaround for Werror
-compileJava.options.warnings = false
-
-// Resolve dependency conflict between ES sink and main project
-configurations.all {
-    resolutionStrategy {
-        force 'com.amazonaws:aws-java-sdk-core:1.12.159'
-        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2'
-        force 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
-        force 'com.fasterxml.jackson.core:jackson-databind:2.13.2'
-        force 'com.fasterxml.jackson.core:jackson-core:2.13.2'
-        force 'com.fasterxml.jackson:jackson-bom:2.13.2'
-        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2'
-        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.2'
-        force 'commons-codec:commons-codec:1.15'
-        force 'commons-logging:commons-logging:1.2'
-        force 'org.apache.httpcomponents:httpclient:4.5.13'
-        force 'org.apache.httpcomponents:httpcore:4.4.15'
-        force "org.hdrhistogram:HdrHistogram:2.1.12"
-        force 'joda-time:joda-time:2.10.13'
-        force 'org.yaml:snakeyaml:1.30'
-        force 'com.google.guava:guava:31.0.1-jre'
-        force 'junit:junit:4.13.2'
-        force "org.slf4j:slf4j-api:1.7.36"
-        force 'org.apache.logging.log4j:log4j-api:2.17.1'
-        force 'org.apache.logging.log4j:log4j-core:2.17.1'
-        force 'commons-beanutils:commons-beanutils:1.9.4'
-    }
-    // The OpenSearch plugins appear to provide their own version of Mockito
-    // which is causing problems, so we exclude it.
-    exclude (group: 'org.elasticsearch', module: "securemock");
-}
-
-test {
-    // Workaround: opensearch plugin is not compatible with JUnitPlatform
-    useJUnit()
-
-    if (System.getProperty("os.host") == null) {
-        exclude '**/OpenSearchTests.class'
-    }
-    systemProperty "os.host", System.getProperty("os.host")
-    if (System.getProperty("os.user") != null) {
-        systemProperty "os.user", System.getProperty("os.user")
-        systemProperty "os.password", System.getProperty("os.password")
+sourceSets {
+    integrationTest {
+        java {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+            srcDir file('src/integrationTest/java')
+        }
+        resources.srcDir file('src/integrationTest/resources')
     }
 }
 
-testClusters.integTest {
-    testDistribution = "INTEG_TEST"
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntime.extendsFrom testRuntime
 }
 
-integTest {
-    systemProperty 'tests.security.manager', 'false'
+task integrationTest(type: Test) {
+    group = 'verification'
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
 
-    systemProperty "os", System.getProperty("os")
-    systemProperty "user", System.getProperty("user")
-    systemProperty "password", System.getProperty("password")
+    useJUnitPlatform()
+
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    systemProperty 'tests.opensearch.host', System.getProperty('tests.opensearch.host')
+    systemProperty 'tests.opensearch.bundle', System.getProperty('tests.opensearch.bundle')
+    systemProperty 'tests.opensearch.user', System.getProperty('tests.opensearch.user')
+    systemProperty 'tests.opensearch.password', System.getProperty('tests.opensearch.password')
+
+    filter {
+        includeTestsMatching '*IT'
+    }
 }
+
 
 jacocoTestReport {
     dependsOn test
@@ -168,13 +127,3 @@ jacocoTestCoverageVerification {
         }
     }
 }
-
-checkstyleMain.ignoreFailures = true
-checkstyleTest.ignoreFailures = true
-forbiddenApis.ignoreFailures = true
-testingConventions.enabled = false
-licenseHeaders.enabled = false
-dependencyLicenses.enabled = false
-thirdPartyAudit.enabled = false
-loggerUsageCheck.enabled = false
-validateNebulaPom.enabled = false

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchIT.java
@@ -17,14 +17,15 @@ import java.util.Collections;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class OpenSearchTests {
+public class OpenSearchIT {
     @Test
     public void testOpenSearchConnection() throws IOException {
-        final String host = System.getProperty("os.host");
+        final String host = System.getProperty("tests.opensearch.host");
+        final String hostUrl = "https://" + host;
         final ConnectionConfiguration.Builder builder = new ConnectionConfiguration.Builder(
-                Collections.singletonList(host));
-        final String user = System.getProperty("os.user");
-        final String password = System.getProperty("os.password");
+                Collections.singletonList(hostUrl));
+        final String user = System.getProperty("tests.opensearch.user");
+        final String password = System.getProperty("tests.opensearch.password");
         if (user != null) {
             builder.withUsername(user);
             builder.withPassword(password);

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -504,8 +504,8 @@ public class OpenSearchSinkIT {
     metadata.put(ConnectionConfiguration.HOSTS, getHosts());
     metadata.put(IndexConfiguration.INDEX_ALIAS, indexAlias);
     metadata.put(IndexConfiguration.TEMPLATE_FILE, templateFilePath);
-    final String user = System.getProperty("user");
-    final String password = System.getProperty("password");
+    final String user = System.getProperty("tests.opensearch.user");
+    final String password = System.getProperty("tests.opensearch.password");
     if (user != null) {
       metadata.put(ConnectionConfiguration.USERNAME, user);
       metadata.put(ConnectionConfiguration.PASSWORD, password);

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
@@ -68,7 +68,7 @@ public class ConnectionConfiguration {
   /**
    * The valid port range per https://tools.ietf.org/html/rfc6335.
    */
-  private final static ValueRange VALID_PORT_RANGE = ValueRange.of(0, 65535);
+  private static final ValueRange VALID_PORT_RANGE = ValueRange.of(0, 65535);
 
 
   private final List<String> hosts;

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexManager.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexManager.java
@@ -50,14 +50,14 @@ public abstract class IndexManager {
 
     //For matching a string that begins with a "%{" and ends with a "}".
     //For a string like "data-prepper-%{yyyy-MM-dd}", "%{yyyy-MM-dd}" is matched.
-    private final static String TIME_PATTERN_REGULAR_EXPRESSION  = "%\\{.*?\\}";
+    private static final String TIME_PATTERN_REGULAR_EXPRESSION  = "%\\{.*?\\}";
 
     //For matching a string enclosed by "%{" and "}".
     //For a string like "data-prepper-%{yyyy-MM}", "yyyy-MM" is matched.
-    private final static String TIME_PATTERN_INTERNAL_EXTRACTOR_REGULAR_EXPRESSION  = "%\\{(.*?)\\}";
+    private static final String TIME_PATTERN_INTERNAL_EXTRACTOR_REGULAR_EXPRESSION  = "%\\{(.*?)\\}";
 
     private Optional<DateTimeFormatter> indexTimeSuffixFormatter;
-    private final static ZoneId UTC_ZONE_ID = ZoneId.of(TimeZone.getTimeZone("UTC").getID());
+    private static final ZoneId UTC_ZONE_ID = ZoneId.of(TimeZone.getTimeZone("UTC").getID());
 
     protected IndexManager(final RestHighLevelClient restHighLevelClient, final OpenSearchSinkConfiguration openSearchSinkConfiguration){
         checkNotNull(restHighLevelClient);

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IsmPolicyManagementTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IsmPolicyManagementTests.java
@@ -30,7 +30,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 public class IsmPolicyManagementTests {
     private IsmPolicyManagement ismPolicyManagementStrategy;
     private final String INDEX_ALIAS = "test-alias-abcd";
-    private final static String POLICY_NAME = "test-policy-name";
+    private static final String POLICY_NAME = "test-policy-name";
 
     @Mock
     private RestHighLevelClient restHighLevelClient;

--- a/e2e-test/log/build.gradle
+++ b/e2e-test/log/build.gradle
@@ -155,6 +155,8 @@ task basicLogEndToEndTest(type: Test) {
 }
 
 dependencies {
+    integrationTestImplementation project(':data-prepper-api')
+    integrationTestImplementation project(':data-prepper-plugins:common')
     integrationTestImplementation project(':data-prepper-plugins:opensearch')
     integrationTestImplementation "com.linecorp.armeria:armeria:1.0.0"
     integrationTestImplementation "org.awaitility:awaitility:4.1.1"

--- a/e2e-test/trace/build.gradle
+++ b/e2e-test/trace/build.gradle
@@ -250,6 +250,8 @@ def serviceMapOTLPAndEventEndToEndTest = createEndToEndTest("serviceMapOTLPAndEv
         serviceMapDataPrepperOTLP, serviceMapDataPrepperEvent)
 
 dependencies {
+    integrationTestImplementation project(':data-prepper-api')
+    integrationTestImplementation project(':data-prepper-plugins:common')
     integrationTestImplementation project(':data-prepper-plugins:opensearch')
     integrationTestImplementation project(':data-prepper-plugins:otel-trace-group-processor')
     integrationTestImplementation "org.awaitility:awaitility:4.1.1"

--- a/research/zipkin-opensearch-to-otel/build.gradle
+++ b/research/zipkin-opensearch-to-otel/build.gradle
@@ -29,6 +29,8 @@ run {
 
 dependencies {
     implementation project(':data-prepper-plugins:blocking-buffer')
+    implementation project(':data-prepper-api')
+    implementation project(':data-prepper-plugins:common')
     implementation project(':data-prepper-plugins:opensearch')
     implementation project(':data-prepper-plugins:otel-trace-source')
     implementation project(':data-prepper-plugins:otel-trace-raw-prepper')


### PR DESCRIPTION
### Description

This change extracts the OpenSearch `build-tools` plugin and testing framework from the `opensearch` plugin in Data Prepper. The `build-tools` plugin is really designed for OpenSearch plugins and is not appropriate for Data Prepper. It has imposed several restrictions on our build (e.g. JUnit versions, Mockito versions) and has made it difficult to update this project. Additionally, it has been blocking updating to Gradle 7.

This change has one important implication: Running the Gradle build will not perform integration tests against OpenSearch. The GitHub Actions already run these tests against different versions of OpenSearch and OpenDistro. So we will catch errors in PRs. However, developers will have to run similar commands if they wish to test locally. I believe we can eventually re-add this support if we desire.

Additionally, I updated some names for consistency and clarity. And I had to fix some Checkstyle errors since now Checkstyle can run on the `opensearch` plugin.
 
### Issues Resolved

Resolves #593
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
