### PR TITLE
Upload and publish the JUnit test reports for some tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,11 +1,10 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Data Prepper Java CI with Gradle
+name: Gradle Build
 
 on:
   push:
-    branches: [ main ]
   pull_request:
   workflow_dispatch:
 
@@ -26,7 +25,30 @@ jobs:
       uses: actions/checkout@v2
     - name: Build with Gradle
       run: ./gradlew build
+    - name: Upload Unit Test Results
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: data-prepper-test-results-java-${{ matrix.java }}
+        path: '**/test-results/**/*.xml'
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1
     - name: Generate Javadocs
       run: ./gradlew javadoc
+
+  publish-test-results:
+    name: "Publish Unit Tests Results"
+    needs: build
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: test-results
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: "test-results/**/*.xml"

--- a/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  integration_tests:
+  integration-tests:
     strategy:
       matrix:
         java: [14]
@@ -34,3 +34,26 @@ jobs:
         run: |
           ./gradlew :data-prepper-plugins:opensearch:integrationTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchIT" -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=admin
           ./gradlew :data-prepper-plugins:opensearch:integrationTest -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=admin -Dtests.opensearch.bundle=true
+      - name: Upload Unit Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: data-prepper-opensearch-integration-tests-opendistro-${{ matrix.opendistro }}-java-${{ matrix.java }}
+          path: '**/test-results/**/*.xml'
+
+  publish-test-results:
+    name: "Publish Unit Tests Results"
+    needs: integration-tests
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: test-results
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: "test-results/**/*.xml"

--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -6,7 +6,7 @@ name: Data Prepper OpenSearchSink integration tests with OpenSearch
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  integration_tests:
+  integration-tests:
     strategy:
       matrix:
         java: [14]
@@ -30,3 +30,26 @@ jobs:
         run: |
           ./gradlew :data-prepper-plugins:opensearch:integrationTest --tests "com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchIT" -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=admin
           ./gradlew :data-prepper-plugins:opensearch:integrationTest -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=admin -Dtests.opensearch.bundle=true
+      - name: Upload Unit Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: data-prepper-opensearch-integration-tests-opensearch-${{ matrix.opensearch }}-java-${{ matrix.java }}
+          path: '**/test-results/**/*.xml'
+
+  publish-test-results:
+    name: "Publish Unit Tests Results"
+    needs: integration-tests
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: test-results
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: "test-results/**/*.xml"

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -215,6 +215,16 @@ Testing Guidelines:
 1. Our Gradle builds use Groovy, so follow our normal Java styles in the build files. For example, use camel case rather than snake case.
 2. Use Gradle strings (single quote) unless you need string interpolation. If you need string interpolation, use a GString (double quotes)
 
+## CI Builds
+
+Before merging in your PR, the Data Prepper continuous integration (CI) builds mush pass. These builds
+run as GitHub Actions.
+
+If an Action is failing, please view the log and determine what is causing your commit to fail. If a test
+fails, please check the *Summary* section of that Action. There may be artifacts for the test results. You
+can download these and view the result information. Additionally, many builds have *Unit Test Results* job
+which includes a summary of the results.
+
 ## More Information
 
 We have the following pages for specific development guidance on the topics:

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -217,7 +217,7 @@ Testing Guidelines:
 
 ## CI Builds
 
-Before merging in your PR, the Data Prepper continuous integration (CI) builds mush pass. These builds
+Before merging in your PR, the Data Prepper continuous integration (CI) builds must pass. These builds
 run as GitHub Actions.
 
 If an Action is failing, please view the log and determine what is causing your commit to fail. If a test


### PR DESCRIPTION
### Description
Upload and publish the JUnit test reports for the Gradle build and OpenSearch sink integration tests. This allows us to download test reports in order to track down issues. Additionally, build the Gradle GitHub Action for all pushes since this is the core build for the project. Renamed the Gradle build to be more compact and easier to find in the list of runs. Upload and publish JUnit reports for OpenSearch sink integration tests.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
