### PR TITLE
Updated Mockito in the opensearch plugin

### DIFF
--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -51,12 +51,9 @@ dependencies {
     implementation 'software.amazon.awssdk:url-connection-client:2.17.15'
     implementation 'software.amazon.awssdk:arns:2.17.15'
     implementation 'io.micrometer:micrometer-core:1.7.5'
-    testImplementation('junit:junit:4.13.2') {
-        exclude group:'org.hamcrest' // workaround for jarHell
-    }
-    testImplementation "org.awaitility:awaitility:4.1.1"
+    testImplementation 'org.awaitility:awaitility:4.1.1'
     testImplementation "org.opensearch.test:framework:${opensearchVersion}"
-    testImplementation "commons-io:commons-io:2.11.0"
+    testImplementation 'commons-io:commons-io:2.11.0'
     testImplementation 'net.bytebuddy:byte-buddy:1.12.8'
     testImplementation 'net.bytebuddy:byte-buddy-agent:1.11.20'
 }

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/DefaultIndexManagerTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/DefaultIndexManagerTests.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/TraceAnalyticsRawIndexManagerTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/TraceAnalyticsRawIndexManagerTests.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/TraceAnalyticsServiceMapIndexManagerTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/TraceAnalyticsServiceMapIndexManagerTests.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;


### PR DESCRIPTION
### Description

The `opensearch` plugin was using some Mockito methods which were removed in later versions. These changes are needed to support updating the OpenSearch version to the 2.x series.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
