### PR TITLE
Run OpenSearch sink integration tests against more versions of OpenDistro

### DIFF
--- a/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [14]
-        opendistro: [1.12.0, 1.13.2]
+        opendistro: [1.6.0, 1.8.0, 1.9.0, 1.11.0, 1.12.0, 1.13.3]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### Description

Data Prepper has an integration test for the OpenSearch sink. It currently runs against two OpenDistro versions. This PR adds support for testing against four additional versions. With this PR, Data Prepper integration tests verify from OpenDistro 1.6.0 / Elasticsearch 7.6.1 and beyond. Additionally, it tests against OpenDistro 1.13.3 instead of 1.13.2 since this addresses a security vulnerability.

In order to support this range of versions, the code to wipe indices between tests now uses the Get Indices API instead of the `_cat/indices` API.

For reference:

https://opendistro.github.io/for-elasticsearch-docs/version-history/
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
