### PR TITLE
Migrated Data Prepper to use the opensearch-java client for bulk requests

### DIFF
--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -8,7 +8,7 @@ ext.versionMap = [
         junitJupiter : '5.8.2',
         mockito : '3.11.2',
         opentelemetryProto : '1.7.1-alpha',
-        opensearchVersion : '1.1.0'
+        opensearchVersion : '1.3.1'
 ]
 
 ext.coreProjects = [

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation project(':data-prepper-plugins:common')
     implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearchVersion}"
+    implementation "org.opensearch.client:opensearch-rest-client:${opensearchVersion}"
+    implementation 'org.opensearch.client:opensearch-java:1.0.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
@@ -52,10 +54,10 @@ dependencies {
     implementation 'software.amazon.awssdk:arns:2.17.15'
     implementation 'io.micrometer:micrometer-core:1.8.5'
     testImplementation 'org.awaitility:awaitility:4.1.1'
-    testImplementation "org.opensearch.test:framework:${opensearchVersion}"
     testImplementation 'commons-io:commons-io:2.11.0'
     testImplementation 'net.bytebuddy:byte-buddy:1.12.8'
     testImplementation 'net.bytebuddy:byte-buddy-agent:1.11.20'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
 }
 
 sourceSets {

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/ErrorCauseStringCreator.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/ErrorCauseStringCreator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.sink.opensearch;
+
+import org.opensearch.client.opensearch._types.ErrorCause;
+
+class ErrorCauseStringCreator {
+    static String toSingleLineDisplayString(ErrorCause errorCause) {
+        ErrorCause currentErrorCause = errorCause;
+
+        StringBuilder errorString = new StringBuilder();
+        while (currentErrorCause != null) {
+            final String reasonLine = currentErrorCause.reason() != null ? currentErrorCause.reason() : "unknown";
+            if (currentErrorCause != errorCause) {
+                errorString.append(" caused by ");
+            }
+            errorString.append(reasonLine);
+            currentErrorCause = currentErrorCause.causedBy();
+        }
+
+        return errorString.toString();
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/bulk/AccumulatingBulkRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/bulk/AccumulatingBulkRequest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.sink.opensearch.bulk;
+
+import java.util.List;
+
+/**
+ * Accumulates Bulk Requests.
+ *
+ * @param <O>
+ * @param <R>
+ */
+public interface AccumulatingBulkRequest<O, R> {
+    long estimateSizeInBytesWithDocument(O documentOrOperation);
+
+    void addOperation(O documentOrOperation);
+
+    O getOperationAt(int index);
+
+    long getEstimatedSizeInBytes();
+
+    int getOperationsCount();
+
+    List<O> getOperations();
+
+    R getRequest();
+}

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/bulk/BulkOperationWriter.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/bulk/BulkOperationWriter.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package com.amazon.dataprepper.plugins.sink.opensearch.bulk;
+
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.common.unit.ByteSizeValue;
+
+/**
+ * Based on low-level REST client's <code>org.opensearch.action.index.IndexRequest::toString</code> method.
+ */
+public class BulkOperationWriter {
+    private static final int MAX_SOURCE_LENGTH_IN_TOSTRING = 2048;
+
+    public static String bulkOperationToString(BulkOperation bulkOperation) {
+        String index = bulkOperation.index().index();
+        String source = extractDocumentSource(bulkOperation);
+        String id = bulkOperation.index().id();
+
+        String sSource = "_na_";
+        try {
+            if (source.length() > MAX_SOURCE_LENGTH_IN_TOSTRING) {
+                sSource = "n/a, actual length: ["
+                        + new ByteSizeValue(source.length()).toString()
+                        + "], max length: "
+                        + new ByteSizeValue(MAX_SOURCE_LENGTH_IN_TOSTRING).toString();
+            } else {
+                sSource = source;
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+        return "index {[" + index + "][" + id + "], source[" + sSource + "]}";
+    }
+
+    private static String extractDocumentSource(BulkOperation bulkOperation) {
+        final JsonData document = (JsonData) bulkOperation.index().document();
+
+        return document.toJson().toString();
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingBulkRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingBulkRequest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.sink.opensearch.bulk;
+
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkRequest<BulkOperation, BulkRequest> {
+    static final int OPERATION_OVERHEAD = 50;
+
+    private final List<BulkOperation> bulkOperations;
+    private BulkRequest.Builder bulkRequestBuilder;
+    private long currentBulkSize = 0L;
+    private int operationCount = 0;
+    private BulkRequest builtRequest;
+
+    public JavaClientAccumulatingBulkRequest(BulkRequest.Builder bulkRequestBuilder) {
+        this.bulkRequestBuilder = bulkRequestBuilder;
+        bulkOperations = new ArrayList<>();
+    }
+
+    @Override
+    public long estimateSizeInBytesWithDocument(BulkOperation documentOrOperation) {
+        return currentBulkSize + estimateBulkOperationSize(documentOrOperation);
+    }
+
+    @Override
+    public void addOperation(BulkOperation bulkOperation) {
+        final Long documentLength = estimateBulkOperationSize(bulkOperation);
+
+        currentBulkSize += documentLength;
+
+        bulkRequestBuilder = bulkRequestBuilder.operations(bulkOperation);
+
+        operationCount++;
+        bulkOperations.add(bulkOperation);
+    }
+
+    @Override
+    public BulkOperation getOperationAt(int index) {
+        return bulkOperations.get(index);
+    }
+
+    @Override
+    public long getEstimatedSizeInBytes() {
+        return currentBulkSize;
+    }
+
+    @Override
+    public int getOperationsCount() {
+        return operationCount;
+    }
+
+    @Override
+    public List<BulkOperation> getOperations() {
+        return Collections.unmodifiableList(bulkOperations);
+    }
+
+    @Override
+    public BulkRequest getRequest() {
+        if(builtRequest == null)
+            builtRequest = bulkRequestBuilder.build();
+        return builtRequest;
+    }
+
+    private long estimateBulkOperationSize(BulkOperation bulkOperation) {
+
+        if (!bulkOperation.isIndex()) {
+            throw new UnsupportedOperationException("Only index operations are supported currently. " + bulkOperation);
+        }
+
+        Object anyDocument = bulkOperation.index().document();
+
+        if (anyDocument == null)
+            return OPERATION_OVERHEAD;
+
+        if (!(anyDocument instanceof SizedJsonData)) {
+            throw new IllegalArgumentException("Only SizedJsonData is permitted for accumulating bulk requests. " + bulkOperation);
+        }
+
+        SizedJsonData sizedDocument = (SizedJsonData) anyDocument;
+
+        final long documentLength = sizedDocument.getDocumentSize();
+        return documentLength + OPERATION_OVERHEAD;
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/bulk/SizedJsonData.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/bulk/SizedJsonData.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.sink.opensearch.bulk;
+
+import jakarta.json.spi.JsonProvider;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.json.JsonpMapper;
+
+import java.io.StringReader;
+
+/**
+ * Extends the {@link JsonData} interface from the opensearch-java client with
+ * the addition of having a document size.
+ */
+public interface SizedJsonData extends JsonData {
+    /**
+     * The size of the document represented by this {@link JsonData}.
+     *
+     * @return The document size in bytes
+     */
+    long getDocumentSize();
+
+    /**
+     * Creates a new {@link SizedJsonData} from a JSON string.
+     *
+     * @param jsonString The serialized JSON string which forms this JSON data.
+     * @param jsonpMapper The {@link JsonpMapper} to use for mapping.
+     * @return A new {@link SizedJsonData}.
+     */
+    static SizedJsonData fromString(String jsonString, JsonpMapper jsonpMapper) {
+        JsonProvider jsonProvider = jsonpMapper.jsonProvider();
+        final JsonData jsonData = JsonData.from(jsonProvider.createParser(new StringReader(jsonString)), jsonpMapper);
+
+        final String serializedJsonLength = jsonData.toJson().toString();
+
+        return new SizedJsonDataImpl(jsonData, serializedJsonLength.length());
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/bulk/SizedJsonDataImpl.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/bulk/SizedJsonDataImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.sink.opensearch.bulk;
+
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonGenerator;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+
+class SizedJsonDataImpl implements SizedJsonData {
+    private final JsonData innerJsonData;
+    private final long documentSize;
+
+    public SizedJsonDataImpl(final JsonData innerJsonData, final long documentSize) {
+        this.innerJsonData = innerJsonData;
+        this.documentSize = documentSize;
+    }
+
+    @Override
+    public long getDocumentSize() {
+        return documentSize;
+    }
+
+    @Override
+    public JsonValue toJson() {
+        return innerJsonData.toJson();
+    }
+
+    @Override
+    public JsonValue toJson(JsonpMapper mapper) {
+        return innerJsonData.toJson(mapper);
+    }
+
+    @Override
+    public <T> T to(Class<T> clazz) {
+        return innerJsonData.to(clazz);
+    }
+
+    @Override
+    public <T> T to(Class<T> clazz, JsonpMapper mapper) {
+        return innerJsonData.to(clazz, mapper);
+    }
+
+    @Override
+    public <T> T deserialize(JsonpDeserializer<T> deserializer) {
+        return innerJsonData.deserialize(deserializer);
+    }
+
+    @Override
+    public <T> T deserialize(JsonpDeserializer<T> deserializer, JsonpMapper mapper) {
+        return innerJsonData.deserialize(deserializer, mapper);
+    }
+
+    @Override
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        innerJsonData.serialize(generator, mapper);
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/ErrorCauseStringCreatorTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/ErrorCauseStringCreatorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.sink.opensearch;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch._types.ErrorCause;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ErrorCauseStringCreatorTest {
+    @Test
+    void toSingleLineDisplayString_returns_empty_string_with_null_ErrorCause() {
+        assertThat(ErrorCauseStringCreator.toSingleLineDisplayString(null),
+                equalTo(""));
+    }
+
+    @Test
+    void toSingleLineDisplayString_returns_empty_when_reason_is_null() {
+        ErrorCause errorCause = mock(ErrorCause.class);
+
+        assertThat(ErrorCauseStringCreator.toSingleLineDisplayString(errorCause),
+                equalTo("unknown"));
+    }
+
+    @Test
+    void toSingleLineDisplayString_returns_string_with_reason_when_no_nested_cause() {
+        String reason = UUID.randomUUID().toString();
+        ErrorCause errorCause = mock(ErrorCause.class);
+        when(errorCause.reason()).thenReturn(reason);
+
+        assertThat(ErrorCauseStringCreator.toSingleLineDisplayString(errorCause),
+                equalTo(reason));
+    }
+
+    @Test
+    void toSingleLineDisplayString_returns_string_of_reasons_with_a_single_nested_cause() {
+        String innerReason = UUID.randomUUID().toString();
+        ErrorCause innerErrorCause = mock(ErrorCause.class);
+        when(innerErrorCause.reason()).thenReturn(innerReason);
+
+        String outerReason = UUID.randomUUID().toString();
+        ErrorCause outerErrorCause = mock(ErrorCause.class);
+        when(outerErrorCause.reason()).thenReturn(outerReason);
+        when(outerErrorCause.causedBy()).thenReturn(innerErrorCause);
+
+        assertThat(ErrorCauseStringCreator.toSingleLineDisplayString(outerErrorCause),
+                equalTo(outerReason + " caused by " + innerReason));
+    }
+
+    @Test
+    void toSingleLineDisplayString_returns_string_of_reasons_with_multiple_nested_causes() {
+        String innerReason = UUID.randomUUID().toString();
+        ErrorCause innerErrorCause = mock(ErrorCause.class);
+        when(innerErrorCause.reason()).thenReturn(innerReason);
+
+        String middleReason = UUID.randomUUID().toString();
+        ErrorCause middleErrorCause = mock(ErrorCause.class);
+        when(middleErrorCause.reason()).thenReturn(middleReason);
+        when(middleErrorCause.causedBy()).thenReturn(innerErrorCause);
+
+        String outerReason = UUID.randomUUID().toString();
+        ErrorCause outerErrorCause = mock(ErrorCause.class);
+        when(outerErrorCause.reason()).thenReturn(outerReason);
+        when(outerErrorCause.causedBy()).thenReturn(middleErrorCause);
+
+        assertThat(ErrorCauseStringCreator.toSingleLineDisplayString(outerErrorCause),
+                equalTo(outerReason + " caused by " + middleReason + " caused by " + innerReason));
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingBulkRequestTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingBulkRequestTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.sink.opensearch.bulk;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.client.opensearch.core.bulk.IndexOperation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JavaClientAccumulatingBulkRequestTest {
+
+    private BulkRequest.Builder bulkRequestBuilder;
+
+    @BeforeEach
+    void setUp() {
+        bulkRequestBuilder = mock(BulkRequest.Builder.class);
+
+        when(bulkRequestBuilder.operations(any(BulkOperation.class)))
+                .thenReturn(bulkRequestBuilder);
+
+    }
+
+    private JavaClientAccumulatingBulkRequest createObjectUnderTest() {
+        return new JavaClientAccumulatingBulkRequest(bulkRequestBuilder);
+    }
+
+    @Test
+    void getOperationCount_returns_0_if_no_interactions() {
+        assertThat(createObjectUnderTest().getOperationsCount(), equalTo(0));
+    }
+
+    @Test
+    void getOperations_returns_empty_list_if_no_interactions() {
+        assertThat(createObjectUnderTest().getOperations(),
+                equalTo(Collections.emptyList()));
+    }
+
+    @Test
+    void getOperations_returns_unmodifiable_list() {
+        final List<BulkOperation> operations = createObjectUnderTest().getOperations();
+
+        final BulkOperation bulkOperation = createBulkOperation(generateDocument());
+        assertThrows(UnsupportedOperationException.class, () -> operations.add(bulkOperation));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 10})
+    void getOperationsCount_returns_the_correct_operation_count(final int operationCount) {
+        final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
+        for (int i = 0; i < operationCount; i++) {
+            BulkOperation bulkOperation = createBulkOperation(generateDocument());
+            objectUnderTest.addOperation(bulkOperation);
+        }
+
+        assertThat(objectUnderTest.getOperationsCount(), equalTo(operationCount));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 10})
+    void getEstimatedSizeInBytes_returns_the_current_size(final int operationCount) {
+        final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
+        final long arbitraryDocumentSize = 175;
+        for (int i = 0; i < operationCount; i++) {
+            BulkOperation bulkOperation = createBulkOperation(generateDocumentWithLength(arbitraryDocumentSize));
+            objectUnderTest.addOperation(bulkOperation);
+        }
+
+        final long expectedSize = operationCount * (arbitraryDocumentSize + JavaClientAccumulatingBulkRequest.OPERATION_OVERHEAD);
+        assertThat(objectUnderTest.getEstimatedSizeInBytes(), equalTo(expectedSize));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 10})
+    void getEstimatedSizeInBytes_returns_the_operation_overhead_if_requests_have_no_documents(final int operationCount) {
+        final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
+        for (int i = 0; i < operationCount; i++) {
+            objectUnderTest.addOperation(createBulkOperation(null));
+        }
+
+        final long expectedSize = operationCount * JavaClientAccumulatingBulkRequest.OPERATION_OVERHEAD;
+        assertThat(objectUnderTest.getEstimatedSizeInBytes(), equalTo(expectedSize));
+    }
+
+    @Test
+    void getOperationAt_returns_the_correct_index() {
+        final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
+
+        List<BulkOperation> knownOperations = new ArrayList<>();
+
+        for (int i = 0; i < 7; i++) {
+            BulkOperation bulkOperation = createBulkOperation(generateDocument());
+            objectUnderTest.addOperation(bulkOperation);
+            knownOperations.add(bulkOperation);
+        }
+
+        for (int i = 0; i < 7; i++) {
+            assertThat(objectUnderTest.getOperationAt(i), equalTo(knownOperations.get(i)));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0, 1, 2, 10, 50, 100})
+    void estimateSizeInBytesWithDocument_on_new_object_returns_estimated_document_size_plus_operation_overhead(long inputDocumentSize) {
+        final JsonData document = generateDocumentWithLength(inputDocumentSize);
+        final BulkOperation bulkOperation = createBulkOperation(document);
+
+        assertThat(createObjectUnderTest().estimateSizeInBytesWithDocument(bulkOperation),
+                equalTo(inputDocumentSize + JavaClientAccumulatingBulkRequest.OPERATION_OVERHEAD));
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0, 1, 2, 10, 50, 100})
+    void estimateSizeInBytesWithDocument_on_request_with_operations_returns_estimated_document_size_plus_operation_overhead(long inputDocumentSize) {
+        final JsonData document = generateDocumentWithLength(inputDocumentSize);
+        final BulkOperation bulkOperation = createBulkOperation(document);
+
+        final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
+        objectUnderTest.addOperation(createBulkOperation(generateDocumentWithLength(inputDocumentSize)));
+
+        final long expectedSize = 2 * (inputDocumentSize + JavaClientAccumulatingBulkRequest.OPERATION_OVERHEAD);
+        assertThat(objectUnderTest.estimateSizeInBytesWithDocument(bulkOperation),
+                equalTo(expectedSize));
+    }
+
+    @Test
+    void estimateSizeInBytesWithDocument_on_new_object_returns_operation_overhead_if_no_document() {
+        BulkOperation bulkOperation = createBulkOperation(null);
+
+        assertThat(createObjectUnderTest().estimateSizeInBytesWithDocument(bulkOperation),
+                equalTo((long) JavaClientAccumulatingBulkRequest.OPERATION_OVERHEAD));
+    }
+
+    @Test
+    void addOperation_adds_operation_to_the_BulkRequestBuilder() {
+        final BulkOperation bulkOperation = createBulkOperation(generateDocument());
+
+        createObjectUnderTest().addOperation(bulkOperation);
+
+        verify(bulkRequestBuilder).operations(bulkOperation);
+    }
+
+    @Test
+    void addOperation_throws_when_BulkOperation_is_not_an_index_request() {
+        final BulkOperation bulkOperation = mock(BulkOperation.class);
+
+        final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
+
+        assertThrows(UnsupportedOperationException.class, () -> objectUnderTest.addOperation(bulkOperation));
+    }
+
+    @Test
+    void addOperation_throws_when_document_is_not_JsonSize() {
+        final BulkOperation bulkOperation = createBulkOperation(UUID.randomUUID().toString());
+
+        final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
+
+        assertThrows(IllegalArgumentException.class, () -> objectUnderTest.addOperation(bulkOperation));
+    }
+
+    @Test
+    void getRequest_returns_BulkRequestBuilder_build() {
+        BulkRequest expectedBulkRequest = mock(BulkRequest.class);
+        when(bulkRequestBuilder.build()).thenReturn(expectedBulkRequest);
+
+        assertThat(createObjectUnderTest().getRequest(), equalTo(expectedBulkRequest));
+    }
+
+    @Test
+    void getRequest_called_multiple_times_only_builds_once_and_reuses_the_built_request() {
+        BulkRequest expectedBulkRequest = mock(BulkRequest.class);
+        when(bulkRequestBuilder.build()).thenReturn(expectedBulkRequest);
+
+        final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
+
+        assertThat(objectUnderTest.getRequest(), equalTo(expectedBulkRequest));
+        assertThat(objectUnderTest.getRequest(), sameInstance(objectUnderTest.getRequest()));
+
+        verify(bulkRequestBuilder, times(1)).build();
+    }
+
+    private BulkOperation createBulkOperation(Object document) {
+        final IndexOperation indexOperation = mock(IndexOperation.class);
+        when(indexOperation.document()).thenReturn(document);
+        final BulkOperation bulkOperation = mock(BulkOperation.class);
+        when(bulkOperation.isIndex()).thenReturn(true);
+        when(bulkOperation.index()).thenReturn(indexOperation);
+
+        return bulkOperation;
+    }
+
+    private JsonData generateDocument() {
+        return generateDocumentWithLength(10L);
+    }
+
+    private JsonData generateDocumentWithLength(long documentLength) {
+        final SizedJsonData sizedJsonData = mock(SizedJsonData.class);
+        when(sizedJsonData.getDocumentSize()).thenReturn(documentLength);
+        return sizedJsonData;
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/bulk/SizedJsonDataImplTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/bulk/SizedJsonDataImplTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.sink.opensearch.bulk;
+
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+
+import java.util.Random;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SizedJsonDataImplTest {
+    private JsonData innerJsonData;
+    private long documentSize;
+
+    @BeforeEach
+    void setUp() {
+        Random random = new Random();
+        innerJsonData = mock(JsonData.class);
+        documentSize = random.nextInt(10_000) + 100;
+    }
+
+    private SizedJsonDataImpl createObjectUnderTest() {
+        return new SizedJsonDataImpl(innerJsonData, documentSize);
+    }
+
+    @Test
+    void getDocumentSize_returns_the_documentSize() {
+        assertThat(createObjectUnderTest().getDocumentSize(), equalTo(documentSize));
+    }
+
+    @Nested
+    class ToJson {
+        private JsonValue jsonValue;
+
+        @BeforeEach
+        void setUp() {
+            jsonValue = mock(JsonValue.class);
+        }
+
+        @Test
+        void toJson_returns_inner_JsonData_toJson() {
+            when(innerJsonData.toJson()).thenReturn(jsonValue);
+
+            assertThat(createObjectUnderTest().toJson(), equalTo(jsonValue));
+        }
+
+        @Test
+        void toJson_with_mapper_returns_inner_JsonData_toJson() {
+            JsonpMapper jsonpMapper = mock(JsonpMapper.class);
+            when(innerJsonData.toJson(jsonpMapper)).thenReturn(jsonValue);
+
+            assertThat(createObjectUnderTest().toJson(jsonpMapper), equalTo(jsonValue));
+        }
+    }
+
+    @Nested
+    class ToClass {
+        private Class toClass;
+        private Object expectedToObject;
+
+        @BeforeEach
+        void setUp() {
+            toClass = String.class;
+
+            expectedToObject = mock(Object.class);
+        }
+
+        @Test
+        void to_returns_inner_JsonData_to() {
+            when(innerJsonData.to(toClass)).thenReturn(expectedToObject);
+
+            assertThat(createObjectUnderTest().to(toClass), equalTo(expectedToObject));
+        }
+
+        @Test
+        void to_with_mapper_returns_inner_JsonData_to() {
+            JsonpMapper jsonpMapper = mock(JsonpMapper.class);
+            when(innerJsonData.to(toClass, jsonpMapper)).thenReturn(expectedToObject);
+
+            assertThat(createObjectUnderTest().to(toClass, jsonpMapper), equalTo(expectedToObject));
+        }
+    }
+
+    @Nested
+    class Deserialize {
+        private JsonpDeserializer jsonpDeserializer;
+        private Object expectedDeserializedObject;
+
+        @BeforeEach
+        void setUp() {
+            jsonpDeserializer = mock(JsonpDeserializer.class);
+            expectedDeserializedObject = mock(Object.class);
+        }
+
+        @Test
+        void deserialize_returns_inner_JsonData_deserialize() {
+            when(innerJsonData.deserialize(jsonpDeserializer)).thenReturn(expectedDeserializedObject);
+
+            assertThat(createObjectUnderTest().deserialize(jsonpDeserializer), equalTo(expectedDeserializedObject));
+        }
+
+        @Test
+        void deserialize_with_mapper_returns_inner_JsonData_deserialize() {
+            JsonpMapper jsonpMapper = mock(JsonpMapper.class);
+            when(innerJsonData.deserialize(jsonpDeserializer, jsonpMapper)).thenReturn(expectedDeserializedObject);
+
+            assertThat(createObjectUnderTest().deserialize(jsonpDeserializer, jsonpMapper), equalTo(expectedDeserializedObject));
+        }
+    }
+
+    @Test
+    void serialize_calls_inner_JsonData_serialize() {
+        JsonGenerator generator = mock(JsonGenerator.class);
+        JsonpMapper mapper = mock(JsonpMapper.class);
+
+        createObjectUnderTest().serialize(generator, mapper);
+
+        verify(innerJsonData).serialize(generator, mapper);
+    }
+}


### PR DESCRIPTION
### Description

This PR updates Data Prepper to use the opensearch-java client for _bulk requests to OpenSearch. It does not update all interactions to the opensearch-java client. Others can come in subsequent PRs.

With this change, Data Prepper also runs against OpenSearch 2.0.0-rc1.

Related changes included in this PR include:

* Updated the OpenSearchSinkIT tests to test against both the `Record<String>` and `Record<Event>` models. Previously these tests only ran against `Record<Sink>`.
* Updated the OpenSearch client to 1.3.2, which is the current latest for the 1.x series.
 
### Issues Resolved

Resolves #1347
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
