### PR TITLE
Fix the file uploads to S3 with Gradle 7

### DIFF
--- a/release/archives/build.gradle
+++ b/release/archives/build.gradle
@@ -7,9 +7,7 @@ plugins {
     id 'de.undercouch.download' version '4.1.2' apply false
 }
 
-import com.amazonaws.services.s3.model.ObjectMetadata
-import jp.classmethod.aws.gradle.s3.AmazonS3FileUploadTask
-import jp.classmethod.aws.gradle.s3.CreateBucketTask
+import com.mgd.core.gradle.S3Upload
 
 subprojects {
     apply plugin: 'de.undercouch.download'
@@ -93,10 +91,6 @@ subprojects {
         }
     }
 
-    task createBucket(type: CreateBucketTask) {
-        bucketName awsS3Bucket
-        ifNotExists true
-    }
     afterEvaluate {
         supportedArchitectures.each {
             def platformWithArchitecture = "${platform}${it}"
@@ -106,31 +100,23 @@ subprojects {
 
             tasks.getByName("${platformWithArchitecture}WithJDKDistTar").dependsOn("download${it}JDK")
 
-            tasks.create(name: "upload${platformWithArchitecture}TarToS3", type: AmazonS3FileUploadTask, dependsOn: createBucket) {
+            tasks.create(name: "upload${platformWithArchitecture}TarToS3", type: S3Upload) {
                 dependsOn tarTask.name
-                file file(tarTask.archiveFile.get().asFile.absolutePath)
-                bucketName awsS3Bucket
-                key "${destinationKeyPath}/${tarTask.archiveName}"
-
-                def m = new ObjectMetadata()
-                m.setCacheControl('no-cache, no-store')
-                objectMetadata = m
+                file = tarTask.archiveFile.get().asFile.absolutePath
+                bucket = awsS3Bucket
+                key = "${destinationKeyPath}/${tarTask.archiveName}"
             }
 
-            tasks.create(name: "upload${platformWithArchitecture}TarWithJDKToS3", type: AmazonS3FileUploadTask, dependsOn: createBucket) {
+            tasks.create(name: "upload${platformWithArchitecture}TarWithJDKToS3", type: S3Upload) {
                 dependsOn tarWithJDKTask.name
-                file file(tarWithJDKTask.archiveFile.get().asFile.absolutePath)
-                bucketName awsS3Bucket
-                key "${destinationKeyPath}/${tarWithJDKTask.archiveName}"
-
-                def m = new ObjectMetadata()
-                m.setCacheControl('no-cache, no-store')
-                objectMetadata = m
+                file = tarWithJDKTask.archiveFile.get().asFile.absolutePath
+                bucket = awsS3Bucket
+                key = "${destinationKeyPath}/${tarWithJDKTask.archiveName}"
             }
         }
 
         tasks.create("uploadToS3") {
-            tasks.withType(AmazonS3FileUploadTask).each {
+            tasks.withType(S3Upload).each {
                 dependsOn it.name
             }
         }

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -4,13 +4,13 @@
  */
 
 plugins {
-    id 'jp.classmethod.aws.s3' version '0.41' apply false
+    id 'com.mgd.core.gradle.s3' version '1.1.4' apply false
 }
 
 apply from: file('build-resources.gradle')
 
 allprojects {
-    apply plugin: 'jp.classmethod.aws.s3'
+    apply plugin: 'com.mgd.core.gradle.s3'
 
     ext {
         awsS3Bucket = project.hasProperty('bucket') ? project.getProperty('bucket') : awsResources.get('default_bucket')
@@ -18,8 +18,8 @@ allprojects {
         archiveRootKey = "${project.rootProject.version}/${project.buildNumber}"
     }
 
-    aws {
-        profileName = project.hasProperty('profile') ? project.getProperty('profile') : awsResources.get('default_profile')
+    s3 {
+        profile = project.hasProperty('profile') ? project.getProperty('profile') : awsResources.get('default_profile')
         region = project.hasProperty('region') ? project.getProperty('region') : awsResources.get('default_region')
     }
 

--- a/release/maven/build.gradle
+++ b/release/maven/build.gradle
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import com.amazonaws.services.s3.model.ObjectMetadata
-import jp.classmethod.aws.gradle.s3.BulkUploadTask
+import com.mgd.core.gradle.S3Upload
 
 dependencies {
     /* required to resolve below issue with aws sdk
@@ -13,17 +12,11 @@ dependencies {
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
 }
 
-tasks.create(name: 'uploadMavenArtifactsToS3', type: BulkUploadTask) {
+tasks.create(name: 'uploadMavenArtifactsToS3', type: S3Upload) {
     dependsOn ':release:releasePrerequisites'
-    source = fileTree(dir: mavenPublicationRootFile)
-    bucketName = awsS3Bucket
-    prefix = "${archiveRootKey}/maven/"
-
-    metadataProvider = { bucketName, key, file ->
-        def metadata = new ObjectMetadata()
-        metadata.setCacheControl('no-cache, no-store')
-        return metadata
-    }
+    bucket = awsS3Bucket
+    keyPrefix = "${archiveRootKey}/maven/"
+    sourceDir = mavenPublicationRootFile.absolutePath
 }
 
 task uploadArtifacts {


### PR DESCRIPTION
### Description

Data Prepper's release process uploads artifacts to AWS S3. Prior to this PR, Data Prepper was using the [gradle-aws-plugin](https://github.com/classmethod/gradle-aws-plugin) for S3 uploads. This plugin no longer works with Gradle 7, and appears to be unmaintained. This PR changes to using the MIT-licensed [gradle-s3-plugin](https://github.com/mygrocerydeals/gradle-s3-plugin) plugin to perform the S3 upload.
 
### Issues Resolved

No issues, but this is currently breaking the release build.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
