### PR TITLE
Sets a 30 minute timeout on each job in the GitHub Actions release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - name: Set up JDK
@@ -58,6 +59,7 @@ jobs:
   validate-docker:
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 30
 
     steps:
       - name: Checkout Data-Prepper
@@ -73,6 +75,7 @@ jobs:
   validate-tarball:
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 30
 
     steps:
       - name: Checkout Data-Prepper


### PR DESCRIPTION
### Description

During the GitHub Actions release process, the smoke tests sometimes run on indefinitely. This PR introduces a timeout so that the job doesn't run on indefinitely.

I chose 30 minutes for each job. The main build and Docker smoke tests tend to complete around 10 minutes and tar.gz smoke tests tend to complete around 14-15 minutes. The 30 minute timeout should leave plenty of extra time for a slow-running test.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
