### PR TITLE
Support disabling any form of OpenSearch index management

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -84,7 +84,7 @@ Default is null.
 
 - `proxy`(optional): A String of the address of a forward HTTP proxy. The format is like "<host-name-or-ip>:\<port\>". Examples: "example.com:8100", "http://example.com:8100", "112.112.112.112:8100". Note: port number cannot be omitted.
 
-- `index_type` (optional): a String from the list [`custom`, `trace-analytics-raw`, `trace-analytics-service-map`], which represents an index type. Defaults to `custom`. This index_type instructs Sink plugin what type of data it is handling. 
+- `index_type` (optional): a String from the list [`custom`, `trace-analytics-raw`, `trace-analytics-service-map`, `management-disabled`], which represents an index type. Defaults to `custom`. This index_type instructs Sink plugin what type of data it is handling. 
 
 ```
     APM trace analytics raw span data type example:
@@ -143,6 +143,20 @@ all the records received from the upstream prepper at a time will be sent as a s
 If a single record turns out to be larger than the set bulk size, it will be sent as a bulk request of a single document.
 
 - `ism_policy_file` (optional): A String of absolute file path for an ISM (Index State Management) policy JSON file. This policy file is effective only when there is no built-in policy file for the index type. For example, `custom` index type is currently the only one without a built-in policy file, thus it would use the policy file here if it's provided through this parameter. OpenSearch documentation has more about [ISM policies.](https://opensearch.org/docs/latest/im-plugin/ism/policies/)
+
+### Management Disabled Index Type
+
+When `index_type` is set to `management_disabled`, Data Prepper will not perform any index management.
+It will not use ISM, create templates, or even validate the index. This setting can be useful when
+you want to minimize the permissions granted to Data Prepper. You must configure some other mechanism
+(e.g. ISM) to create and configure you indices.
+
+With management disabled, Data Prepper can run with only being granted the
+`["indices:data/write/index", "indices:data/write/bulk*", "indices:admin/mapping/put"]` permissions on
+the desired indices. It is strongly recommend to retain the `"indices:admin/mapping/put"`
+permission. If Data Prepper lacks this permission, then it cannot write any documents
+which would rely on dynamic mapping. You would need to take great care to ensure that every possible field
+is explicitly mapped by your index template.
 
 ## Metrics
 

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSecurityAccessor.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSecurityAccessor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.sink.opensearch;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.RestClient;
+import org.opensearch.common.Strings;
+import org.opensearch.common.xcontent.XContentFactory;
+
+import javax.ws.rs.HttpMethod;
+import java.io.IOException;
+
+class OpenSearchSecurityAccessor {
+    private static final String PLUGINS_SECURITY_API = "_opendistro/_security/api/";
+    private RestClient client;
+
+    OpenSearchSecurityAccessor(RestClient client) {
+        this.client = client;
+    }
+
+    void createBulkWritingRole(String role, String indexPattern) throws IOException {
+        createRole(role, indexPattern, "indices:data/write/index", "indices:data/write/bulk*");
+    }
+
+    private void createRole(String role, String indexPattern, String... allowedActions) throws IOException {
+        final Request request = new Request(HttpMethod.PUT, PLUGINS_SECURITY_API + "roles/" + role);
+
+        final String createRoleJson = Strings.toString(
+                XContentFactory.jsonBuilder()
+                        .startObject()
+                        .startArray("index_permissions")
+                        .startObject()
+                        .array("index_patterns", new String[]{indexPattern})
+                        .array("allowed_actions", allowedActions)
+                        .endObject()
+                        .endArray()
+                        .endObject()
+        );
+        request.setJsonEntity(createRoleJson);
+        final Response response = client.performRequest(request);
+    }
+
+    public void createUser(String username, String password, String... roles) throws IOException {
+        final Request request = new Request(HttpMethod.PUT, PLUGINS_SECURITY_API + "internalusers/" + username);
+
+        final String createUserJson = Strings.toString(
+                XContentFactory.jsonBuilder()
+                        .startObject()
+                        .field("password", password)
+                        .array("opendistro_security_roles", roles)
+                        .endObject()
+        );
+        request.setJsonEntity(createUserJson);
+        final Response response = client.performRequest(request);
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexManagerFactory.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexManagerFactory.java
@@ -20,6 +20,8 @@ public class IndexManagerFactory {
                 return new TraceAnalyticsRawIndexManager(restHighLevelClient, openSearchSinkConfiguration);
             case TRACE_ANALYTICS_SERVICE_MAP:
                 return new TraceAnalyticsServiceMapIndexManager(restHighLevelClient, openSearchSinkConfiguration);
+            case MANAGEMENT_DISABLED:
+                return new ManagementDisabledIndexManager(restHighLevelClient, openSearchSinkConfiguration);
             default:
                 return new DefaultIndexManager(restHighLevelClient, openSearchSinkConfiguration);
         }
@@ -69,5 +71,16 @@ public class IndexManagerFactory {
             this.ismPolicyManagementStrategy = new NoIsmPolicyManagement(restHighLevelClient);
         }
 
+    }
+
+    private class ManagementDisabledIndexManager extends IndexManager {
+        protected ManagementDisabledIndexManager(RestHighLevelClient restHighLevelClient, OpenSearchSinkConfiguration openSearchSinkConfiguration) {
+            super(restHighLevelClient, openSearchSinkConfiguration);
+        }
+
+        @Override
+        public void setupIndex() {
+
+        }
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexType.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexType.java
@@ -14,7 +14,8 @@ import java.util.stream.Collectors;
 public enum IndexType {
     TRACE_ANALYTICS_RAW("trace-analytics-raw"),
     TRACE_ANALYTICS_SERVICE_MAP("trace-analytics-service-map"),
-    CUSTOM("custom");
+    CUSTOM("custom"),
+    MANAGEMENT_DISABLED("management_disabled");
 
     private final String value;
 
@@ -32,7 +33,7 @@ public enum IndexType {
         this.value = value;
     }
 
-    String getValue(){
+    public String getValue(){
         return value;
     }
 

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexManagerFactoryTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexManagerFactoryTests.java
@@ -6,16 +6,18 @@
 package com.amazon.dataprepper.plugins.sink.opensearch.index;
 
 import com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchSinkConfiguration;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.client.RestHighLevelClient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
+@ExtendWith(MockitoExtension.class)
 public class IndexManagerFactoryTests {
 
     private static final String INDEX_ALIAS = "test-index-alias";
@@ -30,9 +32,8 @@ public class IndexManagerFactoryTests {
     @Mock
     private IndexConfiguration indexConfiguration;
 
-    @Before
+    @BeforeEach
     public void setup() {
-        initMocks(this);
         when(openSearchSinkConfiguration.getIndexConfiguration()).thenReturn(indexConfiguration);
         when(indexConfiguration.getIndexAlias()).thenReturn(INDEX_ALIAS);
         indexManagerFactory = new IndexManagerFactory();
@@ -56,6 +57,13 @@ public class IndexManagerFactoryTests {
     public void getIndexManager_Default() {
         final IndexManager indexManager =
                 indexManagerFactory.getIndexManager(IndexType.CUSTOM, restHighLevelClient, openSearchSinkConfiguration);
+        assertThat(indexManager, instanceOf(IndexManager.class));
+    }
+
+    @Test
+    public void getIndexManager_returns_IndexManager_when_provided_MANAGEMENT_DISABLED() {
+        final IndexManager indexManager =
+                indexManagerFactory.getIndexManager(IndexType.MANAGEMENT_DISABLED, restHighLevelClient, openSearchSinkConfiguration);
         assertThat(indexManager, instanceOf(IndexManager.class));
     }
 

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexTypeTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexTypeTests.java
@@ -5,10 +5,15 @@
 
 package com.amazon.dataprepper.plugins.sink.opensearch.index;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.Optional;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 
@@ -19,13 +24,22 @@ public class IndexTypeTests {
         assertEquals(Optional.empty(), IndexType.getByValue(null));
         assertEquals(Optional.empty(), IndexType.getByValue("illegal-index-type"));
         assertEquals(Optional.of(IndexType.CUSTOM), IndexType.getByValue("custom"));
+        assertEquals(Optional.of(IndexType.MANAGEMENT_DISABLED), IndexType.getByValue("management_disabled"));
         assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_RAW), IndexType.getByValue("trace-analytics-raw"));
         assertEquals(Optional.of(IndexType.TRACE_ANALYTICS_SERVICE_MAP), IndexType.getByValue("trace-analytics-service-map"));
     }
 
     @Test
     public void getIndexTypeValues() {
-        assertEquals("[trace-analytics-raw, trace-analytics-service-map, custom]", IndexType.getIndexTypeValues());
+        assertEquals("[trace-analytics-raw, trace-analytics-service-map, custom, management_disabled]", IndexType.getIndexTypeValues());
     }
 
+    @ParameterizedTest
+    @EnumSource(IndexType.class)
+    void getByValue_on_IndexType_getValue_returns_the_IndexType(IndexType indexType) {
+        final Optional<IndexType> optionReturnedIndex = IndexType.getByValue(indexType.getValue());
+        assertThat(optionReturnedIndex, notNullValue());
+        assertThat(optionReturnedIndex.isPresent(), equalTo(true));
+        assertThat(optionReturnedIndex.get(), equalTo(indexType));
+    }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/ManagementDisabledIndexManagerTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/index/ManagementDisabledIndexManagerTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.sink.opensearch.index;
+
+import com.amazon.dataprepper.plugins.sink.opensearch.OpenSearchSinkConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.action.admin.cluster.settings.ClusterGetSettingsResponse;
+import org.opensearch.client.ClusterClient;
+import org.opensearch.client.IndicesClient;
+import org.opensearch.client.ResponseException;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.indices.GetIndexTemplatesResponse;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ManagementDisabledIndexManagerTest {
+    private IndexManagerFactory indexManagerFactory;
+    private String baseIndexAlias;
+    private String indexAliasWithTimePattern;
+
+    @Mock
+    private RestHighLevelClient restHighLevelClient;
+
+    @Mock
+    private OpenSearchSinkConfiguration openSearchSinkConfiguration;
+
+    @Mock
+    private ClusterClient cluster;
+
+    @Mock
+    private ClusterGetSettingsResponse clusterGetSettingsResponse;
+
+    @Mock
+    private IndexConfiguration indexConfiguration;
+
+    @Mock
+    private IndicesClient indicesClient;
+
+    @Mock
+    private GetIndexTemplatesResponse getIndexTemplatesResponse;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock
+    private ResponseException responseException;
+
+    @BeforeEach
+    void setup() throws IOException {
+        baseIndexAlias = UUID.randomUUID().toString();
+        indexAliasWithTimePattern = baseIndexAlias + "-%{yyyy.MM.dd.HH}";
+        indexManagerFactory = new IndexManagerFactory();
+        when(openSearchSinkConfiguration.getIndexConfiguration()).thenReturn(indexConfiguration);
+        when(indexConfiguration.getIndexAlias()).thenReturn(baseIndexAlias);
+    }
+
+    @AfterEach
+    void verifyMocksHaveNoUnnecessaryInteractions() {
+        verifyNoMoreInteractions(
+                restHighLevelClient,
+                openSearchSinkConfiguration,
+                cluster,
+                clusterGetSettingsResponse,
+                indexConfiguration,
+                indicesClient,
+                getIndexTemplatesResponse,
+                restClient,
+                responseException
+        );
+    }
+
+    @Test
+    void getIndexAlias_IndexWithTimePattern() {
+        when(indexConfiguration.getIndexAlias()).thenReturn(indexAliasWithTimePattern);
+        IndexManager objectUnderTest = indexManagerFactory.getIndexManager(IndexType.MANAGEMENT_DISABLED, restHighLevelClient, openSearchSinkConfiguration);
+        final Pattern expectedIndexPattern = Pattern.compile(baseIndexAlias + "-\\d{4}.\\d{2}.\\d{2}.\\d{2}");
+        final String actualIndexPattern = objectUnderTest.getIndexAlias();
+        assertThat(actualIndexPattern, matchesPattern(expectedIndexPattern));
+        verify(openSearchSinkConfiguration).getIndexConfiguration();
+        verify(indexConfiguration).getIndexAlias();
+    }
+
+    @Test
+    void getIndexAlias_IndexWithTimePattern_Exceptional_NotAsSuffix() {
+        when(indexConfiguration.getIndexAlias()).thenReturn(indexAliasWithTimePattern + "randomtext");
+        assertThrows(IllegalArgumentException.class,
+                () -> indexManagerFactory.getIndexManager(IndexType.MANAGEMENT_DISABLED, restHighLevelClient, openSearchSinkConfiguration));
+        verify(openSearchSinkConfiguration).getIndexConfiguration();
+        verify(indexConfiguration).getIndexAlias();
+    }
+
+    @ParameterizedTest
+    @ValueSource(chars = {'#', '\\', '/', '*', '?', '"', '<', '>', '|', ',', ':'})
+    void getIndexAlias_IndexWithTimePattern_Exceptional_WithSpecialChars(char invalidCharacter) {
+        when(indexConfiguration.getIndexAlias()).thenReturn(baseIndexAlias + "-%{yyyy" + invalidCharacter + ".MM.dd.HH}");
+        assertThrows(IllegalArgumentException.class,
+                () -> indexManagerFactory.getIndexManager(IndexType.MANAGEMENT_DISABLED, restHighLevelClient, openSearchSinkConfiguration));
+        verify(openSearchSinkConfiguration).getIndexConfiguration();
+        verify(indexConfiguration).getIndexAlias();
+    }
+
+    @Test
+    void testIndexTimePattern_Exceptional_MultipleTimePatterns() {
+        when(indexConfiguration.getIndexAlias()).thenReturn(baseIndexAlias + "-%{yyyy}-%{MM.dd.HH}");
+        assertThrows(IllegalArgumentException.class,
+                () -> indexManagerFactory.getIndexManager(IndexType.MANAGEMENT_DISABLED, restHighLevelClient, openSearchSinkConfiguration));
+        verify(openSearchSinkConfiguration).getIndexConfiguration();
+        verify(indexConfiguration).getIndexAlias();
+    }
+
+    @Test
+    void testIndexTimePattern_Exceptional_NestedPatterns() {
+        when(indexConfiguration.getIndexAlias()).thenReturn(baseIndexAlias + "-%{%{yyyy.MM.dd}}");
+        assertThrows(IllegalArgumentException.class,
+                () -> indexManagerFactory.getIndexManager(IndexType.MANAGEMENT_DISABLED, restHighLevelClient, openSearchSinkConfiguration));
+        verify(openSearchSinkConfiguration).getIndexConfiguration();
+        verify(indexConfiguration).getIndexAlias();
+    }
+
+    @ParameterizedTest
+    @ValueSource(chars = {'m', 's', 'S', 'A', 'n', 'N'})
+    void getIndexAlias_IndexWithTimePattern_TooGranular(char granularTimePattern) {
+        when(indexConfiguration.getIndexAlias()).thenReturn(baseIndexAlias + "-%{yyyy.MM.dd.HH." + granularTimePattern + "}");
+        assertThrows(IllegalArgumentException.class,
+                () -> indexManagerFactory.getIndexManager(IndexType.MANAGEMENT_DISABLED, restHighLevelClient, openSearchSinkConfiguration));
+        verify(openSearchSinkConfiguration).getIndexConfiguration();
+        verify(indexConfiguration).getIndexAlias();
+    }
+
+    @Test
+    void setupIndex_does_nothing() throws IOException {
+        when(indexConfiguration.getIndexAlias()).thenReturn(indexAliasWithTimePattern);
+        IndexManager objectUnderTest = indexManagerFactory.getIndexManager(IndexType.MANAGEMENT_DISABLED, restHighLevelClient, openSearchSinkConfiguration);
+
+        verifyNoMoreInteractions(
+                restHighLevelClient,
+                openSearchSinkConfiguration,
+                cluster,
+                clusterGetSettingsResponse,
+                indexConfiguration,
+                indicesClient,
+                getIndexTemplatesResponse,
+                restClient,
+                responseException
+        );
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/resources/management-disabled-index-template.json
+++ b/data-prepper-plugins/opensearch/src/test/resources/management-disabled-index-template.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "settings": {
+    "number_of_shards" : 1,
+    "number_of_replicas" : 0
+  },
+  "mappings": {
+    "date_detection": false,
+    "properties": {
+      "name": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "someId": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description

Adds the `management_disabled` `index_type` option. If set, then this would disable any form of index management from Data Prepper. This means that Data Prepper will not create any templates, indices, or configure ISM in anyway.
 
### Issues Resolved

Resolves #1051.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
