### PR TITLE
ENH: support custom metric tags

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/config/MetricsConfig.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/config/MetricsConfig.java
@@ -32,8 +32,10 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.core.exception.SdkClientException;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.amazon.dataprepper.DataPrepper.getServiceNameForMetrics;
 import static com.amazon.dataprepper.metrics.MetricNames.SERVICE_NAME;
@@ -78,11 +80,14 @@ public class MetricsConfig {
         return new JvmThreadMetrics();
     }
 
-    private void configureMetricRegistry(final MeterRegistry meterRegistry) {
+    private void configureMetricRegistry(final Map<String, String> metricTags, final MeterRegistry meterRegistry) {
+        final Map<String, String> metricTagsWithServiceName = new HashMap<>(metricTags);
+        metricTagsWithServiceName.putIfAbsent(SERVICE_NAME, getServiceNameForMetrics());
         meterRegistry.config()
-                .commonTags(Collections.singletonList(
-                        Tag.of(SERVICE_NAME, getServiceNameForMetrics())
-                ));
+                .commonTags(
+                        metricTagsWithServiceName.entrySet().stream().map(e -> Tag.of(e.getKey(), e.getValue()))
+                                .collect(Collectors.toList())
+                );
 
     }
 
@@ -90,7 +95,7 @@ public class MetricsConfig {
     public PrometheusMeterRegistry prometheusMeterRegistry(final DataPrepperConfiguration dataPrepperConfiguration) {
         if (dataPrepperConfiguration.getMetricRegistryTypes().contains(MetricRegistryType.Prometheus)) {
             final PrometheusMeterRegistry meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-            configureMetricRegistry(meterRegistry);
+            configureMetricRegistry(dataPrepperConfiguration.getMetricTags(), meterRegistry);
 
             return meterRegistry;
         }
@@ -124,7 +129,7 @@ public class MetricsConfig {
 
             try {
                 final CloudWatchMeterRegistry meterRegistry = cloudWatchMeterRegistryProvider.getCloudWatchMeterRegistry();
-                configureMetricRegistry(meterRegistry);
+                configureMetricRegistry(dataPrepperConfiguration.getMetricTags(), meterRegistry);
 
                 return meterRegistry;
             } catch (final SdkClientException e) {
@@ -141,7 +146,7 @@ public class MetricsConfig {
     public EMFLoggingMeterRegistry emfLoggingMeterRegistry(final DataPrepperConfiguration dataPrepperConfiguration) {
         if (dataPrepperConfiguration.getMetricRegistryTypes().contains(MetricRegistryType.EmbeddedMetricsFormat)) {
             final EMFLoggingMeterRegistry meterRegistry = new EMFLoggingMeterRegistry();
-            configureMetricRegistry(meterRegistry);
+            configureMetricRegistry(dataPrepperConfiguration.getMetricTags(), meterRegistry);
             return meterRegistry;
         } else {
             return null;

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/DataPrepperConfiguration.java
@@ -37,6 +37,7 @@ public class DataPrepperConfiguration {
 
     public DataPrepperConfiguration() {}
 
+    // TODO: camel case to snake eyes in JsonProperty
     @JsonCreator
     public DataPrepperConfiguration(
             @JsonProperty("ssl") final Boolean ssl,

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/DataPrepperConfiguration.java
@@ -12,12 +12,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Class to hold configuration for DataPrepper, including server port and Log4j settings
  */
 public class DataPrepperConfiguration {
+    static final int MAX_TAGS_NUMBER = 3;
     private static final List<MetricRegistryType> DEFAULT_METRIC_REGISTRY_TYPE = Collections.singletonList(MetricRegistryType.Prometheus);
     private int serverPort = 4900;
     private boolean ssl = true;
@@ -26,6 +29,7 @@ public class DataPrepperConfiguration {
     private String privateKeyPassword = "";
     private List<MetricRegistryType> metricRegistries = DEFAULT_METRIC_REGISTRY_TYPE;
     private PluginModel authentication;
+    private Map<String, String> metricTags = new HashMap<>();
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
 
@@ -41,7 +45,8 @@ public class DataPrepperConfiguration {
             @JsonProperty("privateKeyPassword") final String privateKeyPassword,
             @JsonProperty("serverPort") final String serverPort,
             @JsonProperty("metricRegistries") final List<MetricRegistryType> metricRegistries,
-            @JsonProperty("authentication") final PluginModel authentication
+            @JsonProperty("authentication") final PluginModel authentication,
+            @JsonProperty("metricTags") final Map<String, String> metricTags
             ) {
         this.authentication = authentication;
         setSsl(ssl);
@@ -49,6 +54,7 @@ public class DataPrepperConfiguration {
         this.keyStorePassword = keyStorePassword != null ? keyStorePassword : "";
         this.privateKeyPassword = privateKeyPassword != null ? privateKeyPassword : "";
         this.metricRegistries = metricRegistries != null && !metricRegistries.isEmpty() ? metricRegistries : DEFAULT_METRIC_REGISTRY_TYPE;
+        setMetricTags(metricTags);
         setServerPort(serverPort);
     }
 
@@ -76,6 +82,10 @@ public class DataPrepperConfiguration {
         return metricRegistries;
     }
 
+    public Map<String, String> getMetricTags() {
+        return metricTags;
+    }
+
     private void setSsl(final Boolean ssl) {
         if (ssl != null) {
             this.ssl = ssl;
@@ -97,6 +107,15 @@ public class DataPrepperConfiguration {
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException("Server port must be a positive integer");
             }
+        }
+    }
+
+    private void setMetricTags(final Map<String, String> metricTags) {
+        if (metricTags != null) {
+            if (metricTags.size() > MAX_TAGS_NUMBER) {
+                throw new IllegalArgumentException("metricTags cannot be more than 3");
+            }
+            this.metricTags = metricTags;
         }
     }
 }

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/TestDataProvider.java
@@ -48,7 +48,9 @@ public class TestDataProvider {
     public static final String VALID_DATA_PREPPER_SOME_DEFAULT_CONFIG_FILE = "src/test/resources/valid_data_prepper_some_default_config.yml";
     public static final String VALID_DATA_PREPPER_CLOUDWATCH_METRICS_CONFIG_FILE = "src/test/resources/valid_data_prepper_cloudwatch_metrics_config.yml";
     public static final String VALID_DATA_PREPPER_MULTIPLE_METRICS_CONFIG_FILE = "src/test/resources/valid_data_prepper_multiple_metrics_config.yml";
+    public static final String VALID_DATA_PREPPER_CONFIG_FILE_WITH_TAGS = "src/test/resources/valid_data_prepper_config_with_tags.yml";
     public static final String INVALID_DATA_PREPPER_CONFIG_FILE = "src/test/resources/invalid_data_prepper_config.yml";
+    public static final String INVALID_DATA_PREPPER_CONFIG_FILE_WITH_TAGS = "src/test/resources/invalid_data_prepper_config_with_tags.yml";
     public static final String INVALID_PORT_DATA_PREPPER_CONFIG_FILE = "src/test/resources/invalid_port_data_prepper_config.yml";
     public static final String INVALID_KEYSTORE_PASSWORD_DATA_PREPPER_CONFIG_FILE = "src/test/resources/invalid_data_prepper_config_with_bad_keystore_password.yml";
 

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/config/MetricsConfigTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/config/MetricsConfigTest.java
@@ -183,9 +183,12 @@ class MetricsConfigTest {
     @MethodSource("provideMetricRegistryTypesAndCreators")
     public void testGivenConfigWithMetricTagsThenMeterRegistryConfigured(final MetricRegistryType metricRegistryType,
                                                                          final Function<DataPrepperConfiguration, MeterRegistry> creator) {
+        final String testKey = "testKey";
+        final String testValue = "testValue";
+        final String testServiceName = "testServiceName";
         final DataPrepperConfiguration dataPrepperConfiguration = mock(DataPrepperConfiguration.class);
         when(dataPrepperConfiguration.getMetricRegistryTypes()).thenReturn(Collections.singletonList(metricRegistryType));
-        when(dataPrepperConfiguration.getMetricTags()).thenReturn(Map.of("testKey", "testValue"));
+        when(dataPrepperConfiguration.getMetricTags()).thenReturn(Map.of(testKey, testValue));
 
         MeterRegistry meterRegistry = creator.apply(dataPrepperConfiguration);
         Counter counter = meterRegistry.counter("counter");
@@ -194,12 +197,12 @@ class MetricsConfigTest {
         assertThat(commonTags.equals(
                 Arrays.asList(
                         Tag.of(MetricNames.SERVICE_NAME, DataPrepper.getServiceNameForMetrics()),
-                        Tag.of("testKey", "testValue")
+                        Tag.of(testKey, testValue)
                         )
         ), is(true));
 
         when(dataPrepperConfiguration.getMetricRegistryTypes()).thenReturn(Collections.singletonList(metricRegistryType));
-        when(dataPrepperConfiguration.getMetricTags()).thenReturn(Map.of(MetricNames.SERVICE_NAME, "testServiceName"));
+        when(dataPrepperConfiguration.getMetricTags()).thenReturn(Map.of(MetricNames.SERVICE_NAME, testServiceName));
 
         meterRegistry = creator.apply(dataPrepperConfiguration);
         counter = meterRegistry.counter("counter");
@@ -207,7 +210,7 @@ class MetricsConfigTest {
 
         assertThat(commonTags.size(), equalTo(1));
         assertThat(commonTags.equals(
-                List.of(Tag.of(MetricNames.SERVICE_NAME, "testServiceName"))
+                List.of(Tag.of(MetricNames.SERVICE_NAME, testServiceName))
         ), is(true));
     }
 

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/config/MetricsConfigTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/config/MetricsConfigTest.java
@@ -194,12 +194,11 @@ class MetricsConfigTest {
         Counter counter = meterRegistry.counter("counter");
         List<Tag> commonTags = counter.getId().getConventionTags(meterRegistry.config().namingConvention());
 
-        assertThat(commonTags.equals(
+        assertThat(commonTags, equalTo(
                 Arrays.asList(
                         Tag.of(MetricNames.SERVICE_NAME, DataPrepper.getServiceNameForMetrics()),
-                        Tag.of(testKey, testValue)
-                        )
-        ), is(true));
+                        Tag.of(testKey, testValue))
+        ));
 
         when(dataPrepperConfiguration.getMetricRegistryTypes()).thenReturn(Collections.singletonList(metricRegistryType));
         when(dataPrepperConfiguration.getMetricTags()).thenReturn(Map.of(MetricNames.SERVICE_NAME, testServiceName));
@@ -208,10 +207,7 @@ class MetricsConfigTest {
         counter = meterRegistry.counter("counter");
         commonTags = counter.getId().getConventionTags(meterRegistry.config().namingConvention());
 
-        assertThat(commonTags.size(), equalTo(1));
-        assertThat(commonTags.equals(
-                List.of(Tag.of(MetricNames.SERVICE_NAME, testServiceName))
-        ), is(true));
+        assertThat(commonTags, equalTo(List.of(Tag.of(MetricNames.SERVICE_NAME, testServiceName))));
     }
 
     @Test

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/model/DataPrepperConfigurationTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/model/DataPrepperConfigurationTests.java
@@ -15,12 +15,15 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 
 import static com.amazon.dataprepper.TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE;
+import static com.amazon.dataprepper.TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_TAGS;
 import static com.amazon.dataprepper.TestDataProvider.INVALID_PORT_DATA_PREPPER_CONFIG_FILE;
 import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_CLOUDWATCH_METRICS_CONFIG_FILE;
 import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_CONFIG_FILE;
 import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_CONFIG_FILE_WITH_BASIC_AUTHENTICATION;
+import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_CONFIG_FILE_WITH_TAGS;
 import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_MULTIPLE_METRICS_CONFIG_FILE;
 import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_SOME_DEFAULT_CONFIG_FILE;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -89,6 +92,18 @@ public class DataPrepperConfigurationTests {
     }
 
     @Test
+    void testConfigWithValidMetricTags() throws IOException {
+        final DataPrepperConfiguration dataPrepperConfiguration = makeConfig(
+                VALID_DATA_PREPPER_CONFIG_FILE_WITH_TAGS);
+
+        assertThat(dataPrepperConfiguration, notNullValue());
+        final Map<String, String> metricTags = dataPrepperConfiguration.getMetricTags();
+        assertThat(metricTags, notNullValue());
+        assertThat(metricTags.get("testKey1"), equalTo("testValue1"));
+        assertThat(metricTags.get("testKey2"), equalTo("testValue2"));
+    }
+
+    @Test
     public void testInvalidConfig() {
         assertThrows(UnrecognizedPropertyException.class, () ->
                     makeConfig(INVALID_DATA_PREPPER_CONFIG_FILE));
@@ -98,5 +113,11 @@ public class DataPrepperConfigurationTests {
     public void testInvalidPortConfig() {
         assertThrows(ValueInstantiationException.class, () ->
                 makeConfig(INVALID_PORT_DATA_PREPPER_CONFIG_FILE));
+    }
+
+    @Test
+    void testConfigWithInValidMetricTags() {
+        assertThrows(ValueInstantiationException.class, () ->
+                makeConfig(INVALID_DATA_PREPPER_CONFIG_FILE_WITH_TAGS));
     }
 }

--- a/data-prepper-core/src/test/resources/invalid_data_prepper_config_with_tags.yml
+++ b/data-prepper-core/src/test/resources/invalid_data_prepper_config_with_tags.yml
@@ -1,0 +1,6 @@
+ssl: false
+metricTags:
+  testKey1: testValue1
+  testKey2: testValue2
+  testKey3: testValue3
+  testKey4: testValue4

--- a/data-prepper-core/src/test/resources/valid_data_prepper_config_with_tags.yml
+++ b/data-prepper-core/src/test/resources/valid_data_prepper_config_with_tags.yml
@@ -1,0 +1,4 @@
+ssl: false
+metricTags:
+  testKey1: testValue1
+  testKey2: testValue2

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,7 @@ Data Prepper allows the following properties to be configured:
 * `privateKeyPassword` string password for private key within keystore. Optional, defaults to empty string
 * `serverPort`: integer port number to use for server APIs. Defaults to `4900`
 * `metricRegistries`: list of metrics registries for publishing the generated metrics. Defaults to Prometheus; Prometheus and CloudWatch are currently supported.
+* `metricTags`: map of metric tag key-value pairs applied as common metric tags to meter registries. Defaults to empty map. The maximum number of pairs is limited to 3. Note that `serviceName` is a special tag key with `DataPrepper` as default tag value. Its value could also be set through the environment variable `DATAPREPPER_SERVICE_NAME`. If `serviceName` is defined in `metricTags`, the value will overwrite those set through the above mechanism.
 
 Example Data Prepper configuration file (data-prepper-config.yaml) with SSL enabled:
 
@@ -70,6 +71,8 @@ keyStorePassword: "password"
 privateKeyPassword: "password"
 serverPort: 4900
 metricRegistries: [Prometheus]
+metricTags:
+  customKey: customValue
 ```
 
 The Data Prepper Docker image runs with SSL enabled using a default self-signed certificate. 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,7 +60,7 @@ Data Prepper allows the following properties to be configured:
 * `privateKeyPassword` string password for private key within keystore. Optional, defaults to empty string
 * `serverPort`: integer port number to use for server APIs. Defaults to `4900`
 * `metricRegistries`: list of metrics registries for publishing the generated metrics. Defaults to Prometheus; Prometheus and CloudWatch are currently supported.
-* `metricTags`: map of metric tag key-value pairs applied as common metric tags to meter registries. Defaults to empty map. The maximum number of pairs is limited to 3. Note that `serviceName` is a special tag key with `DataPrepper` as default tag value. Its value could also be set through the environment variable `DATAPREPPER_SERVICE_NAME`. If `serviceName` is defined in `metricTags`, the value will overwrite those set through the above mechanism.
+* `metricTags`: map of metric tag key-value pairs applied as common metric tags to meter registries. Defaults to empty map. The maximum number of pairs is limited to 3. Note that `serviceName` is a reserved tag key with `DataPrepper` as default tag value. Its value could also be set through the environment variable `DATAPREPPER_SERVICE_NAME`. If `serviceName` is defined in `metricTags`, the value will overwrite those set through the above mechanism.
 
 Example Data Prepper configuration file (data-prepper-config.yaml) with SSL enabled:
 


### PR DESCRIPTION
### Description
This PR 

* adds support for custom metric tags in data-prepper-config.yml. The number of custom metric tags is limited to 3.
* for reserved tag key serviceName, the value configured in YAML will overwrite the value set from env variable
 
### Issues Resolved
Resolves #1415 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
