### PR TITLE
Support building on JDK 17

### DIFF
--- a/.github/workflows/data-prepper-performance-test-compile-check.yml
+++ b/.github/workflows/data-prepper-performance-test-compile-check.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11]
+        java: [11, 17]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11]
+        java: [11, 17]
 
     runs-on: ubuntu-latest
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.diffplug.spotless' version '6.1.0'
+    id 'com.diffplug.spotless' version '6.6.1'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 }
 
@@ -249,8 +249,4 @@ task generateThirdPartyReport(type: Copy) {
     include 'THIRD-PARTY-NOTICES.txt'
     rename 'THIRD-PARTY-NOTICES.txt', 'THIRD-PARTY'
     generateThirdPartyReport.dependsOn(generateLicenseReport)
-}
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
 }

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -10,7 +10,7 @@ First, please read our [contribution guide](../CONTRIBUTING.md) for more informa
 
 ### Java Versions
 
-Building Data Prepper requires JDK 11. The Data Prepper Gradle build runs in a Java 11 JVM, but uses
+Building Data Prepper requires JDK 11 or 17. The Data Prepper Gradle build runs in a Java 11 or 17 JVM, but uses
 [Gradle toolchains](https://docs.gradle.org/current/userguide/toolchains.html) to compile the Java
 code using Java 8. If you have a JDK 8 installed locally, Gradle will use your installed JDK 8. If you
 do not, Gradle will install JDK 8.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,12 @@
 #
 
 version=1.5.0-SNAPSHOT
+
+# Work-around for a Spotless Gradle issue:
+# https://github.com/diffplug/spotless/issues/834#issuecomment-819118761
+org.gradle.jvmargs=\
+  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED


### PR DESCRIPTION
### Description

Building Data Prepper on JDK 17 failed with an error from Spotless. This PR resolves this by [providing a workaround](https://github.com/diffplug/spotless/issues/834#issuecomment-819118761) suggested by the Spotless team.

Additionally, update to the latest version of the Spotless Gradle plugin. Older versions prevented the `clean` task from working correctly for the root build directory. With this update, we can clean up an unnecessary `clean` task.

Spotless fix:

https://github.com/diffplug/spotless/pull/1179
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
