### PR TITLE
#818: Moving to AWS SDK v2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,6 @@ configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
     dependencies {
         implementation platform('com.fasterxml.jackson:jackson-bom:2.13.2')
         implementation platform('software.amazon.awssdk:bom:2.17.15')
-        implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.155')
         implementation 'jakarta.validation:jakarta.validation-api:3.0.1'
     }
 }

--- a/data-prepper-plugins/common/build.gradle
+++ b/data-prepper-plugins/common/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation "commons-io:commons-io:2.11.0"
-    implementation 'com.amazonaws:aws-java-sdk-s3'
-    implementation 'com.amazonaws:aws-java-sdk-acm'
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:acm'
     implementation "org.apache.commons:commons-lang3:3.12.0"
     implementation "org.bouncycastle:bcprov-jdk15on:1.69"
     implementation "org.bouncycastle:bcpkix-jdk15on:1.69"

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/certificate/acm/ACMCertificateProvider.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/certificate/acm/ACMCertificateProvider.java
@@ -7,13 +7,7 @@ package com.amazon.dataprepper.plugins.certificate.acm;
 
 import com.amazon.dataprepper.plugins.certificate.CertificateProvider;
 import com.amazon.dataprepper.plugins.certificate.model.Certificate;
-import com.amazonaws.arn.Arn;
-import com.amazonaws.services.certificatemanager.AWSCertificateManager;
-import com.amazonaws.services.certificatemanager.model.ExportCertificateRequest;
-import com.amazonaws.services.certificatemanager.model.ExportCertificateResult;
-import com.amazonaws.services.certificatemanager.model.InvalidArnException;
-import com.amazonaws.services.certificatemanager.model.RequestInProgressException;
-import com.amazonaws.services.certificatemanager.model.ResourceNotFoundException;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -30,10 +24,18 @@ import org.bouncycastle.pkcs.jcajce.JcePKCSPBEInputDecryptorProviderBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import software.amazon.awssdk.arns.Arn;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.acm.AcmClient;
+import software.amazon.awssdk.services.acm.model.ExportCertificateRequest;
+import software.amazon.awssdk.services.acm.model.ExportCertificateResponse;
+import software.amazon.awssdk.services.acm.model.InvalidArnException;
+import software.amazon.awssdk.services.acm.model.RequestInProgressException;
+import software.amazon.awssdk.services.acm.model.ResourceNotFoundException;
+
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.nio.ByteBuffer;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
 import java.security.Security;
@@ -48,21 +50,21 @@ public class ACMCertificateProvider implements CertificateProvider {
     private static final String BOUNCY_CASTLE_PROVIDER = "BC";
     private static final Random SECURE_RANDOM = new SecureRandom();
 
-    private final AWSCertificateManager awsCertificateManager;
+    private final AcmClient acmClient;
     private final String acmArn;
     private final long totalTimeout;
     private final String passphrase;
 
-    public ACMCertificateProvider(final AWSCertificateManager awsCertificateManager,
+    public ACMCertificateProvider(final AcmClient acmClient,
                                   final String acmArn,
                                   final long totalTimeout,
                                   final String passphrase) {
-        this.awsCertificateManager = Objects.requireNonNull(awsCertificateManager);
+        this.acmClient = Objects.requireNonNull(acmClient);
         this.acmArn = Objects.requireNonNull(acmArn);
         try {
             Arn.fromString(acmArn);
         } catch (Exception e) {
-            throw new InvalidArnException("Invalid ARN format for acmArn");
+            throw InvalidArnException.builder().message("Invalid ARN format for acmArn").build();
         }
         this.totalTimeout = Objects.requireNonNull(totalTimeout);
         // Passphrase can be null. If null a random passphrase will be generated.
@@ -71,19 +73,21 @@ public class ACMCertificateProvider implements CertificateProvider {
     }
 
     public Certificate getCertificate() {
-        ExportCertificateResult exportCertificateResult = null;
+        ExportCertificateResponse exportCertificateResponse = null;
         long timeSlept = 0L;
 
         // The private key from ACM is encrypted. Passphrase is the privateKey password that will be used to decrypt the
         // private key. If it's not provided, generate a random password. The configured passphrase can
         // be used to decrypt the private key manually using openssl commands for any inspection or debugging.
         final String pkPassphrase = Optional.ofNullable(passphrase).orElse(generatePassphrase(PASSPHRASE_CHAR_COUNT));
-        while (exportCertificateResult == null && timeSlept < totalTimeout) {
+        while (exportCertificateResponse == null && timeSlept < totalTimeout) {
             try {
-                final ExportCertificateRequest exportCertificateRequest = new ExportCertificateRequest()
-                        .withCertificateArn(acmArn)
-                        .withPassphrase(ByteBuffer.wrap(pkPassphrase.getBytes()));
-                exportCertificateResult = awsCertificateManager.exportCertificate(exportCertificateRequest);
+                ExportCertificateRequest exportCertificateRequest = ExportCertificateRequest.builder()
+                        .certificateArn(acmArn)
+                        .passphrase(SdkBytes.fromByteArray(pkPassphrase.getBytes()))
+                        .build();
+
+                exportCertificateResponse = acmClient.exportCertificate(exportCertificateRequest);
 
             } catch (final RequestInProgressException ex) {
                 try {
@@ -97,9 +101,9 @@ public class ACMCertificateProvider implements CertificateProvider {
             }
             timeSlept += SLEEP_INTERVAL;
         }
-        if (exportCertificateResult != null) {
-            final String decryptedPrivateKey = getDecryptedPrivateKey(exportCertificateResult.getPrivateKey(), pkPassphrase);
-            return new Certificate(exportCertificateResult.getCertificate(), decryptedPrivateKey);
+        if (exportCertificateResponse != null) {
+            final String decryptedPrivateKey = getDecryptedPrivateKey(exportCertificateResponse.privateKey(), pkPassphrase);
+            return new Certificate(exportCertificateResponse.certificate(), decryptedPrivateKey);
         } else {
             throw new IllegalStateException(String.format("Exception retrieving certificate results. Time spent retrieving certificate is" +
                     " %d ms and total time out set is %d ms.", timeSlept, totalTimeout));

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/certificate/s3/S3CertificateProvider.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/certificate/s3/S3CertificateProvider.java
@@ -12,12 +12,9 @@ import software.amazon.awssdk.services.s3.S3Client;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.services.s3.model.S3Object;
 
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/certificate/s3/S3CertificateProvider.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/certificate/s3/S3CertificateProvider.java
@@ -7,45 +7,62 @@ package com.amazon.dataprepper.plugins.certificate.s3;
 
 import com.amazon.dataprepper.plugins.certificate.CertificateProvider;
 import com.amazon.dataprepper.plugins.certificate.model.Certificate;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3URI;
-import com.amazonaws.services.s3.model.S3Object;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.S3Utilities;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 public class S3CertificateProvider implements CertificateProvider {
     private static final Logger LOG = LoggerFactory.getLogger(S3CertificateProvider.class);
-    private final AmazonS3 s3Client;
-    private final String certificateFilePath;
-    private final String privateKeyFilePath;
+    private final S3Client s3Client;
+    private final String certificateFile;
+    private final String privateKeyFile;
 
-    public S3CertificateProvider(final AmazonS3 s3Client,
-                                 final String certificateFilePath,
-                                 final String privateKeyFilePath) {
+    public S3CertificateProvider(final S3Client s3Client,
+                                 final String certificateFile,
+                                 final String privateKeyFile) {
         this.s3Client = Objects.requireNonNull(s3Client);
-        this.certificateFilePath = Objects.requireNonNull(certificateFilePath);
-        this.privateKeyFilePath = Objects.requireNonNull(privateKeyFilePath);
+        this.certificateFile = Objects.requireNonNull(certificateFile);
+        this.privateKeyFile = Objects.requireNonNull(privateKeyFile);
     }
 
     public Certificate getCertificate() {
-        final AmazonS3URI certificateS3URI = new AmazonS3URI(certificateFilePath);
-        final AmazonS3URI privateKeyS3URI = new AmazonS3URI(privateKeyFilePath);
-        final String certificate = getObjectWithKey(certificateS3URI.getBucket(), certificateS3URI.getKey());
-        final String privateKey = getObjectWithKey(privateKeyS3URI.getBucket(), privateKeyS3URI.getKey());
 
-        return new Certificate(certificate, privateKey);
+        try {
+
+            final URI certificateFileUri = new URI(certificateFile);
+            final URI privateKeyFileUri = new URI(privateKeyFile);
+
+            final String certificate = getObjectWithKey(certificateFileUri.getHost(), certificateFileUri.getPath().substring(1));
+            final String privateKey = getObjectWithKey(privateKeyFileUri.getHost(), privateKeyFileUri.getPath().substring(1));
+
+            return new Certificate(certificate, privateKey);
+
+        } catch (URISyntaxException ex) {
+            LOG.error("Error encountered while parsing the certificate's Amazon S3 URI.", ex);
+            throw new RuntimeException(ex);
+        }
+
     }
 
     private String getObjectWithKey(final String bucketName, final String key) {
 
         // Download the object
-        try (final S3Object s3Object = s3Client.getObject(bucketName, key)) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(bucketName).key(key).build();
+        try (final ResponseInputStream<GetObjectResponse> s3Object = s3Client.getObject(getObjectRequest)) {
             LOG.info("Object with key \"{}\" downloaded.", key);
-            return IOUtils.toString(s3Object.getObjectContent(), StandardCharsets.UTF_8);
+            return IOUtils.toString(s3Object, StandardCharsets.UTF_8);
         } catch (final Exception ex) {
             LOG.error("Error encountered while processing the response from Amazon S3.", ex);
             throw new RuntimeException(ex);

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/certificate/s3/S3CertificateProviderTest.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/certificate/s3/S3CertificateProviderTest.java
@@ -6,15 +6,19 @@
 package com.amazon.dataprepper.plugins.certificate.s3;
 
 import com.amazon.dataprepper.plugins.certificate.model.Certificate;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectInputStream;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -22,19 +26,12 @@ import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class S3CertificateProviderTest {
     @Mock
-    private AmazonS3 amazonS3;
-
-    @Mock
-    private S3Object certS3Object;
-
-    @Mock
-    private S3Object privateKeyS3Object;
+    private S3Client s3Client;
 
     private S3CertificateProvider s3CertificateProvider;
 
@@ -50,15 +47,18 @@ public class S3CertificateProviderTest {
         final String s3SslKeyFile = String.format("s3://%s/%s",bucketName, privateKeyPath);
 
         final InputStream certObjectStream = IOUtils.toInputStream(certificateContent, StandardCharsets.UTF_8);
+        final ResponseInputStream certResponseInputStream = new ResponseInputStream<>(GetObjectResponse.builder().build(), AbortableInputStream.create(certObjectStream));
+
         final InputStream privateKeyObjectStream = IOUtils.toInputStream(privateKeyContent, StandardCharsets.UTF_8);
+        final ResponseInputStream<GetObjectResponse> privateKeyResponseInputStream = new ResponseInputStream<>(GetObjectResponse.builder().build(), AbortableInputStream.create(privateKeyObjectStream));
 
-        when(certS3Object.getObjectContent()).thenReturn(new S3ObjectInputStream(certObjectStream,null));
-        when(privateKeyS3Object.getObjectContent()).thenReturn(new S3ObjectInputStream(privateKeyObjectStream,null));
+        final GetObjectRequest certRequest = GetObjectRequest.builder().bucket(bucketName).key(certificatePath).build();
+        when(s3Client.getObject(certRequest)).thenReturn(certResponseInputStream);
 
-        when(amazonS3.getObject(bucketName, certificatePath)).thenReturn(certS3Object);
-        when(amazonS3.getObject(bucketName, privateKeyPath)).thenReturn(privateKeyS3Object);
+        final GetObjectRequest keyRequest = GetObjectRequest.builder().bucket(bucketName).key(privateKeyPath).build();
+        when(s3Client.getObject(keyRequest)).thenReturn(privateKeyResponseInputStream);
 
-        s3CertificateProvider = new S3CertificateProvider(amazonS3, s3SslKeyCertChainFile, s3SslKeyFile);
+        s3CertificateProvider = new S3CertificateProvider(s3Client, s3SslKeyCertChainFile, s3SslKeyFile);
 
         final Certificate certificate = s3CertificateProvider.getCertificate();
 
@@ -75,8 +75,9 @@ public class S3CertificateProviderTest {
         final String s3SslKeyCertChainFile = String.format("s3://%s/%s",bucketName, certificatePath);
         final String s3SslKeyFile = String.format("s3://%s/%s",bucketName, privateKeyPath);
 
-        s3CertificateProvider = new S3CertificateProvider(amazonS3, s3SslKeyCertChainFile, s3SslKeyFile);
-        when(amazonS3.getObject(anyString(), anyString())).thenThrow(new RuntimeException("S3 exception"));
+        s3CertificateProvider = new S3CertificateProvider(s3Client, s3SslKeyCertChainFile, s3SslKeyFile);
+
+        when(s3Client.getObject(Mockito.any(GetObjectRequest.class))).thenThrow(new RuntimeException("S3 exception"));
 
         Assertions.assertThrows(RuntimeException.class, () -> s3CertificateProvider.getCertificate());
     }

--- a/data-prepper-plugins/otel-metrics-source/build.gradle
+++ b/data-prepper-plugins/otel-metrics-source/build.gradle
@@ -16,8 +16,10 @@ dependencies {
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
     implementation "commons-io:commons-io:2.11.0"
-    implementation 'com.amazonaws:aws-java-sdk-s3'
-    implementation 'com.amazonaws:aws-java-sdk-acm'
+    implementation 'software.amazon.awssdk:acm'
+    implementation 'software.amazon.awssdk:auth'
+    implementation 'software.amazon.awssdk:regions'
+    implementation 'software.amazon.awssdk:s3'
     implementation 'com.google.protobuf:protobuf-java-util:3.19.4'
     implementation "com.linecorp.armeria:armeria:1.9.2"
     implementation "com.linecorp.armeria:armeria-grpc:1.9.2"

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/com/amazon/dataprepper/plugins/source/otelmetrics/certificate/CertificateProviderFactory.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/com/amazon/dataprepper/plugins/source/otelmetrics/certificate/CertificateProviderFactory.java
@@ -10,15 +10,16 @@ import com.amazon.dataprepper.plugins.certificate.acm.ACMCertificateProvider;
 import com.amazon.dataprepper.plugins.certificate.file.FileCertificateProvider;
 import com.amazon.dataprepper.plugins.certificate.s3.S3CertificateProvider;
 import com.amazon.dataprepper.plugins.source.otelmetrics.OTelMetricsSourceConfig;
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.services.certificatemanager.AWSCertificateManager;
-import com.amazonaws.services.certificatemanager.AWSCertificateManagerClientBuilder;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.acm.AcmClient;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class CertificateProviderFactory {
     private static final Logger LOG = LoggerFactory.getLogger(CertificateProviderFactory.class);
@@ -32,24 +33,29 @@ public class CertificateProviderFactory {
         // ACM Cert for SSL takes preference
         if (oTelMetricsSourceConfig.useAcmCertForSSL()) {
             LOG.info("Using ACM certificate and private key for SSL/TLS.");
-            final AWSCredentialsProvider credentialsProvider = new DefaultAWSCredentialsProviderChain();
-            final ClientConfiguration clientConfig = new ClientConfiguration()
-                    .withThrottledRetries(true);
-            final AWSCertificateManager awsCertificateManager = AWSCertificateManagerClientBuilder.standard()
-                    .withRegion(oTelMetricsSourceConfig.getAwsRegion())
-                    .withCredentials(credentialsProvider)
-                    .withClientConfiguration(clientConfig)
+            final AwsCredentialsProvider credentialsProvider = AwsCredentialsProviderChain.builder()
+                    .addCredentialsProvider(DefaultCredentialsProvider.create()).build();
+            final ClientOverrideConfiguration clientConfig = ClientOverrideConfiguration.builder()
+                    .retryPolicy(RetryMode.STANDARD)
+                    .build();
+            final AcmClient awsCertificateManager = AcmClient.builder()
+                    .region(Region.of(oTelMetricsSourceConfig.getAwsRegion()))
+                    .credentialsProvider(credentialsProvider)
+                    .overrideConfiguration(clientConfig)
                     .build();
             return new ACMCertificateProvider(awsCertificateManager, oTelMetricsSourceConfig.getAcmCertificateArn(),
                     oTelMetricsSourceConfig.getAcmCertIssueTimeOutMillis(), oTelMetricsSourceConfig.getAcmPrivateKeyPassword());
         } else if (oTelMetricsSourceConfig.isSslCertAndKeyFileInS3()) {
             LOG.info("Using S3 to fetch certificate and private key for SSL/TLS.");
-            final AWSCredentialsProvider credentialsProvider = new DefaultAWSCredentialsProviderChain();
-            final AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
-                    .withRegion(oTelMetricsSourceConfig.getAwsRegion())
-                    .withCredentials(credentialsProvider)
+            final AwsCredentialsProvider credentialsProvider = AwsCredentialsProviderChain.builder()
+                    .addCredentialsProvider(DefaultCredentialsProvider.create()).build();
+            final S3Client s3Client = S3Client.builder()
+                    .region(Region.of(oTelMetricsSourceConfig.getAwsRegion()))
+                    .credentialsProvider(credentialsProvider)
                     .build();
-            return new S3CertificateProvider(s3Client, oTelMetricsSourceConfig.getSslKeyCertChainFile(), oTelMetricsSourceConfig.getSslKeyFile());
+            return new S3CertificateProvider(s3Client,
+                    oTelMetricsSourceConfig.getSslKeyCertChainFile(),
+                    oTelMetricsSourceConfig.getSslKeyFile());
         } else {
             LOG.info("Using local file system to get certificate and private key for SSL/TLS.");
             return new FileCertificateProvider(oTelMetricsSourceConfig.getSslKeyCertChainFile(), oTelMetricsSourceConfig.getSslKeyFile());

--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
     implementation "commons-io:commons-io:2.11.0"
-    implementation 'com.amazonaws:aws-java-sdk-s3'
-    implementation 'com.amazonaws:aws-java-sdk-acm'
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:acm'
     implementation 'com.google.protobuf:protobuf-java-util:3.19.4'
     implementation "com.linecorp.armeria:armeria:1.9.2"
     implementation "com.linecorp.armeria:armeria-grpc:1.9.2"

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/certificate/CertificateProviderFactory.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/certificate/CertificateProviderFactory.java
@@ -10,15 +10,16 @@ import com.amazon.dataprepper.plugins.certificate.acm.ACMCertificateProvider;
 import com.amazon.dataprepper.plugins.certificate.file.FileCertificateProvider;
 import com.amazon.dataprepper.plugins.certificate.s3.S3CertificateProvider;
 import com.amazon.dataprepper.plugins.source.oteltrace.OTelTraceSourceConfig;
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.services.certificatemanager.AWSCertificateManager;
-import com.amazonaws.services.certificatemanager.AWSCertificateManagerClientBuilder;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.acm.AcmClient;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class CertificateProviderFactory {
     private static final Logger LOG = LoggerFactory.getLogger(CertificateProviderFactory.class);
@@ -32,22 +33,25 @@ public class CertificateProviderFactory {
         // ACM Cert for SSL takes preference
         if (oTelTraceSourceConfig.useAcmCertForSSL()) {
             LOG.info("Using ACM certificate and private key for SSL/TLS.");
-            final AWSCredentialsProvider credentialsProvider = new DefaultAWSCredentialsProviderChain();
-            final ClientConfiguration clientConfig = new ClientConfiguration()
-                    .withThrottledRetries(true);
-            final AWSCertificateManager awsCertificateManager = AWSCertificateManagerClientBuilder.standard()
-                    .withRegion(oTelTraceSourceConfig.getAwsRegion())
-                    .withCredentials(credentialsProvider)
-                    .withClientConfiguration(clientConfig)
+            final AwsCredentialsProvider credentialsProvider = AwsCredentialsProviderChain.builder()
+                    .addCredentialsProvider(DefaultCredentialsProvider.create()).build();
+            final ClientOverrideConfiguration clientConfig = ClientOverrideConfiguration.builder()
+                    .retryPolicy(RetryMode.STANDARD)
+                    .build();
+            final AcmClient awsCertificateManager = AcmClient.builder()
+                    .region(Region.of(oTelTraceSourceConfig.getAwsRegion()))
+                    .credentialsProvider(credentialsProvider)
+                    .overrideConfiguration(clientConfig)
                     .build();
             return new ACMCertificateProvider(awsCertificateManager, oTelTraceSourceConfig.getAcmCertificateArn(),
                     oTelTraceSourceConfig.getAcmCertIssueTimeOutMillis(), oTelTraceSourceConfig.getAcmPrivateKeyPassword());
         } else if (oTelTraceSourceConfig.isSslCertAndKeyFileInS3()) {
             LOG.info("Using S3 to fetch certificate and private key for SSL/TLS.");
-            final AWSCredentialsProvider credentialsProvider = new DefaultAWSCredentialsProviderChain();
-            final AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
-                    .withRegion(oTelTraceSourceConfig.getAwsRegion())
-                    .withCredentials(credentialsProvider)
+            final AwsCredentialsProvider credentialsProvider = AwsCredentialsProviderChain.builder()
+                    .addCredentialsProvider(DefaultCredentialsProvider.create()).build();
+            final S3Client s3Client = S3Client.builder()
+                    .region(Region.of(oTelTraceSourceConfig.getAwsRegion()))
+                    .credentialsProvider(credentialsProvider)
                     .build();
             return new S3CertificateProvider(s3Client, oTelTraceSourceConfig.getSslKeyCertChainFile(), oTelTraceSourceConfig.getSslKeyFile());
         } else {

--- a/data-prepper-plugins/peer-forwarder/build.gradle
+++ b/data-prepper-plugins/peer-forwarder/build.gradle
@@ -21,11 +21,12 @@ dependencies {
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
     implementation "com.linecorp.armeria:armeria:1.9.2"
     implementation "com.linecorp.armeria:armeria-grpc:1.9.2"
-    implementation 'com.amazonaws:aws-java-sdk-s3'
-    implementation 'com.amazonaws:aws-java-sdk-acm'
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:acm'
     implementation 'software.amazon.awssdk:servicediscovery'
     implementation "commons-io:commons-io:2.11.0"
     implementation "org.apache.commons:commons-lang3:3.12.0"
+    implementation 'commons-codec:commons-codec:1.15'
     implementation "commons-validator:commons-validator:1.7"
     testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/CertificateProviderConfig.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/CertificateProviderConfig.java
@@ -5,8 +5,8 @@
 
 package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate;
 
-import com.amazonaws.arn.Arn;
-import com.amazonaws.services.certificatemanager.model.InvalidArnException;
+import software.amazon.awssdk.arns.Arn;
+import software.amazon.awssdk.services.acm.model.InvalidArnException;
 
 public class CertificateProviderConfig {
     private static final String S3_PREFIX = "s3://";
@@ -24,7 +24,7 @@ public class CertificateProviderConfig {
             try {
                 Arn.fromString(acmCertificateArn);
             } catch(Exception e) {
-                throw new InvalidArnException("Invalid ARN format for acmCertificateArn");
+                throw InvalidArnException.builder().message("Invalid ARN format for acmCertificateArn").build();
             }
         }
         this.awsRegion = awsRegion;

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/CertificateProviderFactory.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/CertificateProviderFactory.java
@@ -8,15 +8,16 @@ package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate;
 import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.acm.ACMCertificateProvider;
 import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.file.FileCertificateProvider;
 import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.s3.S3CertificateProvider;
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.services.certificatemanager.AWSCertificateManager;
-import com.amazonaws.services.certificatemanager.AWSCertificateManagerClientBuilder;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.acm.AcmClient;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class CertificateProviderFactory {
     private static final Logger LOG = LoggerFactory.getLogger(CertificateProviderFactory.class);
@@ -30,22 +31,25 @@ public class CertificateProviderFactory {
         // ACM Cert for SSL takes preference
         if (certificateProviderConfig.useAcmCertForSSL()) {
             LOG.info("Using ACM certificate for SSL/TLS to setup trust store.");
-            final AWSCredentialsProvider credentialsProvider = new DefaultAWSCredentialsProviderChain();
-            final ClientConfiguration clientConfig = new ClientConfiguration()
-                    .withThrottledRetries(true);
-            final AWSCertificateManager awsCertificateManager = AWSCertificateManagerClientBuilder.standard()
-                    .withRegion(certificateProviderConfig.getAwsRegion())
-                    .withCredentials(credentialsProvider)
-                    .withClientConfiguration(clientConfig)
+            final AwsCredentialsProvider credentialsProvider = AwsCredentialsProviderChain.builder()
+                    .addCredentialsProvider(DefaultCredentialsProvider.create()).build();
+            final ClientOverrideConfiguration clientConfig = ClientOverrideConfiguration.builder()
+                    .retryPolicy(RetryMode.STANDARD)
+                    .build();
+            final AcmClient awsCertificateManager = AcmClient.builder()
+                    .region(Region.of(certificateProviderConfig.getAwsRegion()))
+                    .credentialsProvider(credentialsProvider)
+                    .overrideConfiguration(clientConfig)
                     .build();
             return new ACMCertificateProvider(awsCertificateManager, certificateProviderConfig.getAcmCertificateArn(),
                     certificateProviderConfig.getAcmCertIssueTimeOutMillis());
         } else if (certificateProviderConfig.isSslCertFileInS3()) {
             LOG.info("Using S3 to fetch certificate for SSL/TLS to setup trust store.");
-            final AWSCredentialsProvider credentialsProvider = new DefaultAWSCredentialsProviderChain();
-            final AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
-                    .withRegion(certificateProviderConfig.getAwsRegion())
-                    .withCredentials(credentialsProvider)
+            final AwsCredentialsProvider credentialsProvider = AwsCredentialsProviderChain.builder()
+                    .addCredentialsProvider(DefaultCredentialsProvider.create()).build();
+            final S3Client s3Client = S3Client.builder()
+                    .region(Region.of(certificateProviderConfig.getAwsRegion()))
+                    .credentialsProvider(credentialsProvider)
                     .build();
             return new S3CertificateProvider(s3Client, certificateProviderConfig.getSslKeyCertChainFile());
         } else {

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/acm/ACMCertificateProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/acm/ACMCertificateProvider.java
@@ -7,40 +7,43 @@ package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.acm;
 
 import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.CertificateProvider;
 import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model.Certificate;
-import com.amazonaws.services.certificatemanager.AWSCertificateManager;
-import com.amazonaws.services.certificatemanager.model.GetCertificateRequest;
-import com.amazonaws.services.certificatemanager.model.GetCertificateResult;
-import com.amazonaws.services.certificatemanager.model.InvalidArnException;
-import com.amazonaws.services.certificatemanager.model.RequestInProgressException;
-import com.amazonaws.services.certificatemanager.model.ResourceNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.acm.AcmClient;
+import software.amazon.awssdk.services.acm.model.ExportCertificateRequest;
+import software.amazon.awssdk.services.acm.model.ExportCertificateResponse;
+import software.amazon.awssdk.services.acm.model.GetCertificateRequest;
+import software.amazon.awssdk.services.acm.model.GetCertificateResponse;
+import software.amazon.awssdk.services.acm.model.InvalidArnException;
+import software.amazon.awssdk.services.acm.model.RequestInProgressException;
+import software.amazon.awssdk.services.acm.model.ResourceNotFoundException;
 
 import java.util.Objects;
 
 public class ACMCertificateProvider implements CertificateProvider {
     private static final Logger LOG = LoggerFactory.getLogger(ACMCertificateProvider.class);
     private static final long SLEEP_INTERVAL = 10000L;
-    private final AWSCertificateManager awsCertificateManager;
+    private final AcmClient acmClient;
     private final String acmArn;
     private final long totalTimeout;
-    public ACMCertificateProvider(final AWSCertificateManager awsCertificateManager,
+    public ACMCertificateProvider(final AcmClient acmClient,
                                   final String acmArn,
                                   final long totalTimeout) {
-        this.awsCertificateManager = Objects.requireNonNull(awsCertificateManager);
+        this.acmClient = Objects.requireNonNull(acmClient);
         this.acmArn = Objects.requireNonNull(acmArn);
         this.totalTimeout = totalTimeout;
     }
 
     public Certificate getCertificate() {
-        GetCertificateResult getCertificateResult = null;
+        GetCertificateResponse getCertificateResponse = null;
         long timeSlept = 0L;
 
-        while (getCertificateResult == null && timeSlept < totalTimeout) {
+        while (getCertificateResponse == null && timeSlept < totalTimeout) {
             try {
-                final GetCertificateRequest getCertificateRequest = new GetCertificateRequest()
-                        .withCertificateArn(acmArn);
-                getCertificateResult = awsCertificateManager.getCertificate(getCertificateRequest);
+                GetCertificateRequest getCertificateRequest = GetCertificateRequest.builder()
+                        .certificateArn(acmArn)
+                        .build();
+                getCertificateResponse = acmClient.getCertificate(getCertificateRequest);
 
             } catch (final RequestInProgressException ex) {
                 try {
@@ -54,8 +57,8 @@ public class ACMCertificateProvider implements CertificateProvider {
             }
             timeSlept += SLEEP_INTERVAL;
         }
-        if(getCertificateResult != null) {
-            return new Certificate(getCertificateResult.getCertificate());
+        if(getCertificateResponse != null) {
+            return new Certificate(getCertificateResponse.certificate());
         } else {
             throw new IllegalStateException(String.format("Exception retrieving certificate results. Time spent retrieving certificate is %d ms and total time out set is %d ms.", timeSlept, totalTimeout));
         }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/acm/ACMCertificateProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/acm/ACMCertificateProvider.java
@@ -10,8 +10,6 @@ import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model.Ce
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.acm.AcmClient;
-import software.amazon.awssdk.services.acm.model.ExportCertificateRequest;
-import software.amazon.awssdk.services.acm.model.ExportCertificateResponse;
 import software.amazon.awssdk.services.acm.model.GetCertificateRequest;
 import software.amazon.awssdk.services.acm.model.GetCertificateResponse;
 import software.amazon.awssdk.services.acm.model.InvalidArnException;

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/s3/S3CertificateProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/s3/S3CertificateProvider.java
@@ -7,40 +7,53 @@ package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.s3;
 
 import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.CertificateProvider;
 import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model.Certificate;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3URI;
-import com.amazonaws.services.s3.model.S3Object;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 public class S3CertificateProvider implements CertificateProvider {
     private static final Logger LOG = LoggerFactory.getLogger(S3CertificateProvider.class);
-    private final AmazonS3 s3Client;
+    private final S3Client s3Client;
     private final String certificateFilePath;
 
-    public S3CertificateProvider(final AmazonS3 s3Client,
+    public S3CertificateProvider(final S3Client s3Client,
                                  final String certificateFilePath) {
         this.s3Client = Objects.requireNonNull(s3Client);
         this.certificateFilePath = Objects.requireNonNull(certificateFilePath);
     }
 
     public Certificate getCertificate() {
-        final AmazonS3URI certificateS3URI = new AmazonS3URI(certificateFilePath);
-        final String certificate = getObjectWithKey(certificateS3URI.getBucket(), certificateS3URI.getKey());
 
-        return new Certificate(certificate);
+        try {
+
+            final URI certificateFileUri = new URI(certificateFilePath);
+            final String certificate = getObjectWithKey(certificateFileUri.getHost(), certificateFileUri.getPath().substring(1));
+
+            return new Certificate(certificate);
+
+        } catch (URISyntaxException ex) {
+            LOG.error("Error encountered while parsing the certificate's Amazon S3 URI.", ex);
+            throw new RuntimeException(ex);
+        }
+
     }
 
     private String getObjectWithKey(final String bucketName, final String key) {
 
         // Download the object
-        try (final S3Object s3Object = s3Client.getObject(bucketName, key)) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(bucketName).key(key).build();
+        try (final ResponseInputStream<GetObjectResponse> s3Object = s3Client.getObject(getObjectRequest)) {
             LOG.info("Object with key \"{}\" downloaded.", key);
-            return IOUtils.toString(s3Object.getObjectContent(), StandardCharsets.UTF_8);
+            return IOUtils.toString(s3Object, StandardCharsets.UTF_8);
         } catch (final Exception ex) {
             LOG.error("Error encountered while processing the response from Amazon S3.", ex);
             throw new RuntimeException(ex);

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/s3/S3CertificateProviderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/s3/S3CertificateProviderTest.java
@@ -6,14 +6,17 @@
 package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.s3;
 
 import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model.Certificate;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectInputStream;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -21,16 +24,14 @@ import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class S3CertificateProviderTest {
-    @Mock
-    private AmazonS3 amazonS3;
 
     @Mock
-    private S3Object certS3Object;
+    private S3Client s3Client;
 
     private S3CertificateProvider s3CertificateProvider;
 
@@ -43,12 +44,12 @@ public class S3CertificateProviderTest {
         final String s3SslKeyCertChainFile = String.format("s3://%s/%s",bucketName, certificatePath);
 
         final InputStream certObjectStream = IOUtils.toInputStream(certificateContent, StandardCharsets.UTF_8);
+        final ResponseInputStream certResponseInputStream = new ResponseInputStream<>(GetObjectResponse.builder().build(), AbortableInputStream.create(certObjectStream));
 
-        when(certS3Object.getObjectContent()).thenReturn(new S3ObjectInputStream(certObjectStream,null));
+        final GetObjectRequest certRequest = GetObjectRequest.builder().bucket(bucketName).key(certificatePath).build();
+        when(s3Client.getObject(certRequest)).thenReturn(certResponseInputStream);
 
-        when(amazonS3.getObject(bucketName, certificatePath)).thenReturn(certS3Object);
-
-        s3CertificateProvider = new S3CertificateProvider(amazonS3, s3SslKeyCertChainFile);
+        s3CertificateProvider = new S3CertificateProvider(s3Client, s3SslKeyCertChainFile);
 
         final Certificate certificate = s3CertificateProvider.getCertificate();
 
@@ -62,8 +63,8 @@ public class S3CertificateProviderTest {
 
         final String s3SslKeyCertChainFile = String.format("s3://%s/%s",bucketName, certificatePath);
 
-        s3CertificateProvider = new S3CertificateProvider(amazonS3, s3SslKeyCertChainFile);
-        when(amazonS3.getObject(anyString(), anyString())).thenThrow(new RuntimeException("S3 exception"));
+        s3CertificateProvider = new S3CertificateProvider(s3Client, s3SslKeyCertChainFile);
+        when(s3Client.getObject(any(GetObjectRequest.class))).thenThrow(new RuntimeException("S3 exception"));
 
         s3CertificateProvider.getCertificate();
     }


### PR DESCRIPTION
Signed-off-by: jzonthemtn <jzemerick@opensourceconnections.com>

### Description
Removes the AWS SDK v1 dependency. Updates the code using it to use AWS SDK v2 instead.

This pull request adds no new functionality. 

### Issues Resolved
#818 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
