### PR TITLE
Get S3 objects and support newline-delimited parsing in the S3 Source

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/BufferAccumulator.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/BufferAccumulator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import com.amazon.dataprepper.model.buffer.Buffer;
+import com.amazon.dataprepper.model.record.Record;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Accumulates {@link Record} objects before placing them into a Data Prepper
+ * {@link Buffer}. This class is not thread-safe and should only be used by one
+ * thread at a time.
+ *
+ * @param <T> Type of record to accumulate
+ */
+class BufferAccumulator<T extends Record<?>> {
+    private final Buffer<T> buffer;
+    private final int recordsToAccumulate;
+    private final int timeoutMillis;
+
+    private final Collection<T> recordsAccumulated;
+
+    private BufferAccumulator(final Buffer<T> buffer, final int recordsToAccumulate, final int timeoutMillis) {
+        this.buffer = buffer;
+        this.recordsToAccumulate = recordsToAccumulate;
+        this.timeoutMillis = timeoutMillis;
+
+        recordsAccumulated = new ArrayList<>(recordsToAccumulate);
+    }
+
+    static <T extends Record<?>> BufferAccumulator<T> create(final Buffer<T> buffer, final int recordsToAccumulate, final int timeoutMillis) {
+        return new BufferAccumulator<T>(buffer, recordsToAccumulate, timeoutMillis);
+    }
+
+    void add(final T record) throws Exception {
+        recordsAccumulated.add(record);
+        if (recordsAccumulated.size() == recordsToAccumulate) {
+            flushAccumulatedToBuffer();
+        }
+    }
+
+    void flush() throws Exception {
+        flushAccumulatedToBuffer();
+    }
+
+    private void flushAccumulatedToBuffer() throws Exception {
+        if (recordsAccumulated.size() > 0) {
+            buffer.writeAll(recordsAccumulated, timeoutMillis);
+            recordsAccumulated.clear();
+        }
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectReference.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectReference.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import java.util.Objects;
+
+/**
+ * Reference to an S3 object.
+ */
+class S3ObjectReference {
+    private final String bucketName;
+    private final String key;
+
+    private S3ObjectReference(final String bucketName, final String key) {
+        Objects.requireNonNull(bucketName, "bucketName must be non null");
+        Objects.requireNonNull(key, "key must be non null");
+
+        this.bucketName = bucketName;
+        this.key = key;
+    }
+
+    static S3ObjectReference fromBucketAndKey(final String bucketName, final String key) {
+        return new S3ObjectReference(bucketName, key);
+    }
+
+    String getBucketName() {
+        return bucketName;
+    }
+
+    String getKey() {
+        return key;
+    }
+
+    @Override
+    public String toString() {
+        return "[bucketName=" + bucketName + ", key=" + key + "]";
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectWorker.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import com.amazon.dataprepper.model.buffer.Buffer;
+import com.amazon.dataprepper.model.event.Event;
+import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.plugins.source.codec.Codec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.io.IOException;
+
+/**
+ * Class responsible for taking an {@link S3ObjectReference} and creating all the necessary {@link Event}
+ * objects in the Data Prepper {@link Buffer}.
+ */
+class S3ObjectWorker {
+    private static final Logger LOG = LoggerFactory.getLogger(S3ObjectWorker.class);
+
+    private final S3Client s3Client;
+    private final Buffer<Record<Event>> buffer;
+    private final Codec codec;
+    private final int bufferTimeoutInMillis;
+    private final int recordsToAccumulate;
+
+    public S3ObjectWorker(final S3Client s3Client,
+                          final Buffer<Record<Event>> buffer,
+                          final Codec codec,
+                          final int bufferTimeoutInMillis,
+                          final int recordsToAccumulate) {
+        this.s3Client = s3Client;
+        this.buffer = buffer;
+        this.codec = codec;
+        this.bufferTimeoutInMillis = bufferTimeoutInMillis;
+        this.recordsToAccumulate = recordsToAccumulate;
+    }
+
+    void parseS3Object(final S3ObjectReference s3ObjectPointer) throws IOException {
+        final GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(s3ObjectPointer.getBucketName())
+                .key(s3ObjectPointer.getKey())
+                .build();
+
+        final BufferAccumulator bufferAccumulator = BufferAccumulator.create(buffer, recordsToAccumulate, bufferTimeoutInMillis);
+
+        try (final ResponseInputStream<GetObjectResponse> object = s3Client.getObject(getObjectRequest)) {
+            codec.parse(object, record -> {
+                try {
+                    bufferAccumulator.add(record);
+                } catch (Exception e) {
+                    LOG.error("Failed writing S3 objects to buffer.", e);
+                }
+            });
+        } catch (IOException e) {
+            LOG.error("Error reading from S3 object: s3ObjectReference={}.", s3ObjectPointer, e);
+            throw e;
+        }
+
+        try {
+            bufferAccumulator.flush();
+        } catch (Exception e) {
+            LOG.error("Failed writing S3 objects to buffer.", e);
+        }
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/Codec.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/Codec.java
@@ -13,8 +13,8 @@ import java.io.InputStream;
 import java.util.function.Consumer;
 
 /**
- * A codec parsing S3 objects. Each implementation of this class should
- * support parsing a specific type of S3 object. See sub-classes for examples.
+ * A codec parsing data through an input stream. Each implementation of this class should
+ * support parsing a specific type or format of data. See sub-classes for examples.
  */
 public interface Codec {
     /**

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/Codec.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/Codec.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.codec;
+
+import com.amazon.dataprepper.model.event.Event;
+import com.amazon.dataprepper.model.record.Record;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Consumer;
+
+/**
+ * A codec parsing S3 objects. Each implementation of this class should
+ * support parsing a specific type of S3 object. See sub-classes for examples.
+ */
+public interface Codec {
+    /**
+     * Parses an {@link InputStream}. Implementors should call the {@link Consumer} for each
+     * {@link Record} loaded from the {@link InputStream}.
+     *
+     * @param inputStream   The input stream for the S3 object
+     * @param eventConsumer The consumer which handles each event from the stream
+     */
+    void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException;
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedCodec.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedCodec.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.codec;
+
+import com.amazon.dataprepper.model.event.Event;
+import com.amazon.dataprepper.model.event.JacksonEvent;
+import com.amazon.dataprepper.model.record.Record;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public class NewlineDelimitedCodec implements Codec {
+    private final int skipLines;
+
+    public NewlineDelimitedCodec(final NewlineDelimitedConfig config) {
+        Objects.requireNonNull(config);
+        skipLines = config.getSkipLines();
+
+        if (skipLines < 0) {
+            throw new IllegalArgumentException("skipLines must be non-negative.");
+        }
+    }
+
+    @Override
+    public void parse(final InputStream inputStream, final Consumer<Record<Event>> eventConsumer) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+
+        parseBufferedReader(reader, eventConsumer);
+    }
+
+    private void parseBufferedReader(final BufferedReader reader, final Consumer<Record<Event>> eventConsumer) throws IOException {
+        int linesToSkip = skipLines;
+        String line;
+        while ((line = reader.readLine()) != null) {
+
+            if (linesToSkip > 0) {
+                linesToSkip--;
+                continue;
+            }
+
+            final Event event = JacksonEvent.fromMessage(line);
+            eventConsumer.accept(new Record<>(event));
+        }
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedCodec.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedCodec.java
@@ -30,7 +30,7 @@ public class NewlineDelimitedCodec implements Codec {
 
     @Override
     public void parse(final InputStream inputStream, final Consumer<Record<Event>> eventConsumer) throws IOException {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+        final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
 
         parseBufferedReader(reader, eventConsumer);
     }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedConfig.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.codec;
+
+/**
+ * Configuration class for the newline delimited codec.
+ */
+public class NewlineDelimitedConfig {
+    private final int skipLines = 0;
+
+    /**
+     * The number of lines to skip from the start of the S3 object.
+     * Use 0 to skip no lines.
+     *
+     * @return The number of lines to skip.
+     */
+    public int getSkipLines() {
+        return skipLines;
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/BufferAccumulatorTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/BufferAccumulatorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import com.amazon.dataprepper.model.buffer.Buffer;
+import com.amazon.dataprepper.model.record.Record;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class BufferAccumulatorTest {
+    @Mock
+    private Buffer<Record<?>> buffer;
+    private int recordsToAccumulate;
+    private int timeoutMillis;
+
+    @BeforeEach
+    void setUp() {
+        recordsToAccumulate = 20;
+        timeoutMillis = 100;
+    }
+
+    private BufferAccumulator createObjectUnderTest() {
+        return BufferAccumulator.create(buffer, recordsToAccumulate, timeoutMillis);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2, 10, 20})
+    void add_should_not_write_to_Buffer(final int accumulationCount) throws Exception {
+        recordsToAccumulate = accumulationCount;
+
+        createObjectUnderTest().add(createRecord());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2, 10, 20})
+    void adding_to_accumulation_count_should_write_to_Buffer(final int accumulationCount) throws Exception {
+        recordsToAccumulate = accumulationCount;
+
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+        final List<Record<?>> knownRecords = new ArrayList<>();
+        for (int i = 0; i < accumulationCount - 1; i++) {
+            final Record record = createRecord();
+            knownRecords.add(record);
+            objectUnderTest.add(record);
+        }
+        verifyNoInteractions(buffer);
+
+        final Collection<Record<?>> actualRecordsWritten = new ArrayList<>();
+        doAnswer(a -> actualRecordsWritten.addAll(a.getArgument(0, Collection.class)))
+                .when(buffer).writeAll(anyCollection(), anyInt());
+
+        final Record record = createRecord();
+        knownRecords.add(record);
+        objectUnderTest.add(record);
+
+        verify(buffer).writeAll(anyCollection(), eq(timeoutMillis));
+
+        assertThat(actualRecordsWritten.size(), equalTo(accumulationCount));
+        assertThat(actualRecordsWritten, equalTo(knownRecords));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2, 10, 20})
+    void adding_past_accumulation_count_should_write_to_Buffer_every_accumulation_count(final int accumulationCount) throws Exception {
+        recordsToAccumulate = accumulationCount;
+
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+        final int expectedWrites = 37;
+
+        final Set<Record<?>> actualRecordsWritten = new HashSet<>();
+        doAnswer(a -> actualRecordsWritten.addAll(a.getArgument(0, Collection.class)))
+                .when(buffer).writeAll(anyCollection(), anyInt());
+
+        final int totalRecordsToWrite = accumulationCount * 37;
+        for (int i = 0; i < totalRecordsToWrite; i++) {
+            objectUnderTest.add(createRecord());
+        }
+        verify(buffer, times(expectedWrites)).writeAll(anyCollection(), eq(timeoutMillis));
+
+        assertThat(actualRecordsWritten.size(), equalTo(totalRecordsToWrite));
+    }
+
+    @Test
+    void flush_on_new_buffer_will_not_write() throws Exception {
+        createObjectUnderTest().flush();
+
+        verifyNoInteractions(buffer);
+    }
+
+    @Test
+    void flush_after_add_writes_to_buffer() throws Exception {
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+        final Record record = createRecord();
+        objectUnderTest.add(record);
+
+        verifyNoInteractions(buffer);
+
+        final List<Record<?>> actualRecordsWritten = new ArrayList<>();
+        doAnswer(a -> actualRecordsWritten.addAll(a.getArgument(0, Collection.class)))
+                .when(buffer).writeAll(anyCollection(), anyInt());
+
+        objectUnderTest.flush();
+
+        verify(buffer).writeAll(anyCollection(), eq(timeoutMillis));
+
+        assertThat(actualRecordsWritten.size(), equalTo(1));
+        assertThat(actualRecordsWritten, equalTo(Collections.singletonList(record)));
+    }
+
+    private Record createRecord() {
+        return mock(Record.class);
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/BufferAccumulatorTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/BufferAccumulatorTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -24,6 +25,7 @@ import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -38,16 +40,37 @@ class BufferAccumulatorTest {
     @Mock
     private Buffer<Record<?>> buffer;
     private int recordsToAccumulate;
+    private Duration bufferTimeout;
     private int timeoutMillis;
 
     @BeforeEach
     void setUp() {
         recordsToAccumulate = 20;
         timeoutMillis = 100;
+        bufferTimeout = Duration.ofMillis(timeoutMillis);
     }
 
     private BufferAccumulator createObjectUnderTest() {
-        return BufferAccumulator.create(buffer, recordsToAccumulate, timeoutMillis);
+        return BufferAccumulator.create(buffer, recordsToAccumulate, bufferTimeout);
+    }
+
+    @Test
+    void constructor_should_throw_if_buffer_is_null() {
+        buffer = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1, -2, Integer.MIN_VALUE})
+    void constructor_should_throw_if_numberOfRecordsToAccumulate_is_not_positive(int nonPositiveNumber) {
+        recordsToAccumulate = nonPositiveNumber;
+        assertThrows(IllegalArgumentException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void constructor_should_throw_if_bufferTimeout_is_null() {
+        bufferTimeout = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
     }
 
     @ParameterizedTest

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3ObjectReferenceTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3ObjectReferenceTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class S3ObjectReferenceTest {
+
+    private String bucketName;
+    private String key;
+
+    @BeforeEach
+    void setUp() {
+        bucketName = UUID.randomUUID().toString();
+        key = UUID.randomUUID().toString();
+    }
+
+    @Test
+    void fromBucketAndKey_throws_with_null_bucketName() {
+        assertThrows(NullPointerException.class, () -> S3ObjectReference.fromBucketAndKey(null, key));
+    }
+
+    @Test
+    void fromBucketAndKey_throws_with_null_key() {
+        assertThrows(NullPointerException.class, () -> S3ObjectReference.fromBucketAndKey(bucketName, null));
+    }
+
+    @Test
+    void fromBucketAndKey_creates_object_with_correct_values() {
+        final S3ObjectReference objectUnderTest = S3ObjectReference.fromBucketAndKey(bucketName, key);
+
+        assertThat(objectUnderTest.getBucketName(), equalTo(bucketName));
+        assertThat(objectUnderTest.getKey(), equalTo(key));
+    }
+
+    @Test
+    void toString_returns_string_with_bucket_and_key() {
+        final S3ObjectReference objectUnderTest = S3ObjectReference.fromBucketAndKey(bucketName, key);
+
+        assertThat(objectUnderTest.toString(), containsString(bucketName));
+        assertThat(objectUnderTest.toString(), containsString(key));
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import com.amazon.dataprepper.model.buffer.Buffer;
+import com.amazon.dataprepper.model.event.Event;
+import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.plugins.source.codec.Codec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Random;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class S3ObjectWorkerTest {
+
+    @Mock
+    private S3Client s3Client;
+
+    @Mock
+    private Buffer<Record<Event>> buffer;
+
+    @Mock
+    private Codec codec;
+
+    private int bufferTimeoutInMillis;
+    private int recordsToAccumulate;
+
+    @Mock
+    private S3ObjectReference s3ObjectReference;
+    private String bucketName;
+    private String key;
+
+    @BeforeEach
+    void setUp() {
+        final Random random = new Random();
+        bufferTimeoutInMillis = random.nextInt(100) + 100;
+        recordsToAccumulate = random.nextInt(10) + 2;
+
+        bucketName = UUID.randomUUID().toString();
+        key = UUID.randomUUID().toString();
+        when(s3ObjectReference.getBucketName()).thenReturn(bucketName);
+        when(s3ObjectReference.getKey()).thenReturn(key);
+    }
+
+    private S3ObjectWorker createObjectUnderTest() {
+        return new S3ObjectWorker(s3Client, buffer, codec, bufferTimeoutInMillis, recordsToAccumulate);
+    }
+
+    @Test
+    void parseS3Object_calls_getObject_with_correct_GetObjectRequest() throws IOException {
+        final ResponseInputStream<GetObjectResponse> objectInputStream = mock(ResponseInputStream.class);
+        when(s3Client.getObject(any(GetObjectRequest.class)))
+                .thenReturn(objectInputStream);
+
+        createObjectUnderTest().parseS3Object(s3ObjectReference);
+
+        final ArgumentCaptor<GetObjectRequest> getObjectRequestArgumentCaptor = ArgumentCaptor.forClass(GetObjectRequest.class);
+        verify(s3Client).getObject(getObjectRequestArgumentCaptor.capture());
+
+        final GetObjectRequest actualGetObjectRequest = getObjectRequestArgumentCaptor.getValue();
+
+        assertThat(actualGetObjectRequest, notNullValue());
+        assertThat(actualGetObjectRequest.bucket(), equalTo(bucketName));
+        assertThat(actualGetObjectRequest.key(), equalTo(key));
+    }
+
+    @Test
+    void parseS3Object_calls_Codec_parse_on_S3InputStream() throws Exception {
+        final ResponseInputStream<GetObjectResponse> objectInputStream = mock(ResponseInputStream.class);
+        when(s3Client.getObject(any(GetObjectRequest.class)))
+                .thenReturn(objectInputStream);
+
+        createObjectUnderTest().parseS3Object(s3ObjectReference);
+
+        verify(codec).parse(eq(objectInputStream), any(Consumer.class));
+    }
+
+    @Test
+    void parseS3Object_calls_Codec_parse_with_Consumer_that_adds_to_BufferAccumulator() throws Exception {
+        final ResponseInputStream<GetObjectResponse> objectInputStream = mock(ResponseInputStream.class);
+        when(s3Client.getObject(any(GetObjectRequest.class)))
+                .thenReturn(objectInputStream);
+
+        final BufferAccumulator bufferAccumulator = mock(BufferAccumulator.class);
+        try (final MockedStatic<BufferAccumulator> bufferAccumulatorMockedStatic = mockStatic(BufferAccumulator.class)) {
+            bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(buffer, recordsToAccumulate, bufferTimeoutInMillis))
+                    .thenReturn(bufferAccumulator);
+            createObjectUnderTest().parseS3Object(s3ObjectReference);
+        }
+
+        final ArgumentCaptor<Consumer<Record<Event>>> eventConsumerArgumentCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(codec).parse(any(InputStream.class), eventConsumerArgumentCaptor.capture());
+
+        final Consumer<Record<Event>> consumerUnderTest = eventConsumerArgumentCaptor.getValue();
+
+        final Record record = mock(Record.class);
+        consumerUnderTest.accept(record);
+        verify(bufferAccumulator).add(record);
+    }
+
+    @Test
+    void parseS3Object_calls_BufferAccumulator_flush_after_Codec_parse() throws Exception {
+        final ResponseInputStream<GetObjectResponse> objectInputStream = mock(ResponseInputStream.class);
+        when(s3Client.getObject(any(GetObjectRequest.class)))
+                .thenReturn(objectInputStream);
+
+        final BufferAccumulator bufferAccumulator = mock(BufferAccumulator.class);
+        try (final MockedStatic<BufferAccumulator> bufferAccumulatorMockedStatic = mockStatic(BufferAccumulator.class)) {
+            bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(buffer, recordsToAccumulate, bufferTimeoutInMillis))
+                    .thenReturn(bufferAccumulator);
+            createObjectUnderTest().parseS3Object(s3ObjectReference);
+        }
+
+        final InOrder inOrder = inOrder(codec, bufferAccumulator);
+
+        inOrder.verify(codec).parse(any(InputStream.class), any(Consumer.class));
+        inOrder.verify(bufferAccumulator).flush();
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerTest.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.Random;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -51,7 +52,7 @@ class S3ObjectWorkerTest {
     @Mock
     private Codec codec;
 
-    private int bufferTimeoutInMillis;
+    private Duration bufferTimeout;
     private int recordsToAccumulate;
 
     @Mock
@@ -62,7 +63,7 @@ class S3ObjectWorkerTest {
     @BeforeEach
     void setUp() {
         final Random random = new Random();
-        bufferTimeoutInMillis = random.nextInt(100) + 100;
+        bufferTimeout = Duration.ofMillis(random.nextInt(100) + 100);
         recordsToAccumulate = random.nextInt(10) + 2;
 
         bucketName = UUID.randomUUID().toString();
@@ -72,7 +73,7 @@ class S3ObjectWorkerTest {
     }
 
     private S3ObjectWorker createObjectUnderTest() {
-        return new S3ObjectWorker(s3Client, buffer, codec, bufferTimeoutInMillis, recordsToAccumulate);
+        return new S3ObjectWorker(s3Client, buffer, codec, bufferTimeout, recordsToAccumulate);
     }
 
     @Test
@@ -112,7 +113,7 @@ class S3ObjectWorkerTest {
 
         final BufferAccumulator bufferAccumulator = mock(BufferAccumulator.class);
         try (final MockedStatic<BufferAccumulator> bufferAccumulatorMockedStatic = mockStatic(BufferAccumulator.class)) {
-            bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(buffer, recordsToAccumulate, bufferTimeoutInMillis))
+            bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(buffer, recordsToAccumulate, bufferTimeout))
                     .thenReturn(bufferAccumulator);
             createObjectUnderTest().parseS3Object(s3ObjectReference);
         }
@@ -135,7 +136,7 @@ class S3ObjectWorkerTest {
 
         final BufferAccumulator bufferAccumulator = mock(BufferAccumulator.class);
         try (final MockedStatic<BufferAccumulator> bufferAccumulatorMockedStatic = mockStatic(BufferAccumulator.class)) {
-            bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(buffer, recordsToAccumulate, bufferTimeoutInMillis))
+            bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(buffer, recordsToAccumulate, bufferTimeout))
                     .thenReturn(bufferAccumulator);
             createObjectUnderTest().parseS3Object(s3ObjectReference);
         }

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedCodecTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedCodecTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.codec;
+
+import com.amazon.dataprepper.model.event.Event;
+import com.amazon.dataprepper.model.record.Record;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NewlineDelimitedCodecTest {
+
+    @Mock
+    private NewlineDelimitedConfig config;
+
+    private NewlineDelimitedCodec createObjectUnderTest() {
+        return new NewlineDelimitedCodec(config);
+    }
+
+    @Test
+    void constructor_throws_if_config_is_null() {
+        config = null;
+
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, -2, Integer.MIN_VALUE})
+    void constructor_throws_if_skipLines_is_less_than_zero(int negativeSkipLines) {
+        when(config.getSkipLines()).thenReturn(negativeSkipLines);
+
+        assertThrows(IllegalArgumentException.class, this::createObjectUnderTest);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 10, 50})
+    void parse_calls_Consumer_for_each_line(int numberOfLines) throws IOException {
+        final List<String> linesList = generateLinesAsList(numberOfLines);
+        final InputStream inputStream = createInputStream(linesList);
+
+        List<Record<Event>> actualEvents = new ArrayList<>();
+        createObjectUnderTest().parse(inputStream, actualEvents::add);
+
+        assertThat(actualEvents.size(), equalTo(numberOfLines));
+        for (int i = 0; i < actualEvents.size(); i++) {
+            final Record<Event> record = actualEvents.get(i);
+            assertThat(record, notNullValue());
+            assertThat(record.getData(), notNullValue());
+            assertThat(record.getData().get("message", String.class), equalTo(linesList.get(i)));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 50})
+    void parse_calls_Consumer_for_each_line_after_skipping(int numberOfLines) throws IOException {
+        final List<String> linesList = generateLinesAsList(numberOfLines);
+        final InputStream inputStream = createInputStream(linesList);
+
+        final int skipLines = 1;
+        when(config.getSkipLines()).thenReturn(skipLines);
+        final List<Record<Event>> actualEvents = new ArrayList<>();
+        createObjectUnderTest().parse(inputStream, actualEvents::add);
+
+        assertThat(actualEvents.size(), equalTo(numberOfLines - skipLines));
+        for (int i = 0; i < actualEvents.size(); i++) {
+            final Record<Event> record = actualEvents.get(i);
+            assertThat(record, notNullValue());
+            assertThat(record.getData(), notNullValue());
+            assertThat(record.getData().get("message", String.class), equalTo(linesList.get(i + skipLines)));
+        }
+    }
+
+    @Test
+    void parse_on_empty_InputStream_with_skipLines_does_not_call_Consumer() throws IOException {
+        final InputStream inputStream = createInputStream(generateLinesAsList(0));
+
+        when(config.getSkipLines()).thenReturn(1);
+        Consumer<Record<Event>> eventConsumer = mock(Consumer.class);
+        createObjectUnderTest().parse(inputStream, eventConsumer);
+
+        verifyNoInteractions(eventConsumer);
+    }
+
+    private InputStream createInputStream(List<String> lines) {
+        final String inputString = generateMultilineString(lines);
+
+        return new ByteArrayInputStream(inputString.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private List<String> generateLinesAsList(int numberOfLines) {
+        List<String> linesList = new ArrayList<>(numberOfLines);
+        for (int i = 0; i < numberOfLines; i++)
+            linesList.add(UUID.randomUUID().toString());
+        return Collections.unmodifiableList(linesList);
+    }
+
+    private String generateMultilineString(List<String> numberOfLines) {
+        final StringWriter stringWriter = new StringWriter();
+        for (String line : numberOfLines) {
+            stringWriter.write(line);
+            stringWriter.write(System.lineSeparator());
+        }
+
+        return stringWriter.toString();
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/s3-source/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,3 @@
+# To enable mocking of final classes with vanilla Mockito
+# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
+mock-maker-inline


### PR DESCRIPTION
### Description

This PR adds initial support for getting uncompressed S3 objects, parsing them with the supplied Codec, and writing Events to the Buffer. It includes the `newline-delimited` Codec.

The code which is reading from SQS will call the `S3ObjectWorker::parseS3Object` on any S3 object which should be parsed. This should happen after the S3 Event filtering. The `S3ObjectWorker` and related classes will take responsibility from here to get the Event into the Buffer, which concludes the the flow of data for the source.

Some of the error handling has been deferred and will be worked in #1464 where the source will produce metrics for S3 errors.
 
### Issues Resolved

Resolves #1434 
Resolves #1461 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
