### PR TITLE
Run a GHA against OpenSearch 2.0.0

### DIFF
--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         java: [11]
-        opensearch: [1.0.1, 1.1.0, 1.2.4, 1.3.0]
+        opensearch: [1.0.1, 1.1.0, 1.2.4, 1.3.1, 2.0.0]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         java: [11]
-        opensearch: [1.0.1, 1.1.0, 1.2.4, 1.3.1, 2.0.0]
+        opensearch: [1.0.1, 1.1.0, 1.2.4, 1.3.2, 2.0.0]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### Description

Now that OpenSearch 2.0.0 is released, run a GHA to verify that Data Prepper runs against OpenSearch 2.0.0. Also bumped 1.3.0 to 1.3.1 which is the current latest in that series.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
