### PR TITLE
Integration test to verify that the S3 source can load S3 objects

### DIFF
--- a/data-prepper-plugins/s3-source/README.md
+++ b/data-prepper-plugins/s3-source/README.md
@@ -1,0 +1,16 @@
+# S3 Source
+
+This source allows Data Prepper to use S3 as a source. It uses SQS for notifications
+of which S3 objects are new and loads those new objects to parse out events.
+
+_This plugin and its documentation are currently a work-in-progress._
+
+## Developer Guide
+
+The integration tests for this plugin do not run as part of the Data Prepper build.
+
+You can run them via:
+
+```
+./gradlew :data-prepper-plugins:s3-source:integrationTest -Dtests.s3source.region=<your-aws-region> -Dtests.s3source.bucket=<your-bucket>
+```

--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -23,3 +23,44 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+sourceSets {
+    integrationTest {
+        java {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+            srcDir file('src/integrationTest/java')
+        }
+        resources.srcDir file('src/integrationTest/resources')
+    }
+}
+
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntime.extendsFrom testRuntime
+}
+
+tasks.withType(JavaCompile).getByName('compileIntegrationTestJava').configure {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+task integrationTest(type: Test) {
+    group = 'verification'
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+
+    useJUnitPlatform()
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    systemProperty 'tests.s3source.bucket', System.getProperty('tests.s3source.bucket')
+    systemProperty 'tests.s3source.region', System.getProperty('tests.s3source.region')
+
+    filter {
+        includeTestsMatching '*IT'
+    }
+}
+

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/NewlineDelimitedRecordsGenerator.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/NewlineDelimitedRecordsGenerator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Random;
+
+/**
+ * Generates records where each record is on a single line.
+ */
+public class NewlineDelimitedRecordsGenerator implements RecordsGenerator {
+    private final Random random = new Random();
+    private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MMM/yyyy:hh:mm:ss");
+
+    @Override
+    public void write(final int numberOfRecords, final OutputStream outputStream) throws IOException {
+        try (final PrintWriter printWriter = new PrintWriter(outputStream)) {
+            for (int i = 0; i < numberOfRecords; i++) {
+                writeLine(printWriter);
+            }
+        }
+    }
+
+    private void writeLine(final PrintWriter printWriter) {
+        final String dateString = dateTimeFormatter.format(LocalDateTime.now());
+        final String line = "127.0.0.1 - - [" + dateString + "] GET /my/endpoint HTTP/1.1 200 " + random.nextInt(3000) + " \"http://localhost\" \"Mozilla/5.0\"";
+        printWriter.write(line + "\n");
+    }
+}

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/RecordsGenerator.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/RecordsGenerator.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public interface RecordsGenerator {
+    void write(int numberOfRecords, OutputStream outputStream) throws IOException;
+}

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/S3ObjectGenerator.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/S3ObjectGenerator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class S3ObjectGenerator {
+    private final S3Client s3Client;
+    private final String bucketName;
+
+    S3ObjectGenerator(final S3Client s3Client, final String bucketName) {
+        this.bucketName = bucketName;
+        this.s3Client = s3Client;
+    }
+
+    void write(final int numberOfRecords, final String key, final RecordsGenerator objectGenerator) throws IOException {
+        final File tempFile = File.createTempFile("s3-source-" + numberOfRecords + "-", null);
+
+        try {
+            try (final OutputStream outputStream = new FileOutputStream(tempFile)) {
+
+                objectGenerator.write(numberOfRecords, outputStream);
+                outputStream.flush();
+            }
+
+            final PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+            s3Client.putObject(putObjectRequest, tempFile.toPath());
+        } finally {
+            tempFile.delete();
+        }
+    }
+}

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import com.amazon.dataprepper.model.buffer.Buffer;
+import com.amazon.dataprepper.model.event.Event;
+import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.plugins.source.codec.Codec;
+import com.amazon.dataprepper.plugins.source.codec.NewlineDelimitedCodec;
+import com.amazon.dataprepper.plugins.source.codec.NewlineDelimitedConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class S3ObjectWorkerIT {
+    public static final int NUMBER_OF_RECORDS_TO_ACCUMULATE = 100;
+    public static final int TIMEOUT_IN_MILLIS = 200;
+    private S3Client s3Client;
+    private S3ObjectGenerator s3ObjectGenerator;
+    private Buffer<Record<Event>> buffer;
+    private String bucket;
+    private int recordsReceived;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        s3Client = S3Client.builder()
+                .region(Region.of(System.getProperty("tests.s3source.region")))
+                .build();
+        bucket = System.getProperty("tests.s3source.bucket");
+        s3ObjectGenerator = new S3ObjectGenerator(s3Client, bucket);
+
+        buffer = mock(Buffer.class);
+        recordsReceived = 0;
+        doAnswer(a -> {
+            final Collection<Record<Event>> recordsCollection = a.<Collection<Record<Event>>>getArgument(0);
+            assertThat(recordsCollection.size(), greaterThanOrEqualTo(1));
+            for (Record<Event> eventRecord : recordsCollection) {
+                assertThat(eventRecord, notNullValue());
+                assertThat(eventRecord.getData(), notNullValue());
+                assertThat(eventRecord.getData().get("message", String.class), notNullValue());
+
+            }
+            recordsReceived += recordsCollection.size();
+            return null;
+        })
+                .when(buffer).writeAll(anyCollection(), anyInt());
+    }
+
+    private S3ObjectWorker createObjectUnderTest(final Codec codec, final int numberOfRecordsToAccumulate) {
+        return new S3ObjectWorker(s3Client, buffer, codec, Duration.ofMillis(TIMEOUT_IN_MILLIS), numberOfRecordsToAccumulate);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(RecordAndAccumulationCounts.class)
+    void get_newline_delimited_object(final int numberOfRecords, final int numberOfRecordsToAccumulate) throws Exception {
+
+        final String key = "s3source/newlines/" + numberOfRecords + "_" + Instant.now().toString() + ".json";
+        s3ObjectGenerator.write(numberOfRecords, key, new NewlineDelimitedRecordsGenerator());
+
+        final S3ObjectWorker objectUnderTest = createObjectUnderTest(new NewlineDelimitedCodec(new NewlineDelimitedConfig()), numberOfRecordsToAccumulate);
+
+        final S3ObjectReference s3ObjectReference = S3ObjectReference.fromBucketAndKey(bucket, key);
+        objectUnderTest.parseS3Object(s3ObjectReference);
+
+        final int expectedWrites = numberOfRecords / numberOfRecordsToAccumulate + (numberOfRecords % numberOfRecordsToAccumulate != 0 ? 1 : 0);
+
+        verify(buffer, times(expectedWrites)).writeAll(anyCollection(), eq(TIMEOUT_IN_MILLIS));
+
+        assertThat(recordsReceived, equalTo(numberOfRecords));
+    }
+
+    static class RecordAndAccumulationCounts implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) throws Exception {
+            final List<Integer> numberOfRecordsList = List.of(0, 1, 25, 500, 5000);
+            final List<Integer> recordsToAccumulateList = List.of(1, 100, 1000);
+
+            return numberOfRecordsList
+                    .stream()
+                    .flatMap(records -> recordsToAccumulateList
+                            .stream()
+                            .map(accumulate -> arguments(records, accumulate))
+                    );
+        }
+    }
+}


### PR DESCRIPTION
### Description

Adds a new integration test to the S3 source. This does not build as part of the standard build because we don't want to require having AWS resources to contribute to and build Data Prepper.

When run, it will create log files in S3 and then run part of the S3 source on these to verify that the S3 source is able to correctly load a file from S3 and write to the buffer.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
