### PR TITLE
#970: Fixing OS dependent paths related to / in path.

### DIFF
--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/certificate/file/FileCertificateProvider.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/certificate/file/FileCertificateProvider.java
@@ -10,9 +10,9 @@ import com.amazon.dataprepper.plugins.certificate.model.Certificate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Objects;
 
 public class FileCertificateProvider implements CertificateProvider {
@@ -29,8 +29,8 @@ public class FileCertificateProvider implements CertificateProvider {
 
     public Certificate getCertificate() {
         try {
-            final Path certFilePath = Paths.get(certificateFilePath);
-            final Path pkFilePath = Paths.get(privateKeyFilePath);
+            final Path certFilePath = new File(certificateFilePath).toPath();
+            final Path pkFilePath = new File(privateKeyFilePath).toPath();
 
             final byte[] certFileBytes = Files.readAllBytes(certFilePath);
             final byte[] pkFileBytes = Files.readAllBytes(pkFilePath);

--- a/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
@@ -42,6 +42,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -448,8 +449,8 @@ class HTTPSourceTest {
             armeriaServerMock.when(Server::builder).thenReturn(serverBuilder);
             when(server.stop()).thenReturn(completableFuture);
 
-            final Path certFilePath = Path.of(TEST_SSL_CERTIFICATE_FILE);
-            final Path keyFilePath = Path.of(TEST_SSL_KEY_FILE);
+            final Path certFilePath = new File(TEST_SSL_CERTIFICATE_FILE).toPath();
+            final Path keyFilePath = new File(TEST_SSL_KEY_FILE).toPath();
             final String certAsString = Files.readString(certFilePath);
             final String keyAsString = Files.readString(keyFilePath);
 

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
@@ -32,10 +32,10 @@ import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 import javax.net.ssl.SSLContext;
+import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
@@ -360,7 +360,7 @@ public class ConnectionConfiguration {
 
     public Builder withCert(final String certPath) {
       checkArgument(certPath != null, "cert cannot be null");
-      this.certPath = Paths.get(certPath);
+      this.certPath = new File(certPath).toPath();
       return this;
     }
 

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/file/FileCertificateProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/file/FileCertificateProvider.java
@@ -10,9 +10,9 @@ import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model.Ce
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Objects;
 
 public class FileCertificateProvider implements CertificateProvider {
@@ -26,7 +26,7 @@ public class FileCertificateProvider implements CertificateProvider {
 
     public Certificate getCertificate() {
         try {
-            final Path certFilePath = Paths.get(certificateFilePath);
+            final Path certFilePath = new File(certificateFilePath).toPath();
 
             final byte[] bytes = Files.readAllBytes(certFilePath);
 

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerClientPoolTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerClientPoolTest.java
@@ -58,7 +58,7 @@ public class PeerClientPoolTest {
             PeerClientPool pool = PeerClientPool.getInstance();
             pool.setSsl(true);
 
-            final Path certFilePath = Path.of(PeerClientPoolTest.class.getClassLoader().getResource("test-crt.crt").getPath());
+            final Path certFilePath = new File(PeerClientPoolTest.class.getClassLoader().getResource("test-crt.crt").getFile()).toPath();
             final String certAsString = Files.readString(certFilePath);
             final Certificate certificate = new Certificate(certAsString);
             pool.setCertificate(certificate);

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderConfigTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderConfigTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -121,7 +122,7 @@ public class PeerForwarderConfigTest {
         verify(peerClientPool, times(1)).setCertificate(certificateArgumentCaptor.capture());
         final Certificate certificate = certificateArgumentCaptor.getValue();
 
-        final Path certFilePath = Path.of(VALID_SSL_KEY_CERT_FILE);
+        final Path certFilePath = new File(VALID_SSL_KEY_CERT_FILE).toPath();
         final String certAsString = Files.readString(certFilePath);
         Assert.assertEquals(certificate.getCertificate(), certAsString);
     }

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/file/FileCertificateProviderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/file/FileCertificateProviderTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,7 +31,7 @@ public class FileCertificateProviderTest {
 
         final Certificate certificate = fileCertificateProvider.getCertificate();
 
-        final Path certFilePath = Path.of(certificateFilePath);
+        final Path certFilePath = new File(certificateFilePath).toPath();
         final String certAsString = Files.readString(certFilePath);
 
         assertThat(certificate.getCertificate(), is(certAsString));


### PR DESCRIPTION
Signed-off-by: jzonthemtn <jzemerick@opensourceconnections.com>

### Description
Fixes OS-specific paths by changing from `Path.of` to `File.toPath`. No new functionality.
 
### Issues Resolved
#970 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
