### PR TITLE
Added a counter metric for when the S3 Source fails to load or parse an object

### DIFF
--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -13,6 +13,7 @@ repositories {
 
 dependencies {
     implementation project(':data-prepper-api')
+    implementation 'io.micrometer:micrometer-core'
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:sts'
     implementation 'software.amazon.awssdk:sqs'


### PR DESCRIPTION
### Description

When the S3 source fails to load an S3 object, or the codec throws an exception during parsing, add a metric indicating that the object was in failure.
 
### Issues Resolved

Part of #1464.
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
