### PR TITLE
Consolidate the Jackson and Micrometer versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,8 +94,9 @@ subprojects {
         }
     }
     dependencies {
+        implementation platform('com.fasterxml.jackson:jackson-bom:2.13.3')
+        implementation platform('io.micrometer:micrometer-bom:1.9.0')
         implementation 'com.google.guava:guava:31.0.1-jre'
-        implementation platform('io.micrometer:micrometer-bom:1.7.5')
         implementation 'org.slf4j:slf4j-api:1.7.36'
         testImplementation platform("org.junit:junit-bom:${versionMap.junitJupiter}")
         testImplementation 'org.junit.jupiter:junit-jupiter'
@@ -163,7 +164,6 @@ subprojects {
 
 configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
     dependencies {
-        implementation platform('com.fasterxml.jackson:jackson-bom:2.13.2')
         implementation platform('software.amazon.awssdk:bom:2.17.15')
         implementation 'jakarta.validation:jakarta.validation-api:3.0.1'
     }

--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -5,7 +5,7 @@
 
 dependencies {
     implementation 'io.micrometer:micrometer-core'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/data-prepper-expression/build.gradle
+++ b/data-prepper-expression/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl'
     testImplementation 'org.springframework:spring-test:5.3.20'
-    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 generateGrammarSource {

--- a/data-prepper-plugins/drop-events-processor/build.gradle
+++ b/data-prepper-plugins/drop-events-processor/build.gradle
@@ -10,7 +10,7 @@ plugins {
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation 'software.amazon.awssdk:sts:2.17.15'
     implementation 'software.amazon.awssdk:url-connection-client:2.17.15'
     implementation 'software.amazon.awssdk:arns:2.17.15'
-    implementation 'io.micrometer:micrometer-core:1.8.5'
+    implementation 'io.micrometer:micrometer-core'
     testImplementation 'org.awaitility:awaitility:4.1.1'
     testImplementation 'commons-io:commons-io:2.11.0'
     testImplementation 'net.bytebuddy:byte-buddy:1.12.8'


### PR DESCRIPTION
### Description

This PR consolidates the Jackson and Micrometer versions to the same version. The root project includes the BOM files for both projects, and sub-projects no longer need to define the specific version. Additionally, it updates both dependencies to the current latest in Maven Central.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
