### PR TITLE
Test against OpenDistro 1.3.0 (Elasticsearch 7.3.2)

### DIFF
--- a/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [11]
-        opendistro: [1.6.0, 1.8.0, 1.9.0, 1.11.0, 1.12.0, 1.13.3]
+        opendistro: [1.3.0, 1.6.0, 1.8.0, 1.9.0, 1.11.0, 1.12.0, 1.13.3]
 
     runs-on: ubuntu-latest
 

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -1,6 +1,8 @@
-# OpenSearch sink
+# OpenSearch Sink
 
 This is the Data Prepper OpenSearch sink plugin that sends records to an OpenSearch cluster via REST client. You can use the sink to send data to OpenSearch, Amazon OpenSearch Service, or Elasticsearch.
+
+The OpenSearch sink plugin supports OpenSearch 1.0 and greater and Elasticsearch 7.3 and greater.
 
 ## Usages
 


### PR DESCRIPTION
### Description

* Added OpenDistro 1.3.0 (Elasticsearch 7.3.2) to the list of OpenDistro versions to test against.
* Updated the OpenSearch sink README to document that Elasticsearch 7.3.2 is the minimum working version.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
