### PR TITLE
Support S3 event filters for accountId and bucket names

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3Source.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3Source.java
@@ -12,6 +12,8 @@ import com.amazon.dataprepper.model.buffer.Buffer;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.source.Source;
+import com.amazon.dataprepper.plugins.source.filter.ConfigFilterConfigFactory;
+import com.amazon.dataprepper.plugins.source.filter.S3EventFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,11 +25,14 @@ public class S3Source implements Source<Record<Event>> {
     private final S3SourceConfig s3SourceConfig;
 
     private SqsService sqsService;
+    private final S3EventFilter s3EventFilter;
 
     @DataPrepperPluginConstructor
-    public S3Source(PluginMetrics pluginMetrics, final S3SourceConfig s3SourceConfig) {
+    public S3Source(final PluginMetrics pluginMetrics, final S3SourceConfig s3SourceConfig) {
         this.pluginMetrics = pluginMetrics;
         this.s3SourceConfig = s3SourceConfig;
+
+        s3EventFilter = new ConfigFilterConfigFactory().createFilter(s3SourceConfig);
     }
 
     @Override
@@ -37,7 +42,7 @@ public class S3Source implements Source<Record<Event>> {
         }
 
         S3Service s3Service = new S3Service(s3SourceConfig);
-        sqsService = new SqsService(s3SourceConfig, s3Service);
+        sqsService = new SqsService(s3SourceConfig, s3Service, s3EventFilter);
 
         sqsService.start();
     }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3SourceConfig.java
@@ -15,6 +15,8 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.List;
+
 public class S3SourceConfig {
 
     @JsonProperty("notification_type")
@@ -42,6 +44,15 @@ public class S3SourceConfig {
     @Min(0)
     private int threadCount;
 
+    @JsonProperty("allow_any_account_id")
+    private boolean allowAnyAccountId = false;
+
+    @JsonProperty("account_ids")
+    private List<String> accountIds;
+
+    @JsonProperty("buckets")
+    private List<String> buckets;
+
     public NotificationTypeOption getNotificationType() {
         return notificationType;
     }
@@ -64,5 +75,17 @@ public class S3SourceConfig {
 
     public int getThreadCount() {
         return threadCount;
+    }
+
+    public boolean isAllowAnyAccountId() {
+        return allowAnyAccountId;
+    }
+
+    public List<String> getAccountIds() {
+        return accountIds;
+    }
+
+    public List<String> getBuckets() {
+        return buckets;
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsService.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsService.java
@@ -5,6 +5,7 @@
 
 package com.amazon.dataprepper.plugins.source;
 
+import com.amazon.dataprepper.plugins.source.filter.S3EventFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
@@ -18,18 +19,20 @@ public class SqsService {
 
     private final S3SourceConfig s3SourceConfig;
     private final S3Service s3Accessor;
+    private final S3EventFilter s3EventFilter;
     private final SqsClient sqsClient;
 
     private Thread sqsWorkerThread;
 
-    public SqsService(final S3SourceConfig s3SourceConfig, final S3Service s3Accessor) {
+    public SqsService(final S3SourceConfig s3SourceConfig, final S3Service s3Accessor, final S3EventFilter s3EventFilter) {
         this.s3SourceConfig = s3SourceConfig;
         this.s3Accessor = s3Accessor;
+        this.s3EventFilter = s3EventFilter;
         this.sqsClient = createSqsClient(StsClient.create());
     }
 
     public void start() {
-        sqsWorkerThread = new Thread(new SqsWorker(sqsClient, s3Accessor, s3SourceConfig));
+        sqsWorkerThread = new Thread(new SqsWorker(sqsClient, s3Accessor, s3SourceConfig, s3EventFilter));
         sqsWorkerThread.start();
     }
 

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsUrl.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsUrl.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class SqsUrl {
+    private final URL queueUrl;
+    private final String accountId;
+
+    private SqsUrl(final URL queueUrl) throws MalformedURLException {
+        this.queueUrl = queueUrl;
+        final String path = queueUrl.getPath();
+
+        if (path.isEmpty())
+            throw new MalformedURLException();
+
+        final String[] pathParts = path.split("/");
+        if (pathParts.length < 3)
+            throw new MalformedURLException();
+
+        accountId = pathParts[1];
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public static SqsUrl parse(final String queueUrl) throws MalformedURLException {
+        return new SqsUrl(new URL(queueUrl));
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/filter/AccountIdFilterFactory.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/filter/AccountIdFilterFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.filter;
+
+import com.amazon.dataprepper.plugins.source.S3SourceConfig;
+import com.amazon.dataprepper.plugins.source.SqsUrl;
+
+import java.net.MalformedURLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+class AccountIdFilterFactory implements FilterConfigFactory {
+    @Override
+    public Optional<S3EventFilter> createFilter(final S3SourceConfig s3SourceConfig) {
+        final S3EventFilter accountIdFilter;
+        if (s3SourceConfig.getAccountIds() != null && !s3SourceConfig.getAccountIds().isEmpty()) {
+            accountIdFilter = createFilter(s3SourceConfig.getAccountIds());
+        } else if (!s3SourceConfig.isAllowAnyAccountId()) {
+            final String queueUrl = s3SourceConfig.getSqsOptions().getSqsUrl();
+            final String accountId;
+            try {
+                accountId = SqsUrl.parse(queueUrl).getAccountId();
+            } catch (final MalformedURLException e) {
+                throw new IllegalArgumentException("queueUrl is invalid");
+            }
+            accountIdFilter = createFilter(Collections.singletonList(accountId));
+        } else {
+            accountIdFilter = null;
+        }
+        return Optional.ofNullable(accountIdFilter);
+    }
+
+    private static S3EventFilter createFilter(final List<String> accountIds) {
+        return new FieldContainsS3EventFilter<>(
+                record -> record.getS3().getBucket().getOwnerIdentity().getPrincipalId(),
+                accountIds);
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/filter/BucketFilterFactory.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/filter/BucketFilterFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.filter;
+
+import com.amazon.dataprepper.plugins.source.S3SourceConfig;
+
+import java.util.List;
+import java.util.Optional;
+
+class BucketFilterFactory implements FilterConfigFactory {
+    @Override
+    public Optional<S3EventFilter> createFilter(final S3SourceConfig s3SourceConfig) {
+        final List<String> buckets = s3SourceConfig.getBuckets();
+        if (buckets == null || buckets.isEmpty())
+            return Optional.empty();
+
+        return Optional.of(new FieldContainsS3EventFilter<>(
+                record -> record.getS3().getBucket().getName(),
+                buckets));
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/filter/ConfigFilterConfigFactory.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/filter/ConfigFilterConfigFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.filter;
+
+import com.amazon.dataprepper.plugins.source.S3SourceConfig;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Creates an {@link S3EventFilter} from a configuration. This filter will filter out
+ * S3 events which should not be processed by the S3 source.
+ */
+public class ConfigFilterConfigFactory {
+
+    private final List<FilterConfigFactory> delegateFactories;
+
+    public ConfigFilterConfigFactory() {
+        this(Arrays.asList(
+                new AccountIdFilterFactory(),
+                new BucketFilterFactory(),
+                new ObjectCreatedFilter.Factory()
+        ));
+    }
+
+    ConfigFilterConfigFactory(final List<FilterConfigFactory> delegateFactories) {
+        this.delegateFactories = delegateFactories;
+    }
+
+    public S3EventFilter createFilter(final S3SourceConfig s3SourceConfig) {
+        final List<S3EventFilter> filters = delegateFactories.stream()
+                .map(filterConfigFactory -> filterConfigFactory.createFilter(s3SourceConfig))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+
+        return new S3EventFilterChain(filters);
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/filter/FieldContainsS3EventFilter.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/filter/FieldContainsS3EventFilter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.filter;
+
+import com.amazonaws.services.s3.event.S3EventNotification;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+class FieldContainsS3EventFilter<T> implements S3EventFilter {
+    private final Function<S3EventNotification.S3EventNotificationRecord, T> fieldProvider;
+    private final Collection<T> eligibleValues;
+
+    public FieldContainsS3EventFilter(final Function<S3EventNotification.S3EventNotificationRecord, T> fieldProvider, final Collection<T> eligibleValues) {
+        Objects.requireNonNull(eligibleValues);
+        if (eligibleValues.isEmpty())
+            throw new IllegalArgumentException("The eligibleValues must be non-empty.");
+
+        this.eligibleValues = new HashSet<>(eligibleValues);
+        this.fieldProvider = fieldProvider;
+    }
+
+    @Override
+    public Optional<S3EventNotification.S3EventNotificationRecord> filter(final S3EventNotification.S3EventNotificationRecord notification) {
+        final T fieldValue = fieldProvider.apply(notification);
+
+        if (eligibleValues.contains(fieldValue))
+            return Optional.of(notification);
+
+        return Optional.empty();
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/filter/FilterConfigFactory.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/filter/FilterConfigFactory.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.filter;
+
+import com.amazon.dataprepper.plugins.source.S3SourceConfig;
+
+import java.util.Optional;
+
+interface FilterConfigFactory {
+    Optional<S3EventFilter> createFilter(S3SourceConfig config);
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/filter/ObjectCreatedFilter.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/filter/ObjectCreatedFilter.java
@@ -5,16 +5,26 @@
 
 package com.amazon.dataprepper.plugins.source.filter;
 
+import com.amazon.dataprepper.plugins.source.S3SourceConfig;
 import com.amazonaws.services.s3.event.S3EventNotification;
 
 import java.util.Optional;
 
-public class ObjectCreatedFilter implements S3EventFilter {
+class ObjectCreatedFilter implements S3EventFilter {
+    private ObjectCreatedFilter() {}
+
     @Override
     public Optional<S3EventNotification.S3EventNotificationRecord> filter(final S3EventNotification.S3EventNotificationRecord notification) {
         if (notification.getEventName().startsWith("ObjectCreated"))
             return Optional.of(notification);
         else
             return Optional.empty();
+    }
+
+    static class Factory implements FilterConfigFactory {
+        @Override
+        public Optional<S3EventFilter> createFilter(final S3SourceConfig config) {
+            return Optional.of(new ObjectCreatedFilter());
+        }
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/filter/S3EventFilterChain.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/filter/S3EventFilterChain.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.filter;
+
+import com.amazonaws.services.s3.event.S3EventNotification;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * An {@link S3EventFilter} which filters through a set of other {@link S3EventFilter} objects.
+ */
+class S3EventFilterChain implements S3EventFilter {
+    private final List<S3EventFilter> delegateFilters;
+
+    public S3EventFilterChain(final List<S3EventFilter> delegateFilters) {
+        this.delegateFilters = Objects.requireNonNull(delegateFilters);
+    }
+
+    @Override
+    public Optional<S3EventNotification.S3EventNotificationRecord> filter(final S3EventNotification.S3EventNotificationRecord notification) {
+        if (notification == null)
+            return Optional.empty();
+
+        Optional<S3EventNotification.S3EventNotificationRecord> lastResult = Optional.of(notification);
+        for (S3EventFilter innerFilter : delegateFilters) {
+            lastResult = innerFilter.filter(lastResult.get());
+
+            if (!lastResult.isPresent())
+                break;
+        }
+
+        return lastResult;
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3SourceTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3SourceTest.java
@@ -6,11 +6,13 @@
 package com.amazon.dataprepper.plugins.source;
 
 import com.amazon.dataprepper.metrics.PluginMetrics;
+import com.amazon.dataprepper.plugins.source.configuration.SqsOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class S3SourceTest {
     private final String PLUGIN_NAME = "s3";
@@ -25,6 +27,10 @@ class S3SourceTest {
     void setUp() {
         pluginMetrics = PluginMetrics.fromNames(PLUGIN_NAME, TEST_PIPELINE_NAME);
         s3SourceConfig = mock(S3SourceConfig.class);
+
+        final SqsOptions sqsOptions = mock(SqsOptions.class);
+        when(s3SourceConfig.getSqsOptions()).thenReturn(sqsOptions);
+        when(sqsOptions.getSqsUrl()).thenReturn("https://sqs/123/abc");
 
         s3Source = new S3Source(pluginMetrics, s3SourceConfig);
     }

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsUrlTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsUrlTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.MalformedURLException;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SqsUrlTest {
+    @Test
+    void parse_throws_when_URL_is_not_a_URL() {
+        assertThrows(MalformedURLException.class, () -> SqsUrl.parse(UUID.randomUUID().toString()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "https://sqs.us-east-1.amazonaws.com",
+            "https://sqs.us-east-1.amazonaws.com/",
+            "https://sqs.us-east-1.amazonaws.com/123456789",
+            "https://sqs.us-east-1.amazonaws.com/123456789/"
+    })
+    void parse_throws_when_URL_has_invalid_paths(final String queueUrl) {
+        assertThrows(MalformedURLException.class, () -> SqsUrl.parse(queueUrl));
+    }
+
+    @Test
+    void getAccountId_returns_accountId_part() throws MalformedURLException {
+        final String accountId = UUID.randomUUID().toString();
+        final String queueName = UUID.randomUUID().toString();
+
+        final String queueUrl = String.format("https://sqs.us-east-1.amazonaws.com/%s/%s", accountId, queueName);
+
+        final SqsUrl objectUnderTest = SqsUrl.parse(queueUrl);
+
+        assertThat(objectUnderTest, notNullValue());
+        assertThat(objectUnderTest.getAccountId(), equalTo(accountId));
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsWorkerTest.java
@@ -7,12 +7,13 @@ package com.amazon.dataprepper.plugins.source;
 
 import com.amazon.dataprepper.plugins.source.configuration.AwsAuthenticationOptions;
 import com.amazon.dataprepper.plugins.source.configuration.SqsOptions;
-import com.amazon.dataprepper.plugins.source.filter.ObjectCreatedFilter;
 import com.amazon.dataprepper.plugins.source.filter.S3EventFilter;
+import com.amazonaws.services.s3.event.S3EventNotification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
@@ -20,11 +21,13 @@ import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 import software.amazon.awssdk.services.sqs.model.SqsException;
 
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -33,14 +36,14 @@ class SqsWorkerTest {
     private SqsClient sqsClient;
     private S3Service s3Service;
     private S3SourceConfig s3SourceConfig;
-    private S3EventFilter objectCreatedFilter;
+    private S3EventFilter s3EventFilter;
 
     @BeforeEach
     void setUp() {
         sqsClient = mock(SqsClient.class);
         s3Service = mock(S3Service.class);
         s3SourceConfig = mock(S3SourceConfig.class);
-        objectCreatedFilter = new ObjectCreatedFilter();
+        s3EventFilter = mock(S3EventFilter.class);
 
         AwsAuthenticationOptions awsAuthenticationOptions = mock(AwsAuthenticationOptions.class);
         when(awsAuthenticationOptions.getAwsRegion()).thenReturn("us-east-1");
@@ -52,7 +55,7 @@ class SqsWorkerTest {
         when(s3SourceConfig.getAWSAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
         when(s3SourceConfig.getSqsOptions()).thenReturn(sqsOptions);
 
-        sqsWorker = new SqsWorker(sqsClient, s3Service, s3SourceConfig);
+        sqsWorker = new SqsWorker(sqsClient, s3Service, s3SourceConfig, s3EventFilter);
     }
 
     @Test
@@ -128,6 +131,55 @@ class SqsWorkerTest {
 
         final int messagesProcessed = sqsWorker.processSqsMessages();
         assertThat(messagesProcessed, equalTo(1));
+        verifyNoInteractions(s3Service);
+    }
+
+    @Test
+    void processSqsMessages_should_add_S3References_to_S3ObjectWorker() {
+        final Message message = mock(Message.class);
+        when(message.body()).thenReturn("{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-east-1\"," +
+                "\"eventTime\":\"2022-06-06T18:02:33.495Z\",\"eventName\":\"ObjectRemoved:Delete\",\"userIdentity\":{\"principalId\":\"AWS:AROAX:xxxxxx\"}," +
+                "\"requestParameters\":{\"sourceIPAddress\":\"99.99.999.99\"},\"responseElements\":{\"x-amz-request-id\":\"ABCD\"," +
+                "\"x-amz-id-2\":\"abcd\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"s3SourceEventNotification\"," +
+                "\"bucket\":{\"name\":\"bucketName\",\"ownerIdentity\":{\"principalId\":\"ID\"},\"arn\":\"arn:aws:s3:::bucketName\"}," +
+                "\"object\":{\"key\":\"File.gz\",\"size\":72,\"eTag\":\"abcd\",\"sequencer\":\"ABCD\"}}}]}");
+
+        final ReceiveMessageResponse receiveMessageResponse = mock(ReceiveMessageResponse.class);
+        when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResponse);
+        when(receiveMessageResponse.messages()).thenReturn(Collections.singletonList(message));
+
+        when(s3EventFilter.filter(any(S3EventNotification.S3EventNotificationRecord.class)))
+                .thenAnswer(a -> Optional.of(a.getArgument(0, S3EventNotification.S3EventNotificationRecord.class)));
+
+        sqsWorker.processSqsMessages();
+
+        final ArgumentCaptor<S3ObjectReference> s3ObjectReferenceArgumentCaptor = ArgumentCaptor.forClass(S3ObjectReference.class);
+        verify(s3Service).addS3Object(s3ObjectReferenceArgumentCaptor.capture());
+
+        final S3ObjectReference actualS3Reference = s3ObjectReferenceArgumentCaptor.getValue();
+        assertThat(actualS3Reference.getBucketName(), equalTo("bucketName"));
+        assertThat(actualS3Reference.getKey(), equalTo("File.gz"));
+    }
+
+    @Test
+    void processSqsMessages_should_add_not_S3References_to_S3ObjectWorker_if_filter_provides_empty() {
+        final Message message = mock(Message.class);
+        when(message.body()).thenReturn("{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-east-1\"," +
+                "\"eventTime\":\"2022-06-06T18:02:33.495Z\",\"eventName\":\"ObjectRemoved:Delete\",\"userIdentity\":{\"principalId\":\"AWS:AROAX:xxxxxx\"}," +
+                "\"requestParameters\":{\"sourceIPAddress\":\"99.99.999.99\"},\"responseElements\":{\"x-amz-request-id\":\"ABCD\"," +
+                "\"x-amz-id-2\":\"abcd\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"s3SourceEventNotification\"," +
+                "\"bucket\":{\"name\":\"bucketName\",\"ownerIdentity\":{\"principalId\":\"ID\"},\"arn\":\"arn:aws:s3:::bucketName\"}," +
+                "\"object\":{\"key\":\"File.gz\",\"size\":72,\"eTag\":\"abcd\",\"sequencer\":\"ABCD\"}}}]}");
+
+        final ReceiveMessageResponse receiveMessageResponse = mock(ReceiveMessageResponse.class);
+        when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResponse);
+        when(receiveMessageResponse.messages()).thenReturn(Collections.singletonList(message));
+
+        when(s3EventFilter.filter(any(S3EventNotification.S3EventNotificationRecord.class)))
+                .thenReturn(Optional.empty());
+
+        sqsWorker.processSqsMessages();
+
         verifyNoInteractions(s3Service);
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/filter/AccountIdFilterFactoryTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/filter/AccountIdFilterFactoryTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.filter;
+
+import com.amazon.dataprepper.plugins.source.S3SourceConfig;
+import com.amazon.dataprepper.plugins.source.configuration.SqsOptions;
+import com.amazonaws.services.s3.event.S3EventNotification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AccountIdFilterFactoryTest {
+    @Mock
+    private S3SourceConfig s3SourceConfig;
+
+    @Mock
+    private S3EventNotification.S3EventNotificationRecord notification;
+
+
+    private AccountIdFilterFactory createObjectUnderTest() {
+        return new AccountIdFilterFactory();
+    }
+
+    @Test
+    void factory_produces_no_filter_if_isAllowAnyAccountId() {
+        when(s3SourceConfig.isAllowAnyAccountId()).thenReturn(true);
+
+        final Optional<S3EventFilter> optionalFilter = createObjectUnderTest().createFilter(s3SourceConfig);
+
+        assertThat(optionalFilter, notNullValue());
+        assertThat(optionalFilter.isPresent(), equalTo(false));
+    }
+
+    @Nested
+    class ForDefaultConfiguration {
+        private String queueAccountId;
+        @Mock
+        private S3EventNotification.UserIdentityEntity ownerIdentity;
+
+        @BeforeEach
+        void setUp() {
+
+            final SqsOptions sqsOptions = mock(SqsOptions.class);
+            when(s3SourceConfig.getSqsOptions()).thenReturn(sqsOptions);
+
+            queueAccountId = UUID.randomUUID().toString();
+            final String sqsUrl = String.format("https://sqs.amazonaws.com/%s/%s", queueAccountId, UUID.randomUUID());
+            when(sqsOptions.getSqsUrl()).thenReturn(sqsUrl);
+
+            final S3EventNotification.S3BucketEntity s3BucketEntity = mock(S3EventNotification.S3BucketEntity.class);
+            final S3EventNotification.S3Entity s3Entity = mock(S3EventNotification.S3Entity.class);
+            when(s3BucketEntity.getOwnerIdentity()).thenReturn(ownerIdentity);
+            when(s3Entity.getBucket()).thenReturn(s3BucketEntity);
+            when(notification.getS3()).thenReturn(s3Entity);
+        }
+
+
+        @Test
+        void filter_from_default_configuration_includes_if_owned_by_Sqs_accountId() {
+            final Optional<S3EventFilter> optionalFilter = createObjectUnderTest().createFilter(s3SourceConfig);
+            assertThat(optionalFilter, notNullValue());
+            assertThat(optionalFilter.isPresent(), equalTo(true));
+
+            when(ownerIdentity.getPrincipalId()).thenReturn(queueAccountId);
+
+            final S3EventFilter objectUnderTest = optionalFilter.get();
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> optionalRecord = objectUnderTest.filter(notification);
+            assertThat(optionalRecord, notNullValue());
+            assertThat(optionalRecord.isPresent(), equalTo(true));
+            assertThat(optionalRecord.get(), equalTo(notification));
+        }
+
+        @Test
+        void filter_from_default_configuration_filters_out_if_not_owned_by_Sqs_accountId() {
+            final Optional<S3EventFilter> optionalFilter = createObjectUnderTest().createFilter(s3SourceConfig);
+            assertThat(optionalFilter, notNullValue());
+            assertThat(optionalFilter.isPresent(), equalTo(true));
+
+            when(ownerIdentity.getPrincipalId()).thenReturn(UUID.randomUUID().toString());
+
+            final S3EventFilter objectUnderTest = optionalFilter.get();
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> optionalRecord = objectUnderTest.filter(notification);
+            assertThat(optionalRecord, notNullValue());
+            assertThat(optionalRecord.isPresent(), equalTo(false));
+        }
+
+    }
+
+    @Nested
+    class WithConfiguredAccountIds {
+
+        private String knownAccountId;
+        @Mock
+        private S3EventNotification.UserIdentityEntity ownerIdentity;
+
+
+        @BeforeEach
+        void setUp() {
+
+            knownAccountId = UUID.randomUUID().toString();
+
+            when(s3SourceConfig.getAccountIds()).thenReturn(Arrays.asList(UUID.randomUUID().toString(), knownAccountId, UUID.randomUUID().toString()));
+
+            final S3EventNotification.S3BucketEntity s3BucketEntity = mock(S3EventNotification.S3BucketEntity.class);
+            final S3EventNotification.S3Entity s3Entity = mock(S3EventNotification.S3Entity.class);
+            when(s3BucketEntity.getOwnerIdentity()).thenReturn(ownerIdentity);
+            when(s3Entity.getBucket()).thenReturn(s3BucketEntity);
+            when(notification.getS3()).thenReturn(s3Entity);
+        }
+
+
+        @Test
+        void filter_from_default_configuration_includes_if_owned_by_Sqs_accountId() {
+            final Optional<S3EventFilter> optionalFilter = createObjectUnderTest().createFilter(s3SourceConfig);
+            assertThat(optionalFilter, notNullValue());
+            assertThat(optionalFilter.isPresent(), equalTo(true));
+
+            when(ownerIdentity.getPrincipalId()).thenReturn(knownAccountId);
+
+            final S3EventFilter objectUnderTest = optionalFilter.get();
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> optionalRecord = objectUnderTest.filter(notification);
+            assertThat(optionalRecord, notNullValue());
+            assertThat(optionalRecord.isPresent(), equalTo(true));
+            assertThat(optionalRecord.get(), equalTo(notification));
+        }
+
+        @Test
+        void filter_from_default_configuration_filters_out_if_not_owned_by_Sqs_accountId() {
+            final Optional<S3EventFilter> optionalFilter = createObjectUnderTest().createFilter(s3SourceConfig);
+            assertThat(optionalFilter, notNullValue());
+            assertThat(optionalFilter.isPresent(), equalTo(true));
+
+            when(ownerIdentity.getPrincipalId()).thenReturn(UUID.randomUUID().toString());
+
+            final S3EventFilter objectUnderTest = optionalFilter.get();
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> optionalRecord = objectUnderTest.filter(notification);
+            assertThat(optionalRecord, notNullValue());
+            assertThat(optionalRecord.isPresent(), equalTo(false));
+        }
+
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/filter/BucketFilterFactoryTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/filter/BucketFilterFactoryTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.filter;
+
+import com.amazon.dataprepper.plugins.source.S3SourceConfig;
+import com.amazonaws.services.s3.event.S3EventNotification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BucketFilterFactoryTest {
+    @Mock
+    private S3SourceConfig s3SourceConfig;
+
+    private BucketFilterFactory createObjectUnderTest() {
+        return new BucketFilterFactory();
+    }
+
+    @Test
+    void factory_with_null_buckets_returns_empty() {
+        when(s3SourceConfig.getBuckets()).thenReturn(null);
+        final Optional<S3EventFilter> optionalFilter = createObjectUnderTest().createFilter(s3SourceConfig);
+        assertThat(optionalFilter, notNullValue());
+        assertThat(optionalFilter.isPresent(), equalTo(false));
+    }
+
+    @Test
+    void factory_without_buckets_returns_empty() {
+        when(s3SourceConfig.getBuckets()).thenReturn(Collections.emptyList());
+        final Optional<S3EventFilter> optionalFilter = createObjectUnderTest().createFilter(s3SourceConfig);
+        assertThat(optionalFilter, notNullValue());
+        assertThat(optionalFilter.isPresent(), equalTo(false));
+    }
+
+    @Nested
+    class WithBucketRestriction {
+
+        @Mock
+        private S3EventNotification.S3EventNotificationRecord notification;
+        private String updatedBucket;
+        private List<String> restrictedBuckets;
+
+        @BeforeEach
+        void setUp() {
+
+            updatedBucket = UUID.randomUUID().toString();
+
+            final S3EventNotification.S3BucketEntity s3BucketEntity = mock(S3EventNotification.S3BucketEntity.class);
+            when(s3BucketEntity.getName()).thenReturn(updatedBucket);
+            final S3EventNotification.S3Entity s3Entity = mock(S3EventNotification.S3Entity.class);
+            when(s3Entity.getBucket()).thenReturn(s3BucketEntity);
+            when(notification.getS3()).thenReturn(s3Entity);
+        }
+
+        @Test
+        void filter_returns_empty_if_the_bucket_is_not_present() {
+            restrictedBuckets = Collections.singletonList(UUID.randomUUID().toString());
+            when(s3SourceConfig.getBuckets()).thenReturn(restrictedBuckets);
+
+            final Optional<S3EventFilter> optionalFilter = createObjectUnderTest().createFilter(s3SourceConfig);
+            assertThat(optionalFilter, notNullValue());
+            assertThat(optionalFilter.isPresent(), equalTo(true));
+            assertThat(optionalFilter.get(), instanceOf(FieldContainsS3EventFilter.class));
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> result = optionalFilter.get().filter(notification);
+
+            assertThat(result, notNullValue());
+            assertThat(result.isPresent(), equalTo(false));
+        }
+
+        @Test
+        void filter_returns_notification_if_the_bucket_is_present() {
+            restrictedBuckets = Collections.singletonList(updatedBucket);
+            when(s3SourceConfig.getBuckets()).thenReturn(restrictedBuckets);
+
+            final Optional<S3EventFilter> optionalFilter = createObjectUnderTest().createFilter(s3SourceConfig);
+            assertThat(optionalFilter, notNullValue());
+            assertThat(optionalFilter.isPresent(), equalTo(true));
+            assertThat(optionalFilter.get(), instanceOf(FieldContainsS3EventFilter.class));
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> result = optionalFilter.get().filter(notification);
+
+            assertThat(result, notNullValue());
+            assertThat(result.isPresent(), equalTo(true));
+            assertThat(result.get(), equalTo(notification));
+        }
+
+        @Test
+        void filter_returns_empty_if_the_bucket_is_not_present_when_multiple_buckets() {
+            restrictedBuckets = Arrays.asList(UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString());
+            when(s3SourceConfig.getBuckets()).thenReturn(restrictedBuckets);
+
+            final Optional<S3EventFilter> optionalFilter = createObjectUnderTest().createFilter(s3SourceConfig);
+            assertThat(optionalFilter, notNullValue());
+            assertThat(optionalFilter.isPresent(), equalTo(true));
+            assertThat(optionalFilter.get(), instanceOf(FieldContainsS3EventFilter.class));
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> result = optionalFilter.get().filter(notification);
+
+            assertThat(result, notNullValue());
+            assertThat(result.isPresent(), equalTo(false));
+        }
+
+        @Test
+        void filter_returns_notification_if_the_bucket_is_present_when_multiple_buckets() {
+            restrictedBuckets = Arrays.asList(UUID.randomUUID().toString(), updatedBucket, UUID.randomUUID().toString());
+            when(s3SourceConfig.getBuckets()).thenReturn(restrictedBuckets);
+
+            final Optional<S3EventFilter> optionalFilter = createObjectUnderTest().createFilter(s3SourceConfig);
+            assertThat(optionalFilter, notNullValue());
+            assertThat(optionalFilter.isPresent(), equalTo(true));
+            assertThat(optionalFilter.get(), instanceOf(FieldContainsS3EventFilter.class));
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> result = optionalFilter.get().filter(notification);
+
+            assertThat(result, notNullValue());
+            assertThat(result.isPresent(), equalTo(true));
+            assertThat(result.get(), equalTo(notification));
+        }
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/filter/ConfigFilterConfigFactoryTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/filter/ConfigFilterConfigFactoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.filter;
+
+import com.amazon.dataprepper.plugins.source.S3SourceConfig;
+import com.amazon.dataprepper.plugins.source.configuration.SqsOptions;
+import com.amazonaws.services.s3.event.S3EventNotification;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigFilterConfigFactoryTest {
+    private List<FilterConfigFactory> factories;
+
+    @Mock
+    private S3SourceConfig s3SourceConfig;
+
+    private ConfigFilterConfigFactory createObjectUnderTest() {
+        return new ConfigFilterConfigFactory(factories);
+    }
+
+    @Test
+    void createFilter_creates_a_filter_which_calls_delegate_filters() {
+        final S3EventFilter applicableFilter = mock(S3EventFilter.class);
+        final FilterConfigFactory applicableFactory = mock(FilterConfigFactory.class);
+        when(applicableFactory.createFilter(s3SourceConfig)).thenReturn(Optional.of(applicableFilter));
+
+        final FilterConfigFactory notApplicableFactory = mock(FilterConfigFactory.class);
+        when(notApplicableFactory.createFilter(s3SourceConfig)).thenReturn(Optional.empty());
+
+        factories = Arrays.asList(notApplicableFactory, applicableFactory);
+
+        final S3EventFilter filterCreated = createObjectUnderTest().createFilter(s3SourceConfig);
+
+        assertThat(filterCreated, notNullValue());
+        assertThat(filterCreated, instanceOf(S3EventFilterChain.class));
+
+        final S3EventNotification.S3EventNotificationRecord record = mock(S3EventNotification.S3EventNotificationRecord.class);
+        filterCreated.filter(record);
+
+        verify(applicableFilter).filter(record);
+    }
+
+    @Test
+    void sanity_check_on_public_constructor() {
+        final SqsOptions sqsOptions = mock(SqsOptions.class);
+        when(sqsOptions.getSqsUrl()).thenReturn("https://sqs.amazonaws.com/12345/MyQueue");
+        when(s3SourceConfig.getSqsOptions()).thenReturn(sqsOptions);
+
+        final S3EventFilter filterCreated = new ConfigFilterConfigFactory().createFilter(s3SourceConfig);
+
+        assertThat(filterCreated, notNullValue());
+        assertThat(filterCreated, instanceOf(S3EventFilterChain.class));
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/filter/FieldContainsS3EventFilterTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/filter/FieldContainsS3EventFilterTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.filter;
+
+import com.amazonaws.services.s3.event.S3EventNotification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FieldContainsS3EventFilterTest {
+    @Mock
+    private Function<S3EventNotification.S3EventNotificationRecord, String> fieldProvider;
+    private Collection<String> validValues;
+
+    private FieldContainsS3EventFilter<String> createObjectUnderTest() {
+        return new FieldContainsS3EventFilter<>(fieldProvider, validValues);
+    }
+
+    @Test
+    void constructor_throws_if_fieldProvider_is_null() {
+        fieldProvider = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void constructor_throws_if_validValues_is_null() {
+        validValues = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void constructor_throws_if_validValues_is_empty() {
+        validValues = Collections.emptyList();
+        assertThrows(IllegalArgumentException.class, this::createObjectUnderTest);
+    }
+
+    @Nested
+    class WithNotification {
+
+        @Mock
+        private S3EventNotification.S3EventNotificationRecord notification;
+        private String actualValue;
+
+        @BeforeEach
+        void setUp() {
+            validValues = Collections.emptyList();
+
+            actualValue = UUID.randomUUID().toString();
+            when(fieldProvider.apply(notification)).thenReturn(actualValue);
+        }
+
+        @Test
+        void filter_returns_empty_if_the_field_is_not_present() {
+            validValues = Collections.singletonList(UUID.randomUUID().toString());
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> result = createObjectUnderTest().filter(notification);
+
+            assertThat(result, notNullValue());
+            assertThat(result.isPresent(), equalTo(false));
+        }
+
+        @Test
+        void filter_returns_notification_if_the_field_is_present() {
+            validValues = Collections.singletonList(actualValue);
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> result = createObjectUnderTest().filter(notification);
+
+            assertThat(result, notNullValue());
+            assertThat(result.isPresent(), equalTo(true));
+            assertThat(result.get(), equalTo(notification));
+        }
+
+        @Test
+        void filter_returns_empty_if_the_field_is_not_present_when_multiple_validValues() {
+            validValues = Arrays.asList(UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> result = createObjectUnderTest().filter(notification);
+
+            assertThat(result, notNullValue());
+            assertThat(result.isPresent(), equalTo(false));
+        }
+
+        @Test
+        void filter_returns_notification_if_the_field_is_present_when_multiple_validValues() {
+            validValues = Arrays.asList(UUID.randomUUID().toString(), actualValue, UUID.randomUUID().toString());
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> result = createObjectUnderTest().filter(notification);
+
+            assertThat(result, notNullValue());
+            assertThat(result.isPresent(), equalTo(true));
+            assertThat(result.get(), equalTo(notification));
+        }
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/filter/ObjectCreatedFilterTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/filter/ObjectCreatedFilterTest.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,20 +22,25 @@ import static org.mockito.Mockito.when;
 
 class ObjectCreatedFilterTest {
 
-    private ObjectCreatedFilter objectCreatedFilter;
     private S3EventNotification.S3EventNotificationRecord s3EventNotificationRecord;
-
 
     @BeforeEach
     void setUp() {
-        objectCreatedFilter = new ObjectCreatedFilter();
         s3EventNotificationRecord = mock(S3EventNotification.S3EventNotificationRecord.class);
+    }
+
+    private Optional<S3EventFilter> createObjectUnderTest() {
+        return new ObjectCreatedFilter.Factory().createFilter(null);
     }
 
     @Test
     void filter_with_eventName_ObjectCreated_should_return_non_empty_instance_of_optional() {
         when(s3EventNotificationRecord.getEventName()).thenReturn("ObjectCreated:Put");
-        Optional<S3EventNotification.S3EventNotificationRecord> actualValue = objectCreatedFilter.filter(s3EventNotificationRecord);
+        final Optional<S3EventFilter> optionalFilter = createObjectUnderTest();
+        assertThat(optionalFilter, notNullValue());
+        assertThat(optionalFilter.isPresent(), equalTo(true));
+        final S3EventFilter objectCreatedFilter = optionalFilter.get();
+        final Optional<S3EventNotification.S3EventNotificationRecord> actualValue = objectCreatedFilter.filter(s3EventNotificationRecord);
 
         assertThat(actualValue, instanceOf(Optional.class));
         assertTrue(actualValue.isPresent());
@@ -44,7 +50,11 @@ class ObjectCreatedFilterTest {
     @Test
     void filter_with_eventName_ObjectRemoved_should_return_empty_instance_of_optional() {
         when(s3EventNotificationRecord.getEventName()).thenReturn("ObjectRemoved:Delete");
-        Optional<S3EventNotification.S3EventNotificationRecord> actualValue = objectCreatedFilter.filter(s3EventNotificationRecord);
+        final Optional<S3EventFilter> optionalFilter = createObjectUnderTest();
+        assertThat(optionalFilter, notNullValue());
+        assertThat(optionalFilter.isPresent(), equalTo(true));
+        final S3EventFilter objectCreatedFilter = optionalFilter.get();
+        final Optional<S3EventNotification.S3EventNotificationRecord> actualValue = objectCreatedFilter.filter(s3EventNotificationRecord);
 
         assertThat(actualValue, instanceOf(Optional.class));
         assertFalse(actualValue.isPresent());

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/filter/S3EventFilterChainTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/filter/S3EventFilterChainTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.filter;
+
+import com.amazonaws.services.s3.event.S3EventNotification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class S3EventFilterChainTest {
+
+    @Mock
+    private S3EventNotification.S3EventNotificationRecord notification;
+    private List<S3EventFilter> innerFilters;
+
+    @BeforeEach
+    void setUp() {
+        innerFilters = Collections.emptyList();
+    }
+
+    private S3EventFilterChain createObjectUnderTest() {
+        return new S3EventFilterChain(innerFilters);
+    }
+
+    @Test
+    void constructor_throws_if_filters_is_null() {
+        innerFilters = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void filter_with_empty_filters_returns_empty_if_notification_is_null() {
+        final Optional<S3EventNotification.S3EventNotificationRecord> actualValue = createObjectUnderTest().filter(null);
+
+        assertThat(actualValue, notNullValue());
+        assertThat(actualValue.isPresent(), equalTo(false));
+    }
+
+    @Test
+    void filter_with_empty_filters_returns_input_notification() {
+        final Optional<S3EventNotification.S3EventNotificationRecord> actualValue = createObjectUnderTest().filter(notification);
+
+        assertThat(actualValue, notNullValue());
+        assertThat(actualValue.isPresent(), equalTo(true));
+        assertThat(actualValue.get(), equalTo(notification));
+    }
+
+    @Nested
+    class WithOneFilter {
+
+        private S3EventFilter innerFilter;
+
+        @BeforeEach
+        void setUp() {
+            innerFilter = mock(S3EventFilter.class);
+            innerFilters = Collections.singletonList(innerFilter);
+        }
+
+
+        @Test
+        void filter_returns_empty_if_notification_is_null() {
+            final Optional<S3EventNotification.S3EventNotificationRecord> actualValue = createObjectUnderTest().filter(null);
+
+            assertThat(actualValue, notNullValue());
+            assertThat(actualValue.isPresent(), equalTo(false));
+        }
+
+
+        @Test
+        void filter_returns_the_notification_when_inner_filter_returns_it() {
+            when(innerFilter.filter(notification)).thenReturn(Optional.of(notification));
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> actualValue = createObjectUnderTest().filter(notification);
+
+            assertThat(actualValue, notNullValue());
+            assertThat(actualValue.isPresent(), equalTo(true));
+            assertThat(actualValue.get(), equalTo(notification));
+        }
+
+        @Test
+        void filter_returns_empty_when_inner_filter_returns_empty() {
+            when(innerFilter.filter(notification)).thenReturn(Optional.empty());
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> actualValue = createObjectUnderTest().filter(notification);
+
+            assertThat(actualValue, notNullValue());
+            assertThat(actualValue.isPresent(), equalTo(false));
+        }
+    }
+
+    @Nested
+    class WithMultipleFilters {
+
+        @BeforeEach
+        void setUp() {
+            innerFilters = IntStream.range(0, 5)
+                    .mapToObj(i -> mock(S3EventFilter.class))
+                    .collect(Collectors.toList());
+        }
+
+        @Test
+        void filter_with_multiple_filters_returns_empty_when_first_filter_is_empty() {
+            final S3EventFilter firstFilter = innerFilters.get(0);
+            when(firstFilter.filter(notification)).thenReturn(Optional.empty());
+
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> actualValue = createObjectUnderTest().filter(notification);
+
+            assertThat(actualValue, notNullValue());
+            assertThat(actualValue.isPresent(), equalTo(false));
+
+            for (int i = 1; i < innerFilters.size(); i++) {
+                final S3EventFilter otherFilters = innerFilters.get(i);
+                verifyNoInteractions(otherFilters);
+            }
+        }
+
+        @Test
+        void filter_with_multiple_filters_returns_empty_when_last_filter_is_empty() {
+            final S3EventFilter firstFilter = innerFilters.get(innerFilters.size() - 1);
+            when(firstFilter.filter(notification)).thenReturn(Optional.empty());
+
+            for (int i = 0; i < innerFilters.size() - 1; i++) {
+                final S3EventFilter otherFilters = innerFilters.get(i);
+                when(otherFilters.filter(notification))
+                        .thenReturn(Optional.of(notification));
+            }
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> actualValue = createObjectUnderTest().filter(notification);
+
+            assertThat(actualValue, notNullValue());
+            assertThat(actualValue.isPresent(), equalTo(false));
+        }
+
+        @Test
+        void filter_with_multiple_filters_returns_the_final_notification() {
+            S3EventNotification.S3EventNotificationRecord previousNotification = notification;
+            for (S3EventFilter innerFilter : innerFilters) {
+                final S3EventNotification.S3EventNotificationRecord nextNotification = mock(S3EventNotification.S3EventNotificationRecord.class);
+                when(innerFilter.filter(previousNotification))
+                        .thenReturn(Optional.of(nextNotification));
+                previousNotification = nextNotification;
+            }
+
+            final Optional<S3EventNotification.S3EventNotificationRecord> actualValue = createObjectUnderTest().filter(notification);
+
+            assertThat(actualValue, notNullValue());
+            assertThat(actualValue.isPresent(), equalTo(true));
+            assertThat(actualValue.get(), equalTo(previousNotification));
+        }
+    }
+}


### PR DESCRIPTION
### Description

Added the following configurations:

* `buckets` - an optional list of buckets to read from
* `account_ids` - an optional list of account Ids to trust for reading buckets.
* `allow_any_account_id` - an optional boolean which will allow reading from any account.

By default, the S3 source will only read from buckets owned by the same account which owns the SQS queue. If any of the above are configured they allow for alternate restrictions on which buckets to read from.
 
### Issues Resolved

Resolves #1463 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
