### PR TITLE
Added delete SQS messages feature to SqsWorker

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3SourceConfig.java
@@ -44,7 +44,7 @@ public class S3SourceConfig {
     private int threadCount;
 
     @JsonProperty("on_error")
-    private OnErrorOption onErrorOption = OnErrorOption.DLQ;
+    private OnErrorOption onErrorOption = OnErrorOption.RETAIN_MESSAGES;
 
     public NotificationTypeOption getNotificationType() {
         return notificationType;

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3SourceConfig.java
@@ -10,6 +10,7 @@ import com.amazon.dataprepper.plugins.source.configuration.CompressionOption;
 import com.amazon.dataprepper.plugins.source.configuration.CodecOption;
 import com.amazon.dataprepper.plugins.source.configuration.SqsOptions;
 import com.amazon.dataprepper.plugins.source.configuration.AwsAuthenticationOptions;
+import com.amazon.dataprepper.plugins.source.configuration.OnErrorOption;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -42,6 +43,9 @@ public class S3SourceConfig {
     @Min(0)
     private int threadCount;
 
+    @JsonProperty("on_error")
+    private OnErrorOption onErrorOption = OnErrorOption.DLQ;
+
     public NotificationTypeOption getNotificationType() {
         return notificationType;
     }
@@ -64,5 +68,9 @@ public class S3SourceConfig {
 
     public int getThreadCount() {
         return threadCount;
+    }
+
+    public OnErrorOption getOnErrorOption() {
+        return onErrorOption;
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsWorker.java
@@ -96,7 +96,6 @@ public class SqsWorker implements Runnable {
         return sqsMessages.stream().collect(Collectors.toMap(message -> message, this::convertS3EventMessages));
     }
 
-    // on_error: delete_from_queue|visibility_expiration
     private List<S3EventNotification.S3EventNotificationRecord> convertS3EventMessages(final Message message) {
         try {
             final S3EventNotification s3EventNotification = S3EventNotification.parseJson(message.body());
@@ -127,8 +126,10 @@ public class SqsWorker implements Runnable {
                 deleteMessageBatchRequestEntryCollection.add(buildDeleteMessageBatchRequestEntry(entry.getKey()));
             }
         }
-        DeleteMessageBatchRequest deleteMessageBatchRequest = buildDeleteMessageBatchRequest(deleteMessageBatchRequestEntryCollection);
-        sqsClient.deleteMessageBatch(deleteMessageBatchRequest);
+        if (!deleteMessageBatchRequestEntryCollection.isEmpty()) {
+            DeleteMessageBatchRequest deleteMessageBatchRequest = buildDeleteMessageBatchRequest(deleteMessageBatchRequestEntryCollection);
+            sqsClient.deleteMessageBatch(deleteMessageBatchRequest);
+        }
     }
 
     private DeleteMessageBatchRequestEntry buildDeleteMessageBatchRequestEntry(Message message) {

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsWorker.java
@@ -5,6 +5,7 @@
 
 package com.amazon.dataprepper.plugins.source;
 
+import com.amazon.dataprepper.plugins.source.configuration.OnErrorOption;
 import com.amazon.dataprepper.plugins.source.configuration.SqsOptions;
 import com.amazon.dataprepper.plugins.source.filter.ObjectCreatedFilter;
 import com.amazon.dataprepper.plugins.source.filter.S3EventFilter;
@@ -13,10 +14,13 @@ import com.amazonaws.services.s3.event.S3EventNotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SqsException;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -110,16 +114,35 @@ public class SqsWorker implements Runnable {
     }
 
     private void processS3ObjectAndDeleteSqsMessages(final Map<Message, List<S3EventNotification.S3EventNotificationRecord>> s3EventNotificationRecords) {
+        List<DeleteMessageBatchRequestEntry> deleteMessageBatchRequestEntryCollection = new ArrayList<>();
         for (Map.Entry<Message, List<S3EventNotification.S3EventNotificationRecord>> entry: s3EventNotificationRecords.entrySet()) {
             if (entry.getValue().isEmpty()) {
-                // TODO: delete or ignore based on configuration
+                if (s3SourceConfig.getOnErrorOption().equals(OnErrorOption.DELETE_MESSAGES)) {
+                    deleteMessageBatchRequestEntryCollection.add(buildDeleteMessageBatchRequestEntry(entry.getKey()));
+                }
             }
             else if (isEventNameCreated(entry.getValue().get(0))) {
                 final S3ObjectReference s3ObjectReference = populateS3Reference(entry.getValue().get(0));
                 s3Service.addS3Object(s3ObjectReference);
-                // TODO: delete sqsMessages which are successfully processed
+                deleteMessageBatchRequestEntryCollection.add(buildDeleteMessageBatchRequestEntry(entry.getKey()));
             }
         }
+        DeleteMessageBatchRequest deleteMessageBatchRequest = buildDeleteMessageBatchRequest(deleteMessageBatchRequestEntryCollection);
+        sqsClient.deleteMessageBatch(deleteMessageBatchRequest);
+    }
+
+    private DeleteMessageBatchRequestEntry buildDeleteMessageBatchRequestEntry(Message message) {
+        return DeleteMessageBatchRequestEntry.builder()
+                .id(message.messageId())
+                .receiptHandle(message.receiptHandle())
+                .build();
+    }
+
+    private DeleteMessageBatchRequest buildDeleteMessageBatchRequest(List<DeleteMessageBatchRequestEntry> deleteMessageBatchRequestEntryCollection) {
+        return DeleteMessageBatchRequest.builder()
+                .queueUrl(s3SourceConfig.getSqsOptions().getSqsUrl())
+                .entries(deleteMessageBatchRequestEntryCollection)
+                .build();
     }
 
     private boolean isEventNameCreated(final S3EventNotification.S3EventNotificationRecord s3EventNotificationRecord) {

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/configuration/OnErrorOption.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/configuration/OnErrorOption.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.configuration;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public enum OnErrorOption {
+    DELETE_MESSAGES("delete_messages"),
+    DLQ("dlq");
+
+    private static final Map<String, OnErrorOption> OPTIONS_MAP = Arrays.stream(OnErrorOption.values())
+            .collect(Collectors.toMap(
+                    value -> value.option,
+                    value -> value
+            ));
+
+    private final String option;
+
+    OnErrorOption(final String option) {
+        this.option = option.toLowerCase();
+    }
+
+    @JsonCreator
+    static OnErrorOption fromOptionValue(final String option) {
+        return OPTIONS_MAP.get(option.toLowerCase());
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/configuration/OnErrorOption.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/configuration/OnErrorOption.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 
 public enum OnErrorOption {
     DELETE_MESSAGES("delete_messages"),
-    DLQ("dlq");
+    RETAIN_MESSAGES("retain_messages");
 
     private static final Map<String, OnErrorOption> OPTIONS_MAP = Arrays.stream(OnErrorOption.values())
             .collect(Collectors.toMap(

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/configuration/OnErrorOption.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/configuration/OnErrorOption.java
@@ -24,11 +24,11 @@ public enum OnErrorOption {
     private final String option;
 
     OnErrorOption(final String option) {
-        this.option = option.toLowerCase();
+        this.option = option;
     }
 
     @JsonCreator
     static OnErrorOption fromOptionValue(final String option) {
-        return OPTIONS_MAP.get(option.toLowerCase());
+        return OPTIONS_MAP.get(option);
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsWorkerTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -113,7 +114,7 @@ class SqsWorkerTest {
 
         assertThat(messagesProcessed, equalTo(1));
         verifyNoInteractions(s3Service);
-        verify(sqsClient, times(0)).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
+        verify(sqsClient, never()).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
     }
 
     @Test
@@ -121,7 +122,7 @@ class SqsWorkerTest {
         when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenThrow(SqsException.class);
         final int messagesProcessed = sqsWorker.processSqsMessages();
         assertThat(messagesProcessed, equalTo(0));
-        verify(sqsClient, times(0)).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
+        verify(sqsClient, never()).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
     }
 
     @ParameterizedTest
@@ -137,7 +138,7 @@ class SqsWorkerTest {
         final int messagesProcessed = sqsWorker.processSqsMessages();
         assertThat(messagesProcessed, equalTo(1));
         verifyNoInteractions(s3Service);
-        verify(sqsClient, times(0)).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
+        verify(sqsClient, never()).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
     }
 
     @ParameterizedTest
@@ -153,7 +154,7 @@ class SqsWorkerTest {
         final int messagesProcessed = sqsWorker.processSqsMessages();
         assertThat(messagesProcessed, equalTo(1));
         verifyNoInteractions(s3Service);
-        verify(sqsClient, times(0)).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
+        verify(sqsClient, never()).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
     }
 
     @ParameterizedTest

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/configuration/OnErrorOptionTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/configuration/OnErrorOptionTest.java
@@ -15,7 +15,7 @@ class OnErrorOptionTest {
     @ParameterizedTest
     @EnumSource(OnErrorOption.class)
     void fromOptionValue(final OnErrorOption option) {
-        assertThat(OnErrorOption.fromOptionValue(option.name()), is(option));
+        assertThat(OnErrorOption.fromOptionValue(option.name().toLowerCase()), is(option));
     }
 
 }

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/configuration/OnErrorOptionTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/configuration/OnErrorOptionTest.java
@@ -15,8 +15,6 @@ class OnErrorOptionTest {
     @ParameterizedTest
     @EnumSource(OnErrorOption.class)
     void fromOptionValue(final OnErrorOption option) {
-        System.out.println(option);
-        System.out.println(OnErrorOption.fromOptionValue(option.name()));
         assertThat(OnErrorOption.fromOptionValue(option.name()), is(option));
     }
 

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/configuration/OnErrorOptionTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/configuration/OnErrorOptionTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.configuration;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class OnErrorOptionTest {
+    @ParameterizedTest
+    @EnumSource(OnErrorOption.class)
+    void fromOptionValue(final OnErrorOption option) {
+        System.out.println(option);
+        System.out.println(OnErrorOption.fromOptionValue(option.name()));
+        assertThat(OnErrorOption.fromOptionValue(option.name()), is(option));
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description

- Added support to delete processed SQS messages
- Added on_error configuration which will be used to look for DLQ if enabled and not delete failed messages

 
### Issues Resolved
Resolves #1425 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
