### PR TITLE
Moved Hamcrest and Awaitility dependencies to the root project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,8 @@ subprojects {
         testImplementation 'org.junit.vintage:junit-vintage-engine'
         testImplementation "org.mockito:mockito-core:${versionMap.mockito}"
         testImplementation "org.mockito:mockito-junit-jupiter:${versionMap.mockito}"
+        testImplementation 'org.hamcrest:hamcrest:2.2'
+        testImplementation 'org.awaitility:awaitility:4.2.0'
         constraints {
             implementation('org.apache.httpcomponents:httpclient') {
                 version {

--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    testImplementation 'org.hamcrest:hamcrest:2.2'
     implementation "org.apache.commons:commons-lang3:3.12.0"
     testImplementation project(':data-prepper-test-common')
 }

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     }
     implementation 'software.amazon.cloudwatchlogs:aws-embedded-metrics:2.0.0-beta-1'
     testImplementation 'org.springframework:spring-test:5.3.20'
-    testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
 }
 

--- a/data-prepper-logstash-configuration/build.gradle
+++ b/data-prepper-logstash-configuration/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation "org.apache.commons:commons-lang3:3.12.0"
     testImplementation 'org.slf4j:slf4j-simple:1.7.36'
-    testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
 }
 

--- a/data-prepper-plugins/aggregate-processor/build.gradle
+++ b/data-prepper-plugins/aggregate-processor/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     implementation project(':data-prepper-plugins:common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'
-    testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
 }
 

--- a/data-prepper-plugins/common/build.gradle
+++ b/data-prepper-plugins/common/build.gradle
@@ -19,7 +19,6 @@ dependencies {
     implementation 'org.reflections:reflections:0.10.2'
     testImplementation project(':data-prepper-plugins:blocking-buffer')
     testImplementation 'commons-io:commons-io:2.11.0'
-    testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
 }
 

--- a/data-prepper-plugins/date-processor/build.gradle
+++ b/data-prepper-plugins/date-processor/build.gradle
@@ -13,5 +13,4 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
-    testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/data-prepper-plugins/grok-prepper/build.gradle
+++ b/data-prepper-plugins/grok-prepper/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation "io.krakens:java-grok:0.1.9"
     implementation 'io.micrometer:micrometer-core'
-    testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
     testImplementation project(':data-prepper-test-common')
 }

--- a/data-prepper-plugins/http-source/build.gradle
+++ b/data-prepper-plugins/http-source/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation "commons-io:commons-io:2.11.0"
     testImplementation project(':data-prepper-api').sourceSets.test.output
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation "org.hamcrest:hamcrest:2.2"
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/mapdb-prepper-state/build.gradle
+++ b/data-prepper-plugins/mapdb-prepper-state/build.gradle
@@ -20,7 +20,6 @@ dependencies {
 
     testImplementation project(':data-prepper-plugins:common').sourceSets.test.output
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.hamcrest:hamcrest:2.2'
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     implementation 'software.amazon.awssdk:url-connection-client'
     implementation 'software.amazon.awssdk:arns'
     implementation 'io.micrometer:micrometer-core'
-    testImplementation 'org.awaitility:awaitility:4.1.1'
     testImplementation 'commons-io:commons-io:2.11.0'
     testImplementation 'net.bytebuddy:byte-buddy:1.12.8'
     testImplementation 'net.bytebuddy:byte-buddy-agent:1.11.20'

--- a/data-prepper-plugins/otel-metrics-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-metrics-raw-processor/build.gradle
@@ -22,8 +22,6 @@ dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
-    testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "org.awaitility:awaitility:4.2.0"
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/otel-metrics-source/build.gradle
+++ b/data-prepper-plugins/otel-metrics-source/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     implementation "org.bouncycastle:bcpkix-jdk15on:1.69"
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
-    testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation("commons-io:commons-io:2.10.0")
 }
 

--- a/data-prepper-plugins/otel-proto-common/build.gradle
+++ b/data-prepper-plugins/otel-proto-common/build.gradle
@@ -15,5 +15,4 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation "org.apache.commons:commons-lang3:3.12.0"
     implementation 'commons-codec:commons-codec:1.15'
-    testImplementation "org.hamcrest:hamcrest:2.2"
 }

--- a/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
@@ -21,8 +21,6 @@ dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
-    testImplementation 'org.hamcrest:hamcrest:2.2'
-    testImplementation 'org.awaitility:awaitility:4.2.0'
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/otel-trace-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-processor/build.gradle
@@ -21,8 +21,6 @@ dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
-    testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "org.awaitility:awaitility:4.2.0"
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation "org.bouncycastle:bcpkix-jdk15on:1.70"
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
-    testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation("commons-io:commons-io:2.10.0")
 }
 

--- a/data-prepper-plugins/peer-forwarder/build.gradle
+++ b/data-prepper-plugins/peer-forwarder/build.gradle
@@ -28,10 +28,8 @@ dependencies {
     implementation "org.apache.commons:commons-lang3:3.12.0"
     implementation 'commons-codec:commons-codec:1.15'
     implementation "commons-validator:commons-validator:1.7"
-    testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
     testImplementation "commons-io:commons-io:2.10.0"
-    testImplementation 'org.awaitility:awaitility:4.2.0'
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     implementation 'software.amazon.awssdk:sts'
     implementation 'software.amazon.awssdk:sqs'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.220'
-    testImplementation 'org.hamcrest:hamcrest:2.2'
 }
 
 test {

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetryProto}"
-    testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
 }
 


### PR DESCRIPTION
### Description

Moved two common test dependencies of ours into the root project so that they need only be defined in one location for most tests. I did not change the end-to-end tests.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
