### PR TITLE
New metrics on the S3 source - Succeeded Count and Read Time Elapsed

### DIFF
--- a/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerIT.java
@@ -13,6 +13,10 @@ import com.amazon.dataprepper.plugins.source.codec.Codec;
 import com.amazon.dataprepper.plugins.source.compression.CompressionEngine;
 import com.amazon.dataprepper.plugins.source.compression.NoneCompressionEngine;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.noop.NoopTimer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,7 +34,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import static com.amazon.dataprepper.plugins.source.S3ObjectWorker.S3_OBJECTS_FAILED_METRIC_NAME;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,6 +41,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -69,7 +73,9 @@ class S3ObjectWorkerIT {
 
         pluginMetrics = mock(PluginMetrics.class);
         final Counter counter = mock(Counter.class);
-        when(pluginMetrics.counter(S3_OBJECTS_FAILED_METRIC_NAME)).thenReturn(counter);
+        final Timer timer = new NoopTimer(new Meter.Id("test", Tags.empty(), null, null, Meter.Type.TIMER));
+        when(pluginMetrics.counter(anyString())).thenReturn(counter);
+        when(pluginMetrics.timer(anyString())).thenReturn(timer);
     }
 
     private void stubBufferWriter(final Consumer<Event> additionalEventAssertions) throws Exception {

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerTest.java
@@ -88,7 +88,7 @@ class S3ObjectWorkerTest {
     private Exception exceptionThrownByCallable;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         final Random random = new Random();
         bufferTimeout = Duration.ofMillis(random.nextInt(100) + 100);
         recordsToAccumulate = random.nextInt(10) + 2;
@@ -99,7 +99,7 @@ class S3ObjectWorkerTest {
         when(s3ObjectReference.getKey()).thenReturn(key);
 
         exceptionThrownByCallable = null;
-        when(s3ObjectReadTimer.wrap(any(Callable.class)))
+        when(s3ObjectReadTimer.recordCallable(any(Callable.class)))
                 .thenAnswer(a -> {
                     try {
                         a.getArgument(0, Callable.class).call();
@@ -296,7 +296,7 @@ class S3ObjectWorkerTest {
     }
 
     @Test
-    void parseS3Object_calls_GetObject_after_Callable() throws IOException {
+    void parseS3Object_calls_GetObject_after_Callable() throws Exception {
         final ResponseInputStream<GetObjectResponse> objectInputStream = mock(ResponseInputStream.class);
         when(s3Client.getObject(any(GetObjectRequest.class)))
                 .thenReturn(objectInputStream);
@@ -306,7 +306,7 @@ class S3ObjectWorkerTest {
 
         final InOrder inOrder = inOrder(s3ObjectReadTimer, s3Client);
 
-        inOrder.verify(s3ObjectReadTimer).wrap(any(Callable.class));
+        inOrder.verify(s3ObjectReadTimer).recordCallable(any(Callable.class));
         inOrder.verify(s3Client).getObject(any(GetObjectRequest.class));
     }
 }


### PR DESCRIPTION
### Description

Two new metrics for the S3 Source:

* `s3ObjectsSucceeded` - Counter for each S3 Object which is successfully parsed.
* `s3ObjectReadTimeElapsed` - A timer to track how long reading S3 objects takes.

These are the last metrics I expect to add to the S3 Source related to S3 itself. There is another issue - #1501 - to track metrics more directly related to SQS.
 
### Issues Resolved

Resolves #1464 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
