### PR TITLE
Updated to Spotless 6.7.1 and removed JDK 17 work-around.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.diffplug.spotless' version '6.6.1'
+    id 'com.diffplug.spotless' version '6.7.1'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,3 @@
 #
 
 version=1.5.0-SNAPSHOT
-
-# Work-around for a Spotless Gradle issue:
-# https://github.com/diffplug/spotless/issues/834#issuecomment-819118761
-org.gradle.jvmargs=\
-  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED


### PR DESCRIPTION
### Description

Spotless 6.7.1 fixes an issue which made it incompatible with JDK 17. There was previously a work-around (which was applied in Data Prepper). This PR updates to the latest version of Spotless for Gradle and removes that old work-around.

https://github.com/diffplug/spotless/issues/834#issuecomment-1152635256
 
For reference, the previous PR which added the work-around was #1430.

### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
