### PR TITLE
Updated the AWS SDK v2 to 2.17.209

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ subprojects {
 
 configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
     dependencies {
-        implementation platform('software.amazon.awssdk:bom:2.17.15')
+        implementation platform('software.amazon.awssdk:bom:2.17.209')
         implementation 'jakarta.validation:jakarta.validation-api:3.0.1'
     }
 }


### PR DESCRIPTION
### Description

Updates the AWS SDK v2 to 2.17.209. Previously, Data Prepper was not able to update this version due to a conflict with Netty and Armeria.
 
### Issues Resolved

Resolves #924 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
