### PR TITLE
Performance Test compile GitHub Actions workflow clean-up

### DIFF
--- a/.github/workflows/performance-test-compile.yml
+++ b/.github/workflows/performance-test-compile.yml
@@ -1,12 +1,18 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Data Prepper Performance Tests Compile
+name: Performance Tests Compile
 
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'performance-test/**'
+      - '*gradle*'
   pull_request:
+    paths:
+      - 'performance-test/**'
+      - '*gradle*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Description

These tests run on all PRs, but they really are needed often. I added a path filter which only runs when either: 1) The performance-test directory changes, or 2) the overall Gradle project changes.

Also, this PR shortens the name somewhat since our current names have some noise in them. If this looks good, I'd probably want to change the end-to-end tests as well.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
