### PR TITLE
Validate bucket ownership when loading an object from S3

### DIFF
--- a/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerIT.java
@@ -116,7 +116,7 @@ class S3ObjectWorkerIT {
     }
 
     private void parseObject(final String key, final S3ObjectWorker objectUnderTest) throws IOException {
-        final S3ObjectReference s3ObjectReference = S3ObjectReference.fromBucketAndKey(bucket, key);
+        final S3ObjectReference s3ObjectReference = S3ObjectReference.bucketAndKey(bucket, key).build();
         objectUnderTest.parseS3Object(s3ObjectReference);
     }
 

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectReference.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectReference.java
@@ -6,6 +6,7 @@
 package com.amazon.dataprepper.plugins.source;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Reference to an S3 object.
@@ -13,17 +14,18 @@ import java.util.Objects;
 class S3ObjectReference {
     private final String bucketName;
     private final String key;
+    private final String owner;
 
-    private S3ObjectReference(final String bucketName, final String key) {
-        Objects.requireNonNull(bucketName, "bucketName must be non null");
-        Objects.requireNonNull(key, "key must be non null");
-
+    private S3ObjectReference(final String bucketName, final String key, final String owner) {
         this.bucketName = bucketName;
         this.key = key;
+        this.owner = owner;
     }
 
-    static S3ObjectReference fromBucketAndKey(final String bucketName, final String key) {
-        return new S3ObjectReference(bucketName, key);
+    static Builder bucketAndKey(final String bucketName, final String key) {
+        Objects.requireNonNull(bucketName, "bucketName must be non null");
+        Objects.requireNonNull(key, "key must be non null");
+        return new Builder(bucketName, key);
     }
 
     String getBucketName() {
@@ -37,5 +39,30 @@ class S3ObjectReference {
     @Override
     public String toString() {
         return "[bucketName=" + bucketName + ", key=" + key + "]";
+    }
+
+    public Optional<String> getBucketOwner() {
+        return Optional.ofNullable(owner);
+    }
+
+    public static final class Builder {
+
+        private final String bucketName;
+        private final String key;
+        private String owner;
+
+        public Builder(final String bucketName, final String key) {
+            this.bucketName = bucketName;
+            this.key = key;
+        }
+
+        Builder owner(final String owner) {
+            this.owner = owner;
+            return this;
+        }
+
+        S3ObjectReference build() {
+            return new S3ObjectReference(bucketName, key, owner);
+        }
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectReference.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectReference.java
@@ -36,13 +36,13 @@ class S3ObjectReference {
         return key;
     }
 
+    Optional<String> getBucketOwner() {
+        return Optional.ofNullable(owner);
+    }
+
     @Override
     public String toString() {
         return "[bucketName=" + bucketName + ", key=" + key + "]";
-    }
-
-    public Optional<String> getBucketOwner() {
-        return Optional.ofNullable(owner);
     }
 
     public static final class Builder {

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectReference.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectReference.java
@@ -51,17 +51,17 @@ class S3ObjectReference {
         private final String key;
         private String owner;
 
-        public Builder(final String bucketName, final String key) {
+        private Builder(final String bucketName, final String key) {
             this.bucketName = bucketName;
             this.key = key;
         }
 
-        Builder owner(final String owner) {
+        public Builder owner(final String owner) {
             this.owner = owner;
             return this;
         }
 
-        S3ObjectReference build() {
+        public S3ObjectReference build() {
             return new S3ObjectReference(bucketName, key, owner);
         }
     }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectWorker.java
@@ -57,9 +57,11 @@ class S3ObjectWorker {
     }
 
     void parseS3Object(final S3ObjectReference s3ObjectReference) throws IOException {
-        final GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+        final GetObjectRequest.Builder getObjectBuilder = GetObjectRequest.builder()
                 .bucket(s3ObjectReference.getBucketName())
-                .key(s3ObjectReference.getKey())
+                .key(s3ObjectReference.getKey());
+        s3ObjectReference.getBucketOwner().ifPresent(getObjectBuilder::expectedBucketOwner);
+        final GetObjectRequest getObjectRequest = getObjectBuilder
                 .build();
 
         final BufferAccumulator<Record<Event>> bufferAccumulator = BufferAccumulator.create(buffer, numberOfRecordsToAccumulate, bufferTimeout);

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsWorker.java
@@ -152,7 +152,10 @@ public class SqsWorker implements Runnable {
     }
 
     private S3ObjectReference populateS3Reference(final S3EventNotification.S3EventNotificationRecord s3EventNotificationRecord) {
-        return S3ObjectReference.fromBucketAndKey(s3EventNotificationRecord.getS3().getBucket().getName(),
-                s3EventNotificationRecord.getS3().getObject().getKey());
+        final S3EventNotification.S3Entity s3Entity = s3EventNotificationRecord.getS3();
+        return S3ObjectReference.bucketAndKey(s3Entity.getBucket().getName(),
+                s3Entity.getObject().getKey())
+                .owner(s3Entity.getBucket().getOwnerIdentity().getPrincipalId())
+                .build();
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3ObjectReferenceTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3ObjectReferenceTest.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -27,26 +28,43 @@ class S3ObjectReferenceTest {
     }
 
     @Test
-    void fromBucketAndKey_throws_with_null_bucketName() {
-        assertThrows(NullPointerException.class, () -> S3ObjectReference.fromBucketAndKey(null, key));
+    void bucketAndKey_throws_with_null_bucketName() {
+        assertThrows(NullPointerException.class, () -> S3ObjectReference.bucketAndKey(null, key));
     }
 
     @Test
-    void fromBucketAndKey_throws_with_null_key() {
-        assertThrows(NullPointerException.class, () -> S3ObjectReference.fromBucketAndKey(bucketName, null));
+    void bucketAndKey_throws_with_null_key() {
+        assertThrows(NullPointerException.class, () -> S3ObjectReference.bucketAndKey(bucketName, null));
     }
 
     @Test
-    void fromBucketAndKey_creates_object_with_correct_values() {
-        final S3ObjectReference objectUnderTest = S3ObjectReference.fromBucketAndKey(bucketName, key);
+    void build_creates_object_with_correct_values() {
+        final S3ObjectReference objectUnderTest = S3ObjectReference.bucketAndKey(bucketName, key).build();
 
         assertThat(objectUnderTest.getBucketName(), equalTo(bucketName));
         assertThat(objectUnderTest.getKey(), equalTo(key));
+        assertThat(objectUnderTest.getBucketOwner(), notNullValue());
+        assertThat(objectUnderTest.getBucketOwner().isPresent(), equalTo(false));
+    }
+
+    @Test
+    void build_creates_object_with_correct_values_when_owner_is_provided() {
+        final String owner = UUID.randomUUID().toString();
+        final S3ObjectReference objectUnderTest = S3ObjectReference
+                .bucketAndKey(bucketName, key)
+                .owner(owner)
+                .build();
+
+        assertThat(objectUnderTest.getBucketName(), equalTo(bucketName));
+        assertThat(objectUnderTest.getKey(), equalTo(key));
+        assertThat(objectUnderTest.getBucketOwner(), notNullValue());
+        assertThat(objectUnderTest.getBucketOwner().isPresent(), equalTo(true));
+        assertThat(objectUnderTest.getBucketOwner().get(), equalTo(owner));
     }
 
     @Test
     void toString_returns_string_with_bucket_and_key() {
-        final S3ObjectReference objectUnderTest = S3ObjectReference.fromBucketAndKey(bucketName, key);
+        final S3ObjectReference objectUnderTest = S3ObjectReference.bucketAndKey(bucketName, key).build();
 
         assertThat(objectUnderTest.toString(), containsString(bucketName));
         assertThat(objectUnderTest.toString(), containsString(key));


### PR DESCRIPTION
### Description

When performing a request to GetObject in the S3 source, add the bucket owner from the S3 Event in the `x-amz-expected-bucket-owner` header. S3 will reject the request with a 403 Forbidden if the bucket is not owned by the expected account.
 
This is a draft currently because it will need to be merged with other upcoming PRs. But, I want to get any early feedback on the overall approach.

### Issues Resolved

Resolves #1463 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
