### PR TITLE
Updated call to s3 object worker

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3Service.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3Service.java
@@ -40,7 +40,7 @@ public class S3Service {
         this.s3Client = createS3Client(StsClient.create());
         this.compressionEngine = s3SourceConfig.getCompression().getEngine();
         this.s3ObjectWorker = new S3ObjectWorker(s3Client, buffer, compressionEngine, codec,
-                s3SourceConfig.getRequestTimeout(), s3SourceConfig.getNumberOfRecordsToAccumulate(), pluginMetrics);
+                s3SourceConfig.getBufferTimeout(), s3SourceConfig.getNumberOfRecordsToAccumulate(), pluginMetrics);
     }
 
     void addS3Object(final S3ObjectReference s3ObjectReference) {

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3Service.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3Service.java
@@ -5,10 +5,12 @@
 
 package com.amazon.dataprepper.plugins.source;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.buffer.Buffer;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.source.codec.Codec;
+import com.amazon.dataprepper.plugins.source.compression.CompressionEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
@@ -17,6 +19,8 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.sts.StsClient;
 
+import java.io.IOException;
+
 public class S3Service {
     private static final Logger LOG = LoggerFactory.getLogger(S3Service.class);
 
@@ -24,24 +28,34 @@ public class S3Service {
     private final Buffer<Record<Event>> buffer;
     private final S3Client s3Client;
     private final Codec codec;
+    private final CompressionEngine compressionEngine;
+    private final PluginMetrics pluginMetrics;
+    private final S3ObjectWorker s3ObjectWorker;
 
-    public S3Service(final S3SourceConfig s3SourceConfig,  Buffer<Record<Event>> buffer, Codec codec) {
+    public S3Service(final S3SourceConfig s3SourceConfig, Buffer<Record<Event>> buffer, Codec codec, PluginMetrics pluginMetrics) {
         this.s3SourceConfig = s3SourceConfig;
         this.buffer = buffer;
         this.codec = codec;
+        this.pluginMetrics = pluginMetrics;
         this.s3Client = createS3Client(StsClient.create());
+        this.compressionEngine = s3SourceConfig.getCompression().getEngine();
+        this.s3ObjectWorker = new S3ObjectWorker(s3Client, buffer, compressionEngine, codec,
+                s3SourceConfig.getRequestTimeout(), s3SourceConfig.getNumberOfRecordsToAccumulate(), pluginMetrics);
     }
 
-    S3ObjectReference addS3Object(final S3ObjectReference s3ObjectReference) {
-        // TODO: should return message id and receipt handle if successfully converted to event
-        return null;
+    void addS3Object(final S3ObjectReference s3ObjectReference) {
+        try {
+            s3ObjectWorker.parseS3Object(s3ObjectReference);
+        } catch (IOException e) {
+            LOG.error("Unable to read S3 object from S3ObjectReference = {}", s3ObjectReference, e);
+        }
     }
 
     S3Client createS3Client(final StsClient stsClient) {
         LOG.info("Creating S3 client");
         return S3Client.builder()
-                .region(Region.of(s3SourceConfig.getAWSAuthenticationOptions().getAwsRegion()))
-                .credentialsProvider(s3SourceConfig.getAWSAuthenticationOptions().authenticateAwsConfiguration(stsClient))
+                .region(Region.of(s3SourceConfig.getAwsAuthenticationOptions().getAwsRegion()))
+                .credentialsProvider(s3SourceConfig.getAwsAuthenticationOptions().authenticateAwsConfiguration(stsClient))
                 .overrideConfiguration(ClientOverrideConfiguration.builder()
                         .retryPolicy(RetryPolicy.builder().numRetries(5).build())
                         .build())

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3Source.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3Source.java
@@ -16,12 +16,9 @@ import com.amazon.dataprepper.model.plugin.PluginFactory;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.source.Source;
 import com.amazon.dataprepper.plugins.source.codec.Codec;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @DataPrepperPlugin(name = "s3", pluginType = Source.class, pluginConfigurationType = S3SourceConfig.class)
 public class S3Source implements Source<Record<Event>> {
-    private static final Logger LOG = LoggerFactory.getLogger(S3Source.class);
 
     private final PluginMetrics pluginMetrics;
     private final S3SourceConfig s3SourceConfig;
@@ -45,7 +42,7 @@ public class S3Source implements Source<Record<Event>> {
             throw new IllegalStateException("Buffer provided is null");
         }
 
-        S3Service s3Service = new S3Service(s3SourceConfig, buffer, codec);
+        S3Service s3Service = new S3Service(s3SourceConfig, buffer, codec, pluginMetrics);
         sqsService = new SqsService(s3SourceConfig, s3Service);
 
         sqsService.start();

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3SourceConfig.java
@@ -13,10 +13,13 @@ import com.amazon.dataprepper.plugins.source.configuration.AwsAuthenticationOpti
 import com.amazon.dataprepper.plugins.source.configuration.OnErrorOption;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.Duration;
+
 public class S3SourceConfig {
+    static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofMillis(10_000);
+    static final int DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE = 100;
 
     @JsonProperty("notification_type")
     @NotNull
@@ -38,12 +41,14 @@ public class S3SourceConfig {
     @Valid
     private AwsAuthenticationOptions awsAuthenticationOptions;
 
-    @JsonProperty("thread_count")
-    @Min(0)
-    private int threadCount;
-
     @JsonProperty("on_error")
     private OnErrorOption onErrorOption = OnErrorOption.RETAIN_MESSAGES;
+
+    @JsonProperty("request_timeout")
+    private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+
+    @JsonProperty("records_to_accumulate")
+    private int numberOfRecordsToAccumulate = DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE;
 
     public NotificationTypeOption getNotificationType() {
         return notificationType;
@@ -61,15 +66,19 @@ public class S3SourceConfig {
         return sqsOptions;
     }
 
-    public AwsAuthenticationOptions getAWSAuthenticationOptions() {
+    public AwsAuthenticationOptions getAwsAuthenticationOptions() {
         return awsAuthenticationOptions;
-    }
-
-    public int getThreadCount() {
-        return threadCount;
     }
 
     public OnErrorOption getOnErrorOption() {
         return onErrorOption;
+    }
+
+    public Duration getRequestTimeout() {
+        return requestTimeout;
+    }
+
+    public int getNumberOfRecordsToAccumulate() {
+        return numberOfRecordsToAccumulate;
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3SourceConfig.java
@@ -18,7 +18,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
 
 public class S3SourceConfig {
-    static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofMillis(10_000);
+    static final Duration DEFAULT_BUFFER_TIMEOUT = Duration.ofSeconds(10);
     static final int DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE = 100;
 
     @JsonProperty("notification_type")
@@ -44,8 +44,8 @@ public class S3SourceConfig {
     @JsonProperty("on_error")
     private OnErrorOption onErrorOption = OnErrorOption.RETAIN_MESSAGES;
 
-    @JsonProperty("request_timeout")
-    private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+    @JsonProperty("buffer_timeout")
+    private Duration bufferTimeout = DEFAULT_BUFFER_TIMEOUT;
 
     @JsonProperty("records_to_accumulate")
     private int numberOfRecordsToAccumulate = DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE;
@@ -74,8 +74,8 @@ public class S3SourceConfig {
         return onErrorOption;
     }
 
-    public Duration getRequestTimeout() {
-        return requestTimeout;
+    public Duration getBufferTimeout() {
+        return bufferTimeout;
     }
 
     public int getNumberOfRecordsToAccumulate() {

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsService.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsService.java
@@ -36,8 +36,8 @@ public class SqsService {
     SqsClient createSqsClient(final StsClient stsClient) {
         LOG.info("Creating SQS client");
         return SqsClient.builder()
-                .region(Region.of(s3SourceConfig.getAWSAuthenticationOptions().getAwsRegion()))
-                .credentialsProvider(s3SourceConfig.getAWSAuthenticationOptions().authenticateAwsConfiguration(stsClient))
+                .region(Region.of(s3SourceConfig.getAwsAuthenticationOptions().getAwsRegion()))
+                .credentialsProvider(s3SourceConfig.getAwsAuthenticationOptions().authenticateAwsConfiguration(stsClient))
                 .overrideConfiguration(ClientOverrideConfiguration.builder()
                         .retryPolicy(RetryPolicy.builder().numRetries(5).build())
                         .build())

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/configuration/CompressionOption.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/configuration/CompressionOption.java
@@ -5,6 +5,10 @@
 
 package com.amazon.dataprepper.plugins.source.configuration;
 
+import com.amazon.dataprepper.plugins.source.compression.AutomaticCompressionEngine;
+import com.amazon.dataprepper.plugins.source.compression.CompressionEngine;
+import com.amazon.dataprepper.plugins.source.compression.GZipCompressionEngine;
+import com.amazon.dataprepper.plugins.source.compression.NoneCompressionEngine;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import java.util.Arrays;
@@ -12,9 +16,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public enum CompressionOption {
-    NONE("none"),
-    GZIP("gzip"),
-    AUTOMATIC("automatic");
+    NONE("none", new NoneCompressionEngine()),
+    GZIP("gzip", new GZipCompressionEngine()),
+    AUTOMATIC("automatic", new AutomaticCompressionEngine());
 
     private static final Map<String, CompressionOption> OPTIONS_MAP = Arrays.stream(CompressionOption.values())
             .collect(Collectors.toMap(
@@ -24,8 +28,15 @@ public enum CompressionOption {
 
     private final String option;
 
-    CompressionOption(final String option) {
+    private final CompressionEngine engine;
+
+    CompressionOption(final String option, final CompressionEngine engine) {
         this.option = option.toLowerCase();
+        this.engine = engine;
+    }
+
+    public CompressionEngine getEngine() {
+        return engine;
     }
 
     @JsonCreator

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3SourceConfigTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3SourceConfigTest.java
@@ -6,8 +6,11 @@
 package com.amazon.dataprepper.plugins.source;
 
 import com.amazon.dataprepper.plugins.source.configuration.CompressionOption;
+import com.amazon.dataprepper.plugins.source.configuration.OnErrorOption;
 import org.junit.jupiter.api.Test;
 
+import static com.amazon.dataprepper.plugins.source.S3SourceConfig.DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE;
+import static com.amazon.dataprepper.plugins.source.S3SourceConfig.DEFAULT_REQUEST_TIMEOUT;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -16,5 +19,20 @@ class S3SourceConfigTest {
     @Test
     void default_compression_test() {
         assertThat(new S3SourceConfig().getCompression(), equalTo(CompressionOption.NONE));
+    }
+
+    @Test
+    void default_on_error_test() {
+        assertThat(new S3SourceConfig().getOnErrorOption(), equalTo(OnErrorOption.RETAIN_MESSAGES));
+    }
+
+    @Test
+    void default_request_timeout_test() {
+        assertThat(new S3SourceConfig().getRequestTimeout(), equalTo(DEFAULT_REQUEST_TIMEOUT));
+    }
+
+    @Test
+    void default_records_to_accumulate_test() {
+        assertThat(new S3SourceConfig().getNumberOfRecordsToAccumulate(), equalTo(DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE));
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3SourceConfigTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3SourceConfigTest.java
@@ -10,7 +10,7 @@ import com.amazon.dataprepper.plugins.source.configuration.OnErrorOption;
 import org.junit.jupiter.api.Test;
 
 import static com.amazon.dataprepper.plugins.source.S3SourceConfig.DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE;
-import static com.amazon.dataprepper.plugins.source.S3SourceConfig.DEFAULT_REQUEST_TIMEOUT;
+import static com.amazon.dataprepper.plugins.source.S3SourceConfig.DEFAULT_BUFFER_TIMEOUT;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -28,7 +28,7 @@ class S3SourceConfigTest {
 
     @Test
     void default_request_timeout_test() {
-        assertThat(new S3SourceConfig().getRequestTimeout(), equalTo(DEFAULT_REQUEST_TIMEOUT));
+        assertThat(new S3SourceConfig().getBufferTimeout(), equalTo(DEFAULT_BUFFER_TIMEOUT));
     }
 
     @Test

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsWorkerTest.java
@@ -57,7 +57,7 @@ class SqsWorkerTest {
         SqsOptions sqsOptions = mock(SqsOptions.class);
         when(sqsOptions.getSqsUrl()).thenReturn("https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue");
 
-        when(s3SourceConfig.getAWSAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
+        when(s3SourceConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
         when(s3SourceConfig.getSqsOptions()).thenReturn(sqsOptions);
         when(s3SourceConfig.getOnErrorOption()).thenReturn(OnErrorOption.RETAIN_MESSAGES);
 

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/configuration/CompressionOptionTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/configuration/CompressionOptionTest.java
@@ -5,9 +5,11 @@
 
 package com.amazon.dataprepper.plugins.source.configuration;
 
+import com.amazon.dataprepper.plugins.source.compression.CompressionEngine;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -16,5 +18,6 @@ class CompressionOptionTest {
     @EnumSource(CompressionOption.class)
     void fromOptionValue(final CompressionOption option) {
         assertThat(CompressionOption.fromOptionValue(option.name()), is(option));
+        assertThat(option.getEngine(), instanceOf(CompressionEngine.class));
     }
 }


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description

- Update call to S3ObjectWorker from S3Service to connect SQS and S3 workers
- Added configuration for `request_timeout` and `records_to_accumulate`

 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
