### PR TITLE
S3 Source to include the bucket and key in Event

### DIFF
--- a/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/JsonRecordsGenerator.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/JsonRecordsGenerator.java
@@ -15,9 +15,11 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.Instant;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
@@ -57,8 +59,10 @@ class JsonRecordsGenerator implements RecordsGenerator {
     @Override
     public void assertEventIsCorrect(final Event event) {
 
-        assertThat(event.get(EVENT_VERSION_FIELD, String.class), equalTo(EVENT_VERSION_VALUE));
-        assertThat(event.toMap().size(), greaterThanOrEqualTo(7));
+        final Map<String, Object> messageMap = event.get("message", Map.class);
+        assertThat(messageMap, notNullValue());
+        assertThat(messageMap.size(), greaterThanOrEqualTo(7));
+        assertThat(messageMap.get(EVENT_VERSION_FIELD), equalTo(EVENT_VERSION_VALUE));
     }
 
     private void writeSingleRecord(final JsonGenerator jsonGenerator) throws IOException {

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/NewlineDelimitedRecordsGenerator.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/NewlineDelimitedRecordsGenerator.java
@@ -17,7 +17,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Random;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -51,7 +50,6 @@ class NewlineDelimitedRecordsGenerator implements RecordsGenerator {
     @Override
     public void assertEventIsCorrect(final Event event) {
         final String message = event.get("message", String.class);
-        assertThat(event.toMap().size(), equalTo(1));
         assertThat(message, notNullValue());
         assertThat(message, containsString(KNOWN_HTTP_LINE));
     }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectWorker.java
@@ -95,6 +95,8 @@ class S3ObjectWorker {
              final InputStream inputStream = compressionEngine.createInputStream(getObjectRequest.key(), responseInputStream)) {
             codec.parse(inputStream, record -> {
                 try {
+                    record.getData().put("bucket", s3ObjectReference.getBucketName());
+                    record.getData().put("key", s3ObjectReference.getKey());
                     bufferAccumulator.add(record);
                 } catch (final Exception e) {
                     LOG.error("Failed writing S3 objects to buffer.", e);

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/JsonCodec.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/JsonCodec.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -56,7 +57,7 @@ public class JsonCodec implements Codec {
 
     private Record<Event> createRecord(final Map<String, Object> json) {
         final JacksonEvent event = JacksonLog.builder()
-                .withData(json)
+                .withData(Collections.singletonMap("message", json))
                 .build();
 
         return new Record<>(event);

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerTest.java
@@ -190,8 +190,15 @@ class S3ObjectWorkerTest {
         final Consumer<Record<Event>> consumerUnderTest = eventConsumerArgumentCaptor.getValue();
 
         final Record<Event> record = mock(Record.class);
+        final Event event = mock(Event.class);
+        when(record.getData()).thenReturn(event);
+
         consumerUnderTest.accept(record);
-        verify(bufferAccumulator).add(record);
+
+        final InOrder inOrder = inOrder(event, bufferAccumulator);
+        inOrder.verify(event).put("bucket", bucketName);
+        inOrder.verify(event).put("key", key);
+        inOrder.verify(bufferAccumulator).add(record);
     }
 
     @Test

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/codec/JsonCodecTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/codec/JsonCodecTest.java
@@ -140,7 +140,7 @@ class JsonCodecTest {
             assertThat(actualRecord.getData().getMetadata().getEventType(), equalTo(EventType.LOG.toString()));
 
             final Map<String, Object> expectedMap = jsonObjects.get(i);
-            assertThat(actualRecord.getData().toMap(), equalTo(expectedMap));
+            assertThat(actualRecord.getData().get("message", Map.class), equalTo(expectedMap));
         }
     }
 
@@ -167,7 +167,7 @@ class JsonCodecTest {
             assertThat(actualRecord.getData().getMetadata().getEventType(), equalTo(EventType.LOG.toString()));
 
             final Map<String, Object> expectedMap = jsonObjects.get(i);
-            assertThat(actualRecord.getData().toMap(), equalTo(expectedMap));
+            assertThat(actualRecord.getData().get("message", Map.class), equalTo(expectedMap));
         }
     }
 
@@ -200,7 +200,7 @@ class JsonCodecTest {
             assertThat(actualRecord.getData().getMetadata().getEventType(), equalTo(EventType.LOG.toString()));
 
             final Map<String, Object> expectedMap = expectedJsonObjects.get(i);
-            assertThat(actualRecord.getData().toMap(), equalTo(expectedMap));
+            assertThat(actualRecord.getData().get("message", Map.class), equalTo(expectedMap));
         }
     }
 


### PR DESCRIPTION
### Description

Include the `bucket` and `key` in the Event produced as noted in #251. Also, moved the JSON data down in the `message` key.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
