### PR TITLE
Use @DurationMin and @DurationMax for Duration-based fields in S3 Source

### DIFF
--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation 'software.amazon.awssdk:sts'
     implementation 'software.amazon.awssdk:sqs'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.220'
+    implementation 'org.hibernate.validator:hibernate-validator:7.0.4.Final'
 }
 
 test {

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/configuration/SqsOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/configuration/SqsOptions.java
@@ -6,9 +6,9 @@
 package com.amazon.dataprepper.plugins.source.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.time.DurationMax;
+import org.hibernate.validator.constraints.time.DurationMin;
 
 import java.time.Duration;
 
@@ -26,17 +26,17 @@ public class SqsOptions {
     private int maximumMessages = DEFAULT_MAXIMUM_MESSAGES;
 
     @JsonProperty("visibility_timeout")
-    @Min(0)
-    @Max(43200)
+    @DurationMin(seconds = 0)
+    @DurationMax(seconds = 43200)
     private Duration visibilityTimeout = DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
 
     @JsonProperty("wait_time")
-    @Min(0)
-    @Max(20)
+    @DurationMin(seconds = 0)
+    @DurationMax(seconds = 20)
     private Duration waitTime = DEFAULT_WAIT_TIME_SECONDS;
 
     @JsonProperty("poll_delay")
-    @Min(0)
+    @DurationMin(seconds = 0)
     private Duration pollDelay = DEFAULT_POLL_DELAY_SECONDS;
 
     public String getSqsUrl() {


### PR DESCRIPTION
### Description

The Hibernate validator provides `@DurationMin` and `@DurationMax` which performs validation on Java `Duration` objects. Use these to validate configuration items in the S3 Source.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
