### PR TITLE
Fix exception when plugin settings are empty

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginConfigurationConverter.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginConfigurationConverter.java
@@ -16,6 +16,8 @@ import jakarta.validation.Validator;
 
 import javax.inject.Named;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -45,7 +47,7 @@ class PluginConfigurationConverter {
      * Java Bean Validation 2.0.
      *
      * @param pluginConfigurationType the destination type
-     * @param pluginSetting The source {@link PluginSetting}
+     * @param pluginSetting           The source {@link PluginSetting}
      * @return The converted object of type pluginConfigurationType
      * @throws InvalidPluginConfigurationException - If the plugin configuration is invalid
      */
@@ -53,14 +55,14 @@ class PluginConfigurationConverter {
         Objects.requireNonNull(pluginConfigurationType);
         Objects.requireNonNull(pluginSetting);
 
-        if(pluginConfigurationType.equals(PluginSetting.class))
+        if (pluginConfigurationType.equals(PluginSetting.class))
             return pluginSetting;
 
-        final Object configuration = objectMapper.convertValue(pluginSetting.getSettings(), pluginConfigurationType);
+        final Object configuration = convertSettings(pluginConfigurationType, pluginSetting);
 
         final Set<ConstraintViolation<Object>> constraintViolations = validator.validate(configuration);
 
-        if(!constraintViolations.isEmpty()) {
+        if (!constraintViolations.isEmpty()) {
             final String violationsString = constraintViolations.stream()
                     .map(v -> v.getPropertyPath().toString() + " " + v.getMessage())
                     .collect(Collectors.joining(". "));
@@ -71,5 +73,12 @@ class PluginConfigurationConverter {
         }
 
         return configuration;
+    }
+
+    private Object convertSettings(final Class<?> pluginConfigurationType, final PluginSetting pluginSetting) {
+        Map<String, Object> settingsMap = pluginSetting.getSettings();
+        if (settingsMap == null)
+            settingsMap = Collections.emptyMap();
+        return objectMapper.convertValue(settingsMap, pluginConfigurationType);
     }
 }

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginConfigurationConverterTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginConfigurationConverterTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -92,6 +93,21 @@ class PluginConfigurationConverterTest {
         final TestConfiguration convertedTestConfiguration = (TestConfiguration) convertedConfiguration;
 
         assertThat(convertedTestConfiguration.getMyValue(), equalTo(value));
+    }
+
+    @Test
+    void convert_with_other_target_should_return_empty_when_settings_are_null() {
+        given(pluginSetting.getSettings())
+                .willReturn(null);
+
+        final Object convertedConfiguration = createObjectUnderTest().convert(TestConfiguration.class, pluginSetting);
+
+        assertThat(convertedConfiguration, notNullValue());
+        assertThat(convertedConfiguration, instanceOf(TestConfiguration.class));
+
+        final TestConfiguration convertedTestConfiguration = (TestConfiguration) convertedConfiguration;
+
+        assertThat(convertedTestConfiguration.getMyValue(), nullValue());
     }
 
     @Test


### PR DESCRIPTION
### Description

When creating a plugin configuration with an empty plug-in settings, make that configuration non-null. This fixes a bug where the call to `validate()` was provided a null pointer. Additionally, plugins should expect that their configurations are non-null.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
