### PR TITLE
Use the SQS Queue URL account Id to get the bucket ownership

### DIFF
--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'software.amazon.awssdk:sqs'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.220'
     implementation 'org.hibernate.validator:hibernate-validator:7.0.4.Final'
+    testImplementation 'org.apache.commons:commons-lang3:3.12.0'
 }
 
 test {

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3ObjectWorker.java
@@ -11,6 +11,7 @@ import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.source.codec.Codec;
 import com.amazon.dataprepper.plugins.source.compression.CompressionEngine;
+import com.amazon.dataprepper.plugins.source.ownership.BucketOwnerProvider;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import org.slf4j.Logger;
@@ -41,6 +42,7 @@ class S3ObjectWorker {
     private final Buffer<Record<Event>> buffer;
     private final CompressionEngine compressionEngine;
     private final Codec codec;
+    private final BucketOwnerProvider bucketOwnerProvider;
     private final Duration bufferTimeout;
     private final int numberOfRecordsToAccumulate;
     private final Counter s3ObjectsFailedCounter;
@@ -51,6 +53,7 @@ class S3ObjectWorker {
                           final Buffer<Record<Event>> buffer,
                           final CompressionEngine compressionEngine,
                           final Codec codec,
+                          final BucketOwnerProvider bucketOwnerProvider,
                           final Duration bufferTimeout,
                           final int numberOfRecordsToAccumulate,
                           final PluginMetrics pluginMetrics) {
@@ -58,6 +61,7 @@ class S3ObjectWorker {
         this.buffer = buffer;
         this.compressionEngine = compressionEngine;
         this.codec = codec;
+        this.bucketOwnerProvider = bucketOwnerProvider;
         this.bufferTimeout = bufferTimeout;
         this.numberOfRecordsToAccumulate = numberOfRecordsToAccumulate;
 
@@ -70,7 +74,7 @@ class S3ObjectWorker {
         final GetObjectRequest.Builder getObjectBuilder = GetObjectRequest.builder()
                 .bucket(s3ObjectReference.getBucketName())
                 .key(s3ObjectReference.getKey());
-        s3ObjectReference.getBucketOwner().ifPresent(getObjectBuilder::expectedBucketOwner);
+        bucketOwnerProvider.getBucketOwner(s3ObjectReference.getBucketName()).ifPresent(getObjectBuilder::expectedBucketOwner);
         final GetObjectRequest getObjectRequest = getObjectBuilder
                 .build();
 

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3Service.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3Service.java
@@ -11,6 +11,7 @@ import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.source.codec.Codec;
 import com.amazon.dataprepper.plugins.source.compression.CompressionEngine;
+import com.amazon.dataprepper.plugins.source.ownership.BucketOwnerProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
@@ -30,23 +31,29 @@ public class S3Service {
     private final Codec codec;
     private final CompressionEngine compressionEngine;
     private final PluginMetrics pluginMetrics;
+    private final BucketOwnerProvider bucketOwnerProvider;
     private final S3ObjectWorker s3ObjectWorker;
 
-    public S3Service(final S3SourceConfig s3SourceConfig, Buffer<Record<Event>> buffer, Codec codec, PluginMetrics pluginMetrics) {
+    public S3Service(final S3SourceConfig s3SourceConfig,
+                     final Buffer<Record<Event>> buffer,
+                     final Codec codec,
+                     final PluginMetrics pluginMetrics,
+                     final BucketOwnerProvider bucketOwnerProvider) {
         this.s3SourceConfig = s3SourceConfig;
         this.buffer = buffer;
         this.codec = codec;
         this.pluginMetrics = pluginMetrics;
+        this.bucketOwnerProvider = bucketOwnerProvider;
         this.s3Client = createS3Client(StsClient.create());
         this.compressionEngine = s3SourceConfig.getCompression().getEngine();
-        this.s3ObjectWorker = new S3ObjectWorker(s3Client, buffer, compressionEngine, codec,
+        this.s3ObjectWorker = new S3ObjectWorker(s3Client, buffer, compressionEngine, codec, bucketOwnerProvider,
                 s3SourceConfig.getBufferTimeout(), s3SourceConfig.getNumberOfRecordsToAccumulate(), pluginMetrics);
     }
 
     void addS3Object(final S3ObjectReference s3ObjectReference) {
         try {
             s3ObjectWorker.parseS3Object(s3ObjectReference);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             LOG.error("Unable to read S3 object from S3ObjectReference = {}", s3ObjectReference, e);
         }
     }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3Source.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3Source.java
@@ -16,6 +16,8 @@ import com.amazon.dataprepper.model.plugin.PluginFactory;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.source.Source;
 import com.amazon.dataprepper.plugins.source.codec.Codec;
+import com.amazon.dataprepper.plugins.source.ownership.BucketOwnerProvider;
+import com.amazon.dataprepper.plugins.source.ownership.ConfigBucketOwnerProviderFactory;
 
 @DataPrepperPlugin(name = "s3", pluginType = Source.class, pluginConfigurationType = S3SourceConfig.class)
 public class S3Source implements Source<Record<Event>> {
@@ -42,7 +44,10 @@ public class S3Source implements Source<Record<Event>> {
             throw new IllegalStateException("Buffer provided is null");
         }
 
-        S3Service s3Service = new S3Service(s3SourceConfig, buffer, codec, pluginMetrics);
+        final ConfigBucketOwnerProviderFactory configBucketOwnerProviderFactory = new ConfigBucketOwnerProviderFactory();
+        final BucketOwnerProvider bucketOwnerProvider = configBucketOwnerProviderFactory.createBucketOwnerProvider(s3SourceConfig);
+
+        final S3Service s3Service = new S3Service(s3SourceConfig, buffer, codec, pluginMetrics, bucketOwnerProvider);
         sqsService = new SqsService(s3SourceConfig, s3Service, pluginMetrics);
 
         sqsService.start();

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3SourceConfig.java
@@ -50,6 +50,9 @@ public class S3SourceConfig {
     @JsonProperty("records_to_accumulate")
     private int numberOfRecordsToAccumulate = DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE;
 
+    @JsonProperty("disable_bucket_ownership_validation")
+    private boolean disableBucketOwnershipValidation = false;
+
     public NotificationTypeOption getNotificationType() {
         return notificationType;
     }
@@ -80,5 +83,9 @@ public class S3SourceConfig {
 
     public int getNumberOfRecordsToAccumulate() {
         return numberOfRecordsToAccumulate;
+    }
+
+    public boolean isDisableBucketOwnershipValidation() {
+        return disableBucketOwnershipValidation;
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsQueueUrl.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsQueueUrl.java
@@ -22,6 +22,13 @@ public class SqsQueueUrl {
             throw new IllegalArgumentException("Not enough path parts for the SQS queue URL.");
 
         accountId = pathParts[1];
+
+        if(accountId.length() != 12) {
+            throw new IllegalArgumentException("SQS queue URL has accountId of invalid length.");
+        }
+        if(!accountId.chars().allMatch(Character::isDigit)) {
+            throw new IllegalArgumentException("SQS queue URL has accountId with invalid characters.");
+        }
     }
 
     public String getAccountId() {

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsQueueUrl.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsQueueUrl.java
@@ -9,19 +9,17 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 public class SqsQueueUrl {
-    private final URL queueUrl;
     private final String accountId;
 
-    private SqsQueueUrl(final URL queueUrl) throws MalformedURLException {
-        this.queueUrl = queueUrl;
+    private SqsQueueUrl(final URL queueUrl) {
         final String path = queueUrl.getPath();
 
         if (path.isEmpty())
-            throw new MalformedURLException();
+            throw new IllegalArgumentException("No path for the SQS queue URL.");
 
         final String[] pathParts = path.split("/");
         if (pathParts.length < 3)
-            throw new MalformedURLException();
+            throw new IllegalArgumentException("Not enough path parts for the SQS queue URL.");
 
         accountId = pathParts[1];
     }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsQueueUrl.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsQueueUrl.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class SqsQueueUrl {
+    private final URL queueUrl;
+    private final String accountId;
+
+    private SqsQueueUrl(final URL queueUrl) throws MalformedURLException {
+        this.queueUrl = queueUrl;
+        final String path = queueUrl.getPath();
+
+        if (path.isEmpty())
+            throw new MalformedURLException();
+
+        final String[] pathParts = path.split("/");
+        if (pathParts.length < 3)
+            throw new MalformedURLException();
+
+        accountId = pathParts[1];
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public static SqsQueueUrl parse(final String queueUrl) throws MalformedURLException {
+        return new SqsQueueUrl(new URL(queueUrl));
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsQueueUrl.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsQueueUrl.java
@@ -7,6 +7,7 @@ package com.amazon.dataprepper.plugins.source;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Objects;
 
 public class SqsQueueUrl {
     private final String accountId;
@@ -36,6 +37,7 @@ public class SqsQueueUrl {
     }
 
     public static SqsQueueUrl parse(final String queueUrl) throws MalformedURLException {
+        Objects.requireNonNull(queueUrl);
         return new SqsQueueUrl(new URL(queueUrl));
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/SqsWorker.java
@@ -200,7 +200,6 @@ public class SqsWorker implements Runnable {
         final S3EventNotification.S3Entity s3Entity = s3EventNotificationRecord.getS3();
         return S3ObjectReference.bucketAndKey(s3Entity.getBucket().getName(),
                 s3Entity.getObject().getKey())
-                .owner(s3Entity.getBucket().getOwnerIdentity().getPrincipalId())
                 .build();
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/BucketOwnerProvider.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/BucketOwnerProvider.java
@@ -12,5 +12,11 @@ import java.util.Optional;
  */
 @FunctionalInterface
 public interface BucketOwnerProvider {
+    /**
+     * Gets the accountId of the owner bucket. Returns an empty optional
+     * if no account owner is known.
+     * @param bucket the name of the bucket
+     * @return The accountId or empty
+     */
     Optional<String> getBucketOwner(final String bucket);
 }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/BucketOwnerProvider.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/BucketOwnerProvider.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.ownership;
+
+import java.util.Optional;
+
+/**
+ * Gets the expected owner of an S3 bucket.
+ */
+@FunctionalInterface
+public interface BucketOwnerProvider {
+    Optional<String> getBucketOwner(final String bucket);
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/ConfigBucketOwnerProviderFactory.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/ConfigBucketOwnerProviderFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.ownership;
+
+import com.amazon.dataprepper.plugins.source.S3SourceConfig;
+import com.amazon.dataprepper.plugins.source.SqsQueueUrl;
+
+import java.net.MalformedURLException;
+
+public class ConfigBucketOwnerProviderFactory {
+    public BucketOwnerProvider createBucketOwnerProvider(final S3SourceConfig s3SourceConfig) {
+        if(s3SourceConfig.isDisableBucketOwnershipValidation())
+            return new NoOwnershipBucketOwnerProvider();
+
+        final String queueUrl = s3SourceConfig.getSqsOptions().getSqsUrl();
+        final String accountId;
+        try {
+            accountId = SqsQueueUrl.parse(queueUrl).getAccountId();
+        } catch (final MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+
+        return new StaticBucketOwnerProvider(accountId);
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/ConfigBucketOwnerProviderFactory.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/ConfigBucketOwnerProviderFactory.java
@@ -15,6 +15,12 @@ public class ConfigBucketOwnerProviderFactory {
         if(s3SourceConfig.isDisableBucketOwnershipValidation())
             return new NoOwnershipBucketOwnerProvider();
 
+        final String accountId = extractQueueAccountId(s3SourceConfig);
+
+        return new StaticBucketOwnerProvider(accountId);
+    }
+
+    private String extractQueueAccountId(final S3SourceConfig s3SourceConfig) {
         final String queueUrl = s3SourceConfig.getSqsOptions().getSqsUrl();
         final String accountId;
         try {
@@ -22,7 +28,6 @@ public class ConfigBucketOwnerProviderFactory {
         } catch (final MalformedURLException e) {
             throw new RuntimeException(e);
         }
-
-        return new StaticBucketOwnerProvider(accountId);
+        return accountId;
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/ConfigBucketOwnerProviderFactory.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/ConfigBucketOwnerProviderFactory.java
@@ -10,7 +10,16 @@ import com.amazon.dataprepper.plugins.source.SqsQueueUrl;
 
 import java.net.MalformedURLException;
 
+/**
+ * Produces a {@link BucketOwnerProvider} from the S3 source configuration as
+ * provided in a {@link S3SourceConfig}.
+ */
 public class ConfigBucketOwnerProviderFactory {
+    /**
+     * Creates the {@link BucketOwnerProvider}
+     * @param s3SourceConfig The input {@link S3SourceConfig}
+     * @return The {@link BucketOwnerProvider}
+     */
     public BucketOwnerProvider createBucketOwnerProvider(final S3SourceConfig s3SourceConfig) {
         if(s3SourceConfig.isDisableBucketOwnershipValidation())
             return new NoOwnershipBucketOwnerProvider();

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/NoOwnershipBucketOwnerProvider.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/NoOwnershipBucketOwnerProvider.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.ownership;
+
+import java.util.Optional;
+
+class NoOwnershipBucketOwnerProvider implements BucketOwnerProvider {
+    @Override
+    public Optional<String> getBucketOwner(final String bucket) {
+        return Optional.empty();
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/NoOwnershipBucketOwnerProvider.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/NoOwnershipBucketOwnerProvider.java
@@ -7,6 +7,10 @@ package com.amazon.dataprepper.plugins.source.ownership;
 
 import java.util.Optional;
 
+/**
+ * An implementation of {@link BucketOwnerProvider} which does not provide
+ * a bucket owner, effectively skipping owner validation.
+ */
 class NoOwnershipBucketOwnerProvider implements BucketOwnerProvider {
     @Override
     public Optional<String> getBucketOwner(final String bucket) {

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/StaticBucketOwnerProvider.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/StaticBucketOwnerProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.ownership;
+
+import java.util.Objects;
+import java.util.Optional;
+
+class StaticBucketOwnerProvider implements BucketOwnerProvider {
+    private final String accountId;
+
+    public StaticBucketOwnerProvider(final String accountId) {
+        this.accountId = Objects.requireNonNull(accountId);
+    }
+
+    @Override
+    public Optional<String> getBucketOwner(final String bucket) {
+        return Optional.of(accountId);
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/StaticBucketOwnerProvider.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/ownership/StaticBucketOwnerProvider.java
@@ -8,6 +8,10 @@ package com.amazon.dataprepper.plugins.source.ownership;
 import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * An implementation of {@link BucketOwnerProvider} which provides the
+ * same owner for all buckets.
+ */
 class StaticBucketOwnerProvider implements BucketOwnerProvider {
     private final String accountId;
 

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsQueueUrlTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsQueueUrlTest.java
@@ -37,6 +37,19 @@ class SqsQueueUrlTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
+            "12345678901",
+            "1234567890123",
+            "A23456789012",
+            "12345678901A",
+            "12345678901!"
+    })
+    void parse_throws_when_URL_has_invalid_accountId(final String accountId) {
+        final String queueUrl = String.format("https://sqs.us-east-1.amazonaws.com/%s/%s", accountId, UUID.randomUUID());
+        assertThrows(IllegalArgumentException.class, () -> SqsQueueUrl.parse(queueUrl));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
             "https://sqs.us-east-1.amazonaws.com/%s/%s",
             "https://sqs.us-east-1.amazonaws.com/%s/%s/",
             "https://sqs.us-east-1.amazonaws.com/%s/%s.fifo",

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsQueueUrlTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsQueueUrlTest.java
@@ -20,6 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SqsQueueUrlTest {
     @Test
+    void parse_throws_when_URL_is_null() {
+        assertThrows(NullPointerException.class, () -> SqsQueueUrl.parse(null));
+    }
+
+    @Test
     void parse_throws_when_URL_is_not_a_URL() {
         assertThrows(MalformedURLException.class, () -> SqsQueueUrl.parse(UUID.randomUUID().toString()));
     }

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsQueueUrlTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsQueueUrlTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.MalformedURLException;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SqsQueueUrlTest {
+    @Test
+    void parse_throws_when_URL_is_not_a_URL() {
+        assertThrows(MalformedURLException.class, () -> SqsQueueUrl.parse(UUID.randomUUID().toString()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "https://sqs.us-east-1.amazonaws.com",
+            "https://sqs.us-east-1.amazonaws.com/",
+            "https://sqs.us-east-1.amazonaws.com/123456789",
+            "https://sqs.us-east-1.amazonaws.com/123456789/"
+    })
+    void parse_throws_when_URL_has_invalid_paths(final String queueUrl) {
+        assertThrows(MalformedURLException.class, () -> SqsQueueUrl.parse(queueUrl));
+    }
+
+    @Test
+    void getAccountId_returns_accountId_part() throws MalformedURLException {
+        final String accountId = UUID.randomUUID().toString();
+        final String queueName = UUID.randomUUID().toString();
+
+        final String queueUrl = String.format("https://sqs.us-east-1.amazonaws.com/%s/%s", accountId, queueName);
+
+        final SqsQueueUrl objectUnderTest = SqsQueueUrl.parse(queueUrl);
+
+        assertThat(objectUnderTest, notNullValue());
+        assertThat(objectUnderTest.getAccountId(), equalTo(accountId));
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsQueueUrlTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/SqsQueueUrlTest.java
@@ -5,6 +5,7 @@
 
 package com.amazon.dataprepper.plugins.source;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -31,19 +32,30 @@ class SqsQueueUrlTest {
             "https://sqs.us-east-1.amazonaws.com/123456789/"
     })
     void parse_throws_when_URL_has_invalid_paths(final String queueUrl) {
-        assertThrows(MalformedURLException.class, () -> SqsQueueUrl.parse(queueUrl));
+        assertThrows(IllegalArgumentException.class, () -> SqsQueueUrl.parse(queueUrl));
     }
 
-    @Test
-    void getAccountId_returns_accountId_part() throws MalformedURLException {
-        final String accountId = UUID.randomUUID().toString();
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "https://sqs.us-east-1.amazonaws.com/%s/%s",
+            "https://sqs.us-east-1.amazonaws.com/%s/%s/",
+            "https://sqs.us-east-1.amazonaws.com/%s/%s.fifo",
+            "https://sqs.us-east-1.amazonaws.com/%s/%s.fifo/",
+            "https://sqs.us-west-2.amazonaws.com/%s/%s"
+    })
+    void getAccountId_returns_accountId_part(final String queueFormatString) throws MalformedURLException {
+        final String accountId = randomAccountId();
         final String queueName = UUID.randomUUID().toString();
 
-        final String queueUrl = String.format("https://sqs.us-east-1.amazonaws.com/%s/%s", accountId, queueName);
+        final String queueUrl = String.format(queueFormatString, accountId, queueName);
 
         final SqsQueueUrl objectUnderTest = SqsQueueUrl.parse(queueUrl);
 
         assertThat(objectUnderTest, notNullValue());
         assertThat(objectUnderTest.getAccountId(), equalTo(accountId));
+    }
+
+    private String randomAccountId() {
+        return RandomStringUtils.randomNumeric(12);
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/ownership/ConfigBucketOwnerProviderFactoryTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/ownership/ConfigBucketOwnerProviderFactoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.ownership;
+
+import com.amazon.dataprepper.plugins.source.S3SourceConfig;
+import com.amazon.dataprepper.plugins.source.SqsQueueUrl;
+import com.amazon.dataprepper.plugins.source.configuration.SqsOptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigBucketOwnerProviderFactoryTest {
+
+    @Mock
+    private S3SourceConfig s3SourceConfig;
+
+    private ConfigBucketOwnerProviderFactory createObjectUnderTest() {
+        return new ConfigBucketOwnerProviderFactory();
+    }
+
+    @Test
+    void createBucketOwnerProvider_returns_NoOwnershipBucketOwnerProvider_when_disabled() {
+        when(s3SourceConfig.isDisableBucketOwnershipValidation()).thenReturn(true);
+
+        final BucketOwnerProvider bucketOwnerProvider = createObjectUnderTest().createBucketOwnerProvider(s3SourceConfig);
+
+        assertThat(bucketOwnerProvider, instanceOf(NoOwnershipBucketOwnerProvider.class));
+    }
+
+    @Test
+    void createBucketOwnerProvider_returns_ownership_based_on_SQS_queueUrl() {
+        final SqsOptions sqsOptions = mock(SqsOptions.class);
+        final String accountId = UUID.randomUUID().toString();
+        final String sqsUrl = UUID.randomUUID().toString();
+        when(sqsOptions.getSqsUrl()).thenReturn(sqsUrl);
+        when(s3SourceConfig.getSqsOptions()).thenReturn(sqsOptions);
+
+        when(s3SourceConfig.isDisableBucketOwnershipValidation()).thenReturn(false);
+
+        final SqsQueueUrl sqsQueueUrl = mock(SqsQueueUrl.class);
+        when(sqsQueueUrl.getAccountId()).thenReturn(accountId);
+
+        final BucketOwnerProvider bucketOwnerProvider;
+        try (final MockedStatic<SqsQueueUrl> sqsQueueUrlMockedStatic = mockStatic(SqsQueueUrl.class)) {
+            sqsQueueUrlMockedStatic.when(() -> SqsQueueUrl.parse(sqsUrl))
+                    .thenReturn(sqsQueueUrl);
+            bucketOwnerProvider = createObjectUnderTest().createBucketOwnerProvider(s3SourceConfig);
+        }
+
+        assertThat(bucketOwnerProvider, notNullValue());
+
+        final Optional<String> optionalOwner = bucketOwnerProvider.getBucketOwner(UUID.randomUUID().toString());
+
+        assertThat(optionalOwner, notNullValue());
+        assertThat(optionalOwner.isPresent(), equalTo(true));
+        assertThat(optionalOwner.get(), equalTo(accountId));
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/ownership/NoOwnershipBucketOwnerProviderTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/ownership/NoOwnershipBucketOwnerProviderTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.ownership;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class NoOwnershipBucketOwnerProviderTest {
+    private NoOwnershipBucketOwnerProvider createObjectUnderTest() {
+        return new NoOwnershipBucketOwnerProvider();
+    }
+
+    @Test
+    void getBucketOwner_returns_empty() {
+        final Optional<String> optionalOwner = createObjectUnderTest().getBucketOwner(UUID.randomUUID().toString());
+
+        assertThat(optionalOwner, notNullValue());
+        assertThat(optionalOwner.isPresent(), equalTo(false));
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/ownership/StaticBucketOwnerProviderTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/ownership/StaticBucketOwnerProviderTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.ownership;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class StaticBucketOwnerProviderTest {
+    private String accountId;
+
+    @BeforeEach
+    void setUp() {
+        accountId = UUID.randomUUID().toString();
+    }
+
+    private StaticBucketOwnerProvider createObjectUnderTest() {
+        return new StaticBucketOwnerProvider(accountId);
+    }
+
+    @Test
+    void constructor_throws_with_null() {
+        accountId = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void getBucketOwner_returns_the_predefined_accountId() {
+        final Optional<String> optionalOwner = createObjectUnderTest().getBucketOwner(UUID.randomUUID().toString());
+
+        assertThat(optionalOwner, notNullValue());
+        assertThat(optionalOwner.isPresent(), equalTo(true));
+        assertThat(optionalOwner.get(), equalTo(accountId));
+    }
+}


### PR DESCRIPTION
### Description

The owner identity as provided by S3 Events is not actually a valid AWS accountId which can be used to validate that the object is owned by the expected account.

This changes the approach to use the accountId of the SQS URL to determine the expected account Id. Pipeline authors can disable the validate altogether if the bucket is in a different account than the SQS queue.

We can expand this later with a map of bucket names to expected accountIds. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
