### PR TITLE
Add in getHttpAuthenticationService to GrpcAuthenticationProvider

### DIFF
--- a/data-prepper-plugins/armeria-common/src/main/java/com/amazon/dataprepper/armeria/authentication/GrpcAuthenticationProvider.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/com/amazon/dataprepper/armeria/authentication/GrpcAuthenticationProvider.java
@@ -33,7 +33,8 @@ public interface GrpcAuthenticationProvider {
     ServerInterceptor getAuthenticationInterceptor();
 
     /**
-     * Returns an optional service for HTTP authentication
+     * Allows implementors to provide an {@link HttpService} to either intercept the HTTP request prior to validation,
+     * or to perform validation on the HTTP request. This may be optional, in which case it is not used.
      * @since 1.5
      */
     default Optional<Function<? super HttpService, ? extends HttpService>> getHttpAuthenticationService() {

--- a/data-prepper-plugins/armeria-common/src/main/java/com/amazon/dataprepper/armeria/authentication/GrpcAuthenticationProvider.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/com/amazon/dataprepper/armeria/authentication/GrpcAuthenticationProvider.java
@@ -32,6 +32,10 @@ public interface GrpcAuthenticationProvider {
      */
     ServerInterceptor getAuthenticationInterceptor();
 
+    /**
+     * Returns an optional service for HTTP authentication
+     * @since 1.5
+     */
     default Optional<Function<? super HttpService, ? extends HttpService>> getHttpAuthenticationService() {
         return Optional.empty();
     }

--- a/data-prepper-plugins/armeria-common/src/main/java/com/amazon/dataprepper/armeria/authentication/GrpcAuthenticationProvider.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/com/amazon/dataprepper/armeria/authentication/GrpcAuthenticationProvider.java
@@ -5,7 +5,11 @@
 
 package com.amazon.dataprepper.armeria.authentication;
 
+import com.linecorp.armeria.server.HttpService;
 import io.grpc.ServerInterceptor;
+
+import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * An interface for providing authentication in GRPC servers.
@@ -27,4 +31,8 @@ public interface GrpcAuthenticationProvider {
      * @since 1.2
      */
     ServerInterceptor getAuthenticationInterceptor();
+
+    default Optional<Function<? super HttpService, ? extends HttpService>> getHttpAuthenticationService() {
+        return Optional.empty();
+    }
 }

--- a/data-prepper-plugins/armeria-common/src/test/java/com/amazon/dataprepper/plugins/GrpcAuthenticationProviderTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/com/amazon/dataprepper/plugins/GrpcAuthenticationProviderTest.java
@@ -24,7 +24,8 @@ public class GrpcAuthenticationProviderTest {
     public void confirmDefaultBehavior() {
         when(provider.getHttpAuthenticationService()).thenCallRealMethod();
 
-        Assertions.assertNotNull(provider.getHttpAuthenticationService());
-        Assertions.assertFalse(provider.getHttpAuthenticationService().isPresent());
+        var result = provider.getHttpAuthenticationService();
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.isPresent());
     }
 }

--- a/data-prepper-plugins/armeria-common/src/test/java/com/amazon/dataprepper/plugins/GrpcAuthenticationProviderTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/com/amazon/dataprepper/plugins/GrpcAuthenticationProviderTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins;
+
+import com.amazon.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class GrpcAuthenticationProviderTest {
+
+    @Mock
+    private GrpcAuthenticationProvider provider;
+
+    @Test
+    public void confirmDefaultBehavior() {
+        when(provider.getHttpAuthenticationService()).thenCallRealMethod();
+
+        Assertions.assertNotNull(provider.getHttpAuthenticationService());
+        Assertions.assertFalse(provider.getHttpAuthenticationService().isPresent());
+    }
+}

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/com/amazon/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/com/amazon/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
@@ -104,15 +104,11 @@ public class OTelMetricsSource implements Source<Record<ExportMetricsServiceRequ
 
             final ServerBuilder sb = Server.builder();
             sb.disableServerHeader();
+            sb.service(grpcServiceBuilder.build());
 
             final Optional<Function<? super HttpService, ? extends HttpService>> optionalHttpAuthenticationService =
                     authenticationProvider.getHttpAuthenticationService();
-            final GrpcService grpcService = grpcServiceBuilder.build();
-            if(optionalHttpAuthenticationService.isPresent()) {
-                sb.service(grpcService, optionalHttpAuthenticationService.get());
-            } else {
-                sb.service(grpcService);
-            }
+            optionalHttpAuthenticationService.ifPresent(sb::decorator);
 
             sb.requestTimeoutMillis(oTelMetricsSourceConfig.getRequestTimeoutInMillis());
 

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/com/amazon/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/com/amazon/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
@@ -19,6 +19,7 @@ import com.amazon.dataprepper.plugins.certificate.CertificateProvider;
 import com.amazon.dataprepper.plugins.certificate.model.Certificate;
 import com.amazon.dataprepper.plugins.health.HealthGrpcService;
 import com.amazon.dataprepper.plugins.source.otelmetrics.certificate.CertificateProviderFactory;
+import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
@@ -35,8 +36,10 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.function.Function;
 
 @DataPrepperPlugin(name = "otel_metrics_source", pluginType = Source.class, pluginConfigurationType = OTelMetricsSourceConfig.class)
 public class OTelMetricsSource implements Source<Record<ExportMetricsServiceRequest>> {
@@ -101,7 +104,16 @@ public class OTelMetricsSource implements Source<Record<ExportMetricsServiceRequ
 
             final ServerBuilder sb = Server.builder();
             sb.disableServerHeader();
-            sb.service(grpcServiceBuilder.build());
+
+            final Optional<Function<? super HttpService, ? extends HttpService>> optionalHttpAuthenticationService =
+                    authenticationProvider.getHttpAuthenticationService();
+            final GrpcService grpcService = grpcServiceBuilder.build();
+            if(optionalHttpAuthenticationService.isPresent()) {
+                sb.service(grpcService, optionalHttpAuthenticationService.get());
+            } else {
+                sb.service(grpcService);
+            }
+
             sb.requestTimeoutMillis(oTelMetricsSourceConfig.getRequestTimeoutInMillis());
 
             // ACM Cert for SSL takes preference

--- a/data-prepper-plugins/otel-metrics-source/src/test/java/com/amazon/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceTest.java
+++ b/data-prepper-plugins/otel-metrics-source/src/test/java/com/amazon/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceTest.java
@@ -12,7 +12,6 @@ import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.plugin.PluginFactory;
 import com.amazon.dataprepper.model.record.Record;
 
-import com.amazon.dataprepper.plugins.GrpcBasicAuthenticationProvider;
 import com.amazon.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
 import com.amazon.dataprepper.plugins.certificate.CertificateProvider;
 import com.amazon.dataprepper.plugins.certificate.model.Certificate;
@@ -30,6 +29,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
@@ -60,6 +60,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
@@ -80,7 +81,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -115,6 +115,9 @@ public class OTelMetricsSourceTest {
 
     @Mock
     private PluginFactory pluginFactory;
+
+    @Mock
+    private GrpcAuthenticationProvider authenticationProvider;
 
     private PluginSetting pluginSetting;
     private PluginSetting testPluginSetting;
@@ -170,7 +173,6 @@ public class OTelMetricsSourceTest {
 
         oTelMetricsSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelMetricsSourceConfig.class);
 
-        final GrpcAuthenticationProvider authenticationProvider = mock(GrpcBasicAuthenticationProvider.class);
         when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))
                 .thenReturn(authenticationProvider);
 
@@ -459,16 +461,30 @@ public class OTelMetricsSourceTest {
 
     @Test
     public void testOptionalHttpAuthServiceNotInPlace() {
-        try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
+        when(server.stop()).thenReturn(completableFuture);
+
+        try (final MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
             armeriaServerMock.when(Server::builder).thenReturn(serverBuilder);
-            when(server.stop()).thenReturn(completableFuture);
-
-            // starting server
             SOURCE.start(buffer);
-
-            verify(serverBuilder, never()).service(isA(GrpcService.class), isA(Function.class));
-            verify(serverBuilder).service(isA(GrpcService.class));
         }
+
+        verify(serverBuilder).service(isA(GrpcService.class));
+        verify(serverBuilder, never()).decorator(isA(Function.class));
+    }
+
+    @Test
+    public void testOptionalHttpAuthServiceInPlace() {
+        final Optional<Function<? super HttpService, ? extends HttpService>> function = Optional.of(httpService -> httpService);
+        when(server.stop()).thenReturn(completableFuture);
+        when(authenticationProvider.getHttpAuthenticationService()).thenReturn(function);
+
+        try (final MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
+            armeriaServerMock.when(Server::builder).thenReturn(serverBuilder);
+            SOURCE.start(buffer);
+        }
+
+        verify(serverBuilder).service(isA(GrpcService.class));
+        verify(serverBuilder).decorator(isA(Function.class));
     }
 
     @Test

--- a/data-prepper-plugins/otel-metrics-source/src/test/java/com/amazon/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceTest.java
+++ b/data-prepper-plugins/otel-metrics-source/src/test/java/com/amazon/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceTest.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.amazon.dataprepper.plugins.source.otelmetrics.OTelMetricsSourceConfig.SSL;
@@ -453,6 +454,20 @@ public class OTelMetricsSourceTest {
             // When/Then
             final RuntimeException ex = assertThrows(RuntimeException.class, () -> source.start(buffer));
             assertEquals(expCause, ex);
+        }
+    }
+
+    @Test
+    public void testOptionalHttpAuthServiceNotInPlace() {
+        try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
+            armeriaServerMock.when(Server::builder).thenReturn(serverBuilder);
+            when(server.stop()).thenReturn(completableFuture);
+
+            // starting server
+            SOURCE.start(buffer);
+
+            verify(serverBuilder, never()).service(isA(GrpcService.class), isA(Function.class));
+            verify(serverBuilder).service(isA(GrpcService.class));
         }
     }
 

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
@@ -105,15 +105,11 @@ public class OTelTraceSource implements Source<Record<Object>> {
 
             final ServerBuilder sb = Server.builder();
             sb.disableServerHeader();
+            sb.service(grpcServiceBuilder.build());
 
             final Optional<Function<? super HttpService, ? extends HttpService>> optionalHttpAuthenticationService =
                     authenticationProvider.getHttpAuthenticationService();
-            final GrpcService grpcService = grpcServiceBuilder.build();
-            if(optionalHttpAuthenticationService.isPresent()) {
-                sb.service(grpcService, optionalHttpAuthenticationService.get());
-            } else {
-                sb.service(grpcService);
-            }
+            optionalHttpAuthenticationService.ifPresent(sb::decorator);
 
             sb.requestTimeoutMillis(oTelTraceSourceConfig.getRequestTimeoutInMillis());
 

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -28,8 +28,6 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.server.HttpService;
-import com.linecorp.armeria.server.HttpServiceWithRoutes;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;


### PR DESCRIPTION
Signed-off-by: David Powers <ddpowers@amazon.com>

### Description
Create an optional plugin to get an HTTP Auth service for the GRPC Auth Provider
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
