### PR TITLE
Version bump to 2.0.0-SNAPSHOT on the main branch.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version=1.5.0-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
### Description

The `main` branch is now working toward Data Prepper 2.0.0, so updated the version to `2.0.0-SNAPSHOT`.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
