### PR TITLE
Updated the sample OTel Collector to the current latest version: 0.54.0.

### DIFF
--- a/examples/jaeger-hotrod/docker-compose.yml
+++ b/examples/jaeger-hotrod/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - "opensearch"
   otel-collector:
     container_name: otel-collector
-    image: otel/opentelemetry-collector:0.24.0
+    image: otel/opentelemetry-collector:0.54.0
     command: [ "--config=/etc/otel-collector-config.yml" ]
     working_dir: "/project"
     volumes:

--- a/examples/jaeger-hotrod/otel-collector-config.yml
+++ b/examples/jaeger-hotrod/otel-collector-config.yml
@@ -6,7 +6,9 @@ receivers:
 exporters:
   otlp/2:
     endpoint: data-prepper:21890
-    insecure: true
+    tls:
+      insecure: true
+      insecure_skip_verify: true
   logging:
 
 service:


### PR DESCRIPTION
### Description

Updates the OTel Collector in the Jaeger HotRod sample to 0.54.0. The configure for disabling TLS changed along the way, so this includes the necessary configuration update.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
