### PR TITLE
Enable HTTP Health Check for OTelTraceSource and OTelMetricsSource.

### DIFF
--- a/data-prepper-plugins/otel-metrics-source/README.md
+++ b/data-prepper-plugins/otel-metrics-source/README.md
@@ -16,11 +16,9 @@ source:
 
 * port(Optional) => An `int` represents the port Otel metrics source is running on. Default is ```21891```.
 * request_timeout(Optional) => An `int` represents request timeout in millis. Default is ```10_000```.
-* health_check_service(Optional) => A boolean enables health check service. When ```true``` enables a gRPC health check service under ```grpc.health.v1.Health/Check```. Default is ```false```. 
-  * ```proto_reflection_service``` should be enabled to use the health check service.
+* health_check_service(Optional) => A boolean enables health check service. When ```true``` enables a gRPC health check service under ```grpc.health.v1.Health/Check```. Default is ```false```. In order to use the health check service, you must also enable ```proto_reflection_service```.
 * proto_reflection_service(Optional) => A boolean enables a reflection service for Protobuf services (see [ProtoReflectionService](https://grpc.github.io/grpc-java/javadoc/io/grpc/protobuf/services/ProtoReflectionService.html) and [gRPC reflection](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md) docs). Default is ```false```.
-* unframed_requests(Optional) => A boolean to enable requests not framed using the gRPC wire protocol. 
-  * when ```health_check_service``` is true and ```unframed_requests``` is true, enables HTTP health check service under ```/health```
+* unframed_requests(Optional) => A boolean to enable requests not framed using the gRPC wire protocol. When ```health_check_service``` is true and ```unframed_requests``` is true, enables HTTP health check service under ```/health```
 * thread_count(Optional) => the number of threads to keep in the ScheduledThreadPool. Default is `200`.
 * max_connection_count(Optional) => the maximum allowed number of open connections. Default is `500`.
 

--- a/data-prepper-plugins/otel-metrics-source/README.md
+++ b/data-prepper-plugins/otel-metrics-source/README.md
@@ -16,9 +16,11 @@ source:
 
 * port(Optional) => An `int` represents the port Otel metrics source is running on. Default is ```21891```.
 * request_timeout(Optional) => An `int` represents request timeout in millis. Default is ```10_000```.
-* health_check_service(Optional) => A boolean enables a gRPC health check service under ```grpc.health.v1 / Health / Check```. Default is ```false```.
+* health_check_service(Optional) => A boolean enables health check service. When ```true``` enables a gRPC health check service under ```grpc.health.v1.Health/Check```. Default is ```false```. 
+  * ```proto_reflection_service``` should be enabled to use the health check service.
 * proto_reflection_service(Optional) => A boolean enables a reflection service for Protobuf services (see [ProtoReflectionService](https://grpc.github.io/grpc-java/javadoc/io/grpc/protobuf/services/ProtoReflectionService.html) and [gRPC reflection](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md) docs). Default is ```false```.
 * unframed_requests(Optional) => A boolean to enable requests not framed using the gRPC wire protocol. 
+  * when ```health_check_service``` is true and ```unframed_requests``` is true, enables HTTP health check service under ```/health```
 * thread_count(Optional) => the number of threads to keep in the ScheduledThreadPool. Default is `200`.
 * max_connection_count(Optional) => the maximum allowed number of open connections. Default is `500`.
 

--- a/data-prepper-plugins/otel-metrics-source/README.md
+++ b/data-prepper-plugins/otel-metrics-source/README.md
@@ -18,7 +18,7 @@ source:
 * request_timeout(Optional) => An `int` represents request timeout in millis. Default is ```10_000```.
 * health_check_service(Optional) => A boolean enables health check service. When ```true``` enables a gRPC health check service under ```grpc.health.v1.Health/Check```. Default is ```false```. In order to use the health check service, you must also enable ```proto_reflection_service```.
 * proto_reflection_service(Optional) => A boolean enables a reflection service for Protobuf services (see [ProtoReflectionService](https://grpc.github.io/grpc-java/javadoc/io/grpc/protobuf/services/ProtoReflectionService.html) and [gRPC reflection](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md) docs). Default is ```false```.
-* unframed_requests(Optional) => A boolean to enable requests not framed using the gRPC wire protocol. When ```health_check_service``` is true and ```unframed_requests``` is true, enables HTTP health check service under ```/health```
+* unframed_requests(Optional) => A boolean to enable requests not framed using the gRPC wire protocol. When ```health_check_service``` is true and ```unframed_requests``` is true, enables HTTP health check service under ```/health```.
 * thread_count(Optional) => the number of threads to keep in the ScheduledThreadPool. Default is `200`.
 * max_connection_count(Optional) => the maximum allowed number of open connections. Default is `500`.
 

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/com/amazon/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceConfig.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/com/amazon/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceConfig.java
@@ -131,6 +131,10 @@ public class OTelMetricsSourceConfig {
         return healthCheck;
     }
 
+    public boolean enableHttpHealthCheck() {
+        return enableUnframedRequests() && hasHealthCheck();
+    }
+
     public boolean hasProtoReflectionService() {
         return protoReflectionService;
     }

--- a/data-prepper-plugins/otel-metrics-source/src/test/java/com/amazon/dataprepper/plugins/source/otelmetrics/OtelMetricsSourceConfigTests.java
+++ b/data-prepper-plugins/otel-metrics-source/src/test/java/com/amazon/dataprepper/plugins/source/otelmetrics/OtelMetricsSourceConfigTests.java
@@ -48,11 +48,48 @@ public class OtelMetricsSourceConfigTests {
         assertEquals(DEFAULT_THREAD_COUNT, otelMetricsSourceConfig.getThreadCount());
         assertEquals(OTelMetricsSourceConfig.DEFAULT_MAX_CONNECTION_COUNT, otelMetricsSourceConfig.getMaxConnectionCount());
         assertFalse(otelMetricsSourceConfig.hasHealthCheck());
+        assertFalse(otelMetricsSourceConfig.enableHttpHealthCheck());
         assertFalse(otelMetricsSourceConfig.hasProtoReflectionService());
         assertFalse(otelMetricsSourceConfig.isSslCertAndKeyFileInS3());
         assertTrue(otelMetricsSourceConfig.isSsl());
         assertNull(otelMetricsSourceConfig.getSslKeyCertChainFile());
         assertNull(otelMetricsSourceConfig.getSslKeyFile());
+    }
+
+    @Test
+    public void testHttpHealthCheckWithUnframedRequestEnabled() {
+        // Prepare
+        final Map<String, Object> settings = new HashMap<>();
+        settings.put(OTelMetricsSourceConfig.ENABLE_UNFRAMED_REQUESTS, "true");
+        settings.put(OTelMetricsSourceConfig.HEALTH_CHECK_SERVICE, "true");
+        settings.put(OTelMetricsSourceConfig.PROTO_REFLECTION_SERVICE, "true");
+
+        final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, settings);
+        final OTelMetricsSourceConfig otelMetricsSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelMetricsSourceConfig.class);
+
+        // When/Then
+        assertTrue(otelMetricsSourceConfig.hasHealthCheck());
+        assertTrue(otelMetricsSourceConfig.enableUnframedRequests());
+        assertTrue(otelMetricsSourceConfig.hasProtoReflectionService());
+        assertTrue(otelMetricsSourceConfig.enableHttpHealthCheck());
+    }
+
+    @Test
+    public void testHttpHealthCheckWithUnframedRequestDisabled() {
+        // Prepare
+        final Map<String, Object> settings = new HashMap<>();
+        settings.put(OTelMetricsSourceConfig.ENABLE_UNFRAMED_REQUESTS, "false");
+        settings.put(OTelMetricsSourceConfig.HEALTH_CHECK_SERVICE, "true");
+        settings.put(OTelMetricsSourceConfig.PROTO_REFLECTION_SERVICE, "true");
+
+        final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, settings);
+        final OTelMetricsSourceConfig otelMetricsSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelMetricsSourceConfig.class);
+
+        // When/Then
+        assertTrue(otelMetricsSourceConfig.hasHealthCheck());
+        assertFalse(otelMetricsSourceConfig.enableUnframedRequests());
+        assertTrue(otelMetricsSourceConfig.hasProtoReflectionService());
+        assertFalse(otelMetricsSourceConfig.enableHttpHealthCheck());
     }
 
     @Test
@@ -81,6 +118,7 @@ public class OtelMetricsSourceConfigTests {
         assertEquals(TEST_MAX_CONNECTION_COUNT, otelMetricsSourceConfig.getMaxConnectionCount());
         assertTrue(otelMetricsSourceConfig.hasHealthCheck());
         assertTrue(otelMetricsSourceConfig.hasProtoReflectionService());
+        assertFalse(otelMetricsSourceConfig.enableHttpHealthCheck());
         assertTrue(otelMetricsSourceConfig.isSsl());
         assertFalse(otelMetricsSourceConfig.isSslCertAndKeyFileInS3());
         assertEquals(TEST_KEY_CERT, otelMetricsSourceConfig.getSslKeyCertChainFile());
@@ -113,6 +151,7 @@ public class OtelMetricsSourceConfigTests {
         assertEquals(TEST_THREAD_COUNT, otelMetricsSourceConfig.getThreadCount());
         assertEquals(TEST_MAX_CONNECTION_COUNT, otelMetricsSourceConfig.getMaxConnectionCount());
         assertFalse(otelMetricsSourceConfig.hasHealthCheck());
+        assertFalse(otelMetricsSourceConfig.enableHttpHealthCheck());
         assertFalse(otelMetricsSourceConfig.hasProtoReflectionService());
         assertTrue(otelMetricsSourceConfig.isSsl());
         assertTrue(otelMetricsSourceConfig.isSslCertAndKeyFileInS3());

--- a/data-prepper-plugins/otel-trace-source/README.md
+++ b/data-prepper-plugins/otel-trace-source/README.md
@@ -14,11 +14,9 @@ source:
 
 * port(Optional) => An `int` represents the port Otel trace source is running on. Default is ```21890```.
 * request_timeout(Optional) => An `int` represents request timeout in millis. Default is ```10_000```.
-* health_check_service(Optional) => A boolean enables health check service. When ```true``` enables a gRPC health check service under ```grpc.health.v1.Health/Check```. Default is ```false```.
-  * ```proto_reflection_service``` should be enabled to use the health check service.
+* health_check_service(Optional) => A boolean enables health check service. When ```true``` enables a gRPC health check service under ```grpc.health.v1.Health/Check```. Default is ```false```. In order to use the health check service, you must also enable ```proto_reflection_service```.
 * proto_reflection_service(Optional) => A boolean enables a reflection service for Protobuf services (see [ProtoReflectionService](https://grpc.github.io/grpc-java/javadoc/io/grpc/protobuf/services/ProtoReflectionService.html) and [gRPC reflection](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md) docs). Default is ```false```.
-* unframed_requests(Optional) => A boolean to enable requests not framed using the gRPC wire protocol. 
-  * when ```health_check_service``` is true and ```unframed_requests``` is true, enables HTTP health check service under ```/health```.
+* unframed_requests(Optional) => A boolean to enable requests not framed using the gRPC wire protocol. When ```health_check_service``` is true and ```unframed_requests``` is true, enables HTTP health check service under ```/health```.
 * thread_count(Optional) => the number of threads to keep in the ScheduledThreadPool. Default is `200`.
 * max_connection_count(Optional) => the maximum allowed number of open connections. Default is `500`. 
 * authentication(Optional) => An authentication configuration. By default, this runs an unauthenticated server. See below for more information.

--- a/data-prepper-plugins/otel-trace-source/README.md
+++ b/data-prepper-plugins/otel-trace-source/README.md
@@ -14,9 +14,11 @@ source:
 
 * port(Optional) => An `int` represents the port Otel trace source is running on. Default is ```21890```.
 * request_timeout(Optional) => An `int` represents request timeout in millis. Default is ```10_000```.
-* health_check_service(Optional) => A boolean enables a gRPC health check service under ```grpc.health.v1 / Health / Check```. Default is ```false```.
+* health_check_service(Optional) => A boolean enables health check service. When ```true``` enables a gRPC health check service under ```grpc.health.v1.Health/Check```. Default is ```false```.
+  * ```proto_reflection_service``` should be enabled to use the health check service.
 * proto_reflection_service(Optional) => A boolean enables a reflection service for Protobuf services (see [ProtoReflectionService](https://grpc.github.io/grpc-java/javadoc/io/grpc/protobuf/services/ProtoReflectionService.html) and [gRPC reflection](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md) docs). Default is ```false```.
 * unframed_requests(Optional) => A boolean to enable requests not framed using the gRPC wire protocol. 
+  * when ```health_check_service``` is true and ```unframed_requests``` is true, enables HTTP health check service under ```/health```.
 * thread_count(Optional) => the number of threads to keep in the ScheduledThreadPool. Default is `200`.
 * max_connection_count(Optional) => the maximum allowed number of open connections. Default is `500`. 
 * authentication(Optional) => An authentication configuration. By default, this runs an unauthenticated server. See below for more information.

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
@@ -135,6 +135,10 @@ public class OTelTraceSourceConfig {
         return healthCheck;
     }
 
+    public boolean enableHttpHealthCheck() {
+        return enableUnframedRequests() && hasHealthCheck();
+    }
+
     public boolean hasProtoReflectionService() {
         return protoReflectionService;
     }

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
+import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import io.grpc.BindableService;
 import io.grpc.ServerServiceDefinition;
 import io.netty.util.AsciiString;
@@ -415,6 +416,50 @@ public class OTelTraceSourceTest {
         verify(grpcServiceBuilder, times(1)).useClientTimeoutHeader(false);
         verify(grpcServiceBuilder, times(1)).useBlockingTaskExecutor(true);
         verify(grpcServiceBuilder).addService(isA(HealthGrpcService.class));
+        verify(serverBuilder, never()).service(eq("/health"),isA(HealthCheckService.class));
+    }
+
+    @Test
+    void start_with_Health_configured_unframed_requests_includes_HTTPHealthCheck_service() throws IOException {
+        try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class);
+             MockedStatic<GrpcService> grpcServerMock = Mockito.mockStatic(GrpcService.class)) {
+            armeriaServerMock.when(Server::builder).thenReturn(serverBuilder);
+            grpcServerMock.when(GrpcService::builder).thenReturn(grpcServiceBuilder);
+            when(grpcServiceBuilder.addService(any(ServerServiceDefinition.class))).thenReturn(grpcServiceBuilder);
+            when(grpcServiceBuilder.useClientTimeoutHeader(anyBoolean())).thenReturn(grpcServiceBuilder);
+
+            when(server.stop()).thenReturn(completableFuture);
+            final Path certFilePath = Path.of("data/certificate/test_cert.crt");
+            final Path keyFilePath = Path.of("data/certificate/test_decrypted_key.key");
+            final String certAsString = Files.readString(certFilePath);
+            final String keyAsString = Files.readString(keyFilePath);
+            when(certificate.getCertificate()).thenReturn(certAsString);
+            when(certificate.getPrivateKey()).thenReturn(keyAsString);
+            when(certificateProvider.getCertificate()).thenReturn(certificate);
+            when(certificateProviderFactory.getCertificateProvider()).thenReturn(certificateProvider);
+            final Map<String, Object> settingsMap = new HashMap<>();
+            settingsMap.put(SSL, true);
+            settingsMap.put("useAcmCertForSSL", true);
+            settingsMap.put("awsRegion", "us-east-1");
+            settingsMap.put("acmCertificateArn", "arn:aws:acm:us-east-1:account:certificate/1234-567-856456");
+            settingsMap.put("sslKeyCertChainFile", "data/certificate/test_cert.crt");
+            settingsMap.put("sslKeyFile", "data/certificate/test_decrypted_key.key");
+            settingsMap.put("health_check_service", "true");
+            settingsMap.put("unframed_requests", "true");
+
+            testPluginSetting = new PluginSetting(null, settingsMap);
+            testPluginSetting.setPipelineName("pipeline");
+
+            oTelTraceSourceConfig = OBJECT_MAPPER.convertValue(testPluginSetting.getSettings(), OTelTraceSourceConfig.class);
+            final OTelTraceSource source = new OTelTraceSource(oTelTraceSourceConfig, pluginMetrics, pluginFactory, certificateProviderFactory);
+            source.start(buffer);
+            source.stop();
+        }
+
+        verify(grpcServiceBuilder, times(1)).useClientTimeoutHeader(false);
+        verify(grpcServiceBuilder, times(1)).useBlockingTaskExecutor(true);
+        verify(grpcServiceBuilder).addService(isA(HealthGrpcService.class));
+        verify(serverBuilder).service(eq("/health"), isA(HealthCheckService.class));
     }
 
     @Test
@@ -455,6 +500,49 @@ public class OTelTraceSourceTest {
         verify(grpcServiceBuilder, times(1)).useClientTimeoutHeader(false);
         verify(grpcServiceBuilder, times(1)).useBlockingTaskExecutor(true);
         verify(grpcServiceBuilder, never()).addService(isA(HealthGrpcService.class));
+        verify(serverBuilder, never()).service(eq("/health"),isA(HealthCheckService.class));
+    }
+
+    @Test
+    void start_without_Health_configured_unframed_requests_does_not_include_HealthCheck_service() throws IOException {
+        try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class);
+             MockedStatic<GrpcService> grpcServerMock = Mockito.mockStatic(GrpcService.class)) {
+            armeriaServerMock.when(Server::builder).thenReturn(serverBuilder);
+            grpcServerMock.when(GrpcService::builder).thenReturn(grpcServiceBuilder);
+            when(grpcServiceBuilder.addService(any(ServerServiceDefinition.class))).thenReturn(grpcServiceBuilder);
+            when(grpcServiceBuilder.useClientTimeoutHeader(anyBoolean())).thenReturn(grpcServiceBuilder);
+
+            when(server.stop()).thenReturn(completableFuture);
+            final Path certFilePath = Path.of("data/certificate/test_cert.crt");
+            final Path keyFilePath = Path.of("data/certificate/test_decrypted_key.key");
+            final String certAsString = Files.readString(certFilePath);
+            final String keyAsString = Files.readString(keyFilePath);
+            when(certificate.getCertificate()).thenReturn(certAsString);
+            when(certificate.getPrivateKey()).thenReturn(keyAsString);
+            when(certificateProvider.getCertificate()).thenReturn(certificate);
+            when(certificateProviderFactory.getCertificateProvider()).thenReturn(certificateProvider);
+            final Map<String, Object> settingsMap = new HashMap<>();
+            settingsMap.put(SSL, true);
+            settingsMap.put("useAcmCertForSSL", true);
+            settingsMap.put("awsRegion", "us-east-1");
+            settingsMap.put("acmCertificateArn", "arn:aws:acm:us-east-1:account:certificate/1234-567-856456");
+            settingsMap.put("sslKeyCertChainFile", "data/certificate/test_cert.crt");
+            settingsMap.put("sslKeyFile", "data/certificate/test_decrypted_key.key");
+            settingsMap.put("health_check_service", "false");
+            settingsMap.put("unframed_requests", "true");
+
+            testPluginSetting = new PluginSetting(null, settingsMap);
+            testPluginSetting.setPipelineName("pipeline");
+            oTelTraceSourceConfig = OBJECT_MAPPER.convertValue(testPluginSetting.getSettings(), OTelTraceSourceConfig.class);
+            final OTelTraceSource source = new OTelTraceSource(oTelTraceSourceConfig, pluginMetrics, pluginFactory, certificateProviderFactory);
+            source.start(buffer);
+            source.stop();
+        }
+
+        verify(grpcServiceBuilder, times(1)).useClientTimeoutHeader(false);
+        verify(grpcServiceBuilder, times(1)).useBlockingTaskExecutor(true);
+        verify(grpcServiceBuilder, never()).addService(isA(HealthGrpcService.class));
+        verify(serverBuilder, never()).service(eq("/health"),isA(HealthCheckService.class));
     }
 
     @Test

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
@@ -52,10 +52,47 @@ public class OtelTraceSourceConfigTests {
         assertEquals(OTelTraceSourceConfig.DEFAULT_RECORD_TYPE, otelTraceSourceConfig.getRecordType());
         assertFalse(otelTraceSourceConfig.hasHealthCheck());
         assertFalse(otelTraceSourceConfig.hasProtoReflectionService());
+        assertFalse(otelTraceSourceConfig.enableHttpHealthCheck());
         assertFalse(otelTraceSourceConfig.isSslCertAndKeyFileInS3());
         assertTrue(otelTraceSourceConfig.isSsl());
         assertNull(otelTraceSourceConfig.getSslKeyCertChainFile());
         assertNull(otelTraceSourceConfig.getSslKeyFile());
+    }
+
+    @Test
+    public void testHttpHealthCheckWithUnframedRequestEnabled() {
+        // Prepare
+        final Map<String, Object> settings = new HashMap<>();
+        settings.put(OTelTraceSourceConfig.ENABLE_UNFRAMED_REQUESTS, "true");
+        settings.put(OTelTraceSourceConfig.HEALTH_CHECK_SERVICE, "true");
+        settings.put(OTelTraceSourceConfig.PROTO_REFLECTION_SERVICE, "true");
+
+        final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, settings);
+        final OTelTraceSourceConfig otelTraceSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelTraceSourceConfig.class);
+
+        // When/Then
+        assertTrue(otelTraceSourceConfig.hasHealthCheck());
+        assertTrue(otelTraceSourceConfig.enableUnframedRequests());
+        assertTrue(otelTraceSourceConfig.hasProtoReflectionService());
+        assertTrue(otelTraceSourceConfig.enableHttpHealthCheck());
+    }
+
+    @Test
+    public void testHttpHealthCheckWithUnframedRequestDisabled() {
+        // Prepare
+        final Map<String, Object> settings = new HashMap<>();
+        settings.put(OTelTraceSourceConfig.ENABLE_UNFRAMED_REQUESTS, "false");
+        settings.put(OTelTraceSourceConfig.HEALTH_CHECK_SERVICE, "true");
+        settings.put(OTelTraceSourceConfig.PROTO_REFLECTION_SERVICE, "true");
+
+        final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, settings);
+        final OTelTraceSourceConfig otelTraceSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelTraceSourceConfig.class);
+
+        // When/Then
+        assertTrue(otelTraceSourceConfig.hasHealthCheck());
+        assertFalse(otelTraceSourceConfig.enableUnframedRequests());
+        assertTrue(otelTraceSourceConfig.hasProtoReflectionService());
+        assertFalse(otelTraceSourceConfig.enableHttpHealthCheck());
     }
 
     @Test
@@ -85,6 +122,7 @@ public class OtelTraceSourceConfigTests {
         assertEquals(TEST_MAX_CONNECTION_COUNT, otelTraceSourceConfig.getMaxConnectionCount());
         assertTrue(otelTraceSourceConfig.hasHealthCheck());
         assertTrue(otelTraceSourceConfig.hasProtoReflectionService());
+        assertFalse(otelTraceSourceConfig.enableHttpHealthCheck());
         assertTrue(otelTraceSourceConfig.isSsl());
         assertFalse(otelTraceSourceConfig.isSslCertAndKeyFileInS3());
         assertEquals(TEST_KEY_CERT, otelTraceSourceConfig.getSslKeyCertChainFile());
@@ -119,6 +157,7 @@ public class OtelTraceSourceConfigTests {
         assertEquals(TEST_MAX_CONNECTION_COUNT, otelTraceSourceConfig.getMaxConnectionCount());
         assertFalse(otelTraceSourceConfig.hasHealthCheck());
         assertFalse(otelTraceSourceConfig.hasProtoReflectionService());
+        assertFalse(otelTraceSourceConfig.enableHttpHealthCheck());
         assertTrue(otelTraceSourceConfig.isSsl());
         assertTrue(otelTraceSourceConfig.isSslCertAndKeyFileInS3());
         assertEquals(TEST_KEY_CERT_S3, otelTraceSourceConfig.getSslKeyCertChainFile());


### PR DESCRIPTION
Signed-off-by: Dinu John <dinujohn@amazon.com>

### Description
Enable HTTP Health Check for OTelTraceSource and OTelMetricsSource
 
### Issues Resolved
[1546](https://github.com/opensearch-project/data-prepper/issues/1546)
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
