### PR TITLE
Fix: Added exception handling for S3 processing

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/configuration/SqsOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/configuration/SqsOptions.java
@@ -6,6 +6,8 @@
 package com.amazon.dataprepper.plugins.source.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import org.hibernate.validator.constraints.time.DurationMax;
 import org.hibernate.validator.constraints.time.DurationMin;
@@ -23,6 +25,8 @@ public class SqsOptions {
     private String sqsUrl;
 
     @JsonProperty("maximum_messages")
+    @Min(1)
+    @Max(10)
     private int maximumMessages = DEFAULT_MAXIMUM_MESSAGES;
 
     @JsonProperty("visibility_timeout")


### PR DESCRIPTION
…y condition

Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description

- Updated exception handling for S3Object processing when there's no permission to getObject from S3
- Added min and max validation to `maximum_messages` configuration option
- Updated poll delay logic

 
### Issues Resolved
Resolves #1544 
Resolves #1550 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
