### PR TITLE
Add QueryParameters option to AWS CloudMap-based peer discovery

### DIFF
--- a/data-prepper-plugins/peer-forwarder/README.md
+++ b/data-prepper-plugins/peer-forwarder/README.md
@@ -59,6 +59,9 @@ Your pipeline configuration needs to include:
 * `awsRegion` - The AWS region where your namespace exists.
 * `discovery_mode` - Set to `aws_cloud_map`
 
+Your pipeline configuration can optionally include:
+* `awsCloudMapQueryParameters` - Key/value pairs to filter the results based on custom attributes for the instance. Only instances that match all the specified key-value pairs are returned.
+
 Example configuration:
 
 ```
@@ -67,6 +70,8 @@ Example configuration:
         discovery_mode: aws_cloud_map
         awsCloudMapNamespaceName: my-namespace
         awsCloudMapServiceName: data-prepper-cluster
+        awsCloudMapQueryParameters:
+            instance_type: r5.xlarge
         awsRegion: us-east-1
 ```
 

--- a/data-prepper-plugins/peer-forwarder/README.md
+++ b/data-prepper-plugins/peer-forwarder/README.md
@@ -60,7 +60,7 @@ Your pipeline configuration needs to include:
 * `discovery_mode` - Set to `aws_cloud_map`
 
 Your pipeline configuration can optionally include:
-* `awsCloudMapQueryParameters` - Key/value pairs to filter the results based on custom attributes for the instance. Only instances that match all the specified key-value pairs are returned.
+* `awsCloudMapQueryParameters` - Key/value pairs to filter the results based on the custom attributes attached to an instance. Only instances that match all the specified key-value pairs are returned.
 
 Example configuration:
 

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderConfig.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderConfig.java
@@ -35,6 +35,7 @@ public class PeerForwarderConfig {
     public static final String AWS_REGION = "awsRegion";
     public static final String AWS_CLOUD_MAP_NAMESPACE_NAME = "awsCloudMapNamespaceName";
     public static final String AWS_CLOUD_MAP_SERVICE_NAME = "awsCloudMapServiceName";
+    public static final String AWS_CLOUD_MAP_QUERY_PARAMETERS = "awsCloudMapQueryParameters";
 
     private final HashRing hashRing;
     private final PeerClientPool peerClientPool;

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/AwsCloudMapPeerListProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/AwsCloudMapPeerListProvider.java
@@ -45,6 +45,7 @@ class AwsCloudMapPeerListProvider implements PeerListProvider, AutoCloseable {
     private final ServiceDiscoveryAsyncClient awsServiceDiscovery;
     private final String namespaceName;
     private final String serviceName;
+    private final Map<String, String> queryParameters;
     private final AwsCloudMapDynamicEndpointGroup endpointGroup;
     private final int timeToRefreshSeconds;
     private final Backoff backoff;
@@ -55,12 +56,14 @@ class AwsCloudMapPeerListProvider implements PeerListProvider, AutoCloseable {
             final ServiceDiscoveryAsyncClient awsServiceDiscovery,
             final String namespaceName,
             final String serviceName,
+            final Map<String, String> queryParameters,
             final int timeToRefreshSeconds,
             final Backoff backoff,
             final PluginMetrics pluginMetrics) {
         this.awsServiceDiscovery = Objects.requireNonNull(awsServiceDiscovery);
         this.namespaceName = Objects.requireNonNull(namespaceName);
         this.serviceName = Objects.requireNonNull(serviceName);
+        this.queryParameters = Objects.requireNonNull(queryParameters);
         this.timeToRefreshSeconds = timeToRefreshSeconds;
         this.backoff = Objects.requireNonNull(backoff);
 
@@ -82,6 +85,7 @@ class AwsCloudMapPeerListProvider implements PeerListProvider, AutoCloseable {
         final String awsRegion = getRequiredSettingString(pluginSetting, PeerForwarderConfig.AWS_REGION);
         final String namespace = getRequiredSettingString(pluginSetting, PeerForwarderConfig.AWS_CLOUD_MAP_NAMESPACE_NAME);
         final String serviceName = getRequiredSettingString(pluginSetting, PeerForwarderConfig.AWS_CLOUD_MAP_SERVICE_NAME);
+        final Map<String, String> queryParameters = getOptionalSettingMap(pluginSetting, PeerForwarderConfig.AWS_CLOUD_MAP_QUERY_PARAMETERS);
 
         final Backoff standardBackoff = Backoff.exponential(ONE_SECOND, TWENTY_SECONDS).withJitter(TWENTY_PERCENT);
         final int timeToRefreshSeconds = 20;
@@ -96,6 +100,7 @@ class AwsCloudMapPeerListProvider implements PeerListProvider, AutoCloseable {
                 serviceDiscoveryAsyncClient,
                 namespace,
                 serviceName,
+                queryParameters,
                 timeToRefreshSeconds,
                 standardBackoff,
                 pluginMetrics);
@@ -104,6 +109,16 @@ class AwsCloudMapPeerListProvider implements PeerListProvider, AutoCloseable {
     private static String getRequiredSettingString(final PluginSetting pluginSetting, final String propertyName) {
         final String propertyValue = pluginSetting.getStringOrDefault(propertyName, null);
         return Objects.requireNonNull(propertyValue, String.format("Missing '%s' configuration value", propertyName));
+    }
+
+    private static Map<String, String> getOptionalSettingMap(final PluginSetting pluginSetting, final String propertyName) {
+        final Map<String, String> propertyValue = pluginSetting.getTypedMap(propertyName, String.class, String.class);
+
+        if (propertyValue == null) {
+            return Collections.emptyMap();
+        }
+
+        return propertyValue;
     }
 
     @Override
@@ -152,6 +167,7 @@ class AwsCloudMapPeerListProvider implements PeerListProvider, AutoCloseable {
                     .builder()
                     .namespaceName(namespaceName)
                     .serviceName(serviceName)
+                    .queryParameters(queryParameters)
                     .build();
 
             LOG.info("Discovering instances.");

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/AwsCloudMapPeerListProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/AwsCloudMapPeerListProvider.java
@@ -23,7 +23,9 @@ import software.amazon.awssdk.services.servicediscovery.model.DiscoverInstancesR
 import software.amazon.awssdk.services.servicediscovery.model.DiscoverInstancesResponse;
 import software.amazon.awssdk.services.servicediscovery.model.HttpInstanceSummary;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/AwsCloudMapPeerListProviderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/AwsCloudMapPeerListProviderTest.java
@@ -153,6 +153,7 @@ class AwsCloudMapPeerListProviderTest {
 
         assertThat(actualRequest.namespaceName(), equalTo(namespaceName));
         assertThat(actualRequest.serviceName(), equalTo(serviceName));
+        assertThat(actualRequest.queryParameters(), equalTo(queryParameters));
         assertThat(actualRequest.healthStatusAsString(), nullValue());
     }
 
@@ -244,6 +245,7 @@ class AwsCloudMapPeerListProviderTest {
             for (DiscoverInstancesRequest actualRequest : requestArgumentCaptor.getAllValues()) {
                 assertThat(actualRequest.namespaceName(), equalTo(namespaceName));
                 assertThat(actualRequest.serviceName(), equalTo(serviceName));
+                assertThat(actualRequest.queryParameters(), equalTo(queryParameters));
                 assertThat(actualRequest.healthStatusAsString(), nullValue());
             }
         }

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/AwsCloudMapPeerListProviderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/AwsCloudMapPeerListProviderTest.java
@@ -55,6 +55,7 @@ class AwsCloudMapPeerListProviderTest {
     private ServiceDiscoveryAsyncClient awsServiceDiscovery;
     private String namespaceName;
     private String serviceName;
+    private Map<String, String> queryParameters;
     private int timeToRefreshSeconds;
     private Backoff backoff;
     private PluginMetrics pluginMetrics;
@@ -65,6 +66,7 @@ class AwsCloudMapPeerListProviderTest {
         awsServiceDiscovery = mock(ServiceDiscoveryAsyncClient.class);
         namespaceName = RandomStringUtils.randomAlphabetic(10);
         serviceName = RandomStringUtils.randomAlphabetic(10);
+        queryParameters = Collections.emptyMap();
 
         timeToRefreshSeconds = 1;
         backoff = mock(Backoff.class);
@@ -103,6 +105,14 @@ class AwsCloudMapPeerListProviderTest {
     @Test
     void constructor_throws_with_null_ServiceName() {
         serviceName = null;
+
+        assertThrows(NullPointerException.class,
+                this::createObjectUnderTest);
+    }
+
+    @Test
+    void constructor_throws_with_null_QueryParameters() {
+        queryParameters = null;
 
         assertThrows(NullPointerException.class,
                 this::createObjectUnderTest);

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/AwsCloudMapPeerListProviderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/AwsCloudMapPeerListProviderTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -81,7 +82,7 @@ class AwsCloudMapPeerListProviderTest {
     }
 
     private AwsCloudMapPeerListProvider createObjectUnderTest() {
-        final AwsCloudMapPeerListProvider objectUnderTest = new AwsCloudMapPeerListProvider(awsServiceDiscovery, namespaceName, serviceName, timeToRefreshSeconds, backoff, pluginMetrics);
+        final AwsCloudMapPeerListProvider objectUnderTest = new AwsCloudMapPeerListProvider(awsServiceDiscovery, namespaceName, serviceName, queryParameters, timeToRefreshSeconds, backoff, pluginMetrics);
         objectsToClose.add(objectUnderTest);
         return objectUnderTest;
     }

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/AwsCloudMapPeerListProviderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/AwsCloudMapPeerListProviderTest.java
@@ -26,11 +26,13 @@ import software.amazon.awssdk.services.servicediscovery.model.HttpInstanceSummar
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -67,7 +69,7 @@ class AwsCloudMapPeerListProviderTest {
         awsServiceDiscovery = mock(ServiceDiscoveryAsyncClient.class);
         namespaceName = RandomStringUtils.randomAlphabetic(10);
         serviceName = RandomStringUtils.randomAlphabetic(10);
-        queryParameters = Collections.emptyMap();
+        queryParameters = generateRandomStringMap();
 
         timeToRefreshSeconds = 1;
         backoff = mock(Backoff.class);
@@ -401,5 +403,15 @@ class AwsCloudMapPeerListProviderTest {
                 .map(i -> random.nextInt(255))
                 .mapToObj(Integer::toString)
                 .collect(Collectors.joining("."));
+    }
+
+    private static Map<String, String> generateRandomStringMap() {
+        final Random random = new Random();
+
+        final Map<String, String> map = new HashMap<>();
+        IntStream.range(0, random.nextInt(5) + 1)
+                .mapToObj(num -> map.put(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+
+        return map;
     }
 }

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/AwsCloudMapPeerListProvider_CreateTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/AwsCloudMapPeerListProvider_CreateTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import software.amazon.awssdk.regions.Region;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -48,6 +49,8 @@ class AwsCloudMapPeerListProvider_CreateTest {
         pluginSetting.getSettings().put(PeerForwarderConfig.AWS_CLOUD_MAP_NAMESPACE_NAME, UUID.randomUUID().toString());
         pluginSetting.getSettings().put(PeerForwarderConfig.AWS_CLOUD_MAP_SERVICE_NAME, UUID.randomUUID().toString());
         pluginSetting.getSettings().put(PeerForwarderConfig.AWS_REGION, "us-east-1");
+        pluginSetting.getSettings().put(PeerForwarderConfig.AWS_CLOUD_MAP_QUERY_PARAMETERS,
+                Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
 
     }
 
@@ -70,6 +73,18 @@ class AwsCloudMapPeerListProvider_CreateTest {
         assertThrows(NullPointerException.class,
                 () -> AwsCloudMapPeerListProvider.createPeerListProvider(pluginSetting, pluginMetrics));
 
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            PeerForwarderConfig.AWS_CLOUD_MAP_QUERY_PARAMETERS
+    })
+    void createPeerListProvider_with_missing_optional_map_property(final String propertyToRemove) {
+        pluginSetting.getSettings().remove(propertyToRemove);
+
+        final PeerListProvider result = AwsCloudMapPeerListProvider.createPeerListProvider(pluginSetting, pluginMetrics);
+
+        assertThat(result, instanceOf(AwsCloudMapPeerListProvider.class));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Description
This PR adds `awsCloudMapQueryParameters` as an optional setting when using AWS CloudMap for peer discovery. The implementation accepts a `Map<String, String>` which is passed directly to the `queryParameters` field of the `DiscoverInstancesRequest`.

Documentation on this field: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/servicediscovery/model/DiscoverInstancesRequest.Builder.html#queryParameters-java.util.Map-
 
### Testing
AWS CloudMap service contents:
```
aws servicediscovery --region eu-west-1 discover-instances --namespace serv-disc --service serv-disc
{
    "Instances": [
        {
            "InstanceId": "a2ae948ed1244897bf8dfa404fc9593c",
            "NamespaceName": "serv-disc",
            "ServiceName": "serv-disc",
            "HealthStatus": "HEALTHY",
            "Attributes": {
                "AWS_INSTANCE_IPV4": "<redacted>",
                "REGION": "eu-west-1"
            }
        },
        {
            "InstanceId": "30e368d910bf421e98a246d7275987ba",
            "NamespaceName": "serv-disc",
            "ServiceName": "serv-disc",
            "HealthStatus": "HEALTHY",
            "Attributes": {
                "AWS_INSTANCE_IPV4": "<redacted>",
                "REGION": "eu-west-1",
                "test": "filter-params"
            }
        },
        {
            "InstanceId": "c18c00a21852483ebefbb020510bb910",
            "NamespaceName": "serv-disc",
            "ServiceName": "serv-disc",
            "HealthStatus": "HEALTHY",
            "Attributes": {
                "AWS_INSTANCE_IPV4": "<redacted>",
                "REGION": "eu-west-1"
            }
        }
    ]
}
```
#### Testing no filters
pipelines.yaml:
```
simple-sample-pipeline:
  workers: 2
  delay: "5000"
  source:
    random:
  processor:
    - peer_forwarder:
        discovery_mode: aws_cloud_map
        ssl: false
        awsCloudMapNamespaceName: serv-disc
        awsCloudMapServiceName: serv-disc
        awsRegion: eu-west-1
  sink:
    - stdout:
```
Logs:
```
2022-07-01T22:41:13,504 [sdk-async-response-0-0] INFO  com.amazon.dataprepper.plugins.prepper.peerforwarder.discovery.AwsCloudMapPeerListProvider$AwsCloudMapDynamicEndpointGroup - Discovered 3 instances.
```
#### Testing filter has match:
pipelines.yaml:
```
simple-sample-pipeline:
  workers: 2
  delay: "5000"
  source:
    random:
  processor:
    - peer_forwarder:
        discovery_mode: aws_cloud_map
        ssl: false
        awsCloudMapNamespaceName: serv-disc
        awsCloudMapServiceName: serv-disc
        awsRegion: eu-west-1
        awsCloudMapQueryParameters:
          test: filter-params
  sink:
    - stdout:
```
Logs:
```
2022-07-01T22:58:23,312 [sdk-async-response-0-0] INFO  com.amazon.dataprepper.plugins.prepper.peerforwarder.discovery.AwsCloudMapPeerListProvider$AwsCloudMapDynamicEndpointGroup - Discovered 1 instances.
```
#### Testing filter has no matches
pipelines.yaml:
```
simple-sample-pipeline:
  workers: 2
  delay: "5000"
  source:
    random:
  processor:
    - peer_forwarder:
        discovery_mode: aws_cloud_map
        ssl: false
        awsCloudMapNamespaceName: serv-disc
        awsCloudMapServiceName: serv-disc
        awsRegion: eu-west-1
        awsCloudMapQueryParameters:
          test: no-match
  sink:
    - stdout:
```
Logs:
```
2022-07-01T22:59:47,138 [sdk-async-response-0-0] INFO  com.amazon.dataprepper.plugins.prepper.peerforwarder.discovery.AwsCloudMapPeerListProvider$AwsCloudMapDynamicEndpointGroup - Discovered 0 instances.
2022-07-01T22:59:47,141 [sdk-async-response-0-0] INFO  com.amazon.dataprepper.plugins.prepper.peerforwarder.HashRing - Building hash ring with endpoints: []
```
#### Testing blank entry
pipelines.yaml:
```
simple-sample-pipeline:
  workers: 2
  delay: "5000"
  source:
    random:
  processor:
    - peer_forwarder:
        discovery_mode: aws_cloud_map
        ssl: false
        awsCloudMapNamespaceName: serv-disc
        awsCloudMapServiceName: serv-disc
        awsRegion: eu-west-1
        awsCloudMapQueryParameters:
  sink:
    - stdout:
```
Logs:
```
2022-07-01T23:02:33,129 [sdk-async-response-0-0] INFO  com.amazon.dataprepper.plugins.prepper.peerforwarder.discovery.AwsCloudMapPeerListProvider$AwsCloudMapDynamicEndpointGroup - Discovered 3 instances.
```

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [N/A] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
