### PR TITLE
Updated integration tests with GZIP compression tests

### DIFF
--- a/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/S3ObjectGenerator.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/S3ObjectGenerator.java
@@ -46,7 +46,7 @@ public class S3ObjectGenerator {
                                      final boolean isCompressionEnabled,
                                      final OutputStream outputStream) throws IOException {
         if (isCompressionEnabled) {
-            try (final GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream);){
+            try (final GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream)){
                 objectGenerator.write(numberOfRecords, gzipOutputStream);
                 gzipOutputStream.flush();
             }

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/S3ObjectWorkerIT.java
@@ -11,6 +11,7 @@ import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.source.codec.Codec;
 import com.amazon.dataprepper.plugins.source.compression.CompressionEngine;
+import com.amazon.dataprepper.plugins.source.compression.GZipCompressionEngine;
 import com.amazon.dataprepper.plugins.source.compression.NoneCompressionEngine;
 import com.amazon.dataprepper.plugins.source.ownership.BucketOwnerProvider;
 import io.micrometer.core.instrument.Counter;
@@ -56,7 +57,6 @@ class S3ObjectWorkerIT {
     private S3Client s3Client;
     private S3ObjectGenerator s3ObjectGenerator;
     private Buffer<Record<Event>> buffer;
-    private CompressionEngine compressionEngine;
     private String bucket;
     private int recordsReceived;
     private PluginMetrics pluginMetrics;
@@ -71,7 +71,6 @@ class S3ObjectWorkerIT {
         s3ObjectGenerator = new S3ObjectGenerator(s3Client, bucket);
 
         buffer = mock(Buffer.class);
-        compressionEngine = new NoneCompressionEngine();
         recordsReceived = 0;
 
         pluginMetrics = mock(PluginMetrics.class);
@@ -101,7 +100,7 @@ class S3ObjectWorkerIT {
                 .when(buffer).writeAll(anyCollection(), anyInt());
     }
 
-    private S3ObjectWorker createObjectUnderTest(final Codec codec, final int numberOfRecordsToAccumulate) {
+    private S3ObjectWorker createObjectUnderTest(final Codec codec, final int numberOfRecordsToAccumulate, final CompressionEngine compressionEngine) {
         return new S3ObjectWorker(s3Client, buffer, compressionEngine, codec, bucketOwnerProvider, Duration.ofMillis(TIMEOUT_IN_MILLIS), numberOfRecordsToAccumulate, pluginMetrics);
     }
 
@@ -110,13 +109,22 @@ class S3ObjectWorkerIT {
     void parseS3Object_correctly_loads_data_into_Buffer(
             final RecordsGenerator recordsGenerator,
             final int numberOfRecords,
-            final int numberOfRecordsToAccumulate) throws Exception {
+            final int numberOfRecordsToAccumulate,
+            final boolean shouldCompress) throws Exception {
 
-        final String key = "s3source/s3/" + numberOfRecords + "_" + Instant.now().toString() + recordsGenerator.getFileExtension();
-        s3ObjectGenerator.write(numberOfRecords, key, recordsGenerator);
+        S3ObjectWorker objectUnderTest;
+        String key;
 
-        final S3ObjectWorker objectUnderTest = createObjectUnderTest(recordsGenerator.getCodec(), numberOfRecordsToAccumulate);
+        if (shouldCompress) {
+            key = "s3source/s3/" + numberOfRecords + "_" + Instant.now().toString() + recordsGenerator.getFileExtension() + ".gz";
+            objectUnderTest = createObjectUnderTest(recordsGenerator.getCodec(), numberOfRecordsToAccumulate, new GZipCompressionEngine());
+        }
+        else {
+            key = "s3source/s3/" + numberOfRecords + "_" + Instant.now().toString() + recordsGenerator.getFileExtension();
+            objectUnderTest = createObjectUnderTest(recordsGenerator.getCodec(), numberOfRecordsToAccumulate, new NoneCompressionEngine());
+        }
 
+        s3ObjectGenerator.write(numberOfRecords, key, recordsGenerator, shouldCompress);
         stubBufferWriter(recordsGenerator::assertEventIsCorrect, key);
 
         parseObject(key, objectUnderTest);
@@ -140,16 +148,18 @@ class S3ObjectWorkerIT {
             final List<RecordsGenerator> recordsGenerators = List.of(new NewlineDelimitedRecordsGenerator(), new JsonRecordsGenerator());
             final List<Integer> numberOfRecordsList = List.of(0, 1, 25, 500, 5000);
             final List<Integer> recordsToAccumulateList = List.of(1, 100, 1000);
+            final List<Boolean> booleanList = List.of(Boolean.TRUE, Boolean.FALSE);
 
             return recordsGenerators
                     .stream()
-                    .flatMap(recordsGenerator ->
-                            numberOfRecordsList
+                    .flatMap(recordsGenerator -> numberOfRecordsList
+                            .stream()
+                            .flatMap(records -> recordsToAccumulateList
                                     .stream()
-                                    .flatMap(records -> recordsToAccumulateList
+                                    .flatMap(accumulate -> booleanList
                                             .stream()
-                                            .map(accumulate -> arguments(recordsGenerator, records, accumulate))
-                                    ));
+                                            .map(shouldCompress -> arguments(recordsGenerator, records, accumulate, shouldCompress))
+                                    )));
         }
     }
 }

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/SqsWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/SqsWorkerIT.java
@@ -125,7 +125,8 @@ class SqsWorkerIT {
         final NewlineDelimitedRecordsGenerator newlineDelimitedRecordsGenerator = new NewlineDelimitedRecordsGenerator();
         for (int i = 0; i < numberOfObjectsToWrite; i++) {
             final String key = "s3source/sqs/" + UUID.randomUUID() + "_" + Instant.now().toString() + newlineDelimitedRecordsGenerator.getFileExtension();
-            s3ObjectGenerator.write(numberOfRecords, key, newlineDelimitedRecordsGenerator);
+            // isCompressionEnabled is set to false since we test for compression in S3ObjectWorkerIT
+            s3ObjectGenerator.write(numberOfRecords, key, newlineDelimitedRecordsGenerator, false);
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description

- Updated `S3ObjectWorkerIT` to use `GZipCompressionEngine` for compressed files
- Updated `S3ObjectGenerator` to write `.gz` files using `GZIPOutputStream`

This PR doesn't include testing concatenated gzip files.

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
