### PR TITLE
Added the CHANGELOG for 1.5.1

### DIFF
--- a/release/release-notes/data-prepper.change-log-1.5.1.md
+++ b/release/release-notes/data-prepper.change-log-1.5.1.md
@@ -1,0 +1,54 @@
+
+* __Added release notes for Data Prepper 1.5.1. (#1576) (#1579)__
+
+    [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Fri, 8 Jul 2022 11:12:17 -0500
+    
+    EAD -&gt; refs/heads/1.5, refs/remotes/upstream/1.5, refs/remotes/origin/1.5
+    Signed-off-by: David Venable &lt;dlv@amazon.com&gt;
+    (cherry picked from commit 59d43209a239b33a9089248e68e233472cce8ecc)
+     Co-authored-by: David Venable &lt;dlv@amazon.com&gt;
+
+* __Updated the THIRD-PARTY file for 1.5.1 which adds Apache commons-compress. (#1575)__
+
+    [David Venable](mailto:dlv@amazon.com) - Fri, 8 Jul 2022 11:09:32 -0500
+    
+    
+    Signed-off-by: David Venable &lt;dlv@amazon.com&gt;
+
+* __Updated to version 1.5.1 (#1574)__
+
+    [David Venable](mailto:dlv@amazon.com) - Fri, 8 Jul 2022 11:06:36 -0500
+    
+    
+    Signed-off-by: David Venable &lt;dlv@amazon.com&gt;
+
+* __Fix: Updated GZipCompressionEngine to use GzipCompressorInputStream (#1570) (#1572)__
+
+    [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Fri, 8 Jul 2022 00:38:18 -0500
+    
+    
+    Signed-off-by: Asif Sohail Mohammed &lt;nsifmoh@amazon.com&gt;
+    (cherry picked from commit bde1b52ea0b147fefc279b054a509c521bdf3ae7)
+     Co-authored-by: Asif Sohail Mohammed &lt;nsifmoh@amazon.com&gt;
+
+* __Fix: Added exception handling for S3 processing (#1551) (#1565)__
+
+    [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Wed, 6 Jul 2022 08:28:44 -0500
+    
+    
+    * Fix: Added exception handling for S3 processing and updated poll delay
+    condition
+     Signed-off-by: Asif Sohail Mohammed &lt;nsifmoh@amazon.com&gt;
+    (cherry picked from commit 406ae1e09f8b82ecfcebf812a34b79d5340c90cb)
+     Co-authored-by: Asif Sohail Mohammed &lt;nsifmoh@amazon.com&gt;
+
+* __Fixes a bug in the SqsWorkerIT where an NPE occurs. Updated the README.md to include the new steps. (#1538) (#1540)__
+
+    [opensearch-trigger-bot[bot]](mailto:98922864+opensearch-trigger-bot[bot]@users.noreply.github.com) - Fri, 24 Jun 2022 14:14:26 -0500
+    
+    
+    Signed-off-by: David Venable &lt;dlv@amazon.com&gt;
+    (cherry picked from commit bd00a7261291daa878c3f1e57d736f66e1686a31)
+     Co-authored-by: David Venable &lt;dlv@amazon.com&gt;
+
+


### PR DESCRIPTION
### Description

Adds the `CHANGELOG` for 1.5.1.

```
git checkout 1.5
git-release-notes 1.5.0..HEAD markdown > release/release-notes/data-prepper.change-log-1.5.1.md
```
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
