### PR TITLE
Wrote unit tests for LogGeneratorSource, updated gradle.build dependencies

### DIFF
--- a/data-prepper-plugins/log-generator-source/build.gradle
+++ b/data-prepper-plugins/log-generator-source/build.gradle
@@ -9,7 +9,12 @@ plugins {
 
 dependencies {
     implementation project(':data-prepper-api')
+    implementation project(':data-prepper-plugins:blocking-buffer')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/data-prepper-plugins/log-generator-source/src/main/java/com/amazon/dataprepper/plugins/source/loggenerator/LogGeneratorSourceConfig.java
+++ b/data-prepper-plugins/log-generator-source/src/main/java/com/amazon/dataprepper/plugins/source/loggenerator/LogGeneratorSourceConfig.java
@@ -13,13 +13,13 @@ import java.time.Duration;
 
 public class LogGeneratorSourceConfig {
     static int DEFAULT_INTERVAL_SECONDS = 5;
-    static int DEFAULT_LOG_COUNT = 0;
+    static int INFINITE_LOG_COUNT = 0;
 
     @JsonProperty("interval")
     private Duration interval = Duration.ofSeconds(DEFAULT_INTERVAL_SECONDS);
 
     @JsonProperty("total_log_count")
-    private int count = DEFAULT_LOG_COUNT;
+    private int count = INFINITE_LOG_COUNT; // default of 0 => will generate logs until call to stop()
 
     @JsonProperty("log_type")
     @NotNull

--- a/data-prepper-plugins/log-generator-source/src/test/java/com/amazon/dataprepper/plugins/source/loggenerator/LogGeneratorSourceConfigTest.java
+++ b/data-prepper-plugins/log-generator-source/src/test/java/com/amazon/dataprepper/plugins/source/loggenerator/LogGeneratorSourceConfigTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.loggenerator;
+
+
+
+import org.junit.jupiter.api.Test;
+
+import static com.amazon.dataprepper.plugins.source.loggenerator.LogGeneratorSourceConfig.DEFAULT_INTERVAL_SECONDS;
+import static com.amazon.dataprepper.plugins.source.loggenerator.LogGeneratorSourceConfig.DEFAULT_LOG_COUNT;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import java.time.Duration;
+
+class LogGeneratorSourceConfigTest {
+    @Test
+    void GIVEN_defaultLogGeneratorSourceConfig_WHEN_getIntervalCalled_THEN_defaultConstantReturned() {
+        assertThat(new LogGeneratorSourceConfig().getInterval(), equalTo(Duration.ofSeconds(DEFAULT_INTERVAL_SECONDS)));
+    }
+
+    @Test
+    void GIVEN_defaultLogGeneratorSourceConfig_WHEN_getCountCalled_THEN_defaultConstantReturned() {
+        assertThat(new LogGeneratorSourceConfig().getCount(), equalTo(DEFAULT_LOG_COUNT));
+    }
+}

--- a/data-prepper-plugins/log-generator-source/src/test/java/com/amazon/dataprepper/plugins/source/loggenerator/LogGeneratorSourceConfigTest.java
+++ b/data-prepper-plugins/log-generator-source/src/test/java/com/amazon/dataprepper/plugins/source/loggenerator/LogGeneratorSourceConfigTest.java
@@ -10,19 +10,16 @@ package com.amazon.dataprepper.plugins.source.loggenerator;
 import org.junit.jupiter.api.Test;
 
 import static com.amazon.dataprepper.plugins.source.loggenerator.LogGeneratorSourceConfig.DEFAULT_INTERVAL_SECONDS;
-import static com.amazon.dataprepper.plugins.source.loggenerator.LogGeneratorSourceConfig.DEFAULT_LOG_COUNT;
+import static com.amazon.dataprepper.plugins.source.loggenerator.LogGeneratorSourceConfig.INFINITE_LOG_COUNT;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import java.time.Duration;
 
 class LogGeneratorSourceConfigTest {
     @Test
-    void GIVEN_defaultLogGeneratorSourceConfig_WHEN_getIntervalCalled_THEN_defaultConstantReturned() {
-        assertThat(new LogGeneratorSourceConfig().getInterval(), equalTo(Duration.ofSeconds(DEFAULT_INTERVAL_SECONDS)));
-    }
-
-    @Test
-    void GIVEN_defaultLogGeneratorSourceConfig_WHEN_getCountCalled_THEN_defaultConstantReturned() {
-        assertThat(new LogGeneratorSourceConfig().getCount(), equalTo(DEFAULT_LOG_COUNT));
+    void GIVEN_defaultLogGeneratorSourceConfig_THEN_returnExpectedValues() {
+        LogGeneratorSourceConfig objectUnderTest = new LogGeneratorSourceConfig();
+        assertThat(objectUnderTest.getInterval(), equalTo(Duration.ofSeconds(DEFAULT_INTERVAL_SECONDS)));
+        assertThat(objectUnderTest.getCount(), equalTo(INFINITE_LOG_COUNT));
     }
 }

--- a/data-prepper-plugins/log-generator-source/src/test/java/com/amazon/dataprepper/plugins/source/loggenerator/LogGeneratorSourceTest.java
+++ b/data-prepper-plugins/log-generator-source/src/test/java/com/amazon/dataprepper/plugins/source/loggenerator/LogGeneratorSourceTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source.loggenerator;
+
+
+import com.amazon.dataprepper.model.event.JacksonEvent;
+import com.amazon.dataprepper.metrics.PluginMetrics;
+import com.amazon.dataprepper.model.configuration.PluginModel;
+import com.amazon.dataprepper.model.configuration.PluginSetting;
+import com.amazon.dataprepper.model.event.Event;
+import com.amazon.dataprepper.model.plugin.PluginFactory;
+import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.concurrent.TimeoutException;
+import java.time.Duration;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.Assert.assertEquals;
+
+public class LogGeneratorSourceTest {
+    private LogGeneratorSourceConfig sourceConfig;
+    private PluginMetrics pluginMetrics;
+    private PluginFactory pluginFactory;
+    private LogGeneratorSource logGeneratorSource;
+
+    @BeforeEach
+    public void setup() {
+        sourceConfig = mock(LogGeneratorSourceConfig.class);
+        pluginMetrics = mock(PluginMetrics.class);
+        pluginFactory = mock(PluginFactory.class);
+
+        PluginModel mockLogPluginModel = mock(PluginModel.class);
+        when(sourceConfig.getLogType()).thenReturn(mockLogPluginModel);
+
+        when(mockLogPluginModel.getPluginName()).thenReturn(
+                "TestPluginName"
+        );
+        Map<String, Object> emptyMap = new HashMap<>();
+        when(mockLogPluginModel.getPluginSettings()).thenReturn(
+                emptyMap
+        );
+        LogTypeGenerator commonApacheLogTypeGenerator = mock(LogTypeGenerator.class);
+
+
+        when(pluginFactory.loadPlugin(any(), any(PluginSetting.class))).thenReturn(commonApacheLogTypeGenerator);
+        String hardcodedEvent = "127.0.0.1 user pwd [date] \"GET /list HTTP/1.1\" 404 4043";
+        Event stubbedJackson = JacksonEvent.fromMessage(hardcodedEvent);
+        lenient().when(commonApacheLogTypeGenerator.generateEvent()).thenReturn(stubbedJackson); // JacksonEvent type
+
+        logGeneratorSource = new LogGeneratorSource(sourceConfig, pluginMetrics, pluginFactory);
+    }
+
+    @Test
+    void GIVEN_logGeneratorSourceAndBlockingBuffer_WHEN_noLimit_THEN_keepsWritingToBufferUntilStopped()
+            throws InterruptedException, TimeoutException {
+        BlockingBuffer<Record<Event>> spyBuffer = spy(new BlockingBuffer<Record<Event>>("SamplePipeline"));
+
+        lenient().when(sourceConfig.getInterval()).thenReturn(Duration.ofSeconds(1)); // interval of 1 second
+        lenient().when(sourceConfig.getCount()).thenReturn(0); // no limit to log count
+
+        logGeneratorSource.start(spyBuffer);
+        Thread.sleep(1500);
+
+        verify(spyBuffer, atLeast(1)).write(any(Record.class), anyInt());
+        Thread.sleep(700);
+        verify(spyBuffer, atLeast(2)).write(any(Record.class), anyInt());
+        logGeneratorSource.stop();
+    }
+
+    @Test
+    void GIVEN_logGeneratorSourceAndBlockingBuffer_WHEN_reachedLimit_THEN_stopsWritingToBuffer()
+            throws InterruptedException, TimeoutException {
+        BlockingBuffer<Record<Event>> spyBuffer = spy(new BlockingBuffer<Record<Event>>("SamplePipeline"));
+
+        lenient().when(sourceConfig.getInterval()).thenReturn(Duration.ofSeconds(1)); // interval of 1 second
+        lenient().when(sourceConfig.getCount()).thenReturn(1); // max log count of 1 in logGeneratorSource
+
+        logGeneratorSource.start(spyBuffer);
+        assertEquals(spyBuffer.isEmpty(), true);
+        Thread.sleep(1100);
+
+        verify(spyBuffer, times(1)).write(any(Record.class), anyInt());
+
+        Thread.sleep(1000);
+        verify(spyBuffer, times(1)).write(any(Record.class), anyInt());
+        logGeneratorSource.stop();
+    }
+
+    // Below test is possibly redundant because of test:
+    // GIVEN_logGeneratorSourceAndBlockingBuffer_WHEN_noLimit_THEN_keepsWritingToBufferUntilStopped
+//    @Test
+//    void GIVEN_logGeneratorSourceAndBlockingBuffer_WHEN_stopCalled_THEN_stopsWritingToBuffer()
+//            throws InterruptedException, TimeoutException {
+//        BlockingBuffer<Record<Event>> spyBuffer = spy(new BlockingBuffer<Record<Event>>("SamplePipeline"));
+//
+//        lenient().when(sourceConfig.getInterval()).thenReturn(Duration.ofSeconds(1)); // interval of 1 second
+//        lenient().when(sourceConfig.getCount()).thenReturn(2); // max count of 2
+//
+//        logGeneratorSource.start(spyBuffer);
+//        assertEquals(spyBuffer.isEmpty(), true);
+//        Thread.sleep(2500);
+//
+//        verify(spyBuffer, times(2)).write(any(Record.class), anyInt());
+//        logGeneratorSource.stop();
+//        Thread.sleep(500);
+//        verify(spyBuffer, times(2)).write(any(Record.class), anyInt());
+//    }
+    // this test is also possibly redundant
+//    @Test
+//    void GIVEN_logGeneratorSourceAndBlockingBuffer_WHEN_startCalled_THEN_bufferIsNotEmpty()
+//            throws InterruptedException, TimeoutException {
+//        // also need to mock the buffer class
+//        // arbitrary buffer settings
+////        try {
+//        // BlockingBuffer as the Buffer here was arbitrary
+//        BlockingBuffer<Record<Event>> spyBuffer = spy(new BlockingBuffer<Record<Event>>("SamplePipeline"));
+//
+//        lenient().when(sourceConfig.getInterval()).thenReturn(Duration.ofSeconds(1)); // interval of 1 second
+//        lenient().when(sourceConfig.getCount()).thenReturn(2); // max count of 2
+//
+//        logGeneratorSource.start(spyBuffer);
+//        assertEquals(spyBuffer.isEmpty(), true);
+//        Thread.sleep(3000);
+//        assertEquals(spyBuffer.isEmpty(), false);
+//        System.out.println("Succeeded beyond the Thread sleep");
+//
+//        logGeneratorSource.stop();
+//    }
+}

--- a/data-prepper-plugins/log-generator-source/src/test/java/com/amazon/dataprepper/plugins/source/loggenerator/LogGeneratorSourceTest.java
+++ b/data-prepper-plugins/log-generator-source/src/test/java/com/amazon/dataprepper/plugins/source/loggenerator/LogGeneratorSourceTest.java
@@ -49,7 +49,6 @@ public class LogGeneratorSourceTest {
     private PluginMetrics pluginMetrics;
     @Mock
     private PluginFactory pluginFactory;
-    @Mock
     private LogGeneratorSource logGeneratorSource;
     @Mock
     private PluginModel mockLogPluginModel;


### PR DESCRIPTION
Signed-off-by: Finn Roblin <finnrobl@amazon.com>

### Description
This PR adds unit tests for the Log Generator Source plugin.

### Issues Resolved
#1548, Create Log Generator Source with common apache log type
* Documentation and javadoc are still needed.

### Implementation Drawbacks
Because the log generator uses a `ScheduledExecutor` with minimum interval length of 1 second, each `LogGeneratorSourceTest` test uses at least one > 1 second `Thread.sleep` call. To prioritize speed, I test several behaviors with each Thread.sleep call. Happy to switch if there’s a better alternative. 

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
