### PR TITLE
Add buffer PluginModel to PipelineModel, require 1 source and at least 1 sink

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelineModel.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelineModel.java
@@ -80,8 +80,8 @@ public class PipelineModel {
             final List<PluginModel> sinks,
             final Integer workers,
             final Integer delay) {
-        checkArgument(!Objects.isNull(source), "Source must not be null");
-        checkArgument(!Objects.isNull(sinks), "Sinks must not be null");
+        checkArgument(Objects.nonNull(source), "Source must not be null");
+        checkArgument(Objects.nonNull(sinks), "Sinks must not be null");
         checkArgument(sinks.size() > 0, "PipelineModel must include at least 1 sink");
 
 

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelineModel.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelineModel.java
@@ -13,6 +13,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Model class for a Pipeline containing all possible Plugin types in Configuration YAML
@@ -54,7 +57,12 @@ public class PipelineModel {
     private final PluginModel source;
 
     @JsonProperty("processor")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final List<PluginModel> processors;
+
+    @JsonProperty("buffer")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final PluginModel buffer;
 
     @JsonProperty("sink")
     private final List<PluginModel> sinks;
@@ -67,11 +75,18 @@ public class PipelineModel {
 
     public PipelineModel(
             final PluginModel source,
+            final PluginModel buffer,
             final List<PluginModel> processors,
             final List<PluginModel> sinks,
             final Integer workers,
             final Integer delay) {
+        checkArgument(!Objects.isNull(source), "Source must not be null");
+        checkArgument(!Objects.isNull(sinks), "Sinks must not be null");
+        checkArgument(sinks.size() > 0, "PipelineModel must include at least 1 sink");
+
+
         this.source = source;
+        this.buffer = buffer;
         this.processors = processors;
         this.sinks = sinks;
         this.workers = workers;
@@ -91,17 +106,20 @@ public class PipelineModel {
     @Deprecated
     public PipelineModel(
             @JsonProperty("source") final PluginModel source,
+            @JsonProperty("buffer") final PluginModel buffer,
             @Deprecated @JsonProperty("prepper") final List<PluginModel> preppers,
             @JsonProperty("processor") final List<PluginModel> processors,
             @JsonProperty("sink") final List<PluginModel> sinks,
             @JsonProperty("workers") final Integer workers,
             @JsonProperty("delay") final Integer delay) {
-        this(source, validateProcessor(preppers, processors), sinks, workers, delay);
+        this(source, buffer, validateProcessor(preppers, processors), sinks, workers, delay);
     }
 
     public PluginModel getSource() {
         return source;
     }
+
+    public PluginModel getBuffer() { return buffer; }
 
     @Deprecated
     @JsonIgnore

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PipelineModelTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PipelineModelTest.java
@@ -87,7 +87,7 @@ public class PipelineModelTest {
     @Test
     public void testPipelineModelWithPrepperAndProcessorConfigThrowsException() {
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> new PipelineModel(
+        final Exception exception = assertThrows(IllegalArgumentException.class, () -> new PipelineModel(
                 validSourcePluginModel(),
                 validBufferPluginModel(),
                 validPreppersPluginModel(),
@@ -106,8 +106,8 @@ public class PipelineModelTest {
 
     @Test
     public void testPipelineModelWithValidPrepperConfig() {
-        List<PluginModel> expectedPreppersPluginModel = validPreppersPluginModel();
-        PipelineModel pipelineModel = new PipelineModel(
+        final List<PluginModel> expectedPreppersPluginModel = validPreppersPluginModel();
+        final PipelineModel pipelineModel = new PipelineModel(
                 validSourcePluginModel(),
                 null,
                 expectedPreppersPluginModel,
@@ -123,8 +123,8 @@ public class PipelineModelTest {
 
     @Test
     public void testPipelineModelWithValidProcessorConfig() {
-        List<PluginModel> expectedPreppersPluginModel = validPreppersPluginModel();
-        PipelineModel pipelineModel = new PipelineModel(
+        final List<PluginModel> expectedPreppersPluginModel = validPreppersPluginModel();
+        final PipelineModel pipelineModel = new PipelineModel(
                 validSourcePluginModel(),
                 null,
                 null,
@@ -140,7 +140,7 @@ public class PipelineModelTest {
 
     @Test
     public void testPipelineModelWithNullSourceThrowsException() {
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> new PipelineModel(
+        final Exception exception = assertThrows(IllegalArgumentException.class, () -> new PipelineModel(
                 null,
                 validBufferPluginModel(),
                 validPreppersPluginModel(),
@@ -156,7 +156,7 @@ public class PipelineModelTest {
 
     @Test
     public void testPipelineModelWithNullSinksThrowsException() {
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> new PipelineModel(
+        final Exception exception = assertThrows(IllegalArgumentException.class, () -> new PipelineModel(
                 validSourcePluginModel(),
                 validBufferPluginModel(),
                 validPreppersPluginModel(),
@@ -172,7 +172,7 @@ public class PipelineModelTest {
 
     @Test
     public void testPipelineModelWithEmptySinksThrowsException() {
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> new PipelineModel(
+        final Exception exception = assertThrows(IllegalArgumentException.class, () -> new PipelineModel(
                 validSourcePluginModel(),
                 validBufferPluginModel(),
                 validPreppersPluginModel(),

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashMapper.java
@@ -33,7 +33,7 @@ public class LogstashMapper {
 
         List<PluginModel> sinkPluginModels = mapPluginSection(logstashConfiguration, LogstashPluginType.OUTPUT);
 
-        if (sinkPluginModels.size() == 0) {
+        if (sinkPluginModels.isEmpty()) {
             throw new LogstashMappingException("At least one logstash output plugin is required");
         }
 

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/LogstashMapper.java
@@ -25,16 +25,19 @@ public class LogstashMapper {
 
         List<PluginModel> sourcePluginModels = mapPluginSection(logstashConfiguration, LogstashPluginType.INPUT);
         PluginModel sourcePlugin = null;
-        if (sourcePluginModels.size() > 1)
-            throw new LogstashMappingException("More than 1 source plugins are not supported");
-        else if (sourcePluginModels.size() == 1)
-            sourcePlugin = sourcePluginModels.get(0);
+        if (sourcePluginModels.size() != 1)
+            throw new LogstashMappingException("Only logstash configurations with exactly 1 input plugin are supported");
+        else sourcePlugin = sourcePluginModels.get(0);
 
         List<PluginModel> prepperPluginModels = mapPluginSection(logstashConfiguration, LogstashPluginType.FILTER);
 
         List<PluginModel> sinkPluginModels = mapPluginSection(logstashConfiguration, LogstashPluginType.OUTPUT);
 
-        return new PipelineModel(sourcePlugin, prepperPluginModels, sinkPluginModels, null, null);
+        if (sinkPluginModels.size() == 0) {
+            throw new LogstashMappingException("At least one logstash output plugin is required");
+        }
+
+        return new PipelineModel(sourcePlugin, null, prepperPluginModels, sinkPluginModels, null, null);
     }
 
     private List<PluginModel> mapPluginSection(LogstashConfiguration logstashConfiguration, LogstashPluginType logstashPluginType) {

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/LogstashMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/LogstashMapperTest.java
@@ -15,6 +15,7 @@ import org.opensearch.dataprepper.logstash.model.LogstashPluginType;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -34,17 +35,36 @@ class LogstashMapperTest {
         LogstashConfiguration logstashConfiguration = mock(LogstashConfiguration.class);
         when(logstashConfiguration.getPluginSection(LogstashPluginType.INPUT))
                 .thenReturn(Collections.singletonList(TestDataProvider.pluginData()));
+        when(logstashConfiguration.getPluginSection(LogstashPluginType.OUTPUT))
+                .thenReturn(Collections.singletonList(TestDataProvider.pluginData()));
 
         PipelineModel actualPipelineModel =  logstashMapper.mapPipeline(logstashConfiguration);
         PipelineModel expectedPipelineModel = new PipelineModel(TestDataProvider.samplePluginModel(),
-                null, null, null, null);
+                null, null, Collections.singletonList(TestDataProvider.samplePluginModel()), null, null);
 
         assertThat(actualPipelineModel.getSource().getPluginName(),
                 equalTo(expectedPipelineModel.getSource().getPluginName()));
         assertThat(actualPipelineModel.getSource().getPluginSettings(),
                 equalTo(expectedPipelineModel.getSource().getPluginSettings()));
+        assertThat(actualPipelineModel.getBuffer(), equalTo(expectedPipelineModel.getBuffer()));
+        assertThat(actualPipelineModel.getSinks(), notNullValue());
+        assertThat(actualPipelineModel.getSinks().size(), equalTo(1));
+        assertThat(actualPipelineModel.getSinks().get(0).getPluginName(), equalTo(expectedPipelineModel.getSinks().get(0).getPluginName()));
         assertThat(actualPipelineModel.getReadBatchDelay(), equalTo(expectedPipelineModel.getReadBatchDelay()));
         assertThat(actualPipelineModel.getWorkers(), equalTo(expectedPipelineModel.getWorkers()));
+    }
+
+    @Test
+    void mapPipeline_with_no_source_plugins_should_throw_exception() {
+        final LogstashConfiguration logstashConfiguration = TestDataProvider.sampleConfigurationWithEmptyInputPlugins();
+
+        final Exception exception = assertThrows(LogstashMappingException.class, () ->
+                logstashMapper.mapPipeline(logstashConfiguration));
+
+        final String expectedMessage = "Only logstash configurations with exactly 1 input plugin are supported";
+        final String actualMessage = exception.getMessage();
+
+        assertThat(actualMessage, equalTo(expectedMessage));
     }
 
     @Test
@@ -54,29 +74,27 @@ class LogstashMapperTest {
         Exception exception = assertThrows(LogstashMappingException.class, () ->
                 logstashMapper.mapPipeline(logstashConfiguration));
 
-        String expectedMessage = "More than 1 source plugins are not supported";
+        String expectedMessage = "Only logstash configurations with exactly 1 input plugin are supported";
         String actualMessage = exception.getMessage();
 
         assertThat(actualMessage, equalTo(expectedMessage));
     }
 
     @Test
-    void mapPipeline_with_no_plugins_should_return_pipeline_model_without_plugins_Test() {
-        LogstashConfiguration logstashConfiguration = mock(LogstashConfiguration.class);
+    void mapPipeline_with_no_sink_plugins_should_throw_Exception() {
+        final LogstashConfiguration logstashConfiguration = mock(LogstashConfiguration.class);
+
         when(logstashConfiguration.getPluginSection(LogstashPluginType.INPUT))
-                .thenReturn(Collections.emptyList());
-        when(logstashConfiguration.getPluginSection(LogstashPluginType.FILTER))
-                .thenReturn(Collections.emptyList());
+                .thenReturn(Collections.singletonList(TestDataProvider.pluginData()));
         when(logstashConfiguration.getPluginSection(LogstashPluginType.OUTPUT))
                 .thenReturn(Collections.emptyList());
 
-        PipelineModel actualPipelineModel =  logstashMapper.mapPipeline(logstashConfiguration);
+        final Exception exception = assertThrows(LogstashMappingException.class, () ->
+                logstashMapper.mapPipeline(logstashConfiguration));
 
-        assertThat(actualPipelineModel.getSource(), equalTo(null));
-        assertThat(actualPipelineModel.getProcessors(), equalTo(Collections.emptyList()));
-        assertThat(actualPipelineModel.getSinks(), equalTo(Collections.emptyList()));
-        assertThat(actualPipelineModel.getReadBatchDelay(), equalTo(null));
-        assertThat(actualPipelineModel.getWorkers(), equalTo(null));
+        final String expectedMessage = "At least one logstash output plugin is required";
+        final String actualMessage = exception.getMessage();
+
+        assertThat(actualMessage, equalTo(expectedMessage));
     }
-
 }

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/TestDataProvider.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/TestDataProvider.java
@@ -40,6 +40,12 @@ public class TestDataProvider {
                 .build();
     }
 
+    public static LogstashConfiguration sampleConfigurationWithEmptyInputPlugins() {
+        return LogstashConfiguration.builder()
+                .pluginSections(Collections.singletonMap(LogstashPluginType.INPUT, Collections.emptyList()))
+                .build();
+    }
+
     public static LogstashPlugin invalidMappingResourceNameData() {
         return LogstashPlugin.builder()
                 .pluginName(UUID.randomUUID().toString())

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/empty.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/empty.conf
@@ -1,6 +1,0 @@
-input {
-}
-filter {
-}
-output {
-}

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/empty.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/empty.expected.yaml
@@ -1,4 +1,0 @@
-logstash-converted-pipeline:
-  source: null
-  processor: []
-  sink: []

--- a/data-prepper-plugins/log-generator-source/src/test/java/com/amazon/dataprepper/plugins/source/loggenerator/LogGeneratorSourceTest.java
+++ b/data-prepper-plugins/log-generator-source/src/test/java/com/amazon/dataprepper/plugins/source/loggenerator/LogGeneratorSourceTest.java
@@ -6,40 +6,38 @@
 package com.amazon.dataprepper.plugins.source.loggenerator;
 
 
-import com.amazon.dataprepper.model.event.JacksonEvent;
 import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.configuration.PluginModel;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.event.Event;
+import com.amazon.dataprepper.model.event.JacksonEvent;
 import com.amazon.dataprepper.model.plugin.PluginFactory;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
-import static com.amazon.dataprepper.plugins.source.loggenerator.LogGeneratorSourceConfig.INFINITE_LOG_COUNT;
-
-import java.util.Map;
-import java.util.HashMap;
-import java.util.concurrent.TimeoutException;
-import java.time.Duration;
-import java.util.UUID;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.lenient;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertEquals;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+
+import static com.amazon.dataprepper.plugins.source.loggenerator.LogGeneratorSourceConfig.INFINITE_LOG_COUNT;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class LogGeneratorSourceTest {
@@ -107,8 +105,8 @@ public class LogGeneratorSourceTest {
         lenient().when(sourceConfig.getInterval()).thenReturn(Duration.ofSeconds(1)); // interval of 1 second
         lenient().when(sourceConfig.getCount()).thenReturn(1); // max log count of 1 in logGeneratorSource
 
-        logGeneratorSource.start(spyBuffer);
         assertEquals(spyBuffer.isEmpty(), true);
+        logGeneratorSource.start(spyBuffer);
         Thread.sleep(1100);
 
         verify(spyBuffer, times(1)).write(any(Record.class), anyInt());


### PR DESCRIPTION
Signed-off-by: graytaylor0 <tylgry@amazon.com>

### Description
* Add buffer `PluginModel` as optional parameter in `PipelineModel`
* Require a non-null source and at least one sink in `PipelineModel`
* Logstash conversion throws `LogstashMappingException` if no `input` or `output` plugins are provided
 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
