### PR TITLE
Add more robust username/password check in order to allow auth-free health checks

### DIFF
--- a/data-prepper-plugins/armeria-common/src/main/java/com/amazon/dataprepper/plugins/HttpAuthorizer.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/com/amazon/dataprepper/plugins/HttpAuthorizer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins;
+
+import com.amazon.dataprepper.armeria.authentication.HttpBasicAuthenticationConfig;
+import com.google.common.annotations.VisibleForTesting;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.auth.Authorizer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.regex.Pattern;
+
+public class HttpAuthorizer implements Authorizer<HttpRequest> {
+    private final HttpBasicAuthenticationConfig httpBasicAuthenticationConfig;
+    private final Pattern splitPattern = Pattern.compile(":");
+
+    public HttpAuthorizer(final HttpBasicAuthenticationConfig httpBasicAuthenticationConfig) {
+        this.httpBasicAuthenticationConfig = httpBasicAuthenticationConfig;
+    }
+
+    @Override
+    public CompletionStage<Boolean> authorize(final ServiceRequestContext ctx, final HttpRequest data) {
+        final boolean isHealthEndpoint = ctx.mappedPath().toLowerCase(Locale.ROOT).endsWith("health");
+
+        if(isHealthEndpoint) {
+            return CompletableFuture.completedFuture(true);
+        }
+
+        final String encodedAuth = data.headers().get("Authorization");
+        final boolean isBasicAuth = encodedAuth.toLowerCase(Locale.ROOT).startsWith("basic ");
+
+        if(isBasicAuth) {
+            return CompletableFuture.completedFuture(authenticate(encodedAuth));
+        } else {
+            return CompletableFuture.completedFuture(false);
+        }
+    }
+
+    @VisibleForTesting
+    protected boolean authenticate(final String authorization) {
+        final String subEncodedAuth = authorization.substring("basic ".length());
+        final String decodedAuth = new String(Base64.getDecoder().decode(subEncodedAuth), StandardCharsets.UTF_8);
+        final String[] usernamePassword = splitPattern.split(decodedAuth);
+        final String username = usernamePassword[0];
+        final String password = usernamePassword[1];
+        final boolean authenticated = Objects.equals(username, httpBasicAuthenticationConfig.getUsername())
+                && Objects.equals(password, httpBasicAuthenticationConfig.getPassword());
+
+        return authenticated;
+    }
+}

--- a/data-prepper-plugins/armeria-common/src/main/java/com/amazon/dataprepper/plugins/HttpBasicArmeriaHttpAuthenticationProvider.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/com/amazon/dataprepper/plugins/HttpBasicArmeriaHttpAuthenticationProvider.java
@@ -44,10 +44,7 @@ public class HttpBasicArmeriaHttpAuthenticationProvider implements ArmeriaHttpAu
 
     private Function<? super HttpService, ? extends HttpService> createDecorator() {
         return AuthService.builder()
-                .addBasicAuth((context, basic) ->
-                        CompletableFuture.completedFuture(
-                                httpBasicAuthenticationConfig.getUsername().equals(basic.username()) &&
-                                        httpBasicAuthenticationConfig.getPassword().equals(basic.password())))
+                .add(new HttpAuthorizer(httpBasicAuthenticationConfig))
                 .newDecorator();
     }
 }

--- a/data-prepper-plugins/armeria-common/src/test/java/com/amazon/dataprepper/plugins/HttpAuthorizerTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/com/amazon/dataprepper/plugins/HttpAuthorizerTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins;
+
+import com.amazon.dataprepper.armeria.authentication.HttpBasicAuthenticationConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class HttpAuthorizerTest {
+    @Test
+    public void basicAuthValidUsernamePassword() {
+        final HttpBasicAuthenticationConfig config = new HttpBasicAuthenticationConfig("username", "password");
+        final HttpAuthorizer authorizer = new HttpAuthorizer(config);
+        final String encodedAuth = "Basic dXNlcm5hbWU6cGFzc3dvcmQ=";
+
+        assertThat(authorizer.authenticate(encodedAuth), equalTo(true));
+    }
+
+    @Test
+    public void basicAuthInvalidUsernamePassword() {
+        final HttpBasicAuthenticationConfig config = new HttpBasicAuthenticationConfig("username", "password");
+        final HttpAuthorizer authorizer = new HttpAuthorizer(config);
+        final String encodedAuth = "Basic dXNlcm5hbWU6cGFzc3dvcmQy";
+
+        assertThat(authorizer.authenticate(encodedAuth), equalTo(false));
+    }
+}


### PR DESCRIPTION


Signed-off-by: David Powers <ddpowers@amazon.com>

### Description
Allows for health checks to be called without the need for username/password
 
### Issues Resolved
#1600 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
