### PR TITLE
Enhanced Newline Codec w optional header_destination to add first lin…

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedCodec.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedCodec.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -23,6 +25,7 @@ import java.util.function.Consumer;
 public class NewlineDelimitedCodec implements Codec {
     private static final String MESSAGE_FIELD_NAME = "message";
     private final int skipLines;
+    private final String headerDestination;
 
     @DataPrepperPluginConstructor
     public NewlineDelimitedCodec(final NewlineDelimitedConfig config) {
@@ -32,6 +35,8 @@ public class NewlineDelimitedCodec implements Codec {
         if (skipLines < 0) {
             throw new IllegalArgumentException("skipLines must be non-negative.");
         }
+
+        headerDestination = config.getHeaderDestination();
     }
 
     @Override
@@ -42,18 +47,34 @@ public class NewlineDelimitedCodec implements Codec {
     }
 
     private void parseBufferedReader(final BufferedReader reader, final Consumer<Record<Event>> eventConsumer) throws IOException {
+        final boolean doAddHeaderToOutgoingEvents = Objects.nonNull(this.headerDestination);
+        boolean hasReadHeader = false;
+        String header = "";
+
         int linesToSkip = skipLines;
         String line;
         while ((line = reader.readLine()) != null) {
 
-            if (linesToSkip > 0) {
-                linesToSkip--;
+            if (linesToSkip > 0 || (doAddHeaderToOutgoingEvents && !hasReadHeader)) {
+                if (linesToSkip > 0) {
+                    linesToSkip--;
+                } else {
+                    header = line;
+                    hasReadHeader = true;
+                }
                 continue;
             }
 
-            final Event event = JacksonLog.builder()
-                    .withData(Collections.singletonMap(MESSAGE_FIELD_NAME, line))
-                    .build();
+            final Map<String, String> eventData;
+            if (doAddHeaderToOutgoingEvents) {
+                eventData = new HashMap<>();
+                eventData.put(this.headerDestination, header);
+                eventData.put(MESSAGE_FIELD_NAME, line);
+            } else {
+                eventData = Collections.singletonMap(MESSAGE_FIELD_NAME, line);
+            }
+
+            final Event event = JacksonLog.builder().withData(eventData).build();
             eventConsumer.accept(new Record<>(event));
         }
     }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedCodec.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedCodec.java
@@ -15,7 +15,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -47,15 +46,17 @@ public class NewlineDelimitedCodec implements Codec {
     }
 
     private void parseBufferedReader(final BufferedReader reader, final Consumer<Record<Event>> eventConsumer) throws IOException {
-        final boolean doAddHeaderToOutgoingEvents = Objects.nonNull(this.headerDestination);
+        final boolean doAddHeaderToOutgoingEvents = Objects.nonNull(headerDestination);
         boolean hasReadHeader = false;
         String header = "";
 
         int linesToSkip = skipLines;
         String line;
         while ((line = reader.readLine()) != null) {
+            final boolean shouldSkipBecauseThisLineIsHeader = doAddHeaderToOutgoingEvents && !hasReadHeader;
+            final boolean shouldSkipThisLine = linesToSkip > 0 || shouldSkipBecauseThisLineIsHeader;
 
-            if (linesToSkip > 0 || (doAddHeaderToOutgoingEvents && !hasReadHeader)) {
+            if (shouldSkipThisLine) {
                 if (linesToSkip > 0) {
                     linesToSkip--;
                 } else {
@@ -65,14 +66,12 @@ public class NewlineDelimitedCodec implements Codec {
                 continue;
             }
 
-            final Map<String, String> eventData;
+            final Map<String, String> eventData = new HashMap<>();
+
             if (doAddHeaderToOutgoingEvents) {
-                eventData = new HashMap<>();
-                eventData.put(this.headerDestination, header);
-                eventData.put(MESSAGE_FIELD_NAME, line);
-            } else {
-                eventData = Collections.singletonMap(MESSAGE_FIELD_NAME, line);
+                eventData.put(headerDestination, header);
             }
+            eventData.put(MESSAGE_FIELD_NAME, line);
 
             final Event event = JacksonLog.builder().withData(eventData).build();
             eventConsumer.accept(new Record<>(event));

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedConfig.java
@@ -5,11 +5,16 @@
 
 package com.amazon.dataprepper.plugins.source.codec;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Configuration class for the newline delimited codec.
  */
 public class NewlineDelimitedConfig {
     private final int skipLines = 0;
+
+    @JsonProperty("header_destination")
+    private String headerDestination;
 
     /**
      * The number of lines to skip from the start of the S3 object.
@@ -19,5 +24,15 @@ public class NewlineDelimitedConfig {
      */
     public int getSkipLines() {
         return skipLines;
+    }
+
+    /**
+     * The key containing the header line of the S3 object.
+     * If this option is specified then each Event will contain a header_destination field.
+     *
+     * @return The name of the header_destination field.
+     */
+    public String getHeaderDestination() {
+        return headerDestination;
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedConfig.java
@@ -6,12 +6,15 @@
 package com.amazon.dataprepper.plugins.source.codec;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.AssertTrue;
+
+import java.util.Objects;
 
 /**
  * Configuration class for the newline delimited codec.
  */
 public class NewlineDelimitedConfig {
-    private final int skipLines = 0;
+    private int skipLines = 0;
 
     @JsonProperty("header_destination")
     private String headerDestination;
@@ -34,5 +37,11 @@ public class NewlineDelimitedConfig {
      */
     public String getHeaderDestination() {
         return headerDestination;
+    }
+
+    @AssertTrue(message = "header_destination must be either null or length greater than 0. It cannot be empty. " +
+            "To make it null delete header_destination in your configuration YAML file")
+    boolean isValidHeaderDestination() {
+        return Objects.isNull(headerDestination) || (headerDestination.length() > 0);
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedCodecTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/codec/NewlineDelimitedCodecTest.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,6 +50,13 @@ class NewlineDelimitedCodecTest {
         config = null;
 
         assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void constructor_throws_if_header_destination_is_empty() throws NoSuchFieldException, IllegalAccessException {
+        final NewlineDelimitedConfig objectUnderTest = new NewlineDelimitedConfig();
+        reflectivelySetField(objectUnderTest, "headerDestination", "");
+        assertThat(objectUnderTest.isValidHeaderDestination(), equalTo(false));
     }
 
     @ParameterizedTest
@@ -139,12 +147,12 @@ class NewlineDelimitedCodecTest {
     @ValueSource(ints = {1, 2, 10, 50})
     void parse_with_header_calls_Consumer_with_header_fields_after_skip(final int numberOfLines) throws IOException {
         final String headerMessage = "HeaderOnList";
+        final int skipLines = 1;
 
-        final List<String> linesList = generateLinesAsListWithHeaderAfterSingleInitialJunkLine(numberOfLines, headerMessage);
+        final List<String> linesList = generateLinesAsListWithHeaderAfterJunkLines(numberOfLines, headerMessage, skipLines);
         final InputStream inputStream = createInputStream(linesList);
 
         final int headerOffset = 1;
-        final int skipLines = 1;
         when(config.getHeaderDestination()).thenReturn("event_header");
         when(config.getSkipLines()).thenReturn(skipLines);
         final List<Record<Event>> actualEvents = new ArrayList<>();
@@ -162,20 +170,49 @@ class NewlineDelimitedCodecTest {
         }
     }
 
-    private List<String> generateLinesAsListWithHeader(final int numberOfLines, final String headerMessage) {
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 50})
+    void parse_with_header_calls_Consumer_with_header_fields_after_multiple_skips(final int numberOfLines) throws IOException {
+        final String headerMessage = "HeaderOnList";
+        final int skipLines = 3;
+
+        final List<String> linesList = generateLinesAsListWithHeaderAfterJunkLines(numberOfLines, headerMessage, skipLines);
+        final InputStream inputStream = createInputStream(linesList);
+
         final int headerOffset = 1;
-        final List<String> linesList = new ArrayList<>(numberOfLines+headerOffset);
+        when(config.getHeaderDestination()).thenReturn("event_header");
+        when(config.getSkipLines()).thenReturn(skipLines);
+        final List<Record<Event>> actualEvents = new ArrayList<>();
+        createObjectUnderTest().parse(inputStream, actualEvents::add);
+
+        assertThat(actualEvents.size(), equalTo(numberOfLines));
+        for (int i = headerOffset; i < actualEvents.size(); i++) {
+            final Record<Event> record = actualEvents.get(i);
+            assertThat(record, notNullValue());
+            assertThat(record.getData(), notNullValue());
+            assertThat(record.getData().get("event_header", String.class), equalTo(headerMessage));
+            assertThat(record.getData().get("message", String.class), equalTo(linesList.get(i + skipLines + headerOffset)));
+            assertThat(record.getData().getMetadata(), notNullValue());
+            assertThat(record.getData().getMetadata().getEventType(), equalTo(EventType.LOG.toString()));
+        }
+    }
+
+    private List<String> generateLinesAsListWithHeaderAfterJunkLines(int numberOfLines, String headerMessage, int numJunkLines) {
+        final int headerOffset = 1;
+//        final int SKIP_OFFSET = 1;
+        final List<String> linesList = new ArrayList<>(numberOfLines+headerOffset+numJunkLines);
+        for (int i = 0; i < numJunkLines; i++) {
+            linesList.add("JUNK VALUE TO BE SKIPPED, Line: " + i);
+        }
         linesList.add(headerMessage);
         for (int i = 0; i < numberOfLines; i++)
             linesList.add(UUID.randomUUID().toString());
         return Collections.unmodifiableList(linesList);
     }
 
-    private List<String> generateLinesAsListWithHeaderAfterSingleInitialJunkLine(final int numberOfLines, final String headerMessage) {
+    private List<String> generateLinesAsListWithHeader(final int numberOfLines, final String headerMessage) {
         final int headerOffset = 1;
-        final int SKIP_OFFSET = 1;
-        final List<String> linesList = new ArrayList<>(numberOfLines+headerOffset+SKIP_OFFSET);
-        linesList.add("JUNK VALUE TO BE SKIPPED");
+        final List<String> linesList = new ArrayList<>(numberOfLines+headerOffset);
         linesList.add(headerMessage);
         for (int i = 0; i < numberOfLines; i++)
             linesList.add(UUID.randomUUID().toString());
@@ -203,5 +240,16 @@ class NewlineDelimitedCodecTest {
         }
 
         return stringWriter.toString();
+    }
+
+    private void reflectivelySetField(final NewlineDelimitedConfig newlineDelimitedConfig, final String fieldName, final Object value)
+            throws NoSuchFieldException, IllegalAccessException {
+        final Field field = NewlineDelimitedConfig.class.getDeclaredField(fieldName);
+        try {
+            field.setAccessible(true);
+            field.set(newlineDelimitedConfig, value);
+        } finally {
+            field.setAccessible(false);
+        }
     }
 }


### PR DESCRIPTION
…e as header to outgoing events

Signed-off-by: Finn Roblin <finnrobl@amazon.com>

### Description
Adds to the S3 Source `newline` codec. Adds a `header_destination` field to NewlineDelimitedConfig. If `header_destination` is specified, all outgoing Events will have a header field attached to them. The header is the first line in the `inputStream` after `skipLines` have been skipped. If a user does not specify `header_destination` then the `newline` functionality and interface are the exact same.
 
### Issues Resolved
Resolves [#1615](https://github.com/opensearch-project/data-prepper/issues/1615)
 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
