### PR TITLE
Added buffer for core peer forwarder

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/peerforwarder/PeerForwarderReceiveBuffer.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/peerforwarder/PeerForwarderReceiveBuffer.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.peerforwarder;
+
+import com.amazon.dataprepper.model.CheckpointState;
+import com.amazon.dataprepper.model.buffer.Buffer;
+import com.amazon.dataprepper.model.buffer.SizeOverflowException;
+import com.amazon.dataprepper.model.record.Record;
+import com.google.common.base.Stopwatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static java.lang.String.format;
+
+/**
+ * Buffer created for each stateful processor which implements {@link com.amazon.dataprepper.model.peerforwarder.RequiresPeerForwarding}
+ * interface.
+ *
+ * @since 2.0
+ */
+public class PeerForwarderReceiveBuffer<T extends Record<?>> implements Buffer<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(PeerForwarderReceiveBuffer.class);
+
+    private final int bufferSize;
+    private final int batchSize;
+    private final String pluginName;
+    private final Semaphore capacitySemaphore;
+    private final LinkedBlockingQueue<T> blockingQueue;
+    private int recordsInFlight = 0;
+
+    public PeerForwarderReceiveBuffer(final int bufferSize, final int batchSize, final String pluginName) {
+        this.bufferSize = bufferSize;
+        this.batchSize = batchSize;
+        this.pluginName = pluginName;
+        this.blockingQueue = new LinkedBlockingQueue<>(bufferSize);
+        this.capacitySemaphore = new Semaphore(bufferSize);
+    }
+
+    @Override
+    public void write(T record, int timeoutInMillis) throws TimeoutException {
+        try {
+            final boolean permitAcquired = capacitySemaphore.tryAcquire(timeoutInMillis, TimeUnit.MILLISECONDS);
+            if (!permitAcquired) {
+                throw new TimeoutException(format("Plugin [%s] - Buffer is full, timed out waiting for a slot",
+                        pluginName));
+            }
+            blockingQueue.offer(record);
+        } catch (InterruptedException ex) {
+            LOG.error("Plugin [{}] - Buffer is full, interrupted while waiting to write the record", pluginName, ex);
+            throw new TimeoutException("Buffer is full, timed out waiting for a slot");
+        }
+    }
+
+    @Override
+    public void writeAll(Collection<T> records, int timeoutInMillis) throws Exception {
+        final int size = records.size();
+        if (size > bufferSize) {
+            throw new SizeOverflowException(format("Buffer capacity too small for the size of records: %d", size));
+        }
+        try {
+            final boolean permitAcquired = capacitySemaphore.tryAcquire(size, timeoutInMillis, TimeUnit.MILLISECONDS);
+            if (!permitAcquired) {
+                throw new TimeoutException(
+                        format("Plugin [%s] - Buffer does not have enough capacity left for the size of records: %d, " +
+                                        "timed out waiting for slots.",
+                                pluginName, size));
+            }
+            blockingQueue.addAll(records);
+        } catch (InterruptedException ex) {
+            LOG.error("Plugin [{}] - Buffer does not have enough capacity left for the size of records: {}, " +
+                            "interrupted while waiting to write the records",
+                    pluginName, size, ex);
+            throw new TimeoutException(
+                    format("Plugin [%s] - Buffer does not have enough capacity left for the size of records: %d, " +
+                                    "timed out waiting for slots.",
+                            pluginName, size));
+        }
+    }
+
+    @Override
+    public Map.Entry<Collection<T>, CheckpointState> read(int timeoutInMillis) {
+        final List<T> records = new ArrayList<>();
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        try {
+            while (stopwatch.elapsed(TimeUnit.MILLISECONDS) < timeoutInMillis && records.size() < batchSize) {
+                final T record = blockingQueue.poll(timeoutInMillis, TimeUnit.MILLISECONDS);
+                if (record != null) { //record can be null, avoiding adding nulls
+                    records.add(record);
+                }
+                if (records.size() < batchSize) {
+                    blockingQueue.drainTo(records, batchSize - records.size());
+                }
+            }
+        } catch (InterruptedException ex) {
+            LOG.info("Plugin [{}] - Interrupt received while reading from buffer", pluginName);
+            throw new RuntimeException(ex);
+        }
+        final CheckpointState checkpointState = new CheckpointState(records.size());
+        recordsInFlight += checkpointState.getNumRecordsToBeChecked();
+        return new AbstractMap.SimpleEntry<>(records, checkpointState);
+    }
+
+    @Override
+    public void checkpoint(CheckpointState checkpointState) {
+        final int numCheckedRecords = checkpointState.getNumRecordsToBeChecked();
+        capacitySemaphore.release(numCheckedRecords);
+        recordsInFlight -= checkpointState.getNumRecordsToBeChecked();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return blockingQueue.isEmpty() && recordsInFlight == 0;
+    }
+}

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/peerforwarder/PeerForwarderReceiveBufferTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/peerforwarder/PeerForwarderReceiveBufferTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.peerforwarder;
+
+import com.amazon.dataprepper.model.CheckpointState;
+import com.amazon.dataprepper.model.buffer.SizeOverflowException;
+import com.amazon.dataprepper.model.record.Record;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+class PeerForwarderReceiveBufferTest {
+    private static final String TEST_PLUGIN_NAME = "test-plugin";
+    private static final int TEST_BATCH_SIZE = 3;
+    private static final int TEST_BUFFER_SIZE = 13;
+    private static final int TEST_WRITE_TIMEOUT = 100;
+    private static final int TEST_BATCH_READ_TIMEOUT = 5_000;
+
+    PeerForwarderReceiveBuffer<Record<String>> createObjectUnderTest(final int bufferSize) {
+        return new PeerForwarderReceiveBuffer<>(bufferSize, TEST_BATCH_SIZE, TEST_PLUGIN_NAME);
+    }
+
+    @Test
+    void PeerForwarderReceiveBuffer_creation_test() {
+        final PeerForwarderReceiveBuffer<Record<String>> peerForwarderReceiveBuffer = createObjectUnderTest(TEST_BUFFER_SIZE);
+        assertThat(peerForwarderReceiveBuffer, notNullValue());
+    }
+
+    @Test
+    void insert_null_should_throw_NullPointerException_test() {
+        final PeerForwarderReceiveBuffer<Record<String>> peerForwarderReceiveBuffer = createObjectUnderTest(TEST_BUFFER_SIZE);
+        assertThat(peerForwarderReceiveBuffer, notNullValue());
+        assertThrows(NullPointerException.class, () -> peerForwarderReceiveBuffer.write(null, TEST_WRITE_TIMEOUT));
+    }
+
+    @Test
+    void testWriteAllSizeOverflow() {
+        final PeerForwarderReceiveBuffer<Record<String>> peerForwarderReceiveBuffer = createObjectUnderTest(TEST_BUFFER_SIZE);
+        assertThat(peerForwarderReceiveBuffer, notNullValue());
+        final Collection<Record<String>> testRecords = generateBatchRecords(TEST_BUFFER_SIZE + 1);
+        assertThrows(SizeOverflowException.class, () -> peerForwarderReceiveBuffer.writeAll(testRecords, TEST_WRITE_TIMEOUT));
+    }
+
+    @Test
+    void testNoEmptySpaceWriteOnly() throws TimeoutException {
+        final PeerForwarderReceiveBuffer<Record<String>> peerForwarderReceiveBuffer = createObjectUnderTest(1);
+        assertThat(peerForwarderReceiveBuffer, notNullValue());
+        peerForwarderReceiveBuffer.write(new Record<>("FILL_THE_BUFFER"), TEST_WRITE_TIMEOUT);
+        assertThrows(TimeoutException.class, () -> peerForwarderReceiveBuffer.write(new Record<>("TIMEOUT"), TEST_WRITE_TIMEOUT));
+    }
+
+    @Test
+    void testNoAvailSpaceWriteAllOnly() throws Exception {
+        final PeerForwarderReceiveBuffer<Record<String>> peerForwarderReceiveBuffer = createObjectUnderTest(2);
+        assertThat(peerForwarderReceiveBuffer, notNullValue());
+        final Collection<Record<String>> testRecords = generateBatchRecords(2);
+        peerForwarderReceiveBuffer.write(new Record<>("FILL_THE_BUFFER"), TEST_WRITE_TIMEOUT);
+        assertThrows(TimeoutException.class, () -> peerForwarderReceiveBuffer.writeAll(testRecords, TEST_WRITE_TIMEOUT));
+    }
+
+    @Test
+    void testNoEmptySpaceAfterUncheckedRead() throws TimeoutException {
+        // Given
+        final PeerForwarderReceiveBuffer<Record<String>> peerForwarderReceiveBuffer = createObjectUnderTest(1);
+        peerForwarderReceiveBuffer.write(new Record<>("FILL_THE_BUFFER"), TEST_WRITE_TIMEOUT);
+
+        // When
+        peerForwarderReceiveBuffer.read(TEST_BATCH_READ_TIMEOUT);
+
+        // Then
+        final Record<String> timeoutRecord = new Record<>("TIMEOUT");
+        assertThrows(TimeoutException.class, () -> peerForwarderReceiveBuffer.write(timeoutRecord, TEST_WRITE_TIMEOUT));
+        assertThrows(TimeoutException.class, () ->
+                peerForwarderReceiveBuffer.writeAll(Collections.singletonList(timeoutRecord), TEST_WRITE_TIMEOUT));
+    }
+
+    @Test
+    void testWriteIntoEmptySpaceAfterCheckedRead() throws TimeoutException {
+        // Given
+        final PeerForwarderReceiveBuffer<Record<String>> peerForwarderReceiveBuffer = createObjectUnderTest(1);
+        assertThat(peerForwarderReceiveBuffer, notNullValue());
+        peerForwarderReceiveBuffer.write(new Record<>("FILL_THE_BUFFER"), TEST_WRITE_TIMEOUT);
+
+        // When
+        final Map.Entry<Collection<Record<String>>, CheckpointState> readResult = peerForwarderReceiveBuffer.read(TEST_BATCH_READ_TIMEOUT);
+        peerForwarderReceiveBuffer.checkpoint(readResult.getValue());
+
+        // Then
+        peerForwarderReceiveBuffer.write(new Record<>("REFILL_THE_BUFFER"), TEST_WRITE_TIMEOUT);
+        final Map.Entry<Collection<Record<String>>, CheckpointState> readCheckResult = peerForwarderReceiveBuffer.read(TEST_BATCH_READ_TIMEOUT);
+        assertThat(readResult.getKey().size(), equalTo(1));
+    }
+
+    @Test
+    void testWriteAllIntoEmptySpaceAfterCheckedRead() throws Exception {
+        // Given
+        final PeerForwarderReceiveBuffer<Record<String>> peerForwarderReceiveBuffer = createObjectUnderTest(2);
+        assertThat(peerForwarderReceiveBuffer, notNullValue());
+        final Collection<Record<String>> testRecords = generateBatchRecords(2);
+        peerForwarderReceiveBuffer.writeAll(testRecords, TEST_WRITE_TIMEOUT);
+
+        // When
+        final Map.Entry<Collection<Record<String>>, CheckpointState> readResult = peerForwarderReceiveBuffer.read(TEST_BATCH_READ_TIMEOUT);
+        peerForwarderReceiveBuffer.checkpoint(readResult.getValue());
+
+        // Then
+        peerForwarderReceiveBuffer.writeAll(testRecords, TEST_WRITE_TIMEOUT);
+        final Map.Entry<Collection<Record<String>>, CheckpointState> readCheckResult = peerForwarderReceiveBuffer.read(TEST_BATCH_READ_TIMEOUT);
+        assertThat(readResult.getKey().size(), equalTo(2));
+    }
+
+    @Test
+    void testReadEmptyBuffer() {
+        final PeerForwarderReceiveBuffer<Record<String>> peerForwarderReceiveBuffer = createObjectUnderTest(TEST_BUFFER_SIZE);
+        assertThat(peerForwarderReceiveBuffer, notNullValue());
+        final Map.Entry<Collection<Record<String>>, CheckpointState> readResult = peerForwarderReceiveBuffer.read(TEST_BATCH_READ_TIMEOUT);
+        assertThat(readResult.getKey().size(), is(0));
+    }
+
+    @Test
+    void testBatchRead() throws Exception {
+        final PeerForwarderReceiveBuffer<Record<String>> peerForwarderReceiveBuffer = createObjectUnderTest(TEST_BUFFER_SIZE);
+        assertThat(peerForwarderReceiveBuffer, notNullValue());
+        final int testSize = 5;
+
+        final Collection<Record<String>> testRecords = generateBatchRecords(testSize);
+        peerForwarderReceiveBuffer.writeAll(testRecords, TEST_WRITE_TIMEOUT);
+
+        final Map.Entry<Collection<Record<String>>, CheckpointState> partialReadResult = peerForwarderReceiveBuffer.read(TEST_BATCH_READ_TIMEOUT);
+        final Collection<Record<String>> partialRecords = partialReadResult.getKey();
+        final CheckpointState partialCheckpointState = partialReadResult.getValue();
+        assertThat(partialRecords.size(), is(TEST_BATCH_SIZE));
+        assertThat(partialCheckpointState.getNumRecordsToBeChecked(), is(TEST_BATCH_SIZE));
+
+        final Map.Entry<Collection<Record<String>>, CheckpointState> finalReadResult = peerForwarderReceiveBuffer.read(TEST_BATCH_READ_TIMEOUT);
+        final Collection<Record<String>> finalBatch = finalReadResult.getKey();
+        final CheckpointState finalCheckpointState = finalReadResult.getValue();
+        assertThat(finalBatch.size(), is(testSize - TEST_BATCH_SIZE));
+        assertThat(finalCheckpointState.getNumRecordsToBeChecked(), is(testSize - TEST_BATCH_SIZE));
+    }
+
+    @Test
+    void testBufferIsEmpty_without_write() {
+        final PeerForwarderReceiveBuffer<Record<String>> peerForwarderReceiveBuffer = createObjectUnderTest(TEST_BUFFER_SIZE);
+
+        Assertions.assertTrue(peerForwarderReceiveBuffer.isEmpty());
+    }
+
+    @Test
+    void testBufferIsEmpty_after_read_and_checkpoint() throws TimeoutException {
+        final PeerForwarderReceiveBuffer<Record<String>> peerForwarderReceiveBuffer = createObjectUnderTest(TEST_BUFFER_SIZE);
+
+        Record<String> record = new Record<>("TEST");
+        peerForwarderReceiveBuffer.write(record, TEST_WRITE_TIMEOUT);
+
+        Map.Entry<Collection<Record<String>>, CheckpointState> readResult = peerForwarderReceiveBuffer.read(TEST_BATCH_READ_TIMEOUT);
+        peerForwarderReceiveBuffer.checkpoint(readResult.getValue());
+
+        Assertions.assertTrue(peerForwarderReceiveBuffer.isEmpty());
+    }
+
+    @Test
+    void testBufferIsNotEmpty() throws TimeoutException {
+        final PeerForwarderReceiveBuffer<Record<String>> peerForwarderReceiveBuffer = createObjectUnderTest(TEST_BUFFER_SIZE);
+
+        Record<String> record = new Record<>("TEST");
+        peerForwarderReceiveBuffer.write(record, TEST_WRITE_TIMEOUT);
+
+        peerForwarderReceiveBuffer.read(TEST_BATCH_READ_TIMEOUT);
+
+        Assertions.assertFalse(peerForwarderReceiveBuffer.isEmpty());
+    }
+
+    private Collection<Record<String>> generateBatchRecords(final int numRecords) {
+        final Collection<Record<String>> results = new ArrayList<>();
+        for (int i = 0; i < numRecords; i++) {
+            results.add(new Record<>(UUID.randomUUID().toString()));
+        }
+        return results;
+    }
+}

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/peerforwarder/PeerForwarderReceiveBufferTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/peerforwarder/PeerForwarderReceiveBufferTest.java
@@ -25,14 +25,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 
 class PeerForwarderReceiveBufferTest {
-    private static final String TEST_PLUGIN_NAME = "test-plugin";
     private static final int TEST_BATCH_SIZE = 3;
     private static final int TEST_BUFFER_SIZE = 13;
     private static final int TEST_WRITE_TIMEOUT = 100;
     private static final int TEST_BATCH_READ_TIMEOUT = 5_000;
 
     PeerForwarderReceiveBuffer<Record<String>> createObjectUnderTest(final int bufferSize) {
-        return new PeerForwarderReceiveBuffer<>(bufferSize, TEST_BATCH_SIZE, TEST_PLUGIN_NAME);
+        return new PeerForwarderReceiveBuffer<>(bufferSize, TEST_BATCH_SIZE);
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
- Implemented `PeerForwarderReceiveBuffer` which is similar to `BlockingBuffer`. 
 
### Issues Resolved
Resolves #1603 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
