### PR TITLE
Add @JsonProperty to workers and readBatchDelay in PipelineModel

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelineModel.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelineModel.java
@@ -67,9 +67,11 @@ public class PipelineModel {
     @JsonProperty("sink")
     private final List<PluginModel> sinks;
 
+    @JsonProperty("workers")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final Integer workers;
 
+    @JsonProperty("delay")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final Integer readBatchDelay;
 

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
@@ -36,13 +36,13 @@ class PipelinesDataFlowModelTest {
     }
 
     @Test
-    void testSerializing_PipelinesDataFlowModel_empty_Plugins() throws JsonProcessingException {
+    void testSerializing_PipelinesDataFlowModel_empty_Plugins_with_nonEmpty_delay_and_workers() throws JsonProcessingException {
         String pipelineName = "test-pipeline";
 
         final PluginModel source = new PluginModel("testSource", null);
         final List<PluginModel> preppers = Collections.singletonList(new PluginModel("testPrepper", null));
         final List<PluginModel> sinks = Collections.singletonList(new PluginModel("testSink", null));
-        final PipelineModel pipelineModel = new PipelineModel(source, null, preppers, sinks, null, null);
+        final PipelineModel pipelineModel = new PipelineModel(source, null, preppers, sinks, 8, 50);
 
         final PipelinesDataFlowModel pipelinesDataFlowModel = new PipelinesDataFlowModel(Collections.singletonMap(pipelineName, pipelineModel));
 

--- a/data-prepper-api/src/test/resources/pipelines_data_flow_serialized.yaml
+++ b/data-prepper-api/src/test/resources/pipelines_data_flow_serialized.yaml
@@ -5,3 +5,5 @@ test-pipeline:
   - testPrepper: null
   sink:
   - testSink: null
+  workers: 8
+  delay: 50


### PR DESCRIPTION
Signed-off-by: Taylor Gray <tylgry@amazon.com>

### Description
* This change serializes the `PipelineModel` with value `delay`, rather than the variable name of `readBatchDelay`, which is not a valid parameter in Data Prepper
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
