### PR TITLE
Updated pipeline configurations and documentation to prefer index_type

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -19,7 +19,7 @@ pipeline:
       cert: path/to/cert
       username: YOUR_USERNAME_HERE
       password: YOUR_PASSWORD_HERE
-      trace_analytics_raw: true
+      index_type: trace-analytics-raw
       dlq_file: /your/local/dlq-file
       bulk_size: 4
 ```
@@ -37,7 +37,7 @@ pipeline:
       cert: path/to/cert
       username: YOUR_USERNAME_HERE
       password: YOUR_PASSWORD_HERE
-      trace_analytics_service_map: true
+      index_type: trace-analytics-service-map
       dlq_file: /your/local/dlq-file
       bulk_size: 4
 ```

--- a/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
+++ b/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
@@ -145,26 +145,26 @@ Resources:
                     \        hosts: [ \"${AmazonEsEndpoint}\" ]\n
                     \        aws_sigv4: true\n
                     \        aws_region: \"${AmazonEsRegion}\"\n
-                    \        trace_analytics_raw: true"
+                    \        index_type: trace-analytics-raw"
                     - !Sub "\n
                     \        hosts: [ \"${AmazonEsEndpoint}\" ]\n
                     \        aws_sigv4: false\n
                     \        username: \"${Username}\"\n
                     \        password: \"${Password}\"\n
-                    \        trace_analytics_raw: true"
+                    \        index_type: trace-analytics-raw"
                   serviceMapConfig: !If
                     - NoMasterUser
                     - !Sub "\n
                     \        hosts: [ \"${AmazonEsEndpoint}\" ]\n
                     \        aws_sigv4: true\n
                     \        aws_region: \"${AmazonEsRegion}\"\n
-                    \        trace_analytics_service_map: true"
+                    \        index_type: trace-analytics-service-map"
                     - !Sub "\n
                     \        hosts: [ \"${AmazonEsEndpoint}\" ]\n
                     \        aws_sigv4: false\n
                     \        username: \"${Username}\"\n
                     \        password: \"${Password}\"\n
-                    \        trace_analytics_service_map: true"
+                    \        index_type: trace-analytics-service-map"
               mode: "000400"
               owner: root
               group: root

--- a/docs/trace_analytics.md
+++ b/docs/trace_analytics.md
@@ -118,7 +118,7 @@ raw-pipeline:
   sink:
     - opensearch:
         hosts: [ "https://localhost:9200" ]
-        trace_analytics_raw: true
+        index_type: trace-analytics-raw
         # Change to your credentials
         username: "admin"
         password: "admin"
@@ -155,7 +155,7 @@ service-map-pipeline:
   sink:
     - opensearch:
         hosts: [ "https://localhost:9200" ]
-        trace_analytics_service_map: true
+        index_type: trace-analytics-service-map
         # Change to your credentials
         username: "admin"
         password: "admin"

--- a/e2e-test/trace/src/integrationTest/resources/raw-span-e2e-pipeline-event-type.yml
+++ b/e2e-test/trace/src/integrationTest/resources/raw-span-e2e-pipeline-event-type.yml
@@ -22,4 +22,4 @@ raw-pipeline:
         hosts: [ "https://node-0.example.com:9200" ]
         username: "admin"
         password: "admin"
-        trace_analytics_raw: true
+        index_type: trace-analytics-raw

--- a/e2e-test/trace/src/integrationTest/resources/raw-span-e2e-pipeline-latest-release.yml
+++ b/e2e-test/trace/src/integrationTest/resources/raw-span-e2e-pipeline-latest-release.yml
@@ -22,4 +22,4 @@ raw-pipeline:
         hosts: [ "https://node-0.example.com:9200" ]
         username: "admin"
         password: "admin"
-        trace_analytics_raw: true
+        index_type: trace-analytics-raw

--- a/e2e-test/trace/src/integrationTest/resources/raw-span-e2e-pipeline-peer-forwarder-event-type.yml
+++ b/e2e-test/trace/src/integrationTest/resources/raw-span-e2e-pipeline-peer-forwarder-event-type.yml
@@ -23,4 +23,4 @@ raw-pipeline:
         hosts: [ "https://node-0.example.com:9200" ]
         username: "admin"
         password: "admin"
-        trace_analytics_raw: true
+        index_type: trace-analytics-raw

--- a/e2e-test/trace/src/integrationTest/resources/raw-span-e2e-pipeline.yml
+++ b/e2e-test/trace/src/integrationTest/resources/raw-span-e2e-pipeline.yml
@@ -21,4 +21,4 @@ raw-pipeline:
         hosts: [ "https://node-0.example.com:9200" ]
         username: "admin"
         password: "admin"
-        trace_analytics_raw: true
+        index_type: trace-analytics-raw

--- a/e2e-test/trace/src/integrationTest/resources/service-map-e2e-pipeline-event-type.yml
+++ b/e2e-test/trace/src/integrationTest/resources/service-map-e2e-pipeline-event-type.yml
@@ -23,4 +23,4 @@ service-map-pipeline:
         hosts: ["https://node-0.example.com:9200"]
         username: "admin"
         password: "admin"
-        trace_analytics_service_map: true
+        index_type: trace-analytics-service-map

--- a/e2e-test/trace/src/integrationTest/resources/service-map-e2e-pipeline.yml
+++ b/e2e-test/trace/src/integrationTest/resources/service-map-e2e-pipeline.yml
@@ -22,4 +22,4 @@ service-map-pipeline:
         hosts: ["https://node-0.example.com:9200"]
         username: "admin"
         password: "admin"
-        trace_analytics_service_map: true
+        index_type: trace-analytics-service-map

--- a/examples/config/example-pipelines.yaml
+++ b/examples/config/example-pipelines.yaml
@@ -19,7 +19,7 @@ raw-pipeline:
         hosts: [ "https://<your-domain>.<region>.es.amazonaws.com" ]
         aws_sigv4: true
         aws_region: "us-east-1"
-        trace_analytics_raw: true
+        index_type: trace-analytics-raw
 service-map-pipeline:
   delay: "100"
   source:
@@ -32,5 +32,5 @@ service-map-pipeline:
         hosts: [ "https://<your-domain>.<region>.es.amazonaws.com" ]
         aws_sigv4: true
         aws_region: "us-east-1"
-        trace_analytics_service_map: true
+        index_type: trace-analytics-service-map
   

--- a/examples/dev/k8s/data-prepper.yaml
+++ b/examples/dev/k8s/data-prepper.yaml
@@ -37,7 +37,7 @@ data:
             insecure: true
             username: "admin"
             password: "admin"
-            trace_analytics_raw: true
+            index_type: trace-analytics-raw
     service-map-pipeline:
       delay: "100"
       source:
@@ -51,7 +51,7 @@ data:
             insecure: true
             username: "admin"
             password: "admin"
-            trace_analytics_service_map: true
+            index_type: trace-analytics-service-map
 kind: ConfigMap
 metadata:
   creationTimestamp: "2020-12-11T18:07:51Z"

--- a/examples/dev/trace-analytics-sample-app/resources/pipelines.yaml
+++ b/examples/dev/trace-analytics-sample-app/resources/pipelines.yaml
@@ -27,7 +27,7 @@ raw-pipeline:
         cert: "/usr/share/data-prepper/root-ca.pem"
         username: "admin"
         password: "admin"
-        trace_analytics_raw: true
+        index_type: trace-analytics-raw
 service-map-pipeline:
   delay: "100"
   source:
@@ -41,4 +41,4 @@ service-map-pipeline:
         cert: "/usr/share/data-prepper/root-ca.pem"
         username: "admin"
         password: "admin"
-        trace_analytics_service_map: true
+        index_type: trace-analytics-service-map

--- a/examples/trace_analytics.yml
+++ b/examples/trace_analytics.yml
@@ -22,7 +22,7 @@ raw-pipeline:
         cert: "/app/root-ca.pem"
         username: "admin"
         password: "admin"
-        trace_analytics_raw: true
+        index_type: trace-analytics-raw
 service-map-pipeline:
   delay: "100"
   source:
@@ -36,4 +36,4 @@ service-map-pipeline:
         cert: "/app/root-ca.pem"
         username: "admin"
         password: "admin"
-        trace_analytics_service_map: true
+        index_type: trace-analytics-service-map

--- a/examples/trace_analytics_no_ssl.yml
+++ b/examples/trace_analytics_no_ssl.yml
@@ -20,7 +20,7 @@ raw-pipeline:
         cert: "/usr/share/data-prepper/root-ca.pem"
         username: "admin"
         password: "admin"
-        trace_analytics_raw: true
+        index_type: trace-analytics-raw
 service-map-pipeline:
   delay: "100"
   source:
@@ -34,4 +34,4 @@ service-map-pipeline:
         cert: "/usr/share/data-prepper/root-ca.pem"
         username: "admin"
         password: "admin"
-        trace_analytics_service_map: true
+        index_type: trace-analytics-service-map

--- a/release/smoke-tests/data-prepper/config/pipelines.yaml
+++ b/release/smoke-tests/data-prepper/config/pipelines.yaml
@@ -33,7 +33,7 @@ raw-pipeline:
         hosts: [ "https://node-0.example.com:9200" ]
         username: "admin"
         password: "admin"
-        trace_analytics_raw: true
+        index_type: trace-analytics-raw
 
 service-map-pipeline:
   delay: "100"
@@ -47,4 +47,4 @@ service-map-pipeline:
         hosts: ["https://node-0.example.com:9200"]
         username: "admin"
         password: "admin"
-        trace_analytics_service_map: true
+        index_type: trace-analytics-service-map


### PR DESCRIPTION
### Description
The trace_analytics_raw and trace_analytics_service_map boolean configuration values are deprecated and scheduled for removal in 2.0. This PR updates documentation, examples, and integration tests to use the index_type configuration instead.

 
### Issues Resolved

None. But, prepares for #1648.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
