### PR TITLE
Added logstash config conversion for csv processor & added explanatio…

### DIFF
--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/AbstractLogstashPluginAttributesMapper.java
@@ -61,7 +61,7 @@ public abstract class AbstractLogstashPluginAttributesMapper implements Logstash
                         }
                     }
                     else {
-                        LOG.warn("Attribute name {} is not found in mapping file.", logstashAttributeName);
+                        LOG.warn("Logstash Attribute {} is not supported in Data Prepper.", logstashAttributeName);
                     }
                 });
 

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/CsvLogstashPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/CsvLogstashPluginAttributesMapper.java
@@ -32,14 +32,15 @@ public class CsvLogstashPluginAttributesMapper extends AbstractLogstashPluginAtt
 
         final Optional<LogstashAttribute> autogenerateColumnNamesAttribute = findLogstashAttribute(logstashAttributes,
                 LOGSTASH_AUTOGENERATE_COLUMN_NAMES_ATTRIBUTE_NAME);
-        Object autogenerateColumnNamesValue = autogenerateColumnNamesAttribute.map(attribute -> attribute.getAttributeValue().getValue())
+        final Object autogenerateColumnNamesValue = autogenerateColumnNamesAttribute.map(attribute -> attribute.getAttributeValue().getValue())
                 .orElse(false);
-        boolean isAutogenerateColumnNames = autogenerateColumnNamesValue.equals(true);
+        final boolean isAutogenerateColumnNames = autogenerateColumnNamesValue.equals(true);
 
         final Optional<LogstashAttribute> columnsAttribute = findLogstashAttribute(logstashAttributes,
                 LOGSTASH_COLUMNS_ATTRIBUTE_NAME);
-        Object columnsValue = columnsAttribute.map(attribute -> attribute.getAttributeValue().getValue()).orElse(false);
-        boolean columnsValueIsEmptyOrDoesNotExist = columnsValue.equals(false) || ((List<String>) columnsValue).isEmpty();
+        final List<String> columnsValue = (List<String>) columnsAttribute.map(attribute -> attribute.getAttributeValue().getValue())
+                .orElse(Collections.emptyList());
+        final boolean columnsValueIsEmptyOrDoesNotExist = columnsValue.isEmpty();
 
         if (isAutogenerateColumnNames && columnsValueIsEmptyOrDoesNotExist) {
             pluginSettings.put(

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/CsvLogstashPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/CsvLogstashPluginAttributesMapper.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.logstash.mapping;
+
+import org.opensearch.dataprepper.logstash.exception.LogstashConfigurationException;
+import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * LogstashPluginAttributesMapper that maps Logstash's csv filter to Data Prepper's csv processor.
+ * In addition to the settings in csv.mapping.yaml, this mapper supports Logstash's autogenerate_column_names setting.
+ *
+ */
+public class CsvLogstashPluginAttributesMapper extends AbstractLogstashPluginAttributesMapper{
+    protected static final String LOGSTASH_AUTODETECT_COLUMN_NAMES_ATTRIBUTE_NAME = "autodetect_column_names";
+    protected static final String DATA_PREPPER_COLUMN_NAMES_SOURCE_KEY = "column_names_source_key";
+    protected static final String DATA_PREPPER_COLUMN_NAMES = "column_names";
+    protected static final String LOGSTASH_AUTOGENERATE_COLUMN_NAMES_ATTRIBUTE_NAME = "autogenerate_column_names";
+
+    protected static final String LOGSTASH_SKIP_EMPTY_ROWS_ATTRIBUTE_NAME = "skip_empty_rows";
+    protected static final String LOGSTASH_SKIP_EMPTY_COLUMNS_ATTRIBUTE_NAME = "skip_empty_columns";
+    protected static final String LOGSTASH_SKIP_HEADER_ATTRIBUTE_NAME = "skip_header";
+    protected static final String LOGSTASH_CONVERT_ATTRIBUTE_NAME = "convert";
+    protected static final String LOGSTASH_AUTODETECT_COLUMN_NAMES_EXCEPTION_MESSAGE = "Data Prepper logstash conversion does not " +
+            "support the autodetect_column_names setting in Logstash configuration. Consider manually specifying a Data Prepper config " +
+            "file with a CSV Processor for header autodetection functionality.";
+    protected static final String LOGSTASH_SKIP_EMPTY_ROWS_EXCEPTION_MESSAGE = "Data Prepper logstash conversion does not support the " +
+            "skip_empty_columns setting in Logstash configuration. Consider using a delete_entries processor with the empty columns you " +
+            "wish to drop.";
+    protected static final String LOGSTASH_SKIP_EMPTY_COLUMNS_EXCEPTION_MESSAGE = "Data Prepper logstash conversion does not support the " +
+            "skip_empty_rows setting in Logstash configuration. Consider using a drop_events processor to drop empty rows.";
+    protected static final String LOGSTASH_SKIP_HEADER_EXCEPTION_MESSAGE = "Data Prepper logstash conversion does not support the " +
+            "skip_header setting in Logstash configuration. Consider using a drop_events processor to drop tbe first row.";
+    protected static final String LOGSTASH_CONVERT_EXCEPTION_MESSAGE = "Data Prepper logstash conversion does not support the convert " +
+            "setting in Logstash configuration. This feature may be supported in the future; a separate processor to typecast Event " +
+            "fields is in the Data Prepper roadmap.";
+    @Override
+    protected void mapCustomAttributes(final List<LogstashAttribute> logstashAttributes,
+                                       final LogstashAttributesMappings logstashAttributesMappings,
+                                       final Map<String, Object> pluginSettings) {
+        final Optional<LogstashAttribute> autogenerateColumnNamesAttribute = findLogstashAttribute(logstashAttributes,
+                LOGSTASH_AUTOGENERATE_COLUMN_NAMES_ATTRIBUTE_NAME);
+
+        if (logstashAttributeExistsAndIsTrue(autogenerateColumnNamesAttribute)) {
+            pluginSettings.put(
+                    DATA_PREPPER_COLUMN_NAMES,
+                    new ArrayList<String>()
+            );
+        }
+
+        final Optional<LogstashAttribute> autodetectColumnNamesAttribute = findLogstashAttribute(logstashAttributes,
+                LOGSTASH_AUTODETECT_COLUMN_NAMES_ATTRIBUTE_NAME);
+
+        if (logstashAttributeExistsAndIsTrue(autodetectColumnNamesAttribute)) {
+            throw new LogstashConfigurationException(LOGSTASH_AUTODETECT_COLUMN_NAMES_EXCEPTION_MESSAGE);
+        }
+
+        final Optional<LogstashAttribute> skipEmptyRowsAttribute = findLogstashAttribute(logstashAttributes,
+                LOGSTASH_SKIP_EMPTY_ROWS_ATTRIBUTE_NAME);
+
+        if (skipEmptyRowsAttribute.isPresent()) {
+            throw new LogstashConfigurationException(LOGSTASH_SKIP_EMPTY_ROWS_EXCEPTION_MESSAGE);
+        }
+
+        final Optional<LogstashAttribute> skipEmptyColumnsAttribute = findLogstashAttribute(logstashAttributes,
+                LOGSTASH_SKIP_EMPTY_COLUMNS_ATTRIBUTE_NAME);
+        if (skipEmptyColumnsAttribute.isPresent()) {
+            throw new LogstashConfigurationException(LOGSTASH_SKIP_EMPTY_COLUMNS_EXCEPTION_MESSAGE);
+        }
+        final Optional<LogstashAttribute> skipHeaderAttribute = findLogstashAttribute(logstashAttributes,
+                LOGSTASH_SKIP_HEADER_ATTRIBUTE_NAME);
+        if (skipHeaderAttribute.isPresent()) {
+            throw new LogstashConfigurationException(LOGSTASH_SKIP_HEADER_EXCEPTION_MESSAGE);
+        }
+        final Optional<LogstashAttribute> convertAttribute = findLogstashAttribute(logstashAttributes,
+                LOGSTASH_CONVERT_ATTRIBUTE_NAME);
+        if (convertAttribute.isPresent()) {
+            throw new LogstashConfigurationException(LOGSTASH_CONVERT_EXCEPTION_MESSAGE);
+        }
+    }
+
+    private Optional<LogstashAttribute> findLogstashAttribute(final List<LogstashAttribute> logstashAttributes,
+                                                              final String logstashAttributeName) {
+        return logstashAttributes.stream()
+                .filter(logstashAttribute -> logstashAttribute.getAttributeName().equals(logstashAttributeName))
+                .findFirst();
+    }
+
+    private boolean logstashAttributeExistsAndIsTrue(final Optional<LogstashAttribute> optionalLogstashAttribute) {
+        return optionalLogstashAttribute.isPresent() && optionalLogstashAttribute.get().getAttributeValue().getValue().equals(true);
+    }
+
+    @Override
+    protected HashSet<String> getCustomMappedAttributeNames() {
+        final int numberOfCustomAttributeNames = 6;
+        final HashSet<String> names = new HashSet<>(numberOfCustomAttributeNames);
+        names.add(DATA_PREPPER_COLUMN_NAMES_SOURCE_KEY);
+        names.add(DATA_PREPPER_COLUMN_NAMES);
+        names.add(LOGSTASH_SKIP_EMPTY_ROWS_ATTRIBUTE_NAME);
+        names.add(LOGSTASH_SKIP_EMPTY_COLUMNS_ATTRIBUTE_NAME);
+        names.add(LOGSTASH_SKIP_HEADER_ATTRIBUTE_NAME);
+        names.add(LOGSTASH_CONVERT_ATTRIBUTE_NAME);
+        return names;
+    }
+}

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/CsvLogstashPluginAttributesMapper.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/mapping/CsvLogstashPluginAttributesMapper.java
@@ -5,10 +5,10 @@
 
 package org.opensearch.dataprepper.logstash.mapping;
 
-import org.opensearch.dataprepper.logstash.exception.LogstashConfigurationException;
 import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -20,70 +20,25 @@ import java.util.Optional;
  *
  */
 public class CsvLogstashPluginAttributesMapper extends AbstractLogstashPluginAttributesMapper{
-    protected static final String LOGSTASH_AUTODETECT_COLUMN_NAMES_ATTRIBUTE_NAME = "autodetect_column_names";
-    protected static final String DATA_PREPPER_COLUMN_NAMES_SOURCE_KEY = "column_names_source_key";
-    protected static final String DATA_PREPPER_COLUMN_NAMES = "column_names";
     protected static final String LOGSTASH_AUTOGENERATE_COLUMN_NAMES_ATTRIBUTE_NAME = "autogenerate_column_names";
+    protected static final String LOGSTASH_COLUMNS_ATTRIBUTE_NAME = "columns";
+    protected static final String DATA_PREPPER_COLUMN_NAMES = "column_names";
 
-    protected static final String LOGSTASH_SKIP_EMPTY_ROWS_ATTRIBUTE_NAME = "skip_empty_rows";
-    protected static final String LOGSTASH_SKIP_EMPTY_COLUMNS_ATTRIBUTE_NAME = "skip_empty_columns";
-    protected static final String LOGSTASH_SKIP_HEADER_ATTRIBUTE_NAME = "skip_header";
-    protected static final String LOGSTASH_CONVERT_ATTRIBUTE_NAME = "convert";
-    protected static final String LOGSTASH_AUTODETECT_COLUMN_NAMES_EXCEPTION_MESSAGE = "Data Prepper logstash conversion does not " +
-            "support the autodetect_column_names setting in Logstash configuration. Consider manually specifying a Data Prepper config " +
-            "file with a CSV Processor for header autodetection functionality.";
-    protected static final String LOGSTASH_SKIP_EMPTY_ROWS_EXCEPTION_MESSAGE = "Data Prepper logstash conversion does not support the " +
-            "skip_empty_columns setting in Logstash configuration. Consider using a delete_entries processor with the empty columns you " +
-            "wish to drop.";
-    protected static final String LOGSTASH_SKIP_EMPTY_COLUMNS_EXCEPTION_MESSAGE = "Data Prepper logstash conversion does not support the " +
-            "skip_empty_rows setting in Logstash configuration. Consider using a drop_events processor to drop empty rows.";
-    protected static final String LOGSTASH_SKIP_HEADER_EXCEPTION_MESSAGE = "Data Prepper logstash conversion does not support the " +
-            "skip_header setting in Logstash configuration. Consider using a drop_events processor to drop tbe first row.";
-    protected static final String LOGSTASH_CONVERT_EXCEPTION_MESSAGE = "Data Prepper logstash conversion does not support the convert " +
-            "setting in Logstash configuration. This feature may be supported in the future; a separate processor to typecast Event " +
-            "fields is in the Data Prepper roadmap.";
     @Override
     protected void mapCustomAttributes(final List<LogstashAttribute> logstashAttributes,
                                        final LogstashAttributesMappings logstashAttributesMappings,
                                        final Map<String, Object> pluginSettings) {
+        final Optional<LogstashAttribute> columnsAttribute = findLogstashAttribute(logstashAttributes,
+                LOGSTASH_COLUMNS_ATTRIBUTE_NAME);
+
         final Optional<LogstashAttribute> autogenerateColumnNamesAttribute = findLogstashAttribute(logstashAttributes,
                 LOGSTASH_AUTOGENERATE_COLUMN_NAMES_ATTRIBUTE_NAME);
 
-        if (logstashAttributeExistsAndIsTrue(autogenerateColumnNamesAttribute)) {
+        if (logstashAttributeExistsAndIsTrue(autogenerateColumnNamesAttribute) && logstashColumnsDoesNotExistOrIsEmpty(columnsAttribute)) {
             pluginSettings.put(
                     DATA_PREPPER_COLUMN_NAMES,
                     new ArrayList<String>()
             );
-        }
-
-        final Optional<LogstashAttribute> autodetectColumnNamesAttribute = findLogstashAttribute(logstashAttributes,
-                LOGSTASH_AUTODETECT_COLUMN_NAMES_ATTRIBUTE_NAME);
-
-        if (logstashAttributeExistsAndIsTrue(autodetectColumnNamesAttribute)) {
-            throw new LogstashConfigurationException(LOGSTASH_AUTODETECT_COLUMN_NAMES_EXCEPTION_MESSAGE);
-        }
-
-        final Optional<LogstashAttribute> skipEmptyRowsAttribute = findLogstashAttribute(logstashAttributes,
-                LOGSTASH_SKIP_EMPTY_ROWS_ATTRIBUTE_NAME);
-
-        if (skipEmptyRowsAttribute.isPresent()) {
-            throw new LogstashConfigurationException(LOGSTASH_SKIP_EMPTY_ROWS_EXCEPTION_MESSAGE);
-        }
-
-        final Optional<LogstashAttribute> skipEmptyColumnsAttribute = findLogstashAttribute(logstashAttributes,
-                LOGSTASH_SKIP_EMPTY_COLUMNS_ATTRIBUTE_NAME);
-        if (skipEmptyColumnsAttribute.isPresent()) {
-            throw new LogstashConfigurationException(LOGSTASH_SKIP_EMPTY_COLUMNS_EXCEPTION_MESSAGE);
-        }
-        final Optional<LogstashAttribute> skipHeaderAttribute = findLogstashAttribute(logstashAttributes,
-                LOGSTASH_SKIP_HEADER_ATTRIBUTE_NAME);
-        if (skipHeaderAttribute.isPresent()) {
-            throw new LogstashConfigurationException(LOGSTASH_SKIP_HEADER_EXCEPTION_MESSAGE);
-        }
-        final Optional<LogstashAttribute> convertAttribute = findLogstashAttribute(logstashAttributes,
-                LOGSTASH_CONVERT_ATTRIBUTE_NAME);
-        if (convertAttribute.isPresent()) {
-            throw new LogstashConfigurationException(LOGSTASH_CONVERT_EXCEPTION_MESSAGE);
         }
     }
 
@@ -94,20 +49,23 @@ public class CsvLogstashPluginAttributesMapper extends AbstractLogstashPluginAtt
                 .findFirst();
     }
 
+    private boolean logstashColumnsDoesNotExistOrIsEmpty(final Optional<LogstashAttribute> columnsLogstashAttribute) {
+        if (!columnsLogstashAttribute.isPresent()) {
+            return true;
+        }
+        final Object columnsFromLogstashConfiguration = columnsLogstashAttribute.get().getAttributeValue().getValue();
+        if (columnsFromLogstashConfiguration instanceof List) {
+            return ((List<?>) columnsFromLogstashConfiguration).isEmpty();
+        }
+        return true;
+    }
+
     private boolean logstashAttributeExistsAndIsTrue(final Optional<LogstashAttribute> optionalLogstashAttribute) {
         return optionalLogstashAttribute.isPresent() && optionalLogstashAttribute.get().getAttributeValue().getValue().equals(true);
     }
 
     @Override
     protected HashSet<String> getCustomMappedAttributeNames() {
-        final int numberOfCustomAttributeNames = 6;
-        final HashSet<String> names = new HashSet<>(numberOfCustomAttributeNames);
-        names.add(DATA_PREPPER_COLUMN_NAMES_SOURCE_KEY);
-        names.add(DATA_PREPPER_COLUMN_NAMES);
-        names.add(LOGSTASH_SKIP_EMPTY_ROWS_ATTRIBUTE_NAME);
-        names.add(LOGSTASH_SKIP_EMPTY_COLUMNS_ATTRIBUTE_NAME);
-        names.add(LOGSTASH_SKIP_HEADER_ATTRIBUTE_NAME);
-        names.add(LOGSTASH_CONVERT_ATTRIBUTE_NAME);
-        return names;
+        return new HashSet<>(Collections.singleton(LOGSTASH_AUTOGENERATE_COLUMN_NAMES_ATTRIBUTE_NAME));
     }
 }

--- a/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/model/LogstashValueType.java
+++ b/data-prepper-logstash-configuration/src/main/java/org/opensearch/dataprepper/logstash/model/LogstashValueType.java
@@ -6,7 +6,7 @@
 package org.opensearch.dataprepper.logstash.model;
 
 /**
- * Types of attribute values in Logstash configuration
+ * Types of attribute values in Logstash configuration. To specify a boolean, use BAREWORD
  *
  * @since 1.2
  */

--- a/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/csv.mapping.yaml
+++ b/data-prepper-logstash-configuration/src/main/resources/org/opensearch/dataprepper/logstash/mapping/csv.mapping.yaml
@@ -1,0 +1,9 @@
+pluginName: csv
+attributesMapperClass: org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper
+mappedAttributeNames:
+  columns: column_names
+  quote_char: quote_character
+  separator: delimiter
+  source: source
+additionalAttributes:
+  delete_header: true

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/CsvLogstashPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/CsvLogstashPluginAttributesMapperTest.java
@@ -6,9 +6,7 @@
 package org.opensearch.dataprepper.logstash.mapping;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.opensearch.dataprepper.logstash.exception.LogstashConfigurationException;
 import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
 import org.opensearch.dataprepper.logstash.model.LogstashAttributeValue;
 import org.opensearch.dataprepper.logstash.model.LogstashValueType;
@@ -19,21 +17,10 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.DATA_PREPPER_COLUMN_NAMES;
-import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_AUTODETECT_COLUMN_NAMES_ATTRIBUTE_NAME;
-import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_AUTODETECT_COLUMN_NAMES_EXCEPTION_MESSAGE;
 import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_AUTOGENERATE_COLUMN_NAMES_ATTRIBUTE_NAME;
-import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_CONVERT_ATTRIBUTE_NAME;
-import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_CONVERT_EXCEPTION_MESSAGE;
-import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_SKIP_EMPTY_COLUMNS_ATTRIBUTE_NAME;
-import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_SKIP_EMPTY_COLUMNS_EXCEPTION_MESSAGE;
-import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_SKIP_EMPTY_ROWS_ATTRIBUTE_NAME;
-import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_SKIP_EMPTY_ROWS_EXCEPTION_MESSAGE;
-import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_SKIP_HEADER_ATTRIBUTE_NAME;
-import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_SKIP_HEADER_EXCEPTION_MESSAGE;
 
 class CsvLogstashPluginAttributesMapperTest {
     CsvLogstashPluginAttributesMapper csvLogstashPluginAttributesMapper;
@@ -58,89 +45,5 @@ class CsvLogstashPluginAttributesMapperTest {
 
         assertThat(pluginSettings.containsKey(DATA_PREPPER_COLUMN_NAMES), equalTo(true));
         assertThat(pluginSettings.containsValue(Collections.emptyList()), equalTo(true));
-    }
-    @Nested
-    class InvalidConfigurationExceptions {
-        final LogstashAttributesMappings mappings = mock(LogstashAttributesMappings.class);
-        final Map<String, Object> pluginSettings = new LinkedHashMap<>();
-
-        @Test
-        void when_autoDetectColumnNames_then_throws() {
-            when(mappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
-            final LogstashAttribute autoDetectColumnNames = LogstashAttribute.builder()
-                    .attributeName(LOGSTASH_AUTODETECT_COLUMN_NAMES_ATTRIBUTE_NAME)
-                    .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.BAREWORD).value(true).build())
-                    .build();
-
-            Exception autoDetectColumnNamesException = assertThrows(LogstashConfigurationException.class, () ->
-                    csvLogstashPluginAttributesMapper.mapCustomAttributes(Collections.singletonList(autoDetectColumnNames),
-                            mappings, pluginSettings)
-            );
-
-            assertThat(autoDetectColumnNamesException.getMessage(), equalTo(LOGSTASH_AUTODETECT_COLUMN_NAMES_EXCEPTION_MESSAGE));
-        }
-
-        @Test
-        void when_skipEmptyRows_then_throws() {
-            when(mappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
-            final LogstashAttribute skipEmptyRows = LogstashAttribute.builder()
-                    .attributeName(LOGSTASH_SKIP_EMPTY_ROWS_ATTRIBUTE_NAME)
-                    .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.BAREWORD).value(true).build())
-                    .build();
-
-            Exception skipEmptyRowsException = assertThrows(LogstashConfigurationException.class, () ->
-                    csvLogstashPluginAttributesMapper.mapCustomAttributes(Collections.singletonList(skipEmptyRows),
-                            mappings, pluginSettings)
-            );
-
-            assertThat(skipEmptyRowsException.getMessage(), equalTo(LOGSTASH_SKIP_EMPTY_ROWS_EXCEPTION_MESSAGE));
-        }
-
-        @Test
-        void when_skipEmptyColumns_then_throws() {
-            when(mappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
-            final LogstashAttribute skipEmptyColumns = LogstashAttribute.builder()
-                    .attributeName(LOGSTASH_SKIP_EMPTY_COLUMNS_ATTRIBUTE_NAME)
-                    .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.BAREWORD).value(true).build())
-                    .build();
-            Exception skipEmptyColumnsException = assertThrows(LogstashConfigurationException.class, () ->
-                    csvLogstashPluginAttributesMapper.mapCustomAttributes(Collections.singletonList(skipEmptyColumns),
-                            mappings, pluginSettings)
-            );
-
-            assertThat(skipEmptyColumnsException.getMessage(), equalTo(LOGSTASH_SKIP_EMPTY_COLUMNS_EXCEPTION_MESSAGE));
-        }
-
-        @Test
-        void when_skipHeader_then_throws() {
-            when(mappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
-            final LogstashAttribute skipHeader = LogstashAttribute.builder()
-                    .attributeName(LOGSTASH_SKIP_HEADER_ATTRIBUTE_NAME)
-                    .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.BAREWORD).value(true).build())
-                    .build();
-
-            Exception skipHeaderException = assertThrows(LogstashConfigurationException.class, () ->
-                    csvLogstashPluginAttributesMapper.mapCustomAttributes(Collections.singletonList(skipHeader),
-                            mappings, pluginSettings)
-            );
-
-            assertThat(skipHeaderException.getMessage(), equalTo(LOGSTASH_SKIP_HEADER_EXCEPTION_MESSAGE));
-        }
-
-        @Test
-        void when_convert_then_throws() {
-            when(mappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
-            final LogstashAttribute convert = LogstashAttribute.builder()
-                    .attributeName(LOGSTASH_CONVERT_ATTRIBUTE_NAME)
-                    .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.BAREWORD).value(true).build())
-                    .build();
-
-            Exception convertException = assertThrows(LogstashConfigurationException.class, () ->
-                    csvLogstashPluginAttributesMapper.mapCustomAttributes(Collections.singletonList(convert),
-                            mappings, pluginSettings)
-            );
-
-            assertThat(convertException.getMessage(), equalTo(LOGSTASH_CONVERT_EXCEPTION_MESSAGE));
-        }
     }
 }

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/CsvLogstashPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/CsvLogstashPluginAttributesMapperTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.logstash.mapping;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.logstash.exception.LogstashConfigurationException;
+import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
+import org.opensearch.dataprepper.logstash.model.LogstashAttributeValue;
+import org.opensearch.dataprepper.logstash.model.LogstashValueType;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.DATA_PREPPER_COLUMN_NAMES;
+import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_AUTODETECT_COLUMN_NAMES_ATTRIBUTE_NAME;
+import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_AUTODETECT_COLUMN_NAMES_EXCEPTION_MESSAGE;
+import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_AUTOGENERATE_COLUMN_NAMES_ATTRIBUTE_NAME;
+import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_CONVERT_ATTRIBUTE_NAME;
+import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_CONVERT_EXCEPTION_MESSAGE;
+import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_SKIP_EMPTY_COLUMNS_ATTRIBUTE_NAME;
+import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_SKIP_EMPTY_COLUMNS_EXCEPTION_MESSAGE;
+import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_SKIP_EMPTY_ROWS_ATTRIBUTE_NAME;
+import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_SKIP_EMPTY_ROWS_EXCEPTION_MESSAGE;
+import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_SKIP_HEADER_ATTRIBUTE_NAME;
+import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_SKIP_HEADER_EXCEPTION_MESSAGE;
+
+class CsvLogstashPluginAttributesMapperTest {
+    CsvLogstashPluginAttributesMapper csvLogstashPluginAttributesMapper;
+
+    @BeforeEach
+    void createObjectUnderTest() {
+        csvLogstashPluginAttributesMapper = new CsvLogstashPluginAttributesMapper();
+    }
+
+    @Test
+    void when_autogenerateColumnsInLogstash_then_usesDataPrepperAutogenerateFunctionality() {
+        final LogstashAttribute autoDetectColumnNames = LogstashAttribute.builder()
+                .attributeName(LOGSTASH_AUTOGENERATE_COLUMN_NAMES_ATTRIBUTE_NAME)
+                .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.BAREWORD).value(true).build())
+                .build();
+        final LogstashAttributesMappings mappings = mock(LogstashAttributesMappings.class);
+        final Map<String, Object> pluginSettings = new LinkedHashMap<>();
+        when(mappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
+
+        csvLogstashPluginAttributesMapper.mapCustomAttributes(Collections.singletonList(autoDetectColumnNames),
+                mappings, pluginSettings);
+
+        assertThat(pluginSettings.containsKey(DATA_PREPPER_COLUMN_NAMES), equalTo(true));
+        assertThat(pluginSettings.containsValue(Collections.emptyList()), equalTo(true));
+    }
+    @Nested
+    class InvalidConfigurationExceptions {
+        final LogstashAttributesMappings mappings = mock(LogstashAttributesMappings.class);
+        final Map<String, Object> pluginSettings = new LinkedHashMap<>();
+
+        @Test
+        void when_autoDetectColumnNames_then_throws() {
+            when(mappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
+            final LogstashAttribute autoDetectColumnNames = LogstashAttribute.builder()
+                    .attributeName(LOGSTASH_AUTODETECT_COLUMN_NAMES_ATTRIBUTE_NAME)
+                    .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.BAREWORD).value(true).build())
+                    .build();
+
+            Exception autoDetectColumnNamesException = assertThrows(LogstashConfigurationException.class, () ->
+                    csvLogstashPluginAttributesMapper.mapCustomAttributes(Collections.singletonList(autoDetectColumnNames),
+                            mappings, pluginSettings)
+            );
+
+            assertThat(autoDetectColumnNamesException.getMessage(), equalTo(LOGSTASH_AUTODETECT_COLUMN_NAMES_EXCEPTION_MESSAGE));
+        }
+
+        @Test
+        void when_skipEmptyRows_then_throws() {
+            when(mappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
+            final LogstashAttribute skipEmptyRows = LogstashAttribute.builder()
+                    .attributeName(LOGSTASH_SKIP_EMPTY_ROWS_ATTRIBUTE_NAME)
+                    .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.BAREWORD).value(true).build())
+                    .build();
+
+            Exception skipEmptyRowsException = assertThrows(LogstashConfigurationException.class, () ->
+                    csvLogstashPluginAttributesMapper.mapCustomAttributes(Collections.singletonList(skipEmptyRows),
+                            mappings, pluginSettings)
+            );
+
+            assertThat(skipEmptyRowsException.getMessage(), equalTo(LOGSTASH_SKIP_EMPTY_ROWS_EXCEPTION_MESSAGE));
+        }
+
+        @Test
+        void when_skipEmptyColumns_then_throws() {
+            when(mappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
+            final LogstashAttribute skipEmptyColumns = LogstashAttribute.builder()
+                    .attributeName(LOGSTASH_SKIP_EMPTY_COLUMNS_ATTRIBUTE_NAME)
+                    .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.BAREWORD).value(true).build())
+                    .build();
+            Exception skipEmptyColumnsException = assertThrows(LogstashConfigurationException.class, () ->
+                    csvLogstashPluginAttributesMapper.mapCustomAttributes(Collections.singletonList(skipEmptyColumns),
+                            mappings, pluginSettings)
+            );
+
+            assertThat(skipEmptyColumnsException.getMessage(), equalTo(LOGSTASH_SKIP_EMPTY_COLUMNS_EXCEPTION_MESSAGE));
+        }
+
+        @Test
+        void when_skipHeader_then_throws() {
+            when(mappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
+            final LogstashAttribute skipHeader = LogstashAttribute.builder()
+                    .attributeName(LOGSTASH_SKIP_HEADER_ATTRIBUTE_NAME)
+                    .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.BAREWORD).value(true).build())
+                    .build();
+
+            Exception skipHeaderException = assertThrows(LogstashConfigurationException.class, () ->
+                    csvLogstashPluginAttributesMapper.mapCustomAttributes(Collections.singletonList(skipHeader),
+                            mappings, pluginSettings)
+            );
+
+            assertThat(skipHeaderException.getMessage(), equalTo(LOGSTASH_SKIP_HEADER_EXCEPTION_MESSAGE));
+        }
+
+        @Test
+        void when_convert_then_throws() {
+            when(mappings.getMappedAttributeNames()).thenReturn(Collections.emptyMap());
+            final LogstashAttribute convert = LogstashAttribute.builder()
+                    .attributeName(LOGSTASH_CONVERT_ATTRIBUTE_NAME)
+                    .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.BAREWORD).value(true).build())
+                    .build();
+
+            Exception convertException = assertThrows(LogstashConfigurationException.class, () ->
+                    csvLogstashPluginAttributesMapper.mapCustomAttributes(Collections.singletonList(convert),
+                            mappings, pluginSettings)
+            );
+
+            assertThat(convertException.getMessage(), equalTo(LOGSTASH_CONVERT_EXCEPTION_MESSAGE));
+        }
+    }
+}

--- a/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/CsvLogstashPluginAttributesMapperTest.java
+++ b/data-prepper-logstash-configuration/src/test/java/org/opensearch/dataprepper/logstash/mapping/CsvLogstashPluginAttributesMapperTest.java
@@ -5,22 +5,29 @@
 
 package org.opensearch.dataprepper.logstash.mapping;
 
+import com.amazon.dataprepper.model.configuration.PluginModel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.logstash.model.LogstashAttribute;
 import org.opensearch.dataprepper.logstash.model.LogstashAttributeValue;
 import org.opensearch.dataprepper.logstash.model.LogstashValueType;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.DATA_PREPPER_COLUMN_NAMES;
 import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_AUTOGENERATE_COLUMN_NAMES_ATTRIBUTE_NAME;
+import static org.opensearch.dataprepper.logstash.mapping.CsvLogstashPluginAttributesMapper.LOGSTASH_COLUMNS_ATTRIBUTE_NAME;
 
 class CsvLogstashPluginAttributesMapperTest {
     CsvLogstashPluginAttributesMapper csvLogstashPluginAttributesMapper;
@@ -43,7 +50,88 @@ class CsvLogstashPluginAttributesMapperTest {
         csvLogstashPluginAttributesMapper.mapCustomAttributes(Collections.singletonList(autoDetectColumnNames),
                 mappings, pluginSettings);
 
-        assertThat(pluginSettings.containsKey(DATA_PREPPER_COLUMN_NAMES), equalTo(true));
-        assertThat(pluginSettings.containsValue(Collections.emptyList()), equalTo(true));
+        assertThat(pluginSettings, hasKey(DATA_PREPPER_COLUMN_NAMES));
+        assertThat(pluginSettings.get(DATA_PREPPER_COLUMN_NAMES), notNullValue());
+        assertThat(((List<?>) pluginSettings.get(DATA_PREPPER_COLUMN_NAMES)).size(), equalTo(0));
+    }
+
+    @Test
+    void when_autogenerateColumnsAndColumnsIsEmptyInLogstash_then_usesDataPrepperAutogenerateFunctionality() {
+        final LogstashAttribute autoDetectColumnNames = LogstashAttribute.builder()
+                .attributeName(LOGSTASH_AUTOGENERATE_COLUMN_NAMES_ATTRIBUTE_NAME)
+                .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.BAREWORD).value(true).build())
+                .build();
+
+        final List<String> columns = new ArrayList<>();
+        final LogstashAttribute columnsAttribute = LogstashAttribute.builder()
+                .attributeName(LOGSTASH_COLUMNS_ATTRIBUTE_NAME)
+                .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.ARRAY).value(columns).build())
+                .build();
+
+        final LogstashAttributesMappings mappings = mock(LogstashAttributesMappings.class);
+
+        when(mappings.getMappedAttributeNames()).thenReturn(
+                Collections.singletonMap(LOGSTASH_COLUMNS_ATTRIBUTE_NAME, DATA_PREPPER_COLUMN_NAMES));
+
+        final List<PluginModel> actualPluginModel = csvLogstashPluginAttributesMapper.mapAttributes(
+                Collections.singletonList(columnsAttribute), mappings);
+
+        final Map<String, Object> pluginSettings = new LinkedHashMap<>();
+        csvLogstashPluginAttributesMapper.mapCustomAttributes(Collections.singletonList(autoDetectColumnNames),
+                mappings, pluginSettings);
+
+        assertThat(actualPluginModel, notNullValue());
+        assertThat(actualPluginModel.size(), equalTo(1));
+        assertThat(actualPluginModel.get(0), notNullValue());
+
+        final List<String> actualColumns = (List<String>) actualPluginModel.get(0).getPluginSettings().get(DATA_PREPPER_COLUMN_NAMES);
+        final List<String> expectedColumns = columns;
+
+        assertThat(actualColumns, notNullValue());
+        assertThat(actualColumns.size(), equalTo(expectedColumns.size()));
+
+        assertThat(actualPluginModel.get(0).getPluginSettings(), hasKey(DATA_PREPPER_COLUMN_NAMES));
+        assertThat(actualPluginModel.get(0).getPluginSettings().get(DATA_PREPPER_COLUMN_NAMES), notNullValue());
+        assertThat(((List<?>) actualPluginModel.get(0).getPluginSettings().get(DATA_PREPPER_COLUMN_NAMES)).size(), equalTo(0));
+    }
+
+    @Test
+    void when_autogenerateColumnsAndColumnsSetInLogstash_then_usesColumnsInsteadOfAutogenerating() {
+        final LogstashAttribute autoDetectColumnNames = LogstashAttribute.builder()
+                .attributeName(LOGSTASH_AUTOGENERATE_COLUMN_NAMES_ATTRIBUTE_NAME)
+                .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.BAREWORD).value(true).build())
+                .build();
+
+        final List<String> columns = Arrays.asList("col1","col2");
+        final LogstashAttribute columnsAttribute = LogstashAttribute.builder()
+                .attributeName(LOGSTASH_COLUMNS_ATTRIBUTE_NAME)
+                .attributeValue(LogstashAttributeValue.builder().attributeValueType(LogstashValueType.ARRAY).value(columns).build())
+                .build();
+
+        final LogstashAttributesMappings mappings = mock(LogstashAttributesMappings.class);
+
+        when(mappings.getMappedAttributeNames()).thenReturn(
+                Collections.singletonMap(LOGSTASH_COLUMNS_ATTRIBUTE_NAME, DATA_PREPPER_COLUMN_NAMES));
+
+        final List<PluginModel> actualPluginModel = csvLogstashPluginAttributesMapper.mapAttributes(
+                Collections.singletonList(columnsAttribute), mappings);
+
+        final Map<String, Object> pluginSettings = new LinkedHashMap<>();
+        csvLogstashPluginAttributesMapper.mapCustomAttributes(Collections.singletonList(autoDetectColumnNames),
+                mappings, pluginSettings);
+
+        assertThat(actualPluginModel, notNullValue());
+        assertThat(actualPluginModel.size(), equalTo(1));
+        assertThat(actualPluginModel.get(0), notNullValue());
+
+        final List<String> actualColumns = (List<String>) actualPluginModel.get(0).getPluginSettings().get(DATA_PREPPER_COLUMN_NAMES);
+        final List<String> expectedColumns = columns;
+
+        assertThat(actualColumns, notNullValue());
+        assertThat(actualColumns.size(), equalTo(expectedColumns.size()));
+
+        assertThat(actualPluginModel.get(0).getPluginSettings(), hasKey(DATA_PREPPER_COLUMN_NAMES));
+        assertThat(actualColumns.get(0), equalTo(expectedColumns.get(0)));
+        assertThat(actualColumns.get(1), equalTo(expectedColumns.get(1)));
     }
 }

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch.conf
@@ -3,6 +3,9 @@ input {
     }
 }
 filter {
+    csv {
+        autogenerate_column_names => true
+    }
     grok {
         match => {"log" => "%{COMBINEDAPACHELOG}"}
     }

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch.conf
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch.conf
@@ -5,6 +5,10 @@ input {
 filter {
     csv {
         autogenerate_column_names => true
+        columns => ["a", "b"]
+        quote_char => ";"
+        separator => ":"
+        source => "message_source"
     }
     grok {
         match => {"log" => "%{COMBINEDAPACHELOG}"}

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch.expected.yaml
@@ -4,6 +4,9 @@ logstash-converted-pipeline:
       max_connection_count: 500
       request_timeout: 10000
   processor:
+    - csv:
+        delete_header: true
+        column_names: []
     - grok:
         match:
           log:

--- a/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch.expected.yaml
+++ b/data-prepper-logstash-configuration/src/test/resources/org/opensearch/dataprepper/logstash/log-ingest-to-logstash-opensearch.expected.yaml
@@ -6,7 +6,12 @@ logstash-converted-pipeline:
   processor:
     - csv:
         delete_header: true
-        column_names: []
+        column_names:
+          - "a"
+          - "b"
+        quote_character: ";"
+        delimiter: ":"
+        source: "message_source"
     - grok:
         match:
           log:


### PR DESCRIPTION
…n of boolean to LogstashValueType javadoc

Signed-off-by: Finn Roblin <finnrobl@amazon.com>

### Description
Adds `CsvLogstashPluginAttributesMapper` class and `csv.mapping.yaml` file to support converting Logstash configs containing a `csv` filter plugin to Data Prepper pipeline configs. I don't include mappings for the `CsvCodec` class because it's under the umbrella of the S3 Source plugin, which doesn't support Logstash mapping as far as I know. One suspect part of the code is the fact that exceptions are thrown using the `mapCustomAttributes` method of the `CsvLogstashPluginAttributesMapper` class. There might be better ways to throw exceptions when a user specifies an attribute in a Logstash config that can't be directly mapped to a Data Prepper config.
 
### Issues Resolved
Step towards resolving #1618 (#1618 might need to be broken out into two or more separate issues since the S3 Source mapping still needs to be written before the `CsvCodec` class can get a mapping)
 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
