### PR TITLE
Support loading plugins from org.opensearch.dataprepper

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginPackagesSupplier.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/plugin/PluginPackagesSupplier.java
@@ -13,10 +13,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -29,7 +29,9 @@ import java.util.stream.Collectors;
 class PluginPackagesSupplier implements Supplier<String[]> {
 
     private static final Logger LOG = LoggerFactory.getLogger(PluginPackagesSupplier.class);
-    private static final String DEFAULT_PLUGINS_CLASSPATH = "com.amazon.dataprepper.plugins";
+    private static final String DEFAULT_PLUGINS_CLASSPATH = "org.opensearch.dataprepper.plugins";
+    // TODO: Remove this once all plugins have migrated to org.opensearch
+    private static final String DEPRECATED_DEFAULT_PLUGINS_CLASSPATH = "com.amazon.dataprepper.plugins";
 
     PluginPackagesSupplier() {
     }
@@ -60,7 +62,7 @@ class PluginPackagesSupplier implements Supplier<String[]> {
             packageNames = readResources(pluginResources);
         } catch (final IOException ex) {
             LOG.warn("Unable to load data-prepper.plugins.properties file. Reverting to default plugin package.");
-            packageNames = Collections.singleton(DEFAULT_PLUGINS_CLASSPATH);
+            packageNames = new LinkedHashSet<>(Arrays.asList(DEFAULT_PLUGINS_CLASSPATH, DEPRECATED_DEFAULT_PLUGINS_CLASSPATH));
         }
         return packageNames;
     }
@@ -92,6 +94,7 @@ class PluginPackagesSupplier implements Supplier<String[]> {
         if (packageNames.isEmpty()) {
             LOG.warn("Unable to load packages from data-prepper.plugins.properties file. Reverting to default plugin package.");
             packageNames.add(DEFAULT_PLUGINS_CLASSPATH);
+            packageNames.add(DEPRECATED_DEFAULT_PLUGINS_CLASSPATH);
         }
 
         return packageNames;

--- a/data-prepper-core/src/main/resources/META-INF/data-prepper.plugins.properties
+++ b/data-prepper-core/src/main/resources/META-INF/data-prepper.plugins.properties
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-org.opensearch.dataprepper.plugin.packages=com.amazon.dataprepper.plugins
+org.opensearch.dataprepper.plugin.packages=org.opensearch.dataprepper.plugins,com.amazon.dataprepper.plugins

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginPackagesSupplierTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugin/PluginPackagesSupplierTest.java
@@ -30,7 +30,9 @@ import static org.mockito.Mockito.when;
 class PluginPackagesSupplierTest {
 
     private static final String PROPERTIES_PREFIX = "org.opensearch.dataprepper.plugin.packages=";
-    private static final String DEFAULT_PACKAGE_NAME = "com.amazon.dataprepper.plugins";
+    private static final String DEFAULT_PACKAGE_NAME = "org.opensearch.dataprepper.plugins";
+    // TODO: Remove this once all plugins have migrated to org.opensearch
+    private static final String DEPRECATED_DEFAULT_PACKAGE_NAME = "com.amazon.dataprepper.plugins";
 
     private PluginPackagesSupplier createObjectUnderTest() {
         final PluginPackagesSupplier object = new PluginPackagesSupplier();
@@ -46,8 +48,9 @@ class PluginPackagesSupplierTest {
         final String[] actualPackages = objectUnderTest.get();
         assertThat(actualPackages, notNullValue());
 
-        assertThat(actualPackages.length, equalTo(1));
+        assertThat(actualPackages.length, equalTo(2));
         assertThat(actualPackages[0], equalTo(DEFAULT_PACKAGE_NAME));
+        assertThat(actualPackages[1], equalTo(DEPRECATED_DEFAULT_PACKAGE_NAME));
     }
 
     @Test
@@ -59,8 +62,9 @@ class PluginPackagesSupplierTest {
         final String[] actualPackages = objectUnderTest.get();
         assertThat(actualPackages, notNullValue());
 
-        assertThat(actualPackages.length, equalTo(1));
+        assertThat(actualPackages.length, equalTo(2));
         assertThat(actualPackages[0], equalTo(DEFAULT_PACKAGE_NAME));
+        assertThat(actualPackages[1], equalTo(DEPRECATED_DEFAULT_PACKAGE_NAME));
     }
 
     @Test
@@ -77,8 +81,9 @@ class PluginPackagesSupplierTest {
         final String[] actualPackages = objectUnderTest.get();
         assertThat(actualPackages, notNullValue());
 
-        assertThat(actualPackages.length, equalTo(1));
+        assertThat(actualPackages.length, equalTo(2));
         assertThat(actualPackages[0], equalTo(DEFAULT_PACKAGE_NAME));
+        assertThat(actualPackages[1], equalTo(DEPRECATED_DEFAULT_PACKAGE_NAME));
     }
 
     @Test
@@ -96,8 +101,9 @@ class PluginPackagesSupplierTest {
         final String[] actualPackages = objectUnderTest.get();
         assertThat(actualPackages, notNullValue());
 
-        assertThat(actualPackages.length, equalTo(1));
+        assertThat(actualPackages.length, equalTo(2));
         assertThat(actualPackages[0], equalTo(DEFAULT_PACKAGE_NAME));
+        assertThat(actualPackages[1], equalTo(DEPRECATED_DEFAULT_PACKAGE_NAME));
     }
 
     @Test


### PR DESCRIPTION
### Description

Updates the plugin framework and plugin configuration to load plugins from the `org.opensearch.dataprepper.plugins` package in addition to the old `com.amazon.dataprepper.plugins` package.
 
### Issues Resolved

None directly, but will help with #344 by allowing us to migrate over time rather than in one large PR.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
