### PR TITLE
Clean-up Pipeline and added unit tests to for publishToSinks

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/Pipeline.java
@@ -223,11 +223,11 @@ public class Pipeline {
      * @param records records that needs to published to each sink
      * @return List of Future, each future for each sink
      */
-    public List<Future<Void>> publishToSinks(final Collection<Record> records) {
+    List<Future<Void>> publishToSinks(final Collection<Record> records) {
         final int sinksSize = sinks.size();
-        List<Future<Void>> sinkFutures = new ArrayList<>(sinksSize);
+        final List<Future<Void>> sinkFutures = new ArrayList<>(sinksSize);
         for (int i = 0; i < sinksSize; i++) {
-            int finalI = i;
+            final int finalI = i;
             sinkFutures.add(sinkExecutorService.submit(() -> sinks.get(finalI).output(records), null));
         }
         return sinkFutures;


### PR DESCRIPTION
### Description

Updated `Pipeline` somewhat, including making `publishToSinks` package protected.

Added unit tests for `publishToSinks`. This important class had no tests. This will be the basis of testing changes for conditional routing.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
