### PR TITLE
Added ACM and S3 certificate support for HTTP source

### DIFF
--- a/data-prepper-plugins/http-source/build.gradle
+++ b/data-prepper-plugins/http-source/build.gradle
@@ -13,7 +13,9 @@ dependencies {
     implementation project(':data-prepper-plugins:common')
     implementation project(':data-prepper-plugins:armeria-common')
     implementation "com.linecorp.armeria:armeria:${versionMap.armeria}"
-    implementation "commons-io:commons-io:2.11.0"
+    implementation 'commons-io:commons-io:2.11.0'
+    implementation 'software.amazon.awssdk:acm'
+    implementation 'software.amazon.awssdk:s3'
     testImplementation project(':data-prepper-api').sourceSets.test.output
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/data-prepper-plugins/http-source/src/main/java/com/amazon/dataprepper/plugins/source/loghttp/certificate/CertificateProviderFactory.java
+++ b/data-prepper-plugins/http-source/src/main/java/com/amazon/dataprepper/plugins/source/loghttp/certificate/CertificateProviderFactory.java
@@ -6,10 +6,20 @@
 package com.amazon.dataprepper.plugins.source.loghttp.certificate;
 
 import com.amazon.dataprepper.plugins.certificate.CertificateProvider;
+import com.amazon.dataprepper.plugins.certificate.acm.ACMCertificateProvider;
 import com.amazon.dataprepper.plugins.certificate.file.FileCertificateProvider;
+import com.amazon.dataprepper.plugins.certificate.s3.S3CertificateProvider;
 import com.amazon.dataprepper.plugins.source.loghttp.HTTPSourceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.acm.AcmClient;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class CertificateProviderFactory {
     private static final Logger LOG = LoggerFactory.getLogger(CertificateProviderFactory.class);
@@ -20,8 +30,47 @@ public class CertificateProviderFactory {
     }
 
     public CertificateProvider getCertificateProvider() {
-        // TODO: support more certificate providers
-        LOG.info("Using local file system to get certificate and private key for SSL/TLS.");
-        return new FileCertificateProvider(httpSourceConfig.getSslCertificateFile(), httpSourceConfig.getSslKeyFile());
+        if (httpSourceConfig.isUseAcmCertificateForSsl()) {
+            LOG.info("Using ACM certificate and private key for SSL/TLS.");
+            final AwsCredentialsProvider credentialsProvider = AwsCredentialsProviderChain.builder()
+                    .addCredentialsProvider(DefaultCredentialsProvider.create())
+                    .build();
+
+            final ClientOverrideConfiguration clientConfig = ClientOverrideConfiguration.builder()
+                    .retryPolicy(RetryMode.STANDARD)
+                    .build();
+
+            final AcmClient awsCertificateManager = AcmClient.builder()
+                    .region(Region.of(httpSourceConfig.getAwsRegion()))
+                    .credentialsProvider(credentialsProvider)
+                    .overrideConfiguration(clientConfig)
+                    .build();
+
+            return new ACMCertificateProvider(awsCertificateManager,
+                    httpSourceConfig.getAcmCertificateArn(),
+                    httpSourceConfig.getAcmCertificateTimeoutMillis(),
+                    httpSourceConfig.getAcmPrivateKeyPassword());
+        } else if (httpSourceConfig.isSslCertAndKeyFileInS3()) {
+            LOG.info("Using S3 to fetch certificate and private key for SSL/TLS.");
+            final AwsCredentialsProvider credentialsProvider = AwsCredentialsProviderChain.builder()
+                    .addCredentialsProvider(DefaultCredentialsProvider.create()).build();
+
+            final S3Client s3Client = S3Client.builder()
+                    .region(Region.of(httpSourceConfig.getAwsRegion()))
+                    .credentialsProvider(credentialsProvider)
+                    .build();
+
+            return new S3CertificateProvider(
+                    s3Client,
+                    httpSourceConfig.getSslCertificateFile(),
+                    httpSourceConfig.getSslKeyFile()
+            );
+        } else {
+            LOG.info("Using local file system to get certificate and private key for SSL/TLS.");
+            return new FileCertificateProvider(
+                    httpSourceConfig.getSslCertificateFile(),
+                    httpSourceConfig.getSslKeyFile()
+            );
+        }
     }
 }

--- a/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceConfigTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceConfigTest.java
@@ -5,23 +5,20 @@
 
 package com.amazon.dataprepper.plugins.source.loghttp;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.UUID;
 
+import static com.amazon.dataprepper.plugins.source.loghttp.HTTPSourceConfig.S3_PREFIX;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class HTTPSourceConfigTest {
     @Test
-    public void testDefault() {
+    void testDefault() {
         // Prepare
         final HTTPSourceConfig sourceConfig = new HTTPSourceConfig();
 
@@ -31,27 +28,19 @@ public class HTTPSourceConfigTest {
         assertEquals(HTTPSourceConfig.DEFAULT_THREAD_COUNT, sourceConfig.getThreadCount());
         assertEquals(HTTPSourceConfig.DEFAULT_MAX_CONNECTION_COUNT, sourceConfig.getMaxConnectionCount());
         assertEquals(HTTPSourceConfig.DEFAULT_MAX_PENDING_REQUESTS, sourceConfig.getMaxPendingRequests());
+        assertEquals(HTTPSourceConfig.DEFAULT_USE_ACM_CERTIFICATE_FOR_SSL, sourceConfig.isUseAcmCertificateForSsl());
+        assertEquals(HTTPSourceConfig.DEFAULT_ACM_CERTIFICATE_TIMEOUT_MILLIS, sourceConfig.getAcmCertificateTimeoutMillis());
     }
 
     @Nested
-    class Validation {
-        @TempDir
-        File temporaryDirectory;
-        private File file;
-
-        @BeforeEach
-        void setUp() throws IOException {
-            file = new File(temporaryDirectory, UUID.randomUUID().toString());
-            file.createNewFile();
-        }
-
+    class SslValidationWithFile {
         @Test
         void isSslCertificateFileValidation_should_return_true_if_ssl_is_false() throws NoSuchFieldException, IllegalAccessException {
             final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
 
             reflectivelySetField(objectUnderTest, "ssl", false);
 
-            assertThat(objectUnderTest.isSslCertificateFileValidation(), equalTo(true));
+            assertThat(objectUnderTest.isSslCertificateFileValid(), equalTo(true));
         }
 
         @Test
@@ -60,17 +49,17 @@ public class HTTPSourceConfigTest {
 
             reflectivelySetField(objectUnderTest, "ssl", true);
 
-            assertThat(objectUnderTest.isSslCertificateFileValidation(), equalTo(false));
+            assertThat(objectUnderTest.isSslCertificateFileValid(), equalTo(false));
         }
 
         @Test
-        void isSslCertificateFileValidation_should_return_false_if_ssl_is_true_and_sslCertificateFile_is_a_valid_file() throws NoSuchFieldException, IllegalAccessException {
+        void isSslCertificateFileValidation_should_return_true_if_ssl_is_true_and_sslCertificateFile_is_a_valid_file() throws NoSuchFieldException, IllegalAccessException {
             final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
 
             reflectivelySetField(objectUnderTest, "ssl", true);
-            reflectivelySetField(objectUnderTest, "sslCertificateFile", file.getAbsolutePath());
+            reflectivelySetField(objectUnderTest, "sslCertificateFile", UUID.randomUUID().toString());
 
-            assertThat(objectUnderTest.isSslCertificateFileValidation(), equalTo(true));
+            assertThat(objectUnderTest.isSslCertificateFileValid(), equalTo(true));
         }
 
         @Test
@@ -79,26 +68,182 @@ public class HTTPSourceConfigTest {
 
             reflectivelySetField(objectUnderTest, "ssl", false);
 
-            assertThat(objectUnderTest.isSslKeyFileValidation(), equalTo(true));
+            assertThat(objectUnderTest.isSslKeyFileValid(), equalTo(true));
         }
 
         @Test
-        void isSslKeyFileValidation_should_return_true_if_ssl_is_false_and_sslKeyFile_is_null() throws NoSuchFieldException, IllegalAccessException {
+        void isSslKeyFileValidation_should_return_false_if_ssl_is_true_and_sslKeyFile_is_null() throws NoSuchFieldException, IllegalAccessException {
             final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
 
             reflectivelySetField(objectUnderTest, "ssl", true);
 
-            assertThat(objectUnderTest.isSslKeyFileValidation(), equalTo(false));
+            assertThat(objectUnderTest.isSslKeyFileValid(), equalTo(false));
         }
+
         @Test
-        void isSslKeyFileValidation_should_return_true_if_ssl_is_false_and_sslKeyFile_is_a_valid_file() throws NoSuchFieldException, IllegalAccessException {
+        void isSslKeyFileValidation_should_return_true_if_ssl_is_true_and_sslKeyFile_is_a_valid_file() throws NoSuchFieldException, IllegalAccessException {
             final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
 
             reflectivelySetField(objectUnderTest, "ssl", true);
-            reflectivelySetField(objectUnderTest, "sslKeyFile", file.getAbsolutePath());
+            reflectivelySetField(objectUnderTest, "sslKeyFile", UUID.randomUUID().toString());
 
-            assertThat(objectUnderTest.isSslKeyFileValidation(), equalTo(true));
+            assertThat(objectUnderTest.isSslKeyFileValid(), equalTo(true));
         }
+
+    }
+
+    @Nested
+    class SslValidationWithS3 {
+        @Test
+        void isSslCertAndKeyFileInS3_should_return_true_if_ssl_is_true_and_KeyFile_and_certFile_are_s3_paths() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+            reflectivelySetField(objectUnderTest, "sslCertificateFile", getS3FilePath());
+            reflectivelySetField(objectUnderTest, "sslKeyFile", getS3FilePath());
+
+            assertThat(objectUnderTest.isSslKeyFileValid(), equalTo(true));
+            assertThat(objectUnderTest.isSslCertificateFileValid(), equalTo(true));
+            assertThat(objectUnderTest.isSslCertAndKeyFileInS3(), equalTo(true));
+        }
+
+        @Test
+        void isSslCertAndKeyFileInS3_should_return_false_if_ssl_is_true_and_KeyFile_and_certFile_are_not_s3_paths() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+            reflectivelySetField(objectUnderTest, "sslCertificateFile", UUID.randomUUID().toString());
+            reflectivelySetField(objectUnderTest, "sslKeyFile", UUID.randomUUID().toString());
+
+            assertThat(objectUnderTest.isSslKeyFileValid(), equalTo(true));
+            assertThat(objectUnderTest.isSslCertificateFileValid(), equalTo(true));
+            assertThat(objectUnderTest.isSslCertAndKeyFileInS3(), equalTo(false));
+        }
+
+        @Test
+        void isAwsRegionValid_should_return_true_if_ssl_is_true_and_aws_region_is_null_without_s3_paths() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+            reflectivelySetField(objectUnderTest, "sslCertificateFile", UUID.randomUUID().toString());
+            reflectivelySetField(objectUnderTest, "sslKeyFile", UUID.randomUUID().toString());
+
+            assertThat(objectUnderTest.isSslKeyFileValid(), equalTo(true));
+            assertThat(objectUnderTest.isSslCertificateFileValid(), equalTo(true));
+            assertThat(objectUnderTest.isSslCertAndKeyFileInS3(), equalTo(false));
+            assertThat(objectUnderTest.isAwsRegionValid(), equalTo(true));
+        }
+
+        @Test
+        void isAwsRegionValid_should_return_false_if_ssl_is_true_and_aws_region_is_null_with_s3_paths() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+            reflectivelySetField(objectUnderTest, "sslCertificateFile", getS3FilePath());
+            reflectivelySetField(objectUnderTest, "sslKeyFile", getS3FilePath());
+
+            assertThat(objectUnderTest.isSslKeyFileValid(), equalTo(true));
+            assertThat(objectUnderTest.isSslCertificateFileValid(), equalTo(true));
+            assertThat(objectUnderTest.isSslCertAndKeyFileInS3(), equalTo(true));
+            assertThat(objectUnderTest.isAwsRegionValid(), equalTo(false));
+        }
+
+        @Test
+        void isAwsRegionValid_should_return_true_if_ssl_is_true_and_aws_region_is_not_null_with_s3_paths() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+            reflectivelySetField(objectUnderTest, "sslCertificateFile", getS3FilePath());
+            reflectivelySetField(objectUnderTest, "sslKeyFile", getS3FilePath());
+            reflectivelySetField(objectUnderTest, "awsRegion", UUID.randomUUID().toString());
+
+            assertThat(objectUnderTest.isSslKeyFileValid(), equalTo(true));
+            assertThat(objectUnderTest.isSslCertificateFileValid(), equalTo(true));
+            assertThat(objectUnderTest.isSslCertAndKeyFileInS3(), equalTo(true));
+            assertThat(objectUnderTest.isAwsRegionValid(), equalTo(true));
+        }
+
+        @Test
+        void isAwsRegionValid_should_return_false_if_ssl_is_true_and_aws_region_is_not_null_with_s3_paths() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+            reflectivelySetField(objectUnderTest, "sslCertificateFile", getS3FilePath());
+            reflectivelySetField(objectUnderTest, "sslKeyFile", getS3FilePath());
+            reflectivelySetField(objectUnderTest, "awsRegion", UUID.randomUUID().toString());
+
+            assertThat(objectUnderTest.isSslKeyFileValid(), equalTo(true));
+            assertThat(objectUnderTest.isSslCertificateFileValid(), equalTo(true));
+            assertThat(objectUnderTest.isSslCertAndKeyFileInS3(), equalTo(true));
+            assertThat(objectUnderTest.isAwsRegionValid(), equalTo(true));
+        }
+    }
+
+    @Nested
+    class SslValidationWithAcm {
+        @Test
+        void isAwsRegionValid_should_return_false_if_ssl_is_true_and_aws_region_is_null_with_acm() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+            reflectivelySetField(objectUnderTest, "useAcmCertificateForSsl", true);
+
+            assertThat(objectUnderTest.isAwsRegionValid(), equalTo(false));
+        }
+
+        @Test
+        void isAwsRegionValid_should_return_true_if_ssl_is_true_and_aws_region_is_not_null_with_acm() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+            reflectivelySetField(objectUnderTest, "useAcmCertificateForSsl", true);
+            reflectivelySetField(objectUnderTest, "awsRegion", UUID.randomUUID().toString());
+
+            assertThat(objectUnderTest.isAwsRegionValid(), equalTo(true));
+        }
+
+        @Test
+        void isAcmCertificateArnValid_should_return_false_if_ssl_is_true_and_acm_is_true_and_arn_is_null() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+            reflectivelySetField(objectUnderTest, "useAcmCertificateForSsl", true);
+
+            assertThat(objectUnderTest.isAcmCertificateArnValid(), equalTo(false));
+        }
+
+        @Test
+        void isAcmCertificateArnValid_should_return_true_if_ssl_is_true_and_acm_is_true_and_arn_is_not_null() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+            reflectivelySetField(objectUnderTest, "useAcmCertificateForSsl", true);
+            reflectivelySetField(objectUnderTest, "acmCertificateArn", UUID.randomUUID().toString());
+
+            assertThat(objectUnderTest.isAcmCertificateArnValid(), equalTo(true));
+        }
+
+        @Test
+        void isAcmPrivateKeyPasswordValid_should_return_false_if_ssl_is_true_and_acm_is_true_and_arn_is_null() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+            reflectivelySetField(objectUnderTest, "useAcmCertificateForSsl", true);
+
+            assertThat(objectUnderTest.isAcmPrivateKeyPasswordValid(), equalTo(false));
+        }
+
+        @Test
+        void isAcmPrivateKeyPasswordValid_should_return_true_if_ssl_is_true_and_acm_is_true_and_arn_is_not_null() throws NoSuchFieldException, IllegalAccessException {
+            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+            reflectivelySetField(objectUnderTest, "ssl", true);
+            reflectivelySetField(objectUnderTest, "useAcmCertificateForSsl", true);
+            reflectivelySetField(objectUnderTest, "acmPrivateKeyPassword", UUID.randomUUID().toString());
+
+            assertThat(objectUnderTest.isAcmPrivateKeyPasswordValid(), equalTo(true));
+        }
+    }
 
         private void reflectivelySetField(final HTTPSourceConfig httpSourceConfig, final String fieldName, final Object value) throws NoSuchFieldException, IllegalAccessException {
             final Field field = HTTPSourceConfig.class.getDeclaredField(fieldName);
@@ -109,5 +254,8 @@ public class HTTPSourceConfigTest {
                 field.setAccessible(false);
             }
         }
-    }
+
+        private String getS3FilePath() {
+            return S3_PREFIX.concat(UUID.randomUUID().toString());
+        }
 }

--- a/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/certificate/CertificateProviderFactoryTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/certificate/CertificateProviderFactoryTest.java
@@ -6,9 +6,12 @@
 package com.amazon.dataprepper.plugins.source.loghttp.certificate;
 
 import com.amazon.dataprepper.plugins.certificate.CertificateProvider;
+import com.amazon.dataprepper.plugins.certificate.acm.ACMCertificateProvider;
 import com.amazon.dataprepper.plugins.certificate.file.FileCertificateProvider;
+import com.amazon.dataprepper.plugins.certificate.s3.S3CertificateProvider;
 import com.amazon.dataprepper.plugins.source.loghttp.HTTPSourceConfig;
 import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -19,16 +22,48 @@ class CertificateProviderFactoryTest {
     private final String TEST_SSL_CERTIFICATE_FILE = getClass().getClassLoader().getResource("test_cert.crt").getFile();
     private final String TEST_SSL_KEY_FILE = getClass().getClassLoader().getResource("test_decrypted_key.key").getFile();
 
-    @Test
-    public void getFileCertificateProviderSuccess() {
-        final HTTPSourceConfig sourceConfig = mock(HTTPSourceConfig.class);
-        when(sourceConfig.isSsl()).thenReturn(true);
-        when(sourceConfig.getSslCertificateFile()).thenReturn(TEST_SSL_CERTIFICATE_FILE);
-        when(sourceConfig.getSslKeyFile()).thenReturn(TEST_SSL_KEY_FILE);
+    private HTTPSourceConfig httpSourceConfig;
+    private CertificateProviderFactory certificateProviderFactory;
 
-        final CertificateProviderFactory certificateProviderFactory = new CertificateProviderFactory(sourceConfig);
+    @BeforeEach
+    void setUp() {
+        httpSourceConfig = mock(HTTPSourceConfig.class);
+    }
+
+    @Test
+    void getCertificateProviderFileCertificateProviderSuccess() {
+        when(httpSourceConfig.isSsl()).thenReturn(true);
+        when(httpSourceConfig.getSslCertificateFile()).thenReturn(TEST_SSL_CERTIFICATE_FILE);
+        when(httpSourceConfig.getSslKeyFile()).thenReturn(TEST_SSL_KEY_FILE);
+
+        certificateProviderFactory = new CertificateProviderFactory(httpSourceConfig);
         final CertificateProvider certificateProvider = certificateProviderFactory.getCertificateProvider();
 
         assertThat(certificateProvider, IsInstanceOf.instanceOf(FileCertificateProvider.class));
+    }
+
+    @Test
+    void getCertificateProviderS3ProviderSuccess() {
+        when(httpSourceConfig.isSslCertAndKeyFileInS3()).thenReturn(true);
+        when(httpSourceConfig.getAwsRegion()).thenReturn("us-east-1");
+        when(httpSourceConfig.getSslCertificateFile()).thenReturn("s3://data/certificate/test_cert.crt");
+        when(httpSourceConfig.getSslKeyFile()).thenReturn("s3://data/certificate/test_decrypted_key.key");
+
+        certificateProviderFactory = new CertificateProviderFactory(httpSourceConfig);
+        final CertificateProvider certificateProvider = certificateProviderFactory.getCertificateProvider();
+
+        assertThat(certificateProvider, IsInstanceOf.instanceOf(S3CertificateProvider.class));
+    }
+
+    @Test
+    void getCertificateProviderAcmProviderSuccess() {
+        when(httpSourceConfig.isUseAcmCertificateForSsl()).thenReturn(true);
+        when(httpSourceConfig.getAwsRegion()).thenReturn("us-east-1");
+        when(httpSourceConfig.getAcmCertificateArn()).thenReturn("arn:aws:acm:us-east-1:account:certificate/1234-567-856456");
+
+        certificateProviderFactory = new CertificateProviderFactory(httpSourceConfig);
+        final CertificateProvider certificateProvider = certificateProviderFactory.getCertificateProvider();
+
+        assertThat(certificateProvider, IsInstanceOf.instanceOf(ACMCertificateProvider.class));
     }
 }


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
- Added support to read cert files from s3
- Added support for ACM
- Removed unused `ssl_key_password` configuration
- Updating documentation / readme isn't part of this PR. Might need to track it separately.
 
### Issues Resolved
Resolves #1670 
Resolves #365
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
