### PR TITLE
Refactored the PipelineParser/PipelineConfiguration to use the PipelineDataFlowModel

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/PipelineConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/PipelineConfiguration.java
@@ -5,12 +5,10 @@
 
 package org.opensearch.dataprepper.parser.model;
 
+import com.amazon.dataprepper.model.configuration.PipelineModel;
+import com.amazon.dataprepper.model.configuration.PluginModel;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -18,39 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static java.lang.String.format;
-
 public class PipelineConfiguration {
-    private static final Logger LOG = LoggerFactory.getLogger(PipelineConfiguration.class);
-
-    /**
-     * @throws IllegalArgumentException If a non-null value is provided to both parameters.
-     * Guarantees only a prepper, processor, or neither is provided, not both.
-     * @param preppers Deserialized preppers plugin configuration, cannot be used in combination with the processors parameter, nullable
-     * @param processors Deserialized processors plugin configuration, cannot be used in combination with the preppers parameter, nullable
-     * @return the non-null parameter passed or null if both parameters are null.
-     */
-    private static List<Map.Entry<String, Map<String, Object>>> validateProcessor(
-            final List<Map.Entry<String, Map<String, Object>>> preppers,
-            final List<Map.Entry<String, Map<String, Object>>> processors) {
-        if (preppers != null) {
-            LOG.warn("Prepper configurations are deprecated, processor configurations will be required in Data Prepper 2.0");
-        }
-
-        if (preppers != null && processors != null) {
-            final String message = "Pipeline configuration cannot specify a prepper and processor configuration. " +
-                    "It is recommended to move prepper configurations to the processor section to maintain " +
-                    "compatibility with DataPrepper version 1.2 and above.";
-            throw new IllegalArgumentException(message);
-        }
-        else if (preppers != null) {
-            return preppers;
-        }
-        else {
-            return processors;
-        }
-    }
-
     private static final String WORKERS_COMPONENT = "workers";
     private static final String DELAY_COMPONENT = "delay";
     private static final int DEFAULT_READ_BATCH_DELAY = 3_000;
@@ -63,43 +29,13 @@ public class PipelineConfiguration {
     private final Integer workers;
     private final Integer readBatchDelay;
 
-    public PipelineConfiguration(
-            final Map.Entry<String, Map<String, Object>> source,
-            final Map.Entry<String, Map<String, Object>> buffer,
-            final List<Map.Entry<String, Map<String, Object>>> processors,
-            final List<Map.Entry<String, Map<String, Object>>> sinks,
-            final Integer workers,
-            final Integer delay) {
-        this.sourcePluginSetting = getSourceFromConfiguration(source);
-        this.bufferPluginSetting = getBufferFromConfigurationOrDefault(buffer);
-        this.processorPluginSettings = getProcessorsFromConfiguration(processors);
-        this.sinkPluginSettings = getSinksFromConfiguration(sinks);
-        this.workers = getWorkersFromConfiguration(workers);
-        this.readBatchDelay = getReadBatchDelayFromConfiguration(delay);
-    }
-
-    /**
-     * @since 1.2
-     * Constructor for deserialized Json data.
-     * @param source Deserialized source plugin configuration
-     * @param buffer Deserialized buffer plugin configuration, nullable
-     * @param preppers Deserialized preppers plugin configuration, cannot be used in combination with the processors parameter, nullable
-     * @param processors Deserialized processors plugin configuration, cannot be used in combination with the preppers parameter, nullable
-     * @param sinks Deserialized sinks plugin configuration
-     * @param workers Deserialized workers plugin configuration, nullable
-     * @param delay Deserialized delay plugin configuration, nullable
-     */
-    @JsonCreator
-    @Deprecated
-    public PipelineConfiguration(
-            @JsonProperty("source") final Map.Entry<String, Map<String, Object>> source,
-            @JsonProperty("buffer") final Map.Entry<String, Map<String, Object>> buffer,
-            @Deprecated @JsonProperty("prepper") final List<Map.Entry<String, Map<String, Object>>> preppers,
-            @JsonProperty("processor") final List<Map.Entry<String, Map<String, Object>>> processors,
-            @JsonProperty("sink") final List<Map.Entry<String, Map<String, Object>>> sinks,
-            @JsonProperty("workers") final Integer workers,
-            @JsonProperty("delay") final Integer delay) {
-        this(source, buffer, validateProcessor(preppers, processors), sinks, workers, delay);
+    public PipelineConfiguration(final PipelineModel pipelineModel) {
+        this.sourcePluginSetting = getSourceFromPluginModel(pipelineModel.getSource());
+        this.bufferPluginSetting = getBufferFromPluginModelOrDefault(pipelineModel.getBuffer());
+        this.processorPluginSettings = getProcessorsFromPluginModel(pipelineModel.getProcessors());
+        this.sinkPluginSettings = getSinksFromPluginModel(pipelineModel.getSinks());
+        this.workers = getWorkersFromPipelineModel(pipelineModel);
+        this.readBatchDelay = getReadBatchDelayFromPipelineModel(pipelineModel);
     }
 
     public PluginSetting getSourcePluginSetting() {
@@ -141,62 +77,61 @@ public class PipelineConfiguration {
         pluginSetting.setProcessWorkers(this.workers);
     }
 
-    private PluginSetting getSourceFromConfiguration(final Map.Entry<String, Map<String, Object>> sourceConfiguration) {
-        if (sourceConfiguration == null) {
+    private PluginSetting getSourceFromPluginModel(final PluginModel pluginModel) {
+        if (pluginModel == null) {
             throw new IllegalArgumentException("Invalid configuration, source is a required component");
         }
-        return getPluginSettingFromConfiguration(sourceConfiguration);
+        return getPluginSettingFromPluginModel(pluginModel);
     }
 
-    private PluginSetting getBufferFromConfigurationOrDefault(
-            final Map.Entry<String, Map<String, Object>> bufferConfiguration) {
-        if (bufferConfiguration == null) {
+    private PluginSetting getBufferFromPluginModelOrDefault(
+            final PluginModel pluginModel) {
+        if (pluginModel == null) {
             return BlockingBuffer.getDefaultPluginSettings();
         }
-        return getPluginSettingFromConfiguration(bufferConfiguration);
+        return getPluginSettingFromPluginModel(pluginModel);
     }
 
-    private List<PluginSetting> getSinksFromConfiguration(
-            final List<Map.Entry<String, Map<String, Object>>> sinkConfigurations) {
+    private List<PluginSetting> getSinksFromPluginModel(
+            final List<PluginModel> sinkConfigurations) {
         if (sinkConfigurations == null || sinkConfigurations.isEmpty()) {
             throw new IllegalArgumentException("Invalid configuration, at least one sink is required");
         }
-        return sinkConfigurations.stream().map(PipelineConfiguration::getPluginSettingFromConfiguration)
+        return sinkConfigurations.stream().map(PipelineConfiguration::getPluginSettingFromPluginModel)
                 .collect(Collectors.toList());
     }
 
-    private List<PluginSetting> getProcessorsFromConfiguration(
-            final List<Map.Entry<String, Map<String, Object>>> processorConfigurations) {
+    private List<PluginSetting> getProcessorsFromPluginModel(
+            final List<PluginModel> processorConfigurations) {
         if (processorConfigurations == null || processorConfigurations.isEmpty()) {
             return Collections.emptyList();
         }
-        return processorConfigurations.stream().map(PipelineConfiguration::getPluginSettingFromConfiguration)
+        return processorConfigurations.stream().map(PipelineConfiguration::getPluginSettingFromPluginModel)
                 .collect(Collectors.toList());
     }
 
 
-    private static PluginSetting getPluginSettingFromConfiguration(
-            final Map.Entry<String, Map<String, Object>> configuration) {
-        final Map<String, Object> settingsMap = configuration.getValue();
-        //PluginSettings is required to update pipeline name
-        return new PluginSetting(configuration.getKey(), settingsMap == null ? new HashMap<>() : settingsMap);
+    private static PluginSetting getPluginSettingFromPluginModel(final PluginModel pluginModel) {
+        final Map<String, Object> settingsMap = pluginModel.getPluginSettings();
+        return new PluginSetting(pluginModel.getPluginName(), settingsMap == null ? new HashMap<>() : settingsMap);
     }
 
-    private Integer getWorkersFromConfiguration(final Integer workersConfiguration) {
-        final Integer configuredWorkers = getValueFromConfiguration(workersConfiguration, WORKERS_COMPONENT);
+    private Integer getWorkersFromPipelineModel(final PipelineModel pipelineModel) {
+        final Integer configuredWorkers = pipelineModel.getWorkers();
+        validateConfiguration(configuredWorkers, WORKERS_COMPONENT);
         return configuredWorkers == null ? DEFAULT_WORKERS : configuredWorkers;
     }
 
-    private Integer getReadBatchDelayFromConfiguration(final Integer delayConfiguration) {
-        final Integer configuredDelay = getValueFromConfiguration(delayConfiguration, DELAY_COMPONENT);
+    private Integer getReadBatchDelayFromPipelineModel(final PipelineModel pipelineModel) {
+        final Integer configuredDelay = pipelineModel.getReadBatchDelay();
+        validateConfiguration(configuredDelay, DELAY_COMPONENT);
         return configuredDelay == null ? DEFAULT_READ_BATCH_DELAY : configuredDelay;
     }
 
-    private Integer getValueFromConfiguration(final Integer configuration, final String component) {
+    private void validateConfiguration(final Integer configuration, final String component) {
         if (configuration != null && configuration <= 0) {
-            throw new IllegalArgumentException(format("Invalid configuration, %s cannot be %s",
+            throw new IllegalArgumentException(String.format("Invalid configuration, %s cannot be %s",
                     component, configuration));
         }
-        return configuration;
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper;
 
+import com.amazon.dataprepper.model.configuration.PluginModel;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.parser.model.PipelineConfiguration;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -21,6 +22,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestDataProvider {
     public static final String TEST_PIPELINE_NAME = "test-pipeline-1";
@@ -84,16 +88,23 @@ public class TestDataProvider {
         return settingsMap;
     }
 
-    public static Map.Entry<String, Map<String, Object>> validSingleConfiguration() {
-        return Map.entry(TEST_PLUGIN_NAME_1, validSettingsForPlugin());
+    public static PluginModel validSingleConfiguration() {
+        return validPluginModel(TEST_PLUGIN_NAME_1);
     }
 
-    public static List<Map.Entry<String, Map<String, Object>>> validMultipleConfiguration() {
-        return Arrays.asList(Map.entry(TEST_PLUGIN_NAME_1, validSettingsForPlugin()), Map.entry(TEST_PLUGIN_NAME_2, validSettingsForPlugin()));
+    private static PluginModel validPluginModel(final String pluginName) {
+        final PluginModel pluginModel = mock(PluginModel.class);
+        when(pluginModel.getPluginName()).thenReturn(pluginName);
+        when(pluginModel.getPluginSettings()).thenReturn(validSettingsForPlugin());
+        return pluginModel;
     }
 
-    public static List<Map.Entry<String, Map<String, Object>>> validMultipleConfigurationOfSizeOne() {
-        return Collections.singletonList(Map.entry(TEST_PLUGIN_NAME_1, validSettingsForPlugin()));
+    public static List<PluginModel> validMultipleConfiguration() {
+        return Arrays.asList(validPluginModel(TEST_PLUGIN_NAME_1), validPluginModel(TEST_PLUGIN_NAME_2));
+    }
+
+    public static List<PluginModel> validMultipleConfigurationOfSizeOne() {
+        return Collections.singletonList(validSingleConfiguration());
     }
 
     public static Map<String, PipelineConfiguration> readConfigFile(final String configFilePath) throws IOException {


### PR DESCRIPTION
### Description

Prior to this PR, Data Prepper had split approaches for serializing configuration YAML from deserializing YAML. The `PipelineDataFlowModel` is currently being used for serialization. And deserialization is handled by the `PipelineParser` and `PipelineConfiguration` classes. This PR fixes this split-brain issue. Deserialization now uses `PipelineDataFlowModel` as well. This helps ensure that deserialization is consistent with serialization.

This change also starts to remove the legacy `prepper:` configuration in YAML. I wasn't intending to do this, but it would be harder to keep that behavior and we plan to remove it in #619.

This change is important for supporting conditional routing of sinks.
 
### Issues Resolved

None, but contributes toward #619 and #1337 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
