### PR TITLE
Update Prepper plugins to use Processor

### DIFF
--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/NoOpPrepper.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/NoOpPrepper.java
@@ -7,13 +7,12 @@ package com.amazon.dataprepper.plugins.prepper;
 
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.event.Event;
-import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.processor.Processor;
 import com.amazon.dataprepper.model.record.Record;
 
 import java.util.Collection;
 
-@DataPrepperPlugin(name = "no-op", pluginType = Prepper.class)
+@DataPrepperPlugin(name = "no-op", pluginType = Processor.class)
 public class NoOpPrepper implements Processor<Record<Event>, Record<Event>> {
 
     public NoOpPrepper() {

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/StringPrepper.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/StringPrepper.java
@@ -10,7 +10,7 @@ import com.amazon.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.event.JacksonEvent;
-import com.amazon.dataprepper.model.prepper.Prepper;
+import com.amazon.dataprepper.model.processor.Processor;
 import com.amazon.dataprepper.model.record.Record;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -24,11 +24,11 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * An simple String implementation of {@link Prepper} which generates new Records with upper case or lowercase content. The current
+ * A simple String implementation of {@link Processor} which generates new Records with uppercase or lowercase content. The current
  * simpler implementation does not handle errors (if any).
  */
-@DataPrepperPlugin(name = "string_converter", pluginType = Prepper.class, pluginConfigurationType = StringPrepper.Configuration.class)
-public class StringPrepper implements Prepper<Record<Event>, Record<Event>> {
+@DataPrepperPlugin(name = "string_converter", pluginType = Processor.class, pluginConfigurationType = StringPrepper.Configuration.class)
+public class StringPrepper implements Processor<Record<Event>, Record<Event>> {
     private static Logger LOG = LoggerFactory.getLogger(StringPrepper.class);
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final TypeReference<Map<String, Object>> mapTypeReference = new TypeReference<Map<String, Object>>() {};

--- a/data-prepper-plugins/grok-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepper.java
+++ b/data-prepper-plugins/grok-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/grok/GrokPrepper.java
@@ -10,8 +10,8 @@ import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.annotations.SingleThread;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.event.Event;
-import com.amazon.dataprepper.model.prepper.AbstractPrepper;
-import com.amazon.dataprepper.model.prepper.Prepper;
+import com.amazon.dataprepper.model.processor.AbstractProcessor;
+import com.amazon.dataprepper.model.processor.Processor;
 import com.amazon.dataprepper.model.record.Record;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
@@ -52,8 +52,8 @@ import java.util.stream.Collectors;
 
 
 @SingleThread
-@DataPrepperPlugin(name = "grok", pluginType = Prepper.class)
-public class GrokPrepper extends AbstractPrepper<Record<Event>, Record<Event>> {
+@DataPrepperPlugin(name = "grok", pluginType = Processor.class)
+public class GrokPrepper extends AbstractProcessor<Record<Event>, Record<Event>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrokPrepper.class);
 

--- a/data-prepper-plugins/otel-trace-group-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltracegroup/OTelTraceGroupPrepper.java
+++ b/data-prepper-plugins/otel-trace-group-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltracegroup/OTelTraceGroupPrepper.java
@@ -7,8 +7,8 @@ package com.amazon.dataprepper.plugins.prepper.oteltracegroup;
 
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
-import com.amazon.dataprepper.model.prepper.AbstractPrepper;
-import com.amazon.dataprepper.model.prepper.Prepper;
+import com.amazon.dataprepper.model.processor.AbstractProcessor;
+import com.amazon.dataprepper.model.processor.Processor;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.prepper.oteltracegroup.model.TraceGroup;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -42,8 +42,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-@DataPrepperPlugin(name = "otel_trace_group_prepper", pluginType = Prepper.class)
-public class OTelTraceGroupPrepper extends AbstractPrepper<Record<String>, Record<String>> {
+@DataPrepperPlugin(name = "otel_trace_group_prepper", pluginType = Processor.class)
+public class OTelTraceGroupPrepper extends AbstractProcessor<Record<String>, Record<String>> {
 
     public static final String RECORDS_IN_MISSING_TRACE_GROUP = "recordsInMissingTraceGroup";
     public static final String RECORDS_OUT_FIXED_TRACE_GROUP = "recordsOutFixedTraceGroup";

--- a/data-prepper-plugins/otel-trace-raw-prepper/README.md
+++ b/data-prepper-plugins/otel-trace-raw-prepper/README.md
@@ -14,7 +14,7 @@ prepper:
 * `trace_flush_interval`: An `int` represents the time interval in seconds to flush all the descendant spans without any root span. Default to 180.
 
 ## Metrics
-Apart from common metrics in [AbstractPrepper](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/AbstractPrepper.java), otel-trace-raw-prepper introduces the following custom metrics.
+Apart from common metrics in [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java), otel-trace-raw-prepper introduces the following custom metrics.
 
 ### Counter
 - `spanProcessingErrors`: records the number of processing exceptions for invalid spans.

--- a/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OTelTraceRawPrepper.java
+++ b/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OTelTraceRawPrepper.java
@@ -7,8 +7,8 @@ package com.amazon.dataprepper.plugins.prepper.oteltrace;
 
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
-import com.amazon.dataprepper.model.prepper.AbstractPrepper;
-import com.amazon.dataprepper.model.prepper.Prepper;
+import com.amazon.dataprepper.model.processor.AbstractProcessor;
+import com.amazon.dataprepper.model.processor.Processor;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.prepper.oteltrace.model.OTelProtoHelper;
 import com.amazon.dataprepper.plugins.prepper.oteltrace.model.RawSpan;
@@ -39,8 +39,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
 
-@DataPrepperPlugin(name = "otel_trace_raw_prepper", pluginType = Prepper.class)
-public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServiceRequest>, Record<String>> {
+@DataPrepperPlugin(name = "otel_trace_raw_prepper", pluginType = Processor.class)
+public class OTelTraceRawPrepper extends AbstractProcessor<Record<ExportTraceServiceRequest>, Record<String>> {
     private static final long SEC_TO_MILLIS = 1_000L;
     private static final Logger LOG = LoggerFactory.getLogger(OTelTraceRawPrepper.class);
 

--- a/data-prepper-plugins/service-map-stateful/README.md
+++ b/data-prepper-plugins/service-map-stateful/README.md
@@ -14,7 +14,7 @@ processor:
 * window_duration(Optional) => An `int` represents the fixed time window in seconds to evaluate service-map relationships. Default is ```180```.
 
 ## Metrics
-Besides common metrics in [AbstractPrepper](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/AbstractPrepper.java), service-map-stateful prepper introduces the following custom metrics.
+Besides common metrics in [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java), service-map-stateful prepper introduces the following custom metrics.
 
 ### Gauge
 - `spansDbSize`: measures total spans byte sizes in MapDB across the current and previous window durations.


### PR DESCRIPTION
### Description
This change updates plugins that still implement `Prepper` to use `Processor` instead. The plugins affected are `StringPrepper`, `GrokPrepper`, `NoOpPrepper`, `OTelTraceRawPrepper`, and `OTelTraceGroupPrepper`.
 
### Issues Resolved
Resolves #647 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
