### PR TITLE
Remove deprecated configurations for OpenSearch sink

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -24,7 +24,7 @@ pipeline:
       bulk_size: 4
 ```
 
-The OpenSearch sink will reserve `otel-v1-apm-span-*` as index pattern and `otel-v1-apm-span` as index name for record ingestion.
+The OpenSearch sink will reserve `otel-v1-apm-span-*` as index pattern and `otel-v1-apm-span` as index alias for record ingestion.
 
 ### </a>Service map trace analytics
 
@@ -42,7 +42,7 @@ pipeline:
       bulk_size: 4
 ```
 
-The OpenSearch sink will reserve `otel-v1-apm-service-map` as index name for record ingestion.
+The OpenSearch sink will reserve `otel-v1-apm-service-map` as index for record ingestion.
 
 ### Amazon OpenSearch Service
 

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -24,7 +24,7 @@ pipeline:
       bulk_size: 4
 ```
 
-The OpenSearch sink will reserve `otel-v1-apm-span-*` as index pattern and `otel-v1-apm-span` as index alias for record ingestion.
+The OpenSearch sink will reserve `otel-v1-apm-span-*` as index pattern and `otel-v1-apm-span` as index name for record ingestion.
 
 ### </a>Service map trace analytics
 
@@ -42,7 +42,7 @@ pipeline:
       bulk_size: 4
 ```
 
-The OpenSearch sink will reserve `otel-v1-apm-service-map` as index for record ingestion.
+The OpenSearch sink will reserve `otel-v1-apm-service-map` as index name for record ingestion.
 
 ### Amazon OpenSearch Service
 
@@ -57,7 +57,7 @@ pipeline:
       aws_sigv4: true
       cert: path/to/cert
       insecure: false
-      trace_analytics_service_map: true
+      index_type: trace-analytics-service-map
       bulk_size: 4
 ```
 
@@ -119,13 +119,7 @@ Default is null.
       "traceGroupName": "MakePayement.auto"
     }
 ```
-- `trace_analytics_raw`(optional, deprecated in favor of `index_type`): A boolean flag indicates APM trace analytics raw span data type.
-Default value is false. Set it to true for [Raw span trace analytics](#raw_span_trace_analytics). Set it to false for [Service map trace analytics](#service_map_trace_analytics).
-
-- `trace_analytics_service_map`(optional, deprecated in favor of `index_type`): A boolean flag indicates APM trace analytics service map data type.
-Default value is false. Set it to true for [Service map trace analytics](#service_map_trace_analytics). Set it to false for [Raw span trace analytics](#raw_span_trace_analytics).
-
-- <a name="index"></a>`index`: A String used as index name for custom data type. Applicable and required only If index_type is explicitly `custom` or defaults to be `custom` while both `trace_analytics_raw` and `trace_analytics_service_map` are set to false.
+- <a name="index"></a>`index`: A String used as index name for custom data type. Applicable and required only If index_type is explicitly `custom` or defaults to be `custom`.
   * This index name can be a plain string, such as `application`, `my-index-name`.
   * This index name can also be a plain string plus a date-time pattern as a suffix, such as `application-%{yyyy.MM.dd}`, `my-index-name-%{yyyy.MM.dd.HH}`. When OpenSearch Sink is sending data to OpenSearch, the date-time pattern will be replaced by actual UTC time. The pattern supports all the symbols that represent one hour or above and are listed in [Java DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html). For example, with an index pattern like `my-index-name-%{yyyy.MM.dd}`, a new index is created for each day such as `my-index-name-2022.01.25`. For another example, with an index pattern like `my-index-name-%{yyyy.MM.dd.HH}`, a new index is created for each hour such as `my-index-name-2022.01.25.13`.
 
@@ -145,6 +139,10 @@ all the records received from the upstream prepper at a time will be sent as a s
 If a single record turns out to be larger than the set bulk size, it will be sent as a bulk request of a single document.
 
 - `ism_policy_file` (optional): A String of absolute file path for an ISM (Index State Management) policy JSON file. This policy file is effective only when there is no built-in policy file for the index type. For example, `custom` index type is currently the only one without a built-in policy file, thus it would use the policy file here if it's provided through this parameter. OpenSearch documentation has more about [ISM policies.](https://opensearch.org/docs/latest/im-plugin/ism/policies/)
+
+- `trace_analytics_raw`: No longer supported starting Data Prepper 2.0. Use `index_type` instead.
+
+- `trace_analytics_service_map`: No longer supported starting Data Prepper 2.0. Use `index_type` instead.
 
 ### Management Disabled Index Type
 

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -107,7 +107,7 @@ public class OpenSearchSinkIT {
 
   @Test
   public void testInstantiateSinkRawSpanDefault() throws IOException {
-    final PluginSetting pluginSetting = generatePluginSetting(true, false, null, null);
+    final PluginSetting pluginSetting = generatePluginSetting(IndexType.TRACE_ANALYTICS_RAW.getValue(), null, null);
     OpenSearchSink sink = new OpenSearchSink(pluginSetting);
     final String indexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexType.TRACE_ANALYTICS_RAW);
     Request request = new Request(HttpMethod.HEAD, indexAlias);
@@ -153,7 +153,7 @@ public class OpenSearchSinkIT {
     final String reservedIndexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexType.TRACE_ANALYTICS_RAW);
     final Request request = new Request(HttpMethod.PUT, reservedIndexAlias);
     client.performRequest(request);
-    final PluginSetting pluginSetting = generatePluginSetting(true, false, null, null);
+    final PluginSetting pluginSetting = generatePluginSetting(IndexType.TRACE_ANALYTICS_RAW.getValue(), null, null);
     Assert.assertThrows(String.format(IndexManager.INDEX_ALIAS_USED_AS_INDEX_ERROR, reservedIndexAlias),
             RuntimeException.class, () -> new OpenSearchSink(pluginSetting));
   }
@@ -168,7 +168,7 @@ public class OpenSearchSinkIT {
     @SuppressWarnings("unchecked") final Map<String, Object> expData2 = mapper.readValue(testDoc2, Map.class);
 
     final List<Record<Object>> testRecords = Arrays.asList(stringToRecord.apply(testDoc1), stringToRecord.apply(testDoc2));
-    final PluginSetting pluginSetting = generatePluginSetting(true, false, null, null);
+    final PluginSetting pluginSetting = generatePluginSetting(IndexType.TRACE_ANALYTICS_RAW.getValue(), null, null);
     final OpenSearchSink sink = new OpenSearchSink(pluginSetting);
     sink.output(testRecords);
 
@@ -232,7 +232,7 @@ public class OpenSearchSinkIT {
     final ObjectMapper mapper = new ObjectMapper();
     @SuppressWarnings("unchecked") final Map<String, Object> expData = mapper.readValue(testDoc2, Map.class);
     final List<Record<Object>> testRecords = Arrays.asList(stringToRecord.apply(testDoc1), stringToRecord.apply(testDoc2));
-    final PluginSetting pluginSetting = generatePluginSetting(true, false, null, null);
+    final PluginSetting pluginSetting = generatePluginSetting(IndexType.TRACE_ANALYTICS_RAW.getValue(), null, null);
     // generate temporary directory for dlq file
     final File tempDirectory = Files.createTempDirectory("").toFile();
     // add dlq file path into setting
@@ -282,7 +282,7 @@ public class OpenSearchSinkIT {
 
   @Test
   public void testInstantiateSinkServiceMapDefault() throws IOException {
-    final PluginSetting pluginSetting = generatePluginSetting(false, true, null, null);
+    final PluginSetting pluginSetting = generatePluginSetting(IndexType.TRACE_ANALYTICS_SERVICE_MAP.getValue(), null, null);
     final OpenSearchSink sink = new OpenSearchSink(pluginSetting);
     final String indexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexType.TRACE_ANALYTICS_SERVICE_MAP);
     final Request request = new Request(HttpMethod.HEAD, indexAlias);
@@ -307,7 +307,7 @@ public class OpenSearchSinkIT {
     @SuppressWarnings("unchecked") final Map<String, Object> expData = mapper.readValue(testDoc, Map.class);
 
     final List<Record<Object>> testRecords = Collections.singletonList(stringToRecord.apply(testDoc));
-    final PluginSetting pluginSetting = generatePluginSetting(false, true, null, null);
+    final PluginSetting pluginSetting = generatePluginSetting(IndexType.TRACE_ANALYTICS_SERVICE_MAP.getValue(), null, null);
     OpenSearchSink sink = new OpenSearchSink(pluginSetting);
     sink.output(testRecords);
     final String expIndexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexType.TRACE_ANALYTICS_SERVICE_MAP);
@@ -346,7 +346,7 @@ public class OpenSearchSinkIT {
     final String testIndexAlias = "test-alias";
     final String testTemplateFile = Objects.requireNonNull(
             getClass().getClassLoader().getResource(TEST_TEMPLATE_V1_FILE)).getFile();
-    final PluginSetting pluginSetting = generatePluginSetting(false, false, testIndexAlias, testTemplateFile);
+    final PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFile);
     OpenSearchSink sink = new OpenSearchSink(pluginSetting);
     final Request request = new Request(HttpMethod.HEAD, testIndexAlias);
     final Response response = client.performRequest(request);
@@ -363,7 +363,7 @@ public class OpenSearchSinkIT {
     final String indexAlias = "sink-custom-index-ism-test-alias";
     final String testTemplateFile = Objects.requireNonNull(
             getClass().getClassLoader().getResource(TEST_TEMPLATE_V1_FILE)).getFile();
-    final Map<String, Object> metadata = initializeConfigurationMetadata(false, false, indexAlias, testTemplateFile);
+    final Map<String, Object> metadata = initializeConfigurationMetadata(null, indexAlias, testTemplateFile);
     metadata.put(IndexConfiguration.ISM_POLICY_FILE, TEST_CUSTOM_INDEX_POLICY_FILE);
     final PluginSetting pluginSetting = generatePluginSettingByMetadata(metadata);
     OpenSearchSink sink = new OpenSearchSink(pluginSetting);
@@ -413,7 +413,7 @@ public class OpenSearchSinkIT {
     final String testTemplateFileV2 = getClass().getClassLoader().getResource(TEST_TEMPLATE_V2_FILE).getFile();
 
     // Create sink with template version 1
-    PluginSetting pluginSetting = generatePluginSetting(false, false, testIndexAlias, testTemplateFileV1);
+    PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFileV1);
     OpenSearchSink sink = new OpenSearchSink(pluginSetting);
 
     Request getTemplateRequest = new Request(HttpMethod.GET, "/_template/" + expectedIndexTemplateName);
@@ -429,7 +429,7 @@ public class OpenSearchSinkIT {
     sink.shutdown();
 
     // Create sink with template version 2
-    pluginSetting = generatePluginSetting(false, false, testIndexAlias, testTemplateFileV2);
+    pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFileV2);
     sink = new OpenSearchSink(pluginSetting);
 
     getTemplateRequest = new Request(HttpMethod.GET, "/_template/" + expectedIndexTemplateName);
@@ -445,7 +445,7 @@ public class OpenSearchSinkIT {
     sink.shutdown();
 
     // Create sink with template version 1 again
-    pluginSetting = generatePluginSetting(false, false, testIndexAlias, testTemplateFileV1);
+    pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFileV1);
     sink = new OpenSearchSink(pluginSetting);
 
     getTemplateRequest = new Request(HttpMethod.GET, "/_template/" + expectedIndexTemplateName);
@@ -472,7 +472,7 @@ public class OpenSearchSinkIT {
     final String testIdField = "someId";
     final String testId = "foo";
     final List<Record<Object>> testRecords = Collections.singletonList(stringToRecord.apply(generateCustomRecordJson(testIdField, testId)));
-    final PluginSetting pluginSetting = generatePluginSetting(false, false, testIndexAlias, testTemplateFile);
+    final PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFile);
     pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
     final OpenSearchSink sink = new OpenSearchSink(pluginSetting);
     sink.output(testRecords);
@@ -499,7 +499,7 @@ public class OpenSearchSinkIT {
     final String testIdField = "someId";
     final String testId = "foo";
     final List<Record<Object>> testRecords = Collections.singletonList(stringToRecord.apply(generateCustomRecordJson(testIdField, testId)));
-    final PluginSetting pluginSetting = generatePluginSetting(false, false, testIndexAlias, testTemplateFile);
+    final PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFile);
     pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
     pluginSetting.getSettings().put(IndexConfiguration.ACTION, BulkAction.CREATE.toString());
     final OpenSearchSink sink = new OpenSearchSink(pluginSetting);
@@ -528,7 +528,7 @@ public class OpenSearchSinkIT {
 
     final List<Record<Object>> testRecords = Collections.singletonList(new Record<>(testEvent));
 
-    final PluginSetting pluginSetting = generatePluginSetting(true, false, null, null);
+    final PluginSetting pluginSetting = generatePluginSetting(IndexType.TRACE_ANALYTICS_RAW.getValue(), null, null);
     final OpenSearchSink sink = new OpenSearchSink(pluginSetting);
     sink.output(testRecords);
 
@@ -560,7 +560,7 @@ public class OpenSearchSinkIT {
 
     final List<Record<Object>> testRecords = Collections.singletonList(stringToRecord.apply(generateCustomRecordJson(testIdField, testId)));
 
-    final Map<String, Object> metadata = initializeConfigurationMetadata(false, false, testIndexAlias, null);
+    final Map<String, Object> metadata = initializeConfigurationMetadata(null, testIndexAlias, null);
     metadata.put(IndexConfiguration.INDEX_TYPE, IndexType.MANAGEMENT_DISABLED.getValue());
     metadata.put(ConnectionConfiguration.USERNAME, username);
     metadata.put(ConnectionConfiguration.PASSWORD, password);
@@ -588,11 +588,10 @@ public class OpenSearchSinkIT {
     Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
   }
 
-  private Map<String, Object> initializeConfigurationMetadata (final boolean isRaw, final boolean isServiceMap, final String indexAlias,
-                                                  final String templateFilePath) {
+  private Map<String, Object> initializeConfigurationMetadata (final String indexType, final String indexAlias,
+                                                               final String templateFilePath) {
     final Map<String, Object> metadata = new HashMap<>();
-    metadata.put(IndexConfiguration.TRACE_ANALYTICS_RAW_FLAG, isRaw);
-    metadata.put(IndexConfiguration.TRACE_ANALYTICS_SERVICE_MAP_FLAG, isServiceMap);
+    metadata.put(IndexConfiguration.INDEX_TYPE, indexType);
     metadata.put(ConnectionConfiguration.HOSTS, getHosts());
     metadata.put(IndexConfiguration.INDEX_ALIAS, indexAlias);
     metadata.put(IndexConfiguration.TEMPLATE_FILE, templateFilePath);
@@ -605,9 +604,9 @@ public class OpenSearchSinkIT {
     return metadata;
   }
 
-  private PluginSetting generatePluginSetting(final boolean isRaw, final boolean isServiceMap, final String indexAlias,
+  private PluginSetting generatePluginSetting(final String indexType, final String indexAlias,
                                               final String templateFilePath) {
-    final Map<String, Object> metadata = initializeConfigurationMetadata(isRaw, isServiceMap, indexAlias, templateFilePath);
+    final Map<String, Object> metadata = initializeConfigurationMetadata(indexType, indexAlias, templateFilePath);
     return generatePluginSettingByMetadata(metadata);
   }
 

--- a/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/com/amazon/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -25,8 +25,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class IndexConfiguration {
     public static final String SETTINGS = "settings";
-    public static final String TRACE_ANALYTICS_RAW_FLAG = "trace_analytics_raw";
-    public static final String TRACE_ANALYTICS_SERVICE_MAP_FLAG = "trace_analytics_service_map";
     public static final String INDEX_ALIAS = "index";
     public static final String INDEX_TYPE = "index_type";
     public static final String TEMPLATE_FILE = "template_file";
@@ -92,26 +90,13 @@ public class IndexConfiguration {
             indexType = mappedIndexType.orElseThrow(
                     () -> new IllegalArgumentException("Value of the parameter, index_type, must be from the list: "
                     + IndexType.getIndexTypeValues()));
-        } else if (builder.isTraceAnalyticsRaw && builder.isTraceAnalyticsServiceMap) {
-            throw new IllegalStateException("trace_analytics_raw and trace_analytics_service_map cannot be both true.");
-        } else if (builder.isTraceAnalyticsRaw) {
-            this.indexType  = IndexType.TRACE_ANALYTICS_RAW;
-        } else if (builder.isTraceAnalyticsServiceMap) {
-            this.indexType  = IndexType.TRACE_ANALYTICS_SERVICE_MAP;
         } else {
             this.indexType  = IndexType.CUSTOM;
         }
-
-        if(builder.isTraceAnalyticsRaw || builder.isTraceAnalyticsServiceMap) {
-            LOG.warn("The parameters, trace_analytics_raw and trace_analytics_service_map, are deprecated. Please use index_type parameter instead.");
-        }
-
     }
 
     public static IndexConfiguration readIndexConfig(final PluginSetting pluginSetting) {
         IndexConfiguration.Builder builder = new IndexConfiguration.Builder();
-        builder.setIsRaw(pluginSetting.getBooleanOrDefault(TRACE_ANALYTICS_RAW_FLAG, false));
-        builder.setIsServiceMap(pluginSetting.getBooleanOrDefault(TRACE_ANALYTICS_SERVICE_MAP_FLAG, false));
         final String indexAlias = pluginSetting.getStringOrDefault(INDEX_ALIAS, null);
         if (indexAlias != null) {
             builder = builder.withIndexAlias(indexAlias);
@@ -202,8 +187,6 @@ public class IndexConfiguration {
     }
 
     public static class Builder {
-        private boolean isTraceAnalyticsRaw = false;
-        private boolean isTraceAnalyticsServiceMap = false;
         private String indexAlias;
         private String indexType;
         private String templateFile;
@@ -213,18 +196,6 @@ public class IndexConfiguration {
         private long bulkSize = DEFAULT_BULK_SIZE;
         private Optional<String> ismPolicyFile;
         private String action;
-
-        public Builder setIsRaw(final Boolean isRaw) {
-            checkNotNull(isRaw, "trace_analytics_raw cannot be null.");
-            this.isTraceAnalyticsRaw = isRaw;
-            return this;
-        }
-
-        public Builder setIsServiceMap(final Boolean isServiceMap) {
-            checkNotNull(isServiceMap, "trace_analytics_service_map cannot be null.");
-            this.isTraceAnalyticsServiceMap = isServiceMap;
-            return this;
-        }
 
         public Builder withIndexAlias(final String indexAlias) {
             checkArgument(indexAlias != null, "indexAlias cannot be null.");

--- a/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/com/amazon/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
@@ -8,6 +8,7 @@ package com.amazon.dataprepper.plugins.sink.opensearch;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.plugins.sink.opensearch.bulk.BulkAction;
 import com.amazon.dataprepper.plugins.sink.opensearch.index.IndexConfiguration;
+import com.amazon.dataprepper.plugins.sink.opensearch.index.IndexType;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -37,7 +38,7 @@ public class OpenSearchSinkConfigurationTests {
     public void testInvalidAction() {
 
         final Map<String, Object> metadata = new HashMap<>();
-        metadata.put(IndexConfiguration.TRACE_ANALYTICS_RAW_FLAG, true);
+        metadata.put(IndexConfiguration.INDEX_TYPE, IndexType.TRACE_ANALYTICS_RAW.getValue());
         metadata.put(IndexConfiguration.ACTION, "invalid");
         metadata.put(ConnectionConfiguration.HOSTS, TEST_HOSTS);
 
@@ -52,7 +53,7 @@ public class OpenSearchSinkConfigurationTests {
     public void testReadESConfigWithBulkActionCreate() {
 
         final Map<String, Object> metadata = new HashMap<>();
-        metadata.put(IndexConfiguration.TRACE_ANALYTICS_RAW_FLAG, true);
+        metadata.put(IndexConfiguration.INDEX_TYPE, IndexType.TRACE_ANALYTICS_RAW.getValue());
         metadata.put(IndexConfiguration.ACTION, BulkAction.CREATE.toString());
         metadata.put(ConnectionConfiguration.HOSTS, TEST_HOSTS);
 
@@ -69,7 +70,7 @@ public class OpenSearchSinkConfigurationTests {
 
     private PluginSetting generatePluginSetting() {
         final Map<String, Object> metadata = new HashMap<>();
-        metadata.put(IndexConfiguration.TRACE_ANALYTICS_RAW_FLAG, true);
+        metadata.put(IndexConfiguration.INDEX_TYPE, IndexType.TRACE_ANALYTICS_RAW.getValue());
         metadata.put(ConnectionConfiguration.HOSTS, TEST_HOSTS);
 
         final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, metadata);


### PR DESCRIPTION
### Description
This change removes the deprecated `trace_analytics_raw` and `trace_analytics_service_map` fields from OpenSearch sink and updates related tests and the README file.
 
### Issues Resolved
Contributes to #1648 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
