### PR TITLE
Fix for the data-prepper script and running tar smoke tests

### DIFF
--- a/release/archives/linux/data-prepper-jdk-x64.sh
+++ b/release/archives/linux/data-prepper-jdk-x64.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # Copyright OpenSearch Contributors

--- a/release/archives/linux/data-prepper-x64.sh
+++ b/release/archives/linux/data-prepper-x64.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # Copyright OpenSearch Contributors

--- a/release/smoke-tests/data-prepper-tar/Dockerfile
+++ b/release/smoke-tests/data-prepper-tar/Dockerfile
@@ -20,4 +20,4 @@ COPY ${DOCKER_FILE_DIR}/${TAR_FILE} ${DATA_PREPPER_HOME}
 RUN tar -xzf "${DATA_PREPPER_HOME}/${TAR_FILE}" -C "${DATA_PREPPER_HOME}" --strip-components=1 \
     && rm -f "${DATA_PREPPER_HOME}/${TAR_FILE}"
 
-ENTRYPOINT ${DATA_PREPPER_HOME}/data-prepper-tar-install.sh ${DATA_PREPPER_HOME}/pipelines.yaml ${DATA_PREPPER_HOME}/data-prepper-config.yaml
+ENTRYPOINT "${DATA_PREPPER_HOME}/bin/data-prepper" ${DATA_PREPPER_HOME}/pipelines.yaml ${DATA_PREPPER_HOME}/data-prepper-config.yaml

--- a/release/smoke-tests/data-prepper-tar/build.sh
+++ b/release/smoke-tests/data-prepper-tar/build.sh
@@ -29,8 +29,8 @@ if [ -z "${TAR_FILE}" ]; then
     echo -e "build.sh requires environment variable TAR_FILE to be defined."
     exit 1
 fi
-if [ -z "${NAME}" ]; then
-    echo -e "build.sh requires environment variable NAME to be defined."
+if [ -z "${SMOKE_IMAGE_NAME}" ]; then
+    echo -e "build.sh requires environment variable SMOKE_IMAGE_NAME to be defined."
     exit 1
 fi
 
@@ -41,9 +41,9 @@ docker build \
     --build-arg FROM_IMAGE_NAME="${FROM_IMAGE_NAME}" \
     --build-arg FROM_IMAGE_TAG="${FROM_IMAGE_TAG}" \
     --build-arg TAR_FILE="${TAR_FILE}" \
-    -t "${NAME}":"${DATA_PREPPER_VERSION}" \
+    -t "${SMOKE_IMAGE_NAME}":"${DATA_PREPPER_VERSION}" \
     "${DOCKER_FILE_DIR}"
 
 rm -f "${DOCKER_FILE_DIR}/${TAR_FILE}"
 
-echo "Image created: \"${NAME}:${DATA_PREPPER_VERSION}\""
+echo "Image created: \"${SMOKE_IMAGE_NAME}:${DATA_PREPPER_VERSION}\""

--- a/release/smoke-tests/run-tarball-files-smoke-tests.sh
+++ b/release/smoke-tests/run-tarball-files-smoke-tests.sh
@@ -132,13 +132,14 @@ function run_smoke_test() {
         exit 1
     fi
 
+    export SMOKE_IMAGE_NAME="${NAME}-smoke-test"
     echo "Using Docker Image ${FROM_IMAGE_NAME}:${FROM_IMAGE_TAG} as base image"
     eval "${DOCKER_FILE_DIR}/build.sh"
 
     local CURRENT_DIR
     CURRENT_DIR=$(pwd)
 
-    eval "${REPO_DIR}/release/smoke-tests/run-smoke-tests.sh -i ${NAME} -v ${DATA_PREPPER_VERSION}"
+    eval "${REPO_DIR}/release/smoke-tests/run-smoke-tests.sh -i ${SMOKE_IMAGE_NAME} -v ${DATA_PREPPER_VERSION}"
 
     echo echo "Completed smoke testing tar ${TAR_FILE}"
 


### PR DESCRIPTION
### Description

Recent changes to the Data Prepper distribution were not working with the `.tar.gz` smoke tests. This PR fixes these along with a few other changes:

* Move the `bin/data-prepper` back to using `#!/bin/bash` from `#!/bin/sh`. This script does require bash.
* Use the `bin/data-prepper` script in the tar smoke tests
* Changed the tar smoke tests to use its own Docker image. This was to help add clarity when debugging it.
 
### Issues Resolved
N/A
 
### Local Testing


```
./gradlew clean assemble :release:docker:docker -Prelease
```

```
./release/smoke-tests/run-tarball-files-smoke-tests.sh -v 2.0.0-SNAPSHOT -d release/archives/linux/build/distributions/
```

Some output from the smoke test command:

```
Image created: "opensearch-data-prepper-smoke-test:2.0.0-SNAPSHOT"
Will smoke test image "opensearch-data-prepper-smoke-test:2.0.0-SNAPSHOT"
[+] Running 6/6
 ⠿ Network smoke-tests_default                  Created                                                                                                              0.0s
 ⠿ Container node-0.example.com                 Started                                                                                                              0.8s
 ⠿ Container smoke-tests-http-log-generation-1  Started                                                                                                              0.7s
 ⠿ Container smoke-tests-data-prepper-1         Started                                                                                                              1.5s
 ⠿ Container smoke-tests-otel-collector-1       Started                                                                                                              2.1s
 ⠿ Container smoke-tests-otel-span-exporter-1   Started                                                                                                              3.0s
Waiting for Data Prepper to start
Data Prepper started!
Ready to begin smoke tests. Running cURL commands.

Test: Verify logs received via HTTP were processed
Open Search is receiving logs from Data Prepper
Found at least 78 hits
Test passed
Open Search successfully received logs from Data Prepper!

Test: Verify metrics received via grpc were processed
Open Search is receiving logs from Data Prepper
Found at least 16 hits
Test passed
Open Search successfully received OTel spans from Data Prepper!

[+] Running 6/5
 ⠿ Container smoke-tests-otel-span-exporter-1   Removed                                                                                                              0.0s
 ⠿ Container smoke-tests-http-log-generation-1  Removed                                                                                                              2.3s
 ⠿ Container smoke-tests-otel-collector-1       Removed                                                                                                              0.2s
 ⠿ Container smoke-tests-data-prepper-1         Removed                                                                                                             10.3s
 ⠿ Container node-0.example.com                 Removed                                                                                                              0.5s
 ⠿ Network smoke-tests_default                  Removed                                                                                                              0.1s
Smoke tests passed
echo Completed smoke testing tar opensearch-data-prepper-2.0.0-SNAPSHOT-linux-x64.tar.gz

...


Image created: "opensearch-data-prepper-jdk-smoke-test:2.0.0-SNAPSHOT"
Will smoke test image "opensearch-data-prepper-jdk-smoke-test:2.0.0-SNAPSHOT"
[+] Running 6/6
 ⠿ Network smoke-tests_default                  Created                                                                                                              0.0s
 ⠿ Container node-0.example.com                 Started                                                                                                              0.8s
 ⠿ Container smoke-tests-http-log-generation-1  Started                                                                                                              0.8s
 ⠿ Container smoke-tests-data-prepper-1         Started                                                                                                              1.3s
 ⠿ Container smoke-tests-otel-collector-1       Started                                                                                                              1.9s
 ⠿ Container smoke-tests-otel-span-exporter-1   Started                                                                                                              2.4s
Waiting for Data Prepper to start
Data Prepper started!
Ready to begin smoke tests. Running cURL commands.

Test: Verify logs received via HTTP were processed
Open Search is receiving logs from Data Prepper
Found at least 67 hits
Test passed
Open Search successfully received logs from Data Prepper!

Test: Verify metrics received via grpc were processed
Open Search is receiving logs from Data Prepper
Found at least 18 hits
Test passed
Open Search successfully received OTel spans from Data Prepper!

[+] Running 6/5
 ⠿ Container smoke-tests-http-log-generation-1  Removed                                                                                                              0.3s
 ⠿ Container smoke-tests-otel-span-exporter-1   Removed                                                                                                              0.0s
 ⠿ Container smoke-tests-otel-collector-1       Removed                                                                                                              0.2s
 ⠿ Container smoke-tests-data-prepper-1         Removed                                                                                                             10.3s
 ⠿ Container node-0.example.com                 Removed                                                                                                              0.6s
 ⠿ Network smoke-tests_default                  Removed                                                                                                              0.1s
Smoke tests passed
echo Completed smoke testing tar opensearch-data-prepper-jdk-2.0.0-SNAPSHOT-linux-x64.tar.gz
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
