### PR TITLE
Allow specific HTTP methods for core API endpoints

### DIFF
--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'io.micrometer:micrometer-core'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.micrometer:micrometer-registry-cloudwatch2'
+    implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     implementation 'software.amazon.awssdk:cloudwatch'
     implementation 'org.hibernate.validator:hibernate-validator:7.0.4.Final'
     implementation platform('org.apache.logging.log4j:log4j-bom:2.18.0')

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ListPipelinesHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ListPipelinesHandler.java
@@ -12,6 +12,7 @@ import com.sun.net.httpserver.HttpHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.HttpMethod;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Collections;
@@ -42,7 +43,7 @@ public class ListPipelinesHandler implements HttpHandler {
     @Override
     public void handle(final HttpExchange exchange) throws IOException {
         String requestMethod = exchange.getRequestMethod();
-        if (!requestMethod.equals("GET") && !requestMethod.equals("POST")) {
+        if (!requestMethod.equals(HttpMethod.GET) && !requestMethod.equals(HttpMethod.POST)) {
             exchange.sendResponseHeaders(HttpURLConnection.HTTP_BAD_METHOD, 0);
             exchange.getResponseBody().close();
             return;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ListPipelinesHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ListPipelinesHandler.java
@@ -41,6 +41,13 @@ public class ListPipelinesHandler implements HttpHandler {
 
     @Override
     public void handle(final HttpExchange exchange) throws IOException {
+        String requestMethod = exchange.getRequestMethod();
+        if (!requestMethod.equals("GET") && !requestMethod.equals("POST")) {
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_BAD_METHOD, 0);
+            exchange.getResponseBody().close();
+            return;
+        }
+
         try {
             final List<PipelineListing> pipelines = dataPrepper.getTransformationPipelines()
                     .keySet()

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/PrometheusMetricsHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/PrometheusMetricsHandler.java
@@ -11,6 +11,7 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.HttpMethod;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
@@ -30,7 +31,7 @@ public class PrometheusMetricsHandler implements HttpHandler {
     @Override
     public void handle(final HttpExchange exchange) throws IOException {
         String requestMethod = exchange.getRequestMethod();
-        if (!requestMethod.equals("GET") && !requestMethod.equals("POST")) {
+        if (!requestMethod.equals(HttpMethod.GET) && !requestMethod.equals(HttpMethod.POST)) {
             exchange.sendResponseHeaders(HttpURLConnection.HTTP_BAD_METHOD, 0);
             exchange.getResponseBody().close();
             return;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/PrometheusMetricsHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/PrometheusMetricsHandler.java
@@ -29,6 +29,13 @@ public class PrometheusMetricsHandler implements HttpHandler {
 
     @Override
     public void handle(final HttpExchange exchange) throws IOException {
+        String requestMethod = exchange.getRequestMethod();
+        if (!requestMethod.equals("GET") && !requestMethod.equals("POST")) {
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_BAD_METHOD, 0);
+            exchange.getResponseBody().close();
+            return;
+        }
+
         try {
             final byte[] response = prometheusMeterRegistry.scrape().getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandler.java
@@ -27,6 +27,13 @@ public class ShutdownHandler implements HttpHandler {
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
+        String requestMethod = exchange.getRequestMethod();
+        if (!requestMethod.equals("POST")) {
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_BAD_METHOD, 0);
+            exchange.getResponseBody().close();
+            return;
+        }
+
         try {
             dataPrepper.shutdown();
             exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandler.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.pipeline.server;
 
 import org.opensearch.dataprepper.DataPrepper;
+import javax.ws.rs.HttpMethod;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import com.sun.net.httpserver.HttpExchange;
@@ -28,7 +29,7 @@ public class ShutdownHandler implements HttpHandler {
     @Override
     public void handle(HttpExchange exchange) throws IOException {
         String requestMethod = exchange.getRequestMethod();
-        if (!requestMethod.equals("POST")) {
+        if (!requestMethod.equals(HttpMethod.POST)) {
             exchange.sendResponseHeaders(HttpURLConnection.HTTP_BAD_METHOD, 0);
             exchange.getResponseBody().close();
             return;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ListPipelinesHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ListPipelinesHandlerTest.java
@@ -15,6 +15,7 @@ import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import org.junit.jupiter.api.Test;
 
+import javax.ws.rs.HttpMethod;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
@@ -41,7 +42,7 @@ class ListPipelinesHandlerTest {
         when(httpExchange.getResponseBody())
                 .thenReturn(outputStream);
         when(httpExchange.getRequestMethod())
-                .thenReturn("GET");
+                .thenReturn(HttpMethod.GET);
     }
 
     @Test
@@ -103,7 +104,7 @@ class ListPipelinesHandlerTest {
         final DataPrepper dataPrepper = mock(DataPrepper.class);
 
         when(httpExchange.getRequestMethod())
-                .thenReturn("DELETE");
+                .thenReturn(HttpMethod.DELETE);
 
         final ListPipelinesHandler handler = new ListPipelinesHandler(dataPrepper);
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ListPipelinesHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ListPipelinesHandlerTest.java
@@ -99,38 +99,6 @@ class ListPipelinesHandlerTest {
     }
 
     @Test
-    public void testGivenPipelinesUsingPostMethodThenResponseWritten() throws IOException {
-        final DataPrepper dataPrepper = mock(DataPrepper.class);
-        final Headers headers = mock(Headers.class);
-        final Pipeline pipeline = mock(Pipeline.class);
-        final Map<String, Pipeline> transformationPipelines = new HashMap<>();
-        transformationPipelines.put("Pipeline A", pipeline);
-        transformationPipelines.put("Pipeline B", pipeline);
-        transformationPipelines.put("Pipeline C", pipeline);
-
-        when(dataPrepper.getTransformationPipelines())
-                .thenReturn(transformationPipelines);
-
-        when(httpExchange.getRequestMethod())
-                .thenReturn("POST");
-        when(httpExchange.getResponseHeaders())
-                .thenReturn(headers);
-
-        final ListPipelinesHandler handler = new ListPipelinesHandler(dataPrepper);
-
-        handler.handle(httpExchange);
-
-        verify(headers)
-                .add(eq("Content-Type"), eq("text/plain; charset=UTF-8"));
-        verify(httpExchange)
-                .sendResponseHeaders(eq(HttpURLConnection.HTTP_OK), anyLong());
-        verify(outputStream)
-                .write(any(byte[].class));
-        verify(outputStream)
-                .close();
-    }
-
-    @Test
     public void testGivenProhibitedHttpMethodThenErrorResponseWritten() throws IOException {
         final DataPrepper dataPrepper = mock(DataPrepper.class);
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ListPipelinesHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ListPipelinesHandlerTest.java
@@ -7,13 +7,14 @@ package org.opensearch.dataprepper.pipeline.server;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.DataPrepper;
 import org.opensearch.dataprepper.pipeline.Pipeline;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
-import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.HttpMethod;
 import java.io.IOException;
@@ -41,12 +42,11 @@ class ListPipelinesHandlerTest {
     public void beforeEach() {
         when(httpExchange.getResponseBody())
                 .thenReturn(outputStream);
-        when(httpExchange.getRequestMethod())
-                .thenReturn(HttpMethod.GET);
     }
 
-    @Test
-    public void testGivenNoPipelinesThenResponseWritten() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = { HttpMethod.GET, HttpMethod.POST })
+    public void testGivenNoPipelinesThenResponseWritten(String httpMethod) throws IOException {
         final DataPrepper dataPrepper = mock(DataPrepper.class);
         final Headers headers = mock(Headers.class);
         final Map<String, Pipeline> transformationPipelines = new HashMap<>();
@@ -55,6 +55,8 @@ class ListPipelinesHandlerTest {
                 .thenReturn(transformationPipelines);
         when(httpExchange.getResponseHeaders())
                 .thenReturn(headers);
+        when(httpExchange.getRequestMethod())
+                .thenReturn(httpMethod);
 
         final ListPipelinesHandler handler = new ListPipelinesHandler(dataPrepper);
 
@@ -70,8 +72,9 @@ class ListPipelinesHandlerTest {
                 .close();
     }
 
-    @Test
-    public void testGivenPipelinesThenResponseWritten() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = { HttpMethod.GET, HttpMethod.POST })
+    public void testGivenPipelinesThenResponseWritten(String httpMethod) throws IOException {
         final DataPrepper dataPrepper = mock(DataPrepper.class);
         final Headers headers = mock(Headers.class);
         final Pipeline pipeline = mock(Pipeline.class);
@@ -84,6 +87,8 @@ class ListPipelinesHandlerTest {
                 .thenReturn(transformationPipelines);
         when(httpExchange.getResponseHeaders())
                 .thenReturn(headers);
+        when(httpExchange.getRequestMethod())
+                .thenReturn(httpMethod);
 
         final ListPipelinesHandler handler = new ListPipelinesHandler(dataPrepper);
 
@@ -99,14 +104,14 @@ class ListPipelinesHandlerTest {
                 .close();
     }
 
-    @Test
-    public void testGivenProhibitedHttpMethodThenErrorResponseWritten() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = { HttpMethod.DELETE, HttpMethod.PATCH, HttpMethod.PUT })
+    public void testGivenProhibitedHttpMethodThenErrorResponseWritten(String httpMethod) throws IOException {
         final DataPrepper dataPrepper = mock(DataPrepper.class);
+        final ListPipelinesHandler handler = new ListPipelinesHandler(dataPrepper);
 
         when(httpExchange.getRequestMethod())
-                .thenReturn(HttpMethod.DELETE);
-
-        final ListPipelinesHandler handler = new ListPipelinesHandler(dataPrepper);
+                .thenReturn(httpMethod);
 
         handler.handle(httpExchange);
 
@@ -116,8 +121,12 @@ class ListPipelinesHandlerTest {
                 .close();
     }
 
-    @Test
-    public void testGivenExceptionThrownThenErrorResponseWritten() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = { HttpMethod.GET, HttpMethod.POST })
+    public void testGivenExceptionThrownThenErrorResponseWritten(String httpMethod) throws IOException {
+        when(httpExchange.getRequestMethod())
+                .thenReturn(httpMethod);
+
         final ListPipelinesHandler handler = new ListPipelinesHandler(null);
         handler.handle(httpExchange);
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/PrometheusMetricsHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/PrometheusMetricsHandlerTest.java
@@ -15,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.ws.rs.HttpMethod;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
@@ -58,7 +59,7 @@ class PrometheusMetricsHandlerTest {
                 .thenReturn(testString);
 
         when(exchange.getRequestMethod())
-                .thenReturn("GET");
+                .thenReturn(HttpMethod.GET);
 
         metricsHandler.handle(exchange);
 
@@ -78,7 +79,7 @@ class PrometheusMetricsHandlerTest {
     @Test
     public void testWhenUseProhibitedHttpMethodThenErrorResponseWritten() throws IOException {
         when(exchange.getRequestMethod())
-                .thenReturn("DELETE");
+                .thenReturn(HttpMethod.DELETE);
         metricsHandler.handle(exchange);
 
         verify(exchange, times(1))
@@ -90,7 +91,7 @@ class PrometheusMetricsHandlerTest {
     @Test
     public void testHandleException() throws IOException {
         when(exchange.getRequestMethod())
-                .thenReturn("GET");
+                .thenReturn(HttpMethod.GET);
         metricsHandler.handle(exchange);
 
         verify(exchange, times(1))

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/PrometheusMetricsHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/PrometheusMetricsHandlerTest.java
@@ -9,8 +9,9 @@ import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,8 +49,9 @@ class PrometheusMetricsHandlerTest {
                 .thenReturn(responseBody);
     }
 
-    @Test
-    public void testWhenUseGetMethodThenResponseWritten() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = { HttpMethod.GET, HttpMethod.POST })
+    public void testWhenUseValidHttpMethodThenResponseWritten(String httpMethod) throws IOException {
         final Headers headers = mock(Headers.class);
         when(exchange.getResponseHeaders())
                 .thenReturn(headers);
@@ -59,7 +61,7 @@ class PrometheusMetricsHandlerTest {
                 .thenReturn(testString);
 
         when(exchange.getRequestMethod())
-                .thenReturn(HttpMethod.GET);
+                .thenReturn(httpMethod);
 
         metricsHandler.handle(exchange);
 
@@ -76,10 +78,11 @@ class PrometheusMetricsHandlerTest {
                 .close();
     }
 
-    @Test
-    public void testWhenUseProhibitedHttpMethodThenErrorResponseWritten() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = { HttpMethod.DELETE, HttpMethod.PATCH, HttpMethod.PUT })
+    public void testWhenUseProhibitedHttpMethodThenErrorResponseWritten(String httpMethod) throws IOException {
         when(exchange.getRequestMethod())
-                .thenReturn(HttpMethod.DELETE);
+                .thenReturn(httpMethod);
         metricsHandler.handle(exchange);
 
         verify(exchange, times(1))
@@ -88,10 +91,11 @@ class PrometheusMetricsHandlerTest {
                 .close();
     }
 
-    @Test
-    public void testHandleException() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = { HttpMethod.GET, HttpMethod.POST })
+    public void testHandleException(String httpMethod) throws IOException {
         when(exchange.getRequestMethod())
-                .thenReturn(HttpMethod.GET);
+                .thenReturn(httpMethod);
         metricsHandler.handle(exchange);
 
         verify(exchange, times(1))

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/PrometheusMetricsHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/PrometheusMetricsHandlerTest.java
@@ -76,34 +76,6 @@ class PrometheusMetricsHandlerTest {
     }
 
     @Test
-    public void testWhenUsePostMethodThenResponseWritten() throws IOException {
-        final Headers headers = mock(Headers.class);
-        when(exchange.getResponseHeaders())
-                .thenReturn(headers);
-
-        final String testString = "I am a string used in a test";
-        when(meterRegistry.scrape())
-                .thenReturn(testString);
-
-        when(exchange.getRequestMethod())
-                .thenReturn("POST");
-
-        metricsHandler.handle(exchange);
-
-
-        verify(headers, times(1))
-                .add(eq("Content-Type"), eq("text/plain; charset=UTF-8"));
-
-        final byte[] response = testString.getBytes(StandardCharsets.UTF_8);
-        verify(exchange, times(1))
-                .sendResponseHeaders(eq(HttpURLConnection.HTTP_OK), eq((long) response.length));
-        verify(responseBody, times(1))
-                .write(response);
-        verify(responseBody, times(1))
-                .close();
-    }
-
-    @Test
     public void testWhenUseProhibitedHttpMethodThenErrorResponseWritten() throws IOException {
         when(exchange.getRequestMethod())
                 .thenReturn("DELETE");

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandlerTest.java
@@ -9,6 +9,8 @@ import com.sun.net.httpserver.HttpExchange;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -62,10 +64,11 @@ public class ShutdownHandlerTest {
                 .shutdownDataPrepperServer();
     }
 
-    @Test
-    public void testWhenShutdownWithProhibitedHttpMethodThenErrorResponseWritten() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = { HttpMethod.DELETE, HttpMethod.GET, HttpMethod.PATCH, HttpMethod.PUT })
+    public void testWhenShutdownWithProhibitedHttpMethodThenErrorResponseWritten(String httpMethod) throws IOException {
         when(exchange.getRequestMethod())
-                .thenReturn(HttpMethod.GET);
+                .thenReturn(httpMethod);
 
         shutdownHandler.handle(exchange);
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandlerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline.server;
+
+import com.sun.net.httpserver.HttpExchange;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.DataPrepper;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ShutdownHandlerTest {
+    @Mock
+    private DataPrepper dataPrepper;
+
+    @InjectMocks
+    private ShutdownHandler shutdownHandler;
+
+    @Mock
+    private HttpExchange exchange;
+
+    @Mock
+    private OutputStream responseBody;
+
+    @BeforeEach
+    public void beforeEach() {
+        when(exchange.getResponseBody())
+                .thenReturn(responseBody);
+    }
+
+    @Test
+    public void testWhenShutdownWithPostRequestThenResponseWritten() throws IOException {
+        when(exchange.getRequestMethod())
+                .thenReturn("POST");
+
+        shutdownHandler.handle(exchange);
+
+        verify(dataPrepper, times(1))
+                .shutdown();
+        verify(exchange, times(1))
+                .sendResponseHeaders(eq(HttpURLConnection.HTTP_OK), eq(0L));
+        verify(responseBody, times(1))
+                .close();
+        verify(dataPrepper, times(1))
+                .shutdownDataPrepperServer();
+    }
+
+    @Test
+    public void testWhenShutdownWithProhibitedHttpMethodThenErrorResponseWritten() throws IOException {
+        when(exchange.getRequestMethod())
+                .thenReturn("GET");
+
+        shutdownHandler.handle(exchange);
+
+        verify(exchange, times(1))
+                .sendResponseHeaders(eq(HttpURLConnection.HTTP_BAD_METHOD), eq(0L));
+        verify(responseBody, times(1))
+                .close();
+    }
+
+    @Test
+    public void testHandleException() throws IOException {
+        when(exchange.getRequestMethod())
+                .thenReturn("POST");
+        doThrow(RuntimeException.class).when(dataPrepper).shutdown();
+
+        shutdownHandler.handle(exchange);
+
+        verify(exchange, times(1))
+                .sendResponseHeaders(eq(HttpURLConnection.HTTP_INTERNAL_ERROR), eq(0L));
+        verify(responseBody, times(1))
+                .close();
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandlerTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.DataPrepper;
 
+import javax.ws.rs.HttpMethod;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
@@ -47,7 +48,7 @@ public class ShutdownHandlerTest {
     @Test
     public void testWhenShutdownWithPostRequestThenResponseWritten() throws IOException {
         when(exchange.getRequestMethod())
-                .thenReturn("POST");
+                .thenReturn(HttpMethod.POST);
 
         shutdownHandler.handle(exchange);
 
@@ -64,7 +65,7 @@ public class ShutdownHandlerTest {
     @Test
     public void testWhenShutdownWithProhibitedHttpMethodThenErrorResponseWritten() throws IOException {
         when(exchange.getRequestMethod())
-                .thenReturn("GET");
+                .thenReturn(HttpMethod.GET);
 
         shutdownHandler.handle(exchange);
 
@@ -77,7 +78,7 @@ public class ShutdownHandlerTest {
     @Test
     public void testHandleException() throws IOException {
         when(exchange.getRequestMethod())
-                .thenReturn("POST");
+                .thenReturn(HttpMethod.POST);
         doThrow(RuntimeException.class).when(dataPrepper).shutdown();
 
         shutdownHandler.handle(exchange);

--- a/docs/core_apis.md
+++ b/docs/core_apis.md
@@ -14,16 +14,30 @@ curl -X POST http://localhost:4900/shutdown
 
 The following APIs are available:
 
-* GET /list
-    * lists running pipelines
-* POST /shutdown
-    * starts a graceful shutdown of the Data Prepper
-* GET /metrics/prometheus
-    * returns a scrape of the Data Prepper metrics in Prometheus text format. This API is available provided
+```
+GET /list
+POST /list
+```
+* lists running pipelines
+
+```
+POST /shutdown
+```
+* starts a graceful shutdown of the Data Prepper
+
+```
+GET /metrics/prometheus
+POST /metrics/prometheus
+```
+* returns a scrape of the Data Prepper metrics in Prometheus text format. This API is available provided
       `metricsRegistries` parameter in data prepper configuration file `data-prepper-config.yaml` has `Prometheus` as one
       of the registry
-* GET /metrics/sys
-    * returns JVM metrics in Prometheus text format. This API is available provided `metricsRegistries` parameter in data
+
+```
+GET /metrics/sys
+POST /metrics/sys
+```
+* returns JVM metrics in Prometheus text format. This API is available provided `metricsRegistries` parameter in data
       prepper configuration file `data-prepper-config.yaml` has `Prometheus` as one of the registry
 
 ## Configuring the Server

--- a/docs/core_apis.md
+++ b/docs/core_apis.md
@@ -14,15 +14,15 @@ curl -X POST http://localhost:4900/shutdown
 
 The following APIs are available:
 
-* /list
+* GET /list
     * lists running pipelines
-* /shutdown
+* POST /shutdown
     * starts a graceful shutdown of the Data Prepper
-* /metrics/prometheus
+* GET /metrics/prometheus
     * returns a scrape of the Data Prepper metrics in Prometheus text format. This API is available provided
       `metricsRegistries` parameter in data prepper configuration file `data-prepper-config.yaml` has `Prometheus` as one
       of the registry
-* /metrics/sys
+* GET /metrics/sys
     * returns JVM metrics in Prometheus text format. This API is available provided `metricsRegistries` parameter in data
       prepper configuration file `data-prepper-config.yaml` has `Prometheus` as one of the registry
 


### PR DESCRIPTION
### Description

This PR updates data prepper server handlers to support proper HTTP methods specified in #313. Unit tests and docs are updated accordingly.
 
### Issues Resolved
Resolves #313 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
