### PR TITLE
addressing cve while waiting for dependencies to address the issue

### DIFF
--- a/data-prepper-plugins/otel-trace-group-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-group-prepper/build.gradle
@@ -14,7 +14,10 @@ ext {
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:opensearch')
-    implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearchVersion}"
+    implementation("org.opensearch.client:opensearch-rest-high-level-client:${opensearchVersion}") {
+        // todo: remove once opensearch-rest-high-level-client has been updated
+        exclude group: 'org.yaml', module: 'snakeyaml'
+    }
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'io.micrometer:micrometer-core'

--- a/e2e-test/log/build.gradle
+++ b/e2e-test/log/build.gradle
@@ -161,5 +161,8 @@ dependencies {
     integrationTestImplementation project(':data-prepper-plugins:opensearch')
     integrationTestImplementation "com.linecorp.armeria:armeria:${versionMap.armeria}"
     integrationTestImplementation "org.awaitility:awaitility:4.1.1"
-    integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${versionMap.opensearchVersion}"
+    integrationTestImplementation ("org.opensearch.client:opensearch-rest-high-level-client:${versionMap.opensearchVersion}") {
+        // todo: remove once opensearch-rest-high-level-client has been updated
+        exclude group: 'org.yaml', module: 'snakeyaml'
+    }
 }


### PR DESCRIPTION
Signed-off-by: Christopher Manning <cmanning09@users.noreply.github.com>

### Description
Recent opened PR's are failing our workflow because of [CVE-2022-25857](https://www.mend.io/vulnerability-database/CVE-2022-25857). We do not depend on this dependency and have excluded it from our builds. We can remove this check once `opensearch-rest-high-level-client` has addressed the issue.
 
### Issues Resolved
- none
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
