### PR TITLE
Update the e2e test to the org.opensearch package name

### DIFF
--- a/e2e-test/log/build.gradle
+++ b/e2e-test/log/build.gradle
@@ -144,7 +144,7 @@ task basicLogEndToEndTest(type: Test) {
     classpath = sourceSets.integrationTest.runtimeClasspath
 
     filter {
-        includeTestsMatching "com.amazon.dataprepper.integration.log.EndToEndBasicLogTest.testPipelineEndToEnd*"
+        includeTestsMatching "org.opensearch.dataprepper.integration.log.EndToEndBasicLogTest.testPipelineEndToEnd*"
     }
 
     finalizedBy stopOpenSearchDockerContainer

--- a/e2e-test/log/src/integrationTest/java/org/opensearch/dataprepper/integration/log/EndToEndBasicLogTest.java
+++ b/e2e-test/log/src/integrationTest/java/org/opensearch/dataprepper/integration/log/EndToEndBasicLogTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazon.dataprepper.integration.log;
+package org.opensearch.dataprepper.integration.log;
 
 import com.amazon.dataprepper.plugins.sink.opensearch.ConnectionConfiguration;
 import com.amazon.dataprepper.plugins.source.loggenerator.ApacheLogFaker;

--- a/e2e-test/trace/build.gradle
+++ b/e2e-test/trace/build.gradle
@@ -191,7 +191,7 @@ def createEndToEndTest(final String testName, final String includeTestsMatchPatt
     }
 }
 
-def includeRawSpanTestsMatchPattern = "com.amazon.dataprepper.integration.trace.EndToEndRawSpanTest.testPipelineEndToEnd*"
+def includeRawSpanTestsMatchPattern = "org.opensearch.dataprepper.integration.trace.EndToEndRawSpanTest.testPipelineEndToEnd*"
 
 def createRawSpanDataPrepperOTLP1Task = createDataPrepperDockerContainer(
         "rawSpanDataPrepper1", "dataprepper1", 21890, 4900, "/app/${RAW_SPAN_PIPELINE_YAML}")
@@ -230,7 +230,7 @@ def rawSpanEventLatestReleaseCompatibilityEndToEndTest = createEndToEndTest("raw
         includeRawSpanTestsMatchPattern,
         rawSpanDataPrepperEventFromBuild, rawSpanDataPrepperLatestFromPull)
 
-def includeServiceMapTestsMatchPattern = "com.amazon.dataprepper.integration.trace.EndToEndServiceMapTest*"
+def includeServiceMapTestsMatchPattern = "org.opensearch.dataprepper.integration.trace.EndToEndServiceMapTest*"
 
 def createServiceMapDataPrepperOTLP1Task = createDataPrepperDockerContainer(
         "serviceMapDataPrepper1", "dataprepper1", 21890, 4900, "/app/${SERVICE_MAP_PIPELINE_YAML}")

--- a/e2e-test/trace/src/integrationTest/java/org/opensearch/dataprepper/integration/trace/EndToEndRawSpanTest.java
+++ b/e2e-test/trace/src/integrationTest/java/org/opensearch/dataprepper/integration/trace/EndToEndRawSpanTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazon.dataprepper.integration.trace;
+package org.opensearch.dataprepper.integration.trace;
 
 
 import com.amazon.dataprepper.model.trace.DefaultTraceGroupFields;

--- a/e2e-test/trace/src/integrationTest/java/org/opensearch/dataprepper/integration/trace/EndToEndServiceMapTest.java
+++ b/e2e-test/trace/src/integrationTest/java/org/opensearch/dataprepper/integration/trace/EndToEndServiceMapTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazon.dataprepper.integration.trace;
+package org.opensearch.dataprepper.integration.trace;
 
 
 import com.amazon.dataprepper.plugins.sink.opensearch.ConnectionConfiguration;

--- a/e2e-test/trace/src/integrationTest/java/org/opensearch/dataprepper/integration/trace/EndToEndTestSpan.java
+++ b/e2e-test/trace/src/integrationTest/java/org/opensearch/dataprepper/integration/trace/EndToEndTestSpan.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazon.dataprepper.integration.trace;
+package org.opensearch.dataprepper.integration.trace;
 
 import io.opentelemetry.proto.trace.v1.Span;
 


### PR DESCRIPTION
### Description

Updates the end-to-tests to use the `org.opensearch.dataprepper` package name.
 
### Issues Resolved

Partially resolves #344
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
