### PR TITLE
Fix: CVE-2020-36518, CVE-2022-24823

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ subprojects {
 
 configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
     dependencies {
-        implementation platform('software.amazon.awssdk:bom:2.17.209')
+        implementation platform('software.amazon.awssdk:bom:2.17.264')
         implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
     }
 }

--- a/performance-test/build.gradle
+++ b/performance-test/build.gradle
@@ -5,7 +5,7 @@
 
 plugins {
     id 'java'
-    id 'io.gatling.gradle' version '3.7.4'
+    id 'io.gatling.gradle' version '3.8.3.2'
 }
 
 group 'org.opensearch.dataprepper.test.performance'


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
CVE-2020-36518:  `jackson-databind-2.13.1` from `gatling-charts-highcharts-3.7.4`
CVE-2022-24823: `netty-common-4.1.74.Final` from `bom-2.17.209`
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
