### PR TITLE
Run OpenSearch sink integration tests only when the plugin changes

### DIFF
--- a/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
@@ -6,7 +6,11 @@ name: Data Prepper OpenSearchSink integration tests with Open Distro
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'data-prepper-plugins/opensearch/**'
   pull_request:
+    paths:
+      - 'data-prepper-plugins/opensearch/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
@@ -8,9 +8,11 @@ on:
     branches: [ main ]
     paths:
       - 'data-prepper-plugins/opensearch/**'
+      - '*gradle*'
   pull_request:
     paths:
       - 'data-prepper-plugins/opensearch/**'
+      - '*gradle*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -7,9 +7,11 @@ on:
   push:
     paths:
       - 'data-prepper-plugins/opensearch/**'
+      - '*gradle*'
   pull_request:
     paths:
       - 'data-prepper-plugins/opensearch/**'
+      - '*gradle*'
   workflow_dispatch:
 
 

--- a/.github/workflows/opensearch-sink-os-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-os-integration-tests.yml
@@ -3,7 +3,15 @@
 
 name: Data Prepper OpenSearchSink integration tests with OpenSearch
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    paths:
+      - 'data-prepper-plugins/opensearch/**'
+  pull_request:
+    paths:
+      - 'data-prepper-plugins/opensearch/**'
+  workflow_dispatch:
+
 
 jobs:
   integration-tests:


### PR DESCRIPTION
### Description

Each PR we create runs the OpenSearch sink integration tests. This creates a lot of jobs. And sometimes they queue up when we make multiple pushes. This PR updates the OpenSearch integration tests to run only when the sink plugin itself is changed. it also will run if the root Gradle project changes.
 
### Issues Resolved

None
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
