### PR TITLE
Acm private key password is nullable

### DIFF
--- a/data-prepper-plugins/http-source/src/main/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
+++ b/data-prepper-plugins/http-source/src/main/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
@@ -103,11 +103,6 @@ public class HTTPSourceConfig {
         return !useAcmCertificateForSsl || StringUtils.isNotEmpty(acmCertificateArn);
     }
 
-    @AssertTrue(message = "acm_private_key_password cannot be a empty or null when ACM is used for ssl")
-    boolean isAcmPrivateKeyPasswordValid() {
-        return !useAcmCertificateForSsl || StringUtils.isNotEmpty(acmPrivateKeyPassword);
-    }
-
     @AssertTrue(message = "aws_region cannot be a empty or null when ACM / S3 is used for ssl")
     boolean isAwsRegionValid() {
         if (ssl && (useAcmCertificateForSsl || isSslCertAndKeyFileInS3())) {

--- a/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceConfigTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/com/amazon/dataprepper/plugins/source/loghttp/HTTPSourceConfigTest.java
@@ -222,27 +222,6 @@ public class HTTPSourceConfigTest {
 
             assertThat(objectUnderTest.isAcmCertificateArnValid(), equalTo(true));
         }
-
-        @Test
-        void isAcmPrivateKeyPasswordValid_should_return_false_if_ssl_is_true_and_acm_is_true_and_arn_is_null() throws NoSuchFieldException, IllegalAccessException {
-            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
-
-            reflectivelySetField(objectUnderTest, "ssl", true);
-            reflectivelySetField(objectUnderTest, "useAcmCertificateForSsl", true);
-
-            assertThat(objectUnderTest.isAcmPrivateKeyPasswordValid(), equalTo(false));
-        }
-
-        @Test
-        void isAcmPrivateKeyPasswordValid_should_return_true_if_ssl_is_true_and_acm_is_true_and_arn_is_not_null() throws NoSuchFieldException, IllegalAccessException {
-            final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
-
-            reflectivelySetField(objectUnderTest, "ssl", true);
-            reflectivelySetField(objectUnderTest, "useAcmCertificateForSsl", true);
-            reflectivelySetField(objectUnderTest, "acmPrivateKeyPassword", UUID.randomUUID().toString());
-
-            assertThat(objectUnderTest.isAcmPrivateKeyPasswordValid(), equalTo(true));
-        }
     }
 
         private void reflectivelySetField(final HTTPSourceConfig httpSourceConfig, final String fieldName, final Object value) throws NoSuchFieldException, IllegalAccessException {


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
`ACMCertificatProvider` generates a passphrase if not provided.
https://github.com/opensearch-project/data-prepper/blob/caebb1964233c0d400ef40c8c7c24353ee3091ff/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/certificate/acm/ACMCertificateProvider.java#L82
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
