### PR TITLE
Renamed router to route in the PipelineModel

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelineModel.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelineModel.java
@@ -36,9 +36,9 @@ public class PipelineModel {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final PluginModel buffer;
 
-    @JsonProperty("router")
+    @JsonProperty("route")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<ConditionalRoute> router;
+    private List<ConditionalRoute> routes;
 
     @JsonProperty("sink")
     private final List<PluginModel> sinks;
@@ -64,7 +64,7 @@ public class PipelineModel {
             @JsonProperty("source") final PluginModel source,
             @JsonProperty("buffer") final PluginModel buffer,
             @JsonProperty("processor") final List<PluginModel> processors,
-            @JsonProperty("router") final List<ConditionalRoute> router,
+            @JsonProperty("router") final List<ConditionalRoute> routes,
             @JsonProperty("sink") final List<PluginModel> sinks,
             @JsonProperty("workers") final Integer workers,
             @JsonProperty("delay") final Integer delay) {
@@ -76,7 +76,7 @@ public class PipelineModel {
         this.source = source;
         this.buffer = buffer;
         this.processors = processors;
-        this.router = router != null ? router : new ArrayList<>();
+        this.routes = routes != null ? routes : new ArrayList<>();
         this.sinks = sinks;
         this.workers = workers;
         this.readBatchDelay = delay;
@@ -92,8 +92,8 @@ public class PipelineModel {
         return processors;
     }
 
-    public List<ConditionalRoute> getRouter() {
-        return router;
+    public List<ConditionalRoute> getRoutes() {
+        return routes;
     }
 
     public List<PluginModel> getSinks() {

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PipelineModelTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PipelineModelTest.java
@@ -57,8 +57,8 @@ class PipelineModelTest {
         assertThat(originalBuffer.getPluginSettings(), is(equalTo(TEST_VALID_BUFFER_PLUGIN_MODEL.getPluginSettings())));
         assertThat(originalPreppers.get(0).getPluginName(), is(equalTo(TEST_VALID_PREPPERS_PLUGIN_MODEL.getPluginName())));
         assertThat(originalPreppers.get(0).getPluginSettings(), is(equalTo(TEST_VALID_PREPPERS_PLUGIN_MODEL.getPluginSettings())));
-        assertThat(pipelineModel.getRouter(), notNullValue());
-        assertThat(pipelineModel.getRouter().size(), equalTo(1));
+        assertThat(pipelineModel.getRoutes(), notNullValue());
+        assertThat(pipelineModel.getRoutes().size(), equalTo(1));
         assertThat(originalSinks.get(0).getPluginName(), is(equalTo(TEST_VALID_SINKS_PLUGIN_MODEL.getPluginName())));
         assertThat(originalSinks.get(0).getPluginSettings(), is(equalTo(TEST_VALID_SINKS_PLUGIN_MODEL.getPluginSettings())));
         assertThat(pipelineModel.getWorkers(), is(TEST_WORKERS));
@@ -84,7 +84,7 @@ class PipelineModelTest {
     }
 
     private static List<ConditionalRoute> validPipelineRouter() {
-        return Collections.singletonList(new ConditionalRoute("router", "/a==b"));
+        return Collections.singletonList(new ConditionalRoute("my-route", "/a==b"));
     }
 
     static List<PluginModel> validSinksPluginModel() {
@@ -189,8 +189,8 @@ class PipelineModelTest {
         assertThat(pipelineModel.getWorkers(), is(TEST_WORKERS));
         assertThat(pipelineModel.getReadBatchDelay(), is(TEST_READ_BATCH_DELAY));
 
-        assertThat(pipelineModel.getRouter(), notNullValue());
-        assertThat(pipelineModel.getRouter().size(), equalTo(0));
+        assertThat(pipelineModel.getRoutes(), notNullValue());
+        assertThat(pipelineModel.getRoutes().size(), equalTo(0));
     }
 
 }

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
@@ -62,9 +62,9 @@ class PipelinesDataFlowModelTest {
     void testSerializing_PipelinesDataFlowModel_empty_Plugins_with_nonEmpty_delay_and_workers_and_route() throws JsonProcessingException {
         String pipelineName = "test-pipeline";
 
-        final PluginModel source = new PluginModel("testSource", null);
-        final List<PluginModel> preppers = Collections.singletonList(new PluginModel("testPrepper", null));
-        final List<PluginModel> sinks = Collections.singletonList(new PluginModel("testSink", null));
+        final PluginModel source = new PluginModel("testSource", (Map<String, Object>) null);
+        final List<PluginModel> preppers = Collections.singletonList(new PluginModel("testPrepper", (Map<String, Object>) null));
+        final List<PluginModel> sinks = Collections.singletonList(new PluginModel("testSink", (Map<String, Object>) null));
         final PipelineModel pipelineModel = new PipelineModel(source, null, preppers, Collections.singletonList(new ConditionalRoute("my-route", "/a==b")), sinks, 8, 50);
 
         final PipelinesDataFlowModel pipelinesDataFlowModel = new PipelinesDataFlowModel(Collections.singletonMap(pipelineName, pipelineModel));
@@ -135,10 +135,10 @@ class PipelinesDataFlowModelTest {
         assertThat(pipelineModel.getSource(), notNullValue());
         assertThat(pipelineModel.getSource().getPluginName(), equalTo("testSource"));
 
-        assertThat(pipelineModel.getPreppers(), notNullValue());
-        assertThat(pipelineModel.getPreppers().size(), equalTo(1));
-        assertThat(pipelineModel.getPreppers().get(0), notNullValue());
-        assertThat(pipelineModel.getPreppers().get(0).getPluginName(), equalTo("testPrepper"));
+        assertThat(pipelineModel.getProcessors(), notNullValue());
+        assertThat(pipelineModel.getProcessors().size(), equalTo(1));
+        assertThat(pipelineModel.getProcessors().get(0), notNullValue());
+        assertThat(pipelineModel.getProcessors().get(0).getPluginName(), equalTo("testPrepper"));
 
         assertThat(pipelineModel.getSinks(), notNullValue());
         assertThat(pipelineModel.getSinks().size(), equalTo(1));

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.hasKey;
 class PipelinesDataFlowModelTest {
 
     private static final String RESOURCE_PATH = "/pipelines_data_flow_serialized.yaml";
+    private static final String RESOURCE_PATH_WITH_ROUTE = "/pipelines_data_flow_route.yaml";
     private ObjectMapper objectMapper;
 
     @BeforeEach
@@ -50,6 +51,27 @@ class PipelinesDataFlowModelTest {
         final String serializedString = objectMapper.writeValueAsString(pipelinesDataFlowModel);
 
         InputStream inputStream = this.getClass().getResourceAsStream(RESOURCE_PATH);
+
+        final String expectedYaml = PluginModelTests.convertInputStreamToString(inputStream);
+
+        assertThat(serializedString, notNullValue());
+        assertThat(serializedString, equalTo(expectedYaml));
+    }
+
+    @Test
+    void testSerializing_PipelinesDataFlowModel_empty_Plugins_with_nonEmpty_delay_and_workers_and_route() throws JsonProcessingException {
+        String pipelineName = "test-pipeline";
+
+        final PluginModel source = new PluginModel("testSource", null);
+        final List<PluginModel> preppers = Collections.singletonList(new PluginModel("testPrepper", null));
+        final List<PluginModel> sinks = Collections.singletonList(new PluginModel("testSink", null));
+        final PipelineModel pipelineModel = new PipelineModel(source, null, preppers, Collections.singletonList(new ConditionalRoute("my-route", "/a==b")), sinks, 8, 50);
+
+        final PipelinesDataFlowModel pipelinesDataFlowModel = new PipelinesDataFlowModel(Collections.singletonMap(pipelineName, pipelineModel));
+
+        final String serializedString = objectMapper.writeValueAsString(pipelinesDataFlowModel);
+
+        InputStream inputStream = this.getClass().getResourceAsStream(RESOURCE_PATH_WITH_ROUTE);
 
         final String expectedYaml = PluginModelTests.convertInputStreamToString(inputStream);
 
@@ -87,5 +109,47 @@ class PipelinesDataFlowModelTest {
         assertThat(pipelineModel.getSinks().size(), equalTo(1));
         assertThat(pipelineModel.getSinks().get(0), notNullValue());
         assertThat(pipelineModel.getSinks().get(0).getPluginName(), equalTo("testSink"));
+
+        assertThat(pipelineModel.getRoutes(), notNullValue());
+        assertThat(pipelineModel.getRoutes().size(), equalTo(0));
+    }
+
+    @Test
+    void deserialize_PipelinesDataFlowModel_with_route() throws IOException {
+
+        final InputStream inputStream = this.getClass().getResourceAsStream(RESOURCE_PATH_WITH_ROUTE);
+
+        final PipelinesDataFlowModel actualModel = objectMapper.readValue(inputStream, PipelinesDataFlowModel.class);
+
+        final String pipelineName = "test-pipeline";
+
+        assertThat(actualModel, notNullValue());
+        assertThat(actualModel.getPipelines(), notNullValue());
+        assertThat(actualModel.getPipelines().size(), equalTo(1));
+        assertThat(actualModel.getPipelines(), hasKey(pipelineName));
+
+        final PipelineModel pipelineModel = actualModel.getPipelines().get(pipelineName);
+
+        assertThat(pipelineModel, notNullValue());
+
+        assertThat(pipelineModel.getSource(), notNullValue());
+        assertThat(pipelineModel.getSource().getPluginName(), equalTo("testSource"));
+
+        assertThat(pipelineModel.getPreppers(), notNullValue());
+        assertThat(pipelineModel.getPreppers().size(), equalTo(1));
+        assertThat(pipelineModel.getPreppers().get(0), notNullValue());
+        assertThat(pipelineModel.getPreppers().get(0).getPluginName(), equalTo("testPrepper"));
+
+        assertThat(pipelineModel.getSinks(), notNullValue());
+        assertThat(pipelineModel.getSinks().size(), equalTo(1));
+        assertThat(pipelineModel.getSinks().get(0), notNullValue());
+        assertThat(pipelineModel.getSinks().get(0).getPluginName(), equalTo("testSink"));
+
+        assertThat(pipelineModel.getRoutes(), notNullValue());
+        assertThat(pipelineModel.getRoutes().size(), equalTo(1));
+        assertThat(pipelineModel.getRoutes().get(0), notNullValue());
+        assertThat(pipelineModel.getRoutes().get(0).getName(), equalTo("my-route"));
+        assertThat(pipelineModel.getRoutes().get(0).getCondition(), equalTo("/a==b"));
+
     }
 }

--- a/data-prepper-api/src/test/resources/pipelines_data_flow_route.yaml
+++ b/data-prepper-api/src/test/resources/pipelines_data_flow_route.yaml
@@ -1,0 +1,11 @@
+test-pipeline:
+  source:
+    testSource: null
+  processor:
+  - testPrepper: null
+  sink:
+  - testSink: null
+  workers: 8
+  delay: 50
+  route:
+  - my-route: "/a==b"


### PR DESCRIPTION
### Description

Updates the `PipelineModel` to use `route:` instead of `router:`. Additionally, this add some additional testing for serializing/deserializing routes.
 
### Issues Resolved

Part of #1007. Specifically addresses this comment from the RFC: https://github.com/opensearch-project/data-prepper/issues/1007#issuecomment-1235832817
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
