### PR TITLE
Update Docker images to use JDK 17

### DIFF
--- a/examples/dev/data-prepper-emf-monitoring/Dockerfile
+++ b/examples/dev/data-prepper-emf-monitoring/Dockerfile
@@ -1,10 +1,20 @@
-FROM gradle:jdk14 AS builder
+FROM gradle:jdk11 AS builder
+ARG DATA_PREPPER_VERSION
 COPY . /home/gradle/src
 WORKDIR /home/gradle/src
-RUN gradle -p data-prepper-core clean jar --no-daemon
+RUN gradle clean :release:archives:buildArchives -Prelease --no-daemon
+WORKDIR /home/gradle/src/release/archives/linux/build/distributions
+RUN tar -xf opensearch-data-prepper-${DATA_PREPPER_VERSION}-linux-x64.tar.gz
 
-FROM amazoncorretto:15-al2-full
+FROM eclipse-temurin:17-jdk-alpine
+ARG DATA_PREPPER_VERSION
 EXPOSE 21890
+
+RUN apk update
+RUN apk add --no-cache bash bc curl
+
+COPY --from=builder \
+    /home/gradle/src/release/archives/linux/build/distributions/opensearch-data-prepper-${DATA_PREPPER_VERSION}-linux-x64/ \
+    /usr/share/data-prepper/
 WORKDIR /usr/share/data-prepper/
-COPY --from=builder /home/gradle/src/data-prepper-core/build/libs/data-prepper*.jar /usr/share/data-prepper/data-prepper.jar
-CMD ["java", "-Xms512m", "-Xmx512m", "-jar", "data-prepper.jar", "pipelines.yaml", "data-prepper-config.yaml"]
+CMD ./bin/data-prepper pipelines.yaml data-prepper-config.yaml

--- a/examples/dev/data-prepper-emf-monitoring/docker-compose.yml
+++ b/examples/dev/data-prepper-emf-monitoring/docker-compose.yml
@@ -3,8 +3,10 @@ services:
   data-prepper:
     container_name: data-prepper
     build:
+      args:
+        DATA_PREPPER_VERSION: "2.0.0-SNAPSHOT"
       context: ../../..
-      dockerfile: examples/dev/data-prepper-monitoring/firelens.Dockerfile
+      dockerfile: examples/dev/data-prepper-emf-monitoring/Dockerfile
     environment:
       AWS_EMF_AGENT_ENDPOINT: "tcp://fluent-bit:25888"
     volumes:

--- a/examples/dev/trace-analytics-sample-app/Dockerfile
+++ b/examples/dev/trace-analytics-sample-app/Dockerfile
@@ -1,10 +1,19 @@
 FROM gradle:jdk11 AS builder
+ARG DATA_PREPPER_VERSION
 COPY . /home/gradle/src
 WORKDIR /home/gradle/src
-RUN gradle -p data-prepper-core clean jar --no-daemon
+RUN gradle clean :release:archives:buildArchives -Prelease --no-daemon
+WORKDIR /home/gradle/src/release/archives/linux/build/distributions
+RUN tar -xf opensearch-data-prepper-${DATA_PREPPER_VERSION}-linux-x64.tar.gz
 
-FROM amazoncorretto:15-al2-full
-EXPOSE 21890
+FROM eclipse-temurin:17-jdk-alpine
+ARG DATA_PREPPER_VERSION
+
+RUN apk update
+RUN apk add --no-cache bash bc curl
+
+COPY --from=builder \
+    /home/gradle/src/release/archives/linux/build/distributions/opensearch-data-prepper-${DATA_PREPPER_VERSION}-linux-x64/ \
+    /usr/share/data-prepper/
 WORKDIR /usr/share/data-prepper/
-COPY --from=builder /home/gradle/src/data-prepper-core/build/libs/data-prepper*.jar /usr/share/data-prepper/data-prepper.jar
-CMD ["java", "-Xms128m", "-Xmx128m", "-jar", "data-prepper.jar", "pipelines.yaml", "data-prepper-config.yaml"]
+CMD ./bin/data-prepper pipelines.yaml data-prepper-config.yaml

--- a/examples/dev/trace-analytics-sample-app/docker-compose.yml
+++ b/examples/dev/trace-analytics-sample-app/docker-compose.yml
@@ -52,6 +52,8 @@ services:
     dns: 10.10.1.1
     container_name: data-prepper
     build:
+      args:
+        DATA_PREPPER_VERSION: "2.0.0-SNAPSHOT"
       context: ../../..
       dockerfile: examples/dev/trace-analytics-sample-app/Dockerfile
     working_dir: /usr/share/data-prepper/

--- a/examples/dev/trace-analytics-sample-app/resources/data-prepper-wait-for-os-and-start.sh
+++ b/examples/dev/trace-analytics-sample-app/resources/data-prepper-wait-for-os-and-start.sh
@@ -10,4 +10,4 @@ until [[ $(curl --write-out %{http_code} --output /dev/null --silent --head --fa
   sleep 1
 done
 
-java -Dlog4j.configurationFile=log4j.properties -Xms128m -Xmx128m -jar data-prepper.jar pipelines.yaml data-prepper-config.yaml
+./bin/data-prepper pipelines.yaml data-prepper-config.yaml

--- a/release/build-resources.gradle
+++ b/release/build-resources.gradle
@@ -9,7 +9,7 @@ ext {
             linux: ['x64']
     ]
     jdkSources = [
-            linux_x64: 'https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz',
+            linux_x64: 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.4.1_1.tar.gz',
             linux_arm64: 'https://hg.openjdk.java.net/aarch64-port/jdk8/archive/tip.tar.gz'
     ]
     awsResources = [

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -36,12 +36,12 @@ task benchmarkTests {
     // TODO add benchmark test and enable
 }
 
-task buildCore {
-    dependsOn ':data-prepper-core:build'
+task buildMain {
+    dependsOn ':data-prepper-main:build'
 }
 
 task releasePrerequisites {
-    dependsOn 'buildCore'
+    dependsOn 'buildMain'
     dependsOn 'endToEndTests'
     dependsOn 'benchmarkTests'
 }

--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk
+FROM eclipse-temurin:17-jdk-alpine
 ARG PIPELINE_FILEPATH
 ARG CONFIG_FILEPATH
 ARG ARCHIVE_FILE
@@ -9,8 +9,8 @@ ENV ENV_CONFIG_FILEPATH=$CONFIG_FILEPATH
 ENV ENV_PIPELINE_FILEPATH=$PIPELINE_FILEPATH
 
 # Update all packages
-RUN apt update
-RUN apt install -y bc
+RUN apk update
+RUN apk add --no-cache bash bc
 
 RUN mkdir -p /var/log/data-prepper
 ADD $ARCHIVE_FILE /usr/share

--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:15-al2-full
+FROM eclipse-temurin:17-jdk
 ARG PIPELINE_FILEPATH
 ARG CONFIG_FILEPATH
 ARG ARCHIVE_FILE
@@ -9,8 +9,8 @@ ENV ENV_CONFIG_FILEPATH=$CONFIG_FILEPATH
 ENV ENV_PIPELINE_FILEPATH=$PIPELINE_FILEPATH
 
 # Update all packages
-RUN yum update -y && yum clean all
-RUN yum install -y bc
+RUN apt update
+RUN apt install -y bc
 
 RUN mkdir -p /var/log/data-prepper
 ADD $ARCHIVE_FILE /usr/share

--- a/release/docker/README.md
+++ b/release/docker/README.md
@@ -28,7 +28,7 @@ Below is an example command which can also be used to run the built image.
 ```
 docker run \
  --name data-prepper-test \
- -p 21890:21890 -p 4900 \
+ -p 21890:21890 -p 4900:4900 \
  -v ${PWD}/examples/config/example-pipelines.yaml:/usr/share/data-prepper/pipelines.yaml \
  -v ${PWD}/examples/config/example-data-prepper-config.yaml:/usr/share/data-prepper/data-prepper-config.yaml \
  opensearch-data-prepper:1.2.0-SNAPSHOT


### PR DESCRIPTION
### Description
This PR updates the Data Prepper Docker images in release and examples directory to use `eclipse-temurin:17-jdk-alpine` as base image; also updates the JDK in the tar.gz archive file to Temurin 17.
 
### Issues Resolved
Resolves #694 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
