### PR TITLE
Load data prepper configurations from home directory

### DIFF
--- a/data-prepper-main/src/main/java/org/opensearch/dataprepper/ContextManager.java
+++ b/data-prepper-main/src/main/java/org/opensearch/dataprepper/ContextManager.java
@@ -26,6 +26,14 @@ public class ContextManager {
 
     private final AnnotationConfigApplicationContext coreApplicationContext;
 
+    private static final String DATA_PREPPER_HOME = System.getProperty("user.dir");
+    private static final String PIPELINES_CONFIG = DATA_PREPPER_HOME + "/pipelines/pipelines.yaml";
+    private static final String DATA_PREPPER_CONFIG = DATA_PREPPER_HOME + "/config/data-prepper-config.yaml";
+
+    public ContextManager() {
+        this(PIPELINES_CONFIG, DATA_PREPPER_CONFIG);
+    }
+
     /**
      * @since 1.3
      * @param args Application command line arguments

--- a/data-prepper-main/src/main/java/org/opensearch/dataprepper/ContextManager.java
+++ b/data-prepper-main/src/main/java/org/opensearch/dataprepper/ContextManager.java
@@ -26,14 +26,6 @@ public class ContextManager {
 
     private final AnnotationConfigApplicationContext coreApplicationContext;
 
-    private static final String DATA_PREPPER_HOME = System.getProperty("user.dir");
-    private static final String PIPELINES_CONFIG = DATA_PREPPER_HOME + "/pipelines/pipelines.yaml";
-    private static final String DATA_PREPPER_CONFIG = DATA_PREPPER_HOME + "/config/data-prepper-config.yaml";
-
-    public ContextManager() {
-        this(PIPELINES_CONFIG, DATA_PREPPER_CONFIG);
-    }
-
     /**
      * @since 1.3
      * @param args Application command line arguments

--- a/data-prepper-main/src/main/java/org/opensearch/dataprepper/DataPrepperExecute.java
+++ b/data-prepper-main/src/main/java/org/opensearch/dataprepper/DataPrepperExecute.java
@@ -19,7 +19,7 @@ public class DataPrepperExecute {
     public static void main(final String ... args) {
         java.security.Security.setProperty("networkaddress.cache.ttl", "60");
 
-        final ContextManager contextManager = new ContextManager(args);
+        final ContextManager contextManager = new ContextManager();
         final DataPrepper dataPrepper = contextManager.getDataPrepperBean();
 
         LOG.trace("Starting Data Prepper execution");

--- a/data-prepper-main/src/main/java/org/opensearch/dataprepper/DataPrepperExecute.java
+++ b/data-prepper-main/src/main/java/org/opensearch/dataprepper/DataPrepperExecute.java
@@ -19,7 +19,14 @@ public class DataPrepperExecute {
     public static void main(final String ... args) {
         java.security.Security.setProperty("networkaddress.cache.ttl", "60");
 
-        final ContextManager contextManager = new ContextManager();
+        final String dataPrepperHome = System.getProperty("data-prepper.dir");
+        if (dataPrepperHome == null) {
+            throw new RuntimeException("Data Prepper home directory (data-prepper.dir) not set in system properties.");
+        }
+
+        final String dataPrepperPipelines = dataPrepperHome + "/pipelines/pipelines.yaml";
+        final String dataPrepperConfig = dataPrepperHome + "/config/data-prepper-config.yaml";
+        final ContextManager contextManager = new ContextManager(dataPrepperPipelines, dataPrepperConfig);
         final DataPrepper dataPrepper = contextManager.getDataPrepperBean();
 
         LOG.trace("Starting Data Prepper execution");

--- a/data-prepper-main/src/main/java/org/opensearch/dataprepper/DataPrepperExecute.java
+++ b/data-prepper-main/src/main/java/org/opensearch/dataprepper/DataPrepperExecute.java
@@ -9,6 +9,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.ComponentScan;
 
+import java.nio.file.Paths;
+
 /**
  * Execute entry into Data Prepper.
  */
@@ -24,8 +26,8 @@ public class DataPrepperExecute {
             throw new RuntimeException("Data Prepper home directory (data-prepper.dir) not set in system properties.");
         }
 
-        final String dataPrepperPipelines = dataPrepperHome + "/pipelines/pipelines.yaml";
-        final String dataPrepperConfig = dataPrepperHome + "/config/data-prepper-config.yaml";
+        final String dataPrepperPipelines = Paths.get(dataPrepperHome).resolve("pipelines/pipelines.yaml").toString();
+        final String dataPrepperConfig = Paths.get(dataPrepperHome).resolve("config/data-prepper-config.yaml").toString();
         final ContextManager contextManager = new ContextManager(dataPrepperPipelines, dataPrepperConfig);
         final DataPrepper dataPrepper = contextManager.getDataPrepperBean();
 

--- a/e2e-test/log/build.gradle
+++ b/e2e-test/log/build.gradle
@@ -39,11 +39,11 @@ task createDataPrepperDockerFile(type: Dockerfile) {
     dependsOn copyDataPrepperJar
     destFile = project.file('build/docker/Dockerfile')
     from(dataPrepperBaseImage)
-    workingDir("/app")
-    copyFile("${dataPrepperJarFilepath}", "/app/data-prepper")
-    copyFile("src/integrationTest/resources/${BASIC_GROK_PIPELINE_YAML}", "/app/${BASIC_GROK_PIPELINE_YAML}")
-    copyFile("src/integrationTest/resources/data_prepper.yml", "/app/data_prepper.yml")
-    defaultCommand('java', '-cp', 'data-prepper/*', 'org.opensearch.dataprepper.DataPrepperExecute', "/app/${BASIC_GROK_PIPELINE_YAML}", "/app/data_prepper.yml")
+    workingDir("/app/data-prepper")
+    copyFile("${dataPrepperJarFilepath}", "/app/data-prepper/lib")
+    copyFile("src/integrationTest/resources/${BASIC_GROK_PIPELINE_YAML}", "/app/data-prepper/pipelines/pipelines.yaml")
+    copyFile("src/integrationTest/resources/data_prepper.yml", "/app/data-prepper/config/data-prepper-config.yaml")
+    defaultCommand('java', '-Ddata-prepper.dir=/app/data-prepper', '-cp', '/app/data-prepper/lib/*', 'org.opensearch.dataprepper.DataPrepperExecute')
 }
 
 task buildDataPrepperDockerImage(type: DockerBuildImage) {
@@ -54,7 +54,7 @@ task buildDataPrepperDockerImage(type: DockerBuildImage) {
 }
 
 def createDataPrepperDockerContainer(final String taskBaseName, final String dataPrepperName, final int sourcePort,
-                                     final int serverPort, final String pipelineConfigYAML) {
+                                     final int serverPort) {
     return tasks.create("create${taskBaseName}", DockerCreateContainer) {
         dependsOn buildDataPrepperDockerImage
         dependsOn createDataPrepperNetwork
@@ -62,7 +62,7 @@ def createDataPrepperDockerContainer(final String taskBaseName, final String dat
         exposePorts("tcp", [2021, 4900])
         hostConfig.portBindings = [String.format('%d:2021', sourcePort), String.format('%d:4900', serverPort)]
         hostConfig.network = createDataPrepperNetwork.getNetworkName()
-        cmd = ['java', '-cp', 'data-prepper/*', 'org.opensearch.dataprepper.DataPrepperExecute', pipelineConfigYAML, "/app/data_prepper.yml"]
+        cmd = ['java', '-Ddata-prepper.dir=/app/data-prepper', '-cp', '/app/data-prepper/lib/*', 'org.opensearch.dataprepper.DataPrepperExecute']
         targetImageId buildDataPrepperDockerImage.getImageId()
     }
 }
@@ -129,7 +129,7 @@ task basicLogEndToEndTest(type: Test) {
     dependsOn build
     dependsOn startOpenSearchDockerContainer
     def createDataPrepperTask = createDataPrepperDockerContainer(
-            "basicLogDataPrepper", "dataprepper", 2021, 4900, "/app/${BASIC_GROK_PIPELINE_YAML}")
+            "basicLogDataPrepper", "dataprepper", 2021, 4900)
     def startDataPrepperTask = startDataPrepperDockerContainer(createDataPrepperTask as DockerCreateContainer)
     dependsOn startDataPrepperTask
     startDataPrepperTask.mustRunAfter 'startOpenSearchDockerContainer'

--- a/e2e-test/trace/build.gradle
+++ b/e2e-test/trace/build.gradle
@@ -46,14 +46,10 @@ task createDataPrepperDockerFile(type: Dockerfile) {
     from(dataPrepperBaseImage)
     exposePort(21890)
     exposePort(4900)
-    workingDir("/app")
-    copyFile("${dataPrepperJarFilepath}", "/app/data-prepper")
-    copyFile("src/integrationTest/resources/${RAW_SPAN_PIPELINE_YAML}", "/app/${RAW_SPAN_PIPELINE_YAML}")
-    copyFile("src/integrationTest/resources/${RAW_SPAN_PIPELINE_PEER_FORWARDER_YAML}", "/app/${RAW_SPAN_PIPELINE_PEER_FORWARDER_YAML}")
-    copyFile("src/integrationTest/resources/${RAW_SPAN_PIPELINE_LATEST_RELEASE_YAML}", "/app/${RAW_SPAN_PIPELINE_LATEST_RELEASE_YAML}")
-    copyFile("src/integrationTest/resources/${SERVICE_MAP_PIPELINE_YAML}", "/app/${SERVICE_MAP_PIPELINE_YAML}")
-    copyFile("src/integrationTest/resources/data_prepper.yml", "/app/data_prepper.yml")
-    defaultCommand('java', '-cp', 'data-prepper/*', 'org.opensearch.dataprepper.DataPrepperExecute', "/app/${RAW_SPAN_PIPELINE_YAML}", "/app/data_prepper.yml")
+    workingDir("/app/data-prepper")
+    copyFile("${dataPrepperJarFilepath}", "/app/data-prepper/lib")
+    copyFile("src/integrationTest/resources/data_prepper.yml", "/app/data-prepper/config/data-prepper-config.yaml")
+    defaultCommand('java', '-Ddata-prepper.dir=/app/data-prepper', '-cp', '/app/data-prepper/lib/*', 'org.opensearch.dataprepper.DataPrepperExecute')
 }
 
 task buildDataPrepperDockerImage(type: DockerBuildImage) {
@@ -71,7 +67,8 @@ def createDataPrepperDockerContainer(final String taskBaseName, final String dat
         containerName = dataPrepperName
         hostConfig.portBindings = [String.format('%d:21890', grpcPort), String.format('%d:4900', serverPort)]
         hostConfig.network = createDataPrepperNetwork.getNetworkName()
-        cmd = ['java', '-cp', 'data-prepper/*', 'org.opensearch.dataprepper.DataPrepperExecute', pipelineConfigYAML, "/app/data_prepper.yml"]
+        hostConfig.binds = [(project.file("src/integrationTest/resources/${pipelineConfigYAML}").toString()):"/app/data-prepper/pipelines/pipelines.yaml"]
+        cmd = ['java', '-Ddata-prepper.dir=/app/data-prepper', '-cp', '/app/data-prepper/lib/*', 'org.opensearch.dataprepper.DataPrepperExecute']
         targetImageId buildDataPrepperDockerImage.getImageId()
     }
 }
@@ -192,15 +189,15 @@ def createEndToEndTest(final String testName, final String includeTestsMatchPatt
 def includeRawSpanTestsMatchPattern = "org.opensearch.dataprepper.integration.trace.EndToEndRawSpanTest.testPipelineEndToEnd*"
 
 def createRawSpanDataPrepper1Task = createDataPrepperDockerContainer(
-        "rawSpanDataPrepper1", "dataprepper1", 21890, 4900, "/app/${RAW_SPAN_PIPELINE_YAML}")
+        "rawSpanDataPrepper1", "dataprepper1", 21890, 4900, "${RAW_SPAN_PIPELINE_YAML}")
 def createRawSpanDataPrepper2Task = createDataPrepperDockerContainer(
-        "rawSpanDataPrepper2", "dataprepper2", 21891, 4901, "/app/${RAW_SPAN_PIPELINE_YAML}")
+        "rawSpanDataPrepper2", "dataprepper2", 21891, 4901, "${RAW_SPAN_PIPELINE_YAML}")
 
 def rawSpanEndToEndTest = createEndToEndTest("rawSpanEndToEndTest", includeRawSpanTestsMatchPattern,
         createRawSpanDataPrepper1Task, createRawSpanDataPrepper2Task)
 
 def rawSpanDataPrepperEventFromBuild = createDataPrepperDockerContainer(
-        "rawSpanDataPrepperEventFromBuild", "dataprepper1", 21890, 4900, "/app/${RAW_SPAN_PIPELINE_PEER_FORWARDER_YAML}")
+        "rawSpanDataPrepperEventFromBuild", "dataprepper1", 21890, 4900, "${RAW_SPAN_PIPELINE_PEER_FORWARDER_YAML}")
 def rawSpanDataPrepperLatestFromPull = createDataPrepperDockerContainerFromPullImage(
         "rawSpanDataPrepperLatestFromPull", "dataprepper2", 21891, 4901, "src/integrationTest/resources/${RAW_SPAN_PIPELINE_LATEST_RELEASE_YAML}")
 
@@ -211,9 +208,9 @@ def rawSpanLatestReleaseCompatibilityEndToEndTest = createEndToEndTest("rawSpanL
 def includeServiceMapTestsMatchPattern = "org.opensearch.dataprepper.integration.trace.EndToEndServiceMapTest*"
 
 def createServiceMapDataPrepper1Task = createDataPrepperDockerContainer(
-        "serviceMapDataPrepper1", "dataprepper1", 21890, 4900, "/app/${SERVICE_MAP_PIPELINE_YAML}")
+        "serviceMapDataPrepper1", "dataprepper1", 21890, 4900, "${SERVICE_MAP_PIPELINE_YAML}")
 def createServiceMapDataPrepper2Task = createDataPrepperDockerContainer(
-        "serviceMapDataPrepper2", "dataprepper2", 21891, 4901, "/app/${SERVICE_MAP_PIPELINE_YAML}")
+        "serviceMapDataPrepper2", "dataprepper2", 21891, 4901, "${SERVICE_MAP_PIPELINE_YAML}")
 
 def serviceMapEndToEndTest = createEndToEndTest("serviceMapEndToEndTest", includeServiceMapTestsMatchPattern,
         createServiceMapDataPrepper1Task, createServiceMapDataPrepper2Task)

--- a/release/archives/build.gradle
+++ b/release/archives/build.gradle
@@ -140,10 +140,7 @@ CopySpec archiveToTar() {
         into('config') {
             from("${rootDir}/shared-config/log4j2-rolling.properties")
             from("${rootDir}/examples/config/example-data-prepper-config.yaml")
-                    .rename("example-data-prepper-config.yaml", "data-prepper-config.yaml")
-        }
-        into('pipelines') {
-            from("${rootDir}/examples/config/example-pipelines.yaml").rename("example-pipelines.yaml", "pipelines.yaml")
+            from("${rootDir}/examples/config/example-pipelines.yaml")
         }
         into('') {
             from("${rootDir}/LICENSE")

--- a/release/archives/build.gradle
+++ b/release/archives/build.gradle
@@ -140,7 +140,10 @@ CopySpec archiveToTar() {
         into('config') {
             from("${rootDir}/shared-config/log4j2-rolling.properties")
             from("${rootDir}/examples/config/example-data-prepper-config.yaml")
-            from("${rootDir}/examples/config/example-pipelines.yaml")
+                    .rename("example-data-prepper-config.yaml", "data-prepper-config.yaml")
+        }
+        into('pipelines') {
+            from("${rootDir}/examples/config/example-pipelines.yaml").rename("example-pipelines.yaml", "pipelines.yaml")
         }
         into('') {
             from("${rootDir}/LICENSE")

--- a/release/archives/linux/data-prepper-jdk-x64.sh
+++ b/release/archives/linux/data-prepper-jdk-x64.sh
@@ -4,17 +4,14 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-if [[ $# -ne 2 ]]
+if [[ $# -ne 0 ]]
   then
     echo
-    echo "Error: Paths to pipeline and data-prepper configuration files are required. Example:"
-    echo "./bin/data-prepper config/example-pipelines.yaml config/example-data-prepper-config.yaml"
+    echo "Invalid number of arguments. Expected 0, received $#"
     echo
     exit 1
 fi
 
-PIPELINES_FILE_LOCATION=$1
-CONFIG_FILE_LOCATION=$2
 DATA_PREPPER_BIN=$(dirname "$(realpath "$0")")
 DATA_PREPPER_HOME=`realpath "$DATA_PREPPER_BIN/.."`
 DATA_PREPPER_CLASSPATH="$DATA_PREPPER_HOME/lib/*"
@@ -25,4 +22,4 @@ echo "JAVA_HOME is set to $JAVA_HOME"
 export PATH=$JAVA_HOME/bin:$PATH
 
 DATA_PREPPER_JAVA_OPTS="-Dlog4j.configurationFile=$DATA_PREPPER_HOME/config/log4j2-rolling.properties"
-java $JAVA_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute $PIPELINES_FILE_LOCATION $CONFIG_FILE_LOCATION
+java $JAVA_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute

--- a/release/archives/linux/data-prepper-jdk-x64.sh
+++ b/release/archives/linux/data-prepper-jdk-x64.sh
@@ -4,30 +4,21 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-
-MIN_REQ_JAVA_VERSION=1.8
-MIN_REQ_OPENJDK_VERSION=8
-DATA_PREPPER_BIN=$(dirname "$(realpath "$0")")
-DATA_PREPPER_HOME=`realpath "$DATA_PREPPER_BIN/.."`
-DATA_PREPPER_CLASSPATH="$DATA_PREPPER_HOME/lib/*"
-OPENJDK=$(ls -1 $DATA_PREPPER_HOME/openjdk/ 2>/dev/null)
-
-if [[ $# == 2 ]]; then
-  PIPELINES_FILE_LOCATION=$1
-  CONFIG_FILE_LOCATION=$2
-elif [[ $# == 0 ]]; then
-  PIPELINES_FILE_LOCATION="$DATA_PREPPER_HOME/pipelines/pipelines.yaml"
-  CONFIG_FILE_LOCATION="$DATA_PREPPER_HOME/config/data-prepper-config.yaml"
-  echo "Reading pipelines and data-prepper configuration files from Data Prepper home directory."
-else
+if [[ $# -ne 2 ]]
+  then
     echo
-    echo "Error: Invalid number of arguments. Expected 0 or 2, received $#."
-    echo "Use configuration files from Data Prepper home directory and specify no arguments,"
-    echo "or specify both paths to pipeline and data-prepper configuration files, for example:"
+    echo "Error: Paths to pipeline and data-prepper configuration files are required. Example:"
     echo "./bin/data-prepper config/example-pipelines.yaml config/example-data-prepper-config.yaml"
     echo
     exit 1
 fi
+
+PIPELINES_FILE_LOCATION=$1
+CONFIG_FILE_LOCATION=$2
+DATA_PREPPER_BIN=$(dirname "$(realpath "$0")")
+DATA_PREPPER_HOME=`realpath "$DATA_PREPPER_BIN/.."`
+DATA_PREPPER_CLASSPATH="$DATA_PREPPER_HOME/lib/*"
+OPENJDK=$(ls -1 $DATA_PREPPER_HOME/openjdk/ 2>/dev/null)
 
 export JAVA_HOME=$DATA_PREPPER_HOME/openjdk/$OPENJDK
 echo "JAVA_HOME is set to $JAVA_HOME"

--- a/release/archives/linux/data-prepper-jdk-x64.sh
+++ b/release/archives/linux/data-prepper-jdk-x64.sh
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-MIN_REQ_JAVA_VERSION=1.8
-MIN_REQ_OPENJDK_VERSION=8
 DATA_PREPPER_BIN=$(dirname "$(realpath "$0")")
 DATA_PREPPER_HOME=`realpath "$DATA_PREPPER_BIN/.."`
 DATA_PREPPER_CLASSPATH="$DATA_PREPPER_HOME/lib/*"

--- a/release/archives/linux/data-prepper-jdk-x64.sh
+++ b/release/archives/linux/data-prepper-jdk-x64.sh
@@ -15,4 +15,4 @@ echo "JAVA_HOME is set to $JAVA_HOME"
 export PATH=$JAVA_HOME/bin:$PATH
 
 DATA_PREPPER_JAVA_OPTS="-Dlog4j.configurationFile=$DATA_PREPPER_HOME/config/log4j2-rolling.properties"
-java $JAVA_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute
+java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute

--- a/release/archives/linux/data-prepper-jdk-x64.sh
+++ b/release/archives/linux/data-prepper-jdk-x64.sh
@@ -4,13 +4,6 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-if [[ $# -ne 0 ]]
-  then
-    echo
-    echo "Invalid number of arguments. Expected 0, received $#"
-    echo
-    exit 1
-fi
 
 DATA_PREPPER_BIN=$(dirname "$(realpath "$0")")
 DATA_PREPPER_HOME=`realpath "$DATA_PREPPER_BIN/.."`

--- a/release/archives/linux/data-prepper-jdk-x64.sh
+++ b/release/archives/linux/data-prepper-jdk-x64.sh
@@ -14,5 +14,6 @@ export JAVA_HOME=$DATA_PREPPER_HOME/openjdk/$OPENJDK
 echo "JAVA_HOME is set to $JAVA_HOME"
 export PATH=$JAVA_HOME/bin:$PATH
 
+DATA_PREPPER_HOME_OPTS="-Ddata-prepper.dir=$DATA_PREPPER_HOME"
 DATA_PREPPER_JAVA_OPTS="-Dlog4j.configurationFile=$DATA_PREPPER_HOME/config/log4j2-rolling.properties"
 java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute

--- a/release/archives/linux/data-prepper-jdk-x64.sh
+++ b/release/archives/linux/data-prepper-jdk-x64.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+MIN_REQ_JAVA_VERSION=1.8
+MIN_REQ_OPENJDK_VERSION=8
 DATA_PREPPER_BIN=$(dirname "$(realpath "$0")")
 DATA_PREPPER_HOME=`realpath "$DATA_PREPPER_BIN/.."`
 DATA_PREPPER_CLASSPATH="$DATA_PREPPER_HOME/lib/*"

--- a/release/archives/linux/data-prepper-jdk-x64.sh
+++ b/release/archives/linux/data-prepper-jdk-x64.sh
@@ -4,21 +4,30 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-if [[ $# -ne 2 ]]
-  then
-    echo
-    echo "Error: Paths to pipeline and data-prepper configuration files are required. Example:"
-    echo "./bin/data-prepper config/example-pipelines.yaml config/example-data-prepper-config.yaml"
-    echo
-    exit 1
-fi
 
-PIPELINES_FILE_LOCATION=$1
-CONFIG_FILE_LOCATION=$2
+MIN_REQ_JAVA_VERSION=1.8
+MIN_REQ_OPENJDK_VERSION=8
 DATA_PREPPER_BIN=$(dirname "$(realpath "$0")")
 DATA_PREPPER_HOME=`realpath "$DATA_PREPPER_BIN/.."`
 DATA_PREPPER_CLASSPATH="$DATA_PREPPER_HOME/lib/*"
 OPENJDK=$(ls -1 $DATA_PREPPER_HOME/openjdk/ 2>/dev/null)
+
+if [[ $# == 2 ]]; then
+  PIPELINES_FILE_LOCATION=$1
+  CONFIG_FILE_LOCATION=$2
+elif [[ $# == 0 ]]; then
+  PIPELINES_FILE_LOCATION="$DATA_PREPPER_HOME/pipelines/pipelines.yaml"
+  CONFIG_FILE_LOCATION="$DATA_PREPPER_HOME/config/data-prepper-config.yaml"
+  echo "Reading pipelines and data-prepper configuration files from Data Prepper home directory."
+else
+    echo
+    echo "Error: Invalid number of arguments. Expected 0 or 2, received $#."
+    echo "Use configuration files from Data Prepper home directory and specify no arguments,"
+    echo "or specify both paths to pipeline and data-prepper configuration files, for example:"
+    echo "./bin/data-prepper config/example-pipelines.yaml config/example-data-prepper-config.yaml"
+    echo
+    exit 1
+fi
 
 export JAVA_HOME=$DATA_PREPPER_HOME/openjdk/$OPENJDK
 echo "JAVA_HOME is set to $JAVA_HOME"

--- a/release/archives/linux/data-prepper-x64.sh
+++ b/release/archives/linux/data-prepper-x64.sh
@@ -4,13 +4,6 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-if [[ $# -ne 0 ]]
-  then
-    echo
-    echo "Invalid number of arguments. Expected 0, received $#"
-    echo
-    exit 1
-fi
 
 MIN_REQ_JAVA_VERSION=11
 MIN_REQ_OPENJDK_VERSION=11

--- a/release/archives/linux/data-prepper-x64.sh
+++ b/release/archives/linux/data-prepper-x64.sh
@@ -42,5 +42,6 @@ then
     fi
 fi
 
+DATA_PREPPER_HOME_OPTS="-Ddata-prepper.dir=$DATA_PREPPER_HOME"
 DATA_PREPPER_JAVA_OPTS="-Dlog4j.configurationFile=$DATA_PREPPER_HOME/config/log4j2-rolling.properties"
-java $JAVA_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute
+java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute

--- a/release/archives/linux/data-prepper-x64.sh
+++ b/release/archives/linux/data-prepper-x64.sh
@@ -4,22 +4,29 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-if [[ $# -ne 2 ]]
-  then
-    echo
-    echo "Error: Paths to pipeline and data-prepper configuration files are required. Example:"
-    echo "./bin/data-prepper config/example-pipelines.yaml config/example-data-prepper-config.yaml"
-    echo
-    exit 1
-fi
 
-PIPELINES_FILE_LOCATION=$1
-CONFIG_FILE_LOCATION=$2
 MIN_REQ_JAVA_VERSION=11
 MIN_REQ_OPENJDK_VERSION=11
 DATA_PREPPER_BIN=$(dirname "$(realpath "$0")")
 DATA_PREPPER_HOME=`realpath "$DATA_PREPPER_BIN/.."`
 DATA_PREPPER_CLASSPATH="$DATA_PREPPER_HOME/lib/*"
+
+if [[ $# == 2 ]]; then
+  PIPELINES_FILE_LOCATION=$1
+  CONFIG_FILE_LOCATION=$2
+elif [[ $# == 0 ]]; then
+  PIPELINES_FILE_LOCATION="$DATA_PREPPER_HOME/pipelines/pipelines.yaml"
+  CONFIG_FILE_LOCATION="$DATA_PREPPER_HOME/config/data-prepper-config.yaml"
+  echo "Reading pipelines and data-prepper configuration files from Data Prepper home directory."
+else
+    echo
+    echo "Error: Invalid number of arguments. Expected 0 or 2, received $#."
+    echo "Use configuration files from Data Prepper home directory and specify no arguments,"
+    echo "or specify both paths to pipeline and data-prepper configuration files, for example:"
+    echo "./bin/data-prepper config/example-pipelines.yaml config/example-data-prepper-config.yaml"
+    echo
+    exit 1
+fi
 
 #check if java is installed
 if type -p java; then

--- a/release/archives/linux/data-prepper-x64.sh
+++ b/release/archives/linux/data-prepper-x64.sh
@@ -4,29 +4,22 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
+if [[ $# -ne 2 ]]
+  then
+    echo
+    echo "Error: Paths to pipeline and data-prepper configuration files are required. Example:"
+    echo "./bin/data-prepper config/example-pipelines.yaml config/example-data-prepper-config.yaml"
+    echo
+    exit 1
+fi
 
+PIPELINES_FILE_LOCATION=$1
+CONFIG_FILE_LOCATION=$2
 MIN_REQ_JAVA_VERSION=11
 MIN_REQ_OPENJDK_VERSION=11
 DATA_PREPPER_BIN=$(dirname "$(realpath "$0")")
 DATA_PREPPER_HOME=`realpath "$DATA_PREPPER_BIN/.."`
 DATA_PREPPER_CLASSPATH="$DATA_PREPPER_HOME/lib/*"
-
-if [[ $# == 2 ]]; then
-  PIPELINES_FILE_LOCATION=$1
-  CONFIG_FILE_LOCATION=$2
-elif [[ $# == 0 ]]; then
-  PIPELINES_FILE_LOCATION="$DATA_PREPPER_HOME/pipelines/pipelines.yaml"
-  CONFIG_FILE_LOCATION="$DATA_PREPPER_HOME/config/data-prepper-config.yaml"
-  echo "Reading pipelines and data-prepper configuration files from Data Prepper home directory."
-else
-    echo
-    echo "Error: Invalid number of arguments. Expected 0 or 2, received $#."
-    echo "Use configuration files from Data Prepper home directory and specify no arguments,"
-    echo "or specify both paths to pipeline and data-prepper configuration files, for example:"
-    echo "./bin/data-prepper config/example-pipelines.yaml config/example-data-prepper-config.yaml"
-    echo
-    exit 1
-fi
 
 #check if java is installed
 if type -p java; then

--- a/release/archives/linux/data-prepper-x64.sh
+++ b/release/archives/linux/data-prepper-x64.sh
@@ -4,17 +4,14 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-if [[ $# -ne 2 ]]
+if [[ $# -ne 0 ]]
   then
     echo
-    echo "Error: Paths to pipeline and data-prepper configuration files are required. Example:"
-    echo "./bin/data-prepper config/example-pipelines.yaml config/example-data-prepper-config.yaml"
+    echo "Invalid number of arguments. Expected 0, received $#"
     echo
     exit 1
 fi
 
-PIPELINES_FILE_LOCATION=$1
-CONFIG_FILE_LOCATION=$2
 MIN_REQ_JAVA_VERSION=11
 MIN_REQ_OPENJDK_VERSION=11
 DATA_PREPPER_BIN=$(dirname "$(realpath "$0")")
@@ -53,4 +50,4 @@ then
 fi
 
 DATA_PREPPER_JAVA_OPTS="-Dlog4j.configurationFile=$DATA_PREPPER_HOME/config/log4j2-rolling.properties"
-java $JAVA_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute $PIPELINES_FILE_LOCATION $CONFIG_FILE_LOCATION
+java $JAVA_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute


### PR DESCRIPTION
### Description
This change adds the support to load configurations files from home directory, so one can run data prepper without additional arguments after those files are put in place.

The previous method of specifying paths to both pipeline and server config files as command line arguments is no longer supported.
 
### Issues Resolved
Resolves #1728, also contributes to #1736
 
### Local Testing
This PR can be tested by building the archives first:
```shell
./gradlew clean :release:archives:buildArchives -Prelease
```
Then go to `release/archives/linux/build/distributions` directory, you can see the tarball files built, one with jdk, the other without. 

Extract one of them, e.g., the one without jdk assuming jdk is installed locally already, and go to the extracted directory and run data prepper:
```shell
bin/data-prepper
```

It will load `data-prepper-config.yaml` from `config/` and `pipelines.yaml` from `pipelines/`. The example pipelines.yaml contains some placeholders that may not work out of the box; you can try your own pipeline config that works locally for this testing.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
