### PR TITLE
Added server proxy for Peer Forwarder Server

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
@@ -12,7 +12,7 @@ import org.opensearch.dataprepper.peerforwarder.certificate.CertificateProviderF
 import org.opensearch.dataprepper.peerforwarder.client.PeerForwarderClient;
 import org.opensearch.dataprepper.peerforwarder.server.PeerForwarderHttpServerProvider;
 import org.opensearch.dataprepper.peerforwarder.server.PeerForwarderHttpService;
-import org.opensearch.dataprepper.peerforwarder.server.PeerForwarderServer;
+import org.opensearch.dataprepper.peerforwarder.server.PeerForwarderServerProxy;
 import org.opensearch.dataprepper.peerforwarder.server.ResponseHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -96,10 +96,10 @@ public class PeerForwarderAppConfig {
     }
 
     @Bean
-    public PeerForwarderServer peerForwarderServer(
+    public PeerForwarderServerProxy peerForwarderServerProxy(
             @Qualifier("peerForwarderServer") final Server peerForwarderServer,
             final PeerForwarderConfiguration peerForwarderConfiguration) {
-        return new PeerForwarderServer(peerForwarderConfiguration, peerForwarderServer);
+        return new PeerForwarderServerProxy(peerForwarderConfiguration, peerForwarderServer);
     }
 
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
@@ -12,6 +12,7 @@ import org.opensearch.dataprepper.peerforwarder.certificate.CertificateProviderF
 import org.opensearch.dataprepper.peerforwarder.client.PeerForwarderClient;
 import org.opensearch.dataprepper.peerforwarder.server.PeerForwarderHttpServerProvider;
 import org.opensearch.dataprepper.peerforwarder.server.PeerForwarderHttpService;
+import org.opensearch.dataprepper.peerforwarder.server.PeerForwarderServer;
 import org.opensearch.dataprepper.peerforwarder.server.PeerForwarderServerProxy;
 import org.opensearch.dataprepper.peerforwarder.server.ResponseHandler;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,7 +89,7 @@ public class PeerForwarderAppConfig {
                 certificateProviderFactory, peerForwarderHttpService);
     }
 
-    @Bean(name="peerForwarderServer")
+    @Bean(name="peerForwarderHttpServer")
     public Server server(
             final PeerForwarderHttpServerProvider peerForwarderHttpServerProvider
     ) {
@@ -96,8 +97,8 @@ public class PeerForwarderAppConfig {
     }
 
     @Bean
-    public PeerForwarderServerProxy peerForwarderServerProxy(
-            @Qualifier("peerForwarderServer") final Server peerForwarderServer,
+    public PeerForwarderServer peerForwarderServer(
+            @Qualifier("peerForwarderHttpServer") final Server peerForwarderServer,
             final PeerForwarderConfiguration peerForwarderConfiguration) {
         return new PeerForwarderServerProxy(peerForwarderConfiguration, peerForwarderServer);
     }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/NoOpPeerForwarderServer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/NoOpPeerForwarderServer.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.peerforwarder.server;
+
+public class NoOpPeerForwarderServer implements PeerForwarderServer {
+
+    @Override
+    public void start() {
+        // no need to start the server as no peers are configured
+    }
+
+    @Override
+    public void stop() {
+        // server never starts if no peers are configured
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/NoOpPeerForwarderServer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/NoOpPeerForwarderServer.java
@@ -5,6 +5,11 @@
 
 package org.opensearch.dataprepper.peerforwarder.server;
 
+/**
+ * Class to handle NoOp Peer Forwarder server if no peers are configured
+ *
+ * @since 2.0
+ */
 public class NoOpPeerForwarderServer implements PeerForwarderServer {
 
     @Override

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServer.java
@@ -5,67 +5,21 @@
 
 package org.opensearch.dataprepper.peerforwarder.server;
 
-import com.linecorp.armeria.server.Server;
-import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.ExecutionException;
-
 /**
- * Class to handle Peer Forwarder server
+ * Interface to start and stop Peer Forwarder server
  *
  * @since 2.0
  */
-public class PeerForwarderServer {
-    private static final Logger LOG = LoggerFactory.getLogger(PeerForwarderServer.class);
-
-    private final PeerForwarderConfiguration peerForwarderConfiguration;
-    private final Server sever;
-
-    public PeerForwarderServer(final PeerForwarderConfiguration peerForwarderConfiguration, final Server server) {
-        this.peerForwarderConfiguration = peerForwarderConfiguration;
-        this.sever = server;
-    }
-
+public interface PeerForwarderServer {
     /**
      * Start the PeerForwarderServer
+     * @since 2.0
      */
-    public void start() {
-        try {
-            sever.start().get();
-        } catch (ExecutionException ex) {
-            if (ex.getCause() instanceof RuntimeException) {
-                throw (RuntimeException) ex.getCause();
-            } else {
-                throw new RuntimeException(ex);
-            }
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(ex);
-        }
-        LOG.info("Peer Forwarder server started on port: {}", peerForwarderConfiguration.getServerPort());
-    }
+    void start();
 
     /**
      * Stop the PeerForwarderServer
+     * @since 2.0
      */
-    public void stop() {
-        if (sever != null) {
-            try {
-                sever.stop().get();
-            } catch (ExecutionException ex) {
-                if (ex.getCause() instanceof RuntimeException) {
-                    throw (RuntimeException) ex.getCause();
-                } else {
-                    throw new RuntimeException(ex);
-                }
-            } catch (InterruptedException ex) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(ex);
-            }
-        }
-        LOG.info("Peer Forwarder Server stopped.");
-    }
-
+    void stop();
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxy.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxy.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.peerforwarder.server;
+
+import com.linecorp.armeria.server.Server;
+import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
+
+public class PeerForwarderServerProxy implements PeerForwarderServer {
+    private final PeerForwarderServer peerForwarderServer;
+
+    public PeerForwarderServerProxy(final PeerForwarderConfiguration peerForwarderConfiguration, final Server server) {
+
+        // update this conditional based on PeerForwarderProvider
+        if (true) {
+            peerForwarderServer = new RemotePeerForwarderServer(peerForwarderConfiguration, server);
+        }
+        else {
+            peerForwarderServer = new NoOpPeerForwarderServer();
+        }
+    }
+
+    @Override
+    public void start() {
+        peerForwarderServer.start();
+    }
+
+    @Override
+    public void stop() {
+        peerForwarderServer.stop();
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxy.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxy.java
@@ -21,7 +21,7 @@ public class PeerForwarderServerProxy implements PeerForwarderServer {
 
     @Override
     public void start() {
-        // update this conditional based on PeerForwarderProvider
+        // TODO: update this conditional based on PeerForwarderProvider
         if (true) {
             peerForwarderServer = new RemotePeerForwarderServer(peerForwarderConfiguration, server);
         }
@@ -33,6 +33,8 @@ public class PeerForwarderServerProxy implements PeerForwarderServer {
 
     @Override
     public void stop() {
-        peerForwarderServer.stop();
+        if (peerForwarderServer != null) {
+            peerForwarderServer.stop();
+        }
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxy.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxy.java
@@ -9,10 +9,18 @@ import com.linecorp.armeria.server.Server;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
 
 public class PeerForwarderServerProxy implements PeerForwarderServer {
-    private final PeerForwarderServer peerForwarderServer;
+    private final PeerForwarderConfiguration peerForwarderConfiguration;
+    private final Server server;
+
+    private PeerForwarderServer peerForwarderServer;
 
     public PeerForwarderServerProxy(final PeerForwarderConfiguration peerForwarderConfiguration, final Server server) {
+        this.peerForwarderConfiguration = peerForwarderConfiguration;
+        this.server = server;
+    }
 
+    @Override
+    public void start() {
         // update this conditional based on PeerForwarderProvider
         if (true) {
             peerForwarderServer = new RemotePeerForwarderServer(peerForwarderConfiguration, server);
@@ -20,10 +28,6 @@ public class PeerForwarderServerProxy implements PeerForwarderServer {
         else {
             peerForwarderServer = new NoOpPeerForwarderServer();
         }
-    }
-
-    @Override
-    public void start() {
         peerForwarderServer.start();
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/RemotePeerForwarderServer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/RemotePeerForwarderServer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.peerforwarder.server;
+
+import com.linecorp.armeria.server.Server;
+import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Class to handle remote Peer Forwarder server
+ *
+ * @since 2.0
+ */
+public class RemotePeerForwarderServer implements PeerForwarderServer {
+    private static final Logger LOG = LoggerFactory.getLogger(RemotePeerForwarderServer.class);
+
+    private final PeerForwarderConfiguration peerForwarderConfiguration;
+    private final Server sever;
+
+    public RemotePeerForwarderServer(final PeerForwarderConfiguration peerForwarderConfiguration, final Server server) {
+        this.peerForwarderConfiguration = peerForwarderConfiguration;
+        this.sever = server;
+    }
+
+    @Override
+    public void start() {
+        try {
+            sever.start().get();
+        } catch (ExecutionException ex) {
+            if (ex.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) ex.getCause();
+            } else {
+                throw new RuntimeException(ex);
+            }
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(ex);
+        }
+        LOG.info("Peer Forwarder server started on port: {}", peerForwarderConfiguration.getServerPort());
+    }
+
+    @Override
+    public void stop() {
+        if (sever != null) {
+            try {
+                sever.stop().get();
+            } catch (ExecutionException ex) {
+                if (ex.getCause() instanceof RuntimeException) {
+                    throw (RuntimeException) ex.getCause();
+                } else {
+                    throw new RuntimeException(ex);
+                }
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(ex);
+            }
+        }
+        LOG.info("Peer Forwarder Server stopped.");
+    }
+
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/RemotePeerForwarderServer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/RemotePeerForwarderServer.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.ExecutionException;
 
 /**
- * Class to handle remote Peer Forwarder server
+ * Class to handle remote Peer Forwarder server if peers are configured
  *
  * @since 2.0
  */

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/NoOpPeerForwarderServerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/NoOpPeerForwarderServerTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.peerforwarder.server;
+
+import org.junit.jupiter.api.Test;
+
+class NoOpPeerForwarderServerTest {
+
+    private NoOpPeerForwarderServer createObjectUnderTest() {
+        return new NoOpPeerForwarderServer();
+    }
+
+    @Test
+    void test_start() {
+        final NoOpPeerForwarderServer objectUnderTest = createObjectUnderTest();
+        objectUnderTest.start();
+    }
+
+    @Test
+    void test_stop() {
+        final NoOpPeerForwarderServer objectUnderTest = createObjectUnderTest();
+        objectUnderTest.stop();
+    }
+
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxyTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxyTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,11 +47,20 @@ class PeerForwarderServerProxyTest {
     }
 
     @Test
-    void stop_should_stop_server_if_peers_configured() throws ExecutionException, InterruptedException {
+    void stop_should_not_stop_server_if_server_is_not_started() throws ExecutionException, InterruptedException {
+        final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();
+        objectUnderTest.stop();
+        verifyNoInteractions(server);
+    }
+
+    @Test
+    void stop_should_stop_server_if_server_started() throws ExecutionException, InterruptedException {
+        when(server.start()).thenReturn(completableFuture);
         when(server.stop()).thenReturn(completableFuture);
         when(completableFuture.get()).thenReturn(mock(Void.class));
 
         final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();
+        objectUnderTest.start();
         objectUnderTest.stop();
         verify(server).stop();
     }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxyTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxyTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.peerforwarder.server;
+
+import com.linecorp.armeria.server.Server;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PeerForwarderServerProxyTest {
+
+    @Mock
+    Server server;
+
+    @Mock
+    PeerForwarderConfiguration peerForwarderConfiguration;
+
+    @Mock
+    CompletableFuture<Void> completableFuture;
+
+    PeerForwarderServerProxy createObjectUnderTest() {
+        return new PeerForwarderServerProxy(peerForwarderConfiguration, server);
+    }
+
+    @Test
+    void start_should_start_server_if_peers_configured() throws ExecutionException, InterruptedException {
+        when(server.start()).thenReturn(completableFuture);
+        when(completableFuture.get()).thenReturn(mock(Void.class));
+
+        final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();
+        objectUnderTest.start();
+        verify(server).start();
+    }
+
+    @Test
+    void stop_should_stop_server_if_peers_configured() throws ExecutionException, InterruptedException {
+        when(server.stop()).thenReturn(completableFuture);
+        when(completableFuture.get()).thenReturn(mock(Void.class));
+
+        final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();
+        objectUnderTest.stop();
+        verify(server).stop();
+    }
+
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/RemotePeerForwarderServerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/RemotePeerForwarderServerTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class PeerForwarderServerTest {
+class RemotePeerForwarderServerTest {
 
     @Mock
     Server server;
@@ -32,16 +32,16 @@ class PeerForwarderServerTest {
     @Mock
     CompletableFuture<Void> completableFuture;
 
-    private PeerForwarderServer createObjectUnderTest() {
-        return new PeerForwarderServer(peerForwarderConfiguration, server);
+    private RemotePeerForwarderServer createObjectUnderTest() {
+        return new RemotePeerForwarderServer(peerForwarderConfiguration, server);
     }
 
     @Test
     void start_should_invoke_server_start() throws ExecutionException, InterruptedException {
         when(server.start()).thenReturn(completableFuture);
         when(completableFuture.get()).thenReturn(mock(Void.class));
-        final PeerForwarderServer peerForwarderServer = createObjectUnderTest();
-        peerForwarderServer.start();
+        final RemotePeerForwarderServer remotePeerForwarderServer = createObjectUnderTest();
+        remotePeerForwarderServer.start();
 
         verify(server).start();
     }
@@ -50,26 +50,26 @@ class PeerForwarderServerTest {
     void start_should_throw_if_future_completed_exceptionally() throws ExecutionException, InterruptedException {
         when(server.start()).thenReturn(completableFuture);
         when(completableFuture.get()).thenThrow(ExecutionException.class);
-        final PeerForwarderServer peerForwarderServer = createObjectUnderTest();
+        final RemotePeerForwarderServer remotePeerForwarderServer = createObjectUnderTest();
 
-        assertThrows(RuntimeException.class, peerForwarderServer::start);
+        assertThrows(RuntimeException.class, remotePeerForwarderServer::start);
     }
 
     @Test
     void start_should_throw_if_current_thread_is_interrupted() throws ExecutionException, InterruptedException {
         when(server.start()).thenReturn(completableFuture);
         when(completableFuture.get()).thenThrow(InterruptedException.class);
-        final PeerForwarderServer peerForwarderServer = createObjectUnderTest();
+        final RemotePeerForwarderServer remotePeerForwarderServer = createObjectUnderTest();
 
-        assertThrows(RuntimeException.class, peerForwarderServer::start);
+        assertThrows(RuntimeException.class, remotePeerForwarderServer::start);
     }
 
     @Test
     void stop_should_invoke_server_stop() throws ExecutionException, InterruptedException {
         when(server.stop()).thenReturn(completableFuture);
         when(completableFuture.get()).thenReturn(mock(Void.class));
-        final PeerForwarderServer peerForwarderServer = createObjectUnderTest();
-        peerForwarderServer.stop();
+        final RemotePeerForwarderServer remotePeerForwarderServer = createObjectUnderTest();
+        remotePeerForwarderServer.stop();
 
         verify(server).stop();
     }
@@ -78,17 +78,17 @@ class PeerForwarderServerTest {
     void stop_should_throw_if_future_completed_exceptionally() throws ExecutionException, InterruptedException {
         when(server.stop()).thenReturn(completableFuture);
         when(completableFuture.get()).thenThrow(ExecutionException.class);
-        final PeerForwarderServer peerForwarderServer = createObjectUnderTest();
+        final RemotePeerForwarderServer remotePeerForwarderServer = createObjectUnderTest();
 
-        assertThrows(RuntimeException.class, peerForwarderServer::stop);
+        assertThrows(RuntimeException.class, remotePeerForwarderServer::stop);
     }
 
     @Test
     void stop_should_throw_if_current_thread_is_interrupted() throws ExecutionException, InterruptedException {
         when(server.stop()).thenReturn(completableFuture);
         when(completableFuture.get()).thenThrow(InterruptedException.class);
-        final PeerForwarderServer peerForwarderServer = createObjectUnderTest();
+        final RemotePeerForwarderServer remotePeerForwarderServer = createObjectUnderTest();
 
-        assertThrows(RuntimeException.class, peerForwarderServer::stop);
+        assertThrows(RuntimeException.class, remotePeerForwarderServer::stop);
     }
 }


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
This PR adds a `PeerForwarderServerProxy` which determines whether to use `RemotePeerForwarderServer` or `NoOpPeerForwarderServer`. 
- `RemotePeerForwarderServer` will be started if peers are configured
- `NoOpPeerForwarderServer` doesn't use any server as no peers are configured

 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
