### PR TITLE
Added Local peer forwarder and updated http servoce class to write to…

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
@@ -106,9 +106,6 @@ public class PipelineParser {
 
             LOG.info("Building processors for the pipeline [{}]", pipelineName);
             final int processorThreads = pipelineConfiguration.getWorkers();
-            final List<List<Processor>> processorSets = pipelineConfiguration.getProcessorPluginSettings().stream()
-                    .map(this::newProcessor)
-                    .collect(Collectors.toList());
 
             final Map<List<Processor>, String> processorMap = pipelineConfiguration.getProcessorPluginSettings().stream()
                     .collect(Collectors.toMap(this::newProcessor, PluginSetting::getName));
@@ -117,8 +114,6 @@ public class PipelineParser {
                     .map(processorMapEntry -> processorMapEntry.getKey().stream()
                             .map(processor -> {
                                 if (processor instanceof RequiresPeerForwarding) {
-                                    // TODO: Create buffer per stateful processor and store map of processor, buffer
-                                    // TODO: get plugin id from PipelineParser
                                     return new PeerForwardingProcessorDecorator(
                                             processor, peerForwarderProvider, pipelineName, processorMapEntry.getValue()
                                     );

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
@@ -107,21 +107,23 @@ public class PipelineParser {
             LOG.info("Building processors for the pipeline [{}]", pipelineName);
             final int processorThreads = pipelineConfiguration.getWorkers();
 
-            final Map<List<Processor>, String> processorMap = pipelineConfiguration.getProcessorPluginSettings().stream()
-                    .collect(Collectors.toMap(this::newProcessor, PluginSetting::getName));
+            final List<List<IdentifiedComponent<Processor>>> processorSets = pipelineConfiguration.getProcessorPluginSettings().stream()
+                    .map(this::newProcessor)
+                    .collect(Collectors.toList());
 
-            final List<List<Processor>> decoratedProcessorSets = processorMap.entrySet().stream()
-                    .map(processorMapEntry -> processorMapEntry.getKey().stream()
-                            .map(processor -> {
-                                if (processor instanceof RequiresPeerForwarding) {
+            final List<List<Processor>> decoratedProcessorSets = processorSets.stream()
+                    .map(processorComponentList -> processorComponentList.stream()
+                            .map(processorComponent -> {
+                                if (processorComponent.getComponent() instanceof RequiresPeerForwarding) {
                                     return new PeerForwardingProcessorDecorator(
-                                            processor, peerForwarderProvider, pipelineName, processorMapEntry.getValue()
+                                            processorComponent.getComponent(), peerForwarderProvider, pipelineName, processorComponent.getName()
                                     );
                                 }
-                                return processor;
+                                return processorComponent.getComponent();
                             })
                             .collect(Collectors.toList())
-                    ).collect(Collectors.toList());
+                        ).collect(Collectors.toList());
+
 
             final int readBatchDelay = pipelineConfiguration.getReadBatchDelay();
 
@@ -141,13 +143,17 @@ public class PipelineParser {
 
     }
 
-    private List<Processor> newProcessor(final PluginSetting pluginSetting) {
-        return pluginFactory.loadPlugins(
+    private List<IdentifiedComponent<Processor>> newProcessor(final PluginSetting pluginSetting) {
+        final List<Processor> processors = pluginFactory.loadPlugins(
                 Processor.class,
                 pluginSetting,
                 actualClass -> actualClass.isAnnotationPresent(SingleThread.class) ?
                         pluginSetting.getNumberOfProcessWorkers() :
                         1);
+
+        return processors.stream()
+                .map(processor -> new IdentifiedComponent<>(processor, pluginSetting.getName()))
+                .collect(Collectors.toList());
     }
 
     private Optional<Source> getSourceIfPipelineType(
@@ -233,6 +239,24 @@ public class PipelineParser {
             pipelineMap.remove(pipelineName);
             sourceConnectorMap.remove(pipelineName);
             removeConnectedPipelines(pipelineName, pipelineConfigurationMap, pipelineMap);
+        }
+    }
+
+    private static class IdentifiedComponent<T> {
+        private final T component;
+        private final String name;
+
+        private IdentifiedComponent(final T component, final String name) {
+            this.component = component;
+            this.name = name;
+        }
+
+        T getComponent() {
+            return component;
+        }
+
+        String getName() {
+            return name;
         }
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
@@ -110,13 +110,18 @@ public class PipelineParser {
                     .map(this::newProcessor)
                     .collect(Collectors.toList());
 
-            final List<List<Processor>> decoratedProcessorSets = processorSets.stream()
-                    .map(processorSet -> processorSet.stream()
+            final Map<List<Processor>, String> processorMap = pipelineConfiguration.getProcessorPluginSettings().stream()
+                    .collect(Collectors.toMap(this::newProcessor, PluginSetting::getName));
+
+            final List<List<Processor>> decoratedProcessorSets = processorMap.entrySet().stream()
+                    .map(processorMapEntry -> processorMapEntry.getKey().stream()
                             .map(processor -> {
                                 if (processor instanceof RequiresPeerForwarding) {
                                     // TODO: Create buffer per stateful processor and store map of processor, buffer
                                     // TODO: get plugin id from PipelineParser
-                                    return new PeerForwardingProcessorDecorator(processor, peerForwarderProvider, pipelineName, "pluginId");
+                                    return new PeerForwardingProcessorDecorator(
+                                            processor, peerForwarderProvider, pipelineName, processorMapEntry.getValue()
+                                    );
                                 }
                                 return processor;
                             })

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/LocalPeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/LocalPeerForwarder.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.peerforwarder;
+
+import com.amazon.dataprepper.model.event.Event;
+import com.amazon.dataprepper.model.record.Record;
+
+import java.util.Collection;
+
+public class LocalPeerForwarder implements PeerForwarder {
+
+    @Override
+    public Collection<Record<Event>> forwardRecords(final Collection<Record<Event>> records) {
+        return records;
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
@@ -102,8 +102,9 @@ class PeerForwarderAppConfig {
     @Bean
     public PeerForwarderServer peerForwarderServer(
             @Qualifier("peerForwarderHttpServer") final Server peerForwarderServer,
-            final PeerForwarderConfiguration peerForwarderConfiguration) {
-        return new PeerForwarderServerProxy(peerForwarderConfiguration, peerForwarderServer);
+            final PeerForwarderConfiguration peerForwarderConfiguration,
+            final PeerForwarderProvider peerForwarderProvider) {
+        return new PeerForwarderServerProxy(peerForwarderConfiguration, peerForwarderServer, peerForwarderProvider);
     }
 
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
@@ -62,9 +62,11 @@ class PeerForwarderAppConfig {
 
     @Bean
     public PeerForwarderProvider peerForwarderProvider(final PeerForwarderClientFactory peerForwarderClientFactory,
-                                                       final PeerForwarderClient peerForwarderClient) {
-        return new PeerForwarderProvider(peerForwarderClientFactory, peerForwarderClient);
+                                                       final PeerForwarderClient peerForwarderClient,
+                                                       final PeerForwarderConfiguration peerForwarderConfiguration) {
+        return new PeerForwarderProvider(peerForwarderClientFactory, peerForwarderClient, peerForwarderConfiguration);
     }
+
     @Bean
     public ResponseHandler responseHandler() {
         return new ResponseHandler();
@@ -73,9 +75,11 @@ class PeerForwarderAppConfig {
     @Bean
     public PeerForwarderHttpService peerForwarderHttpService(
             final ResponseHandler responseHandler,
+            final PeerForwarderProvider peerForwarderProvider,
+            final PeerForwarderConfiguration peerForwarderConfiguration,
             final ObjectMapper objectMapper
     ) {
-        return new PeerForwarderHttpService(responseHandler, objectMapper);
+        return new PeerForwarderHttpService(responseHandler, peerForwarderProvider, peerForwarderConfiguration, objectMapper);
     }
 
     @Bean

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
@@ -52,18 +52,12 @@ public class PeerForwarderProvider {
     private PeerForwarderReceiveBuffer<Record<?>> createBufferPerPipelineProcessor(final String pipelineName, final String pluginId) {
         final PeerForwarderReceiveBuffer<Record<?>> peerForwarderReceiveBuffer = new
                 PeerForwarderReceiveBuffer<>(peerForwarderConfiguration.getBufferSize(), peerForwarderConfiguration.getBatchSize());
-        if (pipelinePeerForwarderReceiveBufferMap.containsKey(pipelineName)) {
-            pipelinePeerForwarderReceiveBufferMap.get(pipelineName).put(
-                    pluginId, peerForwarderReceiveBuffer
-            );
-        }
-        else {
-            Map<String, PeerForwarderReceiveBuffer<Record<?>>> peerForwarderReceiveBufferMap = new HashMap<>();
-            peerForwarderReceiveBufferMap.put(
-                    pluginId, peerForwarderReceiveBuffer
-            );
-            pipelinePeerForwarderReceiveBufferMap.put(pipelineName, peerForwarderReceiveBufferMap);
-        }
+
+        final Map<String, PeerForwarderReceiveBuffer<Record<?>>> pluginsBufferMap =
+                pipelinePeerForwarderReceiveBufferMap.computeIfAbsent(pipelineName, k -> new HashMap<>());
+
+        pluginsBufferMap.put(pluginId, peerForwarderReceiveBuffer);
+
         return peerForwarderReceiveBuffer;
     }
 
@@ -73,7 +67,7 @@ public class PeerForwarderProvider {
 
     private boolean arePeersConfigured() {
         final DiscoveryMode discoveryMode = peerForwarderConfiguration.getDiscoveryMode();
-        if (discoveryMode.equals(DiscoveryMode.LOCAL)) {
+        if (discoveryMode.equals(DiscoveryMode.LOCAL_NODE)) {
             return false;
         }
         else if (discoveryMode.equals(DiscoveryMode.STATIC) && peerForwarderConfiguration.getStaticEndpoints().size() <= 1) {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
@@ -5,30 +5,74 @@
 
 package org.opensearch.dataprepper.peerforwarder;
 
+import com.amazon.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.peerforwarder.client.PeerForwarderClient;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 public class PeerForwarderProvider {
 
     private final PeerForwarderClientFactory peerForwarderClientFactory;
     private final PeerForwarderClient peerForwarderClient;
+    private final PeerForwarderConfiguration peerForwarderConfiguration;
+    private final Map<String, Map<String, PeerForwarderReceiveBuffer<Record<?>>>> pipelinePeerForwarderReceiveBufferMap = new HashMap<>();
     private HashRing hashRing;
 
-    PeerForwarderProvider(final PeerForwarderClientFactory peerForwarderClientFactory, final PeerForwarderClient peerForwarderClient) {
+    PeerForwarderProvider(final PeerForwarderClientFactory peerForwarderClientFactory,
+                          final PeerForwarderClient peerForwarderClient,
+                          final PeerForwarderConfiguration peerForwarderConfiguration) {
         this.peerForwarderClientFactory = peerForwarderClientFactory;
         this.peerForwarderClient = peerForwarderClient;
+        this.peerForwarderConfiguration = peerForwarderConfiguration;
     }
 
     public PeerForwarder register(final String pipelineName, final String pluginId, final Set<String> identificationKeys) {
 
         // TODO: Data Prepper 2.0 will only support a single peer-forwarder per pipeline/plugin type. Check this condition.
 
+        if (pipelinePeerForwarderReceiveBufferMap.containsKey(pipelineName) &&
+                pipelinePeerForwarderReceiveBufferMap.get(pipelineName).containsKey(pluginId)) {
+            throw new RuntimeException("Data Prepper 2.0 will only support a single peer-forwarder per pipeline/plugin type");
+        }
+
         if(hashRing == null) {
             hashRing = peerForwarderClientFactory.createHashRing();
         }
 
-        // TODO: Support a local-only PeerForwarder when no peers are configured.
-        return new RemotePeerForwarder(peerForwarderClient, hashRing, pipelineName, pluginId, identificationKeys);
+        createBufferPerPipelineProcessor(pipelineName, pluginId);
+
+        if (isAtLeastOnePeerForwarderRegistered()) {
+            return new RemotePeerForwarder(peerForwarderClient, hashRing, pipelineName, pluginId, identificationKeys);
+        }
+        else {
+            return new LocalPeerForwarder();
+        }
+    }
+
+    private void createBufferPerPipelineProcessor(final String pipelineName, final String pluginId) {
+        if (pipelinePeerForwarderReceiveBufferMap.containsKey(pipelineName)) {
+            pipelinePeerForwarderReceiveBufferMap.get(pipelineName).put(
+                    pluginId,
+                    new PeerForwarderReceiveBuffer<>(peerForwarderConfiguration.getBufferSize(), peerForwarderConfiguration.getBatchSize())
+            );
+        }
+        else {
+            Map<String, PeerForwarderReceiveBuffer<Record<?>>> peerForwarderReceiveBufferMap = new HashMap<>();
+            peerForwarderReceiveBufferMap.put(
+                    pluginId,
+                    new PeerForwarderReceiveBuffer<>(peerForwarderConfiguration.getBufferSize(), peerForwarderConfiguration.getBatchSize())
+            );
+            pipelinePeerForwarderReceiveBufferMap.put(pipelineName, peerForwarderReceiveBufferMap);
+        }
+    }
+
+    public boolean isAtLeastOnePeerForwarderRegistered() {
+        return pipelinePeerForwarderReceiveBufferMap.size() > 0;
+    }
+
+    public Map<String, Map<String, PeerForwarderReceiveBuffer<Record<?>>>> getPipelinePeerForwarderReceiveBufferMap() {
+        return pipelinePeerForwarderReceiveBufferMap;
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
@@ -55,7 +55,7 @@ class RemotePeerForwarder implements PeerForwarder {
                 recordsToProcessLocally.addAll(entry.getValue());
             } else {
                 final AggregatedHttpResponse httpResponse = peerForwarderClient.serializeRecordsAndSendHttpRequest(entry.getValue(),
-                        destinationIp, pluginId);
+                        destinationIp, pluginId, pipelineName);
                 if (httpResponse == null || httpResponse.status() != HttpStatus.OK) {
                     recordsToProcessLocally.addAll(entry.getValue());
                 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClient.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClient.java
@@ -52,13 +52,14 @@ public class PeerForwarderClient {
     public AggregatedHttpResponse serializeRecordsAndSendHttpRequest(
             final Collection<Record<Event>> records,
             final String ipAddress,
-            final String pluginId) {
+            final String pluginId,
+            final String pipelineName) {
         // TODO: decide the default values of peer forwarder configuration and move the PeerClientPool to constructor
         peerClientPool = peerForwarderClientFactory.setPeerClientPool();
 
         final WebClient client = peerClientPool.getClient(ipAddress);
 
-        final Optional<String> serializedJsonString = getSerializedJsonString(records, pluginId);
+        final Optional<String> serializedJsonString = getSerializedJsonString(records, pluginId, pipelineName);
         return serializedJsonString.map(value -> {
                     final CompletableFuture<AggregatedHttpResponse> aggregatedHttpResponseCompletableFuture =
                             processHttpRequest(client, value);
@@ -67,9 +68,12 @@ public class PeerForwarderClient {
                 .orElse(AggregatedHttpResponse.of(HttpStatus.BAD_REQUEST));
     }
 
-    private Optional<String> getSerializedJsonString(final Collection<Record<Event>> records, final String pluginId) {
+    private Optional<String> getSerializedJsonString(
+            final Collection<Record<Event>> records,
+            final String pluginId,
+            final String pipelineName) {
         final List<WireEvent> wireEventList = getWireEventList(records);
-        final WireEvents wireEvents = new WireEvents(wireEventList, pluginId);
+        final WireEvents wireEvents = new WireEvents(wireEventList, pluginId, pipelineName);
 
         String serializedJsonString = null;
         try {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/discovery/DiscoveryMode.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/discovery/DiscoveryMode.java
@@ -14,7 +14,7 @@ public enum DiscoveryMode {
     STATIC(StaticPeerListProvider::createPeerListProvider),
     DNS(DnsPeerListProvider::createPeerListProvider),
     AWS_CLOUD_MAP(AwsCloudMapPeerListProvider::createPeerListProvider),
-    LOCAL(LocalPeerListProvider::createPeerListProvider);
+    LOCAL_NODE(LocalPeerListProvider::createPeerListProvider);
 
     private final Function<PeerForwarderConfiguration, PeerListProvider> creationFunction;
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/discovery/DiscoveryMode.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/discovery/DiscoveryMode.java
@@ -13,7 +13,8 @@ import java.util.function.Function;
 public enum DiscoveryMode {
     STATIC(StaticPeerListProvider::createPeerListProvider),
     DNS(DnsPeerListProvider::createPeerListProvider),
-    AWS_CLOUD_MAP(AwsCloudMapPeerListProvider::createPeerListProvider);
+    AWS_CLOUD_MAP(AwsCloudMapPeerListProvider::createPeerListProvider),
+    LOCAL(LocalPeerListProvider::createPeerListProvider);
 
     private final Function<PeerForwarderConfiguration, PeerListProvider> creationFunction;
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/discovery/LocalPeerListProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/discovery/LocalPeerListProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.peerforwarder.discovery;
+
+import com.linecorp.armeria.client.Endpoint;
+import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class LocalPeerListProvider implements PeerListProvider {
+
+    static LocalPeerListProvider createPeerListProvider(PeerForwarderConfiguration peerForwarderConfiguration) {
+        return new LocalPeerListProvider();
+    }
+
+    @Override
+    public List<String> getPeerList() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void addListener(Consumer<? super List<Endpoint>> listener) {
+        // Do nothing
+    }
+
+    @Override
+    public void removeListener(Consumer<?> listener) {
+        // Do nothing
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/model/WireEvents.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/model/WireEvents.java
@@ -17,13 +17,15 @@ import java.util.List;
 public class WireEvents {
     private List<WireEvent> events;
     private String destinationPluginId;
+    private String destinationPipelineName;
 
     public WireEvents() {
     }
 
-    public WireEvents(final List<WireEvent> events, final String destinationPluginId) {
+    public WireEvents(final List<WireEvent> events, final String destinationPluginId, final String destinationPipelineName) {
         this.events = events;
         this.destinationPluginId = destinationPluginId;
+        this.destinationPipelineName = destinationPipelineName;
     }
 
     public List<WireEvent> getEvents() {
@@ -32,5 +34,9 @@ public class WireEvents {
 
     public String getDestinationPluginId() {
         return destinationPluginId;
+    }
+
+    public String getDestinationPipelineName() {
+        return destinationPipelineName;
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpService.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpService.java
@@ -6,7 +6,9 @@
 package org.opensearch.dataprepper.peerforwarder.server;
 
 import com.amazon.dataprepper.model.event.DefaultEventMetadata;
+import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.event.JacksonEvent;
+import com.amazon.dataprepper.model.record.Record;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
@@ -14,10 +16,17 @@ import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Post;
+import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
+import org.opensearch.dataprepper.peerforwarder.PeerForwarderProvider;
+import org.opensearch.dataprepper.peerforwarder.PeerForwarderReceiveBuffer;
 import org.opensearch.dataprepper.peerforwarder.model.WireEvent;
 import org.opensearch.dataprepper.peerforwarder.model.WireEvents;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * An annotated HTTP service class to handle POST requests used by {@link PeerForwarderHttpServerProvider}
@@ -28,10 +37,17 @@ public class PeerForwarderHttpService {
     private static final Logger LOG = LoggerFactory.getLogger(PeerForwarderHttpService.class);
 
     private final ResponseHandler responseHandler;
+    private final PeerForwarderProvider peerForwarderProvider;
+    private final PeerForwarderConfiguration peerForwarderConfiguration;
     private final ObjectMapper objectMapper;
 
-    public PeerForwarderHttpService(final ResponseHandler responseHandler, final ObjectMapper objectMapper) {
+    public PeerForwarderHttpService(final ResponseHandler responseHandler,
+                                    final PeerForwarderProvider peerForwarderProvider,
+                                    final PeerForwarderConfiguration peerForwarderConfiguration,
+                                    final ObjectMapper objectMapper) {
         this.responseHandler = responseHandler;
+        this.peerForwarderProvider = peerForwarderProvider;
+        this.peerForwarderConfiguration = peerForwarderConfiguration;
         this.objectMapper = objectMapper;
     }
 
@@ -52,26 +68,45 @@ public class PeerForwarderHttpService {
             return responseHandler.handleException(e, message);
         }
 
-        final String destinationPluginId = wireEvents.getDestinationPluginId();
-        // TODO: send all events to corresponding buffer based on plugin id
-
-        if (wireEvents.getEvents() != null) {
-            wireEvents.getEvents().stream()
-                    .map(this::transformEvent)
-                    .forEach(event  -> {
-                        // TODO: write event to buffer
-                    }
-            );
-        }
+        writeEventsToBuffer(wireEvents, content);
 
         return HttpResponse.of(HttpStatus.OK);
     }
 
-    private JacksonEvent transformEvent(final WireEvent wireEvent) {
-        return JacksonEvent.builder()
+    private void writeEventsToBuffer(final WireEvents wireEvents, final HttpData content) {
+        final PeerForwarderReceiveBuffer<Record<?>> recordPeerForwarderReceiveBuffer = getPeerForwarderBuffer(wireEvents);
+
+        if (wireEvents.getEvents() != null) {
+            final Collection<Record<?>> jacksonEvents = wireEvents.getEvents().stream()
+                    .map(this::transformEvent)
+                    .collect(Collectors.toList());
+
+            try {
+                recordPeerForwarderReceiveBuffer.writeAll(jacksonEvents, peerForwarderConfiguration.getRequestTimeout());
+            } catch (Exception e) {
+                LOG.error("Failed to write the request content [{}] due to:", content.toStringUtf8(), e);
+            }
+        }
+    }
+
+    private PeerForwarderReceiveBuffer<Record<?>> getPeerForwarderBuffer(final WireEvents wireEvents) {
+        final String destinationPluginId = wireEvents.getDestinationPluginId();
+        final String destinationPipelineName = wireEvents.getDestinationPipelineName();
+
+        final Map<String, Map<String, PeerForwarderReceiveBuffer<Record<?>>>> pipelinePeerForwarderReceiveBufferMap =
+                peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap();
+
+        return pipelinePeerForwarderReceiveBufferMap
+                .get(destinationPipelineName).get(destinationPluginId);
+    }
+
+    private Record<Event> transformEvent(final WireEvent wireEvent) {
+        final JacksonEvent jacksonEvent = JacksonEvent.builder()
                 .withEventMetadata(getEventMetadata(wireEvent))
                 .withData(wireEvent.getEventData())
                 .build();
+
+        return new Record<>(jacksonEvent);
     }
 
     private DefaultEventMetadata getEventMetadata(final WireEvent wireEvent) {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxy.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxy.java
@@ -26,7 +26,7 @@ public class PeerForwarderServerProxy implements PeerForwarderServer {
 
     @Override
     public void start() {
-        if (peerForwarderProvider.isAtLeastOnePeerForwarderRegistered()) {
+        if (peerForwarderProvider.isPeerForwardingRequired()) {
             peerForwarderServer = new RemotePeerForwarderServer(peerForwarderConfiguration, server);
         }
         else {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxy.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxy.java
@@ -7,22 +7,26 @@ package org.opensearch.dataprepper.peerforwarder.server;
 
 import com.linecorp.armeria.server.Server;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
+import org.opensearch.dataprepper.peerforwarder.PeerForwarderProvider;
 
 public class PeerForwarderServerProxy implements PeerForwarderServer {
     private final PeerForwarderConfiguration peerForwarderConfiguration;
     private final Server server;
+    private final PeerForwarderProvider peerForwarderProvider;
 
     private PeerForwarderServer peerForwarderServer;
 
-    public PeerForwarderServerProxy(final PeerForwarderConfiguration peerForwarderConfiguration, final Server server) {
+    public PeerForwarderServerProxy(final PeerForwarderConfiguration peerForwarderConfiguration,
+                                    final Server server,
+                                    final PeerForwarderProvider peerForwarderProvider) {
         this.peerForwarderConfiguration = peerForwarderConfiguration;
         this.server = server;
+        this.peerForwarderProvider = peerForwarderProvider;
     }
 
     @Override
     public void start() {
-        // TODO: update this conditional based on PeerForwarderProvider
-        if (true) {
+        if (peerForwarderProvider.isAtLeastOnePeerForwarderRegistered()) {
             peerForwarderServer = new RemotePeerForwarderServer(peerForwarderConfiguration, server);
         }
         else {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/ResponseHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/ResponseHandler.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder.server;
 
+import com.amazon.dataprepper.model.buffer.SizeOverflowException;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
@@ -20,6 +21,10 @@ public class ResponseHandler {
 
     public HttpResponse handleException(final Exception e, final String message) {
         Objects.requireNonNull(message);
+
+        if (e instanceof SizeOverflowException) {
+            return HttpResponse.of(HttpStatus.REQUEST_ENTITY_TOO_LARGE, MediaType.ANY_TYPE, message);
+        }
 
         return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, MediaType.ANY_TYPE, message);
     }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/LocalPeerForwarderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/LocalPeerForwarderTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.peerforwarder;
+
+import com.amazon.dataprepper.model.event.Event;
+import com.amazon.dataprepper.model.record.Record;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+class LocalPeerForwarderTest {
+
+    @Mock
+    private Record<Event> record;
+
+    @Test
+    void forwardRecords_should_return_same_records() {
+        List<Record<Event>> testData = Collections.singletonList(record);
+
+        final LocalPeerForwarder localPeerForwarder = new LocalPeerForwarder();
+        final Collection<Record<Event>> records = localPeerForwarder.forwardRecords(testData);
+
+        assertThat(records, equalTo(testData));
+    }
+
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProviderTest.java
@@ -59,7 +59,7 @@ class PeerForwarderProviderTest {
         lenient().when(peerForwarderClientFactory.createHashRing()).thenReturn(hashRing);
         lenient().when(peerForwarderConfiguration.getBufferSize()).thenReturn(512);
         lenient().when(peerForwarderConfiguration.getBatchSize()).thenReturn(48);
-        when(peerForwarderConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.LOCAL);
+        when(peerForwarderConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.LOCAL_NODE);
     }
 
     private PeerForwarderProvider createObjectUnderTest() {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProviderTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder;
 
+import com.amazon.dataprepper.model.record.Record;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,22 +14,31 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.peerforwarder.client.PeerForwarderClient;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PeerForwarderProviderTest {
 
     @Mock
     private PeerForwarderClientFactory peerForwarderClientFactory;
+
     @Mock
     private PeerForwarderClient peerForwarderClient;
+
+    @Mock
+    private PeerForwarderConfiguration peerForwarderConfiguration;
 
     @Mock
     private HashRing hashRing;
@@ -43,12 +53,13 @@ class PeerForwarderProviderTest {
         pluginId = UUID.randomUUID().toString();
         identificationKeys = Collections.singleton(UUID.randomUUID().toString());
 
-
-        when(peerForwarderClientFactory.createHashRing()).thenReturn(hashRing);
+        lenient().when(peerForwarderClientFactory.createHashRing()).thenReturn(hashRing);
+        lenient().when(peerForwarderConfiguration.getBufferSize()).thenReturn(512);
+        lenient().when(peerForwarderConfiguration.getBatchSize()).thenReturn(48);
     }
 
     private PeerForwarderProvider createObjectUnderTest() {
-        return new PeerForwarderProvider(peerForwarderClientFactory, peerForwarderClient);
+        return new PeerForwarderProvider(peerForwarderClientFactory, peerForwarderClient, peerForwarderConfiguration);
     }
 
     @Test
@@ -70,8 +81,62 @@ class PeerForwarderProviderTest {
         final PeerForwarderProvider objectUnderTest = createObjectUnderTest();
 
         for (int i = 0; i < 10; i++)
-            objectUnderTest.register(pipelineName, pluginId, identificationKeys);
+            objectUnderTest.register(pipelineName, UUID.randomUUID().toString(), identificationKeys);
 
         verify(peerForwarderClientFactory, times(1)).createHashRing();
+    }
+
+    @Test
+    void isAtLeastOnePeerForwarderRegistered_should_return_false_if_register_is_not_called() {
+        final PeerForwarderProvider objectUnderTest = createObjectUnderTest();
+
+        assertThat(objectUnderTest.isAtLeastOnePeerForwarderRegistered(), equalTo(false));
+    }
+
+    @Test
+    void isAtLeastOnePeerForwarderRegistered_should_throw_when_register_is_called_with_same_pipeline_and_plugin() {
+        final PeerForwarderProvider objectUnderTest = createObjectUnderTest();
+
+        objectUnderTest.register(pipelineName, pluginId, identificationKeys);
+
+        assertThrows(RuntimeException.class, () ->
+                objectUnderTest.register(pipelineName, pluginId, identificationKeys));
+    }
+
+    @Test
+    void isAtLeastOnePeerForwarderRegistered_should_return_true_if_register_is_called_() {
+        final PeerForwarderProvider objectUnderTest = createObjectUnderTest();
+
+        objectUnderTest.register(pipelineName, pluginId, identificationKeys);
+
+        assertThat(objectUnderTest.isAtLeastOnePeerForwarderRegistered(), equalTo(true));
+    }
+
+    @Test
+    void getPipelinePeerForwarderReceiveBufferMap_should_return_empty_map_when_register_is_not_called() {
+        final PeerForwarderProvider objectUnderTest = createObjectUnderTest();
+
+
+        final Map<String, Map<String, PeerForwarderReceiveBuffer<Record<?>>>> pipelinePeerForwarderReceiveBufferMap = objectUnderTest
+                .getPipelinePeerForwarderReceiveBufferMap();
+
+        assertThat(objectUnderTest.isAtLeastOnePeerForwarderRegistered(), equalTo(false));
+        assertThat(pipelinePeerForwarderReceiveBufferMap, is(notNullValue()));
+        assertThat(pipelinePeerForwarderReceiveBufferMap.size(), equalTo(0));
+    }
+
+    @Test
+    void getPipelinePeerForwarderReceiveBufferMap_should_return_non_empty_map_when_register_is_called() {
+        final PeerForwarderProvider objectUnderTest = createObjectUnderTest();
+
+        objectUnderTest.register(pipelineName, UUID.randomUUID().toString(), identificationKeys);
+
+        final Map<String, Map<String, PeerForwarderReceiveBuffer<Record<?>>>> pipelinePeerForwarderReceiveBufferMap = objectUnderTest
+                .getPipelinePeerForwarderReceiveBufferMap();
+
+        assertThat(objectUnderTest.isAtLeastOnePeerForwarderRegistered(), equalTo(true));
+        assertThat(pipelinePeerForwarderReceiveBufferMap, is(notNullValue()));
+        assertThat(pipelinePeerForwarderReceiveBufferMap.size(), equalTo(1));
+        assertThat(pipelinePeerForwarderReceiveBufferMap.containsKey(pipelineName), equalTo(true));
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
@@ -68,10 +68,12 @@ class RemotePeerForwarderTest {
         lenient().when(hashRing.getServerIp(List.of("value2", "value2"))).thenReturn(Optional.of(testIps.get(1)));
 
         RemotePeerForwarder peerForwarder = createObjectUnderTest();
+        final Collection<Record<Event>> testRecords = generateBatchRecords(2, false);
 
-        final Collection<Record<Event>> records = peerForwarder.forwardRecords(generateBatchRecords(2, false));
+        final Collection<Record<Event>> records = peerForwarder.forwardRecords(testRecords);
         verifyNoInteractions(peerForwarderClient);
         assertThat(records.size(), equalTo(2));
+        assertThat(records, equalTo(testRecords));
     }
 
     @Test
@@ -85,8 +87,9 @@ class RemotePeerForwarderTest {
         lenient().when(hashRing.getServerIp(List.of("value2", "value2"))).thenReturn(Optional.of(testIps.get(1)));
 
         RemotePeerForwarder peerForwarder = createObjectUnderTest();
+        final Collection<Record<Event>> testRecords = generateBatchRecords(2, false);
 
-        final Collection<Record<Event>> records = peerForwarder.forwardRecords(generateBatchRecords(2, false));
+        final Collection<Record<Event>> records = peerForwarder.forwardRecords(testRecords);
         verify(peerForwarderClient, times(1)).serializeRecordsAndSendHttpRequest(anyList(), anyString(), anyString(), anyString());
         assertThat(records.size(), equalTo(1));
     }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
@@ -78,7 +78,7 @@ class RemotePeerForwarderTest {
     void test_forwardRecords_with_one_local_ip_and_one_remote_ip_should_process_record_one_record_locally() {
         AggregatedHttpResponse aggregatedHttpResponse = mock(AggregatedHttpResponse.class);
         when(aggregatedHttpResponse.status()).thenReturn(HttpStatus.OK);
-        when(peerForwarderClient.serializeRecordsAndSendHttpRequest(anyCollection(), anyString(), anyString())).thenReturn(aggregatedHttpResponse);
+        when(peerForwarderClient.serializeRecordsAndSendHttpRequest(anyCollection(), anyString(), anyString(), anyString())).thenReturn(aggregatedHttpResponse);
 
         final List<String> testIps = List.of("8.8.8.8", "127.0.0.1");
         lenient().when(hashRing.getServerIp(List.of("value1", "value1"))).thenReturn(Optional.of(testIps.get(0)));
@@ -87,7 +87,7 @@ class RemotePeerForwarderTest {
         RemotePeerForwarder peerForwarder = createObjectUnderTest();
 
         final Collection<Record<Event>> records = peerForwarder.forwardRecords(generateBatchRecords(2, false));
-        verify(peerForwarderClient, times(1)).serializeRecordsAndSendHttpRequest(anyList(), anyString(), anyString());
+        verify(peerForwarderClient, times(1)).serializeRecordsAndSendHttpRequest(anyList(), anyString(), anyString(), anyString());
         assertThat(records.size(), equalTo(1));
     }
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClientTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClientTest.java
@@ -54,6 +54,7 @@ class PeerForwarderClientTest {
 
     private static final String LOCAL_IP = "127.0.0.1";
     private static final String TEST_PLUGIN_ID = "test_plugin_id";
+    private static final String TEST_PIPELINE_NAME = "test_pipeline_name";
 
     private final ObjectMapper objectMapper = new ObjectMapper()
             .registerModule(new JavaTimeModule());
@@ -87,7 +88,7 @@ class PeerForwarderClientTest {
         final PeerForwarderClient peerForwarderClient = createObjectUnderTest(objectMapper);
 
         final AggregatedHttpResponse aggregatedHttpResponse =
-                peerForwarderClient.serializeRecordsAndSendHttpRequest(generateBatchRecords(1), address.toString(), TEST_PLUGIN_ID);
+                peerForwarderClient.serializeRecordsAndSendHttpRequest(generateBatchRecords(1), address.toString(), TEST_PLUGIN_ID, TEST_PIPELINE_NAME);
 
         assertThat(aggregatedHttpResponse, notNullValue());
         assertThat(aggregatedHttpResponse, instanceOf(AggregatedHttpResponse.class));
@@ -106,7 +107,7 @@ class PeerForwarderClientTest {
         final PeerForwarderClient peerForwarderClient = createObjectUnderTest(objectMapper);
 
         final AggregatedHttpResponse aggregatedHttpResponse =
-                peerForwarderClient.serializeRecordsAndSendHttpRequest(generateBatchRecords(1), LOCAL_IP, TEST_PLUGIN_ID);
+                peerForwarderClient.serializeRecordsAndSendHttpRequest(generateBatchRecords(1), LOCAL_IP, TEST_PLUGIN_ID, TEST_PIPELINE_NAME);
 
         assertThat(aggregatedHttpResponse, notNullValue());
         assertThat(aggregatedHttpResponse, instanceOf(AggregatedHttpResponse.class));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/LocalPeerListProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/LocalPeerListProviderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.peerforwarder.discovery;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.peerforwarder.HashRing;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class LocalPeerListProviderTest {
+    private final HashRing hashRing = mock(HashRing.class);
+
+    @Test
+    void testGetPeerList() {
+        final LocalPeerListProvider localPeerListProvider = new LocalPeerListProvider();
+        assertThat(localPeerListProvider.getPeerList(), equalTo(Collections.emptyList()));
+    }
+
+    @Test
+    void testAddListener() {
+        final LocalPeerListProvider localPeerListProvider = new LocalPeerListProvider();
+        localPeerListProvider.addListener(hashRing);
+
+        verifyNoInteractions(hashRing);
+    }
+
+    @Test
+    void testRemoveListener() {
+        final LocalPeerListProvider localPeerListProvider = new LocalPeerListProvider();
+        localPeerListProvider.removeListener(hashRing);
+
+        verifyNoInteractions(hashRing);
+    }
+
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServiceTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServiceTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.peerforwarder.server;
 
 import com.amazon.dataprepper.model.event.JacksonEvent;
+import com.amazon.dataprepper.model.record.Record;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -19,17 +20,24 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
+import org.opensearch.dataprepper.peerforwarder.PeerForwarderProvider;
+import org.opensearch.dataprepper.peerforwarder.PeerForwarderReceiveBuffer;
 import org.opensearch.dataprepper.peerforwarder.model.WireEvent;
 import org.opensearch.dataprepper.peerforwarder.model.WireEvents;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration.DEFAULT_PEER_FORWARDING_URI;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,19 +46,32 @@ class PeerForwarderHttpServiceTest {
     private static final String MESSAGE = "message";
     private static final String LOG = "LOG";
     private static final String PLUGIN_ID = "plugin_id";
+    private static final String PIPELINE_NAME = "pipeline_name";
 
     private final ResponseHandler responseHandler = new ResponseHandler();
     private final ObjectMapper objectMapper = new ObjectMapper()
             .registerModule(new JavaTimeModule());
 
+    @Mock
+    private PeerForwarderProvider peerForwarderProvider;
+
+    @Mock
+    private PeerForwarderConfiguration peerForwarderConfiguration;
+
+    @Mock
+    private PeerForwarderReceiveBuffer peerForwarderReceiveBuffer;
 
     private PeerForwarderHttpService createObjectUnderTest() {
-        return new PeerForwarderHttpService(responseHandler, objectMapper);
+        return new PeerForwarderHttpService(responseHandler, peerForwarderProvider, peerForwarderConfiguration, objectMapper);
     }
 
 
     @Test
     void test_doPost_with_HTTP_request_should_return_OK() throws ExecutionException, JsonProcessingException, InterruptedException {
+        final HashMap<String, Map<String, PeerForwarderReceiveBuffer<Record<?>>>> pipelinePeerForwarderReceiveBufferMap = new HashMap<>();
+        pipelinePeerForwarderReceiveBufferMap.put(PIPELINE_NAME, Map.of(PLUGIN_ID, peerForwarderReceiveBuffer));
+        when(peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap()).thenReturn(pipelinePeerForwarderReceiveBufferMap);
+
         final AggregatedHttpRequest aggregatedHttpRequest = generateRandomValidHTTPRequest();
 
         final PeerForwarderHttpService objectUnderTest = createObjectUnderTest();
@@ -90,7 +111,7 @@ class PeerForwarderHttpServiceTest {
                 event.getMetadata().getAttributes(),
                 event.toJsonString());
 
-        final WireEvents wireEvents = new WireEvents(List.of(wireEvent), PLUGIN_ID);
+        final WireEvents wireEvents = new WireEvents(List.of(wireEvent), PLUGIN_ID, PIPELINE_NAME);
 
         String content = objectMapper.writeValueAsString(wireEvents);
         HttpData httpData = HttpData.ofUtf8(content);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServiceTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServiceTest.java
@@ -5,7 +5,9 @@
 
 package org.opensearch.dataprepper.peerforwarder.server;
 
+import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.event.JacksonEvent;
+import com.amazon.dataprepper.model.log.JacksonLog;
 import com.amazon.dataprepper.model.record.Record;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,11 +31,13 @@ import org.opensearch.dataprepper.peerforwarder.model.WireEvent;
 import org.opensearch.dataprepper.peerforwarder.model.WireEvents;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -47,10 +51,14 @@ class PeerForwarderHttpServiceTest {
     private static final String LOG = "LOG";
     private static final String PLUGIN_ID = "plugin_id";
     private static final String PIPELINE_NAME = "pipeline_name";
+    private static final int TEST_BUFFER_CAPACITY = 3;
+    private static final int TEST_BATCH_SIZE = 3;
 
     private final ResponseHandler responseHandler = new ResponseHandler();
     private final ObjectMapper objectMapper = new ObjectMapper()
             .registerModule(new JavaTimeModule());
+    private final PeerForwarderReceiveBuffer peerForwarderReceiveBuffer =
+            new PeerForwarderReceiveBuffer(TEST_BATCH_SIZE, TEST_BUFFER_CAPACITY);
 
     @Mock
     private PeerForwarderProvider peerForwarderProvider;
@@ -58,8 +66,6 @@ class PeerForwarderHttpServiceTest {
     @Mock
     private PeerForwarderConfiguration peerForwarderConfiguration;
 
-    @Mock
-    private PeerForwarderReceiveBuffer peerForwarderReceiveBuffer;
 
     private PeerForwarderHttpService createObjectUnderTest() {
         return new PeerForwarderHttpService(responseHandler, peerForwarderProvider, peerForwarderConfiguration, objectMapper);
@@ -67,12 +73,12 @@ class PeerForwarderHttpServiceTest {
 
 
     @Test
-    void test_doPost_with_HTTP_request_should_return_OK() throws ExecutionException, JsonProcessingException, InterruptedException {
+    void test_doPost_with_HTTP_request_should_return_OK() throws Exception {
         final HashMap<String, Map<String, PeerForwarderReceiveBuffer<Record<?>>>> pipelinePeerForwarderReceiveBufferMap = new HashMap<>();
         pipelinePeerForwarderReceiveBufferMap.put(PIPELINE_NAME, Map.of(PLUGIN_ID, peerForwarderReceiveBuffer));
         when(peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap()).thenReturn(pipelinePeerForwarderReceiveBufferMap);
 
-        final AggregatedHttpRequest aggregatedHttpRequest = generateRandomValidHTTPRequest();
+        final AggregatedHttpRequest aggregatedHttpRequest = generateRandomValidHTTPRequest(1);
 
         final PeerForwarderHttpService objectUnderTest = createObjectUnderTest();
 
@@ -92,7 +98,21 @@ class PeerForwarderHttpServiceTest {
         assertThat(aggregatedHttpResponse.status(), equalTo(HttpStatus.INTERNAL_SERVER_ERROR));
     }
 
-    private AggregatedHttpRequest generateRandomValidHTTPRequest() throws JsonProcessingException,
+    @Test
+    void test() throws ExecutionException, JsonProcessingException, InterruptedException {
+        final HashMap<String, Map<String, PeerForwarderReceiveBuffer<Record<?>>>> pipelinePeerForwarderReceiveBufferMap = new HashMap<>();
+        pipelinePeerForwarderReceiveBufferMap.put(PIPELINE_NAME, Map.of(PLUGIN_ID, peerForwarderReceiveBuffer));
+        when(peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap()).thenReturn(pipelinePeerForwarderReceiveBufferMap);
+
+        final AggregatedHttpRequest aggregatedHttpRequest = generateRandomValidHTTPRequest(TEST_BUFFER_CAPACITY + 1);
+        final PeerForwarderHttpService objectUnderTest = createObjectUnderTest();
+
+        final AggregatedHttpResponse aggregatedHttpResponse = objectUnderTest.doPost(aggregatedHttpRequest).aggregate().get();
+
+        assertThat(aggregatedHttpResponse.status(), equalTo(HttpStatus.REQUEST_ENTITY_TOO_LARGE));
+    }
+
+    private AggregatedHttpRequest generateRandomValidHTTPRequest(final int numRecords) throws JsonProcessingException,
             ExecutionException, InterruptedException {
         RequestHeaders requestHeaders = RequestHeaders.builder()
                 .contentType(MediaType.JSON)
@@ -106,12 +126,18 @@ class PeerForwarderHttpServiceTest {
                 .withEventType(LOG)
                 .build();
 
-        final WireEvent wireEvent = new WireEvent(event.getMetadata().getEventType(),
+        final List<Record<Event>> records = generateBatchRecords(numRecords);
+
+        final List<WireEvent> wireEventList = records.stream().map(record -> {
+            final WireEvent wireEvent = new WireEvent(record.getData().getMetadata().getEventType(),
                 event.getMetadata().getTimeReceived(),
                 event.getMetadata().getAttributes(),
                 event.toJsonString());
 
-        final WireEvents wireEvents = new WireEvents(List.of(wireEvent), PLUGIN_ID, PIPELINE_NAME);
+            return wireEvent;
+        }).collect(Collectors.toList());
+
+        final WireEvents wireEvents = new WireEvents(wireEventList, PLUGIN_ID, PIPELINE_NAME);
 
         String content = objectMapper.writeValueAsString(wireEvents);
         HttpData httpData = HttpData.ofUtf8(content);
@@ -126,6 +152,18 @@ class PeerForwarderHttpServiceTest {
                 .build();
         HttpData httpData = HttpData.ofUtf8("{");
         return HttpRequest.of(requestHeaders, httpData).aggregate().get();
+    }
+
+    private List<Record<Event>> generateBatchRecords(final int numRecords) {
+        final List<Record<Event>> results = new ArrayList<>();
+        for (int i = 0; i < numRecords; i++) {
+            final Map<String, String> eventData = new HashMap<>();
+            eventData.put("key1", "value");
+            eventData.put("key2", "value");
+            final JacksonEvent event = JacksonLog.builder().withData(eventData).withEventType("LOG").build();
+            results.add(new Record<>(event));
+        }
+        return results;
     }
 
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServiceTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServiceTest.java
@@ -99,7 +99,7 @@ class PeerForwarderHttpServiceTest {
     }
 
     @Test
-    void test() throws ExecutionException, JsonProcessingException, InterruptedException {
+    void test_doPost_with_HTTP_request_size_greater_than_buffer_size_should_return_REQUEST_ENTITY_TOO_LARGE() throws ExecutionException, JsonProcessingException, InterruptedException {
         final HashMap<String, Map<String, PeerForwarderReceiveBuffer<Record<?>>>> pipelinePeerForwarderReceiveBufferMap = new HashMap<>();
         pipelinePeerForwarderReceiveBufferMap.put(PIPELINE_NAME, Map.of(PLUGIN_ID, peerForwarderReceiveBuffer));
         when(peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap()).thenReturn(pipelinePeerForwarderReceiveBufferMap);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxyTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxyTest.java
@@ -44,7 +44,7 @@ class PeerForwarderServerProxyTest {
     void start_should_start_server_if_peers_are_registered() throws ExecutionException, InterruptedException {
         when(server.start()).thenReturn(completableFuture);
         when(completableFuture.get()).thenReturn(mock(Void.class));
-        when(peerForwarderProvider.isAtLeastOnePeerForwarderRegistered()).thenReturn(true);
+        when(peerForwarderProvider.isPeerForwardingRequired()).thenReturn(true);
 
         final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();
         objectUnderTest.start();
@@ -71,7 +71,7 @@ class PeerForwarderServerProxyTest {
         when(server.start()).thenReturn(completableFuture);
         when(server.stop()).thenReturn(completableFuture);
         when(completableFuture.get()).thenReturn(mock(Void.class));
-        when(peerForwarderProvider.isAtLeastOnePeerForwarderRegistered()).thenReturn(true);
+        when(peerForwarderProvider.isPeerForwardingRequired()).thenReturn(true);
 
         final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();
         objectUnderTest.start();
@@ -81,7 +81,7 @@ class PeerForwarderServerProxyTest {
 
     @Test
     void stop_should_do_nothing_if_noop_server_is_started() {
-        when(peerForwarderProvider.isAtLeastOnePeerForwarderRegistered()).thenReturn(false);
+        when(peerForwarderProvider.isPeerForwardingRequired()).thenReturn(false);
 
         final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();
         objectUnderTest.start();

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxyTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxyTest.java
@@ -80,7 +80,7 @@ class PeerForwarderServerProxyTest {
     }
 
     @Test
-    void stop_should_do_nothing_if_noop_server_is_started() {
+    void no_server_interaction_if_peer_forwarding_not_required() {
         when(peerForwarderProvider.isPeerForwardingRequired()).thenReturn(false);
 
         final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxyTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxyTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
+import org.opensearch.dataprepper.peerforwarder.PeerForwarderProvider;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -24,22 +25,26 @@ import static org.mockito.Mockito.when;
 class PeerForwarderServerProxyTest {
 
     @Mock
-    Server server;
+    private Server server;
 
     @Mock
-    PeerForwarderConfiguration peerForwarderConfiguration;
+    private PeerForwarderConfiguration peerForwarderConfiguration;
+
+    @Mock
+    private PeerForwarderProvider peerForwarderProvider;
 
     @Mock
     CompletableFuture<Void> completableFuture;
 
     PeerForwarderServerProxy createObjectUnderTest() {
-        return new PeerForwarderServerProxy(peerForwarderConfiguration, server);
+        return new PeerForwarderServerProxy(peerForwarderConfiguration, server, peerForwarderProvider);
     }
 
     @Test
-    void start_should_start_server_if_peers_configured() throws ExecutionException, InterruptedException {
+    void start_should_start_server_if_peers_are_registered() throws ExecutionException, InterruptedException {
         when(server.start()).thenReturn(completableFuture);
         when(completableFuture.get()).thenReturn(mock(Void.class));
+        when(peerForwarderProvider.isAtLeastOnePeerForwarderRegistered()).thenReturn(true);
 
         final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();
         objectUnderTest.start();
@@ -47,7 +52,15 @@ class PeerForwarderServerProxyTest {
     }
 
     @Test
-    void stop_should_not_stop_server_if_server_is_not_started() throws ExecutionException, InterruptedException {
+    void start_should_not_start_server_if_no_peers_are_registered() {
+        final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();
+        objectUnderTest.start();
+
+        verifyNoInteractions(server);
+    }
+
+    @Test
+    void stop_should_not_stop_server_if_server_is_not_started() {
         final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();
         objectUnderTest.stop();
         verifyNoInteractions(server);
@@ -58,11 +71,22 @@ class PeerForwarderServerProxyTest {
         when(server.start()).thenReturn(completableFuture);
         when(server.stop()).thenReturn(completableFuture);
         when(completableFuture.get()).thenReturn(mock(Void.class));
+        when(peerForwarderProvider.isAtLeastOnePeerForwarderRegistered()).thenReturn(true);
 
         final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();
         objectUnderTest.start();
         objectUnderTest.stop();
         verify(server).stop();
+    }
+
+    @Test
+    void stop_should_do_nothing_if_noop_server_is_started() {
+        when(peerForwarderProvider.isAtLeastOnePeerForwarderRegistered()).thenReturn(false);
+
+        final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();
+        objectUnderTest.start();
+        objectUnderTest.stop();
+        verifyNoInteractions(server);
     }
 
 }


### PR DESCRIPTION
… buffer

Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
- Updated WireEvents to have pipeline name
- Updated HTTP service to write deserialized events to buffer
- Added a getter for buffer map in `PeerForwarderProvider` 
- Added `LocalPeerForwarder` which is used by plugins which don't implement `RequiresPeerForwarding`
- Added `REQUEST_ENTITY_TOO_LARGE` response to response handler if request size is greater than buffer size
 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
