### PR TITLE
Support inherited classes from PluginSetting

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginArgumentsContext.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginArgumentsContext.java
@@ -39,7 +39,7 @@ class PluginArgumentsContext {
 
         typedArgumentsSuppliers = new HashMap<>();
 
-        typedArgumentsSuppliers.put(builder.pluginSetting.getClass(), () -> builder.pluginSetting);
+        typedArgumentsSuppliers.put(PluginSetting.class, () -> builder.pluginSetting);
 
         if(builder.pluginConfiguration != null) {
             typedArgumentsSuppliers.put(builder.pluginConfiguration.getClass(), () -> builder.pluginConfiguration);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/PluginArgumentsContextTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/PluginArgumentsContextTest.java
@@ -18,6 +18,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 
+import java.util.Map;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -43,6 +45,12 @@ class PluginArgumentsContextTest {
 
     private static class TestPluginConfiguration { }
 
+    private static class SubPluginSetting extends PluginSetting {
+        public SubPluginSetting(final String name, final Map<String, Object> settings) {
+            super(name, settings);
+        }
+    }
+
     @Test
     void createArguments_with_unavailable_argument_should_throw() {
         final PluginArgumentsContext objectUnderTest = new PluginArgumentsContext.Builder()
@@ -62,6 +70,18 @@ class PluginArgumentsContextTest {
 
         assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class }),
                 equalTo(new Object[] { testPluginConfiguration}));
+    }
+
+    @Test
+    void createArguments_with_single_class_when_PluginSetting_is_inherited() {
+        pluginSetting = mock(SubPluginSetting.class);
+        final PluginArgumentsContext objectUnderTest = new PluginArgumentsContext.Builder()
+                .withPluginConfiguration(testPluginConfiguration)
+                .withPluginSetting(pluginSetting)
+                .build();
+
+        assertThat(objectUnderTest.createArguments(new Class[] { PluginSetting.class }),
+                equalTo(new Object[] { pluginSetting}));
     }
 
     @Test


### PR DESCRIPTION
### Description

The plugin framework cannot correctly load classes which inherit from `PluginSetting`. This is something we will need to support conditional routing.
 
### Issues Resolved

None
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
