### PR TITLE
Peer Forwarder client-server integration testing and related fixes

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerClientPool.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerClientPool.java
@@ -52,7 +52,7 @@ public class PeerClientPool {
     }
 
     private WebClient getHTTPClient(final String ipAddress) {
-        final String protocol = ssl ? HTTP : HTTPS;
+        final String protocol = ssl ? HTTPS : HTTP;
 
         ClientBuilder clientBuilder = Clients.builder(String.format("%s://%s:%s/", protocol, ipAddress, port))
                 .writeTimeout(Duration.ofSeconds(clientTimeoutSeconds));

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
@@ -54,8 +54,13 @@ class RemotePeerForwarder implements PeerForwarder {
             if (isAddressDefinedLocally(destinationIp)) {
                 recordsToProcessLocally.addAll(entry.getValue());
             } else {
-                final AggregatedHttpResponse httpResponse = peerForwarderClient.serializeRecordsAndSendHttpRequest(entry.getValue(),
-                        destinationIp, pluginId, pipelineName);
+                AggregatedHttpResponse httpResponse = null;
+                try {
+                    httpResponse = peerForwarderClient.serializeRecordsAndSendHttpRequest(entry.getValue(),
+                            destinationIp, pluginId, pipelineName);
+                } catch (Exception ex) {
+                }
+
                 if (httpResponse == null || httpResponse.status() != HttpStatus.OK) {
                     recordsToProcessLocally.addAll(entry.getValue());
                 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
@@ -11,6 +11,8 @@ import org.opensearch.dataprepper.peerforwarder.discovery.StaticPeerListProvider
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import org.opensearch.dataprepper.peerforwarder.client.PeerForwarderClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -25,6 +27,8 @@ import java.util.Map;
 import java.util.Set;
 
 class RemotePeerForwarder implements PeerForwarder {
+    private static final Logger LOG = LoggerFactory.getLogger(RemotePeerForwarder.class);
+
     private final PeerForwarderClient peerForwarderClient;
     private final HashRing hashRing;
     private final String pipelineName;
@@ -54,11 +58,13 @@ class RemotePeerForwarder implements PeerForwarder {
             if (isAddressDefinedLocally(destinationIp)) {
                 recordsToProcessLocally.addAll(entry.getValue());
             } else {
-                AggregatedHttpResponse httpResponse = null;
+                AggregatedHttpResponse httpResponse;
                 try {
                     httpResponse = peerForwarderClient.serializeRecordsAndSendHttpRequest(entry.getValue(),
                             destinationIp, pluginId, pipelineName);
-                } catch (Exception ex) {
+                } catch (final Exception ex) {
+                    httpResponse = null;
+                    LOG.warn("Unable to send request to peer, processing locally.", ex);
                 }
 
                 if (httpResponse == null || httpResponse.status() != HttpStatus.OK) {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClient.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClient.java
@@ -9,9 +9,9 @@ import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.record.Record;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
 import org.opensearch.dataprepper.peerforwarder.PeerClientPool;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderClientFactory;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -59,29 +58,23 @@ public class PeerForwarderClient {
 
         final WebClient client = peerClientPool.getClient(ipAddress);
 
-        final Optional<String> serializedJsonString = getSerializedJsonString(records, pluginId, pipelineName);
-        return serializedJsonString.map(value -> {
-                    final CompletableFuture<AggregatedHttpResponse> aggregatedHttpResponseCompletableFuture =
-                            processHttpRequest(client, value);
-                    return getAggregatedHttpResponse(aggregatedHttpResponseCompletableFuture);
-                })
-                .orElse(AggregatedHttpResponse.of(HttpStatus.BAD_REQUEST));
+        final String serializedJsonString = getSerializedJsonString(records, pluginId, pipelineName);
+
+        final CompletableFuture<AggregatedHttpResponse> aggregatedHttpResponseCompletableFuture =
+                processHttpRequest(client, serializedJsonString);
+        return getAggregatedHttpResponse(aggregatedHttpResponseCompletableFuture);
     }
 
-    private Optional<String> getSerializedJsonString(
-            final Collection<Record<Event>> records,
-            final String pluginId,
-            final String pipelineName) {
+    private String getSerializedJsonString(final Collection<Record<Event>> records, final String pluginId, final String pipelineName) {
         final List<WireEvent> wireEventList = getWireEventList(records);
         final WireEvents wireEvents = new WireEvents(wireEventList, pluginId, pipelineName);
 
-        String serializedJsonString = null;
         try {
-            serializedJsonString = objectMapper.writeValueAsString(wireEvents);
+            return objectMapper.writeValueAsString(wireEvents);
         } catch (JsonProcessingException e) {
             LOG.warn("Unable to send request to peer, processing locally.", e);
+            throw new RuntimeException(e);
         }
-        return Optional.ofNullable(serializedJsonString);
     }
 
     private List<WireEvent> getWireEventList(final Collection<Record<Event>> records) {
@@ -112,18 +105,23 @@ public class PeerForwarderClient {
                 return aggregate.join();
             } catch (Exception e) {
                 LOG.error("Failed to forward request to address: {}", authority, e);
-                return null;
+                throw e;
             }
         }, executorService);
     }
 
-    private AggregatedHttpResponse getAggregatedHttpResponse(final CompletableFuture<AggregatedHttpResponse> aggregatedHttpResponseCompletableFuture) {
+    private AggregatedHttpResponse getAggregatedHttpResponse(final CompletableFuture<AggregatedHttpResponse> aggregatedHttpResponseCompletableFuture) throws UnprocessedRequestException {
         try {
             return aggregatedHttpResponseCompletableFuture.get();
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (InterruptedException e) {
             LOG.error("Problem with asynchronous peer forwarding", e);
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            LOG.error("Problem with asynchronous peer forwarding", e);
+            if(e.getCause() instanceof RuntimeException)
+                throw (RuntimeException) e.getCause();
+            throw new RuntimeException(e.getCause());
         }
-        return AggregatedHttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
     }
 
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerClientPoolTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerClientPoolTest.java
@@ -5,18 +5,23 @@
 
 package org.opensearch.dataprepper.peerforwarder;
 
-import org.opensearch.dataprepper.plugins.certificate.model.Certificate;
 import com.linecorp.armeria.client.WebClient;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.certificate.model.Certificate;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 class PeerClientPoolTest {
@@ -24,18 +29,21 @@ class PeerClientPoolTest {
     private static final String LOCALHOST = "localhost";
     private static final int PORT = 21890;
 
-    @Test
-    void testGetClientValidAddress() {
+    @ParameterizedTest
+    @ValueSource(strings = {VALID_ADDRESS, LOCALHOST})
+    void testGetClientValidAddress(final String address) {
         PeerClientPool pool = new PeerClientPool();
         pool.setPort(PORT);
 
-        WebClient client = pool.getClient(VALID_ADDRESS);
+        WebClient client = pool.getClient(address);
 
         Assertions.assertNotNull(client);
+        assertThat(client.uri(), equalTo(URI.create("http://" + address + ":" + PORT + "/")));
     }
 
-    @Test
-    void testGetClientWithSSL() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = {VALID_ADDRESS, LOCALHOST})
+    void testGetClientWithSSL(final String address) throws IOException {
         PeerClientPool pool = new PeerClientPool();
         pool.setSsl(true);
         pool.setPort(PORT);
@@ -48,9 +56,10 @@ class PeerClientPoolTest {
 
         pool.setCertificate(certificate);
 
-        WebClient client = pool.getClient(LOCALHOST);
+        WebClient client = pool.getClient(address);
 
         Assertions.assertNotNull(client);
+        assertThat(client.uri(), equalTo(URI.create("https://" + address + ":" + PORT + "/")));
     }
 
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.peerforwarder;
+
+import com.amazon.dataprepper.model.event.Event;
+import com.amazon.dataprepper.model.event.JacksonEvent;
+import com.amazon.dataprepper.model.record.Record;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.ClosedSessionException;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.Server;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.peerforwarder.certificate.CertificateProviderFactory;
+import org.opensearch.dataprepper.peerforwarder.client.PeerForwarderClient;
+import org.opensearch.dataprepper.peerforwarder.discovery.DiscoveryMode;
+import org.opensearch.dataprepper.peerforwarder.server.PeerForwarderHttpServerProvider;
+import org.opensearch.dataprepper.peerforwarder.server.PeerForwarderHttpService;
+import org.opensearch.dataprepper.peerforwarder.server.PeerForwarderServer;
+import org.opensearch.dataprepper.peerforwarder.server.RemotePeerForwarderServer;
+import org.opensearch.dataprepper.peerforwarder.server.ResponseHandler;
+
+import javax.net.ssl.SSLHandshakeException;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Integration tests that verify that Peer Forwarder client-server communication
+ * works.
+ */
+class PeerForwarder_ClientServerIT {
+
+    public static final String LOCALHOST = "127.0.0.1";
+    private PeerForwarderHttpService peerForwarderHttpService;
+    private ObjectMapper objectMapper;
+    private String pluginId;
+    private List<Record<Event>> records;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+        peerForwarderHttpService = new PeerForwarderHttpService(new ResponseHandler(), objectMapper);
+
+        records = IntStream.range(0, 5)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+        pluginId = UUID.randomUUID().toString();
+    }
+
+    private PeerForwarderServer createServer(
+            final PeerForwarderConfiguration peerForwarderConfiguration,
+            final CertificateProviderFactory certificateProviderFactory) {
+        Objects.requireNonNull(peerForwarderConfiguration, "Nested classes must supply peerForwarderConfiguration");
+        Objects.requireNonNull(certificateProviderFactory, "Nested classes must supply certificateProviderFactory");
+        final PeerForwarderHttpServerProvider serverProvider = new PeerForwarderHttpServerProvider(peerForwarderConfiguration,
+                certificateProviderFactory, peerForwarderHttpService);
+
+        final Server server = serverProvider.get();
+
+        return new RemotePeerForwarderServer(peerForwarderConfiguration, server);
+    }
+
+    private PeerForwarderClient createClient(
+            final PeerForwarderConfiguration peerForwarderConfiguration,
+            final CertificateProviderFactory certificateProviderFactory) {
+        Objects.requireNonNull(peerForwarderConfiguration, "Nested classes must supply peerForwarderConfiguration");
+        Objects.requireNonNull(certificateProviderFactory, "Nested classes must supply certificateProviderFactory");
+        final PeerClientPool peerClientPool = new PeerClientPool();
+        final PeerForwarderClientFactory peerForwarderClientFactory = new PeerForwarderClientFactory(peerForwarderConfiguration, peerClientPool, certificateProviderFactory);
+        peerForwarderClientFactory.setPeerClientPool();
+        return new PeerForwarderClient(peerForwarderConfiguration, peerForwarderClientFactory, objectMapper);
+    }
+
+    @Nested
+    class WithSSL {
+
+        private PeerForwarderConfiguration peerForwarderConfiguration;
+        private CertificateProviderFactory certificateProviderFactory;
+        private PeerForwarderServer server;
+
+        @BeforeEach
+        void setUp() {
+            peerForwarderConfiguration = createConfiguration(true);
+
+            certificateProviderFactory = new CertificateProviderFactory(peerForwarderConfiguration);
+            server = createServer(peerForwarderConfiguration, certificateProviderFactory);
+            server.start();
+        }
+
+        @AfterEach
+        void tearDown() {
+            server.stop();
+        }
+
+        @Test
+        void send_Events_to_server() {
+            final PeerForwarderClient client = createClient(peerForwarderConfiguration, certificateProviderFactory);
+
+            final AggregatedHttpResponse httpResponse = client.serializeRecordsAndSendHttpRequest(records, LOCALHOST, pluginId);
+
+            assertThat(httpResponse.status(), equalTo(HttpStatus.OK));
+
+            // TODO: Validate that Events are received on the Server
+        }
+
+        @Test
+        void send_Events_to_server_when_client_does_not_expect_SSL_should_throw() {
+            final PeerForwarderConfiguration peerForwarderConfiguration = createConfiguration(false);
+            certificateProviderFactory = new CertificateProviderFactory(peerForwarderConfiguration);
+
+            final PeerForwarderClient client = createClient(peerForwarderConfiguration, certificateProviderFactory);
+
+            assertThrows(ClosedSessionException.class, () -> client.serializeRecordsAndSendHttpRequest(records, LOCALHOST, pluginId));
+        }
+    }
+
+    @Nested
+    class WithoutSSL {
+
+        private PeerForwarderConfiguration peerForwarderConfiguration;
+        private CertificateProviderFactory certificateProviderFactory;
+        private PeerForwarderServer server;
+
+        @BeforeEach
+        void setUp() {
+            peerForwarderConfiguration = createConfiguration(false);
+
+            certificateProviderFactory = new CertificateProviderFactory(peerForwarderConfiguration);
+            server = createServer(peerForwarderConfiguration, certificateProviderFactory);
+            server.start();
+        }
+
+        @AfterEach
+        void tearDown() {
+            server.stop();
+        }
+
+        @Test
+        void send_Events_to_server() {
+            final PeerForwarderClient client = createClient(peerForwarderConfiguration, certificateProviderFactory);
+
+            final AggregatedHttpResponse httpResponse = client.serializeRecordsAndSendHttpRequest(records, LOCALHOST, pluginId);
+
+            assertThat(httpResponse.status(), equalTo(HttpStatus.OK));
+
+            // TODO: Validate that Events are received on the Server
+        }
+
+        @Test
+        void send_Events_to_server_when_expecting_SSL_should_throw() {
+            final PeerForwarderConfiguration peerForwarderConfiguration = createConfiguration(true);
+            certificateProviderFactory = new CertificateProviderFactory(peerForwarderConfiguration);
+
+            final PeerForwarderClient client = createClient(peerForwarderConfiguration, certificateProviderFactory);
+
+            final UnprocessedRequestException actualException = assertThrows(UnprocessedRequestException.class, () -> client.serializeRecordsAndSendHttpRequest(records, LOCALHOST, pluginId));
+
+            assertThat(actualException.getCause(), instanceOf(SSLHandshakeException.class));
+        }
+    }
+
+    private PeerForwarderConfiguration createConfiguration(final boolean ssl) {
+        final String sslCertificateFile = "src/test/resources/test-crt.crt";
+        final String sslKeyFile = "src/test/resources/test-key.key";
+        return new PeerForwarderConfiguration(
+                21890,
+                10_000,
+                200,
+                500,
+                1024,
+                ssl,
+                sslCertificateFile,
+                sslKeyFile,
+                false,
+                null,
+                null,
+                120000,
+                DiscoveryMode.STATIC.toString(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of("127.0.0.1"),
+                200,
+                48,
+                512
+        );
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
@@ -98,7 +98,7 @@ class RemotePeerForwarderTest {
 
     @Test
     void forwardRecords_should_return_all_input_events_when_client_throws() {
-        when(peerForwarderClient.serializeRecordsAndSendHttpRequest(anyCollection(), anyString(), anyString())).thenThrow(RuntimeException.class);
+        when(peerForwarderClient.serializeRecordsAndSendHttpRequest(anyCollection(), anyString(), anyString(), anyString())).thenThrow(RuntimeException.class);
 
         final List<String> testIps = List.of("8.8.8.8", "127.0.0.1");
         lenient().when(hashRing.getServerIp(List.of("value1", "value1"))).thenReturn(Optional.of(testIps.get(0)));
@@ -108,7 +108,7 @@ class RemotePeerForwarderTest {
 
         final Collection<Record<Event>> inputRecords = generateBatchRecords(2, false);
         final Collection<Record<Event>> records = peerForwarder.forwardRecords(inputRecords);
-        verify(peerForwarderClient, times(1)).serializeRecordsAndSendHttpRequest(anyList(), anyString(), anyString());
+        verify(peerForwarderClient, times(1)).serializeRecordsAndSendHttpRequest(anyList(), anyString(), anyString(), anyString());
         assertThat(records, notNullValue());
         assertThat(records.size(), equalTo(inputRecords.size()));
         for (Record<Event> inputRecord : inputRecords) {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.ArgumentMatchers.anyCollection;
@@ -92,6 +94,26 @@ class RemotePeerForwarderTest {
         final Collection<Record<Event>> records = peerForwarder.forwardRecords(testRecords);
         verify(peerForwarderClient, times(1)).serializeRecordsAndSendHttpRequest(anyList(), anyString(), anyString(), anyString());
         assertThat(records.size(), equalTo(1));
+    }
+
+    @Test
+    void forwardRecords_should_return_all_input_events_when_client_throws() {
+        when(peerForwarderClient.serializeRecordsAndSendHttpRequest(anyCollection(), anyString(), anyString())).thenThrow(RuntimeException.class);
+
+        final List<String> testIps = List.of("8.8.8.8", "127.0.0.1");
+        lenient().when(hashRing.getServerIp(List.of("value1", "value1"))).thenReturn(Optional.of(testIps.get(0)));
+        lenient().when(hashRing.getServerIp(List.of("value2", "value2"))).thenReturn(Optional.of(testIps.get(1)));
+
+        final RemotePeerForwarder peerForwarder = createObjectUnderTest();
+
+        final Collection<Record<Event>> inputRecords = generateBatchRecords(2, false);
+        final Collection<Record<Event>> records = peerForwarder.forwardRecords(inputRecords);
+        verify(peerForwarderClient, times(1)).serializeRecordsAndSendHttpRequest(anyList(), anyString(), anyString());
+        assertThat(records, notNullValue());
+        assertThat(records.size(), equalTo(inputRecords.size()));
+        for (Record<Event> inputRecord : inputRecords) {
+            assertThat(records, hasItem(inputRecord));
+        }
     }
 
     private Collection<Record<Event>> generateBatchRecords(final int numRecords, final boolean isSameValues) {


### PR DESCRIPTION
### Description

I created a new integration test, `PeerForwarder_ClientServerIT`, which focuses on client-server interactions. While working on this, I found some bugs and fixed them. Also, some of the errors that Data Prepper was returning on the client were highly misleading. They were all returned as status codes, even when the connection was refused or unable to communicate over SSL. I changed the error handling related to this to make issues clearer.
 
### Issues Resolved

None. Part of #700.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
