### PR TITLE
Refactor PluginDurationDeserializer to DataPrepperDurationDeserializer, add processorShutdownTimeout to DataPrepperConfiguration, use processorShutdownTimeout from DataPrepperConfiguration in Pipeline

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/DataPrepperDurationDeserializer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/DataPrepperDurationDeserializer.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugin;
+package org.opensearch.dataprepper.parser;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -22,15 +22,15 @@ import java.util.regex.Pattern;
  * Whitespace is ignored and leading zeroes are not allowed.
  * @since 1.3
  */
-class PluginDurationDeserializer extends StdDeserializer<Duration> {
+public class DataPrepperDurationDeserializer extends StdDeserializer<Duration> {
 
     private static final String SIMPLE_DURATION_REGEX = "^([1-9]\\d*)(s|ms)$";
     private static final Pattern SIMPLE_DURATION_PATTERN = Pattern.compile(SIMPLE_DURATION_REGEX);
 
-    public PluginDurationDeserializer() {
+    public DataPrepperDurationDeserializer() {
         this(null);
     }
-    protected PluginDurationDeserializer(Class<?> vc) {
+    protected DataPrepperDurationDeserializer(Class<?> vc) {
         super(vc);
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/DataPrepperDurationDeserializer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/DataPrepperDurationDeserializer.java
@@ -16,7 +16,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * This deserializer is used for all plugin configurations that use a {@link Duration} type that is mapped to by Jackson in the {@link PluginConfigurationConverter}.
+ * This deserializer is used for configurations that use a {@link Duration} type when deserialized by Jackson
  * It supports ISO 8601 notation ("PT20.345S", "PT15M", etc.) and simple durations for
  * seconds (60s) and milliseconds (100ms). It does not support combining the units for simple durations ("60s 100ms" is not allowed).
  * Whitespace is ignored and leading zeroes are not allowed.

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
@@ -134,8 +134,8 @@ public class PipelineParser {
                     .map(this::buildSinkOrConnector)
                     .collect(Collectors.toList());
 
-            final long processorShutdownTimeout = dataPrepperConfiguration.getProcessorShutdownTimeout().toMillis();
-            final Pipeline pipeline = new Pipeline(pipelineName, source, buffer, decoratedProcessorSets, sinks, processorThreads, readBatchDelay, processorShutdownTimeout);
+            final Pipeline pipeline = new Pipeline(pipelineName, source, buffer, decoratedProcessorSets, sinks, processorThreads, readBatchDelay,
+                    dataPrepperConfiguration.getProcessorShutdownTimeout(), dataPrepperConfiguration.getSinkShutdownTimeout());
             pipelineMap.put(pipelineName, pipeline);
         } catch (Exception ex) {
             //If pipeline construction errors out, we will skip that pipeline and proceed

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/config/DataPrepperAppConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/config/DataPrepperAppConfiguration.java
@@ -6,7 +6,9 @@
 package org.opensearch.dataprepper.parser.config;
 
 import com.amazon.dataprepper.model.configuration.PluginModel;
+import org.opensearch.dataprepper.parser.DataPrepperDurationDeserializer;
 import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +19,7 @@ import org.springframework.core.env.Environment;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 
 @Configuration
 public class DataPrepperAppConfiguration {
@@ -47,6 +50,8 @@ public class DataPrepperAppConfiguration {
         if (dataPrepperConfigFileLocation != null) {
             final File configurationFile = new File(dataPrepperConfigFileLocation);
             try {
+                final SimpleModule simpleModule = new SimpleModule().addDeserializer(Duration.class, new DataPrepperDurationDeserializer());
+                objectMapper.registerModule(simpleModule);
                 return objectMapper.readValue(configurationFile, DataPrepperConfiguration.class);
             } catch (final IOException e) {
                 throw new IllegalArgumentException("Invalid DataPrepper configuration file.", e);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/config/PipelineParserConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/config/PipelineParserConfiguration.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.parser.config;
 
 import com.amazon.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
 import org.opensearch.dataprepper.parser.PipelineParser;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderProvider;
 import org.springframework.context.annotation.Bean;
@@ -18,10 +19,12 @@ public class PipelineParserConfiguration {
     public PipelineParser pipelineParser(
             final DataPrepperArgs dataPrepperArgs,
             final PluginFactory pluginFactory,
-            final PeerForwarderProvider peerForwarderProvider
+            final PeerForwarderProvider peerForwarderProvider,
+            final DataPrepperConfiguration dataPrepperConfiguration
             ) {
         return new PipelineParser(dataPrepperArgs.getPipelineConfigFileLocation(),
                 pluginFactory,
-                peerForwarderProvider);
+                peerForwarderProvider,
+                dataPrepperConfiguration);
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/DataPrepperConfiguration.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -21,6 +22,8 @@ import java.util.Map;
  * Class to hold configuration for DataPrepper, including server port and Log4j settings
  */
 public class DataPrepperConfiguration {
+    static final Duration DEFAULT_SHUTDOWN_DURATION = Duration.ofSeconds(10L);
+
     static final int MAX_TAGS_NUMBER = 3;
     private static final List<MetricRegistryType> DEFAULT_METRIC_REGISTRY_TYPE = Collections.singletonList(MetricRegistryType.Prometheus);
     private int serverPort = 4900;
@@ -32,6 +35,7 @@ public class DataPrepperConfiguration {
     private PluginModel authentication;
     private Map<String, String> metricTags = new HashMap<>();
     private PeerForwarderConfiguration peerForwarderConfiguration;
+    private Duration processorShutdownTimeout;
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
 
@@ -50,7 +54,8 @@ public class DataPrepperConfiguration {
             @JsonProperty("metricRegistries") final List<MetricRegistryType> metricRegistries,
             @JsonProperty("authentication") final PluginModel authentication,
             @JsonProperty("metricTags") final Map<String, String> metricTags,
-            @JsonProperty("peer_forwarder") final PeerForwarderConfiguration peerForwarderConfiguration
+            @JsonProperty("peer_forwarder") final PeerForwarderConfiguration peerForwarderConfiguration,
+            @JsonProperty("processorShutdownTimeout") final Duration processorShutdownTimeout
             ) {
         this.authentication = authentication;
         setSsl(ssl);
@@ -61,6 +66,7 @@ public class DataPrepperConfiguration {
         setMetricTags(metricTags);
         setServerPort(serverPort);
         this.peerForwarderConfiguration = peerForwarderConfiguration;
+        this.processorShutdownTimeout = processorShutdownTimeout != null ? processorShutdownTimeout : DEFAULT_SHUTDOWN_DURATION;
     }
 
     public int getServerPort() {
@@ -126,5 +132,9 @@ public class DataPrepperConfiguration {
             }
             this.metricTags = metricTags;
         }
+    }
+
+    public Duration getProcessorShutdownTimeout() {
+        return processorShutdownTimeout;
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/DataPrepperConfiguration.java
@@ -36,6 +36,7 @@ public class DataPrepperConfiguration {
     private Map<String, String> metricTags = new HashMap<>();
     private PeerForwarderConfiguration peerForwarderConfiguration;
     private Duration processorShutdownTimeout;
+    private Duration sinkShutdownTimeout;
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
 
@@ -55,7 +56,8 @@ public class DataPrepperConfiguration {
             @JsonProperty("authentication") final PluginModel authentication,
             @JsonProperty("metricTags") final Map<String, String> metricTags,
             @JsonProperty("peer_forwarder") final PeerForwarderConfiguration peerForwarderConfiguration,
-            @JsonProperty("processorShutdownTimeout") final Duration processorShutdownTimeout
+            @JsonProperty("processorShutdownTimeout") final Duration processorShutdownTimeout,
+            @JsonProperty("sinkShutdownTimeout") final Duration sinkShutdownTimeout
             ) {
         this.authentication = authentication;
         setSsl(ssl);
@@ -66,7 +68,16 @@ public class DataPrepperConfiguration {
         setMetricTags(metricTags);
         setServerPort(serverPort);
         this.peerForwarderConfiguration = peerForwarderConfiguration;
+
         this.processorShutdownTimeout = processorShutdownTimeout != null ? processorShutdownTimeout : DEFAULT_SHUTDOWN_DURATION;
+        if (this.processorShutdownTimeout.isNegative()) {
+            throw new IllegalArgumentException("processorShutdownTimeout must be non-negative.");
+        }
+
+        this.sinkShutdownTimeout = sinkShutdownTimeout != null ? sinkShutdownTimeout : DEFAULT_SHUTDOWN_DURATION;
+        if (this.sinkShutdownTimeout.isNegative()) {
+            throw new IllegalArgumentException("sinkShutdownTimeout must be non-negative.");
+        }
     }
 
     public int getServerPort() {
@@ -136,5 +147,9 @@ public class DataPrepperConfiguration {
 
     public Duration getProcessorShutdownTimeout() {
         return processorShutdownTimeout;
+    }
+
+    public Duration getSinkShutdownTimeout() {
+        return sinkShutdownTimeout;
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginConfigurationConverter.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginConfigurationConverter.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
+import org.opensearch.dataprepper.parser.DataPrepperDurationDeserializer;
 
 import javax.inject.Named;
 import java.time.Duration;
@@ -33,7 +34,7 @@ class PluginConfigurationConverter {
 
     PluginConfigurationConverter(final Validator validator) {
         final SimpleModule simpleModule = new SimpleModule();
-        simpleModule.addDeserializer(Duration.class, new PluginDurationDeserializer());
+        simpleModule.addDeserializer(Duration.class, new DataPrepperDurationDeserializer());
 
         this.objectMapper = new ObjectMapper()
                 .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
@@ -55,6 +55,7 @@ public class TestDataProvider {
     public static final String VALID_DATA_PREPPER_CONFIG_FILE_WITH_TAGS = "src/test/resources/valid_data_prepper_config_with_tags.yml";
     public static final String VALID_DATA_PREPPER_CONFIG_FILE_WITH_PROCESSOR_SHUTDOWN_TIMEOUT = "src/test/resources/valid_data_prepper_config_with_processor_shutdown_timeout.yml";
     public static final String VALID_DATA_PREPPER_CONFIG_FILE_WITH_SINK_SHUTDOWN_TIMEOUT = "src/test/resources/valid_data_prepper_config_with_sink_shutdown_timeout.yml";
+    public static final String VALID_DATA_PREPPER_CONFIG_FILE_WITH_ISO8601_SHUTDOWN_TIMEOUTS = "src/test/resources/valid_data_prepper_config_with_iso8601_shutdown_timeouts.yml";
     public static final String INVALID_DATA_PREPPER_CONFIG_FILE = "src/test/resources/invalid_data_prepper_config.yml";
     public static final String INVALID_DATA_PREPPER_CONFIG_FILE_WITH_TAGS = "src/test/resources/invalid_data_prepper_config_with_tags.yml";
     public static final String INVALID_DATA_PREPPER_CONFIG_FILE_WITH_BAD_PROCESSOR_SHUTDOWN_TIMEOUT = "src/test/resources/invalid_data_prepper_config_with_bad_processor_shutdown_timeout.yml";

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
@@ -53,8 +53,14 @@ public class TestDataProvider {
     public static final String VALID_DATA_PREPPER_CLOUDWATCH_METRICS_CONFIG_FILE = "src/test/resources/valid_data_prepper_cloudwatch_metrics_config.yml";
     public static final String VALID_DATA_PREPPER_MULTIPLE_METRICS_CONFIG_FILE = "src/test/resources/valid_data_prepper_multiple_metrics_config.yml";
     public static final String VALID_DATA_PREPPER_CONFIG_FILE_WITH_TAGS = "src/test/resources/valid_data_prepper_config_with_tags.yml";
+    public static final String VALID_DATA_PREPPER_CONFIG_FILE_WITH_PROCESSOR_SHUTDOWN_TIMEOUT = "src/test/resources/valid_data_prepper_config_with_processor_shutdown_timeout.yml";
+    public static final String VALID_DATA_PREPPER_CONFIG_FILE_WITH_SINK_SHUTDOWN_TIMEOUT = "src/test/resources/valid_data_prepper_config_with_sink_shutdown_timeout.yml";
     public static final String INVALID_DATA_PREPPER_CONFIG_FILE = "src/test/resources/invalid_data_prepper_config.yml";
     public static final String INVALID_DATA_PREPPER_CONFIG_FILE_WITH_TAGS = "src/test/resources/invalid_data_prepper_config_with_tags.yml";
+    public static final String INVALID_DATA_PREPPER_CONFIG_FILE_WITH_BAD_PROCESSOR_SHUTDOWN_TIMEOUT = "src/test/resources/invalid_data_prepper_config_with_bad_processor_shutdown_timeout.yml";
+    public static final String INVALID_DATA_PREPPER_CONFIG_FILE_WITH_BAD_SINK_SHUTDOWN_TIMEOUT = "src/test/resources/invalid_data_prepper_config_with_bad_sink_shutdown_timeout.yml";
+    public static final String INVALID_DATA_PREPPER_CONFIG_FILE_WITH_NEGATIVE_PROCESSOR_SHUTDOWN_TIMEOUT = "src/test/resources/invalid_data_prepper_config_with_negative_processor_shutdown_timeout.yml";
+    public static final String INVALID_DATA_PREPPER_CONFIG_FILE_WITH_NEGATIVE_SINK_SHUTDOWN_TIMEOUT = "src/test/resources/invalid_data_prepper_config_with_negative_sink_shutdown_timeout.yml";
     public static final String INVALID_PORT_DATA_PREPPER_CONFIG_FILE = "src/test/resources/invalid_port_data_prepper_config.yml";
     public static final String INVALID_KEYSTORE_PASSWORD_DATA_PREPPER_CONFIG_FILE = "src/test/resources/invalid_data_prepper_config_with_bad_keystore_password.yml";
     public static final String VALID_PEER_FORWARDER_DATA_PREPPER_CONFIG_FILE = "src/test/resources/valid_data_prepper_config_wth_peer_forwarder_config.yml";

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/DataPrepperDurationDeserializerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/DataPrepperDurationDeserializerTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugin;
+package org.opensearch.dataprepper.parser;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -18,13 +18,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class PluginDurationDeserializerTest {
+public class DataPrepperDurationDeserializerTest {
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setup() {
         final SimpleModule simpleModule = new SimpleModule();
-        simpleModule.addDeserializer(Duration.class, new PluginDurationDeserializer());
+        simpleModule.addDeserializer(Duration.class, new DataPrepperDurationDeserializer());
 
         objectMapper = new ObjectMapper();
         objectMapper.registerModule(simpleModule);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
@@ -8,21 +8,33 @@ package org.opensearch.dataprepper.parser;
 import com.amazon.dataprepper.model.plugin.PluginFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
 import org.opensearch.dataprepper.TestDataProvider;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderProvider;
 import org.opensearch.dataprepper.pipeline.Pipeline;
 import org.opensearch.dataprepper.plugin.DefaultPluginFactory;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
+import java.time.Duration;
 import java.util.Map;
+import java.util.Random;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
 
+@ExtendWith(MockitoExtension.class)
 class PipelineParserTests {
     private PeerForwarderProvider peerForwarderProvider;
+
+    @Mock
+    private DataPrepperConfiguration dataPrepperConfiguration;
 
     private PluginFactory pluginFactory;
 
@@ -41,35 +53,44 @@ class PipelineParserTests {
 
     @Test
     void parseConfiguration_with_multiple_valid_pipelines_creates_the_correct_pipelineMap() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.VALID_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider);
+        mockDataPrepperConfigurationAccesses();
+        final PipelineParser pipelineParser =
+                new PipelineParser(TestDataProvider.VALID_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
         final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
         assertThat(actualPipelineMap.keySet(), equalTo(TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES));
+        verifyDataPrepperConfigurationAccesses(actualPipelineMap.keySet().size());
     }
 
     @Test
     void parseConfiguration_with_invalid_root_pipeline_creates_empty_pipelinesMap() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT, pluginFactory, peerForwarderProvider);
+        final PipelineParser pipelineParser =
+                new PipelineParser(TestDataProvider.CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
         final Map<String, Pipeline> connectedPipelines = pipelineParser.parseConfiguration();
         assertThat(connectedPipelines.size(), equalTo(0));
     }
 
     @Test
     void parseConfiguration_with_incorrect_child_pipeline_returns_empty_pipelinesMap() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.CONNECTED_PIPELINE_CHILD_PIPELINE_INCORRECT, pluginFactory, peerForwarderProvider);
+        final PipelineParser pipelineParser =
+                new PipelineParser(TestDataProvider.CONNECTED_PIPELINE_CHILD_PIPELINE_INCORRECT, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
         final Map<String, Pipeline> connectedPipelines = pipelineParser.parseConfiguration();
         assertThat(connectedPipelines.size(), equalTo(0));
     }
 
     @Test
     void parseConfiguration_with_a_single_pipeline_with_empty_source_settings_returns_that_pipeline() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.VALID_SINGLE_PIPELINE_EMPTY_SOURCE_PLUGIN_FILE, pluginFactory, peerForwarderProvider);
+        mockDataPrepperConfigurationAccesses();
+        final PipelineParser pipelineParser =
+                new PipelineParser(TestDataProvider.VALID_SINGLE_PIPELINE_EMPTY_SOURCE_PLUGIN_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
         final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
         assertThat(actualPipelineMap.keySet().size(), equalTo(1));
+        verifyDataPrepperConfigurationAccesses();
     }
 
     @Test
     void parseConfiguration_with_cycles_in_multiple_pipelines_should_throw() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.CYCLE_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider);
+        final PipelineParser pipelineParser =
+                new PipelineParser(TestDataProvider.CYCLE_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
 
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(),
@@ -79,7 +100,8 @@ class PipelineParserTests {
 
     @Test
     void parseConfiguration_with_incorrect_source_mapping_in_multiple_pipelines_should_throw() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.INCORRECT_SOURCE_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider);
+        final PipelineParser pipelineParser =
+                new PipelineParser(TestDataProvider.INCORRECT_SOURCE_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
 
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(),
@@ -88,7 +110,8 @@ class PipelineParserTests {
 
     @Test
     void parseConfiguration_with_missing_pipeline_name_should_throw() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.MISSING_NAME_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider);
+        final PipelineParser pipelineParser =
+                new PipelineParser(TestDataProvider.MISSING_NAME_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
 
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(),
@@ -98,29 +121,48 @@ class PipelineParserTests {
 
     @Test
     void parseConfiguration_with_missing_pipeline_name_in_multiple_pipelines_should_throw() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.MISSING_PIPELINE_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider);
+        final PipelineParser pipelineParser =
+                new PipelineParser(TestDataProvider.MISSING_PIPELINE_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(), equalTo("Invalid configuration, no pipeline is defined with name test-pipeline-4"));
     }
 
     @Test
     void testMultipleSinks() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.VALID_MULTIPLE_SINKS_CONFIG_FILE, pluginFactory, peerForwarderProvider);
+        mockDataPrepperConfigurationAccesses();
+        final PipelineParser pipelineParser =
+                new PipelineParser(TestDataProvider.VALID_MULTIPLE_SINKS_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
         final Map<String, Pipeline> pipelineMap = pipelineParser.parseConfiguration();
         assertThat(pipelineMap.keySet().size(), equalTo(3));
+        verifyDataPrepperConfigurationAccesses(pipelineMap.keySet().size());
     }
 
     @Test
     void testMultipleProcessors() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.VALID_MULTIPLE_PROCESSERS_CONFIG_FILE, pluginFactory, peerForwarderProvider);
+        mockDataPrepperConfigurationAccesses();
+        final PipelineParser pipelineParser =
+                new PipelineParser(TestDataProvider.VALID_MULTIPLE_PROCESSERS_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
         final Map<String, Pipeline> pipelineMap = pipelineParser.parseConfiguration();
         assertThat(pipelineMap.keySet().size(), equalTo(3));
+        verifyDataPrepperConfigurationAccesses(pipelineMap.keySet().size());
     }
 
     @Test
     void parseConfiguration_with_a_configuration_file_which_does_not_exist_should_throw() {
-        final PipelineParser pipelineParser = new PipelineParser("file_does_no_exist.yml", pluginFactory, peerForwarderProvider);
+        final PipelineParser pipelineParser = new PipelineParser("file_does_no_exist.yml", pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(), equalTo("Failed to parse the configuration file file_does_no_exist.yml"));
+    }
+
+    private void mockDataPrepperConfigurationAccesses() {
+        when(dataPrepperConfiguration.getProcessorShutdownTimeout()).thenReturn(Duration.ofSeconds(new Random().nextInt()));
+    }
+
+    private void verifyDataPrepperConfigurationAccesses() {
+        verifyDataPrepperConfigurationAccesses(1);
+    }
+
+    private void verifyDataPrepperConfigurationAccesses(final int times) {
+        verify(dataPrepperConfiguration, times(times)).getProcessorShutdownTimeout();
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
@@ -15,6 +15,7 @@ import org.opensearch.dataprepper.pipeline.Pipeline;
 import org.opensearch.dataprepper.plugin.DefaultPluginFactory;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.mock;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.time.Duration;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
@@ -15,7 +15,7 @@ import org.opensearch.dataprepper.pipeline.Pipeline;
 import org.opensearch.dataprepper.plugin.DefaultPluginFactory;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.mock;
+import org.mockito.Mock;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.time.Duration;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/config/PipelineParserConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/config/PipelineParserConfigurationTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.parser.config;
 
 import com.amazon.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -32,13 +33,16 @@ class PipelineParserConfigurationTest {
     @Mock
     private PeerForwarderProvider peerForwarderProvider;
 
+    @Mock
+    private DataPrepperConfiguration dataPrepperConfiguration;
+
     @Test
     void pipelineParser() {
         final String pipelineConfigFileLocation = "hot soup";
         when(args.getPipelineConfigFileLocation())
                 .thenReturn(pipelineConfigFileLocation);
 
-        final PipelineParser pipelineParser = pipelineParserConfiguration.pipelineParser(args, pluginFactory, peerForwarderProvider);
+        final PipelineParser pipelineParser = pipelineParserConfiguration.pipelineParser(args, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
 
         assertThat(pipelineParser, is(notNullValue()));
         verify(args).getPipelineConfigFileLocation();

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/DataPrepperConfigurationTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/DataPrepperConfigurationTests.java
@@ -7,9 +7,12 @@ package org.opensearch.dataprepper.parser.model;
 
 import org.opensearch.dataprepper.TestDataProvider;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
+import org.opensearch.dataprepper.parser.DataPrepperDurationDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -17,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -27,7 +31,8 @@ import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DataPrepperConfigurationTests {
-    private static ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+    private static SimpleModule simpleModule = new SimpleModule().addDeserializer(Duration.class, new DataPrepperDurationDeserializer());
+    private static ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory()).registerModule(simpleModule);
 
     private static DataPrepperConfiguration makeConfig(String filePath) throws IOException {
         final File configurationFile = new File(filePath);
@@ -98,6 +103,28 @@ public class DataPrepperConfigurationTests {
     }
 
     @Test
+    void testConfigWithValidProcessorShutdownTimeout() throws IOException {
+        final DataPrepperConfiguration dataPrepperConfiguration = makeConfig(
+                TestDataProvider.VALID_DATA_PREPPER_CONFIG_FILE_WITH_PROCESSOR_SHUTDOWN_TIMEOUT);
+
+        assertThat(dataPrepperConfiguration, notNullValue());
+        final Duration processorShutdownTimeout = dataPrepperConfiguration.getProcessorShutdownTimeout();
+        assertThat(processorShutdownTimeout, notNullValue());
+        assertThat(processorShutdownTimeout, equalTo(Duration.ofSeconds(1)));
+    }
+
+    @Test
+    void testConfigWithValidSinkShutdownTimeout() throws IOException {
+        final DataPrepperConfiguration dataPrepperConfiguration = makeConfig(
+                TestDataProvider.VALID_DATA_PREPPER_CONFIG_FILE_WITH_SINK_SHUTDOWN_TIMEOUT);
+
+        assertThat(dataPrepperConfiguration, notNullValue());
+        final Duration sinkShutdownTimeout = dataPrepperConfiguration.getSinkShutdownTimeout();
+        assertThat(sinkShutdownTimeout, notNullValue());
+        assertThat(sinkShutdownTimeout, equalTo(Duration.ofSeconds(1)));
+    }
+
+    @Test
     void testPeerForwarderConfig() throws IOException {
         final DataPrepperConfiguration dataPrepperConfiguration = makeConfig(TestDataProvider.VALID_PEER_FORWARDER_DATA_PREPPER_CONFIG_FILE);
 
@@ -120,5 +147,29 @@ public class DataPrepperConfigurationTests {
     void testConfigWithInValidMetricTags() {
         assertThrows(ValueInstantiationException.class, () ->
                 makeConfig(TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_TAGS));
+    }
+
+    @Test
+    void testConfigWithInValidProcessorShutdownTimeout() {
+        assertThrows(JsonMappingException.class, () ->
+                makeConfig(TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_BAD_PROCESSOR_SHUTDOWN_TIMEOUT));
+    }
+
+    @Test
+    void testConfigWithInValidSinkShutdownTimeout() {
+        assertThrows(JsonMappingException.class, () ->
+                makeConfig(TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_BAD_SINK_SHUTDOWN_TIMEOUT));
+    }
+
+    @Test
+    void testConfigWithNegativeProcessorShutdownTimeout() {
+        assertThrows(ValueInstantiationException.class, () ->
+                makeConfig(TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_NEGATIVE_PROCESSOR_SHUTDOWN_TIMEOUT));
+    }
+
+    @Test
+    void testConfigWithNegativeSinkShutdownTimeout() {
+        assertThrows(ValueInstantiationException.class, () ->
+                makeConfig(TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_NEGATIVE_SINK_SHUTDOWN_TIMEOUT));
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/DataPrepperConfigurationTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/DataPrepperConfigurationTests.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -125,6 +127,20 @@ public class DataPrepperConfigurationTests {
     }
 
     @Test
+    void testConfigWithISO8601ShutdownTimeouts() throws IOException {
+        final DataPrepperConfiguration dataPrepperConfiguration = makeConfig(
+                TestDataProvider.VALID_DATA_PREPPER_CONFIG_FILE_WITH_ISO8601_SHUTDOWN_TIMEOUTS);
+
+        assertThat(dataPrepperConfiguration, notNullValue());
+        final Duration sinkShutdownTimeout = dataPrepperConfiguration.getSinkShutdownTimeout();
+        assertThat(sinkShutdownTimeout, notNullValue());
+        assertThat(sinkShutdownTimeout, equalTo(Duration.ofMinutes(15)));
+        final Duration processorShutdownTimeout = dataPrepperConfiguration.getProcessorShutdownTimeout();
+        assertThat(processorShutdownTimeout, notNullValue());
+        assertThat(processorShutdownTimeout, equalTo(Duration.ofSeconds(45)));
+    }
+
+    @Test
     void testPeerForwarderConfig() throws IOException {
         final DataPrepperConfiguration dataPrepperConfiguration = makeConfig(TestDataProvider.VALID_PEER_FORWARDER_DATA_PREPPER_CONFIG_FILE);
 
@@ -149,27 +165,21 @@ public class DataPrepperConfigurationTests {
                 makeConfig(TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_TAGS));
     }
 
-    @Test
-    void testConfigWithInValidProcessorShutdownTimeout() {
-        assertThrows(JsonMappingException.class, () ->
-                makeConfig(TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_BAD_PROCESSOR_SHUTDOWN_TIMEOUT));
+    @ParameterizedTest
+    @ValueSource(strings = {
+            TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_BAD_PROCESSOR_SHUTDOWN_TIMEOUT,
+            TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_BAD_SINK_SHUTDOWN_TIMEOUT
+    })
+    void testConfigWithInValidShutdownTimeout(final String configFile) {
+        assertThrows(JsonMappingException.class, () -> makeConfig(configFile));
     }
 
-    @Test
-    void testConfigWithInValidSinkShutdownTimeout() {
-        assertThrows(JsonMappingException.class, () ->
-                makeConfig(TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_BAD_SINK_SHUTDOWN_TIMEOUT));
-    }
-
-    @Test
-    void testConfigWithNegativeProcessorShutdownTimeout() {
-        assertThrows(ValueInstantiationException.class, () ->
-                makeConfig(TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_NEGATIVE_PROCESSOR_SHUTDOWN_TIMEOUT));
-    }
-
-    @Test
-    void testConfigWithNegativeSinkShutdownTimeout() {
-        assertThrows(ValueInstantiationException.class, () ->
-                makeConfig(TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_NEGATIVE_SINK_SHUTDOWN_TIMEOUT));
+    @ParameterizedTest
+    @ValueSource(strings = {
+            TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_NEGATIVE_PROCESSOR_SHUTDOWN_TIMEOUT,
+            TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE_WITH_NEGATIVE_SINK_SHUTDOWN_TIMEOUT
+    })
+    void testConfigWithNegativeShutdownTimeout(final String configFile) {
+        assertThrows(ValueInstantiationException.class, () -> makeConfig(configFile));
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineTests.java
@@ -51,8 +51,8 @@ class PipelineTests {
 
     @BeforeEach
     void setup() {
-        processorShutdownTimeout = Duration.ofSeconds(Math.abs(new Random().nextInt()));
-        sinkShutdownTimeout = Duration.ofSeconds(Math.abs(new Random().nextInt()));
+        processorShutdownTimeout = Duration.ofSeconds(Math.abs(new Random().nextInt(10)));
+        sinkShutdownTimeout = Duration.ofSeconds(Math.abs(new Random().nextInt(10)));
     }
 
     @AfterEach

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineTests.java
@@ -21,6 +21,7 @@ import org.opensearch.dataprepper.pipeline.common.TestProcessor;
 import org.opensearch.dataprepper.plugins.TestSink;
 import org.opensearch.dataprepper.plugins.TestSource;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,9 +44,16 @@ class PipelineTests {
     private static final int TEST_READ_BATCH_TIMEOUT = 3000;
     private static final int TEST_PROCESSOR_THREADS = 1;
     private static final String TEST_PIPELINE_NAME = "test-pipeline";
-    private static final long PROCESSOR_SHUTDOWN_TIMEOUT = new Random().nextLong();
 
     private Pipeline testPipeline;
+    private Duration processorShutdownTimeout;
+    private Duration sinkShutdownTimeout;
+
+    @BeforeEach
+    void setup() {
+        processorShutdownTimeout = Duration.ofSeconds(Math.abs(new Random().nextInt()));
+        sinkShutdownTimeout = Duration.ofSeconds(Math.abs(new Random().nextInt()));
+    }
 
     @AfterEach
     void teardown() {
@@ -60,7 +68,7 @@ class PipelineTests {
         final TestSink testSink = new TestSink();
         final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
                 Collections.emptyList(), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT,
-                PROCESSOR_SHUTDOWN_TIMEOUT);
+                processorShutdownTimeout, sinkShutdownTimeout);
         assertThat("Pipeline isStopRequested is expected to be false", testPipeline.isStopRequested(), is(false));
         assertThat("Pipeline is expected to have a default buffer", testPipeline.getBuffer(), notNullValue());
         assertTrue("Pipeline processors should be empty", testPipeline.getProcessorSets().isEmpty());
@@ -79,7 +87,7 @@ class PipelineTests {
         final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
                 Collections.singletonList(Collections.singletonList(testProcessor)),
                 Collections.singletonList(testSink),
-                TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, PROCESSOR_SHUTDOWN_TIMEOUT);
+                TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, processorShutdownTimeout, sinkShutdownTimeout);
         assertThat("Pipeline isStopRequested is expected to be false", testPipeline.isStopRequested(), is(false));
         assertThat("Pipeline is expected to have a default buffer", testPipeline.getBuffer(), notNullValue());
         assertEquals("Pipeline processorSets size should be 1", 1, testPipeline.getProcessorSets().size());
@@ -99,7 +107,7 @@ class PipelineTests {
         final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
                 Collections.singletonList(Collections.singletonList(testProcessor)),
                 Collections.singletonList(testSink),
-                TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, PROCESSOR_SHUTDOWN_TIMEOUT);
+                TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, processorShutdownTimeout, sinkShutdownTimeout);
         assertThat("Pipeline isStopRequested is expected to be false", testPipeline.isStopRequested(), is(false));
         assertThat("Pipeline is expected to have a default buffer", testPipeline.getBuffer(), notNullValue());
         assertEquals("Pipeline processorSets size should be 1", 1, testPipeline.getProcessorSets().size());
@@ -118,7 +126,7 @@ class PipelineTests {
         try {
             final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
                     Collections.emptyList(), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT,
-                    PROCESSOR_SHUTDOWN_TIMEOUT);
+                    processorShutdownTimeout, sinkShutdownTimeout);
             testPipeline.execute();
         } catch (Exception ex) {
             assertThat("Incorrect exception message", ex.getMessage().contains("Source is expected to fail"));
@@ -134,7 +142,7 @@ class PipelineTests {
         try {
             testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
                     Collections.emptyList(), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT,
-                    PROCESSOR_SHUTDOWN_TIMEOUT);
+                    processorShutdownTimeout, sinkShutdownTimeout);
             testPipeline.execute();
             Thread.sleep(TEST_READ_BATCH_TIMEOUT);
         } catch (Exception ex) {
@@ -171,7 +179,7 @@ class PipelineTests {
         try {
             testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
                     Collections.singletonList(Collections.singletonList(testProcessor)), Collections.singletonList(testSink),
-                    TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, PROCESSOR_SHUTDOWN_TIMEOUT);
+                    TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, processorShutdownTimeout, sinkShutdownTimeout);
             testPipeline.execute();
             Thread.sleep(TEST_READ_BATCH_TIMEOUT);
         } catch (Exception ex) {
@@ -186,7 +194,7 @@ class PipelineTests {
         final TestSink testSink = new TestSink();
         final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
                 Collections.emptyList(), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT,
-                PROCESSOR_SHUTDOWN_TIMEOUT);
+                processorShutdownTimeout, sinkShutdownTimeout);
 
         assertEquals(testSource, testPipeline.getSource());
     }
@@ -197,7 +205,7 @@ class PipelineTests {
         final TestSink testSink = new TestSink();
         final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
                 Collections.emptyList(), Collections.singletonList(testSink),
-                TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, PROCESSOR_SHUTDOWN_TIMEOUT);
+                TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, processorShutdownTimeout, sinkShutdownTimeout);
 
         assertEquals(1, testPipeline.getSinks().size());
         assertEquals(testSink, testPipeline.getSinks().iterator().next());
@@ -222,7 +230,7 @@ class PipelineTests {
 
         private Pipeline createObjectUnderTest() {
             return new Pipeline(TEST_PIPELINE_NAME, mock(Source.class), mock(Buffer.class), Collections.emptyList(),
-                    sinks, TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, PROCESSOR_SHUTDOWN_TIMEOUT);
+                    sinks, TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, processorShutdownTimeout, sinkShutdownTimeout);
         }
 
         @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineTests.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -42,6 +43,7 @@ class PipelineTests {
     private static final int TEST_READ_BATCH_TIMEOUT = 3000;
     private static final int TEST_PROCESSOR_THREADS = 1;
     private static final String TEST_PIPELINE_NAME = "test-pipeline";
+    private static final long PROCESSOR_SHUTDOWN_TIMEOUT = new Random().nextLong();
 
     private Pipeline testPipeline;
 
@@ -57,7 +59,8 @@ class PipelineTests {
         final Source<Record<String>> testSource = new TestSource();
         final TestSink testSink = new TestSink();
         final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
-                Collections.emptyList(), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT);
+                Collections.emptyList(), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT,
+                PROCESSOR_SHUTDOWN_TIMEOUT);
         assertThat("Pipeline isStopRequested is expected to be false", testPipeline.isStopRequested(), is(false));
         assertThat("Pipeline is expected to have a default buffer", testPipeline.getBuffer(), notNullValue());
         assertTrue("Pipeline processors should be empty", testPipeline.getProcessorSets().isEmpty());
@@ -76,7 +79,7 @@ class PipelineTests {
         final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
                 Collections.singletonList(Collections.singletonList(testProcessor)),
                 Collections.singletonList(testSink),
-                TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT);
+                TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, PROCESSOR_SHUTDOWN_TIMEOUT);
         assertThat("Pipeline isStopRequested is expected to be false", testPipeline.isStopRequested(), is(false));
         assertThat("Pipeline is expected to have a default buffer", testPipeline.getBuffer(), notNullValue());
         assertEquals("Pipeline processorSets size should be 1", 1, testPipeline.getProcessorSets().size());
@@ -96,7 +99,7 @@ class PipelineTests {
         final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
                 Collections.singletonList(Collections.singletonList(testProcessor)),
                 Collections.singletonList(testSink),
-                TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT);
+                TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, PROCESSOR_SHUTDOWN_TIMEOUT);
         assertThat("Pipeline isStopRequested is expected to be false", testPipeline.isStopRequested(), is(false));
         assertThat("Pipeline is expected to have a default buffer", testPipeline.getBuffer(), notNullValue());
         assertEquals("Pipeline processorSets size should be 1", 1, testPipeline.getProcessorSets().size());
@@ -114,7 +117,8 @@ class PipelineTests {
         final TestSink testSink = new TestSink();
         try {
             final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
-                    Collections.emptyList(), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT);
+                    Collections.emptyList(), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT,
+                    PROCESSOR_SHUTDOWN_TIMEOUT);
             testPipeline.execute();
         } catch (Exception ex) {
             assertThat("Incorrect exception message", ex.getMessage().contains("Source is expected to fail"));
@@ -129,7 +133,8 @@ class PipelineTests {
         final Sink<Record<String>> testSink = new TestSink(true);
         try {
             testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
-                    Collections.emptyList(), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT);
+                    Collections.emptyList(), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT,
+                    PROCESSOR_SHUTDOWN_TIMEOUT);
             testPipeline.execute();
             Thread.sleep(TEST_READ_BATCH_TIMEOUT);
         } catch (Exception ex) {
@@ -166,7 +171,7 @@ class PipelineTests {
         try {
             testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
                     Collections.singletonList(Collections.singletonList(testProcessor)), Collections.singletonList(testSink),
-                    TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT);
+                    TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, PROCESSOR_SHUTDOWN_TIMEOUT);
             testPipeline.execute();
             Thread.sleep(TEST_READ_BATCH_TIMEOUT);
         } catch (Exception ex) {
@@ -180,7 +185,8 @@ class PipelineTests {
         final Source<Record<String>> testSource = new TestSource();
         final TestSink testSink = new TestSink();
         final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
-                Collections.emptyList(), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT);
+                Collections.emptyList(), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT,
+                PROCESSOR_SHUTDOWN_TIMEOUT);
 
         assertEquals(testSource, testPipeline.getSource());
     }
@@ -191,7 +197,7 @@ class PipelineTests {
         final TestSink testSink = new TestSink();
         final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
                 Collections.emptyList(), Collections.singletonList(testSink),
-                TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT);
+                TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, PROCESSOR_SHUTDOWN_TIMEOUT);
 
         assertEquals(1, testPipeline.getSinks().size());
         assertEquals(testSink, testPipeline.getSinks().iterator().next());
@@ -216,7 +222,7 @@ class PipelineTests {
 
         private Pipeline createObjectUnderTest() {
             return new Pipeline(TEST_PIPELINE_NAME, mock(Source.class), mock(Buffer.class), Collections.emptyList(),
-                    sinks, TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT);
+                    sinks, TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT, PROCESSOR_SHUTDOWN_TIMEOUT);
         }
 
         @Test

--- a/data-prepper-core/src/test/resources/invalid_data_prepper_config_with_bad_processor_shutdown_timeout.yml
+++ b/data-prepper-core/src/test/resources/invalid_data_prepper_config_with_bad_processor_shutdown_timeout.yml
@@ -1,0 +1,3 @@
+serverPort: 1234
+ssl: true
+processorShutdownTimeout: "bad"

--- a/data-prepper-core/src/test/resources/invalid_data_prepper_config_with_bad_sink_shutdown_timeout.yml
+++ b/data-prepper-core/src/test/resources/invalid_data_prepper_config_with_bad_sink_shutdown_timeout.yml
@@ -1,0 +1,3 @@
+serverPort: 1234
+ssl: true
+sinkShutdownTimeout: "bad"

--- a/data-prepper-core/src/test/resources/invalid_data_prepper_config_with_negative_processor_shutdown_timeout.yml
+++ b/data-prepper-core/src/test/resources/invalid_data_prepper_config_with_negative_processor_shutdown_timeout.yml
@@ -1,0 +1,3 @@
+serverPort: 1234
+ssl: true
+processorShutdownTimeout: "PT-6H3M"

--- a/data-prepper-core/src/test/resources/invalid_data_prepper_config_with_negative_sink_shutdown_timeout.yml
+++ b/data-prepper-core/src/test/resources/invalid_data_prepper_config_with_negative_sink_shutdown_timeout.yml
@@ -1,0 +1,3 @@
+serverPort: 5678
+ssl: false
+sinkShutdownTimeout: "PT-6H3M"

--- a/data-prepper-core/src/test/resources/valid_data_prepper_config_with_iso8601_shutdown_timeouts.yml
+++ b/data-prepper-core/src/test/resources/valid_data_prepper_config_with_iso8601_shutdown_timeouts.yml
@@ -1,0 +1,4 @@
+serverPort: 5678
+ssl: false
+sinkShutdownTimeout: "PT15M"
+processorShutdownTimeout: "PT45S"

--- a/data-prepper-core/src/test/resources/valid_data_prepper_config_with_processor_shutdown_timeout.yml
+++ b/data-prepper-core/src/test/resources/valid_data_prepper_config_with_processor_shutdown_timeout.yml
@@ -1,0 +1,3 @@
+serverPort: 5678
+ssl: false
+processorShutdownTimeout: 1s

--- a/data-prepper-core/src/test/resources/valid_data_prepper_config_with_sink_shutdown_timeout.yml
+++ b/data-prepper-core/src/test/resources/valid_data_prepper_config_with_sink_shutdown_timeout.yml
@@ -1,0 +1,3 @@
+serverPort: 5678
+ssl: false
+sinkShutdownTimeout: 1s

--- a/docs/core_apis.md
+++ b/docs/core_apis.md
@@ -92,3 +92,13 @@ your Data Prepper instance.
 authentication:
   unauthenticated:
 ```
+
+### Shutdown Timeouts
+When the DataPrepper `shutdown` API is invoked, the sink and processor `ExecutorService`'s are given time to gracefully shutdown and clear any in-flight data. The default graceful shutdown timeout for these `ExecutorService`'s is 10 seconds. This can be configured with the following optional parameters:
+
+```yaml
+processorShutdownTimeout: "PT15M"
+sinkShutdownTimeout: 30s
+```
+
+The values for these parameters are parsed into a `Duration` object via the [DataPrepperDurationDeserializer](https://github.com/opensearch-project/data-prepper/tree/main/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/DataPrepperDurationDeserializer.java).


### PR DESCRIPTION
### Description
This PR makes the `processorShutdownTimeout` and `sinkShutdownTimeout` configurable as parameters in the `data-prepper-config.yaml`. It uses the Data Prepper duration format to parse the value by refactoring the `PluginDurationDeserializer` to be generic.
 
### Issues Resolved
Will resolve #1742 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
