### PR TITLE
Load pipeline configurations from directory

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
@@ -91,6 +91,7 @@ public class PipelineParser {
             }
             return pipelineMap;
         } catch (IOException e) {
+            LOG.error("Failed to parse the configuration file {}", pipelineConfigurationFileLocation);
             throw new ParseException(format("Failed to parse the configuration file %s", pipelineConfigurationFileLocation), e);
         }
     }
@@ -104,22 +105,28 @@ public class PipelineParser {
             FileFilter yamlFilter = pathname -> (pathname.getName().endsWith(".yaml") || pathname.getName().endsWith(".yml"));
             List<InputStream> configurationFiles = Stream.of(configurationLocation.listFiles(yamlFilter))
                     .map(file -> {
+                        InputStream inputStream;
                         try {
-                            return new FileInputStream(file);
+                            inputStream = new FileInputStream(file);
+                            LOG.info("Reading pipeline configuration from {}", file.getName());
                         } catch (FileNotFoundException e) {
-                            return null;
+                            inputStream = null;
+                            LOG.warn("Pipeline configuration file {} not found", file.getName());
                         }
+                        return inputStream;
                     })
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
 
             if (configurationFiles.isEmpty()) {
+                LOG.error("Pipelines configuration file not found at {}", pipelineConfigurationFileLocation);
                 throw new ParseException(
                         format("Pipelines configuration file not found at %s", pipelineConfigurationFileLocation));
             }
 
             return new SequenceInputStream(Collections.enumeration(configurationFiles));
         } else {
+            LOG.error("Pipelines configuration file not found at {}", pipelineConfigurationFileLocation);
             throw new ParseException(format("Pipelines configuration file not found at %s", pipelineConfigurationFileLocation));
         }
     }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -104,7 +105,8 @@ public class PipelineParser {
                 throw new ParseException(format("Pipeline configuration file %s not found.", configurationLocation), e);
             }
         } else if (configurationLocation.isDirectory()) {
-            List<InputStream> configurationFiles = Stream.of(configurationLocation.listFiles()).map(file -> {
+            FileFilter yamlFilter = pathname -> (pathname.getName().endsWith(".yaml") || pathname.getName().endsWith(".yml"));
+            List<InputStream> configurationFiles = Stream.of(configurationLocation.listFiles(yamlFilter)).map(file -> {
                 try {
                     return new FileInputStream(file);
                 } catch (FileNotFoundException e) {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
@@ -42,6 +42,9 @@ public class TestDataProvider {
     public static final String INCORRECT_SOURCE_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/incorrect_source_multiple_pipeline_configuration.yml";
     public static final String MISSING_NAME_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/missing_name_multiple_pipeline_configuration.yml";
     public static final String MISSING_PIPELINE_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/missing_pipeline_multiple_pipeline_configuration.yml";
+    public static final String MULTI_FILE_PIPELINE_DIRECTOTRY = "src/test/resources/multi-pipelines";
+    public static final String SINGLE_FILE_PIPELINE_DIRECTOTRY = "src/test/resources/single-pipeline";
+    public static final String EMPTY_PIPELINE_DIRECTOTRY = "src/test/resources/no-pipelines";
     public static final String VALID_MULTIPLE_SINKS_CONFIG_FILE = "src/test/resources/valid_multiple_sinks.yml";
     public static final String VALID_MULTIPLE_PROCESSERS_CONFIG_FILE = "src/test/resources/valid_multiple_processors.yml";
     public static final String NO_PIPELINES_EXECUTE_CONFIG_FILE = "src/test/resources/no_pipelines_to_execute.yml";

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
@@ -121,6 +121,28 @@ class PipelineParserTests {
     void parseConfiguration_with_a_configuration_file_which_does_not_exist_should_throw() {
         final PipelineParser pipelineParser = new PipelineParser("file_does_no_exist.yml", pluginFactory, peerForwarderProvider);
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
-        assertThat(actualException.getMessage(), equalTo("Failed to parse the configuration file file_does_no_exist.yml"));
+        assertThat(actualException.getMessage(), equalTo("Pipelines configuration file not found at file_does_no_exist.yml"));
+    }
+
+    @Test
+    void parseConfiguration_from_directory_with_multiple_files_creates_the_correct_pipelineMap() {
+        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.MULTI_FILE_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarder);
+        final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
+        assertThat(actualPipelineMap.keySet(), equalTo(TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES));
+    }
+
+    @Test
+    void parseConfiguration_from_directory_with_single_file_creates_the_correct_pipelineMap() {
+        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.SINGLE_FILE_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarder);
+        final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
+        assertThat(actualPipelineMap.keySet(), equalTo(TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES));
+    }
+
+    @Test
+    void parseConfiguration_from_directory_with_no_files_should_throw() {
+        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.EMPTY_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarder);
+        final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
+        assertThat(actualException.getMessage(), equalTo(
+                String.format("Pipelines configuration file not found at %s", TestDataProvider.EMPTY_PIPELINE_DIRECTOTRY)));
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
@@ -126,21 +126,21 @@ class PipelineParserTests {
 
     @Test
     void parseConfiguration_from_directory_with_multiple_files_creates_the_correct_pipelineMap() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.MULTI_FILE_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarder);
+        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.MULTI_FILE_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider);
         final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
         assertThat(actualPipelineMap.keySet(), equalTo(TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES));
     }
 
     @Test
     void parseConfiguration_from_directory_with_single_file_creates_the_correct_pipelineMap() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.SINGLE_FILE_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarder);
+        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.SINGLE_FILE_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider);
         final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
         assertThat(actualPipelineMap.keySet(), equalTo(TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES));
     }
 
     @Test
     void parseConfiguration_from_directory_with_no_files_should_throw() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.EMPTY_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarder);
+        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.EMPTY_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider);
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(), equalTo(
                 String.format("Pipelines configuration file not found at %s", TestDataProvider.EMPTY_PIPELINE_DIRECTOTRY)));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
@@ -139,7 +139,7 @@ class PipelineParserTests {
     }
 
     @Test
-    void parseConfiguration_from_directory_with_no_files_should_throw() {
+    void parseConfiguration_from_directory_with_no_yaml_files_should_throw() {
         final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.EMPTY_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider);
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(), equalTo(

--- a/data-prepper-core/src/test/resources/multi-pipelines/valid_multiple_pipeline_configuration1.yml
+++ b/data-prepper-core/src/test/resources/multi-pipelines/valid_multiple_pipeline_configuration1.yml
@@ -1,0 +1,10 @@
+# this configuration file is solely for testing formatting
+test-pipeline-1:
+  source:
+    file:
+      path: "/tmp/file-source.tmp"
+  buffer:
+    bounded_blocking: #to check non object nodes for plugins
+  sink:
+    - pipeline:
+       name: "test-pipeline-2"

--- a/data-prepper-core/src/test/resources/multi-pipelines/valid_multiple_pipeline_configuration2.yml
+++ b/data-prepper-core/src/test/resources/multi-pipelines/valid_multiple_pipeline_configuration2.yml
@@ -1,0 +1,8 @@
+# this configuration file is solely for testing formatting
+test-pipeline-2:
+  source:
+    pipeline:
+      name: "test-pipeline-1"
+  sink:
+    - pipeline:
+       name: "test-pipeline-3"

--- a/data-prepper-core/src/test/resources/multi-pipelines/valid_multiple_pipeline_configuration3.yml
+++ b/data-prepper-core/src/test/resources/multi-pipelines/valid_multiple_pipeline_configuration3.yml
@@ -1,0 +1,8 @@
+# this configuration file is solely for testing formatting
+test-pipeline-3:
+  source:
+    pipeline:
+      name: "test-pipeline-2"
+  sink:
+    - file:
+       path: "/tmp/todelete.txt"

--- a/data-prepper-core/src/test/resources/no-pipelines/should-not-be-parsed.txt
+++ b/data-prepper-core/src/test/resources/no-pipelines/should-not-be-parsed.txt
@@ -1,0 +1,24 @@
+# this configuration file is solely for testing formatting
+test-pipeline-1:
+  source:
+    file:
+      path: "/tmp/file-source.tmp"
+  buffer:
+    bounded_blocking: #to check non object nodes for plugins
+  sink:
+    - pipeline:
+       name: "test-pipeline-2"
+test-pipeline-2:
+  source:
+    pipeline:
+      name: "test-pipeline-1"
+  sink:
+    - pipeline:
+       name: "test-pipeline-3"
+test-pipeline-3:
+  source:
+    pipeline:
+      name: "test-pipeline-2"
+  sink:
+    - file:
+       path: "/tmp/todelete.txt"

--- a/data-prepper-core/src/test/resources/single-pipeline/valid_multiple_pipeline_configuration.yml
+++ b/data-prepper-core/src/test/resources/single-pipeline/valid_multiple_pipeline_configuration.yml
@@ -1,0 +1,24 @@
+# this configuration file is solely for testing formatting
+test-pipeline-1:
+  source:
+    file:
+      path: "/tmp/file-source.tmp"
+  buffer:
+    bounded_blocking: #to check non object nodes for plugins
+  sink:
+    - pipeline:
+       name: "test-pipeline-2"
+test-pipeline-2:
+  source:
+    pipeline:
+      name: "test-pipeline-1"
+  sink:
+    - pipeline:
+       name: "test-pipeline-3"
+test-pipeline-3:
+  source:
+    pipeline:
+      name: "test-pipeline-2"
+  sink:
+    - file:
+       path: "/tmp/todelete.txt"

--- a/data-prepper-main/src/main/java/org/opensearch/dataprepper/DataPrepperExecute.java
+++ b/data-prepper-main/src/main/java/org/opensearch/dataprepper/DataPrepperExecute.java
@@ -21,14 +21,20 @@ public class DataPrepperExecute {
     public static void main(final String ... args) {
         java.security.Security.setProperty("networkaddress.cache.ttl", "60");
 
-        final String dataPrepperHome = System.getProperty("data-prepper.dir");
-        if (dataPrepperHome == null) {
-            throw new RuntimeException("Data Prepper home directory (data-prepper.dir) not set in system properties.");
+        final ContextManager contextManager;
+        if (args.length == 0) {
+            final String dataPrepperHome = System.getProperty("data-prepper.dir");
+            if (dataPrepperHome == null) {
+                throw new RuntimeException("Data Prepper home directory (data-prepper.dir) not set in system properties.");
+            }
+
+            final String dataPrepperPipelines = Paths.get(dataPrepperHome).resolve("pipelines/").toString();
+            final String dataPrepperConfig = Paths.get(dataPrepperHome).resolve("config/data-prepper-config.yaml").toString();
+            contextManager = new ContextManager(dataPrepperPipelines, dataPrepperConfig);
+        } else {
+            contextManager = new ContextManager(args);
         }
 
-        final String dataPrepperPipelines = Paths.get(dataPrepperHome).resolve("pipelines/").toString();
-        final String dataPrepperConfig = Paths.get(dataPrepperHome).resolve("config/data-prepper-config.yaml").toString();
-        final ContextManager contextManager = new ContextManager(dataPrepperPipelines, dataPrepperConfig);
         final DataPrepper dataPrepper = contextManager.getDataPrepperBean();
 
         LOG.trace("Starting Data Prepper execution");

--- a/data-prepper-main/src/main/java/org/opensearch/dataprepper/DataPrepperExecute.java
+++ b/data-prepper-main/src/main/java/org/opensearch/dataprepper/DataPrepperExecute.java
@@ -26,7 +26,7 @@ public class DataPrepperExecute {
             throw new RuntimeException("Data Prepper home directory (data-prepper.dir) not set in system properties.");
         }
 
-        final String dataPrepperPipelines = Paths.get(dataPrepperHome).resolve("pipelines/pipelines.yaml").toString();
+        final String dataPrepperPipelines = Paths.get(dataPrepperHome).resolve("pipelines/").toString();
         final String dataPrepperConfig = Paths.get(dataPrepperHome).resolve("config/data-prepper-config.yaml").toString();
         final ContextManager contextManager = new ContextManager(dataPrepperPipelines, dataPrepperConfig);
         final DataPrepper dataPrepper = contextManager.getDataPrepperBean();

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,12 +5,29 @@ A Data Prepper instance requires 2 configuration files to run, and allows an opt
 2. A YAML file containing Data Prepper server settings, primarily for interacting with the exposed Data Prepper server APIs
 3. An optional Log4j 2 configuration file (can be JSON, YAML, XML, or .properties)
 
-The resulting `.jar` file expects the pipeline configuration file path followed by the server configuration file path. Example:
+For Data Prepper before version 2.0, the `.jar` file expects the pipeline configuration file path followed by the server configuration file path. Example:
 ```
 java -jar data-prepper-core-$VERSION.jar pipelines.yaml data-prepper-config.yaml
 ```
 
 Optionally add `"-Dlog4j.configurationFile=config/log4j2.properties"` to the command if you would like to pass a custom Log4j 2 configuration file. If no properties file is provided, Data Prepper will default to the log4j2.properties file in the shared-config directory.
+
+
+For Data Prepper 2.0 or above, Data Prepper is launched through `data-prepper` script with no additional command line arguments needed:
+```
+bin/data-prepper
+```
+
+Configuration files are read from specific subdirectories in the application's home directory:
+1. `pipelines/`: for pipelines configurations; pipelines configurations can be written in one and more yaml files
+2. `config/data-prepper-config.yaml`: for Data Prepper server configurations
+
+You can continue to supply your own pipeline configuration file path followed by the server configuration file path, but the support for this method will be dropped in a future release. Example:
+```
+bin/data-prepper pipelines.yaml data-prepper-config.yaml
+```
+
+Additionally, Log4j 2 configuration file is read from `config/log4j2.properties` in the application's home directory.
 
 ## Pipeline Configuration
 
@@ -81,8 +98,19 @@ You can generate the certificate using existing tools such as OpenSSL.
 If you'd like a short primer, you can mimic the [steps used to create the default certificate](https://github.com/opensearch-project/data-prepper/tree/main/release/docker/config/README.md), and change them to suite your needs. 
 Please note that for PKCS12 files (.p12), you should use the same password for the keystore and private key.
 
-To run the Data Prepper Docker image with the default `data-prepper-config.yaml`, the command should look like this.
+To run the Data Prepper Docker image with the default `data-prepper-config.yaml`, the command should look like this:
 
+For Data Prepper 2.0 or above:
+```
+docker run \
+ --name data-prepper-test \
+ -p 4900:4900 \
+ --expose 21890 \
+ -v /full/path/to/pipelines.yaml:/usr/share/data-prepper/pipelines/pipelines.yaml \
+ data-prepper/data-prepper:latest
+```
+
+For Data Prepper before 2.0:
 ```
 docker run \
  --name data-prepper-test \
@@ -98,14 +126,20 @@ To disable SSL, create a `data-prepper-config.yaml` with the following configura
 ssl: false
 ```
 
-In order to pass your own `data-prepper-config.yaml`, mount it as a volume in the Docker image by adding the argument below to `docker run`. Note that the config must be mounted to `/usr/share/data-prepper/data-prepper-config.yaml`
+In order to pass your own `data-prepper-config.yaml`, mount it as a volume in the Docker image by adding the argument below to `docker run`. Note that the config must be mounted to proper path inside the container:
 
+For Data Prepper 2.0 or above:
 ```
-v /full/path/to/data-prepper-config.yaml:/usr/share/data-prepper/data-prepper-config.yaml
+-v /full/path/to/data-prepper-config.yaml:/usr/share/data-prepper/config/data-prepper-config.yaml
+```
+
+For Data Prepper before 2.0:
+```
+-v /full/path/to/data-prepper-config.yaml:/usr/share/data-prepper/data-prepper-config.yaml
 ```
 
 If your `data-prepper-config.yaml` has SSL enabled, and you are using your own keystore, it will need to be mounted as a Docker volume as well. Note that the mount path should correspond with
-the `keyStoreFilePath` field from your `data-prepper-config.yaml`. It is recommended to mount to `/usr/share/data-prepper/data-prepper-config.yaml` to ensure that the path exists in the Docker image.
+the `keyStoreFilePath` field from your `data-prepper-config.yaml`. It is recommended to mount to `/usr/share/data-prepper/config/data-prepper-config.yaml` (for Data Prepper 2.0 or above) or `/usr/share/data-prepper/data-prepper-config.yaml` (for Data Prepper before 2.0) to ensure that the path exists in the Docker image.
 To do so, add the argument below to the `docker run` command.
 
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -46,6 +46,14 @@ built from source, you will need to make some modifications to the example comma
 However you configure your pipeline, you will run Data Prepper the same way. You run the Docker
 image and supply both the `pipelines.yaml` and `data-prepper-config.yaml` files.
 
+For Data Prepper 2.0 or above, use this command:
+
+```
+docker run --name data-prepper -p 4900:4900 -v ${PWD}/pipelines.yaml:/usr/share/data-prepper/pipelines/pipelines.yaml -v ${PWD}/data-prepper-config.yaml:/usr/share/data-prepper/config/data-prepper-config.yaml opensearchproject/data-prepper:latest
+```
+
+For Data Prepper before version 2.0:
+
 ```
 docker run --name data-prepper -p 4900:4900 -v ${PWD}/pipelines.yaml:/usr/share/data-prepper/pipelines.yaml -v ${PWD}/data-prepper-config.yaml:/usr/share/data-prepper/data-prepper-config.yaml opensearchproject/data-prepper:latest
 ```

--- a/release/archives/linux/data-prepper-jdk-x64.sh
+++ b/release/archives/linux/data-prepper-jdk-x64.sh
@@ -5,6 +5,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+if [[ $# -gt 0 ]]
+  then
+    echo
+    echo "Data Prepper expects no command line arguments. Configuration files should be placed in "
+    echo "the application home directory and will be read automatically."
+    echo
+    exit 1
+fi
+
 DATA_PREPPER_BIN=$(dirname "$(realpath "$0")")
 DATA_PREPPER_HOME=`realpath "$DATA_PREPPER_BIN/.."`
 DATA_PREPPER_CLASSPATH="$DATA_PREPPER_HOME/lib/*"

--- a/release/archives/linux/data-prepper-jdk-x64.sh
+++ b/release/archives/linux/data-prepper-jdk-x64.sh
@@ -5,11 +5,21 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if [[ $# -gt 0 ]]
-  then
+if [[ $# == 0 ]]; then
+    echo "Reading pipelines and data-prepper configuration files from Data Prepper home directory."
+elif [[ $# == 2 ]]; then
     echo
-    echo "Data Prepper expects no command line arguments. Configuration files should be placed in "
-    echo "the application home directory and will be read automatically."
+    echo "Data Prepper now supports reading pipeline and data-prepper configuration files"
+    echo "from Data Prepper home directory automatically."
+    echo "You can continue to specify paths to configuration files as command line arguments,"
+    echo "but that support will be dropped in a future release."
+    echo
+else
+    echo
+    echo "Error: Invalid number of arguments. Expected 0 or 2, received $#."
+    echo "Put configuration files in Data Prepper home directory and specify no arguments,"
+    echo "or specify paths to pipeline and data-prepper configuration files, for example:"
+    echo "bin/data-prepper config/example-pipelines.yaml config/example-data-prepper-config.yaml"
     echo
     exit 1
 fi
@@ -25,4 +35,11 @@ export PATH=$JAVA_HOME/bin:$PATH
 
 DATA_PREPPER_HOME_OPTS="-Ddata-prepper.dir=$DATA_PREPPER_HOME"
 DATA_PREPPER_JAVA_OPTS="-Dlog4j.configurationFile=$DATA_PREPPER_HOME/config/log4j2-rolling.properties"
-java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute
+
+if [[ $# == 0 ]]; then
+    java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute
+else
+    PIPELINES_FILE_LOCATION=$1
+    CONFIG_FILE_LOCATION=$2
+    java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute $PIPELINES_FILE_LOCATION $CONFIG_FILE_LOCATION
+fi

--- a/release/archives/linux/data-prepper-x64.sh
+++ b/release/archives/linux/data-prepper-x64.sh
@@ -5,11 +5,21 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if [[ $# -gt 0 ]]
-  then
+if [[ $# == 0 ]]; then
+    echo "Reading pipelines and data-prepper configuration files from Data Prepper home directory."
+elif [[ $# == 2 ]]; then
     echo
-    echo "Data Prepper expects no command line arguments. Configuration files should be placed in "
-    echo "the application home directory and will be read automatically."
+    echo "Data Prepper now supports reading pipeline and data-prepper configuration files"
+    echo "from Data Prepper home directory automatically."
+    echo "You can continue to specify paths to configuration files as command line arguments,"
+    echo "but that support will be dropped in a future release."
+    echo
+else
+    echo
+    echo "Error: Invalid number of arguments. Expected 0 or 2, received $#."
+    echo "Put configuration files in Data Prepper home directory and specify no arguments,"
+    echo "or specify paths to pipeline and data-prepper configuration files, for example:"
+    echo "bin/data-prepper config/example-pipelines.yaml config/example-data-prepper-config.yaml"
     echo
     exit 1
 fi
@@ -53,4 +63,11 @@ fi
 
 DATA_PREPPER_HOME_OPTS="-Ddata-prepper.dir=$DATA_PREPPER_HOME"
 DATA_PREPPER_JAVA_OPTS="-Dlog4j.configurationFile=$DATA_PREPPER_HOME/config/log4j2-rolling.properties"
-java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute
+
+if [[ $# == 0 ]]; then
+    java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute
+else
+    PIPELINES_FILE_LOCATION=$1
+    CONFIG_FILE_LOCATION=$2
+    java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute $PIPELINES_FILE_LOCATION $CONFIG_FILE_LOCATION
+fi

--- a/release/archives/linux/data-prepper-x64.sh
+++ b/release/archives/linux/data-prepper-x64.sh
@@ -5,6 +5,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+if [[ $# -gt 0 ]]
+  then
+    echo
+    echo "Data Prepper expects no command line arguments. Configuration files should be placed in "
+    echo "the application home directory and will be read automatically."
+    echo
+    exit 1
+fi
+
 MIN_REQ_JAVA_VERSION=11
 MIN_REQ_OPENJDK_VERSION=11
 DATA_PREPPER_BIN=$(dirname "$(realpath "$0")")

--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -20,4 +20,4 @@ COPY default-data-prepper-config.yaml $ENV_CONFIG_FILEPATH
 COPY default-keystore.p12 /usr/share/data-prepper/keystore.p12
 
 WORKDIR $DATA_PREPPER_PATH
-CMD ./bin/data-prepper ${ENV_PIPELINE_FILEPATH} ${ENV_CONFIG_FILEPATH}
+CMD bin/data-prepper

--- a/release/docker/README.md
+++ b/release/docker/README.md
@@ -29,7 +29,7 @@ Below is an example command which can also be used to run the built image.
 docker run \
  --name data-prepper-test \
  -p 21890:21890 -p 4900:4900 \
- -v ${PWD}/examples/config/example-pipelines.yaml:/usr/share/data-prepper/pipelines.yaml \
- -v ${PWD}/examples/config/example-data-prepper-config.yaml:/usr/share/data-prepper/data-prepper-config.yaml \
- opensearch-data-prepper:1.2.0-SNAPSHOT
+ -v ${PWD}/examples/config/example-pipelines.yaml:/usr/share/data-prepper/pipelines/pipelines.yaml \
+ -v ${PWD}/examples/config/example-data-prepper-config.yaml:/usr/share/data-prepper/config/data-prepper-config.yaml \
+ opensearch-data-prepper:2.0.0-SNAPSHOT
 ```

--- a/release/docker/build.gradle
+++ b/release/docker/build.gradle
@@ -14,8 +14,8 @@ docker {
     files "${project.projectDir}/config/default-data-prepper-config.yaml", "${project.projectDir}/config/default-keystore.p12"
     buildArgs(['ARCHIVE_FILE' : project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archiveName,
                'ARCHIVE_FILE_UNPACKED' : project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archiveName.replace('.tar.gz', ''),
-               'CONFIG_FILEPATH' : '/usr/share/data-prepper/data-prepper-config.yaml',
-               'PIPELINE_FILEPATH' : '/usr/share/data-prepper/pipelines.yaml'])
+               'CONFIG_FILEPATH' : '/usr/share/data-prepper/config/data-prepper-config.yaml',
+               'PIPELINE_FILEPATH' : '/usr/share/data-prepper/pipelines/pipelines.yaml'])
     dockerfile file('Dockerfile')
 }
 

--- a/release/smoke-tests/data-prepper-tar/Dockerfile
+++ b/release/smoke-tests/data-prepper-tar/Dockerfile
@@ -20,4 +20,4 @@ COPY ${DOCKER_FILE_DIR}/${TAR_FILE} ${DATA_PREPPER_HOME}
 RUN tar -xzf "${DATA_PREPPER_HOME}/${TAR_FILE}" -C "${DATA_PREPPER_HOME}" --strip-components=1 \
     && rm -f "${DATA_PREPPER_HOME}/${TAR_FILE}"
 
-ENTRYPOINT "${DATA_PREPPER_HOME}/bin/data-prepper" ${DATA_PREPPER_HOME}/pipelines.yaml ${DATA_PREPPER_HOME}/data-prepper-config.yaml
+ENTRYPOINT "${DATA_PREPPER_HOME}/bin/data-prepper"

--- a/release/smoke-tests/docker-compose.yml
+++ b/release/smoke-tests/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     image: ${DOCKER_IMAGE}
     working_dir: /usr/share/data-prepper/
     volumes:
-      - ./data-prepper/config/data-prepper-config.yaml:/usr/share/data-prepper/data-prepper-config.yaml
-      - ./data-prepper/config/pipelines.yaml:/usr/share/data-prepper/pipelines.yaml
-      - ../../shared-config/log4j2.properties:/usr/share/data-prepper/log4j.properties
+      - ./data-prepper/config/data-prepper-config.yaml:/usr/share/data-prepper/config/data-prepper-config.yaml
+      - ./data-prepper/config/pipelines.yaml:/usr/share/data-prepper/pipelines/pipelines.yaml
+      - ../../shared-config/log4j2.properties:/usr/share/data-prepper/config/log4j.properties
     depends_on:
       - opensearch
     ports:

--- a/shared-config/log4j2-rolling.properties
+++ b/shared-config/log4j2-rolling.properties
@@ -33,11 +33,11 @@ rootLogger.level = warn
 rootLogger.appenderRef.stdout.ref = STDOUT
 rootLogger.appenderRef.file.ref = RollingFile
 
-logger.pipeline.name = com.amazon.dataprepper.pipeline
+logger.pipeline.name = org.opensearch.dataprepper.pipeline
 logger.pipeline.level = info
 
-logger.parser.name = com.amazon.dataprepper.parser
+logger.parser.name = org.opensearch.dataprepper.parser
 logger.parser.level = info
 
-logger.plugins.name = com.amazon.dataprepper.plugins
+logger.plugins.name = org.opensearch.dataprepper.plugins
 logger.plugins.level = info


### PR DESCRIPTION
### Description
With this change, data prepper loads pipeline configurations from `pipelines/` folder under data prepper home directory. The configurations can be specified in one yaml file or in multiple yaml files as specified in #305. 

Smoke tests were also updated.
 
### Issues Resolved
Resolves #1736  
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
