### PR TITLE
Inject PeerForwarderServer in to DataPrepper class

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/LocalPeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/LocalPeerForwarder.java
@@ -9,11 +9,17 @@ import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.record.Record;
 
 import java.util.Collection;
+import java.util.Collections;
 
 public class LocalPeerForwarder implements PeerForwarder {
 
     @Override
     public Collection<Record<Event>> forwardRecords(final Collection<Record<Event>> records) {
         return records;
+    }
+
+    @Override
+    public Collection<Record<Event>> receiveRecords() {
+        return Collections.emptyList();
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder.java
@@ -10,8 +10,22 @@ import com.amazon.dataprepper.model.record.Record;
 
 import java.util.Collection;
 
+/**
+ * Interface to handle forwarding records and receiving records from peers
+ *
+ * @since 2.0
+ */
 public interface PeerForwarder {
+    /**
+     * Forwards records to peers
+     * @param records collections of records to forward
+     * @return collection of records to process locally
+     */
     Collection<Record<Event>> forwardRecords(final Collection<Record<Event>> records);
 
+    /**
+     * Receives records from {@link PeerForwarderReceiveBuffer} forwarded by peers and process them locally
+     * @return collection of records forwarded by peers
+     */
     Collection<Record<Event>> receiveRecords();
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder.java
@@ -12,4 +12,6 @@ import java.util.Collection;
 
 public interface PeerForwarder {
     Collection<Record<Event>> forwardRecords(final Collection<Record<Event>> records);
+
+    Collection<Record<Event>> receiveRecords();
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpService.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpService.java
@@ -80,10 +80,10 @@ public class PeerForwarderHttpService {
     }
 
     private void writeEventsToBuffer(final WireEvents wireEvents) throws Exception {
-        final PeerForwarderReceiveBuffer<Record<?>> recordPeerForwarderReceiveBuffer = getPeerForwarderBuffer(wireEvents);
+        final PeerForwarderReceiveBuffer<Record<Event>> recordPeerForwarderReceiveBuffer = getPeerForwarderBuffer(wireEvents);
 
         if (wireEvents.getEvents() != null) {
-            final Collection<Record<?>> jacksonEvents = wireEvents.getEvents().stream()
+            final Collection<Record<Event>> jacksonEvents = wireEvents.getEvents().stream()
                     .map(this::transformEvent)
                     .collect(Collectors.toList());
 
@@ -91,11 +91,11 @@ public class PeerForwarderHttpService {
         }
     }
 
-    private PeerForwarderReceiveBuffer<Record<?>> getPeerForwarderBuffer(final WireEvents wireEvents) {
+    private PeerForwarderReceiveBuffer<Record<Event>> getPeerForwarderBuffer(final WireEvents wireEvents) {
         final String destinationPluginId = wireEvents.getDestinationPluginId();
         final String destinationPipelineName = wireEvents.getDestinationPipelineName();
 
-        final Map<String, Map<String, PeerForwarderReceiveBuffer<Record<?>>>> pipelinePeerForwarderReceiveBufferMap =
+        final Map<String, Map<String, PeerForwarderReceiveBuffer<Record<Event>>>> pipelinePeerForwarderReceiveBufferMap =
                 peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap();
 
         return pipelinePeerForwarderReceiveBufferMap

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandler.java
@@ -44,6 +44,7 @@ public class ShutdownHandler implements HttpHandler {
         } finally {
             exchange.getResponseBody().close();
             dataPrepper.shutdownDataPrepperServer();
+            dataPrepper.shutdownPeerForwarderServer();
         }
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/DataPrepperTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/DataPrepperTests.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper;
 
 import com.amazon.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.parser.PipelineParser;
+import org.opensearch.dataprepper.peerforwarder.server.PeerForwarderServer;
 import org.opensearch.dataprepper.pipeline.Pipeline;
 import org.opensearch.dataprepper.pipeline.server.DataPrepperServer;
 import org.hamcrest.Matchers;
@@ -38,6 +39,8 @@ public class DataPrepperTests {
     private PluginFactory pluginFactory;
     @Mock
     private DataPrepperServer dataPrepperServer;
+    @Mock
+    private PeerForwarderServer peerForwarderServer;
     @InjectMocks
     private DataPrepper dataPrepper;
 
@@ -73,7 +76,7 @@ public class DataPrepperTests {
 
         assertThrows(
                 RuntimeException.class,
-                () -> new DataPrepper(pipelineParser, pluginFactory),
+                () -> new DataPrepper(pipelineParser, pluginFactory, peerForwarderServer),
                 "Exception should be thrown if pipeline parser has no pipeline configuration");
     }
 
@@ -93,6 +96,7 @@ public class DataPrepperTests {
 
         verify(pipeline).execute();
         verify(dataPrepperServer).start();
+        verify(peerForwarderServer).start();
     }
 
     @Test
@@ -120,6 +124,13 @@ public class DataPrepperTests {
         dataPrepper.shutdownDataPrepperServer();
 
         verify(dataPrepperServer).stop();
+    }
+
+    @Test
+    public void testShutdownPeerForwarderServer() {
+        dataPrepper.shutdownPeerForwarderServer();
+
+        verify(peerForwarderServer).stop();
     }
     
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/LocalPeerForwarderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/LocalPeerForwarderTest.java
@@ -14,6 +14,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 
@@ -30,6 +32,15 @@ class LocalPeerForwarderTest {
         final Collection<Record<Event>> records = localPeerForwarder.forwardRecords(testData);
 
         assertThat(records, equalTo(testData));
+    }
+
+    @Test
+    void receiveRecords_should_return_empty_collection() {
+        final LocalPeerForwarder localPeerForwarder = new LocalPeerForwarder();
+        final Collection<Record<Event>> records = localPeerForwarder.receiveRecords();
+
+        assertThat(records.size(), equalTo(0));
+        assertThat(records, is(empty()));
     }
 
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProviderTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder;
 
+import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.record.Record;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -159,7 +160,7 @@ class PeerForwarderProviderTest {
         final PeerForwarderProvider objectUnderTest = createObjectUnderTest();
 
 
-        final Map<String, Map<String, PeerForwarderReceiveBuffer<Record<?>>>> pipelinePeerForwarderReceiveBufferMap = objectUnderTest
+        final Map<String, Map<String, PeerForwarderReceiveBuffer<Record<Event>>>> pipelinePeerForwarderReceiveBufferMap = objectUnderTest
                 .getPipelinePeerForwarderReceiveBufferMap();
 
         assertThat(objectUnderTest.isPeerForwardingRequired(), equalTo(false));
@@ -173,7 +174,7 @@ class PeerForwarderProviderTest {
 
         objectUnderTest.register(pipelineName, UUID.randomUUID().toString(), identificationKeys);
 
-        final Map<String, Map<String, PeerForwarderReceiveBuffer<Record<?>>>> pipelinePeerForwarderReceiveBufferMap = objectUnderTest
+        final Map<String, Map<String, PeerForwarderReceiveBuffer<Record<Event>>>> pipelinePeerForwarderReceiveBufferMap = objectUnderTest
                 .getPipelinePeerForwarderReceiveBufferMap();
 
         assertThat(objectUnderTest.isPeerForwardingRequired(), equalTo(false));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -139,12 +139,12 @@ class PeerForwarder_ClientServerIT {
 
             assertThat(httpResponse.status(), equalTo(HttpStatus.OK));
 
-            final Map<String, PeerForwarderReceiveBuffer<Record<?>>> pluginBufferMap = peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap().get(pipelineName);
+            final Map<String, PeerForwarderReceiveBuffer<Record<Event>>> pluginBufferMap = peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap().get(pipelineName);
             assertThat(pluginBufferMap, notNullValue());
-            final PeerForwarderReceiveBuffer<Record<?>> receiveBuffer = pluginBufferMap.get(pluginId);
+            final PeerForwarderReceiveBuffer<Record<Event>> receiveBuffer = pluginBufferMap.get(pluginId);
 
-            final Map.Entry<Collection<Record<?>>, CheckpointState> bufferEntry = receiveBuffer.read(1000);
-            final Collection<Record<?>> receivedRecords = bufferEntry.getKey();
+            final Map.Entry<Collection<Record<Event>>, CheckpointState> bufferEntry = receiveBuffer.read(1000);
+            final Collection<Record<Event>> receivedRecords = bufferEntry.getKey();
             assertThat(receivedRecords, notNullValue());
             assertThat(receivedRecords.size(), equalTo(outgoingRecords.size()));
 
@@ -209,12 +209,12 @@ class PeerForwarder_ClientServerIT {
 
             assertThat(httpResponse.status(), equalTo(HttpStatus.OK));
 
-            final Map<String, PeerForwarderReceiveBuffer<Record<?>>> pluginBufferMap = peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap().get(pipelineName);
+            final Map<String, PeerForwarderReceiveBuffer<Record<Event>>> pluginBufferMap = peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap().get(pipelineName);
             assertThat(pluginBufferMap, notNullValue());
-            final PeerForwarderReceiveBuffer<Record<?>> receiveBuffer = pluginBufferMap.get(pluginId);
+            final PeerForwarderReceiveBuffer<Record<Event>> receiveBuffer = pluginBufferMap.get(pluginId);
 
-            final Map.Entry<Collection<Record<?>>, CheckpointState> bufferEntry = receiveBuffer.read(1000);
-            final Collection<Record<?>> receivedRecords = bufferEntry.getKey();
+            final Map.Entry<Collection<Record<Event>>, CheckpointState> bufferEntry = receiveBuffer.read(1000);
+            final Collection<Record<Event>> receivedRecords = bufferEntry.getKey();
             assertThat(receivedRecords, notNullValue());
             assertThat(receivedRecords.size(), equalTo(outgoingRecords.size()));
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServiceTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServiceTest.java
@@ -74,7 +74,7 @@ class PeerForwarderHttpServiceTest {
 
     @Test
     void test_doPost_with_HTTP_request_should_return_OK() throws Exception {
-        final HashMap<String, Map<String, PeerForwarderReceiveBuffer<Record<?>>>> pipelinePeerForwarderReceiveBufferMap = new HashMap<>();
+        final HashMap<String, Map<String, PeerForwarderReceiveBuffer<Record<Event>>>> pipelinePeerForwarderReceiveBufferMap = new HashMap<>();
         pipelinePeerForwarderReceiveBufferMap.put(PIPELINE_NAME, Map.of(PLUGIN_ID, peerForwarderReceiveBuffer));
         when(peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap()).thenReturn(pipelinePeerForwarderReceiveBufferMap);
 
@@ -100,7 +100,7 @@ class PeerForwarderHttpServiceTest {
 
     @Test
     void test_doPost_with_HTTP_request_size_greater_than_buffer_size_should_return_REQUEST_ENTITY_TOO_LARGE() throws ExecutionException, JsonProcessingException, InterruptedException {
-        final HashMap<String, Map<String, PeerForwarderReceiveBuffer<Record<?>>>> pipelinePeerForwarderReceiveBufferMap = new HashMap<>();
+        final HashMap<String, Map<String, PeerForwarderReceiveBuffer<Record<Event>>>> pipelinePeerForwarderReceiveBufferMap = new HashMap<>();
         pipelinePeerForwarderReceiveBufferMap.put(PIPELINE_NAME, Map.of(PLUGIN_ID, peerForwarderReceiveBuffer));
         when(peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap()).thenReturn(pipelinePeerForwarderReceiveBufferMap);
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandlerTest.java
@@ -62,6 +62,8 @@ public class ShutdownHandlerTest {
                 .close();
         verify(dataPrepper, times(1))
                 .shutdownDataPrepperServer();
+        verify(dataPrepper, times(1))
+                .shutdownPeerForwarderServer();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Description
Start and stop peer forwarder server in `DataPrepper`
 
### Issues Resolved
resolves #1608 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
