### PR TITLE
Create a runnable distribution from assemble task

### DIFF
--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
@@ -166,21 +166,21 @@ class PipelineParserTests {
 
     @Test
     void parseConfiguration_from_directory_with_multiple_files_creates_the_correct_pipelineMap() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.MULTI_FILE_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider);
+        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.MULTI_FILE_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
         final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
         assertThat(actualPipelineMap.keySet(), equalTo(TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES));
     }
 
     @Test
     void parseConfiguration_from_directory_with_single_file_creates_the_correct_pipelineMap() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.SINGLE_FILE_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider);
+        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.SINGLE_FILE_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
         final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
         assertThat(actualPipelineMap.keySet(), equalTo(TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES));
     }
 
     @Test
     void parseConfiguration_from_directory_with_no_yaml_files_should_throw() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.EMPTY_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider);
+        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.EMPTY_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(), equalTo(
                 String.format("Pipelines configuration file not found at %s", TestDataProvider.EMPTY_PIPELINE_DIRECTOTRY)));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
@@ -169,6 +169,7 @@ class PipelineParserTests {
         final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.MULTI_FILE_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
         final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
         assertThat(actualPipelineMap.keySet(), equalTo(TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES));
+        verifyDataPrepperConfigurationAccesses(actualPipelineMap.keySet().size());
     }
 
     @Test
@@ -176,6 +177,7 @@ class PipelineParserTests {
         final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.SINGLE_FILE_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
         final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
         assertThat(actualPipelineMap.keySet(), equalTo(TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES));
+        verifyDataPrepperConfigurationAccesses(actualPipelineMap.keySet().size());
     }
 
     @Test

--- a/release/archives/README.md
+++ b/release/archives/README.md
@@ -78,4 +78,3 @@ or
 ./gradlew uploadArchives -Prelease 
 
 ```
-

--- a/release/archives/build.gradle
+++ b/release/archives/build.gradle
@@ -33,6 +33,7 @@ subprojects {
         def distName = "${platform}${architecture}" //eg linuxarm64
         def distNameWithJDK = "${distName}WithJDK"
         def downloadJDKTask = "download${architecture}JDK"
+        def installTaskName = "install${distName.capitalize()}Dist"
 
         //This adds two distributions for each supported architecture e.g. linuxarm64DistTar, linuxarm64WithJDKDistTar
         distributions {
@@ -66,6 +67,12 @@ subprojects {
             project.version = ""
         }
 
+        tasks.getByName(installTaskName) {
+            dependsOn ':release:releasePrerequisites'
+        }
+
+        assemble.dependsOn(installTaskName)
+
         //Adds one task per supported architecture for downloading appropriate JDK e.g. downloadarm64JDK
         tasks.create("${downloadJDKTask}") {
             doLast {
@@ -76,6 +83,10 @@ subprojects {
                 }
             }
         }
+    }
+
+    tasks.withType(Zip) {
+        enabled false
     }
 
     tasks.withType(Tar) {
@@ -122,7 +133,6 @@ subprojects {
         }
     }
 }
-
 
 CopySpec archiveToTar() {
     return copySpec {

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -24,7 +24,7 @@ allprojects {
     }
 
     dependencies {
-        implementation project(':data-prepper-core')
+        implementation project(':data-prepper-main')
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,13 +12,6 @@ pluginManagement {
 
 rootProject.name = 'opensearch-data-prepper'
 
-if(startParameter.getProjectProperties().containsKey('release')){
-    include 'release'
-    include 'release:archives'
-    include 'release:archives:linux'
-    include 'release:docker'
-    include 'release:maven'
-}
 include 'data-prepper-api'
 include 'data-prepper-plugins'
 include 'data-prepper-core'
@@ -56,3 +49,8 @@ include 'data-prepper-plugins:s3-source'
 include 'data-prepper-plugins:csv-processor'
 include 'data-prepper-plugins:parse-json-processor'
 include 'data-prepper-plugins:trace-peer-forwarder-processor'
+include 'release'
+include 'release:archives'
+include 'release:archives:linux'
+include 'release:docker'
+include 'release:maven'


### PR DESCRIPTION
Signed-off-by: Hai Yan <oeyh@amazon.com>

### Description
This PR improves the `assemble` gradle task. It now calls an additional [install task](https://docs.gradle.org/current/userguide/distribution_plugin.html#sec:distribution_tasks) provided by the `distribution` plugin to create a runnable distribution. With this change, we can build and run data prepper by:
1. Run `./gradlew assemble`
2. Go to `release/archives/linux/build/install/opensearch-data-prepper-{VERSION}-linux-x64` and run `bin/data-prepper`
 
### Issues Resolved
Resolves #1762 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
