### PR TITLE
Fix broken PeerForwardingProcessingDecoratorTest by casting object

### DIFF
--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
@@ -128,9 +128,9 @@ class PeerForwardingProcessingDecoratorTest {
 
             final Collection<Record<Event>> expectedRecordsToProcessLocally = CollectionUtils.union(forwardTestData, receiveTestData);
 
-            when(requiresPeerForwarding.execute(anyCollection())).thenReturn(expectedRecordsToProcessLocally);
+            when(((Processor) requiresPeerForwarding).execute(anyCollection())).thenReturn(expectedRecordsToProcessLocally);
 
-            final PeerForwardingProcessorDecorator objectUnderTest = createObjectUnderTest(requiresPeerForwarding);
+            final PeerForwardingProcessorDecorator objectUnderTest = createObjectUnderTest((Processor) requiresPeerForwarding);
             final Collection<Record<Event>> records = objectUnderTest.execute(forwardTestData);
 
             verify(requiresPeerForwarding).getIdentificationKeys();


### PR DESCRIPTION
### Description

One of our tests is broken.
 
Sample failure:
https://github.com/opensearch-project/data-prepper/actions/runs/3069628849/jobs/4958500535

### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
