### PR TITLE
Implement AggregateProcessor shutdown behavior

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
@@ -49,7 +49,7 @@ class AggregateActionSynchronizer {
         this.actionConcludeGroupEventsProcessingErrors = pluginMetrics.counter(ACTION_CONCLUDE_GROUP_EVENTS_PROCESSING_ERRORS);
     }
 
-    Optional<Event> concludeGroup(final AggregateIdentificationKeysHasher.IdentificationHash hash, final AggregateGroup aggregateGroup) {
+    Optional<Event> concludeGroup(final AggregateIdentificationKeysHasher.IdentificationHash hash, final AggregateGroup aggregateGroup, final boolean isShuttingDown) {
         final Lock concludeGroupLock = aggregateGroup.getConcludeGroupLock();
         final Lock handleEventForGroupLock = aggregateGroup.getHandleEventForGroupLock();
 
@@ -58,7 +58,7 @@ class AggregateActionSynchronizer {
             handleEventForGroupLock.lock();
 
             try {
-                if (aggregateGroup.shouldConcludeGroup(aggregateGroupManager.getGroupDuration())) {
+                if (aggregateGroup.shouldConcludeGroup(aggregateGroupManager.getGroupDuration()) || isShuttingDown) {
                     LOG.debug("Start critical section in concludeGroup");
                     concludeGroupEvent = aggregateAction.concludeGroup(aggregateGroup);
                     aggregateGroupManager.closeGroup(hash, aggregateGroup);

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
@@ -49,7 +49,7 @@ class AggregateActionSynchronizer {
         this.actionConcludeGroupEventsProcessingErrors = pluginMetrics.counter(ACTION_CONCLUDE_GROUP_EVENTS_PROCESSING_ERRORS);
     }
 
-    Optional<Event> concludeGroup(final AggregateIdentificationKeysHasher.IdentificationHash hash, final AggregateGroup aggregateGroup, final boolean isShuttingDown) {
+    Optional<Event> concludeGroup(final AggregateIdentificationKeysHasher.IdentificationHash hash, final AggregateGroup aggregateGroup, final boolean forceConclude) {
         final Lock concludeGroupLock = aggregateGroup.getConcludeGroupLock();
         final Lock handleEventForGroupLock = aggregateGroup.getHandleEventForGroupLock();
 
@@ -58,7 +58,7 @@ class AggregateActionSynchronizer {
             handleEventForGroupLock.lock();
 
             try {
-                if (aggregateGroup.shouldConcludeGroup(aggregateGroupManager.getGroupDuration()) || isShuttingDown) {
+                if (aggregateGroup.shouldConcludeGroup(aggregateGroupManager.getGroupDuration()) || forceConclude) {
                     LOG.debug("Start critical section in concludeGroup");
                     concludeGroupEvent = aggregateAction.concludeGroup(aggregateGroup);
                     aggregateGroupManager.closeGroup(hash, aggregateGroup);

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
@@ -25,7 +25,11 @@ class AggregateGroupManager {
         return allGroups.computeIfAbsent(identificationHash, (hash) -> new AggregateGroup());
     }
 
-    List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> getGroupsToConclude() {
+    List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> getGroupsToConclude(final boolean isShuttingDown) {
+        if (isShuttingDown) {
+            return allGroups;
+        }
+
         final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> groupsToConclude = new ArrayList<>();
         for (final Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> groupEntry : allGroups.entrySet()) {
             if (groupEntry.getValue().shouldConcludeGroup(groupDuration)) {

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
@@ -26,13 +26,9 @@ class AggregateGroupManager {
     }
 
     List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> getGroupsToConclude(final boolean isShuttingDown) {
-        if (isShuttingDown) {
-            return allGroups;
-        }
-
         final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> groupsToConclude = new ArrayList<>();
         for (final Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> groupEntry : allGroups.entrySet()) {
-            if (groupEntry.getValue().shouldConcludeGroup(groupDuration)) {
+            if (groupEntry.getValue().shouldConcludeGroup(groupDuration) || isShuttingDown) {
                 groupsToConclude.add(groupEntry);
             }
         }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
@@ -25,10 +25,10 @@ class AggregateGroupManager {
         return allGroups.computeIfAbsent(identificationHash, (hash) -> new AggregateGroup());
     }
 
-    List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> getGroupsToConclude(final boolean isShuttingDown) {
+    List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> getGroupsToConclude(final boolean forceConclude) {
         final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> groupsToConclude = new ArrayList<>();
         for (final Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> groupEntry : allGroups.entrySet()) {
-            if (groupEntry.getValue().shouldConcludeGroup(groupDuration) || isShuttingDown) {
+            if (groupEntry.getValue().shouldConcludeGroup(groupDuration) || forceConclude) {
                 groupsToConclude.add(groupEntry);
             }
         }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -78,7 +78,7 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
 
         final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> groupsToConclude = aggregateGroupManager.getGroupsToConclude(isShuttingDown);
         for (final Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> groupEntry : groupsToConclude) {
-            final Optional<Event> concludeGroupEvent = aggregateActionSynchronizer.concludeGroup(groupEntry.getKey(), groupEntry.getValue());
+            final Optional<Event> concludeGroupEvent = aggregateActionSynchronizer.concludeGroup(groupEntry.getKey(), groupEntry.getValue(), isShuttingDown);
 
             if (concludeGroupEvent.isPresent()) {
                 recordsOut.add(new Record(concludeGroupEvent.get()));

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -42,6 +42,8 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
     private final AggregateActionSynchronizer aggregateActionSynchronizer;
     private final AggregateIdentificationKeysHasher aggregateIdentificationKeysHasher;
 
+    private boolean isShuttingDown = false;
+
     @DataPrepperPluginConstructor
     public AggregateProcessor(final AggregateProcessorConfig aggregateProcessorConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory) {
         this(aggregateProcessorConfig, pluginMetrics, pluginFactory, new AggregateGroupManager(aggregateProcessorConfig.getGroupDuration()),
@@ -74,7 +76,7 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
     public Collection<Record<Event>> doExecute(Collection<Record<Event>> records) {
         final List<Record<Event>> recordsOut = new LinkedList<>();
 
-        final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> groupsToConclude = aggregateGroupManager.getGroupsToConclude();
+        final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> groupsToConclude = aggregateGroupManager.getGroupsToConclude(isShuttingDown);
         for (final Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> groupEntry : groupsToConclude) {
             final Optional<Event> concludeGroupEvent = aggregateActionSynchronizer.concludeGroup(groupEntry.getKey(), groupEntry.getValue());
 
@@ -112,12 +114,12 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
 
     @Override
     public void prepareForShutdown() {
-
+        isShuttingDown = true;
     }
 
     @Override
     public boolean isReadyForShutdown() {
-        return true;
+        return aggregateGroupManager.getAllGroupsSize() == 0;
     }
 
     @Override

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizerTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizerTest.java
@@ -202,7 +202,7 @@ public class AggregateActionSynchronizerTest {
     }
 
     @Test
-    void conclude_group_with_should_conclude_group_false_shutting_down_true_returns_correct_event() {
+    void conclude_group_with_should_conclude_group_false_force_conclude_true_returns_correct_event() {
         final AggregateActionSynchronizer objectUnderTest = createObjectUnderTest();
         when(concludeGroupLock.tryLock()).thenReturn(true);
         when(aggregateGroup.shouldConcludeGroup(any(Duration.class))).thenReturn(false);

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
@@ -126,10 +126,18 @@ public class AggregateGroupManagerTest {
 
         assertThat(groupsToConclude.size(), equalTo(2));
         assertThat(groupsToConclude.get(0), notNullValue());
-        assertThat(groupsToConclude.get(0).getKey(), equalTo(hashForGroupToConclude1));
-        assertThat(groupsToConclude.get(0).getValue(), equalTo(groupToConclude1));
         assertThat(groupsToConclude.get(1), notNullValue());
-        assertThat(groupsToConclude.get(1).getKey(), equalTo(hashForGroupToConclude2));
-        assertThat(groupsToConclude.get(1).getValue(), equalTo(groupToConclude2));
+
+        if (groupsToConclude.get(0).getKey().equals(hashForGroupToConclude1)) {
+            assertThat(groupsToConclude.get(0).getKey(), equalTo(hashForGroupToConclude1));
+            assertThat(groupsToConclude.get(0).getValue(), equalTo(groupToConclude1));
+            assertThat(groupsToConclude.get(1).getKey(), equalTo(hashForGroupToConclude2));
+            assertThat(groupsToConclude.get(1).getValue(), equalTo(groupToConclude2));
+        } else {
+            assertThat(groupsToConclude.get(0).getKey(), equalTo(hashForGroupToConclude2));
+            assertThat(groupsToConclude.get(0).getValue(), equalTo(groupToConclude2));
+            assertThat(groupsToConclude.get(1).getKey(), equalTo(hashForGroupToConclude1));
+            assertThat(groupsToConclude.get(1).getValue(), equalTo(groupToConclude1));
+        }
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
@@ -110,7 +110,7 @@ public class AggregateGroupManagerTest {
     }
 
     @Test
-    void getGroupsToConclude_is_shutting_down_return_all() {
+    void getGroupsToConclude_with_force_conclude_return_all() {
         aggregateGroupManager = createObjectUnderTest();
 
         final AggregateGroup groupToConclude1 = mock(AggregateGroup.class);

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
@@ -101,11 +101,35 @@ public class AggregateGroupManagerTest {
         aggregateGroupManager.putGroupWithHash(hashForGroupToConclude, groupToConclude);
         aggregateGroupManager.putGroupWithHash(hashForGroupToNotConclude, groupToNotConclude);
 
-        final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> groupsToConclude = aggregateGroupManager.getGroupsToConclude();
+        final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> groupsToConclude = aggregateGroupManager.getGroupsToConclude(false);
 
         assertThat(groupsToConclude.size(), equalTo(1));
         assertThat(groupsToConclude.get(0), notNullValue());
         assertThat(groupsToConclude.get(0).getKey(), equalTo(hashForGroupToConclude));
         assertThat(groupsToConclude.get(0).getValue(), equalTo(groupToConclude));
+    }
+
+    @Test
+    void getGroupsToConclude_is_shutting_down_return_all() {
+        aggregateGroupManager = createObjectUnderTest();
+
+        final AggregateGroup groupToConclude1 = mock(AggregateGroup.class);
+        final AggregateIdentificationKeysHasher.IdentificationHash hashForGroupToConclude1 = mock(AggregateIdentificationKeysHasher.IdentificationHash.class);
+
+        final AggregateGroup groupToConclude2 = mock(AggregateGroup.class);
+        final AggregateIdentificationKeysHasher.IdentificationHash hashForGroupToConclude2 = mock(AggregateIdentificationKeysHasher.IdentificationHash.class);
+
+        aggregateGroupManager.putGroupWithHash(hashForGroupToConclude1, groupToConclude1);
+        aggregateGroupManager.putGroupWithHash(hashForGroupToConclude2, groupToConclude2);
+
+        final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>> groupsToConclude = aggregateGroupManager.getGroupsToConclude(true);
+
+        assertThat(groupsToConclude.size(), equalTo(2));
+        assertThat(groupsToConclude.get(0), notNullValue());
+        assertThat(groupsToConclude.get(0).getKey(), equalTo(hashForGroupToConclude1));
+        assertThat(groupsToConclude.get(0).getValue(), equalTo(groupToConclude1));
+        assertThat(groupsToConclude.get(1), notNullValue());
+        assertThat(groupsToConclude.get(1).getKey(), equalTo(hashForGroupToConclude2));
+        assertThat(groupsToConclude.get(1).getValue(), equalTo(groupToConclude2));
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -281,8 +281,8 @@ public class AggregateProcessorTest {
     private static Stream<Arguments> isReadyForShutdownArgs() {
         return Stream.of(
                 Arguments.of(0, true),
-                Arguments.of(Math.abs(new Random().nextLong(50000)) + 1L, false),
-                Arguments.of((Math.abs(new Random().nextInt(50000)) * -1L) - 1L, false)
+                Arguments.of(Math.abs(new Random().nextLong()) + 1L, false),
+                Arguments.of((Math.abs(new Random().nextInt()) * -1L) - 1L, false)
         );
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -19,6 +19,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -29,7 +32,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -204,7 +204,7 @@ public class AggregateProcessorTest {
             final Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> groupEntry = new AbstractMap.SimpleEntry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>(identificationHash, aggregateGroup);
             when(aggregateGroupManager.getGroupsToConclude(eq(false))).thenReturn(Collections.singletonList(groupEntry));
             when(aggregateActionResponse.getEvent()).thenReturn(null);
-            when(aggregateActionSynchronizer.concludeGroup(identificationHash, aggregateGroup)).thenReturn(Optional.empty());
+            when(aggregateActionSynchronizer.concludeGroup(identificationHash, aggregateGroup, false)).thenReturn(Optional.empty());
 
             final List<Record<Event>> recordsOut = (List<Record<Event>>) objectUnderTest.doExecute(Collections.singletonList(new Record<>(event)));
 
@@ -216,6 +216,7 @@ public class AggregateProcessorTest {
             verifyNoInteractions(actionConcludeGroupEventsOutCounter);
 
             verify(aggregateGroupManager).getGroupsToConclude(eq(false));
+            verify(aggregateActionSynchronizer).concludeGroup(identificationHash, aggregateGroup, false);
         }
 
         @Test
@@ -225,7 +226,7 @@ public class AggregateProcessorTest {
             final Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> groupEntry = new AbstractMap.SimpleEntry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>(identificationHash, aggregateGroup);
             when(aggregateGroupManager.getGroupsToConclude(eq(false))).thenReturn(Collections.singletonList(groupEntry));
             when(aggregateActionResponse.getEvent()).thenReturn(null);
-            when(aggregateActionSynchronizer.concludeGroup(identificationHash, aggregateGroup)).thenReturn(Optional.of(event));
+            when(aggregateActionSynchronizer.concludeGroup(identificationHash, aggregateGroup, false)).thenReturn(Optional.of(event));
 
             final List<Record<Event>> recordsOut = (List<Record<Event>>) objectUnderTest.doExecute(Collections.singletonList(new Record<>(event)));
 
@@ -239,6 +240,7 @@ public class AggregateProcessorTest {
             verifyNoInteractions(actionConcludeGroupEventsDroppedCounter);
 
             verify(aggregateGroupManager).getGroupsToConclude(eq(false));
+            verify(aggregateActionSynchronizer).concludeGroup(identificationHash, aggregateGroup, false);
         }
 
         @Test
@@ -249,7 +251,7 @@ public class AggregateProcessorTest {
             final Map.Entry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup> groupEntry = new AbstractMap.SimpleEntry<AggregateIdentificationKeysHasher.IdentificationHash, AggregateGroup>(identificationHash, aggregateGroup);
             when(aggregateGroupManager.getGroupsToConclude(eq(true))).thenReturn(Collections.singletonList(groupEntry));
             when(aggregateActionResponse.getEvent()).thenReturn(null);
-            when(aggregateActionSynchronizer.concludeGroup(identificationHash, aggregateGroup)).thenReturn(Optional.of(event));
+            when(aggregateActionSynchronizer.concludeGroup(identificationHash, aggregateGroup, true)).thenReturn(Optional.of(event));
 
             final List<Record<Event>> recordsOut = (List<Record<Event>>) objectUnderTest.doExecute(Collections.singletonList(new Record<>(event)));
 
@@ -263,6 +265,7 @@ public class AggregateProcessorTest {
             verifyNoInteractions(actionConcludeGroupEventsDroppedCounter);
 
             verify(aggregateGroupManager).getGroupsToConclude(eq(true));
+            verify(aggregateActionSynchronizer).concludeGroup(identificationHash, aggregateGroup, true);
         }
     }
 

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -284,6 +284,7 @@ public class AggregateProcessorTest {
     private static Stream<Arguments> isReadyForShutdownArgs() {
         return Stream.of(
                 Arguments.of(0, true),
+                Arguments.of(1, false),
                 Arguments.of(Math.abs(new Random().nextLong()) + 1L, false),
                 Arguments.of((Math.abs(new Random().nextInt()) * -1L) - 1L, false)
         );


### PR DESCRIPTION
Signed-off-by: Chase Engelbrecht <engechas@amazon.com>

### Description
This PR implements shutdown behavior for the stateful AggregateProcessor by concluding all groups after `prepareForShutdown` is called and modifying `isReadyForShutdown` to check if the groups size is 0.
 
### Issues Resolved
Partially #1770 
 
### Check List
- [x] New functionality includes testing.
- [N/A] New functionality has been documented.
  - [N/A] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
