### PR TITLE
removed pipelines dir is smoke test container

### DIFF
--- a/release/smoke-tests/docker-compose.yml
+++ b/release/smoke-tests/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     working_dir: /usr/share/data-prepper/
     volumes:
       - ./data-prepper/config/data-prepper-config.yaml:/usr/share/data-prepper/config/data-prepper-config.yaml
-      - ./data-prepper/config/pipelines.yaml:/usr/share/data-prepper/pipelines/pipelines.yaml
+      - ./data-prepper/config/pipelines.yaml:/usr/share/data-prepper/pipelines.yaml
       - ../../shared-config/log4j2.properties:/usr/share/data-prepper/config/log4j.properties
     depends_on:
       - opensearch


### PR DESCRIPTION
Signed-off-by: Steven Bayer <smbayer@amazon.com>

### Description
Removed pipelines directory from docker-compose file, in Data Prepper volumes.
 
### Issues Resolved
Fix broken smoke test
 
### Check List

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
