### PR TITLE
S3 Event Consistency via metadata and JSON changes

### DIFF
--- a/data-prepper-plugins/s3-source/README.md
+++ b/data-prepper-plugins/s3-source/README.md
@@ -64,6 +64,8 @@ All Duration values are a string that represents a duration. They support ISO_86
 
 * `records_to_accumulate` (Optional) : The number of messages to write to accumulate before writing to the Buffer. Defaults to 100.
 
+* `metadata_root_key` (Optional) : String - Sets the base key for adding S3 metadata to each Event. The metadata includes the `key` and `bucket` for each S3 object. Defaults to `s3/`.
+
 * `disable_bucket_ownership_validation` (Optional) : Boolean - If set to true, then the S3 Source will not attempt to validate that the bucket is owned by the expected account. The only expected account is the same account which owns the SQS queue. Defaults to `false`.
 
 ### <a name="sqs_configuration">SQS Configuration</a>

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/JsonRecordsGenerator.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/JsonRecordsGenerator.java
@@ -60,7 +60,7 @@ class JsonRecordsGenerator implements RecordsGenerator {
     @Override
     public void assertEventIsCorrect(final Event event) {
 
-        final Map<String, Object> messageMap = event.get("message", Map.class);
+        final Map<String, Object> messageMap = event.toMap();
         assertThat(messageMap, notNullValue());
         assertThat(messageMap.size(), greaterThanOrEqualTo(KNOWN_FIELD_COUNT_PER_EVENT));
         assertThat(messageMap.get(EVENT_VERSION_FIELD), equalTo(EVENT_VERSION_VALUE));

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/EventMetadataModifier.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/EventMetadataModifier.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import com.amazon.dataprepper.model.event.Event;
+
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+class EventMetadataModifier implements BiConsumer<Event, S3ObjectReference> {
+    private static final String BUCKET_FIELD_NAME = "bucket";
+    private static final String KEY_FIELD_NAME = "key";
+    private final String baseKey;
+
+    EventMetadataModifier(final String metadataRootKey) {
+        baseKey = generateBaseKey(metadataRootKey);
+    }
+
+    @Override
+    public void accept(final Event event, final S3ObjectReference s3ObjectReference) {
+        event.put(baseKey + BUCKET_FIELD_NAME, s3ObjectReference.getBucketName());
+        event.put(baseKey + KEY_FIELD_NAME, s3ObjectReference.getKey());
+    }
+
+    private static String generateBaseKey(String metadataRootKey) {
+        Objects.requireNonNull(metadataRootKey);
+
+        if(metadataRootKey.startsWith("/"))
+            metadataRootKey = metadataRootKey.substring(1);
+
+        if(metadataRootKey.isEmpty() || metadataRootKey.endsWith("/"))
+            return metadataRootKey;
+
+        return metadataRootKey + "/";
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/S3SourceConfig.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 public class S3SourceConfig {
     static final Duration DEFAULT_BUFFER_TIMEOUT = Duration.ofSeconds(10);
     static final int DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE = 100;
+    static final String DEFAULT_METADATA_ROOT_KEY = "s3/";
 
     @JsonProperty("notification_type")
     @NotNull
@@ -52,6 +53,9 @@ public class S3SourceConfig {
 
     @JsonProperty("disable_bucket_ownership_validation")
     private boolean disableBucketOwnershipValidation = false;
+
+    @JsonProperty("metadata_root_key")
+    private String metadataRootKey = DEFAULT_METADATA_ROOT_KEY;
 
     public NotificationTypeOption getNotificationType() {
         return notificationType;
@@ -87,5 +91,9 @@ public class S3SourceConfig {
 
     public boolean isDisableBucketOwnershipValidation() {
         return disableBucketOwnershipValidation;
+    }
+
+    public String getMetadataRootKey() {
+        return metadataRootKey;
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/JsonCodec.java
+++ b/data-prepper-plugins/s3-source/src/main/java/com/amazon/dataprepper/plugins/source/codec/JsonCodec.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -27,7 +26,6 @@ import java.util.function.Consumer;
  */
 @DataPrepperPlugin(name = "json", pluginType = Codec.class)
 public class JsonCodec implements Codec {
-    private static final String MESSAGE_FIELD_NAME = "message";
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final JsonFactory jsonFactory = new JsonFactory();
 
@@ -57,7 +55,7 @@ public class JsonCodec implements Codec {
 
     private Record<Event> createRecord(final Map<String, Object> json) {
         final JacksonEvent event = JacksonLog.builder()
-                .withData(Collections.singletonMap(MESSAGE_FIELD_NAME, json))
+                .withData(json)
                 .build();
 
         return new Record<>(event);

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/EventMetadataModifierTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/EventMetadataModifierTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.dataprepper.plugins.source;
+
+import com.amazon.dataprepper.model.event.Event;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventMetadataModifierTest {
+    @Mock
+    private Event event;
+
+    @Mock
+    private S3ObjectReference s3ObjectReference;
+    private String bucketName;
+    private String key;
+
+    @BeforeEach
+    void setUp() {
+        bucketName = UUID.randomUUID().toString();
+        key = UUID.randomUUID().toString();
+    }
+
+    private EventMetadataModifier createObjectUnderTest(final String metadataRootKey) {
+        return new EventMetadataModifier(metadataRootKey);
+    }
+
+    @Test
+    void constructor_throws_if_metadataRootKey_is_null() {
+        assertThrows(NullPointerException.class, () -> createObjectUnderTest(null));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(KeysArgumentsProvider.class)
+    void accept_sets_correct_S3_bucket_and_key(final String metadataKey, final String expectedRootKey) {
+        when(s3ObjectReference.getBucketName()).thenReturn(bucketName);
+        when(s3ObjectReference.getKey()).thenReturn(key);
+
+        createObjectUnderTest(metadataKey).accept(event, s3ObjectReference);
+
+        verify(event).put(expectedRootKey + "bucket", bucketName);
+        verify(event).put(expectedRootKey + "key", key);
+    }
+
+    static class KeysArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
+            return Stream.of(
+                    arguments("", ""),
+                    arguments("/", ""),
+                    arguments("s3", "s3/"),
+                    arguments("s3/", "s3/"),
+                    arguments("/s3", "s3/"),
+                    arguments("/s3/", "s3/"),
+                    arguments("s3/inner", "s3/inner/"),
+                    arguments("s3/inner/", "s3/inner/"),
+                    arguments("/s3/inner", "s3/inner/"),
+                    arguments("/s3/inner/", "s3/inner/")
+            );
+        }
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/codec/JsonCodecTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/com/amazon/dataprepper/plugins/source/codec/JsonCodecTest.java
@@ -140,7 +140,7 @@ class JsonCodecTest {
             assertThat(actualRecord.getData().getMetadata().getEventType(), equalTo(EventType.LOG.toString()));
 
             final Map<String, Object> expectedMap = jsonObjects.get(i);
-            assertThat(actualRecord.getData().get("message", Map.class), equalTo(expectedMap));
+            assertThat(actualRecord.getData().toMap(), equalTo(expectedMap));
         }
     }
 
@@ -167,7 +167,7 @@ class JsonCodecTest {
             assertThat(actualRecord.getData().getMetadata().getEventType(), equalTo(EventType.LOG.toString()));
 
             final Map<String, Object> expectedMap = jsonObjects.get(i);
-            assertThat(actualRecord.getData().get("message", Map.class), equalTo(expectedMap));
+            assertThat(actualRecord.getData().toMap(), equalTo(expectedMap));
         }
     }
 
@@ -200,7 +200,7 @@ class JsonCodecTest {
             assertThat(actualRecord.getData().getMetadata().getEventType(), equalTo(EventType.LOG.toString()));
 
             final Map<String, Object> expectedMap = expectedJsonObjects.get(i);
-            assertThat(actualRecord.getData().get("message", Map.class), equalTo(expectedMap));
+            assertThat(actualRecord.getData().toMap(), equalTo(expectedMap));
         }
     }
 


### PR DESCRIPTION
### Description

This makes a few end-user changes related to the S3 source:
* Moves the `key` and `bucket` keys into a metadata key that starts with `s3/` by default.
* Adds the `metadata_root_key` S3 source config which allows modifying the key specified above.
* Changes the JSON codec to populate the root Event rather than the `message` key.

Along with this change, I did some refactoring to decouple the metadata population from the S3 object processing.
 
### Issues Resolved

Resolves #1687
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
