### PR TITLE
Updated the package for data-prepper-test-common project

### DIFF
--- a/data-prepper-plugins/csv-processor/src/test/java/com/amazon/dataprepper/plugins/processor/csv/CsvProcessorIT.java
+++ b/data-prepper-plugins/csv-processor/src/test/java/com/amazon/dataprepper/plugins/processor/csv/CsvProcessorIT.java
@@ -8,18 +8,17 @@ package com.amazon.dataprepper.plugins.processor.csv;
 import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.record.Record;
-import org.opensearch.dataprepper.plugins.source.loggenerator.logtypes.VpcFlowLogTypeGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.plugins.source.loggenerator.logtypes.VpcFlowLogTypeGenerator;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-
-import static com.amazon.dataprepper.test.helper.ReflectivelySetField.setField;
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
 public class CsvProcessorIT {
     private static final String PLUGIN_NAME = "csv";

--- a/data-prepper-plugins/parse-json-processor/src/test/java/com/amazon/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfigTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/com/amazon/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfigTest.java
@@ -11,8 +11,7 @@ import org.junit.jupiter.api.Test;
 import static com.amazon.dataprepper.plugins.processor.parsejson.ParseJsonProcessorConfig.DEFAULT_SOURCE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-
-import static com.amazon.dataprepper.test.helper.ReflectivelySetField.setField;
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
 public class ParseJsonProcessorConfigTest {
 

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/CsvRecordsGenerator.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/com/amazon/dataprepper/plugins/source/CsvRecordsGenerator.java
@@ -14,9 +14,9 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.util.Random;
 
-import static com.amazon.dataprepper.test.helper.ReflectivelySetField.setField;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
 /**
  * Generates comma-separated CSV records where each record is on a single line.

--- a/data-prepper-test-common/src/main/java/org/opensearch/dataprepper/test/helper/ReflectivelySetField.java
+++ b/data-prepper-test-common/src/main/java/org/opensearch/dataprepper/test/helper/ReflectivelySetField.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazon.dataprepper.test.helper;
+package org.opensearch.dataprepper.test.helper;
 
 import java.lang.reflect.Field;
 

--- a/data-prepper-test-common/src/test/java/org/opensearch/dataprepper/test/helper/ReflectivelySetFieldTest.java
+++ b/data-prepper-test-common/src/test/java/org/opensearch/dataprepper/test/helper/ReflectivelySetFieldTest.java
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazon.dataprepper.test.helper;
+package org.opensearch.dataprepper.test.helper;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.amazon.dataprepper.test.helper.ReflectivelySetField.setField;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
 class ReflectivelySetFieldTest {
     private ReflectivelySetFieldTestHelper configuration;

--- a/data-prepper-test-common/src/test/java/org/opensearch/dataprepper/test/helper/ReflectivelySetFieldTestHelper.java
+++ b/data-prepper-test-common/src/test/java/org/opensearch/dataprepper/test/helper/ReflectivelySetFieldTestHelper.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazon.dataprepper.test.helper;
+package org.opensearch.dataprepper.test.helper;
 
 public class ReflectivelySetFieldTestHelper {
     private String internalField = "first value";


### PR DESCRIPTION
### Description

Updates the `data-prepper-test-common` project to use `org.opensearch.dataprepper` as the package for all classes.
 
### Issues Resolved

Partially resolves #344 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
