### PR TITLE
Added metrics for peer forwarder

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/PluginMetrics.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/PluginMetrics.java
@@ -29,10 +29,17 @@ public class PluginMetrics {
         return PluginMetrics.fromNames(pluginSetting.getName(), pluginSetting.getPipelineName());
     }
 
-    public static PluginMetrics fromNames(final String name, final String pipelineName) {
+    /**
+     * Provides reference to APIs that register timer, counter, gauge into global registry.
+     *
+     * @param componentId It can be either pluginId or Data Prepper core component id
+     * @param componentScope It can be pipeline name or Data Prepper core component
+     * @return The {@link PluginMetrics}
+     */
+    public static PluginMetrics fromNames(final String componentId, final String componentScope) {
         return new PluginMetrics(new StringJoiner(MetricNames.DELIMITER)
-                .add(pipelineName)
-                .add(name).toString());
+                .add(componentScope)
+                .add(componentId).toString());
     }
 
     private  PluginMetrics(final String metricsPrefix) {

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/metrics/MetricsTestUtil.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/metrics/MetricsTestUtil.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import io.micrometer.core.instrument.Measurement;
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Statistic;
@@ -18,10 +17,8 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 public class MetricsTestUtil {
 
     public static void initMetrics() {
-        final List<MeterRegistry> registriesToRemove = Metrics.globalRegistry.getRegistries().stream().collect(Collectors.toList());
-        registriesToRemove.forEach(registry -> Metrics.globalRegistry.remove(registry));
-        final List<Meter> metersToRemove = Metrics.globalRegistry.getMeters().stream().collect(Collectors.toList());
-        metersToRemove.forEach(registry -> Metrics.globalRegistry.remove(registry));
+        Metrics.globalRegistry.getRegistries().forEach(meterRegistry -> Metrics.globalRegistry.remove(meterRegistry));
+        Metrics.globalRegistry.getMeters().forEach(meter -> Metrics.globalRegistry.remove(meter));
         Metrics.addRegistry(new SimpleMeterRegistry());
     }
 

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/metrics/MetricsTestUtil.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/metrics/MetricsTestUtil.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Statistic;
@@ -17,8 +18,10 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 public class MetricsTestUtil {
 
     public static void initMetrics() {
-        Metrics.globalRegistry.getRegistries().forEach(meterRegistry -> Metrics.globalRegistry.remove(meterRegistry));
-        Metrics.globalRegistry.getMeters().forEach(meter -> Metrics.globalRegistry.remove(meter));
+        final List<MeterRegistry> registriesToRemove = Metrics.globalRegistry.getRegistries().stream().collect(Collectors.toList());
+        registriesToRemove.forEach(registry -> Metrics.globalRegistry.remove(registry));
+        final List<Meter> metersToRemove = Metrics.globalRegistry.getMeters().stream().collect(Collectors.toList());
+        metersToRemove.forEach(registry -> Metrics.globalRegistry.remove(registry));
         Metrics.addRegistry(new SimpleMeterRegistry());
     }
 

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
+    testImplementation project(':data-prepper-api').sourceSets.test.output
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
@@ -64,7 +64,7 @@ class PeerForwarderAppConfig {
             final PeerForwarderConfiguration peerForwarderConfiguration,
             final PeerClientPool peerClientPool,
             final CertificateProviderFactory certificateProviderFactory,
-            @Qualifier("peerForwarderMetrics") PluginMetrics pluginMetrics
+            @Qualifier("peerForwarderMetrics") final PluginMetrics pluginMetrics
     ) {
         return new PeerForwarderClientFactory(peerForwarderConfiguration, peerClientPool, certificateProviderFactory, pluginMetrics);
     }
@@ -73,7 +73,7 @@ class PeerForwarderAppConfig {
     public PeerForwarderClient peerForwarderClient(final PeerForwarderConfiguration peerForwarderConfiguration,
                                                    final PeerForwarderClientFactory peerForwarderClientFactory,
                                                    @Qualifier("peerForwarderObjectMapper") final ObjectMapper objectMapper,
-                                                   @Qualifier("peerForwarderMetrics") PluginMetrics pluginMetrics
+                                                   @Qualifier("peerForwarderMetrics") final PluginMetrics pluginMetrics
     ) {
         return new PeerForwarderClient(peerForwarderConfiguration, peerForwarderClientFactory, objectMapper, pluginMetrics);
     }
@@ -82,13 +82,13 @@ class PeerForwarderAppConfig {
     public PeerForwarderProvider peerForwarderProvider(final PeerForwarderClientFactory peerForwarderClientFactory,
                                                        final PeerForwarderClient peerForwarderClient,
                                                        final PeerForwarderConfiguration peerForwarderConfiguration,
-                                                       @Qualifier("peerForwarderMetrics") PluginMetrics pluginMetrics) {
+                                                       @Qualifier("peerForwarderMetrics") final PluginMetrics pluginMetrics) {
         return new PeerForwarderProvider(peerForwarderClientFactory, peerForwarderClient, peerForwarderConfiguration, pluginMetrics);
     }
 
     @Bean
-    public ResponseHandler responseHandler() {
-        return new ResponseHandler();
+    public ResponseHandler responseHandler(@Qualifier("peerForwarderMetrics") final PluginMetrics pluginMetrics) {
+        return new ResponseHandler(pluginMetrics);
     }
 
     @Bean

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
@@ -96,9 +96,10 @@ class PeerForwarderAppConfig {
             final ResponseHandler responseHandler,
             final PeerForwarderProvider peerForwarderProvider,
             final PeerForwarderConfiguration peerForwarderConfiguration,
-            @Qualifier("peerForwarderObjectMapper") final ObjectMapper objectMapper
+            @Qualifier("peerForwarderObjectMapper") final ObjectMapper objectMapper,
+            @Qualifier("peerForwarderMetrics") final PluginMetrics pluginMetrics
     ) {
-        return new PeerForwarderHttpService(responseHandler, peerForwarderProvider, peerForwarderConfiguration, objectMapper);
+        return new PeerForwarderHttpService(responseHandler, peerForwarderProvider, peerForwarderConfiguration, objectMapper, pluginMetrics);
     }
 
     @Bean

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -24,6 +25,13 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 class PeerForwarderAppConfig {
+    static final String COMPONENT_SCOPE = "core";
+    static final String COMPONENT_ID = "peerForwarder";
+
+    @Bean(name = "peerForwarderMetrics")
+    public PluginMetrics pluginMetrics() {
+        return PluginMetrics.fromNames(COMPONENT_ID, COMPONENT_SCOPE);
+    }
 
     @Bean(name = "peerForwarderObjectMapper")
     public ObjectMapper objectMapper(final YAMLFactory yamlFactory) {
@@ -55,24 +63,27 @@ class PeerForwarderAppConfig {
     public PeerForwarderClientFactory peerForwarderClientFactory(
             final PeerForwarderConfiguration peerForwarderConfiguration,
             final PeerClientPool peerClientPool,
-            final CertificateProviderFactory certificateProviderFactory
+            final CertificateProviderFactory certificateProviderFactory,
+            @Qualifier("peerForwarderMetrics") PluginMetrics pluginMetrics
     ) {
-        return new PeerForwarderClientFactory(peerForwarderConfiguration, peerClientPool, certificateProviderFactory);
+        return new PeerForwarderClientFactory(peerForwarderConfiguration, peerClientPool, certificateProviderFactory, pluginMetrics);
     }
 
     @Bean
     public PeerForwarderClient peerForwarderClient(final PeerForwarderConfiguration peerForwarderConfiguration,
                                                    final PeerForwarderClientFactory peerForwarderClientFactory,
-                                                   @Qualifier("peerForwarderObjectMapper") final ObjectMapper objectMapper
+                                                   @Qualifier("peerForwarderObjectMapper") final ObjectMapper objectMapper,
+                                                   @Qualifier("peerForwarderMetrics") PluginMetrics pluginMetrics
     ) {
-        return new PeerForwarderClient(peerForwarderConfiguration, peerForwarderClientFactory, objectMapper);
+        return new PeerForwarderClient(peerForwarderConfiguration, peerForwarderClientFactory, objectMapper, pluginMetrics);
     }
 
     @Bean
     public PeerForwarderProvider peerForwarderProvider(final PeerForwarderClientFactory peerForwarderClientFactory,
                                                        final PeerForwarderClient peerForwarderClient,
-                                                       final PeerForwarderConfiguration peerForwarderConfiguration) {
-        return new PeerForwarderProvider(peerForwarderClientFactory, peerForwarderClient, peerForwarderConfiguration);
+                                                       final PeerForwarderConfiguration peerForwarderConfiguration,
+                                                       @Qualifier("peerForwarderMetrics") PluginMetrics pluginMetrics) {
+        return new PeerForwarderProvider(peerForwarderClientFactory, peerForwarderClient, peerForwarderConfiguration, pluginMetrics);
     }
 
     @Bean

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactory.java
@@ -17,16 +17,19 @@ public class PeerForwarderClientFactory {
     private final PeerForwarderConfiguration peerForwarderConfiguration;
     private final PeerClientPool peerClientPool;
     private final CertificateProviderFactory certificateProviderFactory;
+    private final PluginMetrics pluginMetrics;
 
     public PeerForwarderClientFactory(final PeerForwarderConfiguration peerForwarderConfiguration,
                                       final PeerClientPool peerClientPool,
-                                      final CertificateProviderFactory certificateProviderFactory) {
+                                      final CertificateProviderFactory certificateProviderFactory,
+                                      final PluginMetrics pluginMetrics) {
         this.peerForwarderConfiguration = peerForwarderConfiguration;
         this.peerClientPool = peerClientPool;
         this.certificateProviderFactory = certificateProviderFactory;
+        this.pluginMetrics = pluginMetrics;
     }
 
-    public HashRing createHashRing(final PluginMetrics pluginMetrics) {
+    public HashRing createHashRing() {
         final DiscoveryMode discoveryMode = peerForwarderConfiguration.getDiscoveryMode();
         final PeerListProvider peerListProvider = discoveryMode.create(peerForwarderConfiguration, pluginMetrics);
         return new HashRing(peerListProvider, NUM_VIRTUAL_NODES);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactory.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.peerforwarder;
 
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.peerforwarder.certificate.CertificateProviderFactory;
 import org.opensearch.dataprepper.peerforwarder.discovery.DiscoveryMode;
 import org.opensearch.dataprepper.peerforwarder.discovery.PeerListProvider;
@@ -25,9 +26,9 @@ public class PeerForwarderClientFactory {
         this.certificateProviderFactory = certificateProviderFactory;
     }
 
-    public HashRing createHashRing() {
+    public HashRing createHashRing(final PluginMetrics pluginMetrics) {
         final DiscoveryMode discoveryMode = peerForwarderConfiguration.getDiscoveryMode();
-        final PeerListProvider peerListProvider = discoveryMode.create(peerForwarderConfiguration);
+        final PeerListProvider peerListProvider = discoveryMode.create(peerForwarderConfiguration, pluginMetrics);
         return new HashRing(peerListProvider, NUM_VIRTUAL_NODES);
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
@@ -20,18 +20,21 @@ public class PeerForwarderProvider {
     private final PeerForwarderClientFactory peerForwarderClientFactory;
     private final PeerForwarderClient peerForwarderClient;
     private final PeerForwarderConfiguration peerForwarderConfiguration;
+    private final PluginMetrics pluginMetrics;
     private final Map<String, Map<String, PeerForwarderReceiveBuffer<Record<Event>>>> pipelinePeerForwarderReceiveBufferMap = new HashMap<>();
     private HashRing hashRing;
 
     PeerForwarderProvider(final PeerForwarderClientFactory peerForwarderClientFactory,
                           final PeerForwarderClient peerForwarderClient,
-                          final PeerForwarderConfiguration peerForwarderConfiguration) {
+                          final PeerForwarderConfiguration peerForwarderConfiguration,
+                          final PluginMetrics pluginMetrics) {
         this.peerForwarderClientFactory = peerForwarderClientFactory;
         this.peerForwarderClient = peerForwarderClient;
         this.peerForwarderConfiguration = peerForwarderConfiguration;
+        this.pluginMetrics = pluginMetrics;
     }
 
-    public PeerForwarder register(final String pipelineName, final String pluginId, final Set<String> identificationKeys, final PluginMetrics pluginMetrics) {
+    public PeerForwarder register(final String pipelineName, final String pluginId, final Set<String> identificationKeys) {
         if (pipelinePeerForwarderReceiveBufferMap.containsKey(pipelineName) &&
                 pipelinePeerForwarderReceiveBufferMap.get(pipelineName).containsKey(pluginId)) {
             throw new RuntimeException("Data Prepper 2.0 will only support a single peer-forwarder per pipeline/plugin type");
@@ -41,7 +44,7 @@ public class PeerForwarderProvider {
 
         if (isPeerForwardingRequired()) {
             if (hashRing == null) {
-                hashRing = peerForwarderClientFactory.createHashRing(pluginMetrics);
+                hashRing = peerForwarderClientFactory.createHashRing();
             }
             return new RemotePeerForwarder(
                     peerForwarderClient, hashRing, peerForwarderReceiveBuffer, pipelineName, pluginId, identificationKeys, pluginMetrics

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.peerforwarder.client.PeerForwarderClient;
@@ -30,7 +31,7 @@ public class PeerForwarderProvider {
         this.peerForwarderConfiguration = peerForwarderConfiguration;
     }
 
-    public PeerForwarder register(final String pipelineName, final String pluginId, final Set<String> identificationKeys) {
+    public PeerForwarder register(final String pipelineName, final String pluginId, final Set<String> identificationKeys, final PluginMetrics pluginMetrics) {
         if (pipelinePeerForwarderReceiveBufferMap.containsKey(pipelineName) &&
                 pipelinePeerForwarderReceiveBufferMap.get(pipelineName).containsKey(pluginId)) {
             throw new RuntimeException("Data Prepper 2.0 will only support a single peer-forwarder per pipeline/plugin type");
@@ -40,10 +41,10 @@ public class PeerForwarderProvider {
 
         if (isPeerForwardingRequired()) {
             if (hashRing == null) {
-                hashRing = peerForwarderClientFactory.createHashRing();
+                hashRing = peerForwarderClientFactory.createHashRing(pluginMetrics);
             }
             return new RemotePeerForwarder(
-                    peerForwarderClient, hashRing, peerForwarderReceiveBuffer, pipelineName, pluginId, identificationKeys
+                    peerForwarderClient, hashRing, peerForwarderReceiveBuffer, pipelineName, pluginId, identificationKeys, pluginMetrics
             );
         }
         else {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.peerforwarder.RequiresPeerForwarding;
 import com.amazon.dataprepper.model.processor.Processor;
@@ -22,6 +23,7 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
     private final PeerForwarder peerForwarder;
     private final String pluginId;
     private final Set<String> identificationKeys;
+    private final PluginMetrics pluginMetrics;
 
     public PeerForwardingProcessorDecorator(final Processor innerProcessor,
                                             final PeerForwarderProvider peerForwarderProvider,
@@ -38,7 +40,8 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
         if (identificationKeys.isEmpty()) {
             throw new EmptyPeerForwarderPluginIdentificationKeysException("Peer Forwarder Plugin: %s cannot have empty identification keys." + pluginId);
         }
-        this.peerForwarder = peerForwarderProvider.register(pipelineName, pluginId, identificationKeys);
+        this.pluginMetrics = PluginMetrics.fromNames(pluginId, pipelineName);
+        this.peerForwarder = peerForwarderProvider.register(pipelineName, pluginId, identificationKeys, pluginMetrics);
     }
 
     @Override

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.peerforwarder;
 
-import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.peerforwarder.RequiresPeerForwarding;
 import com.amazon.dataprepper.model.processor.Processor;
@@ -23,7 +22,6 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
     private final PeerForwarder peerForwarder;
     private final String pluginId;
     private final Set<String> identificationKeys;
-    private final PluginMetrics pluginMetrics;
 
     public PeerForwardingProcessorDecorator(final Processor innerProcessor,
                                             final PeerForwarderProvider peerForwarderProvider,
@@ -40,8 +38,7 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
         if (identificationKeys.isEmpty()) {
             throw new EmptyPeerForwarderPluginIdentificationKeysException("Peer Forwarder Plugin: %s cannot have empty identification keys." + pluginId);
         }
-        this.pluginMetrics = PluginMetrics.fromNames(pluginId, pipelineName);
-        this.peerForwarder = peerForwarderProvider.register(pipelineName, pluginId, identificationKeys, pluginMetrics);
+        this.peerForwarder = peerForwarderProvider.register(pipelineName, pluginId, identificationKeys);
     }
 
     @Override

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
@@ -32,12 +32,12 @@ import java.util.Set;
 class RemotePeerForwarder implements PeerForwarder {
     private static final Logger LOG = LoggerFactory.getLogger(RemotePeerForwarder.class);
     private static final int READ_BATCH_DELAY = 3_000;
-    public static final String RECORDS_ACTUALLY_PROCESSED_LOCALLY = "recordsActuallyProcessedLocally";
-    public static final String RECORDS_TO_BE_PROCESSED_LOCALLY = "recordsToBeProcessedLocally";
-    public static final String RECORDS_TO_BE_FORWARDED = "recordsToBeForwarded";
-    public static final String RECORDS_FAILED_FORWARDING = "recordsFailedForwarding";
-    public static final String RECORDS_RECEIVED_FROM_PEERS = "recordsReceivedFromPeers";
-    public static final String REQUESTS_FAILED = "requestsFailed";
+    static final String RECORDS_ACTUALLY_PROCESSED_LOCALLY = "recordsActuallyProcessedLocally";
+    static final String RECORDS_TO_BE_PROCESSED_LOCALLY = "recordsToBeProcessedLocally";
+    static final String RECORDS_TO_BE_FORWARDED = "recordsToBeForwarded";
+    static final String RECORDS_FAILED_FORWARDING = "recordsFailedForwarding";
+    static final String RECORDS_RECEIVED_FROM_PEERS = "recordsReceivedFromPeers";
+    static final String REQUESTS_FAILED = "requestsFailed";
 
     private final PeerForwarderClient peerForwarderClient;
     private final HashRing hashRing;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
@@ -28,14 +28,16 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
-import static org.opensearch.dataprepper.peerforwarder.client.PeerForwarderClient.DESTINATION;
-import static org.opensearch.dataprepper.peerforwarder.client.PeerForwarderClient.ERRORS;
 
 class RemotePeerForwarder implements PeerForwarder {
     private static final Logger LOG = LoggerFactory.getLogger(RemotePeerForwarder.class);
     private static final int READ_BATCH_DELAY = 3_000;
+    public static final String RECORDS_ACTUALLY_PROCESSED_LOCALLY = "recordsActuallyProcessedLocally";
+    public static final String RECORDS_TO_BE_PROCESSED_LOCALLY = "recordsToBeProcessedLocally";
+    public static final String RECORDS_TO_BE_FORWARDED = "recordsToBeForwarded";
+    public static final String RECORDS_FAILED_FORWARDING = "recordsFailedForwarding";
+    public static final String RECORDS_RECEIVED_FROM_PEERS = "recordsReceivedFromPeers";
+    public static final String REQUESTS_FAILED = "requestsFailed";
 
     private final PeerForwarderClient peerForwarderClient;
     private final HashRing hashRing;
@@ -43,8 +45,12 @@ class RemotePeerForwarder implements PeerForwarder {
     private final String pipelineName;
     private final String pluginId;
     private final Set<String> identificationKeys;
-    private final PluginMetrics pluginMetrics;
-    private final Map<String, Counter> forwardRequestErrorCounters;
+    private final Counter recordsActuallyProcessedLocallyCounter;
+    private final Counter recordsToBeProcessedLocallyCounter;
+    private final Counter recordsToBeForwardedCounter;
+    private final Counter recordsFailedForwardingCounter;
+    private final Counter recordsReceivedFromPeersCounter;
+    private final Counter requestsFailedCounter;
 
     RemotePeerForwarder(final PeerForwarderClient peerForwarderClient,
                         final HashRing hashRing,
@@ -59,8 +65,12 @@ class RemotePeerForwarder implements PeerForwarder {
         this.pipelineName = pipelineName;
         this.pluginId = pluginId;
         this.identificationKeys = identificationKeys;
-        this.pluginMetrics = pluginMetrics;
-        forwardRequestErrorCounters = new ConcurrentHashMap<>();
+        recordsActuallyProcessedLocallyCounter = pluginMetrics.counter(RECORDS_ACTUALLY_PROCESSED_LOCALLY);
+        recordsToBeProcessedLocallyCounter = pluginMetrics.counter(RECORDS_TO_BE_PROCESSED_LOCALLY);
+        recordsToBeForwardedCounter = pluginMetrics.counter(RECORDS_TO_BE_FORWARDED);
+        recordsFailedForwardingCounter = pluginMetrics.counter(RECORDS_FAILED_FORWARDING);
+        recordsReceivedFromPeersCounter = pluginMetrics.counter(RECORDS_RECEIVED_FROM_PEERS);
+        requestsFailedCounter = pluginMetrics.counter(REQUESTS_FAILED);
     }
 
     public Collection<Record<Event>> forwardRecords(final Collection<Record<Event>> records) {
@@ -73,7 +83,9 @@ class RemotePeerForwarder implements PeerForwarder {
 
             if (isAddressDefinedLocally(destinationIp)) {
                 recordsToProcessLocally.addAll(entry.getValue());
+                recordsToBeProcessedLocallyCounter.increment(entry.getValue().size());
             } else {
+                recordsToBeForwardedCounter.increment(entry.getValue().size());
                 AggregatedHttpResponse httpResponse;
                 try {
                     httpResponse = peerForwarderClient.serializeRecordsAndSendHttpRequest(entry.getValue(),
@@ -85,12 +97,12 @@ class RemotePeerForwarder implements PeerForwarder {
 
                 if (httpResponse == null || httpResponse.status() != HttpStatus.OK) {
                     recordsToProcessLocally.addAll(entry.getValue());
-                    final Counter forwardRequestErrorCounter = forwardRequestErrorCounters.computeIfAbsent(
-                            destinationIp, ip -> pluginMetrics.counterWithTags(ERRORS, DESTINATION, ip));
-                    forwardRequestErrorCounter.increment();
+                    recordsFailedForwardingCounter.increment(entry.getValue().size());
+                    requestsFailedCounter.increment();
                 }
             }
         }
+        recordsActuallyProcessedLocallyCounter.increment(recordsToProcessLocally.size());
         return recordsToProcessLocally;
     }
 
@@ -104,7 +116,8 @@ class RemotePeerForwarder implements PeerForwarder {
 
         // Checkpoint the current batch read from the buffer after reading from buffer
         peerForwarderReceiveBuffer.checkpoint(checkpointState);
-        // recordsReceivedFromRemotePeersCounter
+
+        recordsReceivedFromPeersCounter.increment(records.size());
         return records;
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
@@ -37,7 +37,6 @@ class RemotePeerForwarder implements PeerForwarder {
     private static final Logger LOG = LoggerFactory.getLogger(RemotePeerForwarder.class);
     private static final int READ_BATCH_DELAY = 3_000;
 
-
     private final PeerForwarderClient peerForwarderClient;
     private final HashRing hashRing;
     private final PeerForwarderReceiveBuffer<Record<Event>> peerForwarderReceiveBuffer;
@@ -78,7 +77,7 @@ class RemotePeerForwarder implements PeerForwarder {
                 AggregatedHttpResponse httpResponse;
                 try {
                     httpResponse = peerForwarderClient.serializeRecordsAndSendHttpRequest(entry.getValue(),
-                            destinationIp, pluginId, pipelineName, pluginMetrics);
+                            destinationIp, pluginId, pipelineName);
                 } catch (final Exception ex) {
                     httpResponse = null;
                     LOG.warn("Unable to send request to peer, processing locally.", ex);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClient.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClient.java
@@ -36,13 +36,13 @@ import static org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguratio
 public class PeerForwarderClient {
     private static final Logger LOG = LoggerFactory.getLogger(PeerForwarderClient.class);
     static final String REQUESTS = "requests";
-    static final String REQUESTS_FORWARDING_LATENCY = "requestForwardingLatency";
+    static final String CLIENT_REQUEST_FORWARDING_LATENCY = "clientRequestForwardingLatency";
 
     private final PeerForwarderConfiguration peerForwarderConfiguration;
     private final PeerForwarderClientFactory peerForwarderClientFactory;
     private final ObjectMapper objectMapper;
     private final Counter requestsCounter;
-    private final Timer requestsForwardingLatencyTimer;
+    private final Timer clientRequestForwardingLatencyTimer;
 
     private ExecutorService executorService;
     private PeerClientPool peerClientPool;
@@ -56,7 +56,7 @@ public class PeerForwarderClient {
         this.objectMapper = objectMapper;
         executorService = Executors.newFixedThreadPool(peerForwarderConfiguration.getClientThreadCount());
         requestsCounter = pluginMetrics.counter(REQUESTS);
-        requestsForwardingLatencyTimer = pluginMetrics.timer(REQUESTS_FORWARDING_LATENCY);
+        clientRequestForwardingLatencyTimer = pluginMetrics.timer(CLIENT_REQUEST_FORWARDING_LATENCY);
     }
 
     public AggregatedHttpResponse serializeRecordsAndSendHttpRequest(
@@ -71,7 +71,7 @@ public class PeerForwarderClient {
 
         final String serializedJsonString = getSerializedJsonString(records, pluginId, pipelineName);
 
-        final CompletableFuture<AggregatedHttpResponse> aggregatedHttpResponseCompletableFuture = requestsForwardingLatencyTimer.record(() ->
+        final CompletableFuture<AggregatedHttpResponse> aggregatedHttpResponseCompletableFuture = clientRequestForwardingLatencyTimer.record(() ->
             processHttpRequest(client, serializedJsonString)
         );
         requestsCounter.increment();

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClient.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClient.java
@@ -35,8 +35,8 @@ import static org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguratio
 
 public class PeerForwarderClient {
     private static final Logger LOG = LoggerFactory.getLogger(PeerForwarderClient.class);
-    public static final String REQUESTS = "requests";
-    public static final String REQUESTS_FORWARDING_LATENCY = "requestForwardingLatency";
+    static final String REQUESTS = "requests";
+    static final String REQUESTS_FORWARDING_LATENCY = "requestForwardingLatency";
 
     private final PeerForwarderConfiguration peerForwarderConfiguration;
     private final PeerForwarderClientFactory peerForwarderClientFactory;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/discovery/DiscoveryMode.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/discovery/DiscoveryMode.java
@@ -5,10 +5,11 @@
 
 package org.opensearch.dataprepper.peerforwarder.discovery;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
 
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 public enum DiscoveryMode {
     STATIC(StaticPeerListProvider::createPeerListProvider),
@@ -16,9 +17,9 @@ public enum DiscoveryMode {
     AWS_CLOUD_MAP(AwsCloudMapPeerListProvider::createPeerListProvider),
     LOCAL_NODE(LocalPeerListProvider::createPeerListProvider);
 
-    private final Function<PeerForwarderConfiguration, PeerListProvider> creationFunction;
+    private final BiFunction<PeerForwarderConfiguration, PluginMetrics, PeerListProvider> creationFunction;
 
-    DiscoveryMode(final Function<PeerForwarderConfiguration, PeerListProvider> creationFunction) {
+    DiscoveryMode(final BiFunction<PeerForwarderConfiguration, PluginMetrics, PeerListProvider> creationFunction) {
         Objects.requireNonNull(creationFunction);
 
         this.creationFunction = creationFunction;
@@ -27,10 +28,11 @@ public enum DiscoveryMode {
     /**
      * Creates a new {@link PeerListProvider} for this discovery mode.
      *
-     * @param peerForwarderConfiguration The plugin settings
+     * @param peerForwarderConfiguration The peer forwarder configuration
+     * @param pluginMetrics The plugin metrics
      * @return The new {@link PeerListProvider} for this discovery mode
      */
-    public PeerListProvider create(PeerForwarderConfiguration peerForwarderConfiguration) {
-        return creationFunction.apply(peerForwarderConfiguration);
+    public PeerListProvider create(final PeerForwarderConfiguration peerForwarderConfiguration, final PluginMetrics pluginMetrics) {
+        return creationFunction.apply(peerForwarderConfiguration, pluginMetrics);
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/discovery/LocalPeerListProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/discovery/LocalPeerListProvider.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder.discovery;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.linecorp.armeria.client.Endpoint;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
 
@@ -14,7 +15,7 @@ import java.util.function.Consumer;
 
 public class LocalPeerListProvider implements PeerListProvider {
 
-    static LocalPeerListProvider createPeerListProvider(PeerForwarderConfiguration peerForwarderConfiguration) {
+    static LocalPeerListProvider createPeerListProvider(final PeerForwarderConfiguration peerForwarderConfiguration, final PluginMetrics pluginMetrics) {
         return new LocalPeerListProvider();
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpService.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpService.java
@@ -37,13 +37,13 @@ import java.util.stream.Collectors;
  */
 public class PeerForwarderHttpService {
     private static final Logger LOG = LoggerFactory.getLogger(PeerForwarderHttpService.class);
-    static final String REQUEST_PROCESSING_LATENCY = "requestProcessingLatency";
+    static final String SERVER_REQUEST_PROCESSING_LATENCY = "serverRequestProcessingLatency";
 
     private final ResponseHandler responseHandler;
     private final PeerForwarderProvider peerForwarderProvider;
     private final PeerForwarderConfiguration peerForwarderConfiguration;
     private final ObjectMapper objectMapper;
-    private final Timer requestProcessingLatencyTimer;
+    private final Timer serverRequestProcessingLatencyTimer;
 
     public PeerForwarderHttpService(final ResponseHandler responseHandler,
                                     final PeerForwarderProvider peerForwarderProvider,
@@ -54,12 +54,12 @@ public class PeerForwarderHttpService {
         this.peerForwarderProvider = peerForwarderProvider;
         this.peerForwarderConfiguration = peerForwarderConfiguration;
         this.objectMapper = objectMapper;
-        requestProcessingLatencyTimer = pluginMetrics.timer(REQUEST_PROCESSING_LATENCY);
+        serverRequestProcessingLatencyTimer = pluginMetrics.timer(SERVER_REQUEST_PROCESSING_LATENCY);
     }
 
     @Post
     public HttpResponse doPost(final AggregatedHttpRequest aggregatedHttpRequest) {
-        return requestProcessingLatencyTimer.record(() -> processRequest(aggregatedHttpRequest));
+        return serverRequestProcessingLatencyTimer.record(() -> processRequest(aggregatedHttpRequest));
     }
 
     private HttpResponse processRequest(final AggregatedHttpRequest aggregatedHttpRequest) {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/ResponseHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/ResponseHandler.java
@@ -21,10 +21,10 @@ import java.util.concurrent.TimeoutException;
  * @since 2.0
  */
 public class ResponseHandler {
-    public static final String REQUESTS_TOO_LARGE = "requestsTooLarge";
-    public static final String REQUEST_TIMEOUTS = "requestTimeouts";
-    public static final String REQUESTS_UNPROCESSABLE = "requestsUnprocessable";
-    public static final String BAD_REQUESTS = "badRequests";
+    static final String REQUESTS_TOO_LARGE = "requestsTooLarge";
+    static final String REQUEST_TIMEOUTS = "requestTimeouts";
+    static final String REQUESTS_UNPROCESSABLE = "requestsUnprocessable";
+    static final String BAD_REQUESTS = "badRequests";
 
     private final Counter requestsTooLargeCounter;
     private final Counter requestTimeoutsCounter;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineConfigurationValidatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineConfigurationValidatorTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.parser;
+
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.dataprepper.parser.model.PipelineConfiguration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+class PipelineConfigurationValidatorTest {
+
+    @Test
+    void test_with_invalid_pipeline_names_should_throw() {
+        final Map<String, PipelineConfiguration> objectObjectHashMap = new HashMap<>();
+
+        objectObjectHashMap.put("core", mock(PipelineConfiguration.class));
+        objectObjectHashMap.put("data-prepper", mock(PipelineConfiguration.class));
+
+        assertThrows(RuntimeException.class, () -> PipelineConfigurationValidator.validateAndGetPipelineNames(objectObjectHashMap));
+    }
+
+    @Test
+    void test_with_valid_pipeline_names_should_not_throw() {
+        final Map<String, PipelineConfiguration> objectObjectHashMap = new HashMap<>();
+
+        objectObjectHashMap.put("entry-pipeline", mock(PipelineConfiguration.class));
+
+        PipelineConfigurationValidator.validateAndGetPipelineNames(objectObjectHashMap);
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfigTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfigTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.peerforwarder.certificate.CertificateProviderFactory;
@@ -51,7 +52,8 @@ class PeerForwarderAppConfigTest {
         PeerForwarderClientFactory peerForwarderClientFactory = peerForwarderAppConfig.peerForwarderClientFactory(
                 mock(PeerForwarderConfiguration.class),
                 mock(PeerClientPool.class),
-                mock(CertificateProviderFactory.class)
+                mock(CertificateProviderFactory.class),
+                mock(PluginMetrics.class)
         );
 
         assertThat(peerForwarderClientFactory, notNullValue());

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactoryTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactoryTest.java
@@ -48,7 +48,7 @@ class PeerForwarderClientFactoryTest {
     PluginMetrics pluginMetrics;
 
     private PeerForwarderClientFactory createObjectUnderTest() {
-        return new PeerForwarderClientFactory(peerForwarderConfiguration, peerClientPool, certificateProviderFactory);
+        return new PeerForwarderClientFactory(peerForwarderConfiguration, peerClientPool, certificateProviderFactory, pluginMetrics);
     }
 
     @Test
@@ -56,7 +56,7 @@ class PeerForwarderClientFactoryTest {
         when(peerForwarderConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.STATIC);
         when(peerForwarderConfiguration.getStaticEndpoints()).thenReturn(Collections.singletonList("10.10.0.1"));
 
-        HashRing hashRing = createObjectUnderTest().createHashRing(pluginMetrics);
+        HashRing hashRing = createObjectUnderTest().createHashRing();
         assertThat(hashRing, new IsInstanceOf(HashRing.class));
     }
 
@@ -66,7 +66,7 @@ class PeerForwarderClientFactoryTest {
 
         PeerForwarderClientFactory peerForwarderClientFactory = createObjectUnderTest();
 
-        assertThrows(RuntimeException.class, () -> peerForwarderClientFactory.createHashRing(pluginMetrics));
+        assertThrows(RuntimeException.class, () -> peerForwarderClientFactory.createHashRing());
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactoryTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactoryTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,9 @@ class PeerForwarderClientFactoryTest {
     @Mock
     CertificateProviderFactory certificateProviderFactory;
 
+    @Mock
+    PluginMetrics pluginMetrics;
+
     private PeerForwarderClientFactory createObjectUnderTest() {
         return new PeerForwarderClientFactory(peerForwarderConfiguration, peerClientPool, certificateProviderFactory);
     }
@@ -52,7 +56,7 @@ class PeerForwarderClientFactoryTest {
         when(peerForwarderConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.STATIC);
         when(peerForwarderConfiguration.getStaticEndpoints()).thenReturn(Collections.singletonList("10.10.0.1"));
 
-        HashRing hashRing = createObjectUnderTest().createHashRing();
+        HashRing hashRing = createObjectUnderTest().createHashRing(pluginMetrics);
         assertThat(hashRing, new IsInstanceOf(HashRing.class));
     }
 
@@ -62,7 +66,7 @@ class PeerForwarderClientFactoryTest {
 
         PeerForwarderClientFactory peerForwarderClientFactory = createObjectUnderTest();
 
-        assertThrows(RuntimeException.class, peerForwarderClientFactory::createHashRing);
+        assertThrows(RuntimeException.class, () -> peerForwarderClientFactory.createHashRing(pluginMetrics));
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactoryTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactoryTest.java
@@ -66,7 +66,7 @@ class PeerForwarderClientFactoryTest {
 
         PeerForwarderClientFactory peerForwarderClientFactory = createObjectUnderTest();
 
-        assertThrows(RuntimeException.class, () -> peerForwarderClientFactory.createHashRing());
+        assertThrows(RuntimeException.class, peerForwarderClientFactory::createHashRing);
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProviderTest.java
@@ -48,17 +48,18 @@ class PeerForwarderProviderTest {
     @Mock
     private HashRing hashRing;
 
+    @Mock
+    private PluginMetrics pluginMetrics;
+
     private String pipelineName;
     private String pluginId;
     private Set<String> identificationKeys;
-    private PluginMetrics pluginMetrics;
 
     @BeforeEach
     void setUp() {
         pipelineName = UUID.randomUUID().toString();
         pluginId = UUID.randomUUID().toString();
         identificationKeys = Collections.singleton(UUID.randomUUID().toString());
-        pluginMetrics = PluginMetrics.fromNames(pluginId, pipelineName);
 
         lenient().when(peerForwarderClientFactory.createHashRing()).thenReturn(hashRing);
         lenient().when(peerForwarderConfiguration.getBufferSize()).thenReturn(512);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -92,7 +92,7 @@ class PeerForwarder_ClientServerIT {
             final PeerForwarderConfiguration peerForwarderConfiguration,
             final CertificateProviderFactory certificateProviderFactory,
             final PeerForwarderProvider peerForwarderProvider) {
-        final PeerForwarderHttpService peerForwarderHttpService = new PeerForwarderHttpService(new ResponseHandler(pluginMetrics), peerForwarderProvider, peerForwarderConfiguration, objectMapper);
+        final PeerForwarderHttpService peerForwarderHttpService = new PeerForwarderHttpService(new ResponseHandler(pluginMetrics), peerForwarderProvider, peerForwarderConfiguration, objectMapper, pluginMetrics);
         Objects.requireNonNull(peerForwarderConfiguration, "Nested classes must supply peerForwarderConfiguration");
         Objects.requireNonNull(certificateProviderFactory, "Nested classes must supply certificateProviderFactory");
         final PeerForwarderHttpServerProvider serverProvider = new PeerForwarderHttpServerProvider(peerForwarderConfiguration,

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -108,8 +108,8 @@ class PeerForwarder_ClientServerIT {
             final CertificateProviderFactory certificateProviderFactory) {
         final PeerForwarderClient clientForProvider = createClient(peerForwarderConfiguration);
         final PeerClientPool peerClientPool = new PeerClientPool();
-        final PeerForwarderClientFactory clientFactoryForProvider = new PeerForwarderClientFactory(peerForwarderConfiguration, peerClientPool, certificateProviderFactory);
-        return new PeerForwarderProvider(clientFactoryForProvider, clientForProvider, peerForwarderConfiguration);
+        final PeerForwarderClientFactory clientFactoryForProvider = new PeerForwarderClientFactory(peerForwarderConfiguration, peerClientPool, certificateProviderFactory, pluginMetrics);
+        return new PeerForwarderProvider(clientFactoryForProvider, clientForProvider, peerForwarderConfiguration, pluginMetrics);
     }
 
     private PeerForwarderClient createClient(
@@ -117,9 +117,9 @@ class PeerForwarder_ClientServerIT {
         Objects.requireNonNull(peerForwarderConfiguration, "Nested classes must supply peerForwarderConfiguration");
         final CertificateProviderFactory certificateProviderFactory = new CertificateProviderFactory(peerForwarderConfiguration);
         final PeerClientPool peerClientPool = new PeerClientPool();
-        final PeerForwarderClientFactory peerForwarderClientFactory = new PeerForwarderClientFactory(peerForwarderConfiguration, peerClientPool, certificateProviderFactory);
+        final PeerForwarderClientFactory peerForwarderClientFactory = new PeerForwarderClientFactory(peerForwarderConfiguration, peerClientPool, certificateProviderFactory, pluginMetrics);
         peerForwarderClientFactory.setPeerClientPool();
-        return new PeerForwarderClient(peerForwarderConfiguration, peerForwarderClientFactory, objectMapper);
+        return new PeerForwarderClient(peerForwarderConfiguration, peerForwarderClientFactory, objectMapper, pluginMetrics);
     }
 
     private Collection<Record<Event>> getServerSideRecords(final PeerForwarderProvider peerForwarderProvider) {
@@ -144,7 +144,7 @@ class PeerForwarder_ClientServerIT {
 
             final CertificateProviderFactory certificateProviderFactory = new CertificateProviderFactory(peerForwarderConfiguration);
             peerForwarderProvider = createPeerForwarderProvider(peerForwarderConfiguration, certificateProviderFactory);
-            peerForwarderProvider.register(pipelineName, pluginId, Collections.singleton(UUID.randomUUID().toString()), pluginMetrics);
+            peerForwarderProvider.register(pipelineName, pluginId, Collections.singleton(UUID.randomUUID().toString()));
             server = createServer(peerForwarderConfiguration, certificateProviderFactory, peerForwarderProvider);
             server.start();
         }
@@ -158,7 +158,7 @@ class PeerForwarder_ClientServerIT {
         void send_Events_to_server() {
             final PeerForwarderClient client = createClient(peerForwarderConfiguration);
 
-            final AggregatedHttpResponse httpResponse = client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName, pluginMetrics);
+            final AggregatedHttpResponse httpResponse = client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName);
 
             assertThat(httpResponse.status(), equalTo(HttpStatus.OK));
 
@@ -185,7 +185,7 @@ class PeerForwarder_ClientServerIT {
 
             final PeerForwarderClient client = createClient(peerForwarderConfiguration);
 
-            assertThrows(ClosedSessionException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName, pluginMetrics));
+            assertThrows(ClosedSessionException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName));
 
             final Collection<Record<Event>> receivedRecords = getServerSideRecords(peerForwarderProvider);
             assertThat(receivedRecords, notNullValue());
@@ -199,7 +199,7 @@ class PeerForwarder_ClientServerIT {
 
             final PeerForwarderClient client = createClient(peerForwarderConfiguration);
 
-            assertThrows(UnprocessedRequestException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName, pluginMetrics));
+            assertThrows(UnprocessedRequestException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName));
 
             final Collection<Record<Event>> receivedRecords = getServerSideRecords(peerForwarderProvider);
             assertThat(receivedRecords, notNullValue());
@@ -220,7 +220,7 @@ class PeerForwarder_ClientServerIT {
 
             final CertificateProviderFactory certificateProviderFactory = new CertificateProviderFactory(peerForwarderConfiguration);
             peerForwarderProvider = createPeerForwarderProvider(peerForwarderConfiguration, certificateProviderFactory);
-            peerForwarderProvider.register(pipelineName, pluginId, Collections.singleton(UUID.randomUUID().toString()), pluginMetrics);
+            peerForwarderProvider.register(pipelineName, pluginId, Collections.singleton(UUID.randomUUID().toString()));
             server = createServer(peerForwarderConfiguration, certificateProviderFactory, peerForwarderProvider);
             server.start();
         }
@@ -234,7 +234,7 @@ class PeerForwarder_ClientServerIT {
         void send_Events_to_server() {
             final PeerForwarderClient client = createClient(peerForwarderConfiguration);
 
-            final AggregatedHttpResponse httpResponse = client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName, pluginMetrics);
+            final AggregatedHttpResponse httpResponse = client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName);
 
             assertThat(httpResponse.status(), equalTo(HttpStatus.OK));
 
@@ -261,7 +261,7 @@ class PeerForwarder_ClientServerIT {
 
             final PeerForwarderClient client = createClient(peerForwarderConfiguration);
 
-            final UnprocessedRequestException actualException = assertThrows(UnprocessedRequestException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName, pluginMetrics));
+            final UnprocessedRequestException actualException = assertThrows(UnprocessedRequestException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName));
 
             assertThat(actualException.getCause(), instanceOf(SSLHandshakeException.class));
 
@@ -284,7 +284,7 @@ class PeerForwarder_ClientServerIT {
 
             final CertificateProviderFactory certificateProviderFactory = new CertificateProviderFactory(peerForwarderConfiguration);
             peerForwarderProvider = createPeerForwarderProvider(peerForwarderConfiguration, certificateProviderFactory);
-            peerForwarderProvider.register(pipelineName, pluginId, Collections.singleton(UUID.randomUUID().toString()), pluginMetrics);
+            peerForwarderProvider.register(pipelineName, pluginId, Collections.singleton(UUID.randomUUID().toString()));
             server = createServer(peerForwarderConfiguration, certificateProviderFactory, peerForwarderProvider);
             server.start();
         }
@@ -298,7 +298,7 @@ class PeerForwarder_ClientServerIT {
         void send_Events_to_server() {
             final PeerForwarderClient client = createClient(peerForwarderConfiguration);
 
-            final AggregatedHttpResponse httpResponse = client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName, pluginMetrics);
+            final AggregatedHttpResponse httpResponse = client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName);
 
             assertThat(httpResponse.status(), equalTo(HttpStatus.OK));
 
@@ -325,7 +325,7 @@ class PeerForwarder_ClientServerIT {
 
             final PeerForwarderClient client = createClient(peerForwarderConfiguration);
 
-            assertThrows(ClosedSessionException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName,pluginMetrics));
+            assertThrows(ClosedSessionException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName));
 
             final Collection<Record<Event>> receivedRecords = getServerSideRecords(peerForwarderProvider);
             assertThat(receivedRecords, notNullValue());
@@ -338,7 +338,7 @@ class PeerForwarder_ClientServerIT {
                     true, ForwardingAuthentication.MUTUAL_TLS, SSL_CERTIFICATE_FILE, ALTERNATE_SSL_KEY_FILE, true);
 
             final PeerForwarderClient client = createClient(peerForwarderConfiguration);
-            assertThrows(UnprocessedRequestException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName, pluginMetrics));
+            assertThrows(UnprocessedRequestException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName));
 
             final Collection<Record<Event>> receivedRecords = getServerSideRecords(peerForwarderProvider);
             assertThat(receivedRecords, notNullValue());
@@ -352,7 +352,7 @@ class PeerForwarder_ClientServerIT {
 
             final PeerForwarderClient client = createClient(peerForwarderConfiguration);
 
-            assertThrows(UnprocessedRequestException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName, pluginMetrics));
+            assertThrows(UnprocessedRequestException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName));
 
             final Collection<Record<Event>> receivedRecords = getServerSideRecords(peerForwarderProvider);
             assertThat(receivedRecords, notNullValue());

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -92,7 +92,7 @@ class PeerForwarder_ClientServerIT {
             final PeerForwarderConfiguration peerForwarderConfiguration,
             final CertificateProviderFactory certificateProviderFactory,
             final PeerForwarderProvider peerForwarderProvider) {
-        final PeerForwarderHttpService peerForwarderHttpService = new PeerForwarderHttpService(new ResponseHandler(), peerForwarderProvider, peerForwarderConfiguration, objectMapper);
+        final PeerForwarderHttpService peerForwarderHttpService = new PeerForwarderHttpService(new ResponseHandler(pluginMetrics), peerForwarderProvider, peerForwarderConfiguration, objectMapper);
         Objects.requireNonNull(peerForwarderConfiguration, "Nested classes must supply peerForwarderConfiguration");
         Objects.requireNonNull(certificateProviderFactory, "Nested classes must supply certificateProviderFactory");
         final PeerForwarderHttpServerProvider serverProvider = new PeerForwarderHttpServerProvider(peerForwarderConfiguration,

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.peerforwarder;
 
-import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.peerforwarder.RequiresPeerForwarding;
 import com.amazon.dataprepper.model.processor.Processor;
@@ -31,9 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.ArgumentMatchers.anyCollection;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -92,7 +88,7 @@ class PeerForwardingProcessingDecoratorTest {
         void setUp() {
             identificationKeys = Set.of(TEST_IDENTIFICATION_KEY);
 
-            when(peerForwarderProvider.register(anyString(), anyString(), anySet(), any(PluginMetrics.class))).thenReturn(peerForwarder);
+            when(peerForwarderProvider.register(pipelineName, pluginId, identificationKeys)).thenReturn(peerForwarder);
             when(requiresPeerForwarding.getIdentificationKeys()).thenReturn(identificationKeys);
             processor = (Processor) requiresPeerForwarding;
         }
@@ -101,7 +97,7 @@ class PeerForwardingProcessingDecoratorTest {
         void PeerForwardingProcessingDecorator_should_have_interaction_with_getIdentificationKeys() {
             createObjectUnderTest(processor);
             verify(requiresPeerForwarding).getIdentificationKeys();
-            verify(peerForwarderProvider).register(anyString(), anyString(), anySet(), any(PluginMetrics.class));
+            verify(peerForwarderProvider).register(pipelineName, pluginId, identificationKeys);
         }
 
         @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.peerforwarder.RequiresPeerForwarding;
 import com.amazon.dataprepper.model.processor.Processor;
@@ -30,6 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -88,7 +92,7 @@ class PeerForwardingProcessingDecoratorTest {
         void setUp() {
             identificationKeys = Set.of(TEST_IDENTIFICATION_KEY);
 
-            when(peerForwarderProvider.register(pipelineName, pluginId, identificationKeys)).thenReturn(peerForwarder);
+            when(peerForwarderProvider.register(anyString(), anyString(), anySet(), any(PluginMetrics.class))).thenReturn(peerForwarder);
             when(requiresPeerForwarding.getIdentificationKeys()).thenReturn(identificationKeys);
             processor = (Processor) requiresPeerForwarding;
         }
@@ -97,7 +101,7 @@ class PeerForwardingProcessingDecoratorTest {
         void PeerForwardingProcessingDecorator_should_have_interaction_with_getIdentificationKeys() {
             createObjectUnderTest(processor);
             verify(requiresPeerForwarding).getIdentificationKeys();
-            verify(peerForwarderProvider).register(pipelineName, pluginId, identificationKeys);
+            verify(peerForwarderProvider).register(anyString(), anyString(), anySet(), any(PluginMetrics.class));
         }
 
         @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
@@ -46,7 +46,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static org.opensearch.dataprepper.peerforwarder.client.PeerForwarderClient.ERRORS;
+import static org.opensearch.dataprepper.peerforwarder.RemotePeerForwarder.RECORDS_ACTUALLY_PROCESSED_LOCALLY;
+import static org.opensearch.dataprepper.peerforwarder.RemotePeerForwarder.RECORDS_FAILED_FORWARDING;
+import static org.opensearch.dataprepper.peerforwarder.RemotePeerForwarder.RECORDS_RECEIVED_FROM_PEERS;
+import static org.opensearch.dataprepper.peerforwarder.RemotePeerForwarder.RECORDS_TO_BE_FORWARDED;
+import static org.opensearch.dataprepper.peerforwarder.RemotePeerForwarder.RECORDS_TO_BE_PROCESSED_LOCALLY;
 
 @ExtendWith(MockitoExtension.class)
 class RemotePeerForwarderTest {
@@ -95,6 +99,31 @@ class RemotePeerForwarderTest {
         verifyNoInteractions(peerForwarderClient);
         assertThat(records.size(), equalTo(2));
         assertThat(records, equalTo(testRecords));
+
+        final List<Measurement> recordsToBeProcessedLocallyMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_TO_BE_PROCESSED_LOCALLY).toString());
+        final Measurement recordsToBeProcessedLocallyMeasurement = MetricsTestUtil.getMeasurementFromList(recordsToBeProcessedLocallyMeasurementList, Statistic.COUNT);
+        assertThat(recordsToBeProcessedLocallyMeasurement.getValue(), equalTo(2.0));
+
+        final List<Measurement> recordsActuallyProcessedLocallyMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_ACTUALLY_PROCESSED_LOCALLY).toString());
+        final Measurement recordsActuallyProcessedLocallyMeasurement = MetricsTestUtil.getMeasurementFromList(recordsActuallyProcessedLocallyMeasurementList, Statistic.COUNT);
+        assertThat(recordsActuallyProcessedLocallyMeasurement.getValue(), equalTo(2.0));
+
+        final List<Measurement> recordsToBeForwardedMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_TO_BE_FORWARDED).toString());
+        final Measurement recordsToBeForwardedMeasurement = MetricsTestUtil.getMeasurementFromList(recordsToBeForwardedMeasurementList, Statistic.COUNT);
+        assertThat(recordsToBeForwardedMeasurement.getValue(), equalTo(0.0));
+
+        final List<Measurement> recordsFailedForwardingMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_FAILED_FORWARDING).toString());
+        final Measurement recordsFailedForwardingMeasurement = MetricsTestUtil.getMeasurementFromList(recordsFailedForwardingMeasurementList, Statistic.COUNT);
+        assertThat(recordsFailedForwardingMeasurement.getValue(), equalTo(0.0));
+
+        final List<Measurement> requestsFailedMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_FAILED_FORWARDING).toString());
+        final Measurement requestsFailedMeasurement = MetricsTestUtil.getMeasurementFromList(requestsFailedMeasurementList, Statistic.COUNT);
+        assertThat(requestsFailedMeasurement.getValue(), equalTo(0.0));
     }
 
     @Test
@@ -113,11 +142,35 @@ class RemotePeerForwarderTest {
         final Collection<Record<Event>> records = peerForwarder.forwardRecords(testRecords);
         verify(peerForwarderClient, times(1)).serializeRecordsAndSendHttpRequest(anyList(), anyString(), anyString(), anyString());
         assertThat(records.size(), equalTo(1));
+
+        final List<Measurement> recordsToBeProcessedLocallyMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_TO_BE_PROCESSED_LOCALLY).toString());
+        final Measurement recordsToBeProcessedLocallyMeasurement = MetricsTestUtil.getMeasurementFromList(recordsToBeProcessedLocallyMeasurementList, Statistic.COUNT);
+        assertThat(recordsToBeProcessedLocallyMeasurement.getValue(), equalTo(1.0));
+
+        final List<Measurement> recordsActuallyProcessedLocallyMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_ACTUALLY_PROCESSED_LOCALLY).toString());
+        final Measurement recordsActuallyProcessedLocallyMeasurement = MetricsTestUtil.getMeasurementFromList(recordsActuallyProcessedLocallyMeasurementList, Statistic.COUNT);
+        assertThat(recordsActuallyProcessedLocallyMeasurement.getValue(), equalTo(1.0));
+
+        final List<Measurement> recordsToBeForwardedMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_TO_BE_FORWARDED).toString());
+        final Measurement recordsToBeForwardedMeasurement = MetricsTestUtil.getMeasurementFromList(recordsToBeForwardedMeasurementList, Statistic.COUNT);
+        assertThat(recordsToBeForwardedMeasurement.getValue(), equalTo(1.0));
+
+        final List<Measurement> recordsFailedForwardingMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_FAILED_FORWARDING).toString());
+        final Measurement recordsFailedForwardingMeasurement = MetricsTestUtil.getMeasurementFromList(recordsFailedForwardingMeasurementList, Statistic.COUNT);
+        assertThat(recordsFailedForwardingMeasurement.getValue(), equalTo(0.0));
+
+        final List<Measurement> requestsFailedMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_FAILED_FORWARDING).toString());
+        final Measurement requestsFailedMeasurement = MetricsTestUtil.getMeasurementFromList(requestsFailedMeasurementList, Statistic.COUNT);
+        assertThat(requestsFailedMeasurement.getValue(), equalTo(0.0));
     }
 
     @Test
     void forwardRecords_should_return_all_input_events_when_client_throws() {
-        MetricsTestUtil.initMetrics();
         when(peerForwarderClient.serializeRecordsAndSendHttpRequest(anyCollection(), anyString(), anyString(), anyString())).thenThrow(RuntimeException.class);
 
         final List<String> testIps = List.of("8.8.8.8", "127.0.0.1");
@@ -134,11 +187,31 @@ class RemotePeerForwarderTest {
         for (Record<Event> inputRecord : inputRecords) {
             assertThat(records, hasItem(inputRecord));
         }
-        final List<Measurement> forwardRequestErrorCounterMeasurement = MetricsTestUtil.getMeasurementList(new StringJoiner(MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID)
-                .add(ERRORS).toString());
-        final Measurement measurementFromList = MetricsTestUtil.getMeasurementFromList(forwardRequestErrorCounterMeasurement, Statistic.COUNT);
-        assertThat(forwardRequestErrorCounterMeasurement.size(), equalTo(1));
-        assertThat(measurementFromList.getValue(), equalTo(1.0));
+
+        final List<Measurement> recordsToBeProcessedLocallyMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_TO_BE_PROCESSED_LOCALLY).toString());
+        final Measurement recordsToBeProcessedLocallyMeasurement = MetricsTestUtil.getMeasurementFromList(recordsToBeProcessedLocallyMeasurementList, Statistic.COUNT);
+        assertThat(recordsToBeProcessedLocallyMeasurement.getValue(), equalTo(1.0));
+
+        final List<Measurement> recordsActuallyProcessedLocallyMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_ACTUALLY_PROCESSED_LOCALLY).toString());
+        final Measurement recordsActuallyProcessedLocallyMeasurement = MetricsTestUtil.getMeasurementFromList(recordsActuallyProcessedLocallyMeasurementList, Statistic.COUNT);
+        assertThat(recordsActuallyProcessedLocallyMeasurement.getValue(), equalTo(2.0));
+
+        final List<Measurement> recordsToBeForwardedMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_TO_BE_FORWARDED).toString());
+        final Measurement recordsToBeForwardedMeasurement = MetricsTestUtil.getMeasurementFromList(recordsToBeForwardedMeasurementList, Statistic.COUNT);
+        assertThat(recordsToBeForwardedMeasurement.getValue(), equalTo(1.0));
+
+        final List<Measurement> recordsFailedForwardingMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_FAILED_FORWARDING).toString());
+        final Measurement recordsFailedForwardingMeasurement = MetricsTestUtil.getMeasurementFromList(recordsFailedForwardingMeasurementList, Statistic.COUNT);
+        assertThat(recordsFailedForwardingMeasurement.getValue(), equalTo(1.0));
+
+        final List<Measurement> requestsFailedMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_FAILED_FORWARDING).toString());
+        final Measurement requestsFailedMeasurement = MetricsTestUtil.getMeasurementFromList(requestsFailedMeasurementList, Statistic.COUNT);
+        assertThat(requestsFailedMeasurement.getValue(), equalTo(1.0));
     }
 
     @Test
@@ -151,6 +224,11 @@ class RemotePeerForwarderTest {
 
         assertThat(records.size(), equalTo(testRecords.size()));
         assertThat(records, equalTo(testRecords));
+
+        final List<Measurement> recordsReceivedFromPeersMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(RECORDS_RECEIVED_FROM_PEERS).toString());
+        final Measurement recordsReceivedFromPeersMeasurement = MetricsTestUtil.getMeasurementFromList(recordsReceivedFromPeersMeasurementList, Statistic.COUNT);
+        assertThat(recordsReceivedFromPeersMeasurement.getValue(), equalTo(3.0));
     }
 
     private Collection<Record<Event>> generateBatchRecords(final int numRecords) {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClientTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClientTest.java
@@ -58,7 +58,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration.DEFAULT_PEER_FORWARDING_URI;
 import static org.opensearch.dataprepper.peerforwarder.client.PeerForwarderClient.REQUESTS;
-import static org.opensearch.dataprepper.peerforwarder.client.PeerForwarderClient.REQUESTS_FORWARDING_LATENCY;
+import static org.opensearch.dataprepper.peerforwarder.client.PeerForwarderClient.CLIENT_REQUEST_FORWARDING_LATENCY;
 
 @ExtendWith(MockitoExtension.class)
 class PeerForwarderClientTest {
@@ -82,14 +82,13 @@ class PeerForwarderClientTest {
 
     @Mock
     private Counter requestsCounter;
-
-    private NoopTimer timer;
+    private NoopTimer clientRequestForwardingLatencyTimer;
 
     @BeforeEach
     void setUp() {
-        timer = new NoopTimer(new Meter.Id("test", Tags.empty(), null, null, Meter.Type.TIMER));
+        clientRequestForwardingLatencyTimer = new NoopTimer(new Meter.Id("test", Tags.empty(), null, null, Meter.Type.TIMER));
         when(pluginMetrics.counter(REQUESTS)).thenReturn(requestsCounter);
-        when(pluginMetrics.timer(REQUESTS_FORWARDING_LATENCY)).thenReturn(timer);
+        when(pluginMetrics.timer(CLIENT_REQUEST_FORWARDING_LATENCY)).thenReturn(clientRequestForwardingLatencyTimer);
         objectMapper = new ObjectMapper()
                 .registerModule(new JavaTimeModule());
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/AwsCloudMapPeerListProviderCreationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/AwsCloudMapPeerListProviderCreationTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder.discovery;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,10 +29,12 @@ import static org.mockito.Mockito.when;
 class AwsCloudMapPeerListProviderCreationTest {
 
     private PeerForwarderConfiguration peerForwarderConfiguration;
+    private PluginMetrics pluginMetrics;
 
     @BeforeEach
     void setUp() {
         peerForwarderConfiguration = mock(PeerForwarderConfiguration.class);
+        pluginMetrics = mock(PluginMetrics.class);
 
         when(peerForwarderConfiguration.getAwsCloudMapNamespaceName()).thenReturn(UUID.randomUUID().toString());
         when(peerForwarderConfiguration.getAwsCloudMapServiceName()).thenReturn(UUID.randomUUID().toString());
@@ -41,7 +44,7 @@ class AwsCloudMapPeerListProviderCreationTest {
 
     @Test
     void createPeerListProvider_with_valid_configurations() {
-        final PeerListProvider result = AwsCloudMapPeerListProvider.createPeerListProvider(peerForwarderConfiguration);
+        final PeerListProvider result = AwsCloudMapPeerListProvider.createPeerListProvider(peerForwarderConfiguration, pluginMetrics);
 
         assertThat(result, instanceOf(AwsCloudMapPeerListProvider.class));
     }
@@ -51,7 +54,7 @@ class AwsCloudMapPeerListProviderCreationTest {
         when(peerForwarderConfiguration.getAwsCloudMapServiceName()).thenReturn(null);
 
         assertThrows(NullPointerException.class,
-                () -> AwsCloudMapPeerListProvider.createPeerListProvider(peerForwarderConfiguration));
+                () -> AwsCloudMapPeerListProvider.createPeerListProvider(peerForwarderConfiguration, pluginMetrics));
 
     }
 
@@ -60,7 +63,7 @@ class AwsCloudMapPeerListProviderCreationTest {
         when(peerForwarderConfiguration.getAwsCloudMapNamespaceName()).thenReturn(null);
 
         assertThrows(NullPointerException.class,
-                () -> AwsCloudMapPeerListProvider.createPeerListProvider(peerForwarderConfiguration));
+                () -> AwsCloudMapPeerListProvider.createPeerListProvider(peerForwarderConfiguration, pluginMetrics));
 
     }
 
@@ -69,7 +72,7 @@ class AwsCloudMapPeerListProviderCreationTest {
         when(peerForwarderConfiguration.getAwsRegion()).thenReturn(null);
 
         assertThrows(NullPointerException.class,
-                () -> AwsCloudMapPeerListProvider.createPeerListProvider(peerForwarderConfiguration));
+                () -> AwsCloudMapPeerListProvider.createPeerListProvider(peerForwarderConfiguration, pluginMetrics));
 
     }
 
@@ -78,7 +81,7 @@ class AwsCloudMapPeerListProviderCreationTest {
         when(peerForwarderConfiguration.getAwsCloudMapQueryParameters()).thenReturn(null);
 
         assertThrows(NullPointerException.class,
-                () -> AwsCloudMapPeerListProvider.createPeerListProvider(peerForwarderConfiguration));
+                () -> AwsCloudMapPeerListProvider.createPeerListProvider(peerForwarderConfiguration, pluginMetrics));
 
     }
 
@@ -87,7 +90,7 @@ class AwsCloudMapPeerListProviderCreationTest {
     void createPeerListProvider_with_all_current_regions(final Region region) {
         when(peerForwarderConfiguration.getAwsRegion()).thenReturn(String.valueOf(region));
 
-        final PeerListProvider result = AwsCloudMapPeerListProvider.createPeerListProvider(peerForwarderConfiguration);
+        final PeerListProvider result = AwsCloudMapPeerListProvider.createPeerListProvider(peerForwarderConfiguration, pluginMetrics);
 
         assertThat(result, instanceOf(AwsCloudMapPeerListProvider.class));
     }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/AwsCloudMapPeerListProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/AwsCloudMapPeerListProviderTest.java
@@ -85,7 +85,7 @@ class AwsCloudMapPeerListProviderTest {
 
     private AwsCloudMapPeerListProvider createObjectUnderTest() {
         final AwsCloudMapPeerListProvider objectUnderTest =
-                new AwsCloudMapPeerListProvider(awsServiceDiscovery, namespaceName, serviceName, queryParameters, timeToRefreshSeconds, backoff);
+                new AwsCloudMapPeerListProvider(awsServiceDiscovery, namespaceName, serviceName, queryParameters, timeToRefreshSeconds, backoff, pluginMetrics);
         objectsToClose.add(objectUnderTest);
         return objectUnderTest;
     }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/DnsPeerListProviderCreationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/DnsPeerListProviderCreationTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder.discovery;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroupBuilder;
@@ -38,6 +39,7 @@ class DnsPeerListProviderCreationTest {
     private DnsAddressEndpointGroup dnsAddressEndpointGroup;
 
     private PeerForwarderConfiguration peerForwarderConfiguration;
+    private PluginMetrics pluginMetrics;
 
     private CompletableFuture completableFuture;
 
@@ -47,6 +49,7 @@ class DnsPeerListProviderCreationTest {
         completableFuture = CompletableFuture.completedFuture(null);
 
         peerForwarderConfiguration = mock(PeerForwarderConfiguration.class);
+        pluginMetrics = mock(PluginMetrics.class);
     }
 
     @Test
@@ -60,7 +63,7 @@ class DnsPeerListProviderCreationTest {
         try (MockedStatic<DnsAddressEndpointGroup> armeriaMock = Mockito.mockStatic(DnsAddressEndpointGroup.class)) {
             armeriaMock.when(() -> DnsAddressEndpointGroup.builder(anyString())).thenReturn(dnsAddressEndpointGroupBuilder);
 
-            PeerListProvider result = DnsPeerListProvider.createPeerListProvider(peerForwarderConfiguration);
+            PeerListProvider result = DnsPeerListProvider.createPeerListProvider(peerForwarderConfiguration, pluginMetrics);
 
             assertThat(result, instanceOf(DnsPeerListProvider.class));
         }
@@ -69,7 +72,7 @@ class DnsPeerListProviderCreationTest {
     @Test
     void testCreateProviderDnsInstanceWithNoHostname() {
         assertThrows(NullPointerException.class,
-                () -> DnsPeerListProvider.createPeerListProvider(peerForwarderConfiguration));
+                () -> DnsPeerListProvider.createPeerListProvider(peerForwarderConfiguration, pluginMetrics));
     }
 
     @Test
@@ -77,7 +80,7 @@ class DnsPeerListProviderCreationTest {
         when(peerForwarderConfiguration.getDomainName()).thenReturn(INVALID_ENDPOINT);
 
         assertThrows(IllegalStateException.class,
-                () -> DnsPeerListProvider.createPeerListProvider(peerForwarderConfiguration));
+                () -> DnsPeerListProvider.createPeerListProvider(peerForwarderConfiguration, pluginMetrics));
     }
 
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/DnsPeerListProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/DnsPeerListProviderTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder.discovery;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
 import org.junit.Before;
@@ -40,6 +41,9 @@ public class DnsPeerListProviderTest {
     @Mock
     private HashRing hashRing;
 
+    @Mock
+    private PluginMetrics pluginMetrics;
+
     private CompletableFuture completableFuture;
 
     private DnsPeerListProvider dnsPeerListProvider;
@@ -49,12 +53,12 @@ public class DnsPeerListProviderTest {
         completableFuture = CompletableFuture.completedFuture(null);
         when(dnsAddressEndpointGroup.whenReady()).thenReturn(completableFuture);
 
-        dnsPeerListProvider = new DnsPeerListProvider(dnsAddressEndpointGroup);
+        dnsPeerListProvider = new DnsPeerListProvider(dnsAddressEndpointGroup, pluginMetrics);
     }
 
     @Test(expected = NullPointerException.class)
     public void testDefaultListProviderWithNullHostname() {
-        new DnsPeerListProvider(null);
+        new DnsPeerListProvider(null, pluginMetrics);
     }
 
     @Test(expected = RuntimeException.class)
@@ -63,7 +67,7 @@ public class DnsPeerListProviderTest {
         when(mockFuture.get()).thenThrow(new InterruptedException());
         when(dnsAddressEndpointGroup.whenReady()).thenReturn(mockFuture);
 
-        new DnsPeerListProvider(dnsAddressEndpointGroup);
+        new DnsPeerListProvider(dnsAddressEndpointGroup, pluginMetrics);
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/StaticPeerListProviderCreationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/StaticPeerListProviderCreationTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder.discovery;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,10 +27,12 @@ class StaticPeerListProviderCreationTest {
     private static final String INVALID_ENDPOINT = "INVALID_ENDPOINT_";
 
     private PeerForwarderConfiguration peerForwarderConfiguration;
+    private PluginMetrics pluginMetrics;
 
     @BeforeEach
     void setup() {
         peerForwarderConfiguration = mock(PeerForwarderConfiguration.class);
+        pluginMetrics = mock(PluginMetrics.class);
     }
 
     @Test
@@ -37,14 +40,14 @@ class StaticPeerListProviderCreationTest {
         when(peerForwarderConfiguration.getStaticEndpoints()).thenReturn(null);
 
         assertThrows(NullPointerException.class,
-                () -> StaticPeerListProvider.createPeerListProvider(peerForwarderConfiguration));
+                () -> StaticPeerListProvider.createPeerListProvider(peerForwarderConfiguration, pluginMetrics));
     }
 
     @Test
     void testCreateProviderStaticInstanceWithEndpoints() {
         when(peerForwarderConfiguration.getStaticEndpoints()).thenReturn(Collections.singletonList(ENDPOINT));
 
-        PeerListProvider result = StaticPeerListProvider.createPeerListProvider(peerForwarderConfiguration);
+        PeerListProvider result = StaticPeerListProvider.createPeerListProvider(peerForwarderConfiguration, pluginMetrics);
 
         assertThat(result, instanceOf(StaticPeerListProvider.class));
         assertEquals(1, result.getPeerList().size());
@@ -56,7 +59,7 @@ class StaticPeerListProviderCreationTest {
         when(peerForwarderConfiguration.getStaticEndpoints()).thenReturn(Arrays.asList(ENDPOINT, INVALID_ENDPOINT));
 
         assertThrows(IllegalStateException.class,
-                () -> StaticPeerListProvider.createPeerListProvider(peerForwarderConfiguration));
+                () -> StaticPeerListProvider.createPeerListProvider(peerForwarderConfiguration, pluginMetrics));
     }
 
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/StaticPeerListProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/StaticPeerListProviderTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder.discovery;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,21 +30,24 @@ public class StaticPeerListProviderTest {
     @Mock
     private HashRing hashRing;
 
+    @Mock
+    private PluginMetrics pluginMetrics;
+
     private StaticPeerListProvider staticPeerListProvider;
 
     @Before
     public void setup() {
-        staticPeerListProvider = new StaticPeerListProvider(ENDPOINT_LIST);
+        staticPeerListProvider = new StaticPeerListProvider(ENDPOINT_LIST, pluginMetrics);
     }
 
     @Test(expected = RuntimeException.class)
     public void testListProviderWithEmptyList() {
-        new StaticPeerListProvider(Collections.emptyList());
+        new StaticPeerListProvider(Collections.emptyList(), pluginMetrics);
     }
 
     @Test(expected = RuntimeException.class)
     public void testListProviderWithNullList() {
-        new StaticPeerListProvider(null);
+        new StaticPeerListProvider(null, pluginMetrics);
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/StaticPeerListProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/discovery/StaticPeerListProviderTest.java
@@ -5,7 +5,10 @@
 
 package org.opensearch.dataprepper.peerforwarder.discovery;
 
+import com.amazon.dataprepper.metrics.MetricNames;
+import com.amazon.dataprepper.metrics.MetricsTestUtil;
 import com.amazon.dataprepper.metrics.PluginMetrics;
+import io.micrometer.core.instrument.Measurement;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,6 +19,7 @@ import org.opensearch.dataprepper.peerforwarder.HashRing;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.StringJoiner;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -26,17 +30,20 @@ public class StaticPeerListProviderTest {
     private static final String ENDPOINT_1 = "10.10.0.1";
     private static final String ENDPOINT_2 = "10.10.0.2";
     private static final List<String> ENDPOINT_LIST = Arrays.asList(ENDPOINT_1, ENDPOINT_2);
+    private static final String COMPONENT_SCOPE = "testComponentScope";
+    private static final String COMPONENT_ID = "testComponentId";
 
     @Mock
     private HashRing hashRing;
 
-    @Mock
     private PluginMetrics pluginMetrics;
 
     private StaticPeerListProvider staticPeerListProvider;
 
     @Before
     public void setup() {
+        MetricsTestUtil.initMetrics();
+        pluginMetrics = PluginMetrics.fromNames(COMPONENT_ID, COMPONENT_SCOPE);
         staticPeerListProvider = new StaticPeerListProvider(ENDPOINT_LIST, pluginMetrics);
     }
 
@@ -54,6 +61,15 @@ public class StaticPeerListProviderTest {
     public void testListProviderWithNonEmptyList() {
         assertEquals(ENDPOINT_LIST.size(), staticPeerListProvider.getPeerList().size());
         assertEquals(ENDPOINT_LIST, staticPeerListProvider.getPeerList());
+    }
+
+    @Test
+    public void testActivePeerCounter() {
+        final List<Measurement> endpointsMeasures = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(PeerListProvider.PEER_ENDPOINTS).toString());
+        assertEquals(1, endpointsMeasures.size());
+        final Measurement endpointsMeasure = endpointsMeasures.get(0);
+        assertEquals(2.0, endpointsMeasure.getValue(), 0);
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServiceTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServiceTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.peerforwarder.server;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.event.Event;
 import com.amazon.dataprepper.model.event.JacksonEvent;
 import com.amazon.dataprepper.model.log.JacksonLog;
@@ -54,7 +55,8 @@ class PeerForwarderHttpServiceTest {
     private static final int TEST_BUFFER_CAPACITY = 3;
     private static final int TEST_BATCH_SIZE = 3;
 
-    private final ResponseHandler responseHandler = new ResponseHandler();
+    private final PluginMetrics pluginMetrics = PluginMetrics.fromNames(PLUGIN_ID, PIPELINE_NAME);
+    private final ResponseHandler responseHandler = new ResponseHandler(pluginMetrics);
     private final ObjectMapper objectMapper = new ObjectMapper()
             .registerModule(new JavaTimeModule());
     private final PeerForwarderReceiveBuffer peerForwarderReceiveBuffer =

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServiceTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServiceTest.java
@@ -53,7 +53,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration.DEFAULT_PEER_FORWARDING_URI;
-import static org.opensearch.dataprepper.peerforwarder.server.PeerForwarderHttpService.REQUEST_PROCESSING_LATENCY;
+import static org.opensearch.dataprepper.peerforwarder.server.PeerForwarderHttpService.SERVER_REQUEST_PROCESSING_LATENCY;
 
 @ExtendWith(MockitoExtension.class)
 class PeerForwarderHttpServiceTest {
@@ -79,15 +79,14 @@ class PeerForwarderHttpServiceTest {
     @Mock
     private PluginMetrics pluginMetrics;
 
-    private Timer timer;
-
     @Mock
     private ResponseHandler responseHandler;
+    private Timer serverRequestProcessingLatencyTimer;
 
     @BeforeEach
     void setUp() {
-        timer = new NoopTimer(new Meter.Id("test", Tags.empty(), null, null, Meter.Type.TIMER));
-        when(pluginMetrics.timer(REQUEST_PROCESSING_LATENCY)).thenReturn(timer);
+        serverRequestProcessingLatencyTimer = new NoopTimer(new Meter.Id("test", Tags.empty(), null, null, Meter.Type.TIMER));
+        when(pluginMetrics.timer(SERVER_REQUEST_PROCESSING_LATENCY)).thenReturn(serverRequestProcessingLatencyTimer);
     }
 
     private PeerForwarderHttpService createObjectUnderTest() {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/ResponseHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/ResponseHandlerTest.java
@@ -59,7 +59,7 @@ class ResponseHandlerTest {
 
     @AfterEach
     void tearDown() {
-        verifyNoMoreInteractions(requestsTooLargeCounter, requestTimeoutsCounter, badRequestsCounter);
+        verifyNoMoreInteractions(requestsTooLargeCounter, requestTimeoutsCounter, requestsUnprocessableCounter, badRequestsCounter);
     }
 
     private ResponseHandler createObjectUnderTest() {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/ResponseHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/ResponseHandlerTest.java
@@ -5,21 +5,51 @@
 
 package org.opensearch.dataprepper.peerforwarder.server;
 
+import com.amazon.dataprepper.metrics.MetricNames;
+import com.amazon.dataprepper.metrics.MetricsTestUtil;
+import com.amazon.dataprepper.metrics.PluginMetrics;
+import com.amazon.dataprepper.model.buffer.SizeOverflowException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Statistic;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.StringJoiner;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.opensearch.dataprepper.peerforwarder.server.ResponseHandler.REQUEST_INTERNAL_SERVER_ERRORS;
+import static org.opensearch.dataprepper.peerforwarder.server.ResponseHandler.REQUEST_TIMEOUTS;
+import static org.opensearch.dataprepper.peerforwarder.server.ResponseHandler.REQUESTS_TOO_LARGE;
 
 class ResponseHandlerTest {
+    private static final String COMPONENT_SCOPE = "testComponentScope";
+    private static final String COMPONENT_ID = "testComponentId";
+
+    private PluginMetrics pluginMetrics;
+
+    @BeforeAll
+    static void beforeAll() {
+        MetricsTestUtil.initMetrics();
+    }
+
+    @BeforeEach
+    void setUp() {
+        pluginMetrics = PluginMetrics.fromNames(COMPONENT_ID, COMPONENT_SCOPE);
+    }
 
     private ResponseHandler createObjectUnderTest() {
-        return new ResponseHandler();
+        return new ResponseHandler(pluginMetrics);
     }
 
     @Test
@@ -34,6 +64,49 @@ class ResponseHandlerTest {
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, aggregatedHttpResponse.status());
         assertEquals(testMessage, aggregatedHttpResponse.contentUtf8());
+
+        final List<Measurement> internalServerErrorMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(REQUEST_INTERNAL_SERVER_ERRORS).toString());
+        final Measurement internalServerErrorMeasurement = MetricsTestUtil.getMeasurementFromList(internalServerErrorMeasurementList, Statistic.COUNT);
+        assertThat(internalServerErrorMeasurement.getValue(), equalTo(1.0));
+    }
+
+    @Test
+    void test_SizeOverflowException() throws ExecutionException, InterruptedException {
+        final ResponseHandler objectUnderTest = createObjectUnderTest();
+        final SizeOverflowException sizeOverflowException = mock(SizeOverflowException.class);
+
+        final String testMessage = "test exception message";
+
+        final HttpResponse httpResponse = objectUnderTest.handleException(sizeOverflowException, testMessage);
+        final AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
+
+        assertEquals(HttpStatus.REQUEST_ENTITY_TOO_LARGE, aggregatedHttpResponse.status());
+        assertEquals(testMessage, aggregatedHttpResponse.contentUtf8());
+
+        final List<Measurement> requestsTooLargeMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(REQUESTS_TOO_LARGE).toString());
+        final Measurement requestsTooLargeMeasurement = MetricsTestUtil.getMeasurementFromList(requestsTooLargeMeasurementList, Statistic.COUNT);
+        assertThat(requestsTooLargeMeasurement.getValue(), equalTo(1.0));
+    }
+
+    @Test
+    void test_TimeoutException() throws ExecutionException, InterruptedException {
+        final ResponseHandler objectUnderTest = createObjectUnderTest();
+        final TimeoutException timeoutException = mock(TimeoutException.class);
+
+        final String testMessage = "test exception message";
+
+        final HttpResponse httpResponse = objectUnderTest.handleException(timeoutException, testMessage);
+        final AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
+
+        assertEquals(HttpStatus.REQUEST_TIMEOUT, aggregatedHttpResponse.status());
+        assertEquals(testMessage, aggregatedHttpResponse.contentUtf8());
+
+        final List<Measurement> requestTimeoutsMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(REQUEST_TIMEOUTS).toString());
+        final Measurement requestTimeoutsMeasurement = MetricsTestUtil.getMeasurementFromList(requestTimeoutsMeasurementList, Statistic.COUNT);
+        assertThat(requestTimeoutsMeasurement.getValue(), equalTo(1.0));
     }
 
     @Test
@@ -48,6 +121,11 @@ class ResponseHandlerTest {
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, aggregatedHttpResponse.status());
         assertEquals(testMessage, aggregatedHttpResponse.contentUtf8());
+
+        final List<Measurement> internalServerErrorMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
+                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(REQUEST_INTERNAL_SERVER_ERRORS).toString());
+        final Measurement internalServerErrorMeasurement = MetricsTestUtil.getMeasurementFromList(internalServerErrorMeasurementList, Statistic.COUNT);
+        assertThat(internalServerErrorMeasurement.getValue(), equalTo(2.0));
     }
 
     static class UnknownException extends Exception {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/ResponseHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/ResponseHandlerTest.java
@@ -5,47 +5,61 @@
 
 package org.opensearch.dataprepper.peerforwarder.server;
 
-import com.amazon.dataprepper.metrics.MetricNames;
-import com.amazon.dataprepper.metrics.MetricsTestUtil;
 import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.buffer.SizeOverflowException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import io.micrometer.core.instrument.Measurement;
-import io.micrometer.core.instrument.Statistic;
-import org.junit.jupiter.api.BeforeAll;
+import io.micrometer.core.instrument.Counter;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
-import java.util.StringJoiner;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.opensearch.dataprepper.peerforwarder.server.ResponseHandler.REQUEST_INTERNAL_SERVER_ERRORS;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.opensearch.dataprepper.peerforwarder.server.ResponseHandler.BAD_REQUESTS;
 import static org.opensearch.dataprepper.peerforwarder.server.ResponseHandler.REQUEST_TIMEOUTS;
 import static org.opensearch.dataprepper.peerforwarder.server.ResponseHandler.REQUESTS_TOO_LARGE;
+import static org.opensearch.dataprepper.peerforwarder.server.ResponseHandler.REQUESTS_UNPROCESSABLE;
 
+@ExtendWith(MockitoExtension.class)
 class ResponseHandlerTest {
-    private static final String COMPONENT_SCOPE = "testComponentScope";
-    private static final String COMPONENT_ID = "testComponentId";
-
+    @Mock
     private PluginMetrics pluginMetrics;
 
-    @BeforeAll
-    static void beforeAll() {
-        MetricsTestUtil.initMetrics();
-    }
+    @Mock
+    private Counter requestsTooLargeCounter;
+
+    @Mock
+    private Counter requestTimeoutsCounter;
+
+    @Mock
+    private Counter badRequestsCounter;
+
+    @Mock
+    private Counter requestsUnprocessableCounter;
 
     @BeforeEach
     void setUp() {
-        pluginMetrics = PluginMetrics.fromNames(COMPONENT_ID, COMPONENT_SCOPE);
+        when(pluginMetrics.counter(REQUESTS_TOO_LARGE)).thenReturn(requestsTooLargeCounter);
+        when(pluginMetrics.counter(REQUEST_TIMEOUTS)).thenReturn(requestTimeoutsCounter);
+        when(pluginMetrics.counter(REQUESTS_UNPROCESSABLE)).thenReturn(requestsUnprocessableCounter);
+        when(pluginMetrics.counter(BAD_REQUESTS)).thenReturn(badRequestsCounter);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(requestsTooLargeCounter, requestTimeoutsCounter, badRequestsCounter);
     }
 
     private ResponseHandler createObjectUnderTest() {
@@ -62,13 +76,10 @@ class ResponseHandlerTest {
         final HttpResponse httpResponse = objectUnderTest.handleException(jsonProcessingException, testMessage);
         final AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
 
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, aggregatedHttpResponse.status());
+        assertEquals(HttpStatus.BAD_REQUEST, aggregatedHttpResponse.status());
         assertEquals(testMessage, aggregatedHttpResponse.contentUtf8());
 
-        final List<Measurement> internalServerErrorMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
-                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(REQUEST_INTERNAL_SERVER_ERRORS).toString());
-        final Measurement internalServerErrorMeasurement = MetricsTestUtil.getMeasurementFromList(internalServerErrorMeasurementList, Statistic.COUNT);
-        assertThat(internalServerErrorMeasurement.getValue(), equalTo(1.0));
+        verify(badRequestsCounter).increment();
     }
 
     @Test
@@ -84,10 +95,7 @@ class ResponseHandlerTest {
         assertEquals(HttpStatus.REQUEST_ENTITY_TOO_LARGE, aggregatedHttpResponse.status());
         assertEquals(testMessage, aggregatedHttpResponse.contentUtf8());
 
-        final List<Measurement> requestsTooLargeMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
-                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(REQUESTS_TOO_LARGE).toString());
-        final Measurement requestsTooLargeMeasurement = MetricsTestUtil.getMeasurementFromList(requestsTooLargeMeasurementList, Statistic.COUNT);
-        assertThat(requestsTooLargeMeasurement.getValue(), equalTo(1.0));
+        verify(requestsTooLargeCounter).increment();
     }
 
     @Test
@@ -103,10 +111,7 @@ class ResponseHandlerTest {
         assertEquals(HttpStatus.REQUEST_TIMEOUT, aggregatedHttpResponse.status());
         assertEquals(testMessage, aggregatedHttpResponse.contentUtf8());
 
-        final List<Measurement> requestTimeoutsMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
-                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(REQUEST_TIMEOUTS).toString());
-        final Measurement requestTimeoutsMeasurement = MetricsTestUtil.getMeasurementFromList(requestTimeoutsMeasurementList, Statistic.COUNT);
-        assertThat(requestTimeoutsMeasurement.getValue(), equalTo(1.0));
+        verify(requestTimeoutsCounter).increment();
     }
 
     @Test
@@ -119,13 +124,26 @@ class ResponseHandlerTest {
         final HttpResponse httpResponse = objectUnderTest.handleException(unknownException, testMessage);
         final AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
 
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, aggregatedHttpResponse.status());
+        assertEquals(HttpStatus.BAD_REQUEST, aggregatedHttpResponse.status());
         assertEquals(testMessage, aggregatedHttpResponse.contentUtf8());
 
-        final List<Measurement> internalServerErrorMeasurementList = MetricsTestUtil.getMeasurementList(new StringJoiner
-                (MetricNames.DELIMITER).add(COMPONENT_SCOPE).add(COMPONENT_ID).add(REQUEST_INTERNAL_SERVER_ERRORS).toString());
-        final Measurement internalServerErrorMeasurement = MetricsTestUtil.getMeasurementFromList(internalServerErrorMeasurementList, Statistic.COUNT);
-        assertThat(internalServerErrorMeasurement.getValue(), equalTo(2.0));
+        verify(badRequestsCounter).increment();
+    }
+
+    @Test
+    void test_NullPointerException() throws ExecutionException, InterruptedException {
+        final ResponseHandler objectUnderTest = createObjectUnderTest();
+        final NullPointerException nullPointerException = new NullPointerException("");
+
+        final String testMessage = "test exception message";
+
+        final HttpResponse httpResponse = objectUnderTest.handleException(nullPointerException, testMessage);
+        final AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
+
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, aggregatedHttpResponse.status());
+        assertEquals(testMessage, aggregatedHttpResponse.contentUtf8());
+
+        verify(requestsUnprocessableCounter).increment();
     }
 
     static class UnknownException extends Exception {


### PR DESCRIPTION
### Description
- Added metrics (see the linked issue for all the metrics)
- Updated `PluginMetrics` class to take generic arguments for generating metrics
- I wasn't able to test the timer metrics (I tried to Spy `NoopTimer` but it doesn't have a default constructor to spy it). Let me know if you have any suggestions for how to test it. We have 2 timer metrics.
- Added pipeline name validation
 
### Issues Resolved
resolves #1609 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
