### PR TITLE
Make HTTP source request timeout transparent

### DIFF
--- a/data-prepper-plugins/http-source/README.md
+++ b/data-prepper-plugins/http-source/README.md
@@ -15,8 +15,8 @@ source:
 
 * `200`: the request data has been successfully written into the buffer.
 * `400`: the request data is either in mal-format or unsupported codec.
+* `408`: the request data fails to be written into the buffer within the timeout.
 * `413`: the request data size is larger than the configured capacity.
-* `415`: the request fails to be written into the buffer within the timeout.
 * `429`: the request has been rejected due to the HTTP source executor being in full capacity.
 
 ## Configurations

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
@@ -108,9 +108,7 @@ public class HTTPSource implements Source<Record<Log>> {
             }
 
             sb.maxNumConnections(sourceConfig.getMaxConnectionCount());
-            final int requestTimeoutInMillis = sourceConfig.getRequestTimeoutInMillis();
-            // Allow 2*requestTimeoutInMillis to accommodate non-blocking operations other than buffer writing.
-            sb.requestTimeout(Duration.ofMillis(2*requestTimeoutInMillis));
+            sb.requestTimeout(Duration.ofMillis(sourceConfig.getRequestTimeoutInMillis()));
             final int threads = sourceConfig.getThreadCount();
             final ScheduledThreadPoolExecutor blockingTaskExecutor = new ScheduledThreadPoolExecutor(threads);
             sb.blockingTaskExecutor(blockingTaskExecutor, true);
@@ -120,7 +118,7 @@ public class HTTPSource implements Source<Record<Log>> {
             final LogThrottlingRejectHandler logThrottlingRejectHandler = new LogThrottlingRejectHandler(maxPendingRequests, pluginMetrics);
             // TODO: allow customization on URI path for log ingestion
             sb.decorator(HTTPSourceConfig.DEFAULT_LOG_INGEST_URI, ThrottlingService.newDecorator(logThrottlingStrategy, logThrottlingRejectHandler));
-            final LogHTTPService logHTTPService = new LogHTTPService(requestTimeoutInMillis, buffer, pluginMetrics);
+            final LogHTTPService logHTTPService = new LogHTTPService(sourceConfig.getBufferTimeoutInMillis(), buffer, pluginMetrics);
             sb.annotatedService(HTTPSourceConfig.DEFAULT_LOG_INGEST_URI, logHTTPService);
 
             if (sourceConfig.hasHealthCheckService()) {

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
@@ -20,7 +20,7 @@ public class HTTPSourceConfig {
     static final boolean DEFAULT_USE_ACM_CERTIFICATE_FOR_SSL = false;
     static final int DEFAULT_ACM_CERTIFICATE_TIMEOUT_MILLIS = 120000;
     static final int DEFAULT_PORT = 2021;
-    static final int DEFAULT_REQUEST_TIMEOUT_MS = 20000;
+    static final int DEFAULT_REQUEST_TIMEOUT_MS = 10000;
     static final double BUFFER_TIMEOUT_FRACTION = 0.8;
     static final int DEFAULT_THREAD_COUNT = 200;
     static final int DEFAULT_MAX_CONNECTION_COUNT = 500;
@@ -36,7 +36,7 @@ public class HTTPSourceConfig {
     private int port = DEFAULT_PORT;
 
     @JsonProperty("request_timeout")
-    @Min(0)
+    @Min(2)
     private int requestTimeoutInMillis = DEFAULT_REQUEST_TIMEOUT_MS;
 
     @JsonProperty("thread_count")

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
@@ -20,7 +20,8 @@ public class HTTPSourceConfig {
     static final boolean DEFAULT_USE_ACM_CERTIFICATE_FOR_SSL = false;
     static final int DEFAULT_ACM_CERTIFICATE_TIMEOUT_MILLIS = 120000;
     static final int DEFAULT_PORT = 2021;
-    static final int DEFAULT_REQUEST_TIMEOUT_MS = 10000;
+    static final int DEFAULT_REQUEST_TIMEOUT_MS = 20000;
+    static final double BUFFER_TIMEOUT_FRACTION = 0.8;
     static final int DEFAULT_THREAD_COUNT = 200;
     static final int DEFAULT_MAX_CONNECTION_COUNT = 500;
     static final int DEFAULT_MAX_PENDING_REQUESTS = 1024;
@@ -132,6 +133,10 @@ public class HTTPSourceConfig {
 
     public int getRequestTimeoutInMillis() {
         return requestTimeoutInMillis;
+    }
+
+    public int getBufferTimeoutInMillis() {
+        return (int)(BUFFER_TIMEOUT_FRACTION * requestTimeoutInMillis);
     }
 
     public int getThreadCount() {

--- a/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfigTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfigTest.java
@@ -30,6 +30,8 @@ public class HTTPSourceConfigTest {
         assertEquals(HTTPSourceConfig.DEFAULT_MAX_PENDING_REQUESTS, sourceConfig.getMaxPendingRequests());
         assertEquals(HTTPSourceConfig.DEFAULT_USE_ACM_CERTIFICATE_FOR_SSL, sourceConfig.isUseAcmCertificateForSsl());
         assertEquals(HTTPSourceConfig.DEFAULT_ACM_CERTIFICATE_TIMEOUT_MILLIS, sourceConfig.getAcmCertificateTimeoutMillis());
+        assertEquals((int)(HTTPSourceConfig.DEFAULT_REQUEST_TIMEOUT_MS * HTTPSourceConfig.BUFFER_TIMEOUT_FRACTION),
+                     sourceConfig.getBufferTimeoutInMillis());
     }
 
     @Nested

--- a/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
@@ -56,6 +56,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -419,12 +420,13 @@ class HTTPSourceTest {
     @Test
     public void testHTTPJsonResponse429() throws InterruptedException {
         // Prepare
-        final Map<String, Object> settings = new HashMap<>();
         final int testMaxPendingRequests = 1;
         final int testThreadCount = 1;
         final int clientTimeoutInMillis = 100;
         final int serverTimeoutInMillis = (testMaxPendingRequests + testThreadCount + 1) * clientTimeoutInMillis;
-        final int requestTimeoutInMillis = serverTimeoutInMillis * 2;
+        final Random rand = new Random();
+        final double randomFactor = rand.nextDouble() + 1.5;
+        final int requestTimeoutInMillis = (int)(serverTimeoutInMillis * randomFactor);
         when(sourceConfig.getRequestTimeoutInMillis()).thenReturn(requestTimeoutInMillis);
         when(sourceConfig.getBufferTimeoutInMillis()).thenReturn(serverTimeoutInMillis);
         when(sourceConfig.getMaxPendingRequests()).thenReturn(testMaxPendingRequests);

--- a/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
@@ -367,12 +367,14 @@ class HTTPSourceTest {
     }
 
     @Test
-    public void testHTTPJsonResponse415() {
+    public void testHTTPJsonResponse408() {
         // Prepare
         final int testMaxPendingRequests = 1;
         final int testThreadCount = 1;
         final int serverTimeoutInMillis = 500;
+        final int bufferTimeoutInMillis = 400;
         when(sourceConfig.getRequestTimeoutInMillis()).thenReturn(serverTimeoutInMillis);
+        when(sourceConfig.getBufferTimeoutInMillis()).thenReturn(bufferTimeoutInMillis);
         when(sourceConfig.getMaxPendingRequests()).thenReturn(testMaxPendingRequests);
         when(sourceConfig.getThreadCount()).thenReturn(testThreadCount);
         HTTPSourceUnderTest = new HTTPSource(sourceConfig, pluginMetrics, pluginFactory);
@@ -411,7 +413,7 @@ class HTTPSourceTest {
         final Measurement requestProcessDurationMax = MetricsTestUtil.getMeasurementFromList(
                 requestProcessDurationMeasurements, Statistic.MAX);
         final double maxDurationInMillis = 1000 * requestProcessDurationMax.getValue();
-        Assertions.assertTrue(maxDurationInMillis > serverTimeoutInMillis);
+        Assertions.assertTrue(maxDurationInMillis > bufferTimeoutInMillis);
     }
 
     @Test
@@ -422,7 +424,9 @@ class HTTPSourceTest {
         final int testThreadCount = 1;
         final int clientTimeoutInMillis = 100;
         final int serverTimeoutInMillis = (testMaxPendingRequests + testThreadCount + 1) * clientTimeoutInMillis;
-        when(sourceConfig.getRequestTimeoutInMillis()).thenReturn(serverTimeoutInMillis);
+        final int requestTimeoutInMillis = serverTimeoutInMillis * 2;
+        when(sourceConfig.getRequestTimeoutInMillis()).thenReturn(requestTimeoutInMillis);
+        when(sourceConfig.getBufferTimeoutInMillis()).thenReturn(serverTimeoutInMillis);
         when(sourceConfig.getMaxPendingRequests()).thenReturn(testMaxPendingRequests);
         when(sourceConfig.getThreadCount()).thenReturn(testThreadCount);
         HTTPSourceUnderTest = new HTTPSource(sourceConfig, pluginMetrics, pluginFactory);


### PR DESCRIPTION
Signed-off-by: Hai Yan <oeyh@amazon.com>

### Description
This PR made the change to use `request_timeout` as is instead of doubling it, and use 0.8 * `request_timeout` as the buffer write timeout.
 
### Issues Resolved
Resolves #975
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
