### PR TITLE
Add sslVerifyFingerprintOnly flag to PeerForwarderConfiguration

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerClientPool.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerClientPool.java
@@ -5,22 +5,33 @@
 
 package org.opensearch.dataprepper.peerforwarder;
 
+import com.google.common.io.BaseEncoding;
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
+import io.netty.handler.ssl.util.FingerprintTrustManagerFactory;
 import org.opensearch.dataprepper.plugins.certificate.model.Certificate;
+import org.opensearch.dataprepper.peerforwarder.exception.CertificateFingerprintParsingException;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.MessageDigest;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class PeerClientPool {
     private static final String HTTP = "http";
     private static final String HTTPS = "https";
+    private static final String SSL_ALGORITHM = "X.509";
+    private static final String RSA_ALGORITHM = "SHA-1";
     private final Map<String, WebClient> peerClients;
 
     private int port;
@@ -28,6 +39,7 @@ public class PeerClientPool {
     private boolean ssl;
     private Certificate certificate;
     private boolean sslDisableVerification;
+    private boolean sslFingerprintVerificationOnly;
     private ForwardingAuthentication authentication;
 
     public PeerClientPool() {
@@ -54,6 +66,10 @@ public class PeerClientPool {
         this.sslDisableVerification = sslDisableVerification;
     }
 
+    public void setSslFingerprintVerificationOnly(final boolean sslFingerprintVerificationOnly) {
+        this.sslFingerprintVerificationOnly = sslFingerprintVerificationOnly;
+    }
+
     public void setAuthentication(ForwardingAuthentication authentication) {
         this.authentication = authentication;
     }
@@ -69,11 +85,17 @@ public class PeerClientPool {
                 .writeTimeout(Duration.ofSeconds(clientTimeoutSeconds));
 
         if (ssl) {
-            final ClientFactoryBuilder clientFactoryBuilder = ClientFactory.builder()
-                    .tlsCustomizer(sslContextBuilder -> sslContextBuilder.trustManager(
-                                    new ByteArrayInputStream(certificate.getCertificate().getBytes(StandardCharsets.UTF_8))
-                            )
-                    );
+            final ClientFactoryBuilder clientFactoryBuilder = ClientFactory.builder();
+
+            if (sslFingerprintVerificationOnly) {
+                final FingerprintTrustManagerFactory fingerprintTrustManagerFactory = new FingerprintTrustManagerFactory(getCertificateFingerPrint());
+                clientFactoryBuilder.tlsCustomizer(sslContextBuilder -> sslContextBuilder.trustManager(fingerprintTrustManagerFactory));
+            } else {
+                clientFactoryBuilder.tlsCustomizer(sslContextBuilder -> sslContextBuilder.trustManager(
+                                new ByteArrayInputStream(certificate.getCertificate().getBytes(StandardCharsets.UTF_8))
+                        )
+                );
+            }
 
             if(sslDisableVerification) {
                 clientFactoryBuilder.tlsNoVerifyHosts(ipAddress);
@@ -90,5 +112,33 @@ public class PeerClientPool {
         }
 
         return clientBuilder.build(WebClient.class);
+    }
+
+    private String getCertificateFingerPrint() {
+        final X509Certificate x509Certificate = getX509Certificate();
+        return convertX509CertificateToFingerprint(x509Certificate);
+    }
+
+    private X509Certificate getX509Certificate() {
+        try {
+            final CertificateFactory certificateFactory = CertificateFactory.getInstance(SSL_ALGORITHM);
+            return (X509Certificate) certificateFactory.generateCertificate(
+                    new ByteArrayInputStream(certificate.getCertificate().getBytes(StandardCharsets.UTF_8))
+            );
+        } catch (final CertificateException e) {
+            throw new CertificateFingerprintParsingException("Unable to convert certificate to X509Certificate object", e);
+        }
+    }
+
+    private String convertX509CertificateToFingerprint(final X509Certificate x509Certificate) {
+        try {
+            final MessageDigest messageDigest = MessageDigest.getInstance(RSA_ALGORITHM);
+            final byte[] derEncodedCertificate = x509Certificate.getEncoded();
+            messageDigest.update(derEncodedCertificate);
+            final byte[] digest = messageDigest.digest();
+            return BaseEncoding.base16().lowerCase().encode(digest);
+        } catch (final NoSuchAlgorithmException | CertificateEncodingException e) {
+            throw new CertificateFingerprintParsingException("Unable to convert x509Certificate to hexadecimal fingerprint", e);
+        }
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactory.java
@@ -46,6 +46,7 @@ public class PeerForwarderClientFactory {
             peerClientPool.setSsl(true);
 
             peerClientPool.setSslDisableVerification(peerForwarderConfiguration.isSslDisableVerification());
+            peerClientPool.setSslFingerprintVerificationOnly(peerForwarderConfiguration.isSslFingerprintVerificationOnly());
             peerClientPool.setCertificate(certificateProviderFactory.getCertificateProvider().getCertificate());
         }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
@@ -33,6 +33,7 @@ public class PeerForwarderConfiguration {
     private String sslCertificateFile;
     private String sslKeyFile;
     private boolean sslDisableVerification = false;
+    private boolean sslFingerprintVerificationOnly = false;
     private ForwardingAuthentication authentication = ForwardingAuthentication.UNAUTHENTICATED;
     private boolean useAcmCertificateForSsl = false;
     private String acmCertificateArn;
@@ -63,6 +64,7 @@ public class PeerForwarderConfiguration {
             @JsonProperty("ssl_certificate_file") final String sslCertificateFile,
             @JsonProperty("ssl_key_file") final String sslKeyFile,
             @JsonProperty("ssl_insecure_disable_verification") final boolean sslDisableVerification,
+            @JsonProperty("ssl_fingerprint_verification_only") final boolean sslFingerprintVerificationOnly,
             @JsonProperty("authentication") final Map<String, Object> authentication,
             @JsonProperty("use_acm_certificate_for_ssl") final Boolean useAcmCertificateForSsl,
             @JsonProperty("acm_certificate_arn") final String acmCertificateArn,
@@ -89,6 +91,7 @@ public class PeerForwarderConfiguration {
         setSslCertificateFile(sslCertificateFile);
         setSslKeyFile(sslKeyFile);
         setDisableVerification(sslDisableVerification);
+        setFingerprintVerificationOnly(sslFingerprintVerificationOnly);
         setAuthentication(authentication);
         setAcmCertificateArn(acmCertificateArn);
         this.acmPrivateKeyPassword = acmPrivateKeyPassword;
@@ -272,6 +275,14 @@ public class PeerForwarderConfiguration {
 
     public boolean isSslDisableVerification() {
         return sslDisableVerification;
+    }
+
+    private void setFingerprintVerificationOnly(final boolean sslFingerprintVerificationOnly) {
+        this.sslFingerprintVerificationOnly = sslFingerprintVerificationOnly;
+    }
+
+    public boolean isSslFingerprintVerificationOnly() {
+        return sslFingerprintVerificationOnly;
     }
 
     private void setAuthentication(final Map<String, Object> authentication) {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/exception/CertificateFingerprintParsingException.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/exception/CertificateFingerprintParsingException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.peerforwarder.exception;
+
+/**
+ * This exception is thrown when the fingerprint associated with a certificate cannot be parsed
+ *
+ * @since 2.0
+ */
+public class CertificateFingerprintParsingException extends RuntimeException {
+
+    public CertificateFingerprintParsingException(final String errorMessage, final Throwable cause) {
+        super(errorMessage, cause);
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactoryTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactoryTest.java
@@ -102,6 +102,18 @@ class PeerForwarderClientFactoryTest {
 
             verify(peerClientPool).setSslDisableVerification(sslDisableVerification);
         }
+
+        @ParameterizedTest
+        @ValueSource(booleans = { true, false })
+        void setPeerClientPool_should_supply_sslFingerprintVerificationOnly_when_ssl_true(final boolean sslFingerprintVerificationOnly) {
+            when(peerForwarderConfiguration.isSslFingerprintVerificationOnly())
+                    .thenReturn(sslFingerprintVerificationOnly);
+
+
+            createObjectUnderTest().setPeerClientPool();
+
+            verify(peerClientPool).setSslFingerprintVerificationOnly(sslFingerprintVerificationOnly);
+        }
     }
 
     @Test
@@ -109,6 +121,13 @@ class PeerForwarderClientFactoryTest {
         createObjectUnderTest().setPeerClientPool();
 
         verify(peerClientPool, never()).setSslDisableVerification(anyBoolean());
+    }
+
+    @Test
+    void setPeerClientPool_should_not_supply_sslFingerprintVerificationOnly_when_ssl_false() {
+        createObjectUnderTest().setPeerClientPool();
+
+        verify(peerClientPool, never()).setSslFingerprintVerificationOnly(anyBoolean());
     }
 
     @ParameterizedTest

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
@@ -41,6 +41,7 @@ class PeerForwarderConfigurationTest {
         assertThat(peerForwarderConfiguration.getMaxPendingRequests(), equalTo(1024));
         assertThat(peerForwarderConfiguration.isSsl(), equalTo(false));
         assertThat(peerForwarderConfiguration.isSslDisableVerification(), equalTo(false));
+        assertThat(peerForwarderConfiguration.isSslFingerprintVerificationOnly(), equalTo(false));
         assertThat(peerForwarderConfiguration.getAcmPrivateKeyPassword(), equalTo(null));
         assertThat(peerForwarderConfiguration.isUseAcmCertificateForSsl(), equalTo(false));
         assertThat(peerForwarderConfiguration.getDiscoveryMode(), equalTo(DiscoveryMode.LOCAL_NODE));
@@ -61,6 +62,7 @@ class PeerForwarderConfigurationTest {
         assertThat(peerForwarderConfiguration.getMaxPendingRequests(), equalTo(512));
         assertThat(peerForwarderConfiguration.isSsl(), equalTo(false));
         assertThat(peerForwarderConfiguration.isSslDisableVerification(), equalTo(false));
+        assertThat(peerForwarderConfiguration.isSslFingerprintVerificationOnly(), equalTo(false));
         assertThat(peerForwarderConfiguration.isUseAcmCertificateForSsl(), equalTo(false));
         assertThat(peerForwarderConfiguration.getAcmCertificateArn(), equalTo(null));
         assertThat(peerForwarderConfiguration.getDiscoveryMode(), equalTo(DiscoveryMode.STATIC));
@@ -96,6 +98,14 @@ class PeerForwarderConfigurationTest {
 
         assertThat(peerForwarderConfiguration.isSsl(), equalTo(true));
         assertThat(peerForwarderConfiguration.isSslDisableVerification(), equalTo(true));
+    }
+
+    @Test
+    void testValidPeerForwarderConfig_with_FingerprintTls() throws IOException {
+        final PeerForwarderConfiguration peerForwarderConfiguration = makeConfig("src/test/resources/valid_peer_forwarder_config_with_fingerprint.yml");
+
+        assertThat(peerForwarderConfiguration.isSsl(), equalTo(true));
+        assertThat(peerForwarderConfiguration.isSslFingerprintVerificationOnly(), equalTo(true));
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -377,6 +377,7 @@ class PeerForwarder_ClientServerIT {
                 sslCertificateFile,
                 sslKeyFile,
                 sslDisableVerification,
+                false,
                 authenticationMap,
                 false,
                 null,

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -191,7 +191,49 @@ class PeerForwarder_ClientServerIT {
         @Test
         void send_Events_to_an_unknown_server_should_throw() {
             final PeerForwarderConfiguration peerForwarderConfiguration = createConfiguration(
-                    true, ForwardingAuthentication.UNAUTHENTICATED, ALTERNATE_SSL_CERTIFICATE_FILE, ALTERNATE_SSL_KEY_FILE, false);
+                    true, ForwardingAuthentication.UNAUTHENTICATED, ALTERNATE_SSL_CERTIFICATE_FILE, ALTERNATE_SSL_KEY_FILE, false, false);
+
+            final PeerForwarderClient client = createClient(peerForwarderConfiguration);
+
+            assertThrows(UnprocessedRequestException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName));
+
+            final Collection<Record<Event>> receivedRecords = getServerSideRecords(peerForwarderProvider);
+            assertThat(receivedRecords, notNullValue());
+            assertThat(receivedRecords, is(empty()));
+        }
+
+        @Test
+        void send_Events_to_server_with_fingerprint_verification() {
+            final PeerForwarderConfiguration peerForwarderConfiguration = createConfiguration(
+                        true, ForwardingAuthentication.UNAUTHENTICATED, SSL_CERTIFICATE_FILE, SSL_KEY_FILE, false, true);
+
+            final PeerForwarderClient client = createClient(peerForwarderConfiguration);
+
+            final AggregatedHttpResponse httpResponse = client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName);
+
+            assertThat(httpResponse.status(), equalTo(HttpStatus.OK));
+
+            final Collection<Record<Event>> receivedRecords = getServerSideRecords(peerForwarderProvider);
+            assertThat(receivedRecords, notNullValue());
+            assertThat(receivedRecords.size(), equalTo(outgoingRecords.size()));
+
+            final Set<String> receivedMessages = new HashSet<>();
+            for (Record receivedRecord : receivedRecords) {
+                assertThat(receivedRecord, notNullValue());
+                assertThat(receivedRecord.getData(), instanceOf(Event.class));
+                final Event event = (Event) receivedRecord.getData();
+                final String message = event.get("message", String.class);
+                assertThat(message, notNullValue());
+                receivedMessages.add(message);
+            }
+
+            assertThat(receivedMessages, equalTo(expectedMessages));
+        }
+
+        @Test
+        void send_Events_with_fingerprint_verification_to_unknown_server_should_throw() {
+            final PeerForwarderConfiguration peerForwarderConfiguration = createConfiguration(
+                    true, ForwardingAuthentication.UNAUTHENTICATED, ALTERNATE_SSL_CERTIFICATE_FILE, ALTERNATE_SSL_KEY_FILE, false, true);
 
             final PeerForwarderClient client = createClient(peerForwarderConfiguration);
 
@@ -331,7 +373,7 @@ class PeerForwarder_ClientServerIT {
         @Test
         void send_Events_to_server_when_client_has_unknown_certificate_key_closes() {
             final PeerForwarderConfiguration peerForwarderConfiguration = createConfiguration(
-                    true, ForwardingAuthentication.MUTUAL_TLS, SSL_CERTIFICATE_FILE, ALTERNATE_SSL_KEY_FILE, true);
+                    true, ForwardingAuthentication.MUTUAL_TLS, SSL_CERTIFICATE_FILE, ALTERNATE_SSL_KEY_FILE, true, false);
 
             final PeerForwarderClient client = createClient(peerForwarderConfiguration);
             assertThrows(UnprocessedRequestException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName));
@@ -344,7 +386,49 @@ class PeerForwarder_ClientServerIT {
         @Test
         void send_Events_to_an_unknown_server_should_throw() {
             final PeerForwarderConfiguration peerForwarderConfiguration = createConfiguration(
-                    true, ForwardingAuthentication.MUTUAL_TLS, ALTERNATE_SSL_CERTIFICATE_FILE, SSL_KEY_FILE, true);
+                    true, ForwardingAuthentication.MUTUAL_TLS, ALTERNATE_SSL_CERTIFICATE_FILE, SSL_KEY_FILE, true, false);
+
+            final PeerForwarderClient client = createClient(peerForwarderConfiguration);
+
+            assertThrows(UnprocessedRequestException.class, () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName));
+
+            final Collection<Record<Event>> receivedRecords = getServerSideRecords(peerForwarderProvider);
+            assertThat(receivedRecords, notNullValue());
+            assertThat(receivedRecords, is(empty()));
+        }
+
+        @Test
+        void send_Events_to_server_with_fingerprint_verification() {
+            final PeerForwarderConfiguration peerForwarderConfiguration = createConfiguration(
+                    true, ForwardingAuthentication.MUTUAL_TLS, SSL_CERTIFICATE_FILE, SSL_KEY_FILE, false, true);
+
+            final PeerForwarderClient client = createClient(peerForwarderConfiguration);
+
+            final AggregatedHttpResponse httpResponse = client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName);
+
+            assertThat(httpResponse.status(), equalTo(HttpStatus.OK));
+
+            final Collection<Record<Event>> receivedRecords = getServerSideRecords(peerForwarderProvider);
+            assertThat(receivedRecords, notNullValue());
+            assertThat(receivedRecords.size(), equalTo(outgoingRecords.size()));
+
+            final Set<String> receivedMessages = new HashSet<>();
+            for (Record receivedRecord : receivedRecords) {
+                assertThat(receivedRecord, notNullValue());
+                assertThat(receivedRecord.getData(), instanceOf(Event.class));
+                final Event event = (Event) receivedRecord.getData();
+                final String message = event.get("message", String.class);
+                assertThat(message, notNullValue());
+                receivedMessages.add(message);
+            }
+
+            assertThat(receivedMessages, equalTo(expectedMessages));
+        }
+
+        @Test
+        void send_Events_with_fingerprint_verification_to_unknown_server_should_throw() {
+            final PeerForwarderConfiguration peerForwarderConfiguration = createConfiguration(
+                    true, ForwardingAuthentication.MUTUAL_TLS, ALTERNATE_SSL_CERTIFICATE_FILE, SSL_KEY_FILE, false, true);
 
             final PeerForwarderClient client = createClient(peerForwarderConfiguration);
 
@@ -357,7 +441,7 @@ class PeerForwarder_ClientServerIT {
     }
 
     private PeerForwarderConfiguration createConfiguration(final boolean ssl, final ForwardingAuthentication authentication) {
-        return createConfiguration(ssl, authentication, SSL_CERTIFICATE_FILE, SSL_KEY_FILE, true);
+        return createConfiguration(ssl, authentication, SSL_CERTIFICATE_FILE, SSL_KEY_FILE, true, false);
     }
 
     private PeerForwarderConfiguration createConfiguration(
@@ -365,7 +449,8 @@ class PeerForwarder_ClientServerIT {
             final ForwardingAuthentication authentication,
             final String sslCertificateFile,
             final String sslKeyFile,
-            final boolean sslDisableVerification) {
+            final boolean sslDisableVerification,
+            final boolean sslFingerprintVerificationOnly) {
         final Map<String, Object> authenticationMap = Collections.singletonMap(authentication.getName(), null);
         return new PeerForwarderConfiguration(
                 21890,
@@ -377,7 +462,7 @@ class PeerForwarder_ClientServerIT {
                 sslCertificateFile,
                 sslKeyFile,
                 sslDisableVerification,
-                false,
+                sslFingerprintVerificationOnly,
                 authenticationMap,
                 false,
                 null,

--- a/data-prepper-core/src/test/resources/valid_peer_forwarder_config_with_fingerprint.yml
+++ b/data-prepper-core/src/test/resources/valid_peer_forwarder_config_with_fingerprint.yml
@@ -1,0 +1,4 @@
+ssl: true
+ssl_certificate_file: src/test/resources/test-crt.crt
+ssl_key_file: src/test/resources/test-key.crt
+ssl_fingerprint_verification_only: true

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/certificate/exception/CertificateFingerprintParsingException.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/certificate/exception/CertificateFingerprintParsingException.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.peerforwarder.exception;
+package org.opensearch.dataprepper.plugins.certificate.exception;
 
 /**
  * This exception is thrown when the fingerprint associated with a certificate cannot be parsed

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/certificate/model/Certificate.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/certificate/model/Certificate.java
@@ -5,10 +5,25 @@
 
 package org.opensearch.dataprepper.plugins.certificate.model;
 
+import com.google.common.io.BaseEncoding;
+import org.opensearch.dataprepper.plugins.certificate.exception.CertificateFingerprintParsingException;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.MessageDigest;
+
 import static java.util.Objects.requireNonNull;
 
 // TODO: accommodate encrypted private key with password
 public class Certificate {
+    private static final String SSL_ALGORITHM = "X.509";
+    private static final String RSA_ALGORITHM = "SHA-1";
+
     /**
      * The base64 PEM-encoded certificate.
      */
@@ -31,5 +46,33 @@ public class Certificate {
 
     public String getPrivateKey() {
         return privateKey;
+    }
+
+    public String getFingerprint() {
+        final X509Certificate x509Certificate = getX509Certificate();
+        return convertX509CertificateToFingerprint(x509Certificate);
+    }
+
+    private X509Certificate getX509Certificate() {
+        try {
+            final CertificateFactory certificateFactory = CertificateFactory.getInstance(SSL_ALGORITHM);
+            return (X509Certificate) certificateFactory.generateCertificate(
+                    new ByteArrayInputStream(getCertificate().getBytes(StandardCharsets.UTF_8))
+            );
+        } catch (final CertificateException e) {
+            throw new CertificateFingerprintParsingException("Unable to convert certificate to X509Certificate object", e);
+        }
+    }
+
+    private String convertX509CertificateToFingerprint(final X509Certificate x509Certificate) {
+        try {
+            final MessageDigest messageDigest = MessageDigest.getInstance(RSA_ALGORITHM);
+            final byte[] derEncodedCertificate = x509Certificate.getEncoded();
+            messageDigest.update(derEncodedCertificate);
+            final byte[] digest = messageDigest.digest();
+            return BaseEncoding.base16().lowerCase().encode(digest);
+        } catch (final NoSuchAlgorithmException | CertificateEncodingException e) {
+            throw new CertificateFingerprintParsingException("Unable to convert x509Certificate to hexadecimal fingerprint", e);
+        }
     }
 }

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/certificate/model/CertificateTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/certificate/model/CertificateTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.certificate.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.certificate.file.FileCertificateProvider;
+import org.opensearch.dataprepper.plugins.certificate.exception.CertificateFingerprintParsingException;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+public class CertificateTest {
+    private static final String EXPECTED_FINGERPRINT = "fb6d45a36864f6673fa04b5601f54a1c96d3cb45";
+
+    @Test
+    void testGetFingerprint_Success() {
+        final String certificateFilePath = "data/certificate/test_cert.crt";
+        final String privateKeyFilePath = "data/certificate/test_decrypted_key.key";
+        final FileCertificateProvider fileCertificateProvider = new FileCertificateProvider(certificateFilePath, privateKeyFilePath);
+        final Certificate certificate = fileCertificateProvider.getCertificate();
+
+        final String fingerprint = certificate.getFingerprint();
+        assertThat(fingerprint, is(EXPECTED_FINGERPRINT));
+    }
+
+    @Test
+    void testGetFingerprint_InvalidCert() {
+        final Certificate certificate = new Certificate(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+        assertThrows(CertificateFingerprintParsingException.class, () -> certificate.getFingerprint());
+    }
+}

--- a/docs/peer_forwarder.md
+++ b/docs/peer_forwarder.md
@@ -97,6 +97,7 @@ The SSL configuration for setting up trust manager for peer forwarding client to
 * `ssl_certificate_file`(Optional) : A `String` representing the SSL certificate chain file path or AWS S3 path. S3 path example `s3://<bucketName>/<path>`. Required if `ssl` is set to `true`.
 * `ssl_key_file`(Optional) : A `String` represents the SSL key file path or AWS S3 path. S3 path example `s3://<bucketName>/<path>`. Required if `ssl` is set to `true`.
 * `ssl_insecure_disable_verification`(Optional) : A `boolean` that disables the verification of server's TLS certificate chain. Default value is `false`.
+* `ssl_fingerprint_verification_only`(Optional) : A `boolean` that disables the verification of server's TLS certificate chain and instead verifies only the certificate fingerprint. Default value is `false`.
 * `use_acm_certificate_for_ssl`(Optional) : A `boolean` that enables TLS/SSL using certificate and private key from AWS Certificate Manager (ACM). Default is `false`.
 * `acm_certificate_arn`(Optional) : A `String` represents the ACM certificate ARN. ACM certificate take preference over S3 or local file system certificate. Required if `use_acm_certificate_for_ssl` is set to `true`.
 * `acm_certificate_timeout_millis`(Optional) : An `int` representing the timeout in milliseconds for ACM to get certificates. Default value is `120000`.


### PR DESCRIPTION
Signed-off-by: Chase Engelbrecht <engechas@amazon.com>

~Still need to add testing, but shows the proposed approach for a fingerprint-based SSL verification.~

### Description
Adds a new flag to PeerForwarderConfiguration to verify only the fingerprint of the server's certificate through a FingerprintTrustManagerFactory implementation. 
 
### Issues Resolved

 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
