### PR TITLE
Fix jdk version check in script

### DIFF
--- a/release/archives/linux/data-prepper-x64.sh
+++ b/release/archives/linux/data-prepper-x64.sh
@@ -43,7 +43,7 @@ fi
 if [[ "$_java" ]]
 then
     java_type=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $1}')
-    java_version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed 's/\(.*\..*\)\..*/\1/g')
+    java_version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed 's/\([0-9]*\.[0-9]*\)\..*/\1/g')
     echo "Found $java_type of $java_version"
     if [[ $java_type == *"openjdk"* ]]
     then


### PR DESCRIPTION
Signed-off-by: Hai Yan <oeyh@amazon.com>

### Description
This PR makes a small change to the jdk version parser to handle cases that contain more than 3 numbers in version spec.

Before this PR, a version like "17.0.4.1" would be parsed as "17.0.4" and causing a `(standard_in) 1: syntax error` during comparison with minimum required version. With the change, "17.0.4.1" will be parsed as "17.0" so it can be compared numerically.
 
### Issues Resolved
N/A
Issue was mentioned here: https://forum.opensearch.org/t/latest-data-prepper-not-working/11055
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
