### PR TITLE
Fix: Peer forwarder exception with single thread annotated processors

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
@@ -159,18 +159,15 @@ public class PipelineParser {
                     .collect(Collectors.toList());
 
             final List<List<Processor>> decoratedProcessorSets = processorSets.stream()
-                    .map(processorComponentList -> processorComponentList.stream()
-                            .map(processorComponent -> {
-                                if (processorComponent.getComponent() instanceof RequiresPeerForwarding) {
-                                    return new PeerForwardingProcessorDecorator(
-                                            processorComponent.getComponent(), peerForwarderProvider, pipelineName, processorComponent.getName()
-                                    );
-                                }
-                                return processorComponent.getComponent();
-                            })
-                            .collect(Collectors.toList())
-                        ).collect(Collectors.toList());
-
+                    .map(processorComponentList -> {
+                        final List<Processor> processors = processorComponentList.stream().map(IdentifiedComponent::getComponent).collect(Collectors.toList());
+                        if (processorComponentList.get(0) instanceof RequiresPeerForwarding) {
+                            return PeerForwardingProcessorDecorator.decorateProcessors(
+                                    processors, peerForwarderProvider, pipelineName, processorComponentList.get(0).getName()
+                            );
+                        }
+                        return processors;
+                    }).collect(Collectors.toList());
 
             final int readBatchDelay = pipelineConfiguration.getReadBatchDelay();
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
@@ -14,6 +14,7 @@ import org.opensearch.dataprepper.peerforwarder.exception.EmptyPeerForwarderPlug
 import org.opensearch.dataprepper.peerforwarder.exception.UnsupportedPeerForwarderPluginException;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -30,7 +31,13 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
             final String pluginId) {
 
         Set<String> identificationKeys;
-        final Processor firstInnerProcessor = processors.get(0);
+        Processor firstInnerProcessor;
+        if (!processors.isEmpty()) {
+            firstInnerProcessor = processors.get(0);
+        }
+        else {
+            return Collections.emptyList();
+        }
 
         if (firstInnerProcessor instanceof RequiresPeerForwarding) {
             identificationKeys = new HashSet<> (((RequiresPeerForwarding) firstInnerProcessor).getIdentificationKeys());

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.peerforwarder.exception.EmptyPeerForwarderPluginIdentificationKeysException;
 import org.opensearch.dataprepper.peerforwarder.exception.UnsupportedPeerForwarderPluginException;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -31,6 +32,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -47,8 +49,12 @@ class PeerForwardingProcessingDecoratorTest {
     @Mock(extraInterfaces = Processor.class)
     private RequiresPeerForwarding requiresPeerForwarding;
 
+    @Mock(extraInterfaces = Processor.class)
+    private RequiresPeerForwarding requiresPeerForwardingCopy;
+
     @Mock
     private PeerForwarderProvider peerForwarderProvider;
+
     private String pipelineName;
     private String pluginId;
 
@@ -59,13 +65,13 @@ class PeerForwardingProcessingDecoratorTest {
         pluginId = UUID.randomUUID().toString();
     }
 
-    private PeerForwardingProcessorDecorator createObjectUnderTest(final Processor processor) {
-        return new PeerForwardingProcessorDecorator(processor, peerForwarderProvider, pipelineName, pluginId);
+    private List<Processor> createObjectUnderTesDecoratedProcessors(final List<Processor> processors) {
+        return PeerForwardingProcessorDecorator.decorateProcessors(processors, peerForwarderProvider, pipelineName, pluginId);
     }
 
     @Test
     void PeerForwardingProcessingDecorator_should_not_have_any_interactions_if_its_not_an_instance_of_RequiresPeerForwarding() {
-        assertThrows(UnsupportedPeerForwarderPluginException.class, () -> createObjectUnderTest(processor));
+        assertThrows(UnsupportedPeerForwarderPluginException.class, () -> createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor)));
 
         verifyNoInteractions(peerForwarderProvider);
     }
@@ -74,7 +80,19 @@ class PeerForwardingProcessingDecoratorTest {
     void PeerForwardingProcessingDecorator_execute_with_empty_identification_keys_should_throw() {
         when(requiresPeerForwarding.getIdentificationKeys()).thenReturn(Collections.emptySet());
 
-        assertThrows(EmptyPeerForwarderPluginIdentificationKeysException.class, () -> createObjectUnderTest((Processor) requiresPeerForwarding));
+        assertThrows(EmptyPeerForwarderPluginIdentificationKeysException.class, () -> createObjectUnderTesDecoratedProcessors(Collections.singletonList((Processor) requiresPeerForwarding)));
+    }
+
+    @Test
+    void decorateProcessors_with_different_identification_key_should_throw() {
+        List<Processor> processorList = new ArrayList<>();
+        processorList.add((Processor) requiresPeerForwarding);
+        processorList.add((Processor) requiresPeerForwardingCopy);
+
+        when(requiresPeerForwarding.getIdentificationKeys()).thenReturn(Set.of(UUID.randomUUID().toString()));
+        when(requiresPeerForwardingCopy.getIdentificationKeys()).thenReturn(Set.of(UUID.randomUUID().toString()));
+
+        assertThrows(RuntimeException.class, () -> createObjectUnderTesDecoratedProcessors(List.of(((Processor) requiresPeerForwarding), (Processor) requiresPeerForwardingCopy)));
     }
 
     @Nested
@@ -95,8 +113,8 @@ class PeerForwardingProcessingDecoratorTest {
 
         @Test
         void PeerForwardingProcessingDecorator_should_have_interaction_with_getIdentificationKeys() {
-            createObjectUnderTest(processor);
-            verify(requiresPeerForwarding).getIdentificationKeys();
+            createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
+            verify(requiresPeerForwarding, times(2)).getIdentificationKeys();
             verify(peerForwarderProvider).register(pipelineName, pluginId, identificationKeys);
         }
 
@@ -108,10 +126,10 @@ class PeerForwardingProcessingDecoratorTest {
 
             when(processor.execute(testData)).thenReturn(testData);
 
-            final PeerForwardingProcessorDecorator objectUnderTest = createObjectUnderTest(processor);
-            final Collection<Record<Event>> records = objectUnderTest.execute(testData);
+            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
+            final Collection<Record<Event>> records = processors.get(0).execute(testData);
 
-            verify(requiresPeerForwarding).getIdentificationKeys();
+            verify(requiresPeerForwarding, times(2)).getIdentificationKeys();
             verify(peerForwarder).forwardRecords(testData);
             Assertions.assertNotNull(records);
             assertThat(records.size(), equalTo(testData.size()));
@@ -130,10 +148,10 @@ class PeerForwardingProcessingDecoratorTest {
 
             when(((Processor) requiresPeerForwarding).execute(anyCollection())).thenReturn(expectedRecordsToProcessLocally);
 
-            final PeerForwardingProcessorDecorator objectUnderTest = createObjectUnderTest((Processor) requiresPeerForwarding);
-            final Collection<Record<Event>> records = objectUnderTest.execute(forwardTestData);
+            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList((Processor) requiresPeerForwarding));
+            final Collection<Record<Event>> records = processors.get(0).execute(forwardTestData);
 
-            verify(requiresPeerForwarding).getIdentificationKeys();
+            verify(requiresPeerForwarding, times(2)).getIdentificationKeys();
             verify(peerForwarder).forwardRecords(forwardTestData);
             verify(peerForwarder).receiveRecords();
             Assertions.assertNotNull(records);
@@ -143,33 +161,33 @@ class PeerForwardingProcessingDecoratorTest {
 
         @Test
         void PeerForwardingProcessingDecorator_execute_will_call_inner_processors_execute() {
-            PeerForwardingProcessorDecorator objectUnderTest = createObjectUnderTest(processor);
+            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
             Collection<Record<Event>> testData = Collections.singletonList(record);
-            objectUnderTest.execute(testData);
+            processors.get(0).execute(testData);
             verify(processor).execute(anyCollection());
         }
 
         @Test
         void PeerForwardingProcessingDecorator_prepareForShutdown_will_call_inner_processors_prepareForShutdown() {
-            PeerForwardingProcessorDecorator objectUnderTest = createObjectUnderTest(processor);
+            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
 
-            objectUnderTest.prepareForShutdown();
+            processors.get(0).prepareForShutdown();
             verify(processor).prepareForShutdown();
         }
 
         @Test
         void PeerForwardingProcessingDecorator_isReadyForShutdown_will_call_inner_processors_isReadyForShutdown() {
-            PeerForwardingProcessorDecorator objectUnderTest = createObjectUnderTest(processor);
+            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
 
-            objectUnderTest.isReadyForShutdown();
+            processors.get(0).isReadyForShutdown();
             verify(processor).isReadyForShutdown();
         }
 
         @Test
         void PeerForwardingProcessingDecorator_shutdown_will_call_inner_processors_shutdown() {
-            PeerForwardingProcessorDecorator objectUnderTest = createObjectUnderTest(processor);
+            final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
 
-            objectUnderTest.shutdown();
+            processors.get(0).shutdown();
             verify(processor).shutdown();
         }
     }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
@@ -95,6 +95,13 @@ class PeerForwardingProcessingDecoratorTest {
         assertThrows(RuntimeException.class, () -> createObjectUnderTesDecoratedProcessors(List.of(((Processor) requiresPeerForwarding), (Processor) requiresPeerForwardingCopy)));
     }
 
+
+    @Test
+    void decorateProcessors_with_empty_processors_should_return_empty_list_of_processors() {
+        final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.emptyList());
+        assertThat(processors.size(), equalTo(0));
+    }
+
     @Nested
     class WithRegisteredPeerForwarder {
         @Mock
@@ -127,6 +134,7 @@ class PeerForwardingProcessingDecoratorTest {
             when(processor.execute(testData)).thenReturn(testData);
 
             final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
+            assertThat(processors.size(), equalTo(1));
             final Collection<Record<Event>> records = processors.get(0).execute(testData);
 
             verify(requiresPeerForwarding, times(2)).getIdentificationKeys();
@@ -149,6 +157,7 @@ class PeerForwardingProcessingDecoratorTest {
             when(((Processor) requiresPeerForwarding).execute(anyCollection())).thenReturn(expectedRecordsToProcessLocally);
 
             final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList((Processor) requiresPeerForwarding));
+            assertThat(processors.size(), equalTo(1));
             final Collection<Record<Event>> records = processors.get(0).execute(forwardTestData);
 
             verify(requiresPeerForwarding, times(2)).getIdentificationKeys();
@@ -163,6 +172,8 @@ class PeerForwardingProcessingDecoratorTest {
         void PeerForwardingProcessingDecorator_execute_will_call_inner_processors_execute() {
             final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
             Collection<Record<Event>> testData = Collections.singletonList(record);
+
+            assertThat(processors.size(), equalTo(1));
             processors.get(0).execute(testData);
             verify(processor).execute(anyCollection());
         }
@@ -171,6 +182,7 @@ class PeerForwardingProcessingDecoratorTest {
         void PeerForwardingProcessingDecorator_prepareForShutdown_will_call_inner_processors_prepareForShutdown() {
             final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
 
+            assertThat(processors.size(), equalTo(1));
             processors.get(0).prepareForShutdown();
             verify(processor).prepareForShutdown();
         }
@@ -179,6 +191,7 @@ class PeerForwardingProcessingDecoratorTest {
         void PeerForwardingProcessingDecorator_isReadyForShutdown_will_call_inner_processors_isReadyForShutdown() {
             final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
 
+            assertThat(processors.size(), equalTo(1));
             processors.get(0).isReadyForShutdown();
             verify(processor).isReadyForShutdown();
         }
@@ -187,6 +200,7 @@ class PeerForwardingProcessingDecoratorTest {
         void PeerForwardingProcessingDecorator_shutdown_will_call_inner_processors_shutdown() {
             final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
 
+            assertThat(processors.size(), equalTo(1));
             processors.get(0).shutdown();
             verify(processor).shutdown();
         }


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
This PR fixes the bug for service map stateful processor with core peer forwarding. 
Service map stateful is annotated with SingleThread which creates multiple instances(equal to number of process workers) of this processor. As peer forwarder only supports one unique plugin type per pipeline this will result in an exception.
 
### Issues Resolved

 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
