### PR TITLE
Fix Data Prepper Docker container shutdown 

### DIFF
--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -20,4 +20,4 @@ COPY default-data-prepper-config.yaml $ENV_CONFIG_FILEPATH
 COPY default-keystore.p12 /usr/share/data-prepper/keystore.p12
 
 WORKDIR $DATA_PREPPER_PATH
-CMD bin/data-prepper
+CMD ["bin/data-prepper"]


### PR DESCRIPTION
Signed-off-by: Hai Yan <oeyh@amazon.com>

### Description
This changes the CMD instruction in Data Prepper Dockerfile from "shell" form to "exec" form to fix the issue that the container won't exit through Ctrl+C. 

The "exec" form allows shutdown signal to be forwarded to the data prepper process properly. The different behavior between 2.0 and previous versions is likely due to the change of using the new data-prepper script to run the app.
 
### Issues Resolved
Closes #1816
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
