### PR TITLE
Updated default peer forwarder port

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
@@ -24,7 +24,7 @@ public class PeerForwarderConfiguration {
     public static final String DEFAULT_PEER_FORWARDING_URI = "/event/forward";
     private static final String S3_PREFIX = "s3://";
 
-    private Integer serverPort = 21890;
+    private Integer serverPort = 4994;
     private Integer requestTimeout = 10_000;
     private Integer serverThreadCount = 200;
     private Integer maxConnectionCount = 500;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerClientPoolTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerClientPoolTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class PeerClientPoolTest {
     private static final String VALID_ADDRESS = "10.10.10.5";
     private static final String LOCALHOST = "localhost";
-    private static final int PORT = 21890;
+    private static final int PORT = 4994;
 
     @ParameterizedTest
     @ValueSource(strings = {VALID_ADDRESS, LOCALHOST})

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfigIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfigIT.java
@@ -30,7 +30,7 @@ class PeerForwarderAppConfigIT {
     @Test
     void PeerForwarderConfiguration_default_values_test() {
         final PeerForwarderConfiguration objectUnderTest = createObjectUnderTest();
-        assertThat(objectUnderTest.getServerPort(), equalTo(21890));
+        assertThat(objectUnderTest.getServerPort(), equalTo(4994));
         assertThat(objectUnderTest.getRequestTimeout(), equalTo(10_000));
         assertThat(objectUnderTest.getServerThreadCount(), equalTo(200));
         assertThat(objectUnderTest.getMaxConnectionCount(), equalTo(500));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
@@ -34,7 +34,7 @@ class PeerForwarderConfigurationTest {
     void testPeerForwarderDefaultConfig() throws IOException {
         final PeerForwarderConfiguration peerForwarderConfiguration = makeConfig(TestDataProvider.VALID_PEER_FORWARDER_CONFIG_WITHOUT_SSL_FILE);
 
-        assertThat(peerForwarderConfiguration.getServerPort(), equalTo(21890));
+        assertThat(peerForwarderConfiguration.getServerPort(), equalTo(4994));
         assertThat(peerForwarderConfiguration.getRequestTimeout(), equalTo(10_000));
         assertThat(peerForwarderConfiguration.getServerThreadCount(), equalTo(200));
         assertThat(peerForwarderConfiguration.getMaxConnectionCount(), equalTo(500));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -368,7 +368,7 @@ class PeerForwarder_ClientServerIT {
             final boolean sslDisableVerification) {
         final Map<String, Object> authenticationMap = Collections.singletonMap(authentication.getName(), null);
         return new PeerForwarderConfiguration(
-                21890,
+                4994,
                 10_000,
                 200,
                 500,

--- a/data-prepper-core/src/test/resources/valid_data_prepper_config_wth_peer_forwarder_config.yml
+++ b/data-prepper-core/src/test/resources/valid_data_prepper_config_wth_peer_forwarder_config.yml
@@ -1,5 +1,5 @@
 serverPort: 5678
 ssl: false
 peer_forwarder:
-  port: 21890
+  port: 4994
   ssl: false

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerClientPoolTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerClientPoolTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertNotNull;
 public class PeerClientPoolTest {
     private static final String VALID_ADDRESS = "10.10.10.5";
     private static final String LOCALHOST = "localhost";
-    private static final int PORT = 21890;
+    private static final int PORT = 4994;
     private static final File SSL_KEY_FILE = new File(
             PeerClientPoolTest.class.getClassLoader().getResource("test-key.key").getFile());
     private static final File SSL_CRT_FILE = new File(

--- a/docs/peer_forwarder.md
+++ b/docs/peer_forwarder.md
@@ -75,7 +75,7 @@ IAM policy shows the necessary permissions.
 ---
 ## Configuration
 
-* `port`(Optional): An `int` between 0 and 65535 represents the port peer forwarder server is running on. Default value is `21892`.
+* `port`(Optional): An `int` between 0 and 65535 represents the port peer forwarder server is running on. Default value is `4994`.
 * `request_timeout`(Optional): Duration - An `int` representing the request timeout in milliseconds for Peer Forwarder HTTP server. Default value is `10000`.
 * `server_thread_count`(Optional): An `int` representing number of threads used by Peer Forwarder server. Defaults to `200`.
 * `client_thread_count`(Optional): An `int` representing number of threads used by Peer Forwarder client. Defaults to `200`.


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
Updated port from 21890 to 4994
 
### Issues Resolved
resolves #1811 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
