### PR TITLE
Corrected the way that PipelineModel deserializes the route property

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelineModel.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PipelineModel.java
@@ -38,7 +38,7 @@ public class PipelineModel {
 
     @JsonProperty("route")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<ConditionalRoute> routes;
+    private final List<ConditionalRoute> routes;
 
     @JsonProperty("sink")
     private final List<SinkModel> sinks;
@@ -64,7 +64,7 @@ public class PipelineModel {
             @JsonProperty("source") final PluginModel source,
             @JsonProperty("buffer") final PluginModel buffer,
             @JsonProperty("processor") final List<PluginModel> processors,
-            @JsonProperty("router") final List<ConditionalRoute> routes,
+            @JsonProperty("route") final List<ConditionalRoute> routes,
             @JsonProperty("sink") final List<SinkModel> sinks,
             @JsonProperty("workers") final Integer workers,
             @JsonProperty("delay") final Integer delay) {

--- a/data-prepper-api/src/test/resources/pipelines_data_flow_route.yaml
+++ b/data-prepper-api/src/test/resources/pipelines_data_flow_route.yaml
@@ -3,11 +3,11 @@ test-pipeline:
     testSource: null
   processor:
   - testPrepper: null
+  route:
+  - my-route: "/a==b"
   sink:
   - testSink:
       routes:
       - "my-route"
   workers: 8
   delay: 50
-  route:
-  - my-route: "/a==b"


### PR DESCRIPTION
### Description

The previous approach was using setter injection rather than via the constructor. This makes this consistent and more correct.
 
### Issues Resolved

N/A - This was a bug found from previous Conditional Routing PRs.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
