### PR TITLE
Bug fix: peer forwarder not decorating processors

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
@@ -162,7 +162,7 @@ public class PipelineParser {
             final List<List<Processor>> decoratedProcessorSets = processorSets.stream()
                     .map(processorComponentList -> {
                         final List<Processor> processors = processorComponentList.stream().map(IdentifiedComponent::getComponent).collect(Collectors.toList());
-                        if (processorComponentList.get(0) instanceof RequiresPeerForwarding) {
+                        if (!processors.isEmpty() && processors.get(0) instanceof RequiresPeerForwarding) {
                             return PeerForwardingProcessorDecorator.decorateProcessors(
                                     processors, peerForwarderProvider, pipelineName, processorComponentList.get(0).getName()
                             );


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
- Fixes a bug where `IdentifiedComponent` is used instead of `Processor` to check if it's an instance of `RequiresPeerForwarding`
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
