### PR TITLE
Implementation of conditional routing of sinks

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/DataFlowComponent.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/DataFlowComponent.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 /**
  * Represents a part of the pipeline through which data flows. This includes
- * {@link com.amazon.dataprepper.model.sink.Sink} and {@link com.amazon.dataprepper.model.processor.Processor}.
+ * {@link org.opensearch.dataprepper.model.sink.Sink} and {@link org.opensearch.dataprepper.model.processor.Processor}.
  *
  * @param <T> The type of component.
  */

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/DataFlowComponent.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/DataFlowComponent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.parser;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Represents a part of the pipeline through which data flows. This includes
+ * {@link com.amazon.dataprepper.model.sink.Sink} and {@link com.amazon.dataprepper.model.processor.Processor}.
+ *
+ * @param <T> The type of component.
+ */
+public class DataFlowComponent<T> {
+    private final T component;
+    private final Set<String> routes;
+
+    DataFlowComponent(final T component, final Collection<String> routes) {
+        this.component = Objects.requireNonNull(component);
+        this.routes = new HashSet<>(Objects.requireNonNull(routes));
+    }
+
+    public T getComponent() {
+        return component;
+    }
+
+    public Set<String> getRoutes() {
+        return routes;
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
@@ -253,7 +253,6 @@ public class PipelineParser {
     }
 
     private Sink buildSinkOrConnector(final PluginSetting pluginSetting) {
-        // TODO: This will return an object which can perform routing.
         LOG.info("Building [{}] as sink component", pluginSetting.getName());
         final Optional<String> pipelineNameOptional = getPipelineNameIfPipelineType(pluginSetting);
         if (pipelineNameOptional.isPresent()) { //update to ifPresentOrElse when using JDK9

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/config/PipelineParserConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/config/PipelineParserConfiguration.java
@@ -9,6 +9,7 @@ import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
 import org.opensearch.dataprepper.parser.PipelineParser;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderProvider;
+import org.opensearch.dataprepper.pipeline.router.RouterFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,11 +21,13 @@ public class PipelineParserConfiguration {
             final DataPrepperArgs dataPrepperArgs,
             final PluginFactory pluginFactory,
             final PeerForwarderProvider peerForwarderProvider,
+            final RouterFactory routerFactory,
             final DataPrepperConfiguration dataPrepperConfiguration
             ) {
         return new PipelineParser(dataPrepperArgs.getPipelineConfigFileLocation(),
                 pluginFactory,
                 peerForwarderProvider,
+                routerFactory,
                 dataPrepperConfiguration);
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/PipelineConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/PipelineConfiguration.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.parser.model;
 
+import org.opensearch.dataprepper.model.configuration.ConditionalRoute;
 import org.opensearch.dataprepper.model.configuration.PipelineModel;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
@@ -13,9 +14,11 @@ import org.opensearch.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class PipelineConfiguration {
@@ -28,8 +31,10 @@ public class PipelineConfiguration {
     private final PluginSetting bufferPluginSetting;
     private final List<PluginSetting> processorPluginSettings;
     private final List<RoutedPluginSetting> sinkPluginSettings;
+
     private final Integer workers;
     private final Integer readBatchDelay;
+    private final Set<ConditionalRoute> routes;
 
     public PipelineConfiguration(final PipelineModel pipelineModel) {
         this.sourcePluginSetting = getSourceFromPluginModel(pipelineModel.getSource());
@@ -38,6 +43,7 @@ public class PipelineConfiguration {
         this.sinkPluginSettings = getSinksFromPluginModel(pipelineModel.getSinks());
         this.workers = getWorkersFromPipelineModel(pipelineModel);
         this.readBatchDelay = getReadBatchDelayFromPipelineModel(pipelineModel);
+        routes = new HashSet<>(pipelineModel.getRoutes());
     }
 
     public PluginSetting getSourcePluginSetting() {
@@ -54,6 +60,10 @@ public class PipelineConfiguration {
 
     public List<RoutedPluginSetting> getSinkPluginSettings() {
         return sinkPluginSettings;
+    }
+
+    public Set<ConditionalRoute> getRoutes() {
+        return routes;
     }
 
     public Integer getWorkers() {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/DataFlowComponentRouter.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/DataFlowComponentRouter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline.router;
+
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.parser.DataFlowComponent;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+/**
+ * Package-protected utility to route for a single {@link DataFlowComponent}. This is
+ * intended to help break apart {@link Router} for better testing.
+ */
+class DataFlowComponentRouter {
+
+    <C> void route(final Collection<Record> allRecords,
+                   final DataFlowComponent<C> dataFlowComponent,
+                   final Map<Record, Set<String>> recordsToRoutes,
+                   final BiConsumer<C, Collection<Record>> componentRecordsConsumer) {
+
+        final Collection<Record> recordsForComponent;
+        if (dataFlowComponent.getRoutes().isEmpty()) {
+            recordsForComponent = allRecords;
+        } else {
+            recordsForComponent = new ArrayList<>();
+            for (Record event : allRecords) {
+                final Set<String> routesForEvent = recordsToRoutes
+                        .getOrDefault(event, Collections.emptySet());
+
+                boolean routed = false;
+                for (String route : dataFlowComponent.getRoutes()) {
+                    if (routesForEvent.contains(route)) {
+                        routed = true;
+                        break;
+                    }
+                }
+
+                if (routed) {
+                    recordsForComponent.add(event);
+                }
+            }
+
+        }
+        componentRecordsConsumer.accept(dataFlowComponent.getComponent(), recordsForComponent);
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/DataFlowComponentRouter.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/DataFlowComponentRouter.java
@@ -27,7 +27,9 @@ class DataFlowComponentRouter {
                    final BiConsumer<C, Collection<Record>> componentRecordsConsumer) {
 
         final Collection<Record> recordsForComponent;
-        if (dataFlowComponent.getRoutes().isEmpty()) {
+        final Set<String> dataFlowComponentRoutes =  dataFlowComponent.getRoutes();
+
+        if (dataFlowComponentRoutes.isEmpty()) {
             recordsForComponent = allRecords;
         } else {
             recordsForComponent = new ArrayList<>();
@@ -35,19 +37,10 @@ class DataFlowComponentRouter {
                 final Set<String> routesForEvent = recordsToRoutes
                         .getOrDefault(event, Collections.emptySet());
 
-                boolean routed = false;
-                for (String route : dataFlowComponent.getRoutes()) {
-                    if (routesForEvent.contains(route)) {
-                        routed = true;
-                        break;
-                    }
-                }
-
-                if (routed) {
+                if (routesForEvent.stream().anyMatch(dataFlowComponentRoutes::contains)) {
                     recordsForComponent.add(event);
                 }
             }
-
         }
         componentRecordsConsumer.accept(dataFlowComponent.getComponent(), recordsForComponent);
     }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouteEventEvaluator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouteEventEvaluator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline.router;
+
+import org.opensearch.dataprepper.model.configuration.ConditionalRoute;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+class RouteEventEvaluator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RouteEventEvaluator.class);
+
+    private final ExpressionEvaluator<Boolean> evaluator;
+    private final Collection<ConditionalRoute> routes;
+
+    RouteEventEvaluator(final ExpressionEvaluator<Boolean> evaluator, final Collection<ConditionalRoute> routes) {
+        this.evaluator = evaluator;
+        this.routes = routes;
+    }
+
+    Map<Record, Set<String>> evaluateEventRoutes(final Collection<Record> records) {
+        final Map<Record, Set<String>> recordsToRoutes = new HashMap<>();
+
+        int nonEventRecords = 0;
+
+        for (Record record : records) {
+
+            final Object data = record.getData();
+
+            if(data instanceof Event) {
+
+                final Event event = (Event) data;
+
+                recordsToRoutes.put(record, new HashSet<>());
+
+                for (ConditionalRoute route : routes) {
+                    Boolean routed;
+                    try {
+                        routed = evaluator.evaluate(route.getCondition(), event);
+                    } catch (final Exception ex) {
+                        routed = false;
+                        LOG.error("Failed to evaluate route. This route will not be applied to any events.", ex);
+                    }
+                    if (routed) {
+                        recordsToRoutes
+                                .get(record)
+                                .add(route.getName());
+                    }
+                }
+            } else {
+                nonEventRecords++;
+                recordsToRoutes.put(record, Collections.emptySet());
+            }
+        }
+
+        if(nonEventRecords > 0) {
+            LOG.warn("Received {} records which are not events. These will have no routes applied.", nonEventRecords);
+        }
+
+        return recordsToRoutes;
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/Router.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/Router.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline.router;
+
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.parser.DataFlowComponent;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+/**
+ * Provides routing of event records over a collection of {@link DataFlowComponent} objects.
+ */
+public class Router {
+    private final RouteEventEvaluator routeEventEvaluator;
+    private final DataFlowComponentRouter dataFlowComponentRouter;
+
+    Router(final RouteEventEvaluator routeEventEvaluator, final DataFlowComponentRouter dataFlowComponentRouter) {
+        this.routeEventEvaluator = Objects.requireNonNull(routeEventEvaluator);
+        this.dataFlowComponentRouter = dataFlowComponentRouter;
+    }
+
+    public <C> void route(
+            final Collection<Record> allRecords,
+            final Collection<DataFlowComponent<C>> dataFlowComponents,
+            final BiConsumer<C, Collection<Record>> componentRecordsConsumer) {
+
+        Objects.requireNonNull(allRecords);
+        Objects.requireNonNull(dataFlowComponents);
+        Objects.requireNonNull(componentRecordsConsumer);
+
+        final Map<Record, Set<String>> recordsToRoutes = routeEventEvaluator.evaluateEventRoutes(allRecords);
+
+        for (DataFlowComponent<C> dataFlowComponent : dataFlowComponents) {
+            dataFlowComponentRouter.route(allRecords, dataFlowComponent, recordsToRoutes, componentRecordsConsumer);
+        }
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterAppConfig.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline.router;
+
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class RouterAppConfig {
+    @Bean
+    public RouterFactory routeEvaluatorFactory(final ExpressionEvaluator<Boolean> expressionEvaluator) {
+        return new RouterFactory(expressionEvaluator);
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline.router;
+
+import org.opensearch.dataprepper.model.configuration.ConditionalRoute;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+
+import java.util.Objects;
+import java.util.Set;
+
+public class RouterFactory {
+    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final DataFlowComponentRouter dataFlowComponentRouter;
+
+    RouterFactory(final ExpressionEvaluator<Boolean> expressionEvaluator) {
+        this.expressionEvaluator = Objects.requireNonNull(expressionEvaluator);
+        dataFlowComponentRouter = new DataFlowComponentRouter();
+    }
+
+    public Router createRouter(final Set<ConditionalRoute> routes) {
+        final RouteEventEvaluator routeEventEvaluator = new RouteEventEvaluator(expressionEvaluator, routes);
+        return new Router(routeEventEvaluator, dataFlowComponentRouter);
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/DataFlowComponentTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/DataFlowComponentTest.java
@@ -50,12 +50,12 @@ class DataFlowComponentTest {
     }
 
     @Test
-    void getComponent_returns_input_routes() {
+    void getRoutes_returns_input_routes() {
         assertThat(createObjectUnderTest().getRoutes(), equalTo(routes));
     }
 
     @Test
-    void getComponent_returns_input_routes_when_empty() {
+    void getRoutes_returns_input_routes_when_empty() {
         routes = Collections.emptySet();
         assertThat(createObjectUnderTest().getRoutes(), equalTo(routes));
     }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/DataFlowComponentTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/DataFlowComponentTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.parser;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+class DataFlowComponentTest {
+
+    private Object component;
+    private Set<String> routes;
+
+    @BeforeEach
+    void setUp() {
+        component = mock(Object.class);
+        routes = Collections.singleton(UUID.randomUUID().toString());
+    }
+
+    private DataFlowComponent createObjectUnderTest() {
+        return new DataFlowComponent(component, routes);
+    }
+
+    @Test
+    void constructor_throws_with_null_component() {
+        component = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void constructor_throws_with_null_routes() {
+        routes = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void getComponent_returns_input_component() {
+        assertThat(createObjectUnderTest().getComponent(), equalTo(component));
+    }
+
+    @Test
+    void getComponent_returns_input_routes() {
+        assertThat(createObjectUnderTest().getRoutes(), equalTo(routes));
+    }
+
+    @Test
+    void getComponent_returns_input_routes_when_empty() {
+        routes = Collections.emptySet();
+        assertThat(createObjectUnderTest().getRoutes(), equalTo(routes));
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
@@ -212,13 +212,15 @@ class PipelineParserTests {
     void parseConfiguration_with_routes_creates_correct_pipeline() {
         mockDataPrepperConfigurationAccesses();
         final PipelineParser pipelineParser =
-                createObjectUnderTest("src/test/resources/valid_multiple_sinks.yml");
+                createObjectUnderTest("src/test/resources/valid_multiple_sinks_with_routes.yml");
         final Map<String, Pipeline> pipelineMap = pipelineParser.parseConfiguration();
         assertThat(pipelineMap.keySet().size(), equalTo(3));
         verifyDataPrepperConfigurationAccesses(pipelineMap.keySet().size());
 
         final Pipeline entryPipeline = pipelineMap.get("entry-pipeline");
         assertThat(entryPipeline, notNullValue());
+        assertThat(entryPipeline.getSinks(), notNullValue());
+        assertThat(entryPipeline.getSinks().size(), equalTo(2));
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
@@ -17,6 +17,7 @@ import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderProvider;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderReceiveBuffer;
 import org.opensearch.dataprepper.pipeline.Pipeline;
+import org.opensearch.dataprepper.pipeline.router.RouterFactory;
 import org.opensearch.dataprepper.plugin.DefaultPluginFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +37,7 @@ import java.util.stream.Stream;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -48,6 +50,9 @@ import static org.mockito.Mockito.times;
 @ExtendWith(MockitoExtension.class)
 class PipelineParserTests {
     private PeerForwarderProvider peerForwarderProvider;
+
+    @Mock
+    private RouterFactory routerFactory;
 
     @Mock
     private DataPrepperConfiguration dataPrepperConfiguration;
@@ -76,11 +81,15 @@ class PipelineParserTests {
         verifyNoMoreInteractions(dataPrepperConfiguration);
     }
 
+    private PipelineParser createObjectUnderTest(final String pipelineConfigurationFileLocation) {
+        return new PipelineParser(pipelineConfigurationFileLocation, pluginFactory, peerForwarderProvider, routerFactory, dataPrepperConfiguration);
+    }
+
     @Test
     void parseConfiguration_with_multiple_valid_pipelines_creates_the_correct_pipelineMap() {
         mockDataPrepperConfigurationAccesses();
         final PipelineParser pipelineParser =
-                new PipelineParser(TestDataProvider.VALID_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+                createObjectUnderTest(TestDataProvider.VALID_MULTIPLE_PIPELINE_CONFIG_FILE);
         final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
         assertThat(actualPipelineMap.keySet(), equalTo(TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES));
         verifyDataPrepperConfigurationAccesses(actualPipelineMap.keySet().size());
@@ -89,7 +98,7 @@ class PipelineParserTests {
     @Test
     void parseConfiguration_with_invalid_root_pipeline_creates_empty_pipelinesMap() {
         final PipelineParser pipelineParser =
-                new PipelineParser(TestDataProvider.CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+                createObjectUnderTest(TestDataProvider.CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT);
         final Map<String, Pipeline> connectedPipelines = pipelineParser.parseConfiguration();
         assertThat(connectedPipelines.size(), equalTo(0));
     }
@@ -98,7 +107,7 @@ class PipelineParserTests {
     void parseConfiguration_with_incorrect_child_pipeline_returns_empty_pipelinesMap() {
         mockDataPrepperConfigurationAccesses();
         final PipelineParser pipelineParser =
-                new PipelineParser(TestDataProvider.CONNECTED_PIPELINE_CHILD_PIPELINE_INCORRECT, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+                createObjectUnderTest(TestDataProvider.CONNECTED_PIPELINE_CHILD_PIPELINE_INCORRECT);
         final Map<String, Pipeline> connectedPipelines = pipelineParser.parseConfiguration();
         assertThat(connectedPipelines.size(), equalTo(0));
         verifyDataPrepperConfigurationAccesses();
@@ -108,7 +117,7 @@ class PipelineParserTests {
     void parseConfiguration_with_a_single_pipeline_with_empty_source_settings_returns_that_pipeline() {
         mockDataPrepperConfigurationAccesses();
         final PipelineParser pipelineParser =
-                new PipelineParser(TestDataProvider.VALID_SINGLE_PIPELINE_EMPTY_SOURCE_PLUGIN_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+                createObjectUnderTest(TestDataProvider.VALID_SINGLE_PIPELINE_EMPTY_SOURCE_PLUGIN_FILE);
         final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
         assertThat(actualPipelineMap.keySet().size(), equalTo(1));
         verifyDataPrepperConfigurationAccesses();
@@ -117,7 +126,7 @@ class PipelineParserTests {
     @Test
     void parseConfiguration_with_cycles_in_multiple_pipelines_should_throw() {
         final PipelineParser pipelineParser =
-                new PipelineParser(TestDataProvider.CYCLE_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+                createObjectUnderTest(TestDataProvider.CYCLE_MULTIPLE_PIPELINE_CONFIG_FILE);
 
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(),
@@ -128,7 +137,7 @@ class PipelineParserTests {
     @Test
     void parseConfiguration_with_incorrect_source_mapping_in_multiple_pipelines_should_throw() {
         final PipelineParser pipelineParser =
-                new PipelineParser(TestDataProvider.INCORRECT_SOURCE_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+                createObjectUnderTest(TestDataProvider.INCORRECT_SOURCE_MULTIPLE_PIPELINE_CONFIG_FILE);
 
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(),
@@ -138,7 +147,7 @@ class PipelineParserTests {
     @Test
     void parseConfiguration_with_missing_pipeline_name_should_throw() {
         final PipelineParser pipelineParser =
-                new PipelineParser(TestDataProvider.MISSING_NAME_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+                createObjectUnderTest(TestDataProvider.MISSING_NAME_MULTIPLE_PIPELINE_CONFIG_FILE);
 
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(),
@@ -149,7 +158,7 @@ class PipelineParserTests {
     @Test
     void parseConfiguration_with_missing_pipeline_name_in_multiple_pipelines_should_throw() {
         final PipelineParser pipelineParser =
-                new PipelineParser(TestDataProvider.MISSING_PIPELINE_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+                createObjectUnderTest(TestDataProvider.MISSING_PIPELINE_MULTIPLE_PIPELINE_CONFIG_FILE);
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(), equalTo("Invalid configuration, no pipeline is defined with name test-pipeline-4"));
     }
@@ -158,7 +167,7 @@ class PipelineParserTests {
     void testMultipleSinks() {
         mockDataPrepperConfigurationAccesses();
         final PipelineParser pipelineParser =
-                new PipelineParser(TestDataProvider.VALID_MULTIPLE_SINKS_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+                createObjectUnderTest(TestDataProvider.VALID_MULTIPLE_SINKS_CONFIG_FILE);
         final Map<String, Pipeline> pipelineMap = pipelineParser.parseConfiguration();
         assertThat(pipelineMap.keySet().size(), equalTo(3));
         verifyDataPrepperConfigurationAccesses(pipelineMap.keySet().size());
@@ -168,7 +177,7 @@ class PipelineParserTests {
     void testMultipleProcessors() {
         mockDataPrepperConfigurationAccesses();
         final PipelineParser pipelineParser =
-                new PipelineParser(TestDataProvider.VALID_MULTIPLE_PROCESSERS_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+                createObjectUnderTest(TestDataProvider.VALID_MULTIPLE_PROCESSERS_CONFIG_FILE);
         final Map<String, Pipeline> pipelineMap = pipelineParser.parseConfiguration();
         assertThat(pipelineMap.keySet().size(), equalTo(3));
         verifyDataPrepperConfigurationAccesses(pipelineMap.keySet().size());
@@ -176,7 +185,7 @@ class PipelineParserTests {
 
     @Test
     void parseConfiguration_with_a_configuration_file_which_does_not_exist_should_throw() {
-        final PipelineParser pipelineParser = new PipelineParser("file_does_no_exist.yml", pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+        final PipelineParser pipelineParser = createObjectUnderTest("file_does_no_exist.yml");
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(), equalTo("Pipelines configuration file not found at file_does_no_exist.yml"));
     }
@@ -184,7 +193,7 @@ class PipelineParserTests {
     @Test
     void parseConfiguration_from_directory_with_multiple_files_creates_the_correct_pipelineMap() {
         mockDataPrepperConfigurationAccesses();
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.MULTI_FILE_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+        final PipelineParser pipelineParser = createObjectUnderTest(TestDataProvider.MULTI_FILE_PIPELINE_DIRECTOTRY);
         final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
         assertThat(actualPipelineMap.keySet(), equalTo(TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES));
         verifyDataPrepperConfigurationAccesses(actualPipelineMap.keySet().size());
@@ -193,15 +202,28 @@ class PipelineParserTests {
     @Test
     void parseConfiguration_from_directory_with_single_file_creates_the_correct_pipelineMap() {
         mockDataPrepperConfigurationAccesses();
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.SINGLE_FILE_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+        final PipelineParser pipelineParser = createObjectUnderTest(TestDataProvider.SINGLE_FILE_PIPELINE_DIRECTOTRY);
         final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
         assertThat(actualPipelineMap.keySet(), equalTo(TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES));
         verifyDataPrepperConfigurationAccesses(actualPipelineMap.keySet().size());
     }
 
     @Test
+    void parseConfiguration_with_routes_creates_correct_pipeline() {
+        mockDataPrepperConfigurationAccesses();
+        final PipelineParser pipelineParser =
+                createObjectUnderTest("src/test/resources/valid_multiple_sinks.yml");
+        final Map<String, Pipeline> pipelineMap = pipelineParser.parseConfiguration();
+        assertThat(pipelineMap.keySet().size(), equalTo(3));
+        verifyDataPrepperConfigurationAccesses(pipelineMap.keySet().size());
+
+        final Pipeline entryPipeline = pipelineMap.get("entry-pipeline");
+        assertThat(entryPipeline, notNullValue());
+    }
+
+    @Test
     void parseConfiguration_from_directory_with_no_yaml_files_should_throw() {
-        final PipelineParser pipelineParser = new PipelineParser(TestDataProvider.EMPTY_PIPELINE_DIRECTOTRY, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+        final PipelineParser pipelineParser = createObjectUnderTest(TestDataProvider.EMPTY_PIPELINE_DIRECTOTRY);
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(), equalTo(
                 String.format("Pipelines configuration file not found at %s", TestDataProvider.EMPTY_PIPELINE_DIRECTOTRY)));
@@ -211,8 +233,7 @@ class PipelineParserTests {
     void getPeerForwarderDrainDuration_peerForwarderConfigurationNotSet() {
         when(dataPrepperConfiguration.getPeerForwarderConfiguration()).thenReturn(null);
 
-        final PipelineParser pipelineParser =
-                new PipelineParser(TestDataProvider.VALID_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+        final PipelineParser pipelineParser = createObjectUnderTest(TestDataProvider.VALID_MULTIPLE_PIPELINE_CONFIG_FILE);
         final Duration result = pipelineParser.getPeerForwarderDrainTimeout(dataPrepperConfiguration);
         assertThat(result, is(Duration.ofSeconds(0)));
 
@@ -225,8 +246,7 @@ class PipelineParserTests {
         when(dataPrepperConfiguration.getPeerForwarderConfiguration()).thenReturn(peerForwarderConfiguration);
         when(peerForwarderConfiguration.getDrainTimeout()).thenReturn(expectedResult);
 
-        final PipelineParser pipelineParser =
-                new PipelineParser(TestDataProvider.VALID_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+        final PipelineParser pipelineParser = createObjectUnderTest(TestDataProvider.VALID_MULTIPLE_PIPELINE_CONFIG_FILE);
         final Duration result = pipelineParser.getPeerForwarderDrainTimeout(dataPrepperConfiguration);
         assertThat(result, is(expectedResult));
 
@@ -258,8 +278,7 @@ class PipelineParserTests {
         final Map<String, Map<String, PeerForwarderReceiveBuffer<Record<Event>>>> bufferMap = generateBufferMap(outerMapEntryCount, innerMapEntryCount);
         when(peerForwarderProvider.getPipelinePeerForwarderReceiveBufferMap()).thenReturn(bufferMap);
 
-        final PipelineParser pipelineParser =
-                new PipelineParser(TestDataProvider.VALID_MULTIPLE_PIPELINE_CONFIG_FILE, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+        final PipelineParser pipelineParser = createObjectUnderTest(TestDataProvider.VALID_MULTIPLE_PIPELINE_CONFIG_FILE);
         final List<Buffer> secondaryBuffers = pipelineParser.getSecondaryBuffers();
         assertThat(secondaryBuffers.size(), is(outerMapEntryCount * innerMapEntryCount));
         secondaryBuffers.forEach(retrievedBuffer -> assertThat(retrievedBuffer, is(buffer)));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/config/PipelineParserConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/config/PipelineParserConfigurationTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.parser.PipelineParser;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderProvider;
+import org.opensearch.dataprepper.pipeline.router.RouterFactory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -34,6 +35,9 @@ class PipelineParserConfigurationTest {
     private PeerForwarderProvider peerForwarderProvider;
 
     @Mock
+    private RouterFactory routerFactory;
+
+    @Mock
     private DataPrepperConfiguration dataPrepperConfiguration;
 
     @Test
@@ -42,7 +46,8 @@ class PipelineParserConfigurationTest {
         when(args.getPipelineConfigFileLocation())
                 .thenReturn(pipelineConfigFileLocation);
 
-        final PipelineParser pipelineParser = pipelineParserConfiguration.pipelineParser(args, pluginFactory, peerForwarderProvider, dataPrepperConfiguration);
+        final PipelineParser pipelineParser = pipelineParserConfiguration.pipelineParser(
+                args, pluginFactory, peerForwarderProvider, routerFactory, dataPrepperConfiguration);
 
         assertThat(pipelineParser, is(notNullValue()));
         verify(args).getPipelineConfigFileLocation();

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/DataFlowComponentRouterTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/DataFlowComponentRouterTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline.router;
+
+import org.opensearch.dataprepper.model.record.Record;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.parser.DataFlowComponent;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DataFlowComponentRouterTest {
+
+    @Mock
+    private DataFlowComponent<TestComponent> dataFlowComponent;
+    @Mock
+    private TestComponent testComponent;
+    @Mock
+    private BiConsumer<TestComponent, Collection<Record>> componentRecordsConsumer;
+
+    private Collection<Record> recordsIn;
+
+    private static class TestComponent {
+    }
+
+    @BeforeEach
+    void setUp() {
+        recordsIn = Collections.emptyList();
+        when(dataFlowComponent.getComponent()).thenReturn(testComponent);
+    }
+
+    private DataFlowComponentRouter createObjectUnderTest() {
+        return new DataFlowComponentRouter();
+    }
+
+    @Nested
+    class ComponentWithNoRoutes {
+
+        @BeforeEach
+        void setUp() {
+            when(dataFlowComponent.getRoutes()).thenReturn(Collections.emptySet());
+
+            recordsIn = IntStream.range(0, 10)
+                    .mapToObj(i -> mock(Record.class))
+                    .collect(Collectors.toList());
+        }
+
+        @Test
+        void route_all_Events_when_none_have_routes() {
+            final Map<Record, Set<String>> noMatchingRoutes = recordsIn.stream()
+                    .collect(Collectors.toMap(Function.identity(), r -> Collections.emptySet()));
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponent, noMatchingRoutes, componentRecordsConsumer);
+
+            verify(componentRecordsConsumer).accept(testComponent, recordsIn);
+        }
+
+
+        @Test
+        void route_all_Events_when_all_have_routes() {
+            final Map<Record, Set<String>> allWithRoutes = recordsIn.stream()
+                    .collect(Collectors.toMap(Function.identity(), r -> Collections.singleton(UUID.randomUUID().toString())));
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponent, allWithRoutes, componentRecordsConsumer);
+
+            verify(componentRecordsConsumer).accept(testComponent, recordsIn);
+        }
+
+        @Test
+        void route_when_no_records() {
+            recordsIn = Collections.emptyList();
+
+            final Map<Record, Set<String>> noMatchingRoutes = Collections.emptyMap();
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponent, noMatchingRoutes, componentRecordsConsumer);
+
+            verify(componentRecordsConsumer).accept(testComponent, recordsIn);
+        }
+
+    }
+
+    @Nested
+    class ComponentWithSingleRoute {
+
+        private String knownRoute;
+
+        @BeforeEach
+        void setUp() {
+            knownRoute = UUID.randomUUID().toString();
+            when(dataFlowComponent.getRoutes()).thenReturn(Collections.singleton(knownRoute));
+
+            recordsIn = IntStream.range(0, 10)
+                    .mapToObj(i -> mock(Record.class))
+                    .collect(Collectors.toList());
+        }
+
+        @Test
+        void route_no_Events_when_none_have_routes() {
+            final Map<Record, Set<String>> noMatchingRoutes = recordsIn.stream()
+                    .collect(Collectors.toMap(Function.identity(), r -> Collections.emptySet()));
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponent, noMatchingRoutes, componentRecordsConsumer);
+
+            verify(componentRecordsConsumer).accept(testComponent, Collections.emptyList());
+        }
+
+        @Test
+        void route_no_Events_when_none_have_matching_routes() {
+            final Map<Record, Set<String>> noMatchingRoutes = recordsIn.stream()
+                    .collect(Collectors.toMap(Function.identity(), r -> Collections.singleton(UUID.randomUUID().toString())));
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponent, noMatchingRoutes, componentRecordsConsumer);
+
+            verify(componentRecordsConsumer).accept(testComponent, Collections.emptyList());
+        }
+
+
+        @Test
+        void route_all_Events_when_all_have_matched_route() {
+            final Map<Record, Set<String>> allMatchingRoutes = recordsIn.stream()
+                    .collect(Collectors.toMap(Function.identity(), r -> Collections.singleton(knownRoute)));
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponent, allMatchingRoutes, componentRecordsConsumer);
+
+            verify(componentRecordsConsumer).accept(testComponent, recordsIn);
+        }
+
+        @Test
+        void route_matching_Events_when_some_have_matched_route() {
+            final Map<Record, Set<String>> someMatchingRoutes = new HashMap<>();
+            boolean applyRoute = false;
+            Collection<Record> expectedRecords = new ArrayList<>();
+            for (Record record : recordsIn) {
+                someMatchingRoutes.put(record, applyRoute ? Set.of(knownRoute, UUID.randomUUID().toString()) : Set.of(UUID.randomUUID().toString()) );
+                if(applyRoute)
+                    expectedRecords.add(record);
+
+                applyRoute = !applyRoute;
+            }
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponent, someMatchingRoutes, componentRecordsConsumer);
+
+            verify(componentRecordsConsumer).accept(testComponent, expectedRecords);
+        }
+
+        @Test
+        void route_when_no_records() {
+            recordsIn = Collections.emptyList();
+
+            final Map<Record, Set<String>> noMatchingRoutes = Collections.emptyMap();
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponent, noMatchingRoutes, componentRecordsConsumer);
+
+            verify(componentRecordsConsumer).accept(testComponent, recordsIn);
+        }
+
+    }
+
+    @Nested
+    class ComponentWithMultipleRoute {
+
+        private String knownRoute;
+
+        @BeforeEach
+        void setUp() {
+            knownRoute = UUID.randomUUID().toString();
+            when(dataFlowComponent.getComponent()).thenReturn(testComponent);
+            when(dataFlowComponent.getRoutes()).thenReturn(Set.of(UUID.randomUUID().toString(), knownRoute, UUID.randomUUID().toString()));
+
+            recordsIn = IntStream.range(0, 10)
+                    .mapToObj(i -> mock(Record.class))
+                    .collect(Collectors.toList());
+        }
+
+        @Test
+        void route_no_Events_when_none_have_routes() {
+            final Map<Record, Set<String>> noMatchingRoutes = recordsIn.stream()
+                    .collect(Collectors.toMap(Function.identity(), r -> Collections.emptySet()));
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponent, noMatchingRoutes, componentRecordsConsumer);
+
+            verify(componentRecordsConsumer).accept(testComponent, Collections.emptyList());
+        }
+
+        @Test
+        void route_no_Events_when_none_have_matching_routes() {
+            final Map<Record, Set<String>> noMatchingRoutes = recordsIn.stream()
+                    .collect(Collectors.toMap(Function.identity(), r -> Collections.singleton(UUID.randomUUID().toString())));
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponent, noMatchingRoutes, componentRecordsConsumer);
+
+            verify(componentRecordsConsumer).accept(testComponent, Collections.emptyList());
+        }
+
+
+        @Test
+        void route_all_Events_when_all_have_matched_route() {
+            final Map<Record, Set<String>> allMatchingRoutes = recordsIn.stream()
+                    .collect(Collectors.toMap(Function.identity(), r -> Collections.singleton(knownRoute)));
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponent, allMatchingRoutes, componentRecordsConsumer);
+
+            verify(componentRecordsConsumer).accept(testComponent, recordsIn);
+        }
+
+        @Test
+        void route_matching_Events_when_some_have_matched_route() {
+            final Map<Record, Set<String>> someMatchingRoutes = new HashMap<>();
+            boolean applyRoute = false;
+            Collection<Record> expectedRecords = new ArrayList<>();
+            for (Record record : recordsIn) {
+                someMatchingRoutes.put(record, applyRoute ? Set.of(knownRoute, UUID.randomUUID().toString()) : Set.of(UUID.randomUUID().toString()) );
+                if(applyRoute)
+                    expectedRecords.add(record);
+
+                applyRoute = !applyRoute;
+            }
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponent, someMatchingRoutes, componentRecordsConsumer);
+
+            verify(componentRecordsConsumer).accept(testComponent, expectedRecords);
+        }
+
+        @Test
+        void route_when_no_records() {
+            recordsIn = Collections.emptyList();
+
+            final Map<Record, Set<String>> noMatchingRoutes = Collections.emptyMap();
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponent, noMatchingRoutes, componentRecordsConsumer);
+
+            verify(componentRecordsConsumer).accept(testComponent, recordsIn);
+        }
+
+    }
+
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/RouteEventEvaluatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/RouteEventEvaluatorTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline.router;
+
+import org.opensearch.dataprepper.model.configuration.ConditionalRoute;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasKey;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RouteEventEvaluatorTest {
+
+    @Mock
+    private ExpressionEvaluator<Boolean> evaluator;
+    private List<ConditionalRoute> routes;
+
+    private RouteEventEvaluator createObjectUnderTest() {
+        return new RouteEventEvaluator(evaluator, routes);
+    }
+
+    @Nested
+    class WithEmptyRoutes {
+        @BeforeEach
+        void setUp() {
+            routes = Collections.emptyList();
+        }
+
+        @AfterEach
+        void verifyNoEvaluation() {
+            verifyNoInteractions(evaluator);
+        }
+
+        @Test
+        void evaluateEventRoutes_with_empty_Records_returns_empty_map() {
+            final Map<Record, Set<String>> recordsToRoutes = createObjectUnderTest().evaluateEventRoutes(Collections.emptyList());
+
+            assertThat(recordsToRoutes, notNullValue());
+            assertThat(recordsToRoutes, is(anEmptyMap()));
+        }
+
+        @Test
+        void evaluateEventRoutes_with_Event_Records_returns_map_with_all_empty_routes() {
+            final Collection<Record> records = createEventRecords();
+            final Map<Record, Set<String>> recordsToRoutes = createObjectUnderTest().evaluateEventRoutes(records);
+
+            assertThat(recordsToRoutes, notNullValue());
+
+            assertThat(recordsToRoutes.size(), equalTo(records.size()));
+            for (Record record : records) {
+                assertThat(recordsToRoutes, hasKey(record));
+            }
+
+            for (Set<String> routes : recordsToRoutes.values()) {
+                assertThat(routes, is(empty()));
+            }
+        }
+
+        @Test
+        void evaluateEventRoutes_with_non_Event_Records_returns_map_with_all_empty_routes() {
+            final Collection<Record> records = createNonEventRecords();
+            final Map<Record, Set<String>> recordsToRoutes = createObjectUnderTest().evaluateEventRoutes(records);
+
+            assertThat(recordsToRoutes, notNullValue());
+
+            assertThat(recordsToRoutes.size(), equalTo(records.size()));
+            for (Record record : records) {
+                assertThat(recordsToRoutes, hasKey(record));
+            }
+
+            for (Set<String> routes : recordsToRoutes.values()) {
+                assertThat(routes, is(empty()));
+            }
+        }
+    }
+
+    @Nested
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    class WithRoutes {
+        private Set<String> allRouteNames;
+
+        @BeforeEach
+        void setUp() {
+            routes = IntStream.range(0, 3)
+                    .mapToObj(i -> mock(ConditionalRoute.class))
+                    .peek(r -> when(r.getCondition()).thenReturn(UUID.randomUUID().toString()))
+                    .peek(r -> when(r.getName()).thenReturn(UUID.randomUUID().toString()))
+                    .collect(Collectors.toList());
+
+            allRouteNames = routes
+                    .stream()
+                    .map(ConditionalRoute::getName)
+                    .collect(Collectors.toSet());
+        }
+
+        @Test
+        void evaluateEventRoutes_with_empty_Records_returns_empty_map() {
+            final Map<Record, Set<String>> recordsToRoutes = createObjectUnderTest().evaluateEventRoutes(Collections.emptyList());
+
+            assertThat(recordsToRoutes, notNullValue());
+            assertThat(recordsToRoutes, is(anEmptyMap()));
+
+            verifyNoInteractions(evaluator);
+        }
+
+
+        @Test
+        void evaluateEventRoutes_with_non_Event_Records_returns_map_with_all_empty_routes() {
+            final Collection<Record> records = createNonEventRecords();
+            final Map<Record, Set<String>> recordsToRoutes = createObjectUnderTest().evaluateEventRoutes(records);
+
+            assertThat(recordsToRoutes, notNullValue());
+
+            assertThat(recordsToRoutes.size(), equalTo(records.size()));
+            for (Record record : records) {
+                assertThat(recordsToRoutes, hasKey(record));
+            }
+
+            for (Set<String> routes : recordsToRoutes.values()) {
+                assertThat(routes, is(empty()));
+            }
+
+            verifyNoInteractions(evaluator);
+        }
+
+        @Test
+        void evaluateEventRoutes_with_Event_Records_returns_map_with_matching_routes() {
+            final List<Record> records = createEventRecords();
+
+            final Record recordMatchingAllRoutes = records.get(1);
+            final Event eventMatchingAllRoutes = (Event) records.get(1).getData();
+            for (ConditionalRoute route : routes) {
+                when(evaluator.evaluate(route.getCondition(), eventMatchingAllRoutes))
+                        .thenReturn(true);
+
+                for (Record record : records) {
+                    if(recordMatchingAllRoutes == record)
+                        continue;
+
+                    when(evaluator.evaluate(route.getCondition(), (Event) record.getData()))
+                            .thenReturn(false);
+                }
+            }
+
+            final Map<Record, Set<String>> recordsToRoutes = createObjectUnderTest().evaluateEventRoutes(records);
+
+            assertThat(recordsToRoutes, notNullValue());
+
+            assertThat(recordsToRoutes.size(), equalTo(records.size()));
+            for (Record record : records) {
+                assertThat(recordsToRoutes, hasKey(record));
+            }
+
+            final Set<String> actualRoutes = recordsToRoutes.get(recordMatchingAllRoutes);
+            assertThat(actualRoutes.size(), equalTo(routes.size()));
+            assertThat(actualRoutes, equalTo(allRouteNames));
+
+            for (Map.Entry<Record, Set<String>> recordSetEntry : recordsToRoutes.entrySet()) {
+                if(recordSetEntry.getKey() == recordMatchingAllRoutes)
+                    continue;
+
+                assertThat(recordSetEntry.getValue(), is(empty()));
+            }
+        }
+
+        @Test
+        void evaluateEventRoutes_with_Event_Records_returns_map_with_matching_routes_excludes_exceptions() {
+            final List<Record> records = createEventRecords();
+
+            final Record recordMatchingAllRoutes = records.get(1);
+            final Event eventMatchingAllRoutes = (Event) records.get(1).getData();
+            for (ConditionalRoute route : routes) {
+                when(evaluator.evaluate(route.getCondition(), eventMatchingAllRoutes))
+                        .thenReturn(true);
+
+                for (Record record : records) {
+                    if(recordMatchingAllRoutes == record)
+                        continue;
+
+                    when(evaluator.evaluate(route.getCondition(), (Event) record.getData()))
+                            .thenThrow(RuntimeException.class);
+                }
+            }
+
+            final Map<Record, Set<String>> recordsToRoutes = createObjectUnderTest().evaluateEventRoutes(records);
+
+            assertThat(recordsToRoutes, notNullValue());
+
+            assertThat(recordsToRoutes.size(), equalTo(records.size()));
+            for (Record record : records) {
+                assertThat(recordsToRoutes, hasKey(record));
+            }
+
+            final Set<String> actualRoutes = recordsToRoutes.get(recordMatchingAllRoutes);
+            assertThat(actualRoutes.size(), equalTo(routes.size()));
+            assertThat(actualRoutes, equalTo(allRouteNames));
+
+            for (Map.Entry<Record, Set<String>> recordSetEntry : recordsToRoutes.entrySet()) {
+                if(recordSetEntry.getKey() == recordMatchingAllRoutes)
+                    continue;
+
+                assertThat(recordSetEntry.getValue(), is(empty()));
+            }
+        }
+
+    }
+
+    private List<Record> createEventRecords() {
+        return createRecords(() -> mock(Event.class));
+    }
+
+    private List<Record> createNonEventRecords() {
+        return createRecords(() -> UUID.randomUUID().toString());
+    }
+
+    private List<Record> createRecords(final Supplier<Object> dataSupplier) {
+        return IntStream.range(0, 3)
+                .mapToObj(i -> mock(Record.class))
+                .peek(r -> when(r.getData()).thenReturn(dataSupplier.get()))
+                .collect(Collectors.toList());
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/RouterFactoryTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/RouterFactoryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline.router;
+
+import org.opensearch.dataprepper.model.configuration.ConditionalRoute;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class RouterFactoryTest {
+
+    @Mock
+    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private Set<ConditionalRoute> routes;
+
+    @BeforeEach
+    void setUp() {
+        final ConditionalRoute conditionalRoute = mock(ConditionalRoute.class);
+        routes = Collections.singleton(conditionalRoute);
+    }
+
+    private RouterFactory createObjectUnderTest() {
+        return new RouterFactory(expressionEvaluator);
+    }
+
+    @Test
+    void constructor_throws_with_null_expressionEvaluator() {
+        expressionEvaluator = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void createRouter_returns_new_Router() {
+        final Router router = createObjectUnderTest().createRouter(routes);
+
+        assertThat(router, notNullValue());
+    }
+
+    @Test
+    void createRouter_returns_new_Router_with_empty_routes() {
+        routes = Collections.emptySet();
+        final Router router = createObjectUnderTest().createRouter(routes);
+
+        assertThat(router, notNullValue());
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/RouterTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/RouterTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline.router;
+
+import org.opensearch.dataprepper.model.record.Record;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.parser.DataFlowComponent;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RouterTest {
+
+    @Mock
+    private RouteEventEvaluator routeEventEvaluator;
+
+    @Mock
+    private DataFlowComponentRouter dataFlowComponentRouter;
+    private Collection<DataFlowComponent<TestComponent>> dataFlowComponents;
+    @Mock
+    private BiConsumer<TestComponent, Collection<Record>> componentRecordsConsumer;
+
+    private Collection<Record> recordsIn;
+
+    private static class TestComponent {
+    }
+
+    @BeforeEach
+    void setUp() {
+        recordsIn = Collections.emptyList();
+        dataFlowComponents = Collections.emptyList();
+    }
+
+    private Router createObjectUnderTest() {
+        return new Router(routeEventEvaluator, dataFlowComponentRouter);
+    }
+
+    @Test
+    void constructor_throws_with_null_routeEventEvaluator() {
+        routeEventEvaluator = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void route_throws_if_records_is_null() {
+        final Router objectUnderTest = createObjectUnderTest();
+
+        assertThrows(NullPointerException.class, () -> objectUnderTest.route(null, dataFlowComponents, componentRecordsConsumer));
+    }
+
+    @Test
+    void route_throws_if_dataFlowComponents_is_null() {
+        final Router objectUnderTest = createObjectUnderTest();
+
+        assertThrows(NullPointerException.class, () -> objectUnderTest.route(recordsIn, null, componentRecordsConsumer));
+    }
+
+    @Test
+    void route_throws_if_componentRecordsConsumer_is_null() {
+        final Router objectUnderTest = createObjectUnderTest();
+
+        assertThrows(NullPointerException.class, () -> objectUnderTest.route(recordsIn, dataFlowComponents, null));
+    }
+
+    @Nested
+    class WithEmptyRecords {
+
+        private Map<Record, Set<String>> recordsToRoutes;
+
+        @BeforeEach
+        void setUp() {
+            recordsIn = Collections.emptyList();
+            dataFlowComponents = Collections.emptyList();
+
+            recordsToRoutes = Collections.singletonMap(
+                    mock(Record.class), Collections.singleton(UUID.randomUUID().toString())
+            );
+            when(routeEventEvaluator.evaluateEventRoutes(recordsIn)).thenReturn(recordsToRoutes);
+        }
+
+        @Test
+        void route_with_empty_DataFlowComponent() {
+            createObjectUnderTest().route(recordsIn, dataFlowComponents, componentRecordsConsumer);
+        }
+
+        @Test
+        void route_with_single_DataFlowComponent() {
+            DataFlowComponent<TestComponent> dataFlowComponent = mock(DataFlowComponent.class);
+            dataFlowComponents = Collections.singletonList(dataFlowComponent);
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponents, componentRecordsConsumer);
+
+            verify(dataFlowComponentRouter).route(recordsIn, dataFlowComponent, recordsToRoutes, componentRecordsConsumer);
+        }
+
+        @Test
+        void route_with_multiple_DataFlowComponents() {
+
+            dataFlowComponents = new ArrayList<>();
+            for (int i = 0; i < 5; i++) {
+                final DataFlowComponent dataFlowComponent = mock(DataFlowComponent.class);
+                dataFlowComponents.add(dataFlowComponent);
+            }
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponents, componentRecordsConsumer);
+
+            for (DataFlowComponent<TestComponent> dataFlowComponent : dataFlowComponents) {
+                verify(dataFlowComponentRouter).route(recordsIn, dataFlowComponent, recordsToRoutes, componentRecordsConsumer);
+            }
+        }
+    }
+
+    @Nested
+    class WithRecords {
+
+        private Map<Record, Set<String>> recordsToRoutes;
+
+        @BeforeEach
+        void setUp() {
+            recordsIn = IntStream.range(0, 10)
+                    .mapToObj(i -> mock(Record.class))
+                    .collect(Collectors.toList());
+            ;
+            dataFlowComponents = Collections.emptyList();
+
+            recordsToRoutes = recordsIn
+                    .stream()
+                    .collect(Collectors.toMap(Function.identity(), r -> Collections.singleton(UUID.randomUUID().toString())));
+            when(routeEventEvaluator.evaluateEventRoutes(recordsIn)).thenReturn(recordsToRoutes);
+        }
+
+        @Test
+        void route_with_single_DataFlowComponent() {
+            DataFlowComponent<TestComponent> dataFlowComponent = mock(DataFlowComponent.class);
+            dataFlowComponents = Collections.singletonList(dataFlowComponent);
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponents, componentRecordsConsumer);
+
+            verify(dataFlowComponentRouter).route(recordsIn, dataFlowComponent, recordsToRoutes, componentRecordsConsumer);
+        }
+
+        @Test
+        void route_with_multiple_DataFlowComponents() {
+
+            dataFlowComponents = new ArrayList<>();
+            for (int i = 0; i < 5; i++) {
+                final DataFlowComponent dataFlowComponent = mock(DataFlowComponent.class);
+                dataFlowComponents.add(dataFlowComponent);
+            }
+
+            createObjectUnderTest().route(recordsIn, dataFlowComponents, componentRecordsConsumer);
+
+            for (DataFlowComponent<TestComponent> dataFlowComponent : dataFlowComponents) {
+                verify(dataFlowComponentRouter).route(recordsIn, dataFlowComponent, recordsToRoutes, componentRecordsConsumer);
+            }
+        }
+
+    }
+}

--- a/data-prepper-core/src/test/resources/valid_multiple_sinks_with_routes.yml
+++ b/data-prepper-core/src/test/resources/valid_multiple_sinks_with_routes.yml
@@ -1,0 +1,31 @@
+entry-pipeline:
+  source:
+    random:
+  route:
+    - "raw" : "/value == raw"
+    - "service" : "/value == service"
+  sink:
+    - pipeline:
+        name: "raw-pipeline"
+    - pipeline:
+        name: "service-map-pipeline"
+raw-pipeline:
+  source:
+    pipeline:
+      name: "entry-pipeline"
+  processor:
+    - string_converter:
+        upper_case: true
+  sink:
+    - file:
+        someProperty: "someValue"
+service-map-pipeline:
+  source:
+    pipeline:
+      name: "entry-pipeline"
+  processor:
+    - string_converter:
+        upper_case: true
+  sink:
+    - file:
+        someProperty: "someValue"

--- a/data-prepper-core/src/test/resources/valid_multiple_sinks_with_routes.yml
+++ b/data-prepper-core/src/test/resources/valid_multiple_sinks_with_routes.yml
@@ -7,8 +7,12 @@ entry-pipeline:
   sink:
     - pipeline:
         name: "raw-pipeline"
+        routes:
+          - raw
     - pipeline:
         name: "service-map-pipeline"
+        routes:
+          - service
 raw-pipeline:
   source:
     pipeline:


### PR DESCRIPTION
### Description

This PR implements conditional routing.

I've rebased this PR to include #1840 and now it works with multiple processor threads. ~Note that this only works for single-threaded pipelines due to #1189.~

### Issues Resolved

Resolves #1337 
 
### Testing Information

Sample Pipeline:

```
simple-test-pipeline:
  workers: 1
  delay: "5000"
  source:
    file:
      path: /usr/share/data-prepper-file-source/test-in.txt
      record_type: event
      format: json
  route:
    - alpha: '/value == "a"'
    - beta: '/value == "b"'
    - sigma: '/value == "s"'
  sink:
    - file:
        path: /usr/share/data-prepper-file-source/out-alpha.txt
        routes:
          - alpha
    - file:
        path: /usr/share/data-prepper-file-source/out-beta.txt
        routes:
          - beta
    - file:
        path: /usr/share/data-prepper-file-source/out-should-be-empty.txt
        routes:
          - sigma
    - file:
        path: /usr/share/data-prepper-file-source/out-alpha-beta.txt
        routes:
          - alpha
          - beta
    - file:
        path: /usr/share/data-prepper-file-source/out-all.txt
```

File Input Source:

```
cat file-source/test-in.txt
{"value":"a", "other":"x", "sequence" : 1}
{"value":"a", "other":"x", "sequence" : 2}
{"value":"b", "sequence" : 3}
{"value":"b", "sequence" : 4}
{"value":"c", "sequence" : 5}
{"value":"d", "sequence" : 6}
{"value":"b", "sequence" : 7}
{"value":"a", "sequence" : 8}
```

Run with Docker:

```
docker run --name data-prepper -p 4900:4900 \
  -v ${PWD}/pipelines.yaml:/usr/share/data-prepper/pipelines/pipelines.yaml \
  -v ${PWD}/file-source:/usr/share/data-prepper-file-source/ \
  opensearch-data-prepper:2.0.0-SNAPSHOT
```

Results:

```
tail -n +1 file-source/out-*
==> file-source/out-all.txt <==
{"value":"a","other":"x","sequence":1}
{"value":"a","other":"x","sequence":2}
{"value":"b","sequence":3}
{"value":"b","sequence":4}
{"value":"c","sequence":5}
{"value":"d","sequence":6}
{"value":"b","sequence":7}
{"value":"a","sequence":8}

==> file-source/out-alpha-beta.txt <==
{"value":"a","other":"x","sequence":1}
{"value":"a","other":"x","sequence":2}
{"value":"b","sequence":3}
{"value":"b","sequence":4}
{"value":"b","sequence":7}
{"value":"a","sequence":8}

==> file-source/out-alpha.txt <==
{"value":"a","other":"x","sequence":1}
{"value":"a","other":"x","sequence":2}
{"value":"a","sequence":8}

==> file-source/out-beta.txt <==
{"value":"b","sequence":3}
{"value":"b","sequence":4}
{"value":"b","sequence":7}

==> file-source/out-should-be-empty.txt <==

```

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
