### PR TITLE
Updated ssl to true by default for core peer forwarder

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
@@ -8,7 +8,6 @@ package org.opensearch.dataprepper.peerforwarder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.linecorp.armeria.server.Server;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
 import org.opensearch.dataprepper.peerforwarder.certificate.CertificateProviderFactory;
@@ -112,19 +111,12 @@ class PeerForwarderAppConfig {
                 certificateProviderFactory, peerForwarderHttpService);
     }
 
-    @Bean(name="peerForwarderHttpServer")
-    public Server server(
-            final PeerForwarderHttpServerProvider peerForwarderHttpServerProvider
-    ) {
-        return peerForwarderHttpServerProvider.get();
-    }
-
     @Bean
     public PeerForwarderServer peerForwarderServer(
-            @Qualifier("peerForwarderHttpServer") final Server peerForwarderServer,
+            final PeerForwarderHttpServerProvider peerForwarderHttpServerProvider,
             final PeerForwarderConfiguration peerForwarderConfiguration,
             final PeerForwarderProvider peerForwarderProvider) {
-        return new PeerForwarderServerProxy(peerForwarderConfiguration, peerForwarderServer, peerForwarderProvider);
+        return new PeerForwarderServerProxy(peerForwarderHttpServerProvider, peerForwarderConfiguration, peerForwarderProvider);
     }
 
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
@@ -24,6 +24,8 @@ import java.util.Map;
 public class PeerForwarderConfiguration {
     public static final String DEFAULT_PEER_FORWARDING_URI = "/event/forward";
     public static final Duration DEFAULT_DRAIN_TIMEOUT = Duration.ofSeconds(10L);
+    public static final String DEFAULT_CERTIFICATE_FILE_PATH = "config/default_certificate.pem";
+    public static final String DEFAULT_PRIVATE_KEY_FILE_PATH = "config/default_private_key.pem";
     private static final String S3_PREFIX = "s3://";
 
     private Integer serverPort = 4994;
@@ -32,8 +34,8 @@ public class PeerForwarderConfiguration {
     private Integer maxConnectionCount = 500;
     private Integer maxPendingRequests = 1024;
     private boolean ssl = true;
-    private String sslCertificateFile;
-    private String sslKeyFile;
+    private String sslCertificateFile = DEFAULT_CERTIFICATE_FILE_PATH;
+    private String sslKeyFile = DEFAULT_PRIVATE_KEY_FILE_PATH;
     private boolean sslDisableVerification = false;
     private boolean sslFingerprintVerificationOnly = false;
     private ForwardingAuthentication authentication = ForwardingAuthentication.UNAUTHENTICATED;
@@ -259,22 +261,14 @@ public class PeerForwarderConfiguration {
     }
 
     private void setSslCertificateFile(final String sslCertificateFile) {
-        if (ssl && !useAcmCertificateForSsl) {
-            if (StringUtils.isNotBlank(sslCertificateFile)) {
-                this.sslCertificateFile = sslCertificateFile;
-            } else {
-                throw new IllegalArgumentException("SSL certificate file path must be a valid file path when ssl is enabled and not using ACM.");
-            }
+        if (ssl && !useAcmCertificateForSsl && sslCertificateFile != null) {
+            this.sslCertificateFile = sslCertificateFile;
         }
     }
 
     private void setSslKeyFile(final String sslKeyFile) {
-        if (ssl && !useAcmCertificateForSsl) {
-            if (StringUtils.isNotBlank(sslKeyFile)) {
-                this.sslKeyFile = sslKeyFile;
-            } else {
-                throw new IllegalArgumentException("SSL key file path must be a valid file path when ssl is enabled and not using ACM.");
-            }
+        if (ssl && !useAcmCertificateForSsl && sslKeyFile != null) {
+            this.sslKeyFile = sslKeyFile;
         }
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
@@ -31,7 +31,7 @@ public class PeerForwarderConfiguration {
     private Integer serverThreadCount = 200;
     private Integer maxConnectionCount = 500;
     private Integer maxPendingRequests = 1024;
-    private boolean ssl = false;
+    private boolean ssl = true;
     private String sslCertificateFile;
     private String sslKeyFile;
     private boolean sslDisableVerification = false;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxy.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxy.java
@@ -10,23 +10,24 @@ import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderProvider;
 
 public class PeerForwarderServerProxy implements PeerForwarderServer {
+    private final PeerForwarderHttpServerProvider peerForwarderHttpServerProvider;
     private final PeerForwarderConfiguration peerForwarderConfiguration;
-    private final Server server;
     private final PeerForwarderProvider peerForwarderProvider;
 
     private PeerForwarderServer peerForwarderServer;
 
-    public PeerForwarderServerProxy(final PeerForwarderConfiguration peerForwarderConfiguration,
-                                    final Server server,
+    public PeerForwarderServerProxy(final PeerForwarderHttpServerProvider peerForwarderHttpServerProvider,
+                                    final PeerForwarderConfiguration peerForwarderConfiguration,
                                     final PeerForwarderProvider peerForwarderProvider) {
+        this.peerForwarderHttpServerProvider = peerForwarderHttpServerProvider;
         this.peerForwarderConfiguration = peerForwarderConfiguration;
-        this.server = server;
         this.peerForwarderProvider = peerForwarderProvider;
     }
 
     @Override
     public void start() {
         if (peerForwarderProvider.isPeerForwardingRequired()) {
+            final Server server = peerForwarderHttpServerProvider.get();
             peerForwarderServer = new RemotePeerForwarderServer(peerForwarderConfiguration, server);
         }
         else {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
@@ -86,7 +86,6 @@ public class TestDataProvider {
     public static final String INVALID_PEER_FORWARDER_WITH_CLOUD_MAP_WITHOUT_NAMESPACE_NAME_CONFIG_FILE = "src/test/resources/invalid_peer_forwarder_with_cloud_map_without_namespace_name_config.yml";
     public static final String INVALID_PEER_FORWARDER_WITH_CLOUD_MAP_WITHOUT_REGION_CONFIG_FILE = "src/test/resources/invalid_peer_forwarder_with_cloud_map_without_region_config.yml";
     public static final String INVALID_PEER_FORWARDER_WITH_DNS_WITHOUT_DOMAIN_NAME_CONFIG_FILE = "src/test/resources/invalid_peer_forwarder_with_dns_without_domain_name_config.yml";
-    public static final String INVALID_PEER_FORWARDER_WITH_SSL = "src/test/resources/invalid_peer_forwarder_with_ssl.yml";
     public static final String INVALID_PEER_FORWARDER_WITH_BAD_DRAIN_TIMEOUT = "src/test/resources/invalid_peer_forwarder_with_bad_drain_timeout.yml";
     public static final String INVALID_PEER_FORWARDER_WITH_NEGATIVE_DRAIN_TIMEOUT = "src/test/resources/invalid_peer_forwarder_with_negative_drain_timeout.yml";
     public static final String VALID_PEER_FORWARDER_WITH_ACM_SSL_CONFIG_FILE = "src/test/resources/valid_peer_forwarder_config_with_acm_ssl.yml";

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfigIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfigIT.java
@@ -14,6 +14,8 @@ import org.springframework.context.annotation.Configuration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration.DEFAULT_CERTIFICATE_FILE_PATH;
+import static org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration.DEFAULT_PRIVATE_KEY_FILE_PATH;
 
 class PeerForwarderAppConfigIT {
 
@@ -36,8 +38,8 @@ class PeerForwarderAppConfigIT {
         assertThat(objectUnderTest.getMaxConnectionCount(), equalTo(500));
         assertThat(objectUnderTest.getMaxPendingRequests(), equalTo(1024));
         assertThat(objectUnderTest.isSsl(), equalTo(true));
-        assertThat(objectUnderTest.getSslCertificateFile(), equalTo(null));
-        assertThat(objectUnderTest.getSslKeyFile(), equalTo(null));
+        assertThat(objectUnderTest.getSslCertificateFile(), equalTo(DEFAULT_CERTIFICATE_FILE_PATH));
+        assertThat(objectUnderTest.getSslKeyFile(), equalTo(DEFAULT_PRIVATE_KEY_FILE_PATH));
         assertThat(objectUnderTest.getDiscoveryMode(), equalTo(DiscoveryMode.LOCAL_NODE));
         assertThat(objectUnderTest.getClientThreadCount(), equalTo(200));
         assertThat(objectUnderTest.getBatchSize(), equalTo(48));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfigIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfigIT.java
@@ -35,7 +35,7 @@ class PeerForwarderAppConfigIT {
         assertThat(objectUnderTest.getServerThreadCount(), equalTo(200));
         assertThat(objectUnderTest.getMaxConnectionCount(), equalTo(500));
         assertThat(objectUnderTest.getMaxPendingRequests(), equalTo(1024));
-        assertThat(objectUnderTest.isSsl(), equalTo(false));
+        assertThat(objectUnderTest.isSsl(), equalTo(true));
         assertThat(objectUnderTest.getSslCertificateFile(), equalTo(null));
         assertThat(objectUnderTest.getSslKeyFile(), equalTo(null));
         assertThat(objectUnderTest.getDiscoveryMode(), equalTo(DiscoveryMode.LOCAL_NODE));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
@@ -159,7 +159,6 @@ class PeerForwarderConfigurationTest {
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_PORT_CONFIG_FILE,
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_THREAD_COUNT_CONFIG_FILE,
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_CONNECTION_CONFIG_FILE,
-//            TestDataProvider.INVALID_PEER_FORWARDER_WITH_SSL_CONFIG_FILE
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_DISCOVERY_MODE_CONFIG_FILE,
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_BUFFER_SIZE_CONFIG_FILE,
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_BATCH_SIZE_CONFIG_FILE,
@@ -169,7 +168,6 @@ class PeerForwarderConfigurationTest {
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_CLOUD_MAP_WITHOUT_NAMESPACE_NAME_CONFIG_FILE,
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_CLOUD_MAP_WITHOUT_REGION_CONFIG_FILE,
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_DNS_WITHOUT_DOMAIN_NAME_CONFIG_FILE,
-//            TestDataProvider.INVALID_PEER_FORWARDER_WITH_SSL
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_NEGATIVE_DRAIN_TIMEOUT,
             "src/test/resources/invalid_peer_forwarder_config_with_many_authentication.yml",
             "src/test/resources/invalid_peer_forwarder_config_with_mutual_tls_not_ssl.yml"

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration.DEFAULT_PRIVATE_KEY_FILE_PATH;
 
 class PeerForwarderConfigurationTest {
     private static SimpleModule simpleModule = new SimpleModule().addDeserializer(Duration.class, new DataPrepperDurationDeserializer());
@@ -132,7 +133,7 @@ class PeerForwarderConfigurationTest {
     }
 
     @Test
-    void testInvalidPeerForwarderConfig_with_bad_DrainTimeout() throws IOException {
+    void testInvalidPeerForwarderConfig_with_bad_DrainTimeout() {
         assertThrows(JsonMappingException.class, () -> makeConfig(TestDataProvider.INVALID_PEER_FORWARDER_WITH_BAD_DRAIN_TIMEOUT));
     }
 
@@ -144,12 +145,21 @@ class PeerForwarderConfigurationTest {
         assertThat(peerForwarderConfiguration.isUseAcmCertificateForSsl(), equalTo(true));
     }
 
+    @Test
+    void test_cert_paths_with_ssl() throws IOException {
+        final PeerForwarderConfiguration peerForwarderConfiguration = makeConfig(TestDataProvider.INVALID_PEER_FORWARDER_WITH_SSL_CONFIG_FILE);
+
+        assertThat(peerForwarderConfiguration.isSsl(), equalTo(true));
+        assertThat(peerForwarderConfiguration.getSslCertificateFile(), equalTo("invalid_path"));
+        assertThat(peerForwarderConfiguration.getSslKeyFile(), equalTo(DEFAULT_PRIVATE_KEY_FILE_PATH));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_PORT_CONFIG_FILE,
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_THREAD_COUNT_CONFIG_FILE,
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_CONNECTION_CONFIG_FILE,
-            TestDataProvider.INVALID_PEER_FORWARDER_WITH_SSL_CONFIG_FILE,
+//            TestDataProvider.INVALID_PEER_FORWARDER_WITH_SSL_CONFIG_FILE
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_DISCOVERY_MODE_CONFIG_FILE,
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_BUFFER_SIZE_CONFIG_FILE,
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_BATCH_SIZE_CONFIG_FILE,
@@ -159,7 +169,7 @@ class PeerForwarderConfigurationTest {
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_CLOUD_MAP_WITHOUT_NAMESPACE_NAME_CONFIG_FILE,
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_CLOUD_MAP_WITHOUT_REGION_CONFIG_FILE,
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_DNS_WITHOUT_DOMAIN_NAME_CONFIG_FILE,
-            TestDataProvider.INVALID_PEER_FORWARDER_WITH_SSL,
+//            TestDataProvider.INVALID_PEER_FORWARDER_WITH_SSL
             TestDataProvider.INVALID_PEER_FORWARDER_WITH_NEGATIVE_DRAIN_TIMEOUT,
             "src/test/resources/invalid_peer_forwarder_config_with_many_authentication.yml",
             "src/test/resources/invalid_peer_forwarder_config_with_mutual_tls_not_ssl.yml"

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxyTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxyTest.java
@@ -52,6 +52,7 @@ class PeerForwarderServerProxyTest {
 
         final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();
         objectUnderTest.start();
+        verify(peerForwarderHttpServerProvider).get();
         verify(server).start();
     }
 
@@ -81,6 +82,7 @@ class PeerForwarderServerProxyTest {
         final PeerForwarderServerProxy objectUnderTest = createObjectUnderTest();
         objectUnderTest.start();
         objectUnderTest.stop();
+        verify(peerForwarderHttpServerProvider).get();
         verify(server).stop();
     }
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxyTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderServerProxyTest.java
@@ -28,6 +28,9 @@ class PeerForwarderServerProxyTest {
     private Server server;
 
     @Mock
+    private PeerForwarderHttpServerProvider peerForwarderHttpServerProvider;
+
+    @Mock
     private PeerForwarderConfiguration peerForwarderConfiguration;
 
     @Mock
@@ -37,11 +40,12 @@ class PeerForwarderServerProxyTest {
     CompletableFuture<Void> completableFuture;
 
     PeerForwarderServerProxy createObjectUnderTest() {
-        return new PeerForwarderServerProxy(peerForwarderConfiguration, server, peerForwarderProvider);
+        return new PeerForwarderServerProxy(peerForwarderHttpServerProvider, peerForwarderConfiguration, peerForwarderProvider);
     }
 
     @Test
     void start_should_start_server_if_peers_are_registered() throws ExecutionException, InterruptedException {
+        when(peerForwarderHttpServerProvider.get()).thenReturn(server);
         when(server.start()).thenReturn(completableFuture);
         when(completableFuture.get()).thenReturn(mock(Void.class));
         when(peerForwarderProvider.isPeerForwardingRequired()).thenReturn(true);
@@ -68,6 +72,7 @@ class PeerForwarderServerProxyTest {
 
     @Test
     void stop_should_stop_server_if_server_started() throws ExecutionException, InterruptedException {
+        when(peerForwarderHttpServerProvider.get()).thenReturn(server);
         when(server.start()).thenReturn(completableFuture);
         when(server.stop()).thenReturn(completableFuture);
         when(completableFuture.get()).thenReturn(mock(Void.class));

--- a/data-prepper-core/src/test/resources/invalid_peer_forwarder_with_ssl.yml
+++ b/data-prepper-core/src/test/resources/invalid_peer_forwarder_with_ssl.yml
@@ -1,2 +1,0 @@
-ssl: true
-use_acm_certificate_for_ssl: false

--- a/data-prepper-core/src/test/resources/invalid_peer_forwarder_with_ssl_config.yml
+++ b/data-prepper-core/src/test/resources/invalid_peer_forwarder_with_ssl_config.yml
@@ -1,2 +1,1 @@
-ssl: true
-ssl_certificate_path: ""
+ssl_certificate_file: "invalid_path"

--- a/docs/peer_forwarder.md
+++ b/docs/peer_forwarder.md
@@ -95,8 +95,8 @@ IAM policy shows the necessary permissions.
 The SSL configuration for setting up trust manager for peer forwarding client to connect to other Data Prepper instances.
 
 * `ssl`(Optional) : A `boolean` that enables TLS/SSL. Default value is `true`.
-* `ssl_certificate_file`(Optional) : A `String` representing the SSL certificate chain file path or AWS S3 path. S3 path example `s3://<bucketName>/<path>`. Required if `ssl` is set to `true`.
-* `ssl_key_file`(Optional) : A `String` represents the SSL key file path or AWS S3 path. S3 path example `s3://<bucketName>/<path>`. Required if `ssl` is set to `true`.
+* `ssl_certificate_file`(Optional) : A `String` representing the SSL certificate chain file path or AWS S3 path. S3 path example `s3://<bucketName>/<path>`. Defaults to `config/default_certificate.pem` which is default certificate file. Read more about how the certificate file is generated [here](https://github.com/opensearch-project/data-prepper/tree/main/examples/certificates).
+* `ssl_key_file`(Optional) : A `String` represents the SSL key file path or AWS S3 path. S3 path example `s3://<bucketName>/<path>`. Defaults to `config/default_private_key.pem` which is default private key file. Read more about how the private key file is generated [here](https://github.com/opensearch-project/data-prepper/tree/main/examples/certificates).
 * `ssl_insecure_disable_verification`(Optional) : A `boolean` that disables the verification of server's TLS certificate chain. Default value is `false`.
 * `ssl_fingerprint_verification_only`(Optional) : A `boolean` that disables the verification of server's TLS certificate chain and instead verifies only the certificate fingerprint. Default value is `false`.
 * `use_acm_certificate_for_ssl`(Optional) : A `boolean` that enables TLS/SSL using certificate and private key from AWS Certificate Manager (ACM). Default is `false`.

--- a/docs/peer_forwarder.md
+++ b/docs/peer_forwarder.md
@@ -94,7 +94,7 @@ IAM policy shows the necessary permissions.
 ### SSL
 The SSL configuration for setting up trust manager for peer forwarding client to connect to other Data Prepper instances.
 
-* `ssl`(Optional) : A `boolean` that enables TLS/SSL. Default value is `false`.
+* `ssl`(Optional) : A `boolean` that enables TLS/SSL. Default value is `true`.
 * `ssl_certificate_file`(Optional) : A `String` representing the SSL certificate chain file path or AWS S3 path. S3 path example `s3://<bucketName>/<path>`. Required if `ssl` is set to `true`.
 * `ssl_key_file`(Optional) : A `String` represents the SSL key file path or AWS S3 path. S3 path example `s3://<bucketName>/<path>`. Required if `ssl` is set to `true`.
 * `ssl_insecure_disable_verification`(Optional) : A `boolean` that disables the verification of server's TLS certificate chain. Default value is `false`.


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
- Server creation is moved from Spring configuration file to `PeerForwarderServerProxy`, so we don't need cert files for bean creation.
- Now demo certificates added by this [PR](https://github.com/opensearch-project/data-prepper/pull/1813) can be used while running Data Prepper with Peer Forwarder.
- Peer forwarder can be started without configuring `ssl`, `ssl_certificate_file`, `ssl_key_file` and will use default certificates.
- Manually tested it locally to verify if the default certificates are working.

### Issues Resolved
resolves #1699 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
