### PR TITLE
Support evaluating conditional expressions in multiple threads

### DIFF
--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ConditionalExpressionEvaluator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ConditionalExpressionEvaluator.java
@@ -5,10 +5,8 @@
 
 package org.opensearch.dataprepper.expression;
 
-import org.opensearch.dataprepper.model.event.Event;
 import org.antlr.v4.runtime.tree.ParseTree;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.annotation.Scope;
+import org.opensearch.dataprepper.model.event.Event;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -18,7 +16,6 @@ import javax.inject.Named;
  * {@link org.opensearch.dataprepper.model.sink.Sink} and data-prepper-core objects can use to evaluate statements.
  */
 @Named
-@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 class ConditionalExpressionEvaluator implements ExpressionEvaluator<Boolean> {
     private final Parser<ParseTree> parser;
     private final Evaluator<ParseTree, Event> evaluator;

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/MultiThreadParser.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/MultiThreadParser.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Scope;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.Objects;
+
+import static org.opensearch.dataprepper.expression.ParseTreeParser.SINGLE_THREAD_PARSER_NAME;
+
+@Named
+@Primary
+@Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
+class MultiThreadParser implements Parser<ParseTree> {
+    private final ApplicationContext applicationContext;
+    private final ThreadLocal<Parser<ParseTree>> threadLocalParser;
+
+    @Inject
+    MultiThreadParser(final ApplicationContext applicationContext) {
+        this.applicationContext = Objects.requireNonNull(applicationContext);
+        threadLocalParser = ThreadLocal.withInitial(() -> (Parser<ParseTree>) applicationContext.getBean(SINGLE_THREAD_PARSER_NAME, Parser.class));
+    }
+
+    @Override
+    public ParseTree parse(final String expression) throws ParseTreeCompositeException {
+        return threadLocalParser.get().parse(expression);
+    }
+}

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeParser.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeParser.java
@@ -24,9 +24,10 @@ import java.util.Map;
 /**
  * Handles interaction with ANTLR generated parser and lexer classes and caches results.
  */
-@Named
+@Named(ParseTreeParser.SINGLE_THREAD_PARSER_NAME)
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 class ParseTreeParser implements Parser<ParseTree> {
+    static final String SINGLE_THREAD_PARSER_NAME = "singleThreadParser";
     private static final String MISSING_PARSER_ERROR_LISTENER_MESSAGE =
             "Expected DataPrepperExpressionParser to have error listener of type ParserErrorListener but none were found.";
     private final Map<String, ParseTree> cache = new HashMap<>();

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/MultiThreadParserTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/MultiThreadParserTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MultiThreadParserTest {
+
+    @Mock
+    private ApplicationContext applicationContext;
+    private String expression;
+
+    @BeforeEach
+    void setUp() {
+        expression = UUID.randomUUID().toString();
+    }
+
+    private MultiThreadParser createObjectUnderTest() {
+        return new MultiThreadParser(applicationContext);
+    }
+
+    @Test
+    void parse_returns_parse_result_from_ApplicationContext_Parser() {
+        final Parser<ParseTree> parser = mock(Parser.class);
+        when(applicationContext.getBean(ParseTreeParser.SINGLE_THREAD_PARSER_NAME, Parser.class))
+                .thenReturn(parser);
+        final ParseTree parseTree = mock(ParseTree.class);
+        when(parser.parse(expression))
+                .thenReturn(parseTree);
+
+        assertThat(createObjectUnderTest().parse(expression), equalTo(parseTree));
+    }
+
+    @Test
+    void parse_called_multiple_times_only_calls_getBean_once() {
+        final Parser<ParseTree> parser = mock(Parser.class);
+        when(applicationContext.getBean(ParseTreeParser.SINGLE_THREAD_PARSER_NAME, Parser.class))
+                .thenReturn(parser);
+        final ParseTree parseTree = mock(ParseTree.class);
+        when(parser.parse(expression))
+                .thenReturn(parseTree);
+
+        final MultiThreadParser objectUnderTest = createObjectUnderTest();
+        for(int i = 0; i < 10; i++)
+            objectUnderTest.parse(expression);
+
+        verify(applicationContext).getBean(anyString(), any(Class.class));
+    }
+
+    @Test
+    void parse_on_multiple_threads_returns_different_ParseTree() throws ExecutionException, InterruptedException, TimeoutException {
+        final Parser<ParseTree> firstParser = mock(Parser.class);
+        final Parser<ParseTree> secondParser = mock(Parser.class);
+        when(applicationContext.getBean(ParseTreeParser.SINGLE_THREAD_PARSER_NAME, Parser.class))
+                .thenReturn(firstParser)
+                .thenReturn(secondParser);
+        final ParseTree firstParseTree = mock(ParseTree.class);
+        final ParseTree secondParseTree = mock(ParseTree.class);
+        when(firstParser.parse(expression)).thenReturn(firstParseTree);
+        when(secondParser.parse(expression)).thenReturn(secondParseTree);
+
+        final MultiThreadParser objectUnderTest = createObjectUnderTest();
+        final ParseTree mainThreadParseTree = objectUnderTest.parse(expression);
+
+        final Future<ParseTree> futureParseTree = Executors.newFixedThreadPool(1).submit(() -> objectUnderTest.parse(expression));
+
+        final ParseTree otherThreadParseTree = futureParseTree.get(1, TimeUnit.SECONDS);
+
+        assertThat(mainThreadParseTree, not(sameInstance(otherThreadParseTree)));
+
+        assertThat(mainThreadParseTree, equalTo(firstParseTree));
+        assertThat(otherThreadParseTree, equalTo(otherThreadParseTree));
+    }
+}


### PR DESCRIPTION
### Description

This PR allows multiple threads to use the same `Parser<ParseTree>`. It does this by adding a `MultiThreadParser` which uses a `ThreadLocal`. Each thread will get is own `ParseTreeParser`.

One implication of this is that each thread will get its own expression cache. I believe there may be other solutions which can improve the performance here. But, the number of threads is mostly decided upon Data Prepper start-up.
 
### Issues Resolved

Resolves #1189 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
