### PR TITLE
Fixes file sink to work with multiple threads

### DIFF
--- a/data-prepper-core/src/test/resources/valid_multiple_processors.yml
+++ b/data-prepper-core/src/test/resources/valid_multiple_processors.yml
@@ -16,7 +16,7 @@ raw-pipeline:
     - string_converter:
         upper_case: false
   sink:
-    - file:
+    - stdout:
         someProperty: "someValue"
 service-map-pipeline:
   source:
@@ -28,5 +28,5 @@ service-map-pipeline:
     - string_converter:
         upper_case: false
   sink:
-    - file:
+    - stdout:
         someProperty: "someValue"

--- a/data-prepper-core/src/test/resources/valid_multiple_sinks.yml
+++ b/data-prepper-core/src/test/resources/valid_multiple_sinks.yml
@@ -14,7 +14,7 @@ raw-pipeline:
     - string_converter:
         upper_case: true
   sink:
-    - file:
+    - stdout:
         someProperty: "someValue"
 service-map-pipeline:
   source:
@@ -24,5 +24,5 @@ service-map-pipeline:
     - string_converter:
         upper_case: true
   sink:
-    - file:
+    - stdout:
         someProperty: "someValue"

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/sink/FileSinkTests.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/sink/FileSinkTests.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -115,6 +116,18 @@ class FileSinkTests {
         final String outputData = readDocFromFile(TEST_OUTPUT_FILE);
         assertThat(outputData, containsString(TEST_DATA_1));
         assertThat(outputData, containsString(TEST_DATA_2));
+    }
+
+    @Test
+    void testCallingOutputAfterShutdownDoesNotWrite() throws IOException {
+        final FileSink fileSink = new FileSink(completePluginSettingForFileSink(TEST_OUTPUT_FILE.getPath()));
+        fileSink.output(Collections.singletonList(TEST_RECORDS.get(0)));
+        fileSink.shutdown();
+        fileSink.output(Collections.singletonList(TEST_RECORDS.get(1)));
+
+        final String outputData = readDocFromFile(TEST_OUTPUT_FILE);
+        assertThat(outputData, containsString(TEST_DATA_1));
+        assertThat(outputData, not(containsString(TEST_DATA_2)));
     }
 
     private PluginSetting completePluginSettingForFileSink(final String filepath) {


### PR DESCRIPTION
### Description

The `file` sink was not working with multiple processor threads. Each thread would re-open the file without append, which prevented it from working as expected. Now, it keeps a Writer open as long as it is running. It will flush on each output() call.

 
### Issues Resolved

Resolves #1843 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
