### PR TITLE
Fix docker container shutdown issue

### DIFF
--- a/release/archives/linux/data-prepper-jdk-x64.sh
+++ b/release/archives/linux/data-prepper-jdk-x64.sh
@@ -37,9 +37,9 @@ DATA_PREPPER_HOME_OPTS="-Ddata-prepper.dir=$DATA_PREPPER_HOME"
 DATA_PREPPER_JAVA_OPTS="-Dlog4j.configurationFile=$DATA_PREPPER_HOME/config/log4j2-rolling.properties"
 
 if [[ $# == 0 ]]; then
-    java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute
+    exec java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute
 else
     PIPELINES_FILE_LOCATION=$1
     CONFIG_FILE_LOCATION=$2
-    java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute $PIPELINES_FILE_LOCATION $CONFIG_FILE_LOCATION
+    exec java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute $PIPELINES_FILE_LOCATION $CONFIG_FILE_LOCATION
 fi

--- a/release/archives/linux/data-prepper-x64.sh
+++ b/release/archives/linux/data-prepper-x64.sh
@@ -65,9 +65,9 @@ DATA_PREPPER_HOME_OPTS="-Ddata-prepper.dir=$DATA_PREPPER_HOME"
 DATA_PREPPER_JAVA_OPTS="-Dlog4j.configurationFile=$DATA_PREPPER_HOME/config/log4j2-rolling.properties"
 
 if [[ $# == 0 ]]; then
-    java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute
+    exec java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute
 else
     PIPELINES_FILE_LOCATION=$1
     CONFIG_FILE_LOCATION=$2
-    java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute $PIPELINES_FILE_LOCATION $CONFIG_FILE_LOCATION
+    exec java $JAVA_OPTS $DATA_PREPPER_HOME_OPTS $DATA_PREPPER_JAVA_OPTS -cp "$DATA_PREPPER_CLASSPATH" org.opensearch.dataprepper.DataPrepperExecute $PIPELINES_FILE_LOCATION $CONFIG_FILE_LOCATION
 fi


### PR DESCRIPTION
Signed-off-by: Hai Yan <oeyh@amazon.com>

### Description
Use `exec` command to run application so that data prepper is run on the container's primary process (PID 1) and be able to respond to Ctrl+c.

On 2.0, data prepper is launched through a bash script, `/bin/bash` takes PID 1 in the container and it doesn't forward shutdown signals to data prepper, which is on a child process. 
With `exec`, data prepper will replace `/bin/bash` process and runs on PID 1 so it is able to receive signal and respond to Ctrl+c.
 
### Issues Resolved
Closes #1816 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
