### PR TITLE
BUG FIX: Core peer forwarder trace pipeline bug

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
@@ -214,7 +214,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
             try {
                 this.data.putAll(mapper.readValue(data, MAP_TYPE_REFERENCE));
             } catch (final JsonProcessingException e) {
-                throw new RuntimeException(String.format("An exception occurred due to invalid JSON while reading event data: %s", data), e);
+                throw new RuntimeException("An exception occurred due to invalid JSON while converting data to event");
             }
             return this;
         }


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
- Fixed the `ClassCastException` Exception related o trace pipeline as Peer Forwarder server is writing `JacksonEvent` objects to the buffer and trace processors are trying to cast `JacksonEvent` to `Span` objects.
- Added `withJsonData()` and `withEventMetadata()` methods to `JacksonSpan` Builder.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
