### PR TITLE
Use Apache AWS client exclusively to fix AWS Java SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,8 +138,6 @@ subprojects {
                 details.because 'Fixes CVE-2021-43797, CVE-2021-37136 and CVE-2021-37137. See https://netty.io/news/2021/09/09/4-1-68-Final.html'
             }
         }
-        exclude group: 'software.amazon.awssdk', module: 'netty-nio-client'
-        exclude group: 'software.amazon.awssdk', module: 'url-connection-client'
     }
 
     build.dependsOn test

--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,8 @@ subprojects {
                 details.because 'Fixes CVE-2021-43797, CVE-2021-37136 and CVE-2021-37137. See https://netty.io/news/2021/09/09/4-1-68-Final.html'
             }
         }
+        exclude group: 'software.amazon.awssdk', module: 'netty-nio-client'
+        exclude group: 'software.amazon.awssdk', module: 'url-connection-client'
     }
 
     build.dependsOn test

--- a/data-prepper-main/src/main/java/org/opensearch/dataprepper/DataPrepperExecute.java
+++ b/data-prepper-main/src/main/java/org/opensearch/dataprepper/DataPrepperExecute.java
@@ -20,6 +20,7 @@ public class DataPrepperExecute {
 
     public static void main(final String ... args) {
         java.security.Security.setProperty("networkaddress.cache.ttl", "60");
+        System.setProperty("software.amazon.awssdk.http.service.impl", "software.amazon.awssdk.http.apache.ApacheSdkHttpService");
 
         final ContextManager contextManager;
         if (args.length == 0) {


### PR DESCRIPTION
### Description

This PR fixes a bug where Data Prepper cannot connect to an Amazon OpenSearch Service domain. It uses the AWS Apache client exclusively.
 
### Issues Resolved

Resolves #1876
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
