### PR TITLE
Updates the bin/data-prepper script to use "readlink -f"

### DIFF
--- a/release/archives/linux/data-prepper-jdk-x64.sh
+++ b/release/archives/linux/data-prepper-jdk-x64.sh
@@ -24,8 +24,8 @@ else
     exit 1
 fi
 
-DATA_PREPPER_BIN=$(dirname "$(realpath "$0")")
-DATA_PREPPER_HOME=`realpath "$DATA_PREPPER_BIN/.."`
+DATA_PREPPER_BIN=$(dirname "$(readlink -f "$0")")
+DATA_PREPPER_HOME=`readlink -f "$DATA_PREPPER_BIN/.."`
 DATA_PREPPER_CLASSPATH="$DATA_PREPPER_HOME/lib/*"
 OPENJDK=$(ls -1 $DATA_PREPPER_HOME/openjdk/ 2>/dev/null)
 

--- a/release/archives/linux/data-prepper-x64.sh
+++ b/release/archives/linux/data-prepper-x64.sh
@@ -26,8 +26,8 @@ fi
 
 MIN_REQ_JAVA_VERSION=11
 MIN_REQ_OPENJDK_VERSION=11
-DATA_PREPPER_BIN=$(dirname "$(realpath "$0")")
-DATA_PREPPER_HOME=`realpath "$DATA_PREPPER_BIN/.."`
+DATA_PREPPER_BIN=$(dirname "$(readlink -f "$0")")
+DATA_PREPPER_HOME=`readlink -f "$DATA_PREPPER_BIN/.."`
 DATA_PREPPER_CLASSPATH="$DATA_PREPPER_HOME/lib/*"
 
 #check if java is installed


### PR DESCRIPTION
### Description

The current Data Prepper `bin/data-prepper` script uses `realpath` to determine the path from where the script runs. This requires installing `coreutils` on some systems including macOS.

This PR updates Data Prepper to use `readlink -f` instead of `realpath`. This is available by default on more operation systems, including macOS.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
