### PR TITLE
Fix build failure in PipelineParser from conditional routing

### DIFF
--- a/data-prepper-core/src/test/resources/valid_multiple_sinks_with_routes.yml
+++ b/data-prepper-core/src/test/resources/valid_multiple_sinks_with_routes.yml
@@ -21,8 +21,7 @@ raw-pipeline:
     - string_converter:
         upper_case: true
   sink:
-    - file:
-        someProperty: "someValue"
+    - stdout:
 service-map-pipeline:
   source:
     pipeline:
@@ -31,5 +30,4 @@ service-map-pipeline:
     - string_converter:
         upper_case: true
   sink:
-    - file:
-        someProperty: "someValue"
+    - stdout:


### PR DESCRIPTION
### Description

This fixes a problem introduced by two independent PRs: #1832 and #1842. It uses `stdout` as the sink to avoid failures with an inaccessible path.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
