### PR TITLE
Fix PipelineConnector to duplicate the events

### DIFF
--- a/.github/workflows/data-prepper-log-analytics-basic-grok-e2e-tests.yml
+++ b/.github/workflows/data-prepper-log-analytics-basic-grok-e2e-tests.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
       - name: Run basic grok end-to-end tests with Gradle
-        run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:log:${{ test }}
+        run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:log:${{ matrix.test }}

--- a/.github/workflows/data-prepper-log-analytics-basic-grok-e2e-tests.yml
+++ b/.github/workflows/data-prepper-log-analytics-basic-grok-e2e-tests.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [11, 17]
+        test: ['basicLogEndToEndTest', 'parallelGrokStringSubstituteTest']
       fail-fast: false
 
     runs-on: ubuntu-latest
@@ -26,4 +27,4 @@ jobs:
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
       - name: Run basic grok end-to-end tests with Gradle
-        run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:log:basicLogEndToEndTest
+        run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:log:${{ test }}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
@@ -220,6 +220,17 @@ public class JacksonSpan extends JacksonEvent implements Span {
         }
 
         /**
+         * Sets the data of the event.
+         * @param data the data
+         * @since 2.0
+         */
+        @Override
+        public Builder withData(final Object data) {
+            this.data.putAll(mapper.convertValue(data, Map.class));
+            return this;
+        }
+
+        /**
          * Sets the metadata.
          * @param eventMetadata the metadata
          * @since 2.0
@@ -420,6 +431,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
             validateParameters();
             checkAndSetDefaultValues();
             this.withData(data);
+            super.withData(data);
             this.withEventType(EventType.TRACE.toString());
             return new JacksonSpan(this);
         }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
@@ -430,7 +430,6 @@ public class JacksonSpan extends JacksonEvent implements Span {
         public JacksonSpan build() {
             validateParameters();
             checkAndSetDefaultValues();
-            this.withData(data);
             super.withData(data);
             this.withEventType(EventType.TRACE.toString());
             return new JacksonSpan(this);

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonSpanTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonSpanTest.java
@@ -640,5 +640,51 @@ public class JacksonSpanTest {
 
             assertThrows(IllegalArgumentException.class, builder::build);
         }
+
+        @Test
+        void testBuilder_withData_with_event_valid_data() {
+	    final Map<String, Object> data = new HashMap<String, Object>();
+	    final String traceId = "414243";
+	    final String kind = "SPAN_KIND_INTERNAL";
+	    final String traceGroup = "FRUITSGroup";
+	    final String traceGroupFields = "{\"endTime\":\"1970-01-01T00:00:00Z\",\"durationInNanos\": 0,\"statusCode\": 0}";
+	    final String spanId = "313030";
+	    final String name = "FRUITS";
+	    final String startTime = "1970-01-01T00:00:00Z";
+	    final String endTime = "1970-01-02T00:00:00Z";
+	    final String durationInNanos = "100";
+	    data.put("traceId", traceId);
+	    data.put("kind", kind);
+	    data.put("traceGroup", traceGroup);
+	    data.put("traceGroupFields", traceGroupFields);
+	    data.put("spanId", spanId);
+	    data.put("name", name);
+	    data.put("startTime", startTime);
+	    data.put("endTime", endTime);
+	    data.put("durationInNanos", durationInNanos);
+
+            EventMetadata eventMetadata = mock(EventMetadata.class);
+            final Instant now = Instant.now();
+            when(eventMetadata.getEventType()).thenReturn(String.valueOf(EventType.TRACE));
+            when(eventMetadata.getTimeReceived()).thenReturn(now);
+
+
+            final JacksonSpan jacksonSpan = JacksonSpan.builder()
+                    .withData(data)
+                    .withEventMetadata(eventMetadata)
+                    .build();
+
+            assertThat(jacksonSpan, is(notNullValue()));
+            assertThat(jacksonSpan.getMetadata(), is(notNullValue()));
+            assertThat(jacksonSpan.getMetadata().getTimeReceived(), equalTo(now));
+            assertThat(jacksonSpan.toMap().get("traceId"), equalTo(traceId));
+            assertThat(jacksonSpan.toMap().get("kind"), equalTo(kind));
+            assertThat(jacksonSpan.toMap().get("traceGroup"), equalTo(traceGroup));
+            assertThat(jacksonSpan.toMap().get("spanId"), equalTo(spanId));
+            assertThat(jacksonSpan.toMap().get("name"), equalTo(name));
+            assertThat(jacksonSpan.toMap().get("startTime"), equalTo(startTime));
+            assertThat(jacksonSpan.toMap().get("endTime"), equalTo(endTime));
+            assertThat(jacksonSpan.toMap().get("durationInNanos"), equalTo(durationInNanos));
+        }
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/PipelineConnector.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/PipelineConnector.java
@@ -11,6 +11,7 @@ import org.opensearch.dataprepper.model.sink.Sink;
 import org.opensearch.dataprepper.model.source.Source;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.trace.Span;
 import org.opensearch.dataprepper.model.trace.JacksonSpan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,10 +60,10 @@ public final class PipelineConnector<T extends Record<?>> implements Source<T>, 
             for (T record : records) {
 		if(record.getData() instanceof JacksonSpan) {
 		    try {
-		        final JacksonSpan span = (JacksonSpan)record.getData();
-			JacksonSpan newSpanEvent = JacksonSpan.builder()
-			          .withJsonData(span.toJsonString())
-				  .withEventMetadata(span.getMetadata())
+		        final Span spanEvent = (Span)record.getData();
+			Span newSpanEvent = JacksonSpan.builder()
+				  .withData(spanEvent.toMap())
+				  .withEventMetadata(spanEvent.getMetadata())
 			          .build(); 
 			record = (T) (new Record<>(newSpanEvent));
 		    } catch (Exception ex) {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineConnectorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineConnectorTest.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.LinkedHashMap;
 import java.util.UUID;
 import java.util.Queue;
 import java.util.Map;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineConnectorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineConnectorTest.java
@@ -5,19 +5,41 @@
 
 package org.opensearch.dataprepper.pipeline;
 
+import org.opensearch.dataprepper.model.CheckpointState;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.plugins.buffer.TestBuffer;
+import org.opensearch.dataprepper.model.trace.JacksonSpan;
+import org.opensearch.dataprepper.model.trace.DefaultTraceGroupFields;
+import org.opensearch.dataprepper.model.trace.DefaultLink;
+import org.opensearch.dataprepper.model.trace.DefaultSpanEvent;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import org.opensearch.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
+import java.util.Queue;
+import java.util.Map;
+import java.util.Date;
+import java.util.LinkedList;
 import java.util.concurrent.TimeoutException;
+import com.google.common.collect.ImmutableMap;
+
 
 import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Assertions;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -25,24 +47,108 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+
 @RunWith(MockitoJUnitRunner.class)
 public class PipelineConnectorTest {
     private static final String RECORD_DATA = "RECORD_DATA";
     private static final Record<String> RECORD = new Record<>(RECORD_DATA);
+    private static Record<Event> EVENT_RECORD;
+    private static Record<JacksonSpan> SPAN_RECORD;
+
     private static final String SINK_PIPELINE_NAME = "SINK_PIPELINE_NAME";
+    private final String testKey = UUID.randomUUID().toString();
+    private final String testValue = UUID.randomUUID().toString();
+    private static final String TEST_TRACE_ID =  UUID.randomUUID().toString();
+    private static final String TEST_SPAN_ID =  UUID.randomUUID().toString();
+    private static final String TEST_TRACE_STATE =  UUID.randomUUID().toString();
+    private static final String TEST_PARENT_SPAN_ID =  UUID.randomUUID().toString();
+    private static final String TEST_NAME =  UUID.randomUUID().toString();
+    private static final String TEST_KIND =  UUID.randomUUID().toString();
+    private static final String TEST_START_TIME =  UUID.randomUUID().toString();
+    private static final String TEST_END_TIME =  UUID.randomUUID().toString();
+    private static final Map<String, Object> TEST_ATTRIBUTES = ImmutableMap.of("key1", new Date().getTime(), "key2", UUID.randomUUID().toString());
+    private static final Integer TEST_DROPPED_ATTRIBUTES_COUNT = 8;
+    private static final Integer TEST_DROPPED_EVENTS_COUNT =  45;
+    private static final Integer TEST_DROPPED_LINKS_COUNT =  21;
+    private static final String TEST_TRACE_GROUP =  UUID.randomUUID().toString();
+    private static final Long TEST_DURATION_IN_NANOS =  537L;
+    private static final String TEST_SERVICE_NAME = UUID.randomUUID().toString();
 
     @Mock
     private Buffer<Record<String>> buffer;
-
     private List<Record<String>> recordList;
-
     private PipelineConnector<Record<String>> sut;
+
+    private TestBuffer eventBuffer;
+    private List<Record<Event>> eventRecordList;
+    private PipelineConnector<Record<Event>> eut;
+
+    private BlockingBuffer<Record<JacksonSpan>> spanBuffer;
+    private List<Record<JacksonSpan>> spanRecordList;
+    private DefaultTraceGroupFields defaultTraceGroupFields;
+    private PipelineConnector<Record<JacksonSpan>> sput;
+    private DefaultLink defaultLink;
+    private DefaultSpanEvent defaultSpanEvent;
+
+
 
     @Before
     public void setup() {
         recordList = Collections.singletonList(RECORD);
-
         sut = new PipelineConnector<>();
+
+	final Event event = JacksonEvent.builder()
+			.withEventType("event")
+			.withData(Collections.singletonMap(testKey, testValue))
+			.build();
+	EVENT_RECORD = new Record<>(event);
+        eventRecordList = Collections.singletonList(EVENT_RECORD);
+	final Queue<Record<Event>> bufferQueue = new LinkedList<>();
+	eventBuffer = new TestBuffer(bufferQueue, 1);
+        eut = new PipelineConnector<>();
+
+        defaultSpanEvent = DefaultSpanEvent.builder()
+                .withName(UUID.randomUUID().toString())
+                .withTime(UUID.randomUUID().toString())
+                .build();
+
+        defaultLink = DefaultLink.builder()
+                .withTraceId(UUID.randomUUID().toString())
+                .withSpanId(UUID.randomUUID().toString())
+                .withTraceState(UUID.randomUUID().toString())
+                .build();
+
+        defaultTraceGroupFields = DefaultTraceGroupFields.builder()
+                .withDurationInNanos(123L)
+                .withStatusCode(201)
+                .withEndTime("the End")
+                .build();
+	final JacksonSpan span = JacksonSpan.builder()
+                .withSpanId(TEST_SPAN_ID)
+                .withTraceId(TEST_TRACE_ID)
+                .withTraceState(TEST_TRACE_STATE)
+                .withParentSpanId(TEST_PARENT_SPAN_ID)
+                .withName(TEST_NAME)
+                .withServiceName(TEST_SERVICE_NAME)
+                .withKind(TEST_KIND)
+                .withStartTime(TEST_START_TIME)
+                .withEndTime(TEST_END_TIME)
+                .withAttributes(TEST_ATTRIBUTES)
+                .withDroppedAttributesCount(TEST_DROPPED_ATTRIBUTES_COUNT)
+                .withEvents(Arrays.asList(defaultSpanEvent))
+                .withDroppedEventsCount(TEST_DROPPED_EVENTS_COUNT)
+                .withLinks(Arrays.asList(defaultLink))
+                .withDroppedLinksCount(TEST_DROPPED_LINKS_COUNT)
+                .withTraceGroup(TEST_TRACE_GROUP)
+                .withDurationInNanos(TEST_DURATION_IN_NANOS)
+                .withTraceGroupFields(defaultTraceGroupFields)
+		.build();
+
+	SPAN_RECORD = new Record<>(span);
+        spanRecordList = Collections.singletonList(SPAN_RECORD);
+	spanBuffer = new BlockingBuffer<>("Pipeline1");
+        sput = new PipelineConnector<>();
+
     }
 
     @Test(expected = RuntimeException.class)
@@ -76,6 +182,42 @@ public class PipelineConnectorTest {
         sut.output(recordList);
 
         verify(buffer).write(eq(RECORD), anyInt());
+    }
+
+    @Test
+    public void testEventBufferOutputSuccess() throws Exception {
+        eut.start(eventBuffer);
+
+        eut.output(eventRecordList);
+
+	Map.Entry<Collection<Record<Event>>, CheckpointState> ent = eventBuffer.read(1);
+	ArrayList<Record<Event>> records = new ArrayList<>(ent.getKey());
+	// Make sure the records are different
+	Assertions.assertNotEquals(eventRecordList.get(0),  records.get(0));
+	// Make sure the events are different
+	Event event1 = eventRecordList.get(0).getData();
+	Event event2 = records.get(0).getData();
+	Assertions.assertNotEquals(event1, event2);
+	event1.toMap().forEach((k, v)-> Assertions.assertEquals(event2.get(k, String.class), v));
+	event1.toMap().forEach((k, v)-> Assertions.assertEquals(k, testKey));
+	event1.toMap().forEach((k, v)-> Assertions.assertEquals(v, testValue));
+	
+    }
+
+    @Test
+    public void testSpanBufferOutputSuccess() throws Exception {
+        sput.start(spanBuffer);
+
+        sput.output(spanRecordList);
+
+	Map.Entry<Collection<Record<JacksonSpan>>, CheckpointState> ent = spanBuffer.doRead(10000);
+	ArrayList<Record<JacksonSpan>> records = new ArrayList<>(ent.getKey());
+	// Make sure the records are different
+	Assertions.assertNotEquals(spanRecordList.get(0),  records.get(0));
+	// Make sure the spans are different
+	JacksonSpan span1 = spanRecordList.get(0).getData();
+	JacksonSpan span2 = records.get(0).getData();
+	Assertions.assertNotEquals(span1, span2);
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineConnectorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineConnectorTest.java
@@ -16,6 +16,11 @@ import org.opensearch.dataprepper.model.trace.DefaultTraceGroupFields;
 import org.opensearch.dataprepper.model.trace.DefaultLink;
 import org.opensearch.dataprepper.model.trace.DefaultSpanEvent;
 
+
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.UUID;
 import java.util.Queue;
 import java.util.Map;
@@ -193,11 +199,11 @@ public class PipelineConnectorTest {
 	Map.Entry<Collection<Record<Event>>, CheckpointState> ent = eventBuffer.read(1);
 	ArrayList<Record<Event>> records = new ArrayList<>(ent.getKey());
 	// Make sure the records are different
-	Assertions.assertNotEquals(eventRecordList.get(0),  records.get(0));
+	assertThat(eventRecordList.get(0), not(sameInstance(records.get(0))));
 	// Make sure the events are different
 	Event event1 = eventRecordList.get(0).getData();
 	Event event2 = records.get(0).getData();
-	Assertions.assertNotEquals(event1, event2);
+	assertThat(event1, not(sameInstance(event2)));
 	event1.toMap().forEach((k, v)-> Assertions.assertEquals(event2.get(k, String.class), v));
 	event1.toMap().forEach((k, v)-> Assertions.assertEquals(k, testKey));
 	event1.toMap().forEach((k, v)-> Assertions.assertEquals(v, testValue));
@@ -213,11 +219,12 @@ public class PipelineConnectorTest {
 	Map.Entry<Collection<Record<JacksonSpan>>, CheckpointState> ent = spanBuffer.doRead(10000);
 	ArrayList<Record<JacksonSpan>> records = new ArrayList<>(ent.getKey());
 	// Make sure the records are different
-	Assertions.assertNotEquals(spanRecordList.get(0),  records.get(0));
+	assertThat(spanRecordList.get(0), not(sameInstance(records.get(0))));
 	// Make sure the spans are different
 	JacksonSpan span1 = spanRecordList.get(0).getData();
 	JacksonSpan span2 = records.get(0).getData();
-	Assertions.assertNotEquals(span1, span2);
+	assertThat(span1, not(sameInstance(span2)));
+	span1.toMap().forEach((k, v) -> Assertions.assertEquals(span2.toMap().get(k), v));
     }
 
     @Test

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/AbstractStringProcessor.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/AbstractStringProcessor.java
@@ -8,20 +8,14 @@ package org.opensearch.dataprepper.plugins.processor.mutatestring;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.record.Record;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 public abstract class AbstractStringProcessor<T> extends AbstractProcessor<Record<Event>, Record<Event>> {
     private List<T> entries;
-    private static final Logger LOG = LoggerFactory.getLogger(AbstractStringProcessor.class);
 
     @DataPrepperPluginConstructor
     public AbstractStringProcessor(final PluginMetrics pluginMetrics, final StringProcessorConfig<T> config) {
@@ -32,7 +26,7 @@ public abstract class AbstractStringProcessor<T> extends AbstractProcessor<Recor
     @Override
     public Collection<Record<Event>> doExecute(final Collection<Record<Event>> records) {
         for(final Record<Event> record : records) {
-	    final Event recordEvent = record.getData();
+            final Event recordEvent = record.getData();
             performStringAction(recordEvent);
         }
 

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/AbstractStringProcessor.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/AbstractStringProcessor.java
@@ -31,25 +31,12 @@ public abstract class AbstractStringProcessor<T> extends AbstractProcessor<Recor
 
     @Override
     public Collection<Record<Event>> doExecute(final Collection<Record<Event>> records) {
-        final Collection<Record<Event>> modifiedRecords = new ArrayList<>(records.size());
         for(final Record<Event> record : records) {
-            final Event recordEvent = record.getData();
-            Map<String, Object> newData = null;
-	    try {
-		newData = recordEvent.toMap();
-	    } catch (Exception e) {
-                LOG.error("An exception occurred while doing event toMap [{}]", recordEvent, e);
-	    }
-	    final Event newRecordEvent;
-	    newRecordEvent = JacksonEvent.builder()
-                    .withEventMetadata(recordEvent.getMetadata())
-                    .withData(newData)
-                    .build();
-	    modifiedRecords.add(new Record<>(newRecordEvent));
-            performStringAction(newRecordEvent);
+	    final Event recordEvent = record.getData();
+            performStringAction(recordEvent);
         }
 
-        return modifiedRecords;
+        return records;
     }
 
     private void performStringAction(final Event recordEvent)

--- a/e2e-test/log/build.gradle
+++ b/e2e-test/log/build.gradle
@@ -157,11 +157,11 @@ task basicLogEndToEndTest(type: Test) {
     finalizedBy removeDataPrepperNetwork
 }
 
-task parallelGrokStringSubstiteTest(type: Test) {
+task parallelGrokStringSubstituteTest(type: Test) {
     dependsOn build
     dependsOn startOpenSearchDockerContainer
     def createDataPrepperTask = createDataPrepperDockerContainer(
-            "ParallelGrokSubstLogDataPrepper", "dataprepper", 2021, 4900, "${PARALLEL_GROK_SUBSTITUTE_PIPELINE_YAML}", "${DATA_PREPPER_CONFIG_YAML}")
+            "ParallelGrokSubstLogDataPrepper", "dataprepper-pgsts-test", 2021, 4900, "${PARALLEL_GROK_SUBSTITUTE_PIPELINE_YAML}", "${DATA_PREPPER_CONFIG_YAML}")
     def startDataPrepperTask = startDataPrepperDockerContainer(createDataPrepperTask as DockerCreateContainer)
     dependsOn startDataPrepperTask
     startDataPrepperTask.mustRunAfter 'startOpenSearchDockerContainer'

--- a/e2e-test/log/build.gradle
+++ b/e2e-test/log/build.gradle
@@ -31,6 +31,8 @@ task removeDataPrepperNetwork(type: DockerRemoveNetwork) {
 }
 
 def BASIC_GROK_PIPELINE_YAML = "basic-grok-e2e-pipeline.yml"
+def PARALLEL_GROK_SUBSTITUTE_PIPELINE_YAML = "parallel-grok-substitute-e2e-pipeline.yml"
+def DATA_PREPPER_CONFIG_YAML = "data_prepper.yml"
 
 /**
  * DataPrepper Docker tasks
@@ -41,8 +43,6 @@ task createDataPrepperDockerFile(type: Dockerfile) {
     from(dataPrepperBaseImage)
     workingDir("/app/data-prepper")
     copyFile("${dataPrepperJarFilepath}", "/app/data-prepper/lib")
-    copyFile("src/integrationTest/resources/${BASIC_GROK_PIPELINE_YAML}", "/app/data-prepper/pipelines/pipelines.yaml")
-    copyFile("src/integrationTest/resources/data_prepper.yml", "/app/data-prepper/config/data-prepper-config.yaml")
     defaultCommand('java', '-Ddata-prepper.dir=/app/data-prepper', '-cp', '/app/data-prepper/lib/*', 'org.opensearch.dataprepper.DataPrepperExecute')
 }
 
@@ -54,13 +54,16 @@ task buildDataPrepperDockerImage(type: DockerBuildImage) {
 }
 
 def createDataPrepperDockerContainer(final String taskBaseName, final String dataPrepperName, final int sourcePort,
-                                     final int serverPort) {
+                                     final int serverPort, final String pipelineConfigYAML, final String dataPrepperConfigYAML) {
     return tasks.create("create${taskBaseName}", DockerCreateContainer) {
         dependsOn buildDataPrepperDockerImage
         dependsOn createDataPrepperNetwork
         containerName = dataPrepperName
         exposePorts("tcp", [2021, 4900])
         hostConfig.portBindings = [String.format('%d:2021', sourcePort), String.format('%d:4900', serverPort)]
+        hostConfig.binds = [(project.file("src/integrationTest/resources/${pipelineConfigYAML}").toString()):"/app/data-prepper/pipelines/pipelines.yaml",
+			    (project.file("/tmp/AAA.out").toString()):"/tmp/AAA.out",
+                            (project.file("src/integrationTest/resources/${dataPrepperConfigYAML}").toString()):"/app/data-prepper/config/data-prepper-config.yaml"]
         hostConfig.network = createDataPrepperNetwork.getNetworkName()
         cmd = ['java', '-Ddata-prepper.dir=/app/data-prepper', '-cp', '/app/data-prepper/lib/*', 'org.opensearch.dataprepper.DataPrepperExecute']
         targetImageId buildDataPrepperDockerImage.getImageId()
@@ -129,7 +132,7 @@ task basicLogEndToEndTest(type: Test) {
     dependsOn build
     dependsOn startOpenSearchDockerContainer
     def createDataPrepperTask = createDataPrepperDockerContainer(
-            "basicLogDataPrepper", "dataprepper", 2021, 4900)
+            "basicLogDataPrepper", "dataprepper", 2021, 4900, "${BASIC_GROK_PIPELINE_YAML}", "${DATA_PREPPER_CONFIG_YAML}")
     def startDataPrepperTask = startDataPrepperDockerContainer(createDataPrepperTask as DockerCreateContainer)
     dependsOn startDataPrepperTask
     startDataPrepperTask.mustRunAfter 'startOpenSearchDockerContainer'
@@ -145,6 +148,35 @@ task basicLogEndToEndTest(type: Test) {
 
     filter {
         includeTestsMatching "org.opensearch.dataprepper.integration.log.EndToEndBasicLogTest.testPipelineEndToEnd*"
+    }
+
+    finalizedBy stopOpenSearchDockerContainer
+    def stopDataPrepperTask = stopDataPrepperDockerContainer(startDataPrepperTask as DockerStartContainer)
+    finalizedBy stopDataPrepperTask
+    finalizedBy removeDataPrepperDockerContainer(stopDataPrepperTask as DockerStopContainer)
+    finalizedBy removeDataPrepperNetwork
+}
+
+task parallelGrokStringSubstiteTest(type: Test) {
+    dependsOn build
+    dependsOn startOpenSearchDockerContainer
+    def createDataPrepperTask = createDataPrepperDockerContainer(
+            "ParallelGrokSubstLogDataPrepper", "dataprepper", 2021, 4900, "${PARALLEL_GROK_SUBSTITUTE_PIPELINE_YAML}", "${DATA_PREPPER_CONFIG_YAML}")
+    def startDataPrepperTask = startDataPrepperDockerContainer(createDataPrepperTask as DockerCreateContainer)
+    dependsOn startDataPrepperTask
+    startDataPrepperTask.mustRunAfter 'startOpenSearchDockerContainer'
+    // wait for data-preppers to be ready
+    doFirst {
+        sleep(15*1000)
+    }
+
+    description = 'Runs the parallel grok and string substitute end-to-end test.'
+    group = 'verification'
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+
+    filter {
+        includeTestsMatching "org.opensearch.dataprepper.integration.log.ParallelGrokStringSubstituteLogTest.testPipelineEndToEnd*"
     }
 
     finalizedBy stopOpenSearchDockerContainer

--- a/e2e-test/log/src/integrationTest/java/org/opensearch/dataprepper/integration/log/ParallelGrokStringSubstituteLogTest.java
+++ b/e2e-test/log/src/integrationTest/java/org/opensearch/dataprepper/integration/log/ParallelGrokStringSubstituteLogTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.integration.log;
+
+import org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration;
+import org.opensearch.dataprepper.plugins.source.loggenerator.ApacheLogFaker;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import io.netty.util.AsciiString;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.action.admin.indices.refresh.RefreshRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.not;
+
+public class ParallelGrokStringSubstituteLogTest {
+    private static final int HTTP_SOURCE_PORT = 2021;
+    private static final String GROK_INDEX_NAME = "test-grok-index";
+    private static final String SUBSTITUTE_INDEX_NAME = "test-substitute-index";
+    private static final String testString = "firstword secondword thirdword";
+
+    private final ApacheLogFaker apacheLogFaker = new ApacheLogFaker();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testPipelineEndToEnd() throws JsonProcessingException {
+        // Send data to http source
+        sendHttpRequestToSource(HTTP_SOURCE_PORT, generateRandomApacheLogHttpData());
+        // Verify data in OpenSearch backend
+        final RestHighLevelClient restHighLevelClient = prepareOpenSearchRestHighLevelClient();
+        final List<Map<String, Object>> retrievedDocs = new ArrayList<>();
+        // Wait for data to flow through pipeline and be indexed by ES
+        await().atMost(20, TimeUnit.SECONDS).untilAsserted(
+                () -> {
+                    refreshIndices(restHighLevelClient);
+                    final SearchRequest grokRequest = new SearchRequest(GROK_INDEX_NAME);
+                    final SearchRequest substRequest = new SearchRequest(SUBSTITUTE_INDEX_NAME);
+                    grokRequest.source(
+                            SearchSourceBuilder.searchSource().size(100)
+                    );
+                    substRequest.source(
+                            SearchSourceBuilder.searchSource().size(100)
+                    );
+                    final SearchResponse grokResponse = restHighLevelClient.search(grokRequest, RequestOptions.DEFAULT);
+                    final List<Map<String, Object>> grokSources = getSourcesFromSearchHits(grokResponse.getHits());
+                    Assert.assertEquals(1, grokSources.size());
+		    Map<String, Object> grokSource = grokSources.get(0);
+                    Assert.assertEquals(4, grokSource.size());
+		    Assert.assertEquals(grokSource.get("message"), testString);
+		    String[] words = testString.split(" ");
+		    Assert.assertEquals(grokSource.get("word1"), words[0]);
+		    Assert.assertEquals(grokSource.get("word2"), words[1]);
+		    Assert.assertEquals(grokSource.get("word3"), words[2]);
+
+                    final SearchResponse substResponse = restHighLevelClient.search(substRequest, RequestOptions.DEFAULT);
+                    final List<Map<String, Object>> substSources = getSourcesFromSearchHits(substResponse.getHits());
+                    Assert.assertEquals(1, substSources.size());
+		    Map<String, Object> substSource = substSources.get(0);
+                    Assert.assertEquals(1, substSource.size());
+		    String expectedString = testString.replace("word", "WORD");
+		    Assert.assertEquals(substSource.get("message"), expectedString);
+                }
+        );
+    }
+
+    private RestHighLevelClient prepareOpenSearchRestHighLevelClient() {
+        final ConnectionConfiguration.Builder builder = new ConnectionConfiguration.Builder(
+                Collections.singletonList("https://127.0.0.1:9200"));
+        builder.withUsername("admin");
+        builder.withPassword("admin");
+        return builder.build().createClient();
+    }
+
+    private void sendHttpRequestToSource(final int port, final HttpData httpData) {
+        WebClient.of().execute(RequestHeaders.builder()
+                        .scheme(SessionProtocol.HTTP)
+                        .authority(String.format("127.0.0.1:%d", port))
+                        .method(HttpMethod.POST)
+                        .path("/log/ingest")
+                        .contentType(MediaType.JSON_UTF_8)
+                        .build(),
+                httpData)
+                .aggregate()
+                .whenComplete((i, ex) -> {
+                    assertThat(i.status(), is(HttpStatus.OK));
+                    final List<String> headerKeys = i.headers()
+                            .stream()
+                            .map(Map.Entry::getKey)
+                            .map(AsciiString::toString)
+                            .collect(Collectors.toList());
+                    assertThat("Response Header Keys", headerKeys, not(contains("server")));
+                }).join();
+    }
+
+    private List<Map<String, Object>> getSourcesFromSearchHits(final SearchHits searchHits) {
+        final List<Map<String, Object>> sources = new ArrayList<>();
+        searchHits.forEach(hit -> {
+            Map<String, Object> source = hit.getSourceAsMap();
+            sources.add(source);
+        });
+        return sources;
+    }
+
+    private void refreshIndices(final RestHighLevelClient restHighLevelClient) throws IOException {
+        final RefreshRequest requestAll = new RefreshRequest();
+        restHighLevelClient.indices().refresh(requestAll, RequestOptions.DEFAULT);
+    }
+
+    private HttpData generateRandomApacheLogHttpData() throws JsonProcessingException {
+        final List<Map<String, Object>> jsonArray = new ArrayList<>();
+        final Map<String, Object> logObj = new HashMap<String, Object>() {{
+            put("message", testString);
+        }};
+        jsonArray.add(logObj);
+        final String jsonData = objectMapper.writeValueAsString(jsonArray);
+        return HttpData.ofUtf8(jsonData);
+    }
+}

--- a/e2e-test/log/src/integrationTest/resources/parallel-grok-substitute-e2e-pipeline.yml
+++ b/e2e-test/log/src/integrationTest/resources/parallel-grok-substitute-e2e-pipeline.yml
@@ -1,0 +1,40 @@
+pipeline1:
+  source:
+    http:
+  sink:
+    - pipeline:
+        name: "pipeline2"
+    - pipeline:
+        name: "pipeline3"
+
+pipeline2:
+  source:
+    pipeline:
+      name: "pipeline1"
+  processor:
+    - substitute_string:
+        entries:
+          - source: "message"
+            from: "word"
+            to: "WORD"
+  sink:
+    - opensearch:
+        hosts: [ "https://node-0.example.com:9200" ]
+        username: "admin"
+        password: "admin"
+        index: "test-substitute-index"
+
+pipeline3:
+  source:
+    pipeline:
+      name: "pipeline1"
+  processor:
+    - grok:
+        match:
+          message: ['%{WORD:word1} %{WORD:word2} %{WORD:word3}']
+  sink:
+    - opensearch:
+        hosts: [ "https://node-0.example.com:9200" ]
+        username: "admin"
+        password: "admin"
+        index: "test-grok-index"


### PR DESCRIPTION
### Description
This fix resolves the issue reported in the bug https://github.com/opensearch-project/data-prepper/issues/1886. This bug is about some pipeline processors not duplicating the events before modifying them. And that was causing wrong behavior when a pipeline is split into two parallel pipelines.

When pipeline1 has two sinks pipeline2 and pipeline3 and pipeline2 is just doing grok match and pipeline3 is doing string substitution, both the pipelines will see the string substitution because same event is used in both cases. 
Fix is to make a copy of the event whenever an event is modified.

Added a new end-to-end test case that was failing without the fix and verified that the test case is passing with the fix.
                                           
 
### Issues Resolved
Resolves #1886
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
