### PR TITLE
Added AWS STS header override configurations for OpenSearch sink/S3 source

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -74,6 +74,8 @@ Default is null.
 
 - `aws_sts_role_arn`: A IAM role arn which the sink plugin will assume to sign request to Amazon OpenSearch Service. If not provided the plugin will use the default credentials.
 
+- `aws_sts_header_overrides`: An optional map of header overrides to make when assuming the IAM role for the sink plugin.
+
 - `insecure`: A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Default to `false`.
 
 - `socket_timeout`(optional): An integer value indicates the timeout in milliseconds for waiting for data (or, put differently, a maximum period inactivity between two consecutive data packets). A timeout value of zero is interpreted as an infinite timeout. If this timeout value is either negative or not set, the underlying Apache HttpClient would rely on operating system settings for managing socket timeouts.

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfigurationTests.java
@@ -5,9 +5,16 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;
 
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -16,15 +23,27 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
-public class ConnectionConfigurationTests {
+class ConnectionConfigurationTests {
     private static final String PROXY_PARAMETER = "proxy";
     private final List<String> TEST_HOSTS = Collections.singletonList("http://localhost:9200");
     private final String TEST_USERNAME = "admin";
@@ -35,7 +54,7 @@ public class ConnectionConfigurationTests {
     private final String TEST_CERT_PATH = Objects.requireNonNull(getClass().getClassLoader().getResource("test-ca.pem")).getFile();
 
     @Test
-    public void testReadConnectionConfigurationDefault() {
+    void testReadConnectionConfigurationDefault() {
         final PluginSetting pluginSetting = generatePluginSetting(
                 TEST_HOSTS, null, null, null, null, false, null, null, null, false);
         final ConnectionConfiguration connectionConfiguration =
@@ -51,7 +70,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClientDefault() throws IOException {
+    void testCreateClientDefault() throws IOException {
         final PluginSetting pluginSetting = generatePluginSetting(
                 TEST_HOSTS, null, null, null, null, false, null, null, null, false);
         final ConnectionConfiguration connectionConfiguration =
@@ -62,7 +81,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testReadConnectionConfigurationNoCert() {
+    void testReadConnectionConfigurationNoCert() {
         final PluginSetting pluginSetting = generatePluginSetting(
                 TEST_HOSTS, TEST_USERNAME, TEST_PASSWORD, TEST_CONNECT_TIMEOUT, TEST_SOCKET_TIMEOUT, false, null, null, null, false);
         final ConnectionConfiguration connectionConfiguration =
@@ -77,7 +96,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClientNoCert() throws IOException {
+    void testCreateClientNoCert() throws IOException {
         final PluginSetting pluginSetting = generatePluginSetting(
                 TEST_HOSTS, TEST_USERNAME, TEST_PASSWORD, TEST_CONNECT_TIMEOUT, TEST_SOCKET_TIMEOUT, false, null, null, null, false);
         final ConnectionConfiguration connectionConfiguration =
@@ -88,7 +107,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClientInsecure() throws IOException {
+    void testCreateClientInsecure() throws IOException {
         final PluginSetting pluginSetting = generatePluginSetting(
                 TEST_HOSTS, TEST_USERNAME, TEST_PASSWORD, TEST_CONNECT_TIMEOUT, TEST_SOCKET_TIMEOUT, false, null, null, null, true);
         final ConnectionConfiguration connectionConfiguration =
@@ -99,7 +118,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClientWithCertPath() throws IOException {
+    void testCreateClientWithCertPath() throws IOException {
         final PluginSetting pluginSetting = generatePluginSetting(
                 TEST_HOSTS, TEST_USERNAME, TEST_PASSWORD, TEST_CONNECT_TIMEOUT, TEST_SOCKET_TIMEOUT, false, null, null, TEST_CERT_PATH, false);
         final ConnectionConfiguration connectionConfiguration =
@@ -110,7 +129,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClientWithAWSSigV4AndRegion() throws IOException {
+    void testCreateClientWithAWSSigV4AndRegion() throws IOException {
         final PluginSetting pluginSetting = generatePluginSetting(
                 TEST_HOSTS, null, null, null, null, true, "us-west-2", null, null, false);
         final ConnectionConfiguration connectionConfiguration =
@@ -120,7 +139,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClientWithAWSSigV4DefaultRegion() throws IOException {
+    void testCreateClientWithAWSSigV4DefaultRegion() throws IOException {
         final PluginSetting pluginSetting = generatePluginSetting(
                 TEST_HOSTS, null, null, null, null, true, null, null, null, false);
         final ConnectionConfiguration connectionConfiguration =
@@ -131,7 +150,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClientWithAWSSigV4AndInsecure() throws IOException {
+    void testCreateClientWithAWSSigV4AndInsecure() throws IOException {
         final PluginSetting pluginSetting = generatePluginSetting(
                 TEST_HOSTS, null, null, null, null, true, null, null, null, true);
         final ConnectionConfiguration connectionConfiguration =
@@ -142,7 +161,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClientWithAWSSigV4AndCertPath() throws IOException {
+    void testCreateClientWithAWSSigV4AndCertPath() throws IOException {
         final PluginSetting pluginSetting = generatePluginSetting(
                 TEST_HOSTS, null, null, null, null, true, null, null, TEST_CERT_PATH, false);
         final ConnectionConfiguration connectionConfiguration =
@@ -153,19 +172,100 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClientWithAWSSigV4AndSTSRole() throws IOException {
+    void testCreateClientWithAWSSigV4AndSTSRole() throws IOException {
         final PluginSetting pluginSetting = generatePluginSetting(
                 TEST_HOSTS, null, null, null, null, true, null, "arn:aws:iam::123456789012:iam-role", TEST_CERT_PATH, false);
         final ConnectionConfiguration connectionConfiguration =
                 ConnectionConfiguration.readConnectionConfiguration(pluginSetting);
-        assertEquals("us-east-1", connectionConfiguration.getAwsRegion());
-        assertTrue(connectionConfiguration.isAwsSigv4());
-        assertEquals("arn:aws:iam::123456789012:iam-role", connectionConfiguration.getAwsStsRoleArn());
-        assertEquals(TEST_PIPELINE_NAME, connectionConfiguration.getPipelineName());
+        assertThat(connectionConfiguration, notNullValue());
+        assertThat(connectionConfiguration.getAwsRegion(), equalTo("us-east-1"));
+        assertThat(connectionConfiguration.isAwsSigv4(), equalTo(true));
+        assertThat(connectionConfiguration.getAwsStsRoleArn(), equalTo("arn:aws:iam::123456789012:iam-role"));
+        assertThat(connectionConfiguration.getPipelineName(), equalTo(TEST_PIPELINE_NAME));
+
+        final StsClient stsClient = mock(StsClient.class);
+        final AssumeRoleRequest.Builder assumeRoleRequestBuilder = mock(AssumeRoleRequest.Builder.class);
+        when(assumeRoleRequestBuilder.roleSessionName(anyString()))
+                .thenReturn(assumeRoleRequestBuilder);
+        when(assumeRoleRequestBuilder.roleArn(anyString()))
+                .thenReturn(assumeRoleRequestBuilder);
+        when(assumeRoleRequestBuilder.overrideConfiguration(any(Consumer.class)))
+                .thenReturn(assumeRoleRequestBuilder);
+
+        final StsClientBuilder stsClientBuilder = mock(StsClientBuilder.class);
+        when(stsClientBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class))).thenReturn(stsClientBuilder);
+        when(stsClientBuilder.build()).thenReturn(stsClient);
+
+        try(final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
+            final MockedStatic<AssumeRoleRequest> assumeRoleRequestMockedStatic = mockStatic(AssumeRoleRequest.class)) {
+
+            assumeRoleRequestMockedStatic.when(AssumeRoleRequest::builder).thenReturn(assumeRoleRequestBuilder);
+            stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
+            connectionConfiguration.createClient();
+        }
+
+        verify(assumeRoleRequestBuilder).roleArn("arn:aws:iam::123456789012:iam-role");
+        verify(assumeRoleRequestBuilder).roleSessionName(anyString());
+        verify(assumeRoleRequestBuilder).build();
+        verifyNoMoreInteractions(assumeRoleRequestBuilder);
     }
 
     @Test
-    public void testCreateClient_WithValidHttpProxy_HostIP() throws IOException {
+    void testCreateClientWithAWSSigV4AndHeaderOverrides() {
+        final String headerName1 = UUID.randomUUID().toString();
+        final String headerValue1 = UUID.randomUUID().toString();
+        final String headerName2 = UUID.randomUUID().toString();
+        final String headerValue2 = UUID.randomUUID().toString();
+        final Map<String, Object> configurationMetadata = generateConfigurationMetadata(TEST_HOSTS, null, null, null, null, true, null, "arn:aws:iam::123456789012:iam-role", TEST_CERT_PATH, false);
+        configurationMetadata.put("aws_sts_header_overrides", Map.of(headerName1, headerValue1, headerName2, headerValue2));
+        final PluginSetting pluginSetting = getPluginSettingByConfigurationMetadata(configurationMetadata);
+        final ConnectionConfiguration connectionConfiguration =
+                ConnectionConfiguration.readConnectionConfiguration(pluginSetting);
+
+        assertThat(connectionConfiguration, notNullValue());
+        assertThat(connectionConfiguration.isAwsSigv4(), equalTo(true));
+        assertThat(connectionConfiguration.getAwsStsRoleArn(), equalTo("arn:aws:iam::123456789012:iam-role"));
+
+        final StsClient stsClient = mock(StsClient.class);
+        final AssumeRoleRequest.Builder assumeRoleRequestBuilder = mock(AssumeRoleRequest.Builder.class);
+        when(assumeRoleRequestBuilder.roleSessionName(anyString()))
+                .thenReturn(assumeRoleRequestBuilder);
+        when(assumeRoleRequestBuilder.roleArn(anyString()))
+                .thenReturn(assumeRoleRequestBuilder);
+        when(assumeRoleRequestBuilder.overrideConfiguration(any(Consumer.class)))
+                .thenReturn(assumeRoleRequestBuilder);
+
+        final StsClientBuilder stsClientBuilder = mock(StsClientBuilder.class);
+        when(stsClientBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class))).thenReturn(stsClientBuilder);
+        when(stsClientBuilder.build()).thenReturn(stsClient);
+
+        try(final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
+            final MockedStatic<AssumeRoleRequest> assumeRoleRequestMockedStatic = mockStatic(AssumeRoleRequest.class)) {
+
+            assumeRoleRequestMockedStatic.when(AssumeRoleRequest::builder).thenReturn(assumeRoleRequestBuilder);
+            stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
+            connectionConfiguration.createClient();
+        }
+
+        final ArgumentCaptor<Consumer<AwsRequestOverrideConfiguration.Builder>> configurationCaptor = ArgumentCaptor.forClass(Consumer.class);
+
+        verify(assumeRoleRequestBuilder).overrideConfiguration(configurationCaptor.capture());
+        verify(assumeRoleRequestBuilder).roleArn("arn:aws:iam::123456789012:iam-role");
+        verify(assumeRoleRequestBuilder).roleSessionName(anyString());
+        verify(assumeRoleRequestBuilder).build();
+        verifyNoMoreInteractions(assumeRoleRequestBuilder);
+
+        final Consumer<AwsRequestOverrideConfiguration.Builder> actualOverride = configurationCaptor.getValue();
+
+        final AwsRequestOverrideConfiguration.Builder configurationBuilder = mock(AwsRequestOverrideConfiguration.Builder.class);
+        actualOverride.accept(configurationBuilder);
+        verify(configurationBuilder).putHeader(headerName1, headerValue1);
+        verify(configurationBuilder).putHeader(headerName2, headerValue2);
+        verifyNoMoreInteractions(configurationBuilder);
+    }
+
+    @Test
+    void testCreateClient_WithValidHttpProxy_HostIP() throws IOException {
         final Map<String, Object> metadata = generateConfigurationMetadata(
                 TEST_HOSTS, TEST_USERNAME, TEST_PASSWORD, TEST_CONNECT_TIMEOUT, TEST_SOCKET_TIMEOUT, false, null, null, TEST_CERT_PATH, false);
         final String testHttpProxy = "121.121.121.121:80";
@@ -180,7 +280,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClient_WithValidHttpProxy_HostName() throws IOException {
+    void testCreateClient_WithValidHttpProxy_HostName() throws IOException {
         final Map<String, Object> metadata = generateConfigurationMetadata(
                 TEST_HOSTS, TEST_USERNAME, TEST_PASSWORD, TEST_CONNECT_TIMEOUT, TEST_SOCKET_TIMEOUT, false, null, null, TEST_CERT_PATH, false);
         final String testHttpProxy = "example.com:80";
@@ -195,7 +295,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClient_WithValidHttpProxy_SchemeProvided() throws IOException {
+    void testCreateClient_WithValidHttpProxy_SchemeProvided() throws IOException {
         final Map<String, Object> metadata = generateConfigurationMetadata(
                 TEST_HOSTS, TEST_USERNAME, TEST_PASSWORD, TEST_CONNECT_TIMEOUT, TEST_SOCKET_TIMEOUT, false, null, null, TEST_CERT_PATH, false);
         final String testHttpProxy = "http://example.com:4350";
@@ -210,7 +310,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClient_WithInvalidHttpProxy_InvalidPort() {
+    void testCreateClient_WithInvalidHttpProxy_InvalidPort() {
         final Map<String, Object> metadata = generateConfigurationMetadata(
                 TEST_HOSTS, TEST_USERNAME, TEST_PASSWORD, TEST_CONNECT_TIMEOUT, TEST_SOCKET_TIMEOUT, false, null, null, TEST_CERT_PATH, false);
         final String testHttpProxy = "example.com:port";
@@ -223,7 +323,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClient_WithInvalidHttpProxy_NoPort() {
+    void testCreateClient_WithInvalidHttpProxy_NoPort() {
         final Map<String, Object> metadata = generateConfigurationMetadata(
                 TEST_HOSTS, TEST_USERNAME, TEST_PASSWORD, TEST_CONNECT_TIMEOUT, TEST_SOCKET_TIMEOUT, false, null, null, TEST_CERT_PATH, false);
         final String testHttpProxy = "example.com";
@@ -235,7 +335,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClient_WithInvalidHttpProxy_PortNotInRange() {
+    void testCreateClient_WithInvalidHttpProxy_PortNotInRange() {
         final Map<String, Object> metadata = generateConfigurationMetadata(
                 TEST_HOSTS, TEST_USERNAME, TEST_PASSWORD, TEST_CONNECT_TIMEOUT, TEST_SOCKET_TIMEOUT, false, null, null, TEST_CERT_PATH, false);
         final String testHttpProxy = "example.com:888888";
@@ -247,7 +347,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClient_WithInvalidHttpProxy_NotHttp() {
+    void testCreateClient_WithInvalidHttpProxy_NotHttp() {
         final Map<String, Object> metadata = generateConfigurationMetadata(
                 TEST_HOSTS, TEST_USERNAME, TEST_PASSWORD, TEST_CONNECT_TIMEOUT, TEST_SOCKET_TIMEOUT, false, null, null, TEST_CERT_PATH, false);
         final String testHttpProxy = "socket://example.com:port";
@@ -260,7 +360,7 @@ public class ConnectionConfigurationTests {
     }
 
     @Test
-    public void testCreateClient_WithConnectionConfigurationBuilder_ProxyOptionalObjectShouldNotBeNull() throws IOException {
+    void testCreateClient_WithConnectionConfigurationBuilder_ProxyOptionalObjectShouldNotBeNull() throws IOException {
         final ConnectionConfiguration.Builder builder = new ConnectionConfiguration.Builder(TEST_HOSTS);
         final ConnectionConfiguration connectionConfiguration = builder.build();
         assertEquals(Optional.empty(), connectionConfiguration.getProxy());

--- a/data-prepper-plugins/otel-trace-group-processor/README.md
+++ b/data-prepper-plugins/otel-trace-group-processor/README.md
@@ -46,6 +46,10 @@ Default is null.
 
 - `aws_region`: A String represents the region of Amazon OpenSearch Service domain, e.g. us-west-2. Only applies to Amazon OpenSearch Service. Defaults to `us-east-1`.
 
+- `aws_sts_role_arn`: A IAM role arn which the sink plugin will assume to sign request to Amazon OpenSearch Service. If not provided the plugin will use the default credentials.
+
+- `aws_sts_header_overrides`: An optional map of header overrides to make when assuming the IAM role for the sink plugin.
+
 - `insecure`: A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Default to `false`.
 
 - `username`(optional): A String of username used in the [internal users](https://opensearch.org/docs/latest/security-plugin/access-control/users-roles) of OpenSearch cluster. Default is null.

--- a/data-prepper-plugins/s3-source/README.md
+++ b/data-prepper-plugins/s3-source/README.md
@@ -82,6 +82,7 @@ The AWS configuration is the same for both SQS and S3.
 
 * `region` (Optional) : The AWS region to use for credentials. Defaults to [standard SDK behavior to determine the region](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html).
 * `sts_role_arn` (Optional) : The AWS STS role to assume for requests to SQS and S3. Defaults to null, which will use the [standard SDK behavior for credentials](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html).
+* `aws_sts_header_overrides` (Optional): A map of header overrides to make when assuming the IAM role for the sink plugin.
 
 ## Metrics
 

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/configuration/AwsAuthenticationOptionsTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/configuration/AwsAuthenticationOptionsTest.java
@@ -8,23 +8,33 @@ package org.opensearch.dataprepper.plugins.source.configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.StsClientBuilder;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class AwsAuthenticationOptionsTest {
@@ -90,14 +100,26 @@ class AwsAuthenticationOptionsTest {
             reflectivelySetField(awsAuthenticationOptions, "awsStsRoleArn", "arn:aws:iam::123456789012:iam-role");
 
             when(stsClientBuilder.region(Region.US_EAST_1)).thenReturn(stsClientBuilder);
+            final AssumeRoleRequest.Builder assumeRoleRequestBuilder = mock(AssumeRoleRequest.Builder.class);
+            when(assumeRoleRequestBuilder.roleSessionName(anyString()))
+                    .thenReturn(assumeRoleRequestBuilder);
+            when(assumeRoleRequestBuilder.roleArn(anyString()))
+                    .thenReturn(assumeRoleRequestBuilder);
 
             final AwsCredentialsProvider actualCredentialsProvider;
-            try (final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class)) {
+            try (final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
+                 final MockedStatic<AssumeRoleRequest> assumeRoleRequestMockedStatic = mockStatic(AssumeRoleRequest.class)) {
                 stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
+                assumeRoleRequestMockedStatic.when(AssumeRoleRequest::builder).thenReturn(assumeRoleRequestBuilder);
                 actualCredentialsProvider = awsAuthenticationOptions.authenticateAwsConfiguration();
             }
 
             assertThat(actualCredentialsProvider, instanceOf(AwsCredentialsProvider.class));
+
+            verify(assumeRoleRequestBuilder).roleArn("arn:aws:iam::123456789012:iam-role");
+            verify(assumeRoleRequestBuilder).roleSessionName(anyString());
+            verify(assumeRoleRequestBuilder).build();
+            verifyNoMoreInteractions(assumeRoleRequestBuilder);
         }
 
         @Test
@@ -115,6 +137,84 @@ class AwsAuthenticationOptionsTest {
             }
 
             assertThat(actualCredentialsProvider, instanceOf(AwsCredentialsProvider.class));
+        }
+
+        @Test
+        void authenticateAWSConfiguration_should_override_STS_Headers_when_HeaderOverrides_when_set() throws NoSuchFieldException, IllegalAccessException {
+            final String headerName1 = UUID.randomUUID().toString();
+            final String headerValue1 = UUID.randomUUID().toString();
+            final String headerName2 = UUID.randomUUID().toString();
+            final String headerValue2 = UUID.randomUUID().toString();
+            final Map<String, String> overrideHeaders = Map.of(headerName1, headerValue1, headerName2, headerValue2);
+
+            reflectivelySetField(awsAuthenticationOptions, "awsRegion", "us-east-1");
+            reflectivelySetField(awsAuthenticationOptions, "awsStsRoleArn", "arn:aws:iam::123456789012:iam-role");
+            reflectivelySetField(awsAuthenticationOptions, "awsStsHeaderOverrides", overrideHeaders);
+
+            when(stsClientBuilder.region(Region.US_EAST_1)).thenReturn(stsClientBuilder);
+
+            final AssumeRoleRequest.Builder assumeRoleRequestBuilder = mock(AssumeRoleRequest.Builder.class);
+            when(assumeRoleRequestBuilder.roleSessionName(anyString()))
+                    .thenReturn(assumeRoleRequestBuilder);
+            when(assumeRoleRequestBuilder.roleArn(anyString()))
+                    .thenReturn(assumeRoleRequestBuilder);
+            when(assumeRoleRequestBuilder.overrideConfiguration(any(Consumer.class)))
+                    .thenReturn(assumeRoleRequestBuilder);
+
+            final AwsCredentialsProvider actualCredentialsProvider;
+            try (final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
+                 final MockedStatic<AssumeRoleRequest> assumeRoleRequestMockedStatic = mockStatic(AssumeRoleRequest.class)) {
+                stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
+                assumeRoleRequestMockedStatic.when(AssumeRoleRequest::builder).thenReturn(assumeRoleRequestBuilder);
+                actualCredentialsProvider = awsAuthenticationOptions.authenticateAwsConfiguration();
+            }
+
+            assertThat(actualCredentialsProvider, instanceOf(AwsCredentialsProvider.class));
+
+            final ArgumentCaptor<Consumer<AwsRequestOverrideConfiguration.Builder>> configurationCaptor = ArgumentCaptor.forClass(Consumer.class);
+
+            verify(assumeRoleRequestBuilder).roleArn("arn:aws:iam::123456789012:iam-role");
+            verify(assumeRoleRequestBuilder).roleSessionName(anyString());
+            verify(assumeRoleRequestBuilder).overrideConfiguration(configurationCaptor.capture());
+            verify(assumeRoleRequestBuilder).build();
+            verifyNoMoreInteractions(assumeRoleRequestBuilder);
+
+            final Consumer<AwsRequestOverrideConfiguration.Builder> actualOverride = configurationCaptor.getValue();
+
+            final AwsRequestOverrideConfiguration.Builder configurationBuilder = mock(AwsRequestOverrideConfiguration.Builder.class);
+            actualOverride.accept(configurationBuilder);
+            verify(configurationBuilder).putHeader(headerName1, headerValue1);
+            verify(configurationBuilder).putHeader(headerName2, headerValue2);
+            verifyNoMoreInteractions(configurationBuilder);
+        }
+
+        @Test
+        void authenticateAWSConfiguration_should_override_STS_Headers_when_HeaderOverrides_are_empty() throws NoSuchFieldException, IllegalAccessException {
+            reflectivelySetField(awsAuthenticationOptions, "awsRegion", "us-east-1");
+            reflectivelySetField(awsAuthenticationOptions, "awsStsRoleArn", "arn:aws:iam::123456789012:iam-role");
+            reflectivelySetField(awsAuthenticationOptions, "awsStsHeaderOverrides", Collections.emptyMap());
+
+            when(stsClientBuilder.region(Region.US_EAST_1)).thenReturn(stsClientBuilder);
+            final AssumeRoleRequest.Builder assumeRoleRequestBuilder = mock(AssumeRoleRequest.Builder.class);
+            when(assumeRoleRequestBuilder.roleSessionName(anyString()))
+                    .thenReturn(assumeRoleRequestBuilder);
+            when(assumeRoleRequestBuilder.roleArn(anyString()))
+                    .thenReturn(assumeRoleRequestBuilder);
+
+            final AwsCredentialsProvider actualCredentialsProvider;
+            try (final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
+                 final MockedStatic<AssumeRoleRequest> assumeRoleRequestMockedStatic = mockStatic(AssumeRoleRequest.class)) {
+                stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
+                assumeRoleRequestMockedStatic.when(AssumeRoleRequest::builder).thenReturn(assumeRoleRequestBuilder);
+                actualCredentialsProvider = awsAuthenticationOptions.authenticateAwsConfiguration();
+            }
+
+            assertThat(actualCredentialsProvider, instanceOf(AwsCredentialsProvider.class));
+
+            verify(assumeRoleRequestBuilder).roleArn("arn:aws:iam::123456789012:iam-role");
+            verify(assumeRoleRequestBuilder).roleSessionName(anyString());
+            verify(assumeRoleRequestBuilder).build();
+            verifyNoMoreInteractions(assumeRoleRequestBuilder);
         }
     }
 

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/configuration/AwsAuthenticationOptionsTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/configuration/AwsAuthenticationOptionsTest.java
@@ -189,7 +189,7 @@ class AwsAuthenticationOptionsTest {
         }
 
         @Test
-        void authenticateAWSConfiguration_should_override_STS_Headers_when_HeaderOverrides_are_empty() throws NoSuchFieldException, IllegalAccessException {
+        void authenticateAWSConfiguration_should_not_override_STS_Headers_when_HeaderOverrides_are_empty() throws NoSuchFieldException, IllegalAccessException {
             reflectivelySetField(awsAuthenticationOptions, "awsRegion", "us-east-1");
             reflectivelySetField(awsAuthenticationOptions, "awsStsRoleArn", "arn:aws:iam::123456789012:iam-role");
             reflectivelySetField(awsAuthenticationOptions, "awsStsHeaderOverrides", Collections.emptyMap());


### PR DESCRIPTION
### Description

Adds the ability to override the AWS STS headers when using AWS STS for Amazon OpenSearch Service or Amazon S3.
 
Also updates `ConnectionConfigurationTests` to use JUnit 5.

### Issues Resolved

Resolves #1888
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
