### PR TITLE
Adds a stack-trace to failures from OpenSearch

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -219,10 +219,10 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
         dlqWriter.write(String.format("{\"Document\": [%s], \"failure\": %s}\n",
                 BulkOperationWriter.bulkOperationToString(bulkOperation), failure.getMessage()));
       } catch (final IOException e) {
-        LOG.error("DLQ failed for Document [{}]", bulkOperation.toString());
+        LOG.error("DLQ failed for Document [{}]", bulkOperation, e);
       }
     } else {
-      LOG.warn("Document [{}] has failure: {}", bulkOperation.toString(), failure);
+      LOG.warn("Document [{}] has failure.", bulkOperation.toString(), failure);
     }
   }
 


### PR DESCRIPTION
### Description

The current logging of failures in OpenSearch only includes the top-level message. This is not very helpful with unexpected errors. This PR logs the full exception using SLF4J.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
