### PR TITLE
Increase the default buffer configurations by 25

### DIFF
--- a/data-prepper-plugins/blocking-buffer/src/main/java/org/opensearch/dataprepper/plugins/buffer/blockingbuffer/BlockingBuffer.java
+++ b/data-prepper-plugins/blocking-buffer/src/main/java/org/opensearch/dataprepper/plugins/buffer/blockingbuffer/BlockingBuffer.java
@@ -43,8 +43,8 @@ import static java.lang.String.format;
 @DataPrepperPlugin(name = "bounded_blocking", pluginType = Buffer.class)
 public class BlockingBuffer<T extends Record<?>> extends AbstractBuffer<T> {
     private static final Logger LOG = LoggerFactory.getLogger(BlockingBuffer.class);
-    private static final int DEFAULT_BUFFER_CAPACITY = 512;
-    private static final int DEFAULT_BATCH_SIZE = 8;
+    private static final int DEFAULT_BUFFER_CAPACITY = 12_800;
+    private static final int DEFAULT_BATCH_SIZE = 200;
     private static final String PLUGIN_NAME = "bounded_blocking";
     private static final String ATTRIBUTE_BUFFER_CAPACITY = "buffer_size";
     private static final String ATTRIBUTE_BATCH_SIZE = "batch_size";


### PR DESCRIPTION
### Description

This PR increased the default configurations for `bounding_buffer`. It increases both the `buffer_size` and `batch_size` by 25 to 12,800 and 200, respectively.

These may not be the most ideal values. But, they are better than the current defaults. This change should be considered a breaking change since it would change any pipeline which does not configure these values. So I'd rather have some improvement in 2.0 than no improvement on these values.

### Performance Runs

For the old defaults:

```
Simulation org.opensearch.dataprepper.test.performance.TargetRpsSimulation completed in 130 seconds
Parsing log file(s)...
Parsing log file(s) done
Generating reports...

================================================================================
---- Global Information --------------------------------------------------------
> request count                                       3905 (OK=406    KO=3499  )
> min response time                                    112 (OK=112    KO=9994  )
> max response time                                  10078 (OK=10000  KO=10078 )
> mean response time                                  9683 (OK=6974   KO=9997  )
> std deviation                                       1211 (OK=2435   KO=7     )
> response time 50th percentile                       9996 (OK=7593   KO=9996  )
> response time 75th percentile                       9997 (OK=8857   KO=9997  )
> response time 95th percentile                      10003 (OK=9701   KO=10004 )
> response time 99th percentile                      10018 (OK=9921   KO=10022 )
> mean requests/sec                                  39.05 (OK=4.06   KO=34.99 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                            10 (  0%)
> 800 ms <= t < 1200 ms                                  3 (  0%)
> t ≥ 1200 ms                                          393 ( 10%)
> failed                                              3499 ( 90%)
---- Errors --------------------------------------------------------------------
> status.find.in([200, 209], 304), found 503                       3499 (100.0%)
================================================================================
```

Performance run with new configurations:

```
Simulation org.opensearch.dataprepper.test.performance.TargetRpsSimulation completed in 130 seconds
Parsing log file(s)...
Parsing log file(s) done
Generating reports...

================================================================================
---- Global Information --------------------------------------------------------
> request count                                       9668 (OK=9668   KO=0     )
> min response time                                   1114 (OK=1114   KO=-     )
> max response time                                   6929 (OK=6929   KO=-     )
> mean response time                                  4036 (OK=4036   KO=-     )
> std deviation                                       1167 (OK=1167   KO=-     )
> response time 50th percentile                       4244 (OK=4244   KO=-     )
> response time 75th percentile                       4688 (OK=4688   KO=-     )
> response time 95th percentile                       5879 (OK=5879   KO=-     )
> response time 99th percentile                       6685 (OK=6685   KO=-     )
> mean requests/sec                                  96.68 (OK=96.68  KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                             0 (  0%)
> 800 ms <= t < 1200 ms                                 14 (  0%)
> t ≥ 1200 ms                                         9654 (100%)
> failed                                                 0 (  0%)
================================================================================
```

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
