### PR TITLE
Simple duration regex did not allow for 0s or 0ms

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/DataPrepperDurationDeserializer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/DataPrepperDurationDeserializer.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
  */
 public class DataPrepperDurationDeserializer extends StdDeserializer<Duration> {
 
-    private static final String SIMPLE_DURATION_REGEX = "^([1-9]\\d*)(s|ms)$";
+    private static final String SIMPLE_DURATION_REGEX = "^(0|[1-9]\\d*)(s|ms)$";
     private static final Pattern SIMPLE_DURATION_PATTERN = Pattern.compile(SIMPLE_DURATION_REGEX);
 
     public DataPrepperDurationDeserializer() {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/DataPrepperDurationDeserializerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/DataPrepperDurationDeserializerTest.java
@@ -31,7 +31,7 @@ public class DataPrepperDurationDeserializerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"6s1s", "60ms 100s", "20.345s", "0s", "-1s", "06s", "100m", "100sm", "100"})
+    @ValueSource(strings = {"6s1s", "60ms 100s", "20.345s", "-1s", "06s", "100m", "100sm", "100"})
     void invalidDurationStringsThrowIllegalArgumentException(String durationString) {
         assertThrows(IllegalArgumentException.class, () -> objectMapper.convertValue(durationString, Duration.class));
     }
@@ -41,6 +41,14 @@ public class DataPrepperDurationDeserializerTest {
         final String durationString = "PT15M";
         final Duration result = objectMapper.convertValue(durationString, Duration.class);
         assertThat(result, equalTo(Duration.ofMinutes(15)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0s", "0ms"})
+    void simple_duration_strings_of_0_return_correct_duration(String durationString) {
+        final Duration result = objectMapper.convertValue(durationString, Duration.class);
+
+        assertThat(result, equalTo(Duration.ofSeconds(0)));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Signed-off-by: Taylor Gray <tylgry@amazon.com>

### Description
Supports `0s` or `0ms` simple duration values
 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
