### PR TITLE
Attempt to reduce flakiness in RandomStringSourceTests

### DIFF
--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/source/RandomStringSourceTests.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/source/RandomStringSourceTests.java
@@ -5,33 +5,61 @@
 
 package org.opensearch.dataprepper.plugins.source;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.buffer.TestBuffer;
-import org.junit.Test;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
-public class RandomStringSourceTests {
+class RandomStringSourceTests {
+
+    private TestBuffer buffer;
+
+    @BeforeEach
+    void setUp() {
+        final Queue<Record<Event>> bufferQueue = new ConcurrentLinkedQueue<>();
+        buffer = new TestBuffer(bufferQueue, 1);
+    }
+
+    private RandomStringSource createObjectUnderTest() {
+        return new RandomStringSource();
+    }
 
     @Test
-    public void testPutRecord() throws InterruptedException {
-        final RandomStringSource randomStringSource =
-                new RandomStringSource();
-        final Queue<Record<Event>> bufferQueue = new ConcurrentLinkedQueue<>();
-        final TestBuffer buffer = new TestBuffer(bufferQueue, 1);
-        //Start source, and sleep for 1000 millis
+    void testPutRecord() {
+        final RandomStringSource randomStringSource = createObjectUnderTest();
+
         randomStringSource.start(buffer);
-        Thread.sleep(1000);
-        //Stop the source, and wait long enough that another message would be sent
-        //if the source was running
-        assertThat(buffer.size(), greaterThan(0));
-        Thread.sleep(1000);
-        randomStringSource.stop();
+        await().atMost(3, TimeUnit.SECONDS)
+                .pollDelay(200, TimeUnit.MILLISECONDS)
+                .until(() -> buffer.size() > 0);
         assertThat(buffer.size(), greaterThan(0));
     }
+
+    @Test
+    void testStop() throws InterruptedException {
+        final RandomStringSource randomStringSource = createObjectUnderTest();
+        //Start source, and sleep for 1000 millis
+        randomStringSource.start(buffer);
+        await().atMost(3, TimeUnit.SECONDS)
+                .pollDelay(200, TimeUnit.MILLISECONDS)
+                .until(() -> buffer.size() > 0);
+        //Stop the source, and wait long enough that another message would be sent
+        //if the source was running
+        randomStringSource.stop();
+        Thread.sleep(200);  // Ensure the other thread has time to finish writing.
+        final int sizeAfterCompletion = buffer.size();
+        Thread.sleep(1000);
+        assertThat(buffer.size(), equalTo(sizeAfterCompletion));
+    }
+
 }


### PR DESCRIPTION
### Description

I've seen the `RandomStringSourceTests` fail a few times in GitHub Actions. I updated the test to use Awaitility rather than a simple sleep and increased the maximum time.

While I was here, I noticed the test is testing two things, so I split it. And I updated to JUnit 5.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
