### PR TITLE
Jackson 2.13.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,12 @@ subprojects {
                 }
                 because 'the build fails if the Log4j API is not update along with log4j-core'
             }
+            implementation('com.fasterxml.jackson.core:jackson-databind') {
+                version {
+                    require '2.13.4.2'
+                }
+                because 'Fixes CVE-2022-42003. Keep this until Data Prepper uses 2.14.'
+            }
             implementation('com.google.code.gson:gson') {
                 version {
                     require '2.8.9'


### PR DESCRIPTION
### Description

Updates `jackson-databind` to 2.13.4.2 which has a fix for CVE-2022-42003.
 
```
./gradlew -p data-prepper-main dependencies | grep jackson-databind | head -n 10
|    +--- com.fasterxml.jackson.core:jackson-databind:2.13.4 -> 2.13.4.2 (c)
|    |    +--- com.fasterxml.jackson.core:jackson-databind -> 2.13.4.2
|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.4 -> 2.13.4.2 (*)
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 (c)
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 (c)
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 (c)
|    |    +--- com.fasterxml.jackson.core:jackson-databind -> 2.13.4.2 (*)
|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.4 -> 2.13.4.2 (*)
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 (c)
|    |    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 (c)
```

### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
