### PR TITLE
Bug Fix: S3 source key 

### DIFF
--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/SqsWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/SqsWorkerIT.java
@@ -107,7 +107,7 @@ class SqsWorkerIT {
         verify(s3Service, atLeastOnce()).addS3Object(s3ObjectReferenceArgumentCaptor.capture());
 
         assertThat(s3ObjectReferenceArgumentCaptor.getValue().getBucketName(), equalTo(bucket));
-        assertThat(s3ObjectReferenceArgumentCaptor.getValue().getKey(), startsWith("s3source/sqs/"));
+        assertThat(s3ObjectReferenceArgumentCaptor.getValue().getKey(), startsWith("s3 source/sqs/"));
         assertThat(sqsMessagesProcessed, greaterThanOrEqualTo(1));
         assertThat(sqsMessagesProcessed, lessThanOrEqualTo(numberOfObjectsToWrite));
     }
@@ -124,7 +124,7 @@ class SqsWorkerIT {
         final int numberOfRecords = 100;
         final NewlineDelimitedRecordsGenerator newlineDelimitedRecordsGenerator = new NewlineDelimitedRecordsGenerator();
         for (int i = 0; i < numberOfObjectsToWrite; i++) {
-            final String key = "s3source/sqs/" + UUID.randomUUID() + "_" + Instant.now().toString() + newlineDelimitedRecordsGenerator.getFileExtension();
+            final String key = "s3 source/sqs/" + UUID.randomUUID() + "_" + Instant.now().toString() + newlineDelimitedRecordsGenerator.getFileExtension();
             // isCompressionEnabled is set to false since we test for compression in S3ObjectWorkerIT
             s3ObjectGenerator.write(numberOfRecords, key, newlineDelimitedRecordsGenerator, false);
         }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
@@ -219,7 +219,7 @@ public class SqsWorker implements Runnable {
     private S3ObjectReference populateS3Reference(final S3EventNotification.S3EventNotificationRecord s3EventNotificationRecord) {
         final S3EventNotification.S3Entity s3Entity = s3EventNotificationRecord.getS3();
         return S3ObjectReference.bucketAndKey(s3Entity.getBucket().getName(),
-                s3Entity.getObject().getKey())
+                s3Entity.getObject().getUrlDecodedKey())
                 .build();
     }
 }


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
This PR fixes the bug in S3 source where keys with spaces are not decoded correctly. 

I tested it locally with and without the code change. Also made changes to `SqsWorkerIT` to have space in the key. Tested the IT also with and without the changes to verify.

```
 ./gradlew :data-prepper-plugins:s3-source:integrationTest --tests "org.opensearch.dataprepper.plugins.source.SqsWorkerIT" -Dtests.s3source.region=us-east-1 -Dtests.s3source.bucket=<bucket-name> -Dtests.s3source.queue.url=<queue-url>
```

 
### Issues Resolved
resolves #1923 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
