### PR TITLE
Updated k8s manifest to suit Data Prepper 2.0

### DIFF
--- a/deployment-template/k8s/data-prepper-k8s.yaml
+++ b/deployment-template/k8s/data-prepper-k8s.yaml
@@ -13,6 +13,10 @@ data:
           health_check_service: true
           ssl: false
       processor:
+        - peer_forwarder:
+            discovery_mode: "dns"
+            domain_name: "data-prepper-headless"
+            ssl: false
       sink:
         - pipeline:
             name: "raw-pipeline"
@@ -37,10 +41,6 @@ data:
         - stdout:
   data-prepper-config.yaml: |
     ssl: false
-    peer_forwarder:
-      ssl: false
-      discovery_mode: "dns"
-      domain_name: "data-prepper-headless"
 ---
 apiVersion: v1
 kind: Service
@@ -95,25 +95,32 @@ spec:
         app: data-prepper
     spec:
       containers:
-        - args:
-            - java
-            - -jar
-            - /usr/share/data-prepper/data-prepper.jar
-            - /etc/data-prepper/pipelines.yaml
-            - /etc/data-prepper/data-prepper-config.yaml
-          image: opensearchproject/data-prepper:latest
+        - image: amazon/opendistro-for-elasticsearch-data-prepper:2.0
           name: data-prepper
           ports:
             - containerPort: 21890
           resources: {}
           volumeMounts:
-            - mountPath: /etc/data-prepper
-              name: prepper-configmap-claim0
+            - name: prepper-configmap-config
+              mountPath: /usr/share/data-prepper/config/data-prepper-config.yaml
+              subPath: data-prepper-config.yaml
+            - name: prepper-configmap-pipelines
+              mountPath: /usr/share/data-prepper/pipelines/pipelines.yaml
+              subPath: pipelines.yaml
       restartPolicy: Always
       serviceAccountName: ""
       volumes:
-        - name: prepper-configmap-claim0
+        - name: prepper-configmap-config
           configMap:
             name: data-prepper-config
+            items:
+              - key: data-prepper-config.yaml
+                path: data-prepper-config.yaml
+        - name: prepper-configmap-pipelines
+          configMap:
+            name: data-prepper-config
+            items:
+              - key: pipelines.yaml
+                path: pipelines.yaml
 status: {}
 ---

--- a/deployment-template/k8s/data-prepper-k8s.yaml
+++ b/deployment-template/k8s/data-prepper-k8s.yaml
@@ -1,22 +1,22 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: data-prepper
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
     app: data-prepper
   name: data-prepper-config
+  namespace: data-prepper
 data:
   pipelines.yaml: |
     entry-pipeline:
       delay: "100"
       source:
         otel_trace_source:
-          health_check_service: true
           ssl: false
-      processor:
-        - peer_forwarder:
-            discovery_mode: "dns"
-            domain_name: "data-prepper-headless"
-            ssl: false
       sink:
         - pipeline:
             name: "raw-pipeline"
@@ -41,6 +41,9 @@ data:
         - stdout:
   data-prepper-config.yaml: |
     ssl: false
+    peer_forwarder:
+      discovery_mode: dns
+      domain_name: "data-prepper-cluster.my-domain.net"
 ---
 apiVersion: v1
 kind: Service
@@ -48,6 +51,7 @@ metadata:
   labels:
     app: data-prepper
   name: data-prepper-headless
+  namespace: data-prepper
 spec:
   clusterIP: None
   ports:
@@ -65,6 +69,7 @@ metadata:
   labels:
     app: data-prepper
   name: data-prepper-metrics
+  namespace: data-prepper
 spec:
   type: NodePort
   ports:
@@ -82,6 +87,7 @@ metadata:
   labels:
     app: data-prepper
   name: data-prepper
+  namespace: data-prepper
 spec:
   replicas: 1
   selector:
@@ -124,3 +130,4 @@ spec:
                 path: pipelines.yaml
 status: {}
 ---
+

--- a/deployment-template/k8s/data-prepper-k8s.yaml
+++ b/deployment-template/k8s/data-prepper-k8s.yaml
@@ -95,7 +95,7 @@ spec:
         app: data-prepper
     spec:
       containers:
-        - image: amazon/opendistro-for-elasticsearch-data-prepper:2.0
+        - image: opensearchproject/data-prepper:2
           name: data-prepper
           ports:
             - containerPort: 21890


### PR DESCRIPTION
### Description
Due to Data Prepper version 2, breaking changes were introduced that impact the functioning of the current k8s reference manifest.
 
### Issues Resolved
In this PR, the paths of the configuration file and pipelines were changed, the new processor names were used, the peer forwarding was moved to the base configuration file and added the data-prepper namespace to avoid using the default namespace.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
