### PR TITLE
Require protobuf-java-util 3.21.7 to fix #1891

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,12 @@ subprojects {
                 }
                 because 'Fixes WS-2021-0419 DoS vulnerability'
             }
+            implementation('com.google.protobuf:protobuf-java-util') {
+                version {
+                    require '3.21.7'
+                }
+                because 'Fixes CVE-2022-3171'
+            }
         }
         constraints {
             implementation('io.netty:netty-tcnative-boringssl-static') {


### PR DESCRIPTION
### Description

Require `protobuf-java-util` 3.21.7. This is the version that Data Prepper is actually use as it inherits it from Armeria.
 
### Issues Resolved

Resolves #1891 

### Validation

```
./gradlew -p data-prepper-main dependencies | grep protobuf-java-util | head -n 10
|    |    +--- com.google.protobuf:protobuf-java-util:3.21.7 (c)
|    |    +--- com.google.protobuf:protobuf-java-util:3.21.7 (c)
|    |    +--- com.google.protobuf:protobuf-java-util:3.21.7 (c)
|    |    +--- com.google.protobuf:protobuf-java-util:3.21.7 (c)
|    |    |    |    +--- com.google.protobuf:protobuf-java-util:3.21.7 (c)
|    |    |    +--- com.google.protobuf:protobuf-java-util:3.21.7 (c)
|    |    +--- com.google.protobuf:protobuf-java-util:3.21.7 (c)
|    |    |    +--- com.google.protobuf:protobuf-java-util:3.21.1 -> 3.21.7
|    |    |    +--- com.google.protobuf:protobuf-java-util:3.21.1 -> 3.21.7 (*)
|    |    \--- com.google.protobuf:protobuf-java-util:3.21.1 -> 3.21.7 (*)
```
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
