### PR TITLE
Add ExecutorService to DataPrepperServer

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/DataPrepperServer.java
@@ -11,7 +11,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 
 /**
@@ -22,6 +23,7 @@ import javax.inject.Named;
 public class DataPrepperServer {
     private static final Logger LOG = LoggerFactory.getLogger(DataPrepperServer.class);
     private final HttpServer server;
+    static final ExecutorService EXECUTOR_SERVICE = Executors.newFixedThreadPool(3);
 
     @Inject
     public DataPrepperServer(
@@ -34,6 +36,7 @@ public class DataPrepperServer {
      * Start the DataPrepperServer
      */
     public void start() {
+        server.setExecutor(EXECUTOR_SERVICE);
         server.start();
         LOG.info("Data Prepper server running at :{}", server.getAddress().getPort());
     }
@@ -42,6 +45,7 @@ public class DataPrepperServer {
      * Stop the DataPrepperServer
      */
     public void stop() {
+        EXECUTOR_SERVICE.shutdownNow();
         server.stop(0);
         LOG.info("Data Prepper server stopped");
     }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/DataPrepperServer.java
@@ -45,8 +45,8 @@ public class DataPrepperServer {
      * Stop the DataPrepperServer
      */
     public void stop() {
-        EXECUTOR_SERVICE.shutdownNow();
         server.stop(0);
+        EXECUTOR_SERVICE.shutdownNow();
         LOG.info("Data Prepper server stopped");
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/CloudWatchMeterRegistryProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/CloudWatchMeterRegistryProviderTest.java
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.server;
+package org.opensearch.dataprepper.pipeline.server;
 
-import org.opensearch.dataprepper.pipeline.server.CloudWatchMeterRegistryProvider;
 import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/DataPrepperServerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/DataPrepperServerTest.java
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.server;
+package org.opensearch.dataprepper.pipeline.server;
 
-import org.opensearch.dataprepper.pipeline.server.DataPrepperServer;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,6 +45,7 @@ public class DataPrepperServerTest {
 
         dataPrepperServer.start();
 
+        verify(server).setExecutor(DataPrepperServer.EXECUTOR_SERVICE);
         verify(server).start();
         verify(server).getAddress();
         verify(socketAddress).getPort();

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/SslUtilTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/SslUtilTest.java
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.server;
+package org.opensearch.dataprepper.pipeline.server;
 
-import org.opensearch.dataprepper.pipeline.server.SslUtil;
 import org.junit.Test;
 
 import javax.net.ssl.SSLContext;


### PR DESCRIPTION
Signed-off-by: Chase Engelbrecht <engechas@amazon.com>

### Description
This PR adds an ExecutorService to the DataPrepperServer with a fixed thread pool size of 3. This allows the DataPrepperServer to serve multiple requests in parallel
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [N/A] New functionality has been documented.
  - [N/A] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
