### PR TITLE
Data Prepper Core integration tests

### DIFF
--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -53,6 +53,36 @@ dependencies {
     testImplementation project(':data-prepper-api').sourceSets.test.output
 }
 
+sourceSets {
+    integrationTest {
+        java {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+            srcDir file('src/integrationTest/java')
+        }
+    }
+}
+
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntime.extendsFrom testRuntime
+}
+
+task integrationTest(type: Test) {
+    group = 'verification'
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+
+    useJUnitPlatform()
+
+    classpath = sourceSets.integrationTest.runtimeClasspath
+
+    filter {
+        includeTestsMatching '*IT'
+    }
+}
+
+check.dependsOn integrationTest
+
 jacocoTestCoverageVerification {
     dependsOn jacocoTestReport
     violationRules {
@@ -65,3 +95,4 @@ jacocoTestCoverageVerification {
         }
     }
 }
+

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/MinimalPipelineIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/MinimalPipelineIT.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.test.framework.DataPrepperTestRunner;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.InMemorySinkAccessor;
+import org.opensearch.dataprepper.plugins.InMemorySourceAccessor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+class MinimalPipelineIT {
+
+    public static final String IN_MEMORY_IDENTIFIER = "MinimalPipelineIT";
+    private DataPrepperTestRunner dataPrepperTestRunner;
+    private InMemorySourceAccessor inMemorySourceAccessor;
+    private InMemorySinkAccessor inMemorySinkAccessor;
+
+    @BeforeEach
+    void setUp() {
+        dataPrepperTestRunner = DataPrepperTestRunner.builder()
+                .withPipelinesDirectoryOrFile("minimal-pipeline.yaml")
+                .build();
+
+        dataPrepperTestRunner.start();
+        inMemorySourceAccessor = dataPrepperTestRunner.getInMemorySourceAccessor();
+        inMemorySinkAccessor = dataPrepperTestRunner.getInMemorySinkAccessor();
+    }
+
+    @AfterEach
+    void tearDown() {
+        dataPrepperTestRunner.stop();
+    }
+
+    @Test
+    void pipeline_with_no_data() throws InterruptedException {
+
+        final List<Record<Event>> preRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
+        assertThat(preRecords, is(empty()));
+
+        Thread.sleep(1000);
+
+        final List<Record<Event>> postRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
+        assertThat(postRecords, is(empty()));
+    }
+
+    @Test
+    void pipeline_with_single_record() {
+
+        final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        final Record<Event> eventRecord = new Record<>(event);
+
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, Collections.singletonList(eventRecord));
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER), not(empty()));
+        });
+
+        assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER).size(), equalTo(1));
+    }
+
+    @Test
+    void pipeline_with_single_batch_of_records() {
+
+        final int recordsToCreate = 200;
+        final List<Record<Event>> inputRecords = IntStream.range(0, recordsToCreate)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, inputRecords);
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER), not(empty()));
+        });
+
+        assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER).size(), equalTo(recordsToCreate));
+    }
+
+    @Test
+    void pipeline_with_multiple_batches_of_records() {
+
+        final int recordsToCreateBatch1 = 200;
+        final List<Record<Event>> inputRecordsBatch1 = IntStream.range(0, recordsToCreateBatch1)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, inputRecordsBatch1);
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER), not(empty()));
+        });
+
+        assertThat(inMemorySinkAccessor.getAndClear(IN_MEMORY_IDENTIFIER).size(), equalTo(recordsToCreateBatch1));
+
+        final int recordsToCreateBatch2 = 300;
+        final List<Record<Event>> inputRecordsBatch2 = IntStream.range(0, recordsToCreateBatch2)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, inputRecordsBatch2);
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER), not(empty()));
+        });
+
+        assertThat(inMemorySinkAccessor.getAndClear(IN_MEMORY_IDENTIFIER).size(), equalTo(recordsToCreateBatch2));
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/MinimalPipelineIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/MinimalPipelineIT.java
@@ -31,7 +31,8 @@ import static org.hamcrest.Matchers.empty;
 
 class MinimalPipelineIT {
 
-    public static final String IN_MEMORY_IDENTIFIER = "MinimalPipelineIT";
+    private static final String IN_MEMORY_IDENTIFIER = "MinimalPipelineIT";
+    private static final String PIPELINE_CONFIGURATION_UNDER_TEST = "minimal-pipeline.yaml";
     private DataPrepperTestRunner dataPrepperTestRunner;
     private InMemorySourceAccessor inMemorySourceAccessor;
     private InMemorySinkAccessor inMemorySinkAccessor;
@@ -39,7 +40,7 @@ class MinimalPipelineIT {
     @BeforeEach
     void setUp() {
         dataPrepperTestRunner = DataPrepperTestRunner.builder()
-                .withPipelinesDirectoryOrFile("minimal-pipeline.yaml")
+                .withPipelinesDirectoryOrFile(PIPELINE_CONFIGURATION_UNDER_TEST)
                 .build();
 
         dataPrepperTestRunner.start();

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemoryConfig.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemoryConfig.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Configuration for an in_memory plugin.
+ */
+class InMemoryConfig {
+    @JsonProperty("testing_key")
+    private String testingKey;
+
+    public String getTestingKey() {
+        return testingKey;
+    }
+
+    public void setTestingKey(final String testingKey) {
+        this.testingKey = testingKey;
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySink.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySink.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.sink.Sink;
+
+import java.util.Collection;
+
+@DataPrepperPlugin(name = "in_memory", pluginType = Sink.class, pluginConfigurationType = InMemoryConfig.class)
+public class InMemorySink implements Sink<Record<Event>> {
+
+    private final String testingKey;
+    private final InMemorySinkAccessor inMemorySinkAccessor;
+
+    @DataPrepperPluginConstructor
+    public InMemorySink(final InMemoryConfig inMemoryConfig,
+                        final InMemorySinkAccessor inMemorySinkAccessor) {
+        testingKey = inMemoryConfig.getTestingKey();
+        this.inMemorySinkAccessor = inMemorySinkAccessor;
+    }
+
+    @Override
+    public void output(final Collection<Record<Event>> records) {
+        inMemorySinkAccessor.addEvents(testingKey, records);
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySinkAccessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySinkAccessor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Provides a mechanism for accessing the records output by {@link InMemorySink} sinks.
+ */
+public class InMemorySinkAccessor {
+    private final Map<String, List<Record<Event>>> recordsMap = new HashMap<>();
+    private final Lock lock = new ReentrantLock();
+
+    /**
+     * Gets the records from an in_memory sink. This will not remove any records from
+     * the sink's memory store.
+     * @param testingKey The key used to identify the in_memory sink.
+     * @return The records output to the sink.
+     */
+    public List<Record<Event>> get(final String testingKey) {
+        lock.lock();
+        try {
+            return recordsMap.getOrDefault(testingKey, Collections.emptyList());
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Gets the records from an in_memory sink. Then clears those records from
+     * the sink's memory store.
+     * @param testingKey The key used to identify the in_memory sink.
+     * @return The records output to the sink.
+     */
+    public List<Record<Event>> getAndClear(final String testingKey) {
+        lock.lock();
+        try {
+            final List<Record<Event>> records = recordsMap.getOrDefault(testingKey, Collections.emptyList());
+
+            recordsMap.remove(testingKey);
+
+            return records;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    void addEvents(final String testingKey, final Collection<Record<Event>> recordsToAdd) {
+        lock.lock();
+        try {
+            recordsMap.computeIfAbsent(testingKey, i -> new ArrayList<>())
+                    .addAll(recordsToAdd);
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySource.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySource.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.Source;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * A Data Prepper source which can receive records via the {@link InMemorySourceAccessor}.
+ */
+@DataPrepperPlugin(name = "in_memory", pluginType = Source.class, pluginConfigurationType = InMemoryConfig.class)
+public class InMemorySource implements Source<Record<Event>> {
+    private static final Logger LOG = LoggerFactory.getLogger(InMemorySource.class);
+
+    private final String testingKey;
+    private final InMemorySourceAccessor inMemorySourceAccessor;
+    private boolean isStopped = false;
+    private Thread runningThread;
+
+    @DataPrepperPluginConstructor
+    public InMemorySource(
+            final InMemoryConfig inMemoryConfig,
+            final InMemorySourceAccessor inMemorySourceAccessor) {
+        testingKey = inMemoryConfig.getTestingKey();
+
+        this.inMemorySourceAccessor = inMemorySourceAccessor;
+    }
+
+    @Override
+    public void start(final Buffer<Record<Event>> buffer) {
+        runningThread = new Thread(new SourceRunner(buffer));
+
+        runningThread.start();
+    }
+
+    @Override
+    public void stop() {
+        isStopped = true;
+        runningThread.interrupt();
+    }
+
+    private class SourceRunner implements Runnable {
+        private final Buffer<Record<Event>> buffer;
+
+        SourceRunner(final Buffer<Record<Event>> buffer) {
+            this.buffer = buffer;
+        }
+
+        @Override
+        public void run() {
+            while (!isStopped) {
+                try {
+                    final List<Record<Event>> records = inMemorySourceAccessor.read(testingKey);
+                    if(!records.isEmpty()) {
+                        buffer.writeAll(records, 200);
+                    } else {
+                        Thread.sleep(10);
+                    }
+                } catch (final Exception ex) {
+                    LOG.error("Error during source loop.", ex);
+                }
+            }
+        }
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySourceAccessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySourceAccessor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Provides a mechanism to write records to an in_memory source. This allows the pipeline to execute
+ * independently of the test code, but the test code can write to a source.
+ */
+public class InMemorySourceAccessor {
+    private final Map<String, List<Record<Event>>> recordsMap = new HashMap<>();
+    private final Lock lock = new ReentrantLock();
+
+    /**
+     * Submits records to the in_memory source. These will be available to the source
+     * for reading.
+     *
+     * @param testingKey The key for the in_memory source
+     * @param newRecords New records to add.
+     */
+    public void submit(final String testingKey, final List<Record<Event>> newRecords) {
+        lock.lock();
+        try {
+            recordsMap.computeIfAbsent(testingKey, i -> new ArrayList<>())
+                    .addAll(newRecords);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    List<Record<Event>> read(final String testingKey) {
+        final List<Record<Event>> records;
+        lock.lock();
+        try {
+            records = recordsMap.getOrDefault(testingKey, Collections.emptyList());
+
+            recordsMap.remove(testingKey);
+        } finally {
+            lock.unlock();
+        }
+
+        return records;
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/test/framework/DataPrepperTestRunner.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/test/framework/DataPrepperTestRunner.java
@@ -25,14 +25,16 @@ import javax.annotation.Nullable;
 public class DataPrepperTestRunner {
     private static final Logger LOG = LoggerFactory.getLogger(DataPrepperTestRunner.class);
     private static final String BASE_PATH = "src/integrationTest/resources/org/opensearch/dataprepper";
+    private static final String BASE_DATA_PREPPER_PACKAGE = "org.opensearch.dataprepper";
+    private static final String EXPRESSION_PACKAGE = BASE_DATA_PREPPER_PACKAGE + ".expression";
     private final AnnotationConfigApplicationContext coreApplicationContext;
-    private final String dataPrepperConfig;
+    private final String dataPrepperConfigFile;
     private final String pipelinesDirectoryOrFile;
     private final InMemorySourceAccessor inMemorySourceAccessor;
     private final InMemorySinkAccessor inMemorySinkAccessor;
 
     private DataPrepperTestRunner(final Builder builder) {
-        dataPrepperConfig = builder.dataPrepperConfig;
+        dataPrepperConfigFile = builder.dataPrepperConfigFile;
         pipelinesDirectoryOrFile = builder.pipelinesDirectoryOrFile;
 
         inMemorySourceAccessor = new InMemorySourceAccessor();
@@ -40,7 +42,7 @@ public class DataPrepperTestRunner {
         LOG.info("created in memory source accessor {}", inMemorySourceAccessor);
 
         final AnnotationConfigApplicationContext publicApplicationContext = new AnnotationConfigApplicationContext();
-        publicApplicationContext.scan("org.opensearch.dataprepper.expression");
+        publicApplicationContext.scan(EXPRESSION_PACKAGE);
         publicApplicationContext.registerBean(InMemorySourceAccessor.class, () -> inMemorySourceAccessor);
         publicApplicationContext.registerBean(InMemorySinkAccessor.class, () -> inMemorySinkAccessor);
         publicApplicationContext.refresh();
@@ -48,7 +50,7 @@ public class DataPrepperTestRunner {
         coreApplicationContext = new AnnotationConfigApplicationContext();
         coreApplicationContext.setParent(publicApplicationContext);
         coreApplicationContext.registerBean(FileStructurePathProvider.class, TestFileStructurePathProvider::new);
-        coreApplicationContext.scan("org.opensearch.dataprepper");
+        coreApplicationContext.scan(BASE_DATA_PREPPER_PACKAGE);
 
         coreApplicationContext.refresh();
         LOG.info("Started Data Prepper Application context for testing.");
@@ -109,13 +111,13 @@ public class DataPrepperTestRunner {
         @Nullable
         @Override
         public String getDataPrepperConfigFileLocation() {
-            return BASE_PATH + "/configuration/" + dataPrepperConfig;
+            return BASE_PATH + "/configuration/" + dataPrepperConfigFile;
         }
     }
 
     public static class Builder {
         private String pipelinesDirectoryOrFile;
-        private String dataPrepperConfig = "data-prepper-config.yaml";
+        private String dataPrepperConfigFile = "data-prepper-config.yaml";
 
         Builder() {
         }
@@ -126,7 +128,7 @@ public class DataPrepperTestRunner {
         }
 
         public Builder withDataPrepperConfigFile(final String dataPrepperConfig) {
-            this.dataPrepperConfig = dataPrepperConfig;
+            this.dataPrepperConfigFile = dataPrepperConfig;
             return this;
         }
 

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/test/framework/DataPrepperTestRunner.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/test/framework/DataPrepperTestRunner.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.test.framework;
+
+import org.opensearch.dataprepper.DataPrepper;
+import org.opensearch.dataprepper.parser.config.FileStructurePathProvider;
+import org.opensearch.dataprepper.plugins.InMemorySinkAccessor;
+import org.opensearch.dataprepper.plugins.InMemorySourceAccessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import javax.annotation.Nullable;
+
+/**
+ * Provides the ability to run a Data Prepper test instance. Each of these will run
+ * the Data Prepper core application context. This test instance will thus be very
+ * similar to a real Data Prepper instance.
+ * <p>
+ * Test suites can create a new Data Prepper test {@link Builder} class.
+ */
+public class DataPrepperTestRunner {
+    private static final Logger LOG = LoggerFactory.getLogger(DataPrepperTestRunner.class);
+    private static final String BASE_PATH = "src/integrationTest/resources/org/opensearch/dataprepper";
+    private final AnnotationConfigApplicationContext coreApplicationContext;
+    private final String dataPrepperConfig;
+    private final String pipelinesDirectoryOrFile;
+    private final InMemorySourceAccessor inMemorySourceAccessor;
+    private final InMemorySinkAccessor inMemorySinkAccessor;
+
+    private DataPrepperTestRunner(final Builder builder) {
+        dataPrepperConfig = builder.dataPrepperConfig;
+        pipelinesDirectoryOrFile = builder.pipelinesDirectoryOrFile;
+
+        inMemorySourceAccessor = new InMemorySourceAccessor();
+        inMemorySinkAccessor = new InMemorySinkAccessor();
+        LOG.info("created in memory source accessor {}", inMemorySourceAccessor);
+
+        final AnnotationConfigApplicationContext publicApplicationContext = new AnnotationConfigApplicationContext();
+        publicApplicationContext.scan("org.opensearch.dataprepper.expression");
+        publicApplicationContext.registerBean(InMemorySourceAccessor.class, () -> inMemorySourceAccessor);
+        publicApplicationContext.registerBean(InMemorySinkAccessor.class, () -> inMemorySinkAccessor);
+        publicApplicationContext.refresh();
+
+        coreApplicationContext = new AnnotationConfigApplicationContext();
+        coreApplicationContext.setParent(publicApplicationContext);
+        coreApplicationContext.registerBean(FileStructurePathProvider.class, TestFileStructurePathProvider::new);
+        coreApplicationContext.scan("org.opensearch.dataprepper");
+
+        coreApplicationContext.refresh();
+        LOG.info("Started Data Prepper Application context for testing.");
+    }
+
+    /**
+     * Constructs a new {@link Builder} for creating a new test.
+     * @return a new Builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Starts the Data Prepper test instance.
+     */
+    public void start() {
+        coreApplicationContext.getBean(DataPrepper.class)
+                .execute();
+    }
+
+    /**
+     * Stops the Data Prepper test instance.
+     */
+    public void stop() {
+        final DataPrepper dataPrepper = coreApplicationContext.getBean(DataPrepper.class);
+        dataPrepper.shutdown();
+        dataPrepper.shutdownServers();
+    }
+
+    /**
+     * Gets the {@link InMemorySourceAccessor} used by this test Data Prepper instance.
+     * Test suites can use this object to write data to any in_memory source running
+     * in this Data Prepper test instance.
+     * @return The {@link InMemorySourceAccessor}
+     */
+    public InMemorySourceAccessor getInMemorySourceAccessor() {
+        return inMemorySourceAccessor;
+    }
+
+    /**
+     * Gets the {@link InMemorySinkAccessor} used by this test Data Prepper instance.
+     * Test suites can use this object to read data from any in_memory source running
+     * in this Data Prepper test instance.
+     * @return the {@link InMemorySinkAccessor}
+     */
+    public InMemorySinkAccessor getInMemorySinkAccessor() {
+        return inMemorySinkAccessor;
+    }
+
+    private class TestFileStructurePathProvider implements FileStructurePathProvider {
+
+        @Override
+        public String getPipelineConfigFileLocation() {
+            return BASE_PATH + "/pipeline/" + pipelinesDirectoryOrFile;
+        }
+
+        @Nullable
+        @Override
+        public String getDataPrepperConfigFileLocation() {
+            return BASE_PATH + "/configuration/" + dataPrepperConfig;
+        }
+    }
+
+    public static class Builder {
+        private String pipelinesDirectoryOrFile;
+        private String dataPrepperConfig = "data-prepper-config.yaml";
+
+        Builder() {
+        }
+
+        public Builder withPipelinesDirectoryOrFile(final String pipelinesDirectoryOrFile) {
+            this.pipelinesDirectoryOrFile = pipelinesDirectoryOrFile;
+            return this;
+        }
+
+        public Builder withDataPrepperConfigFile(final String dataPrepperConfig) {
+            this.dataPrepperConfig = dataPrepperConfig;
+            return this;
+        }
+
+        public DataPrepperTestRunner build() {
+            return new DataPrepperTestRunner(this);
+        }
+    }
+}

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/configuration/data-prepper-config.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/configuration/data-prepper-config.yaml
@@ -1,0 +1,1 @@
+ssl: false

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/minimal-pipeline.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/minimal-pipeline.yaml
@@ -1,0 +1,8 @@
+minimal-pipeline:
+  delay: 10
+  source:
+    in_memory:
+      testing_key: MinimalPipelineIT
+  sink:
+    - in_memory:
+        testing_key: MinimalPipelineIT


### PR DESCRIPTION
### Description

This PR creates a new `integrationTest` source set for Data Prepper. It also has a small framework for running Data Prepper within test suites so that developers can easily write integration tests which tests core Data Prepper functionality. This does not attempt to test any Data Prepper plugins and only focuses on features from `data-prepper-core` and other core projects (e.g. `data-prepper-expression`).

This includes one small test to verify a minimal pipeline.

I plan to follow on with this PR with an integration test for conditional routing.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
