### PR TITLE
Use Python grpcio 1.50.0 in smoke tests to reduce time to run.

### DIFF
--- a/release/smoke-tests/otel-span-exporter/requirements.txt
+++ b/release/smoke-tests/otel-span-exporter/requirements.txt
@@ -3,7 +3,7 @@ certifi==2021.10.8
 charset-normalizer==2.0.9
 Deprecated==1.2.13
 googleapis-common-protos==1.53.0
-grpcio==1.42.0
+grpcio==1.50.0
 idna==3.3
 opentelemetry-api==1.7.1
 opentelemetry-exporter-otlp==1.7.1


### PR DESCRIPTION
### Description

Our current smoke tests take over 6 minutes to setup the Python test runner locally. These are also somewhat flaky on GitHub and end up taking a long time even if they will fail.

This PR uses `grpcio` 1.50.0 which takes far less time to install. Now the Python test runner takes 10 seconds.

Before the change:

```
./release/smoke-tests/run-smoke-tests.sh -v 2.0.0 -i opensearchproject/data-prepper
Will smoke test image "opensearchproject/data-prepper:2.0.0"
Creating network "smoke-tests_default" with the default driver
Building otel-span-exporter
[+] Building 381.9s (11/11) FINISHED
```

After the change:

```
docker rmi smoke-tests_otel-span-exporter
docker images prune

/release/smoke-tests/run-smoke-tests.sh -v 2.0.0 -i opensearchproject/data-prepper
Will smoke test image "opensearchproject/data-prepper:2.0.0"
Creating network "smoke-tests_default" with the default driver
Building otel-span-exporter
[+] Building 10.6s (12/12) FINISHED
```
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
