### PR TITLE
Run smoke tests against OpenSearch 1.3.6.

### DIFF
--- a/release/smoke-tests/run-smoke-tests.sh
+++ b/release/smoke-tests/run-smoke-tests.sh
@@ -7,7 +7,7 @@ set -e
 
 export IMAGE_NAME="opensearch-data-prepper"
 REPO_ROOT=$(git rev-parse --show-toplevel)
-export OPENSEARCH_VERSION="1.0.1"
+export OPENSEARCH_VERSION="1.3.6"
 OPENSEARCH_HOST="localhost:9200"
 OPENSEARCH_GROK_INDEX="test-grok-index"
 OPENSEARCH_OTEL_INDEX="otel-v1-apm-span-000001"


### PR DESCRIPTION
### Description

The smoke tests currently run against OpenSearch 1.0.1. This updates to 1.3.6. Perhaps we should use the latest 2.x in the future, but I'd like to get this in for the 2.0.1 release and backport for 1.5.2 if it works.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
