### PR TITLE
Updates Spring to 5.3.23 on the 1.5 branch

### DIFF
--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -30,14 +30,14 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl'
     implementation 'javax.inject:javax.inject:1'
-    implementation('org.springframework:spring-core:5.3.21') {
+    implementation('org.springframework:spring-core:5.3.23') {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
-    implementation('org.springframework:spring-context:5.3.21') {
+    implementation('org.springframework:spring-context:5.3.23') {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation 'software.amazon.cloudwatchlogs:aws-embedded-metrics:2.0.0-beta-1'
-    testImplementation 'org.springframework:spring-test:5.3.21'
+    testImplementation 'org.springframework:spring-test:5.3.23'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
 }
 

--- a/data-prepper-expression/build.gradle
+++ b/data-prepper-expression/build.gradle
@@ -16,16 +16,16 @@ dependencies {
     antlr 'org.antlr:antlr4:4.9.3'
     implementation project(':data-prepper-api')
     implementation 'javax.inject:javax.inject:1'
-    implementation('org.springframework:spring-core:5.3.21') {
+    implementation('org.springframework:spring-core:5.3.23') {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
-    implementation('org.springframework:spring-context:5.3.21') {
+    implementation('org.springframework:spring-context:5.3.23') {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation platform('org.apache.logging.log4j:log4j-bom:2.17.2')
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl'
-    testImplementation 'org.springframework:spring-test:5.3.21'
+    testImplementation 'org.springframework:spring-test:5.3.23'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 


### PR DESCRIPTION
### Description

Updates Spring to 5.3.23.

This was probably updated via dependabot and thus not backported. That is why this targets `1.5` directly.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
