### PR TITLE
#1708: Adding backoff for SQS client.

### DIFF
--- a/data-prepper-plugins/s3-source/README.md
+++ b/data-prepper-plugins/s3-source/README.md
@@ -70,11 +70,14 @@ All Duration values are a string that represents a duration. They support ISO_86
 
 ### <a name="sqs_configuration">SQS Configuration</a>
 
-* `queue_url` (Required) : The SQS queue URL of the queue to read from.
-* `maximum_messages` (Optional) : Duration - The maximum number of messages to read from the queue in any request to the SQS queue. Defaults to 10.
+* `queue_url` (Required) : String - The SQS queue URL of the queue to read from.
+* `maximum_messages` (Optional) : Integer - The maximum number of messages to read from the queue in any request to the SQS queue. Defaults to 10.
 * `visibility_timeout` (Optional) : Duration - The visibility timeout to apply to messages read from the SQS queue. This should be set to the amount of time that Data Prepper may take to read all the S3 objects in a batch. Defaults to 30 seconds.
 * `wait_time` (Optional) : Duration - The time to wait for long-polling on the SQS API. Defaults to 20 seconds.
 * `poll_delay` (Optional) : Duration - A delay to place between reading and processing a batch of SQS messages and making a subsequent request. Defaults to 0 seconds.
+* `max_backoff` (Optional) : Duration - The max backoff duration. Defaults to `600` seconds. See the [EqualJitterBackoffStrategy](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/retry/backoff/EqualJitterBackoffStrategy.html) documentation for details on how the exponential backoff is calculated. 
+* `base_delay` (Optional) : Duration - The base delay duration. Defaults to `30` seconds. See the [EqualJitterBackoffStrategy](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/retry/backoff/EqualJitterBackoffStrategy.html) documentation for details on how the exponential backoff is calculated.
+* `max_retries` (Optional) : Integer - The maximum number of times to retry failures receiving messages from SQS. Defaults to `5`.
 
 ### <a name="aws_configuration">AWS Configuration</a>
 

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/SqsOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/SqsOptions.java
@@ -19,6 +19,9 @@ public class SqsOptions {
     private static final Duration DEFAULT_VISIBILITY_TIMEOUT_SECONDS = Duration.ofSeconds(30);
     private static final Duration DEFAULT_WAIT_TIME_SECONDS = Duration.ofSeconds(20);
     private static final Duration DEFAULT_POLL_DELAY_SECONDS = Duration.ofSeconds(0);
+    private static final Duration DEFAULT_MAX_BACKOFF = Duration.ofSeconds(600);
+    private static final Duration DEFAULT_BASE_DELAY = Duration.ofSeconds(30);
+    private static final int DEFAULT_MAX_RETRIES = 5;
 
     @JsonProperty("queue_url")
     @NotBlank(message = "SQS URL cannot be null or empty")
@@ -43,6 +46,17 @@ public class SqsOptions {
     @DurationMin(seconds = 0)
     private Duration pollDelay = DEFAULT_POLL_DELAY_SECONDS;
 
+    @JsonProperty("max_backoff")
+    @DurationMin(seconds = 0)
+    private Duration maxBackOff = DEFAULT_MAX_BACKOFF;
+
+    @JsonProperty("base_delay")
+    @DurationMin(seconds = 0)
+    private Duration baseDelay = DEFAULT_BASE_DELAY;
+
+    @JsonProperty("max_retries")
+    private int maxRetries = DEFAULT_MAX_RETRIES;
+
     public String getSqsUrl() {
         return sqsUrl;
     }
@@ -62,4 +76,17 @@ public class SqsOptions {
     public Duration getPollDelay() {
         return pollDelay;
     }
+
+    public Duration getMaxBackOff() {
+        return maxBackOff;
+    }
+
+    public Duration getBaseDelay() {
+        return baseDelay;
+    }
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
 }


### PR DESCRIPTION
Signed-off-by: jzonthemtn <jzemerick@opensourceconnections.com>

### Description
Adds exponential backoff via the `EqualJitterBackoffStrategy` in the AWS SDK.
 
### Issues Resolved
#1708 
 
### Check List
- [ ] New functionality includes testing.
- [X] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
