### PR TITLE
Pipeline router tests

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/Router_SingleRouteIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/Router_SingleRouteIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.InMemorySinkAccessor;
+import org.opensearch.dataprepper.plugins.InMemorySourceAccessor;
+import org.opensearch.dataprepper.test.framework.DataPrepperTestRunner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+
+class Router_SingleRouteIT {
+    private static final String TESTING_KEY = "ConditionalRoutingIT";
+    private static final String ALPHA_SOURCE_KEY = TESTING_KEY + "_alpha";
+    private static final String KNOWN_CONDITIONAL_KEY = "value";
+    private static final String ALPHA_VALUE = "a";
+    private DataPrepperTestRunner dataPrepperTestRunner;
+    private InMemorySourceAccessor inMemorySourceAccessor;
+    private InMemorySinkAccessor inMemorySinkAccessor;
+
+    @BeforeEach
+    void setUp() {
+        dataPrepperTestRunner = DataPrepperTestRunner.builder()
+                .withPipelinesDirectoryOrFile("route/single-route.yaml")
+                .build();
+
+        dataPrepperTestRunner.start();
+        inMemorySourceAccessor = dataPrepperTestRunner.getInMemorySourceAccessor();
+        inMemorySinkAccessor = dataPrepperTestRunner.getInMemorySinkAccessor();
+    }
+
+    @AfterEach
+    void tearDown() {
+        dataPrepperTestRunner.stop();
+    }
+
+    @Test
+    void sending_alpha_events_sends_to_the_sink_with_alpha_only_routes() {
+        final List<Record<Event>> alphaEvents = createEvents(ALPHA_VALUE, 10);
+        final List<Record<Event>> otherEvents = createEvents(UUID.randomUUID().toString(), 20);
+
+        final List<Record<Event>> allEvents = new ArrayList<>(alphaEvents);
+        allEvents.addAll(otherEvents);
+        Collections.shuffle(allEvents);
+
+        inMemorySourceAccessor.submit(TESTING_KEY, allEvents);
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(ALPHA_SOURCE_KEY), not(empty()));
+                });
+
+        final List<Record<Event>> actualAllRecords = inMemorySinkAccessor.get(ALPHA_SOURCE_KEY);
+
+        assertThat(actualAllRecords.size(), equalTo(alphaEvents.size()));
+
+        assertThat(actualAllRecords, containsInAnyOrder(allEvents.stream()
+                .filter(alphaEvents::contains).toArray()));
+    }
+
+    @Test
+    void sending_non_alpha_events_never_reaches_sink() throws InterruptedException {
+        final List<Record<Event>> randomEvents = createEvents(UUID.randomUUID().toString(), 20);
+
+        Collections.shuffle(randomEvents);
+
+        inMemorySourceAccessor.submit(TESTING_KEY, randomEvents);
+
+        Thread.sleep(1000);
+
+        assertThat(inMemorySinkAccessor.get(ALPHA_SOURCE_KEY), empty());
+    }
+
+    private List<Record<Event>> createEvents(final String value, final int numberToCreate) {
+        return IntStream.range(0, numberToCreate)
+                .mapToObj(i -> Map.of(KNOWN_CONDITIONAL_KEY, value, "arbitrary_field", UUID.randomUUID().toString()))
+                .map(map -> JacksonEvent.builder().withData(map).withEventType("TEST").build())
+                .map(jacksonEvent -> (Event) jacksonEvent)
+                .map(Record::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/Router_ThreeRoutesIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/Router_ThreeRoutesIT.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.InMemorySinkAccessor;
+import org.opensearch.dataprepper.plugins.InMemorySourceAccessor;
+import org.opensearch.dataprepper.test.framework.DataPrepperTestRunner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+
+class Router_ThreeRoutesIT {
+    private static final String TESTING_KEY = "ConditionalRoutingIT";
+    private static final String ALL_SOURCE_KEY = TESTING_KEY + "_all";
+    private static final String ALPHA_SOURCE_KEY = TESTING_KEY + "_alpha";
+    private static final String BETA_SOURCE_KEY = TESTING_KEY + "_beta";
+    private static final String ALPHA_BETA_SOURCE_KEY = TESTING_KEY + "_alpha_beta";
+    private static final String ALPHA_BETA_GAMMA_SOURCE_KEY = TESTING_KEY + "_alpha_beta_gamma";
+    private static final String KNOWN_CONDITIONAL_KEY = "value";
+    private static final String ALPHA_VALUE = "a";
+    private static final String BETA_VALUE = "b";
+    private DataPrepperTestRunner dataPrepperTestRunner;
+    private InMemorySourceAccessor inMemorySourceAccessor;
+    private InMemorySinkAccessor inMemorySinkAccessor;
+
+    @BeforeEach
+    void setUp() {
+        dataPrepperTestRunner = DataPrepperTestRunner.builder()
+                .withPipelinesDirectoryOrFile("route/three-route.yaml")
+                .build();
+
+        dataPrepperTestRunner.start();
+        inMemorySourceAccessor = dataPrepperTestRunner.getInMemorySourceAccessor();
+        inMemorySinkAccessor = dataPrepperTestRunner.getInMemorySinkAccessor();
+    }
+
+    @AfterEach
+    void tearDown() {
+        dataPrepperTestRunner.stop();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            ALL_SOURCE_KEY,
+            ALPHA_BETA_SOURCE_KEY,
+            ALPHA_BETA_GAMMA_SOURCE_KEY
+    })
+    void sending_alpha_and_beta_events_sends_to_sinks_that_take_both(final String sourceKeyToReceiveAll) {
+        final List<Record<Event>> alphaEvents = createEvents(ALPHA_VALUE, 10);
+        final List<Record<Event>> betaEvents = createEvents(BETA_VALUE, 20);
+
+        final List<Record<Event>> allEvents = new ArrayList<>(alphaEvents);
+        allEvents.addAll(betaEvents);
+        Collections.shuffle(allEvents);
+
+        inMemorySourceAccessor.submit(TESTING_KEY, allEvents);
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(sourceKeyToReceiveAll), not(empty()));
+                });
+
+        final List<Record<Event>> actualAllRecords = inMemorySinkAccessor.get(sourceKeyToReceiveAll);
+
+        assertThat(actualAllRecords.size(), equalTo(allEvents.size()));
+        assertThat(actualAllRecords, containsInAnyOrder(allEvents.toArray()));
+    }
+
+    @Test
+    void sending_alpha_and_beta_events_sends_to_the_sink_with_alpha_only_routes() {
+        final List<Record<Event>> alphaEvents = createEvents(ALPHA_VALUE, 10);
+        final List<Record<Event>> betaEvents = createEvents(BETA_VALUE, 20);
+
+        final List<Record<Event>> allEvents = new ArrayList<>(alphaEvents);
+        allEvents.addAll(betaEvents);
+        Collections.shuffle(allEvents);
+
+        inMemorySourceAccessor.submit(TESTING_KEY, allEvents);
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(ALPHA_SOURCE_KEY), not(empty()));
+                });
+
+        final List<Record<Event>> actualAllRecords = inMemorySinkAccessor.get(ALPHA_SOURCE_KEY);
+
+        assertThat(actualAllRecords.size(), equalTo(alphaEvents.size()));
+
+        assertThat(actualAllRecords, containsInAnyOrder(allEvents.stream()
+                .filter(alphaEvents::contains).toArray()));
+    }
+
+    @Test
+    void sending_alpha_and_beta_events_sends_to_the_sink_with_beta_only_routes() {
+        final List<Record<Event>> alphaEvents = createEvents(ALPHA_VALUE, 10);
+        final List<Record<Event>> betaEvents = createEvents(BETA_VALUE, 20);
+
+        final List<Record<Event>> allEvents = new ArrayList<>(alphaEvents);
+        allEvents.addAll(betaEvents);
+        Collections.shuffle(allEvents);
+
+        inMemorySourceAccessor.submit(TESTING_KEY, allEvents);
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(inMemorySinkAccessor.get(BETA_SOURCE_KEY), not(empty()));
+                });
+
+        final List<Record<Event>> actualAllRecords = inMemorySinkAccessor.get(BETA_SOURCE_KEY);
+
+        assertThat(actualAllRecords.size(), equalTo(betaEvents.size()));
+
+        assertThat(actualAllRecords, containsInAnyOrder(allEvents.stream()
+                .filter(betaEvents::contains).toArray()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            ALPHA_SOURCE_KEY,
+            BETA_SOURCE_KEY,
+            ALPHA_BETA_SOURCE_KEY,
+            ALPHA_BETA_GAMMA_SOURCE_KEY
+    })
+    void sending_non_alpha_beta_events_never_reaches_sink(final String sourceKey) throws InterruptedException {
+        final List<Record<Event>> randomEvents = createEvents(UUID.randomUUID().toString(), 20);
+
+        Collections.shuffle(randomEvents);
+
+        inMemorySourceAccessor.submit(sourceKey, randomEvents);
+
+        Thread.sleep(1000);
+
+        assertThat(inMemorySinkAccessor.get(sourceKey), empty());
+    }
+
+    private List<Record<Event>> createEvents(final String value, final int numberToCreate) {
+        return IntStream.range(0, numberToCreate)
+                .mapToObj(i -> Map.of(KNOWN_CONDITIONAL_KEY, value, "arbitrary_field", UUID.randomUUID().toString()))
+                .map(map -> JacksonEvent.builder().withData(map).withEventType("TEST").build())
+                .map(jacksonEvent -> (Event) jacksonEvent)
+                .map(Record::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/route/single-route.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/route/single-route.yaml
@@ -1,0 +1,18 @@
+routing-pipeline:
+  workers: 4
+  delay: 10
+  source:
+    in_memory:
+      testing_key: ConditionalRoutingIT
+  buffer:
+    bounded_blocking:
+      # Use a small batch size to help ensure that multiple threads
+      # are picking up the different routes.
+      batch_size: 10
+  route:
+    - alpha: '/value == "a"'
+  sink:
+    - in_memory:
+        testing_key: ConditionalRoutingIT_alpha
+        routes:
+          - alpha

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/route/three-route.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/route/three-route.yaml
@@ -1,0 +1,37 @@
+routing-pipeline:
+  workers: 4
+  delay: 10
+  source:
+    in_memory:
+      testing_key: ConditionalRoutingIT
+  buffer:
+    bounded_blocking:
+      # Use a small batch size to help ensure that multiple threads
+      # are picking up the different routes.
+      batch_size: 10
+  route:
+    - alpha: '/value == "a"'
+    - beta: '/value == "b"'
+    - gamma: '/value == "g"'
+  sink:
+    - in_memory:
+        testing_key: ConditionalRoutingIT_alpha
+        routes:
+          - alpha
+    - in_memory:
+        testing_key: ConditionalRoutingIT_beta
+        routes:
+          - beta
+    - in_memory:
+        testing_key: ConditionalRoutingIT_alpha_beta
+        routes:
+          - alpha
+          - beta
+    - in_memory:
+        testing_key: ConditionalRoutingIT_alpha_beta_gamma
+        routes:
+          - alpha
+          - beta
+          - gamma
+    - in_memory:
+        testing_key: ConditionalRoutingIT_all


### PR DESCRIPTION
### Description

This PR introduces integration tests for the new router features introduced in Data Prepper 2.0.

This builds on the integration testing support merged in #1949.  Using those tools, this can test pipelines with multiple routes as an integration test using all the Data Prepper core components.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
