### PR TITLE
Update a few logs that were logging customer data on error.

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpService.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpService.java
@@ -79,7 +79,7 @@ public class PeerForwarderHttpService {
         try {
             writeEventsToBuffer(wireEvents);
         } catch (Exception e) {
-            final String message = String.format("Failed to write the request content [%s] due to:", content.toStringUtf8());
+            final String message = String.format("Failed to write the request of size %d due to:", content.length());
             LOG.error(message, e);
             return responseHandler.handleException(e, message);
         }

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPService.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPService.java
@@ -76,7 +76,7 @@ public class LogHTTPService {
         try {
             jsonList = jsonCodec.parse(content);
         } catch (IOException e) {
-            LOG.error("Failed to write the request content [{}] due to:", content.toStringUtf8(), e);
+            LOG.error("Failed to write the request of size {} due to:", content.length(), e);
             return requestExceptionHandler.handleException(e, "Bad request data format. Needs to be json array.");
         }
         final List<Record<Log>> records = jsonList.stream()
@@ -85,7 +85,7 @@ public class LogHTTPService {
         try {
             buffer.writeAll(records, bufferWriteTimeoutInMillis);
         } catch (Exception e) {
-            LOG.error("Failed to write the request content [{}] due to:", content.toStringUtf8(), e);
+            LOG.error("Failed to write the request of size {} due to:", content.length(), e);
             return requestExceptionHandler.handleException(e);
         }
         successRequestsCounter.increment();

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
@@ -94,7 +94,7 @@ public class OTelTraceGrpcService extends TraceServiceGrpc.TraceServiceImplBase 
         try {
             spans = oTelProtoDecoder.parseExportTraceServiceRequest(request);
         } catch (Exception e) {
-            LOG.error("Failed to parse the request content [{}] due to:", request, e);
+            LOG.error("Failed to parse the request due to:", request, e);
             badRequestsCounter.increment();
             responseObserver.onError(Status.INVALID_ARGUMENT.withDescription(e.getMessage()).asException());
             return;
@@ -108,7 +108,7 @@ public class OTelTraceGrpcService extends TraceServiceGrpc.TraceServiceImplBase 
             responseObserver.onNext(ExportTraceServiceResponse.newBuilder().build());
             responseObserver.onCompleted();
         } catch (Exception e) {
-            LOG.error("Failed to write the request content [{}] due to:", request, e);
+            LOG.error("Failed to write the request of size {} due to:", request.toString().length(), e);
             if (e instanceof TimeoutException) {
                 requestTimeoutCounter.increment();
                 responseObserver


### PR DESCRIPTION
…es into the DataPrepper logs on failure. Logging the request sizes instead, to avoid customer data being logged

Signed-off-by: Deep Datta <deedatta@amazon.com>

### Description
Some of the logging in http, otel-trace and peer-forwarder were writing the actual customer logs/traces into DataPrepper logs on failure. Updating the code to not write the message contents into the logs
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
