### PR TITLE
Adding Hai Yan to the maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,3 +11,4 @@
 | Shivani Shukla | [sshivanii](https://github.com/sshivanii) | Amazon |
 | Phill Treddenick | [treddeni-amazon](https://github.com/treddeni-amazon) | Amazon |
 | David Venable | [dlvenable](https://github.com/dlvenable) | Amazon |
+| Hai Yan | [oeyh](https://github.com/oeyh) | Amazon |


### PR DESCRIPTION
### Description

Adding @oeyh to the Data Prepper maintainers as voted by the existing maintainers.

Hai has [contributed 19 PRs](https://github.com/opensearch-project/data-prepper/pulls?q=is:pr+is:closed+author:oeyh) and has provided PR feedback on quite a number of PRs. Here are a handful of his significant and involved PRs:

* #1760
* #1737
* #1727
* #1697
* #1814


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
