### PR TITLE
Adding Chase Engelbrecht to the maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,6 +3,7 @@
 | --------------- | --------- | ----------- |
 | Steven Bayer | [sbayer55](https://github.com/sbayer55) | Amazon |
 | Qi Chen | [chenqi0805](https://github.com/chenqi0805) | Amazon |
+| Chase Engelbrecht | [engechas](https://github.com/engechas) | Amazon |
 | Taylor Gray | [graytaylor0](https://github.com/graytaylor0) | Amazon |
 | Dinu John |  [dinujoh](https://github.com/dinujoh) | Amazon |
 | Christopher Manning | [cmanning09](https://github.com/cmanning09) | Amazon |


### PR DESCRIPTION
### Description

Adding @engechas to the Data Prepper maintainers as voted by the existing maintainers.

He has contributed [8 PRs](https://github.com/opensearch-project/data-prepper/pulls?q=is:pr+is:closed+author:engechas) including significant core changes to [buffer shutdown](https://github.com/opensearch-project/data-prepper/pull/1792). He planned out this significant change to Data Prepper shutdown in #1770 and then implemented through several different PRs. He has also helped with reviewing other PRs.
 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
