### PR TITLE
Update the S3 source automatic compression option to use the same code for GZIP and NONE.

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/compression/AutomaticCompressionEngine.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/compression/AutomaticCompressionEngine.java
@@ -5,18 +5,25 @@
 
 package org.opensearch.dataprepper.plugins.source.compression;
 
+import org.opensearch.dataprepper.plugins.source.configuration.CompressionOption;
+
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.zip.GZIPInputStream;
 
 public class AutomaticCompressionEngine implements CompressionEngine {
     @Override
     public InputStream createInputStream(final String s3Key, final InputStream responseInputStream) throws IOException {
+        return getCompressionOption(s3Key)
+                .getEngine()
+                .createInputStream(s3Key, responseInputStream);
+    }
+
+    private CompressionOption getCompressionOption(final String s3Key) {
         if (s3Key.endsWith(".gz")) {
-            return new GZIPInputStream(responseInputStream);
+            return CompressionOption.GZIP;
+        } else {
+            return CompressionOption.NONE;
         }
-        else {
-            return responseInputStream;
-        }
+
     }
 }


### PR DESCRIPTION
### Description

Use the same compression engines for GZIP and NONE in the AUTOMATIC compression engine. This will fix #2026 by using the correct GZip input stream from Apache Commons and help prevent similar issues where changes to the GZip engine are not applied to the automatic compression engine.
 
### Issues Resolved

Resolves #2026.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
