### PR TITLE
OpenSearch 1.3.6

### DIFF
--- a/.github/workflows/opensearch-sink-opensearch-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opensearch-integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         java: [11]
-        opensearch: [1.0.1, 1.1.0, 1.2.4, 1.3.5, 2.0.1, 2.1.0, 2.2.1, 2.3.0]
+        opensearch: [1.0.1, 1.1.0, 1.2.4, 1.3.6, 2.0.1, 2.1.0, 2.2.1, 2.3.0]
       fail-fast: false
 
     runs-on: ubuntu-latest

--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -8,7 +8,7 @@ ext.versionMap = [
         junitJupiter : '5.8.2',
         mockito : '3.11.2',
         opentelemetryProto : '0.16.0-alpha',
-        opensearchVersion : '1.3.5',
+        opensearchVersion : '1.3.6',
         armeria: '1.19.0',
         armeriaGrpc: '1.19.0',
         protobufJavaUtil: '3.19.6',


### PR DESCRIPTION
### Description

* Updated to the OpenSearch libraries for 1.3.6.
* Run integration tests against 1.3.6 instead of 1.3.5

 
### Issues Resolved

Resolves #2022
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
