### PR TITLE
Use Netty version supplied by dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,26 +130,9 @@ subprojects {
                 because 'Fixes CVE-2022-3509, CVE-2022-3510'
             }
         }
-        constraints {
-            implementation('io.netty:netty-tcnative-boringssl-static') {
-                version {
-                    require '2.0.42.Final'
-                }
-                because 'Netty 4.1.66+ requires new classes and methods in this version.'
-            }
-        }
     }
     test {
         useJUnitPlatform()
-    }
-
-    configurations.all {
-        resolutionStrategy.eachDependency { def details ->
-            if (details.requested.group == 'io.netty' && !details.requested.name.startsWith('netty-tcnative')) {
-                details.useVersion '4.1.86.Final'
-                details.because 'Fixes CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
-            }
-        }
     }
 
     build.dependsOn test

--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,15 @@ subprojects {
         useJUnitPlatform()
     }
 
+    configurations.all {
+        resolutionStrategy.eachDependency { def details ->
+            if (details.requested.group == 'io.netty' && !details.requested.name.startsWith('netty-tcnative')) {
+                details.useVersion '4.1.86.Final'
+                details.because 'Fixes CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
+            }
+        }
+    }
+
     build.dependsOn test
     jacocoTestReport {
         dependsOn test // tests are required to run before generating the report


### PR DESCRIPTION
### Description

Removed old constraints on Netty which were resulting in pulling in older version of Netty. Our dependencies (Armeria and AWS SDK Java client) are pulling in newer versions so these old configurations are not necessary anymore.

Sample of dependencies:

```
./gradlew -p data-prepper-main dependencies | grep netty | head -n 10
|    +--- software.amazon.awssdk:netty-nio-client:2.17.264 -> 2.17.271 (c)
|    |    |    \--- software.amazon.awssdk:netty-nio-client:2.17.264 -> 2.17.271
|    |    |         +--- io.netty:netty-codec-http:4.1.77.Final -> 4.1.79.Final
|    |    |         |    +--- io.netty:netty-common:4.1.79.Final
|    |    |         |    +--- io.netty:netty-buffer:4.1.79.Final
|    |    |         |    |    \--- io.netty:netty-common:4.1.79.Final
|    |    |         |    +--- io.netty:netty-transport:4.1.79.Final
|    |    |         |    |    +--- io.netty:netty-common:4.1.79.Final
|    |    |         |    |    +--- io.netty:netty-buffer:4.1.79.Final (*)
|    |    |         |    |    \--- io.netty:netty-resolver:4.1.79.Final
```
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
