### PR TITLE
Updated to Google Guava 31.1-jre in the OpenSearch sink project.

### DIFF
--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation 'org.opensearch.client:opensearch-java:2.1.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation 'com.google.guava:guava:10.0.1'
+    implementation 'com.google.guava:guava:31.1-jre'
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     implementation 'software.amazon.awssdk:auth'
     implementation 'software.amazon.awssdk:http-client-spi'

--- a/data-prepper-plugins/otel-metrics-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-metrics-raw-processor/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation "com.linecorp.armeria:armeria-grpc:${versionMap.armeriaGrpc}"
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
+    implementation 'com.google.guava:guava:31.1-jre'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
 }


### PR DESCRIPTION
### Description

This updates the `opensearch` plugin to use Guava 31.1-jre. It doesn't make a major difference since the ultimate version deployed was 31.1-jre. But, this should remove some noise about using old versions with security vulnerabilities.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
