### PR TITLE
Count Aggregate Action - fix aggregation temporality

### DIFF
--- a/data-prepper-plugins/aggregate-processor/README.md
+++ b/data-prepper-plugins/aggregate-processor/README.md
@@ -93,7 +93,7 @@ While not necessary, a great way to set up the Aggregate Processor [identificati
       ```
       The following Event will be created and processed by the rest of the pipeline when the group is concluded:
       ```json
-        {"isMonotonic":true,"unit":"1","aggregationTemporality":"AGGREGATION_TEMPORALITY_CUMULATIVE","kind":"SUM","name":"count","description":"Number of events","startTime":"2022-12-02T19:29:51.245358486Z","time":"2022-12-02T19:30:15.247799684Z","value":3.0,"sourceIp":"127.0.0.1","destinationIp":"192.168.0.1"}
+        {"isMonotonic":true,"unit":"1","aggregationTemporality":"AGGREGATION_TEMPORALITY_DELTA","kind":"SUM","name":"count","description":"Number of events","startTime":"2022-12-02T19:29:51.245358486Z","time":"2022-12-02T19:30:15.247799684Z","value":3.0,"sourceIp":"127.0.0.1","destinationIp":"192.168.0.1"}
       ```
       If raw output format is used, the following Event will be created and processed by the rest of the pipeline when the group is concluded:
       ```json
@@ -101,7 +101,7 @@ While not necessary, a great way to set up the Aggregate Processor [identificati
       ```
     * When used in combination with the `aggregate_when` condition like "/status == 200", the above 3 events will generate the following event
       ```json
-        {"isMonotonic":true,"unit":"1","aggregationTemporality":"AGGREGATION_TEMPORALITY_CUMULATIVE","kind":"SUM","name":"count","description":"Number of events","startTime":"2022-12-02T19:29:51.245358486Z","time":"2022-12-02T19:30:15.247799684Z","value":1.0,"sourceIp":"127.0.0.1","destinationIp":"192.168.0.1"}
+        {"isMonotonic":true,"unit":"1","aggregationTemporality":"AGGREGATION_TEMPORALITY_DELTA","kind":"SUM","name":"count","description":"Number of events","startTime":"2022-12-02T19:29:51.245358486Z","time":"2022-12-02T19:30:15.247799684Z","value":1.0,"sourceIp":"127.0.0.1","destinationIp":"192.168.0.1"}
       ```
       If raw output format is used, the following Event will be created and processed by the rest of the pipeline when the group is concluded:
       ```json

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
@@ -25,9 +25,8 @@ import java.util.HashMap;
 import java.util.Optional;
 
 /**
- * An AggregateAction that combines multiple Events into a single Event. This action will add the unique keys of each smaller Event to the overall groupState,
- * and will create a combined Event from the groupState on concludeGroup. If smaller Events have the same keys, then these keys will be overwritten with the keys of the
- * most recently handled Event.
+ * An AggregateAction that combines multiple Events into a single Event. This action will count the number of events with same keys and will create a combined event
+ * from the groupState on concludeGroup. The combined event will have identification keys, count and the start time either in one of the supported output formats.
  * @since 2.1
  */
 @DataPrepperPlugin(name = "count", pluginType = AggregateAction.class, pluginConfigurationType = CountAggregateActionConfig.class)
@@ -96,7 +95,7 @@ public class CountAggregateAction implements AggregateAction {
                 .withStartTime(OTelProtoCodec.convertUnixNanosToISO8601(startTimeNanos))
                 .withIsMonotonic(SUM_METRIC_IS_MONOTONIC)
                 .withUnit(SUM_METRIC_UNIT)
-                .withAggregationTemporality(AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE.name())
+                .withAggregationTemporality(AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA.name())
                 .withValue((double)countValue)
                 .withAttributes(attr)
                 .build();

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
@@ -95,7 +95,7 @@ public class CountAggregateActionTest {
         expectedEventMap.put("name", "count");
         expectedEventMap.put("description", "Number of events");
         expectedEventMap.put("isMonotonic", true);
-        expectedEventMap.put("aggregationTemporality", "AGGREGATION_TEMPORALITY_CUMULATIVE");
+        expectedEventMap.put("aggregationTemporality", "AGGREGATION_TEMPORALITY_DELTA");
         expectedEventMap.put("unit", "1");
         expectedEventMap.forEach((k, v) -> assertThat(result.get().toMap(), hasEntry(k,v)));
         assertThat(result.get().toMap().get("attributes"), equalTo(eventMap));


### PR DESCRIPTION
Signed-off-by: Krishna Kondaka <krishkdk@amazon.com>

### Description
Fix aggregation temporality of the metric generated by Count aggregation. As per the  open telemetry definition of SUM metric, https://opentelemetry.io/docs/reference/specification/metrics/data-model/#sums, the aggregation temporality in this case should be DELTA and not CUMULATIVE.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X ] New functionality includes testing.
- [ X] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
