### PR TITLE
Updated jackson bom dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ subprojects {
         }
     }
     dependencies {
-        implementation platform('com.fasterxml.jackson:jackson-bom:2.13.4')
+        implementation platform('com.fasterxml.jackson:jackson-bom:2.14.1')
         implementation platform('io.micrometer:micrometer-bom:1.9.4')
         implementation 'com.google.guava:guava:31.1-jre'
         implementation 'org.slf4j:slf4j-api:2.0.5'
@@ -110,12 +110,6 @@ subprojects {
                     require '2.17.1'
                 }
                 because 'the build fails if the Log4j API is not update along with log4j-core'
-            }
-            implementation('com.fasterxml.jackson.core:jackson-databind') {
-                version {
-                    require '2.13.4.2'
-                }
-                because 'Fixes CVE-2022-42003. Keep this until Data Prepper uses 2.14.'
             }
             implementation('com.google.code.gson:gson') {
                 version {


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
- Updates all jackson dependencies to latest version `2.14.1`
- Doesn't fix any CVE's related to snakeyaml 1.30, 1.31 and 1.32 but updates it to 1.33 which still has `CVE-2022-41854`.

 
### Issues Resolved
#2060 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
