### PR TITLE
Add retry strategy to StsClient used for sigv4 auth against OpenSearch sinks

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
@@ -27,6 +27,10 @@ import software.amazon.awssdk.arns.Arn;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.backoff.FixedDelayBackoffStrategy;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
@@ -39,6 +43,8 @@ import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.ValueRange;
 import java.util.List;
 import java.util.Optional;
@@ -52,6 +58,8 @@ public class ConnectionConfiguration {
 
   private static final String SERVICE_NAME = "es";
   private static final String DEFAULT_AWS_REGION = "us-east-1";
+  private static final int STS_CLIENT_RETRIES = 10;
+  private static final int STS_CLIENT_BACKOFF_SECONDS = 15;
 
   public static final String HOSTS = "hosts";
   public static final String USERNAME = "username";
@@ -223,7 +231,7 @@ public class ConnectionConfiguration {
     AwsCredentialsProvider credentialsProvider;
     if (awsStsRoleArn != null && !awsStsRoleArn.isEmpty()) {
       credentialsProvider = StsAssumeRoleCredentialsProvider.builder()
-              .stsClient(StsClient.create())
+              .stsClient(getStsClient())
               .refreshRequest(AssumeRoleRequest.builder()
                       .roleSessionName("OpenSearch-Sink-" + UUID.randomUUID()
                               .toString())
@@ -241,6 +249,21 @@ public class ConnectionConfiguration {
       setHttpProxyIfApplicable(httpClientBuilder);
       return httpClientBuilder;
     });
+  }
+
+  private StsClient getStsClient() {
+    final RetryPolicy retryPolicy = RetryPolicy.builder()
+            .numRetries(STS_CLIENT_RETRIES)
+            .retryCondition(RetryCondition.defaultRetryCondition())
+            .backoffStrategy(FixedDelayBackoffStrategy.create(Duration.of(STS_CLIENT_BACKOFF_SECONDS, ChronoUnit.SECONDS)))
+            .build();
+    final ClientOverrideConfiguration clientOverrideConfiguration = ClientOverrideConfiguration.builder()
+            .retryPolicy(retryPolicy)
+            .build();
+
+    return StsClient.builder()
+            .overrideConfiguration(clientOverrideConfiguration)
+            .build();
   }
 
   private void attachUserCredentials(final RestClientBuilder restClientBuilder) {


### PR DESCRIPTION
### Description
Adds a retry strategy to the StsClient used to call AssumeRole when sending sigv4 signed request to OpenSearch sinks

 
### Check List
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented.
  - [N/A] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
