### PR TITLE
Fix: Updated parse json processor documentation

### DIFF
--- a/data-prepper-plugins/parse-json-processor/README.md
+++ b/data-prepper-plugins/parse-json-processor/README.md
@@ -7,7 +7,7 @@ parse-json-pipeline:
   source:
     stdin:
   processor:
-    - json:
+    - parse_json:
   sink:
     - stdout:
 ```
@@ -30,7 +30,7 @@ parse-json-pipeline:
   source:
     stdin:
   processor:
-    - json:
+    - parse_json:
         pointer: "outer_key/inner_key"
   sink:
     - stdout:


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
Rename JSON processor from `json` to `parse_json` in documentation. I will work with docentation team to update it in OpenSearch documentation as well.
 
### Issues Resolved
Resolves #2066 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
