### PR TITLE
Histogram aggregate action

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Histogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/Histogram.java
@@ -22,6 +22,21 @@ public interface Histogram extends Metric {
      */
     Double getSum();
 
+    /**
+     * Gets the min for the histogram
+     *
+     * @return the min of the values in the population
+     * @since 2.1
+     */
+    Double getMin();
+
+    /**
+     * Gets the max for the histogram
+     *
+     * @return the max of the values in the population
+     * @since 2.1
+     */
+    Double getMax();
 
     /**
      * Gets the count of the histogram

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonHistogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonHistogram.java
@@ -54,6 +54,16 @@ public class JacksonHistogram extends JacksonMetric implements Histogram {
     }
 
     @Override
+    public Double getMin() {
+        return this.get(MIN_KEY, Double.class);
+    }
+
+    @Override
+    public Double getMax() {
+        return this.get(MAX_KEY, Double.class);
+    }
+
+    @Override
     public Long getCount() {
         return this.get(COUNT_KEY, Long.class);
     }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonHistogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonHistogram.java
@@ -23,6 +23,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class JacksonHistogram extends JacksonMetric implements Histogram {
 
     private static final String SUM_KEY = "sum";
+    private static final String MAX_KEY = "max";
+    private static final String MIN_KEY = "min";
     private static final String COUNT_KEY = "count";
     private static final String AGGREGATION_TEMPORALITY_KEY = "aggregationTemporality";
     private static final String BUCKET_COUNTS_KEY = "bucketCounts";
@@ -106,6 +108,32 @@ public class JacksonHistogram extends JacksonMetric implements Histogram {
          */
         public JacksonHistogram.Builder withSum(double sum) {
             data.put(SUM_KEY, sum);
+            return this;
+        }
+
+        /**
+         * Sets the min of the histogram
+         * @param min the min of the histogram
+         * @return the builder
+         * @since 2.1
+         */
+        public JacksonHistogram.Builder withMin(Double min) {
+            if (min != null) {
+                data.put(MIN_KEY, min);
+            }
+            return this;
+        }
+
+        /**
+         * Sets the max of the histogram
+         * @param max the max of the histogram
+         * @return the builder
+         * @since 2.1
+         */
+        public JacksonHistogram.Builder withMax(Double max) {
+            if (max != null) {
+                data.put(MAX_KEY, max);
+            }
             return this;
         }
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonHistogramTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonHistogramTest.java
@@ -42,6 +42,8 @@ class JacksonHistogramTest {
     private static final String TEST_TIME = UUID.randomUUID().toString();
     private static final String TEST_EVENT_KIND = Metric.KIND.HISTOGRAM.name();
     private static final Double TEST_SUM = 1D;
+    private static final Double TEST_MIN = 0.5D;
+    private static final Double TEST_MAX = 50.5D;
     private static final List<Bucket> TEST_BUCKETS = Arrays.asList(
             new DefaultBucket(0.0, 5.0, 2L),
             new DefaultBucket(5.0, 10.0, 5L)
@@ -71,6 +73,8 @@ class JacksonHistogramTest {
                 .withUnit(TEST_UNIT_NAME)
                 .withServiceName(TEST_SERVICE_NAME)
                 .withSum(TEST_SUM)
+                .withMin(TEST_MIN)
+                .withMax(TEST_MAX)
                 .withCount(TEST_COUNT)
                 .withBucketCount(TEST_BUCKETS_COUNT)
                 .withBuckets(TEST_BUCKETS)
@@ -115,6 +119,18 @@ class JacksonHistogramTest {
     public void testGetSum() {
         final Double sum = histogram.getSum();
         assertThat(sum, is(equalTo(TEST_SUM)));
+    }
+
+    @Test
+    public void testGetMin() {
+        final Double min = histogram.getMin();
+        assertThat(min, is(equalTo(TEST_MIN)));
+    }
+
+    @Test
+    public void testGetMax() {
+        final Double max = histogram.getMax();
+        assertThat(max, is(equalTo(TEST_MAX)));
     }
 
     @Test

--- a/data-prepper-plugins/aggregate-processor/README.md
+++ b/data-prepper-plugins/aggregate-processor/README.md
@@ -108,6 +108,33 @@ While not necessary, a great way to set up the Aggregate Processor [identificati
         { "sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "aggr._count": 1, "aggr._start_time": "2022-11-05T23:28:31.916Z"}
       ```
 
+### <a name="histogram"></a>
+* `histogram`: Aggreates events belonging to the same group and generate a new event with values of the identification keys and histogram of the aggregated events based on a configured `key`. The histogram contains the number of events, sum, buckets, bucket counts, and optionally min and max of the values corresponding to the `key`. All eents that make up the combined Event will be dropped.
+    * It supports the following config options
+       * `key`: name of the field in the events for which histogram needs to be generated
+       * `generated_key_prefix`: key prefix to be used for all the fields created in the aggregated event. This allows the user to make sure that the names of the histogram event does not conflict with the field names in the event
+       * `units`: name of the units for the values in the `key`
+       * `record_minmax`: a boolean indicating if the histogram should include the min and max of the values during the aggregation duration
+       * `buckets`: a list of buckets (values of type `double`) indicating the buckets in histogram
+       * `output_format`: format of the aggregated event.
+         * `otel_metrics` - Default output format. Outputs in otel metrics SUM type with count as value
+         * `raw` - generates JSON with `count_key` field with count as value and `start_time_key` field with aggregation start time as value
+    * Given the following four Events with `identification_keys: ["sourceIp", "destination_ip", "request"]`,  `key` as "latency", `buckets as `[0.0, 0.25, 0.5]` :
+      ```json
+          { "sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "request" : "/index.html", "latency": 0.2 }
+          { "sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "request" : "/index.html", "latency": 0.55}
+          { "sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "request" : "/index.html", "latency": 0.25 }
+          { "sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "request" : "/index.html", "latency": 0.15 }
+      ```
+      The following Event will be created and processed by the rest of the pipeline when the group is concluded:
+      ```json
+        {"max":0.55,"kind":"HISTOGRAM","buckets":[{"min":-3.4028234663852886E38,"max":0.0,"count":0},{"min":0.0,"max":0.25,"count":2},{"min":0.25,"max":0.50,"count":1},{"min":0.50,"max":3.4028234663852886E38,"count":1}],"count":4,"bucketCountsList":[0,2,1,1],"description":"Histogram of latency in the events","sum":1.15,"unit":"seconds","aggregationTemporality":"AGGREGATION_TEMPORALITY_DELTA","min":0.15,"bucketCounts":4,"name":"histogram","startTime":"2022-12-14T06:43:40.848762215Z","explicitBoundsCount":3,"time":"2022-12-14T06:44:04.852564623Z","explicitBounds":[0.0,0.25,0.5],"request":"/index.html","sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "key": "latency"}
+      ```
+      If raw output format is used, the following event will be created and processed by the rest of the pipeline when the group is concluded:
+      ```json
+        {"request":"/index.html","aggr._max":0.55,"aggr._min":0.15,"aggr._buckets":[0.0, 0.25, 0.5],"sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "aggr._bucket_counts":[0,2,1,1],"aggr._count":4,"aggr._key":"latency","aggr._startTime":"2022-12-14T06:39:06.081Z","aggr._sum":1.15}
+      ```
+
 ## Creating New Aggregate Actions
 
 It is easy to create custom Aggregate Actions to be used by the Aggregate Processor. To do so, create a new class that implements the [AggregateAction interface](src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateAction.java).

--- a/data-prepper-plugins/aggregate-processor/README.md
+++ b/data-prepper-plugins/aggregate-processor/README.md
@@ -110,7 +110,7 @@ While not necessary, a great way to set up the Aggregate Processor [identificati
       ```
 
 ### <a name="histogram"></a>
-* `histogram`: Aggreates events belonging to the same group and generate a new event with values of the identification keys and histogram of the aggregated events based on a configured `key`. The histogram contains the number of events, sum, buckets, bucket counts, and optionally min and max of the values corresponding to the `key`. All eents that make up the combined Event will be dropped.
+* `histogram`: Aggreates events belonging to the same group and generate a new event with values of the identification keys and histogram of the aggregated events based on a configured `key`. The histogram contains the number of events, sum, buckets, bucket counts, and optionally min and max of the values corresponding to the `key`. All events that make up the combined Event will be dropped.
     * It supports the following config options
        * `key`: name of the field in the events for which histogram needs to be generated
        * `generated_key_prefix`: key prefix to be used for all the fields created in the aggregated event. This allows the user to make sure that the names of the histogram event does not conflict with the field names in the event

--- a/data-prepper-plugins/aggregate-processor/README.md
+++ b/data-prepper-plugins/aggregate-processor/README.md
@@ -40,6 +40,7 @@ While not necessary, a great way to set up the Aggregate Processor [identificati
     * [remove_duplicates](#remove_duplicates)
     * [put_all](#put_all)
     * [count](#count)
+    * [histogram](#histogram)
 ### <a name="group_duration"></a>
 * `group_duration` (Optional): A `String` that represents the amount of time that a group should exist before it is concluded automatically. Supports ISO_8601 notation Strings ("PT20.345S", "PT15M", etc.) as well as simple notation Strings for seconds ("60s") and milliseconds ("1500ms"). Default value is `180s`.
 

--- a/data-prepper-plugins/aggregate-processor/build.gradle
+++ b/data-prepper-plugins/aggregate-processor/build.gradle
@@ -13,6 +13,8 @@ dependencies {
     implementation project(':data-prepper-test-common')
     implementation project(':data-prepper-expression')
     implementation project(':data-prepper-plugins:otel-proto-common')
+    implementation project(':data-prepper-plugins:otel-metrics-raw-processor')
+    implementation "org.apache.commons:commons-lang3:3.12.0"
     implementation "io.opentelemetry.proto:opentelemetry-proto:${versionMap.opentelemetryProto}"
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -24,6 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.time.Instant;
 
 @DataPrepperPlugin(name = "aggregate", pluginType = Processor.class, pluginConfigurationType = AggregateProcessorConfig.class)
 public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<Event>> implements RequiresPeerForwarding {
@@ -121,6 +122,13 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
         actionHandleEventsDroppedCounter.increment(handleEventsDropped);
         return recordsOut;
     }
+
+    public static long getTimeNanos(final Instant time) {
+        final long NANO_MULTIPLIER = 1_000 * 1_000 * 1_000;
+        long currentTimeNanos = time.getEpochSecond() * NANO_MULTIPLIER + time.getNano();
+        return currentTimeNanos;
+    }
+
 
     @Override
     public void prepareForShutdown() {

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
@@ -38,19 +38,19 @@ import java.util.Optional;
 @DataPrepperPlugin(name = "histogram", pluginType = AggregateAction.class, pluginConfigurationType = HistogramAggregateActionConfig.class)
 public class HistogramAggregateAction implements AggregateAction {
     private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
-    static final String EVENT_TYPE = "event";
+    private static final String EVENT_TYPE = "event";
     public static final String HISTOGRAM_METRIC_NAME = "histogram";
-    public final String countKey;
-    public final String bucketCountsKey;
-    public final String bucketsKey;
-    public final String startTimeKey;
-    public final String outputFormat;
-    public final String sumKey;
-    public final String maxKey;
-    public final String minKey;
-    public final String key;
-    public final String units;
-    public final boolean recordMinMax;
+    private final String countKey;
+    private final String bucketCountsKey;
+    private final String bucketsKey;
+    private final String startTimeKey;
+    private final String outputFormat;
+    private final String sumKey;
+    private final String maxKey;
+    private final String minKey;
+    private final String key;
+    private final String units;
+    private final boolean recordMinMax;
 
     private long startTimeNanos;
     private double[] buckets;

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
@@ -5,7 +5,8 @@
 
 package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
 
-import org.opensearch.dataprepper.model.metric.JacksonSum;
+import org.opensearch.dataprepper.model.metric.JacksonHistogram;
+import org.opensearch.dataprepper.model.metric.Bucket;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCodec;
@@ -15,13 +16,18 @@ import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateAction;
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionInput;
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionResponse;
 import org.opensearch.dataprepper.plugins.processor.aggregate.GroupState;
+import static org.opensearch.dataprepper.plugins.processor.aggregate.AggregateProcessor.getTimeNanos;
 import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
+import static org.opensearch.dataprepper.plugins.processor.otelmetrics.OTelMetricsProtoHelper.createBuckets;
 
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
+import java.util.List;
 import java.util.HashMap;
+import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Optional;
 
 /**
@@ -33,38 +39,56 @@ import java.util.Optional;
 public class HistogramAggregateAction implements AggregateAction {
     private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
     static final String EVENT_TYPE = "event";
-    static final String SUM_METRIC_NAME = "count";
-    static final String SUM_METRIC_DESCRIPTION = "Number of events";
-    static final String SUM_METRIC_UNIT = "1";
-    static final boolean SUM_METRIC_IS_MONOTONIC = true;
+    public static final String HISTOGRAM_METRIC_NAME = "histogram";
+    public static final String SUM_KEY = "sum";
+    public static final String COUNT_KEY = "count";
+    public static final String BUCKETS_KEY = "buckets";
+    public static final String BUCKET_COUNTS_KEY = "bucket_counts";
+    public static final String MIN_KEY = "min";
+    public static final String MAX_KEY = "max";
+    public static final String START_TIME_KEY = "startTime";
     public final String countKey;
+    public final String bucketCountsKey;
+    public final String bucketsKey;
     public final String startTimeKey;
     public final String outputFormat;
+    public final String sumKey;
+    public final String maxKey;
+    public final String minKey;
+    public final String key;
+    public final String units;
+    public final String keyPrefix;
+    public final boolean recordMinMax;
+
     private long startTimeNanos;
+    private double[] buckets;
 
     @DataPrepperPluginConstructor
     public HistogramAggregateAction(final HistogramAggregateActionConfig histogramAggregateActionConfig) {
         this.key = histogramAggregateActionConfig.getKey();
-        this.type = histogramAggregateActionConfig.getType();
-        this.buckets = histogramAggregateActionConfig.getBuckets();
-        this.histogramKey = histogramAggregateActionConfig.getHistogramKey();
-        this.startTimeKey = histogramAggregateActionConfig.getStartTimeKey();
-        this.outputFormat = histogramAggregateActionConfig.getOutputFormat();
-    }
-
-    private long getTimeNanos(Instant time) {
-        final long NANO_MULTIPLIER = 1_000 * 1_000 * 1_000;
-        long currentTimeNanos = time.getEpochSecond() * NANO_MULTIPLIER + time.getNano();
-        return currentTimeNanos;
-    }
-
-    @Override
-    public AggregateActionResponse handleEvent(final Event event, final AggregateActionInput aggregateActionInput) {
-        final GroupState groupState = aggregateActionInput.getGroupState();
-        NUMBER value = event.get(key, NUMBER.class);
-        if (value == null) {
-            return AggregateActionResponse.nullEventResponse();
+        List<Number> bucketList = histogramAggregateActionConfig.getBuckets();
+        this.buckets = new double[bucketList.size()+2];
+        int bucketIdx = 0;
+        this.buckets[bucketIdx++] = -Float.MAX_VALUE;
+        for (int i = 0; i < bucketList.size(); i++) {
+            this.buckets[bucketIdx++] = convertToDouble(bucketList.get(i));
         }
+        this.buckets[bucketIdx] = Float.MAX_VALUE;
+        Arrays.sort(this.buckets);
+        this.keyPrefix = histogramAggregateActionConfig.getGeneratedKeyPrefix();
+        this.bucketCountsKey = this.keyPrefix + BUCKET_COUNTS_KEY;
+        this.bucketsKey = this.keyPrefix + BUCKETS_KEY;
+        this.countKey = this.keyPrefix + COUNT_KEY;
+        this.sumKey = this.keyPrefix + SUM_KEY;
+        this.maxKey = this.keyPrefix + MAX_KEY;
+        this.minKey = this.keyPrefix + MIN_KEY;
+        this.startTimeKey = this.keyPrefix + START_TIME_KEY;
+        this.outputFormat = histogramAggregateActionConfig.getOutputFormat();
+        this.units = histogramAggregateActionConfig.getUnits();
+        this.recordMinMax = histogramAggregateActionConfig.getRecordMinMax();
+    }
+
+    private double convertToDouble(Number value) {
         double doubleValue;
         if (value instanceof Long) {
             doubleValue = (double)value.longValue();
@@ -79,15 +103,53 @@ public class HistogramAggregateAction implements AggregateAction {
         } else {
             doubleValue = value.doubleValue();
         }
+        return doubleValue;
+    }
+
+    @Override
+    public AggregateActionResponse handleEvent(final Event event, final AggregateActionInput aggregateActionInput) {
+        final GroupState groupState = aggregateActionInput.getGroupState();
+        Number value = event.get(key, Number.class);
+        if (value == null) {
+            return AggregateActionResponse.nullEventResponse();
+        }
+        double doubleValue = convertToDouble(value);
         
-        if (groupState.get(histogramKey) == null) {
+        int idx = Arrays.binarySearch(this.buckets, doubleValue);
+        if (idx < 0) {
+            idx = -idx-2;
+        }
+        if (groupState.get(bucketCountsKey) == null) {
+            Long[] bucketCountsList = new Long[buckets.length-1];
+            Arrays.fill(bucketCountsList, (long)0);
+            bucketCountsList[idx]++;
             groupState.put(startTimeKey, Instant.now());
             groupState.putAll(aggregateActionInput.getIdentificationKeys());
-            groupState.put
+            groupState.put(keyPrefix + "key", key);
+            groupState.put(sumKey, doubleValue);
             groupState.put(countKey, 1);
+            groupState.put(bucketCountsKey, bucketCountsList);
+            if (this.recordMinMax) {
+                groupState.put(minKey, doubleValue);
+                groupState.put(maxKey, doubleValue);
+            }
         } else {
             Integer v = (Integer)groupState.get(countKey) + 1;
             groupState.put(countKey, v);
+            double sum = (double)groupState.get(sumKey);
+            groupState.put(sumKey, sum+doubleValue);
+            Long[] bucketCountsList = (Long[])groupState.get(bucketCountsKey);
+            bucketCountsList[idx]++;
+            if (this.recordMinMax) {
+                double min = (double)groupState.get(minKey);
+                if (doubleValue < min) {
+                    groupState.put(minKey, doubleValue);
+                }
+                double max = (double)groupState.get(maxKey);
+                if (doubleValue > max) {
+                    groupState.put(maxKey, doubleValue);
+                }
+            }
         } 
         return AggregateActionResponse.nullEventResponse();
     }
@@ -98,31 +160,53 @@ public class HistogramAggregateAction implements AggregateAction {
         Event event;
         Instant startTime = (Instant)groupState.get(startTimeKey);
         if (outputFormat.equals(OutputFormat.RAW.toString())) {
+            groupState.put(bucketsKey, Arrays.copyOfRange(this.buckets, 1, this.buckets.length-1));
             groupState.put(startTimeKey, startTime.atZone(ZoneId.of(ZoneId.systemDefault().toString())).format(DateTimeFormatter.ofPattern(DATE_FORMAT)));
             event = JacksonEvent.builder()
                 .withEventType(EVENT_TYPE)
                 .withData(groupState)
                 .build();
         } else {
+            List<Double> explicitBoundsList = new ArrayList<Double>();
+            List<Long> bucketCounts = Arrays.asList((Long[])groupState.get(bucketCountsKey));
+            for (int i = 1; i < this.buckets.length - 1; i++) {
+                explicitBoundsList.add(this.buckets[i]);
+            }
+            List<Bucket> buckets = createBuckets(bucketCounts, explicitBoundsList);
             Integer countValue = (Integer)groupState.get(countKey);
-            groupState.remove(countKey);
-            groupState.remove(startTimeKey);
             long currentTimeNanos = getTimeNanos(Instant.now());
             long startTimeNanos = getTimeNanos(startTime);
             Map<String, Object> attr = new HashMap<String, Object>();
-            groupState.forEach((k, v) -> attr.put((String)k, v));
-            JacksonSum js = JacksonSum.builder()
-                .withName(SUM_METRIC_NAME)
-                .withDescription(SUM_METRIC_DESCRIPTION)
+            groupState.forEach((k, v) -> {
+                if (((String)k).indexOf(keyPrefix) != 0) {
+                    attr.put((String)k, v);
+                }
+            });
+            attr.put("key", key);
+            double sum = (double)groupState.get(sumKey);
+            Double max = (Double)groupState.get(maxKey);
+            Double min = (Double)groupState.get(minKey);
+            Integer count = (Integer)groupState.get(countKey);
+            String description = String.format("Histogram of %s in the events", key);
+            JacksonHistogram histogram = JacksonHistogram.builder()
+                .withName(HISTOGRAM_METRIC_NAME)
+                .withDescription(description)
                 .withTime(OTelProtoCodec.convertUnixNanosToISO8601(currentTimeNanos))
                 .withStartTime(OTelProtoCodec.convertUnixNanosToISO8601(startTimeNanos))
-                .withIsMonotonic(SUM_METRIC_IS_MONOTONIC)
-                .withUnit(SUM_METRIC_UNIT)
-                .withAggregationTemporality(AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE.name())
-                .withValue((double)countValue)
+                .withUnit(this.units)
+                .withSum(sum)
+                .withMin(min)
+                .withMax(max)
+                .withCount(count)
+                .withBucketCount(this.buckets.length-1)
+                .withExplicitBoundsCount(this.buckets.length-2)
+                .withAggregationTemporality(AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA.name())
+                .withBuckets(buckets)
+                .withBucketCountsList(bucketCounts)
+                .withExplicitBoundsList(explicitBoundsList)
                 .withAttributes(attr)
                 .build();
-            event = (Event)js;
+            event = (Event)histogram;
         }
         
         return Optional.of(event);

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-Limense-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
+
+import org.opensearch.dataprepper.model.metric.JacksonSum;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCodec;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateAction;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionInput;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionResponse;
+import org.opensearch.dataprepper.plugins.processor.aggregate.GroupState;
+import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Optional;
+
+/**
+ * An AggregateAction that combines multiple Events into a single Event. This action will create a combined event with histogram buckets of the values 
+ * of specified list of keys from the groupState on concludeGroup. 
+ * @since 2.1
+ */
+@DataPrepperPlugin(name = "histogram", pluginType = AggregateAction.class, pluginConfigurationType = HistogramAggregateActionConfig.class)
+public class HistogramAggregateAction implements AggregateAction {
+    private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+    static final String EVENT_TYPE = "event";
+    static final String SUM_METRIC_NAME = "count";
+    static final String SUM_METRIC_DESCRIPTION = "Number of events";
+    static final String SUM_METRIC_UNIT = "1";
+    static final boolean SUM_METRIC_IS_MONOTONIC = true;
+    public final String countKey;
+    public final String startTimeKey;
+    public final String outputFormat;
+    private long startTimeNanos;
+
+    @DataPrepperPluginConstructor
+    public HistogramAggregateAction(final HistogramAggregateActionConfig histogramAggregateActionConfig) {
+        this.key = histogramAggregateActionConfig.getKey();
+        this.type = histogramAggregateActionConfig.getType();
+        this.buckets = histogramAggregateActionConfig.getBuckets();
+        this.histogramKey = histogramAggregateActionConfig.getHistogramKey();
+        this.startTimeKey = histogramAggregateActionConfig.getStartTimeKey();
+        this.outputFormat = histogramAggregateActionConfig.getOutputFormat();
+    }
+
+    private long getTimeNanos(Instant time) {
+        final long NANO_MULTIPLIER = 1_000 * 1_000 * 1_000;
+        long currentTimeNanos = time.getEpochSecond() * NANO_MULTIPLIER + time.getNano();
+        return currentTimeNanos;
+    }
+
+    @Override
+    public AggregateActionResponse handleEvent(final Event event, final AggregateActionInput aggregateActionInput) {
+        final GroupState groupState = aggregateActionInput.getGroupState();
+        NUMBER value = event.get(key, NUMBER.class);
+        if (value == null) {
+            return AggregateActionResponse.nullEventResponse();
+        }
+        double doubleValue;
+        if (value instanceof Long) {
+            doubleValue = (double)value.longValue();
+        } else if (value instanceof Integer) {
+            doubleValue = (double)value.intValue();
+        } else if (value instanceof Short) {
+            doubleValue = (double)value.shortValue();
+        } else if (value instanceof Byte) {
+            doubleValue = (double)value.byteValue();
+        } else if (value instanceof Float) {
+            doubleValue = (double)value.floatValue();
+        } else {
+            doubleValue = value.doubleValue();
+        }
+        
+        if (groupState.get(histogramKey) == null) {
+            groupState.put(startTimeKey, Instant.now());
+            groupState.putAll(aggregateActionInput.getIdentificationKeys());
+            groupState.put
+            groupState.put(countKey, 1);
+        } else {
+            Integer v = (Integer)groupState.get(countKey) + 1;
+            groupState.put(countKey, v);
+        } 
+        return AggregateActionResponse.nullEventResponse();
+    }
+
+    @Override
+    public Optional<Event> concludeGroup(final AggregateActionInput aggregateActionInput) {
+        GroupState groupState = aggregateActionInput.getGroupState();
+        Event event;
+        Instant startTime = (Instant)groupState.get(startTimeKey);
+        if (outputFormat.equals(OutputFormat.RAW.toString())) {
+            groupState.put(startTimeKey, startTime.atZone(ZoneId.of(ZoneId.systemDefault().toString())).format(DateTimeFormatter.ofPattern(DATE_FORMAT)));
+            event = JacksonEvent.builder()
+                .withEventType(EVENT_TYPE)
+                .withData(groupState)
+                .build();
+        } else {
+            Integer countValue = (Integer)groupState.get(countKey);
+            groupState.remove(countKey);
+            groupState.remove(startTimeKey);
+            long currentTimeNanos = getTimeNanos(Instant.now());
+            long startTimeNanos = getTimeNanos(startTime);
+            Map<String, Object> attr = new HashMap<String, Object>();
+            groupState.forEach((k, v) -> attr.put((String)k, v));
+            JacksonSum js = JacksonSum.builder()
+                .withName(SUM_METRIC_NAME)
+                .withDescription(SUM_METRIC_DESCRIPTION)
+                .withTime(OTelProtoCodec.convertUnixNanosToISO8601(currentTimeNanos))
+                .withStartTime(OTelProtoCodec.convertUnixNanosToISO8601(startTimeNanos))
+                .withIsMonotonic(SUM_METRIC_IS_MONOTONIC)
+                .withUnit(SUM_METRIC_UNIT)
+                .withAggregationTemporality(AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE.name())
+                .withValue((double)countValue)
+                .withAttributes(attr)
+                .build();
+            event = (Event)js;
+        }
+        
+        return Optional.of(event);
+    }
+}

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-Limense-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
+
+import java.util.Set;
+import java.util.HashSet;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class HistogramAggregateActionConfig {
+    public static final String DEFAULT_COUNT_KEY = "aggr._count";
+    public static final String DEFAULT_HISTOGRAM_KEY = "aggr._histogram";
+    public static final String DEFAULT_SUM_KEY = "aggr._sum";
+    public static final String DEFAULT_MIN_KEY = "aggr._min";
+    public static final String DEFAULT_MAX_KEY = "aggr._max";
+    public static final String DEFAULT_START_TIME_KEY = "aggr._start_time";
+    public static final String DEFAULT_END_TIME_KEY = "aggr._end_time";
+    public static final Set<String> validOutputFormats = new HashSet<>(Set.of(OutputFormat.OTEL_METRICS.toString(), OutputFormat.RAW.toString()));
+
+    @JsonProperty("count_key")
+    String countKey = DEFAULT_COUNT_KEY;
+
+    @JsonProperty("start_time_key")
+    String startTimeKey = DEFAULT_START_TIME_KEY;
+
+    @JsonProperty("output_format")
+    String outputFormat = OutputFormat.OTEL_METRICS.toString();
+
+    public String getCountKey() {
+        return countKey;
+    }
+
+    public String getStartTimeKey() {
+        return startTimeKey;
+    }
+
+    public String getOutputFormat() {
+        if (!validOutputFormats.contains(outputFormat)) {
+            throw new IllegalArgumentException("Unknown output format " + outputFormat);
+        }
+        return outputFormat;
+    }
+} 

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfig.java
@@ -6,34 +6,57 @@
 package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
 
 import java.util.Set;
+import java.util.List;
 import java.util.HashSet;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
 
 public class HistogramAggregateActionConfig {
-    public static final String DEFAULT_COUNT_KEY = "aggr._count";
-    public static final String DEFAULT_HISTOGRAM_KEY = "aggr._histogram";
-    public static final String DEFAULT_SUM_KEY = "aggr._sum";
-    public static final String DEFAULT_MIN_KEY = "aggr._min";
-    public static final String DEFAULT_MAX_KEY = "aggr._max";
-    public static final String DEFAULT_START_TIME_KEY = "aggr._start_time";
-    public static final String DEFAULT_END_TIME_KEY = "aggr._end_time";
+    public static final String DEFAULT_GENERATED_KEY_PREFIX = "aggr._";
     public static final Set<String> validOutputFormats = new HashSet<>(Set.of(OutputFormat.OTEL_METRICS.toString(), OutputFormat.RAW.toString()));
 
-    @JsonProperty("count_key")
-    String countKey = DEFAULT_COUNT_KEY;
+    @JsonProperty("key")
+    @NotNull
+    String key;
 
-    @JsonProperty("start_time_key")
-    String startTimeKey = DEFAULT_START_TIME_KEY;
+    @JsonProperty("units")
+    @NotNull
+    String units;
+
+    @JsonProperty("generated_key_prefix")
+    String generatedKeyPrefix = DEFAULT_GENERATED_KEY_PREFIX;
+
+    @JsonProperty("buckets")
+    @NotNull
+    List<Number> buckets;
 
     @JsonProperty("output_format")
     String outputFormat = OutputFormat.OTEL_METRICS.toString();
 
-    public String getCountKey() {
-        return countKey;
+    @JsonProperty("record_minmax")
+    boolean recordMinMax = false;
+
+    public boolean getRecordMinMax() {
+        return recordMinMax;
     }
 
-    public String getStartTimeKey() {
-        return startTimeKey;
+    public String getGeneratedKeyPrefix() {
+        return generatedKeyPrefix;
+    }
+
+    public String getUnits() {
+        return units;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public List<Number> getBuckets() {
+        if (buckets.size() == 0) {
+            throw new IllegalArgumentException("Bucket list must not be empty");
+        }
+        return buckets;
     }
 
     public String getOutputFormat() {

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfig.java
@@ -13,6 +13,13 @@ import jakarta.validation.constraints.NotNull;
 
 public class HistogramAggregateActionConfig {
     public static final String DEFAULT_GENERATED_KEY_PREFIX = "aggr._";
+    public static final String SUM_KEY = "sum";
+    public static final String COUNT_KEY = "count";
+    public static final String BUCKETS_KEY = "buckets";
+    public static final String BUCKET_COUNTS_KEY = "bucket_counts";
+    public static final String MIN_KEY = "min";
+    public static final String MAX_KEY = "max";
+    public static final String START_TIME_KEY = "startTime";
     public static final Set<String> validOutputFormats = new HashSet<>(Set.of(OutputFormat.OTEL_METRICS.toString(), OutputFormat.RAW.toString()));
 
     @JsonProperty("key")
@@ -50,6 +57,34 @@ public class HistogramAggregateActionConfig {
 
     public String getKey() {
         return key;
+    }
+
+    public String getSumKey() {
+        return generatedKeyPrefix + SUM_KEY;
+    }
+
+    public String getMinKey() {
+        return generatedKeyPrefix + MIN_KEY;
+    }
+
+    public String getMaxKey() {
+        return generatedKeyPrefix + MAX_KEY;
+    }
+
+    public String getCountKey() {
+        return generatedKeyPrefix + COUNT_KEY;
+    }
+
+    public String getBucketsKey() {
+        return generatedKeyPrefix + BUCKETS_KEY;
+    }
+
+    public String getBucketCountsKey() {
+        return generatedKeyPrefix + BUCKET_COUNTS_KEY;
+    }
+
+    public String getStartTimeKey() {
+        return generatedKeyPrefix + START_TIME_KEY;
     }
 
     public List<Number> getBuckets() {

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfigTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfigTests.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
+
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
+import org.junit.jupiter.api.extension.ExtendWith; 
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import static org.opensearch.dataprepper.plugins.processor.aggregate.actions.HistogramAggregateActionConfig.DEFAULT_GENERATED_KEY_PREFIX;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.List;
+import java.util.ArrayList;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@ExtendWith(MockitoExtension.class)
+public class HistogramAggregateActionConfigTests {
+    private HistogramAggregateActionConfig histogramAggregateActionConfig;
+
+    private HistogramAggregateActionConfig createObjectUnderTest() {
+        return new HistogramAggregateActionConfig();
+    }
+    
+    @BeforeEach
+    void setup() {
+        histogramAggregateActionConfig = createObjectUnderTest();
+    }
+    
+    @Test
+    void testDefault() {
+        assertThat(histogramAggregateActionConfig.getGeneratedKeyPrefix(), equalTo(DEFAULT_GENERATED_KEY_PREFIX));
+        assertThat(histogramAggregateActionConfig.getRecordMinMax(), equalTo(false));
+        assertThat(histogramAggregateActionConfig.getOutputFormat(), equalTo(OutputFormat.OTEL_METRICS.toString()));
+    }
+
+    @Test
+    void testValidConfig() throws NoSuchFieldException, IllegalAccessException {
+        final String testGeneratedKeyPrefix = RandomStringUtils.randomAlphabetic(10);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "generatedKeyPrefix", testGeneratedKeyPrefix);
+        assertThat(histogramAggregateActionConfig.getGeneratedKeyPrefix(), equalTo(testGeneratedKeyPrefix));
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "recordMinMax", true);
+        assertThat(histogramAggregateActionConfig.getRecordMinMax(), equalTo(true));
+        final String testOutputFormat = OutputFormat.OTEL_METRICS.toString();
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "outputFormat", testOutputFormat);
+        assertThat(histogramAggregateActionConfig.getOutputFormat(), equalTo(OutputFormat.OTEL_METRICS.toString()));
+        final String testKey = RandomStringUtils.randomAlphabetic(10);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "key", testKey);
+        assertThat(histogramAggregateActionConfig.getKey(), equalTo(testKey));
+        final String testUnits = RandomStringUtils.randomAlphabetic(10);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "units", testUnits);
+        assertThat(histogramAggregateActionConfig.getUnits(), equalTo(testUnits));
+        final List<Double> doubleBuckets = new ArrayList<Double>();
+        double doubleValue1 = ThreadLocalRandom.current().nextDouble();
+        double doubleValue2 = ThreadLocalRandom.current().nextDouble();
+        doubleBuckets.add(doubleValue1);
+        doubleBuckets.add(doubleValue2);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "buckets", doubleBuckets);
+        assertThat(histogramAggregateActionConfig.getBuckets(), containsInAnyOrder(doubleBuckets.toArray()));
+
+        final List<Integer> intBuckets = new ArrayList<Integer>();
+        int intValue1 = ThreadLocalRandom.current().nextInt();
+        int intValue2 = ThreadLocalRandom.current().nextInt();
+        intBuckets.add(intValue1);
+        intBuckets.add(intValue2);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "buckets", intBuckets);
+        assertThat(histogramAggregateActionConfig.getBuckets(), containsInAnyOrder(intBuckets.toArray()));
+
+        final List<Float> floatBuckets = new ArrayList<Float>();
+        float floatValue1 = (float)ThreadLocalRandom.current().nextDouble();
+        float floatValue2 = (float)ThreadLocalRandom.current().nextDouble();
+        floatBuckets.add(floatValue1);
+        floatBuckets.add(floatValue2);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "buckets", floatBuckets);
+        assertThat(histogramAggregateActionConfig.getBuckets(), containsInAnyOrder(floatBuckets.toArray()));
+
+        final List<Byte> byteBuckets = new ArrayList<Byte>();
+        byte byteValue1 = (byte)ThreadLocalRandom.current().nextInt();
+        byte byteValue2 = (byte)ThreadLocalRandom.current().nextInt();
+        byteBuckets.add(byteValue1);
+        byteBuckets.add(byteValue2);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "buckets", byteBuckets);
+        assertThat(histogramAggregateActionConfig.getBuckets(), containsInAnyOrder(byteBuckets.toArray()));
+
+        final List<Short> shortBuckets = new ArrayList<Short>();
+        short shortValue1 = (short)ThreadLocalRandom.current().nextInt();
+        short shortValue2 = (short)ThreadLocalRandom.current().nextInt();
+        shortBuckets.add(shortValue1);
+        shortBuckets.add(shortValue2);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "buckets", shortBuckets);
+        assertThat(histogramAggregateActionConfig.getBuckets(), containsInAnyOrder(shortBuckets.toArray()));
+
+        final List<Long> longBuckets = new ArrayList<Long>();
+        long longValue1 = ThreadLocalRandom.current().nextLong();
+        long longValue2 = ThreadLocalRandom.current().nextLong();
+        longBuckets.add(longValue1);
+        longBuckets.add(longValue2);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "buckets", longBuckets);
+        assertThat(histogramAggregateActionConfig.getBuckets(), containsInAnyOrder(longBuckets.toArray()));
+    }
+
+    @Test
+    void testInvalidOutputFormatConfig() throws NoSuchFieldException, IllegalAccessException {
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "outputFormat", RandomStringUtils.randomAlphabetic(10));
+        assertThrows(IllegalArgumentException.class, () -> histogramAggregateActionConfig.getOutputFormat());
+    }
+
+    @Test
+    void testInvalidBucketsConfig() throws NoSuchFieldException, IllegalAccessException {
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "buckets", new ArrayList<Double>());
+        assertThrows(IllegalArgumentException.class, () -> histogramAggregateActionConfig.getBuckets());
+    }
+}

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
+
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.junit.jupiter.api.extension.ExtendWith; 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateAction;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionInput;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionResponse;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionTestUtils;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+
+@ExtendWith(MockitoExtension.class)
+public class HistogramAggregateActionTests {
+    AggregateActionInput aggregateActionInput;
+
+    private AggregateAction histogramAggregateAction;
+
+    private AggregateAction createObjectUnderTest(HistogramAggregateActionConfig config) {
+        return new HistogramAggregateAction(config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {10, 20, 50, 100})
+    void testHistogramAggregate(int testCount) throws NoSuchFieldException, IllegalAccessException {
+        HistogramAggregateActionConfig histogramAggregateActionConfig = new HistogramAggregateActionConfig();
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "outputFormat", OutputFormat.RAW.toString());
+        final String testKeyPrefix = RandomStringUtils.randomAlphabetic(5)+"_";
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "generatedKeyPrefix", testKeyPrefix);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "units", "ms");
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "recordMinMax", true);
+        final double TEST_VALUE_RANGE_MIN = 0.0;
+        final double TEST_VALUE_RANGE_MAX = 6.0;
+        final double TEST_VALUE_RANGE_STEP = 2.0;
+        final double bucket1 = TEST_VALUE_RANGE_MIN;
+        final double bucket2 = bucket1 + TEST_VALUE_RANGE_STEP;
+        final double bucket3 = bucket2 + TEST_VALUE_RANGE_STEP;
+        List<Double> buckets = new ArrayList<Double>();
+        buckets.add(bucket1);
+        buckets.add(bucket2);
+        buckets.add(bucket3);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "buckets", buckets);
+        final String testKey = RandomStringUtils.randomAlphabetic(10);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "key", testKey);
+        histogramAggregateAction = createObjectUnderTest(histogramAggregateActionConfig);
+        final String dataKey = RandomStringUtils.randomAlphabetic(10);
+        final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(Collections.emptyMap());
+        Long[] expectedBucketCounts = new Long[buckets.size()+1];
+        double expectedSum = 0.0;
+        double expectedMin = TEST_VALUE_RANGE_MAX+TEST_VALUE_RANGE_STEP+1.0;
+        double expectedMax = TEST_VALUE_RANGE_MIN-TEST_VALUE_RANGE_STEP-1.0;
+        Arrays.fill(expectedBucketCounts, (long)0);
+        for (int i = 0; i < testCount; i++) { 
+            final double value = ThreadLocalRandom.current().nextDouble(TEST_VALUE_RANGE_MIN-TEST_VALUE_RANGE_STEP, TEST_VALUE_RANGE_MAX+TEST_VALUE_RANGE_STEP);
+            if (value < bucket1) {
+                expectedBucketCounts[0]++;
+            } else if (value < bucket2) {
+                expectedBucketCounts[1]++;
+            } else if (value < bucket3) {
+                expectedBucketCounts[2]++;
+            } else {
+                expectedBucketCounts[3]++;
+            }
+            expectedSum += value;
+            if (value < expectedMin) {
+                expectedMin = value;
+            }
+            if (value > expectedMax) {
+                expectedMax = value;
+            }
+            Map<Object, Object> eventMap = Collections.singletonMap(testKey, value);
+            Event testEvent = JacksonEvent.builder()
+                    .withEventType("event")
+                    .withData(eventMap)
+                    .build();
+            testEvent.put(dataKey, RandomStringUtils.randomAlphabetic(15));
+            final AggregateActionResponse aggregateActionResponse = histogramAggregateAction.handleEvent(testEvent, aggregateActionInput);
+            assertThat(aggregateActionResponse.getEvent(), equalTo(null));
+        }
+
+        final Optional<Event> result = histogramAggregateAction.concludeGroup(aggregateActionInput);
+        assertThat(result.isPresent(), equalTo(true));
+        final String expectedCountKey = testKeyPrefix+HistogramAggregateAction.COUNT_KEY;
+        final String expectedStartTimeKey = testKeyPrefix+HistogramAggregateAction.START_TIME_KEY;
+        Map<String, Object> expectedEventMap = new HashMap<>(Collections.singletonMap(expectedCountKey, testCount));
+        
+        final String expectedSumKey = testKeyPrefix+HistogramAggregateAction.SUM_KEY;
+        expectedEventMap.put(expectedSumKey, expectedSum);
+        final String expectedMaxKey = testKeyPrefix+HistogramAggregateAction.MAX_KEY;
+        expectedEventMap.put(expectedMaxKey, expectedMax);
+        final String expectedMinKey = testKeyPrefix+HistogramAggregateAction.MIN_KEY;
+        expectedEventMap.put(expectedMinKey, expectedMin);
+        expectedEventMap.forEach((k, v) -> assertThat(result.get().toMap(), hasEntry(k,v)));
+        assertThat(result.get().toMap(), hasKey(expectedStartTimeKey));
+        final String expectedBucketCountsKey = testKeyPrefix+HistogramAggregateAction.BUCKET_COUNTS_KEY;
+        final List<Long> bucketCountsFromResult = (ArrayList<Long>)result.get().toMap().get(expectedBucketCountsKey);
+        for (int i = 0; i < expectedBucketCounts.length; i++) {
+            assertThat(expectedBucketCounts[i], equalTo(bucketCountsFromResult.get(i)));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {10, 20, 50, 100})
+    void testHistogramAggregateOTelFormat(int testCount) throws NoSuchFieldException, IllegalAccessException {
+        HistogramAggregateActionConfig histogramAggregateActionConfig = new HistogramAggregateActionConfig();
+        final String testKeyPrefix = RandomStringUtils.randomAlphabetic(5)+"_";
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "generatedKeyPrefix", testKeyPrefix);
+        final String testUnits = "ms";
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "units", testUnits);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "recordMinMax", true);
+        final double TEST_VALUE_RANGE_MIN = 0.0;
+        final double TEST_VALUE_RANGE_MAX = 6.0;
+        final double TEST_VALUE_RANGE_STEP = 2.0;
+        final double bucket1 = TEST_VALUE_RANGE_MIN;
+        final double bucket2 = bucket1 + TEST_VALUE_RANGE_STEP;
+        final double bucket3 = bucket2 + TEST_VALUE_RANGE_STEP;
+        List<Double> buckets = new ArrayList<Double>();
+        buckets.add(bucket1);
+        buckets.add(bucket2);
+        buckets.add(bucket3);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "buckets", buckets);
+        final String testKey = RandomStringUtils.randomAlphabetic(10);
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "key", testKey);
+        histogramAggregateAction = createObjectUnderTest(histogramAggregateActionConfig);
+        final String dataKey = RandomStringUtils.randomAlphabetic(10);
+        final String dataValue = RandomStringUtils.randomAlphabetic(15);
+        final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(Map.of(dataKey, dataValue));
+        Long[] expectedBucketCounts = new Long[buckets.size()+1];
+        double expectedSum = 0.0;
+        double expectedMin = TEST_VALUE_RANGE_MAX+TEST_VALUE_RANGE_STEP+1.0;
+        double expectedMax = TEST_VALUE_RANGE_MIN-TEST_VALUE_RANGE_STEP-1.0;
+        Arrays.fill(expectedBucketCounts, (long)0);
+        for (int i = 0; i < testCount; i++) { 
+            final double value = ThreadLocalRandom.current().nextDouble(TEST_VALUE_RANGE_MIN-TEST_VALUE_RANGE_STEP, TEST_VALUE_RANGE_MAX+TEST_VALUE_RANGE_STEP);
+            if (value < bucket1) {
+                expectedBucketCounts[0]++;
+            } else if (value < bucket2) {
+                expectedBucketCounts[1]++;
+            } else if (value < bucket3) {
+                expectedBucketCounts[2]++;
+            } else {
+                expectedBucketCounts[3]++;
+            }
+            expectedSum += value;
+            if (value < expectedMin) {
+                expectedMin = value;
+            }
+            if (value > expectedMax) {
+                expectedMax = value;
+            }
+            Map<Object, Object> eventMap = Collections.singletonMap(testKey, value);
+            Event testEvent = JacksonEvent.builder()
+                    .withEventType("event")
+                    .withData(eventMap)
+                    .build();
+            final AggregateActionResponse aggregateActionResponse = histogramAggregateAction.handleEvent(testEvent, aggregateActionInput);
+            assertThat(aggregateActionResponse.getEvent(), equalTo(null));
+        }
+
+        final Optional<Event> result = histogramAggregateAction.concludeGroup(aggregateActionInput);
+        assertThat(result.isPresent(), equalTo(true));
+        final String expectedCountKey = testKeyPrefix+HistogramAggregateAction.COUNT_KEY;
+        final String expectedStartTimeKey = testKeyPrefix+HistogramAggregateAction.START_TIME_KEY;
+        Map<String, Object> expectedEventMap = new HashMap<>(Collections.singletonMap("count", (long)testCount));
+        expectedEventMap.put("unit", testUnits);
+        expectedEventMap.put("name", HistogramAggregateAction.HISTOGRAM_METRIC_NAME);
+        expectedEventMap.put("sum", expectedSum);
+        expectedEventMap.put("min", expectedMin);
+        expectedEventMap.put("max", expectedMax);
+        expectedEventMap.put("bucketCounts", expectedBucketCounts.length);
+        expectedEventMap.put("explicitBoundsCount", expectedBucketCounts.length-1);
+        
+        expectedEventMap.forEach((k, v) -> assertThat(result.get().toMap(), hasEntry(k, v)));
+        assertThat(result.get().toMap(), hasKey("startTime"));
+        assertThat(result.get().toMap(), hasKey("time"));
+        final List<Long> bucketCountsFromResult = (ArrayList<Long>)result.get().toMap().get("bucketCountsList");
+        for (int i = 0; i < expectedBucketCounts.length; i++) {
+            assertThat(expectedBucketCounts[i], equalTo(bucketCountsFromResult.get(i)));
+        }
+        assertThat(result.get().toMap().get("attributes"), equalTo(Map.of("key", testKey, dataKey, dataValue)));
+        final List<Double> explicitBoundsFromResult = (ArrayList<Double>)result.get().toMap().get("explicitBounds");
+        double bucketVal = TEST_VALUE_RANGE_MIN;
+        for (int i = 0; i < explicitBoundsFromResult.size(); i++) {
+            assertThat(explicitBoundsFromResult.get(i), equalTo(bucketVal));
+            bucketVal += TEST_VALUE_RANGE_STEP;
+        }
+        final List<Map<String, Object>> bucketsFromResult = (ArrayList<Map<String, Object>>)result.get().toMap().get("buckets");
+        double expectedBucketMin = -Float.MAX_VALUE;
+        double expectedBucketMax = TEST_VALUE_RANGE_MIN;
+        for (int i = 0; i < bucketsFromResult.size(); i++) {
+            assertThat(bucketsFromResult.get(i), hasEntry("min", expectedBucketMin));
+            assertThat(bucketsFromResult.get(i), hasEntry("max", expectedBucketMax));
+            assertThat(bucketsFromResult.get(i), hasEntry("count", expectedBucketCounts[i]));
+            expectedBucketMin = expectedBucketMax;
+            expectedBucketMax += TEST_VALUE_RANGE_STEP;
+            if (i == bucketsFromResult.size()-2) {
+                expectedBucketMax = Float.MAX_VALUE;
+            }
+        }
+    }
+
+
+/*
+        final Optional<Event> result = histogramAggregateAction.concludeGroup(aggregateActionInput);
+        assertThat(result.isPresent(), equalTo(true));
+        Map<String, Object> expectedEventMap = new HashMap<>();
+        expectedEventMap.put("value", (double)testCount);
+        expectedEventMap.put("name", "count");
+        expectedEventMap.put("description", "Number of events");
+        expectedEventMap.put("isMonotonic", true);
+        expectedEventMap.put("aggregationTemporality", "AGGREGATION_TEMPORALITY_CUMULATIVE");
+        expectedEventMap.put("unit", "1");
+        expectedEventMap.forEach((k, v) -> assertThat(result.get().toMap(), hasEntry(k,v)));
+        assertThat(result.get().toMap().get("attributes"), equalTo(eventMap));
+        assertThat(result.get().toMap(), hasKey("startTime"));
+        assertThat(result.get().toMap(), hasKey("time"));
+        */
+}

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
@@ -103,27 +103,28 @@ public class HistogramAggregateActionTests {
 
         final Optional<Event> result = histogramAggregateAction.concludeGroup(aggregateActionInput);
         assertThat(result.isPresent(), equalTo(true));
-        final String expectedCountKey = testKeyPrefix+HistogramAggregateAction.COUNT_KEY;
-        final String expectedStartTimeKey = testKeyPrefix+HistogramAggregateAction.START_TIME_KEY;
+        final String expectedCountKey = histogramAggregateActionConfig.getCountKey();
+        final String expectedStartTimeKey = histogramAggregateActionConfig.getStartTimeKey();
         Map<String, Object> expectedEventMap = new HashMap<>(Collections.singletonMap(expectedCountKey, testCount));
         
-        final String expectedSumKey = testKeyPrefix+HistogramAggregateAction.SUM_KEY;
+        final String expectedSumKey = histogramAggregateActionConfig.getSumKey();
         expectedEventMap.put(expectedSumKey, expectedSum);
-        final String expectedMaxKey = testKeyPrefix+HistogramAggregateAction.MAX_KEY;
+        final String expectedMaxKey = histogramAggregateActionConfig.getMaxKey();
         expectedEventMap.put(expectedMaxKey, expectedMax);
-        final String expectedMinKey = testKeyPrefix+HistogramAggregateAction.MIN_KEY;
+        final String expectedMinKey = histogramAggregateActionConfig.getMinKey();
         expectedEventMap.put(expectedMinKey, expectedMin);
         expectedEventMap.forEach((k, v) -> assertThat(result.get().toMap(), hasEntry(k,v)));
         assertThat(result.get().toMap(), hasKey(expectedStartTimeKey));
-        final String expectedBucketCountsKey = testKeyPrefix+HistogramAggregateAction.BUCKET_COUNTS_KEY;
+        final String expectedBucketCountsKey = histogramAggregateActionConfig.getBucketCountsKey();
         final List<Long> bucketCountsFromResult = (ArrayList<Long>)result.get().toMap().get(expectedBucketCountsKey);
         for (int i = 0; i < expectedBucketCounts.length; i++) {
             assertThat(expectedBucketCounts[i], equalTo(bucketCountsFromResult.get(i)));
         }
     }
 
+    //@ValueSource(ints = {10, 20, 50, 100})
     @ParameterizedTest
-    @ValueSource(ints = {10, 20, 50, 100})
+    @ValueSource(ints = {10})
     void testHistogramAggregateOTelFormat(int testCount) throws NoSuchFieldException, IllegalAccessException {
         HistogramAggregateActionConfig histogramAggregateActionConfig = new HistogramAggregateActionConfig();
         final String testKeyPrefix = RandomStringUtils.randomAlphabetic(5)+"_";
@@ -182,8 +183,8 @@ public class HistogramAggregateActionTests {
 
         final Optional<Event> result = histogramAggregateAction.concludeGroup(aggregateActionInput);
         assertThat(result.isPresent(), equalTo(true));
-        final String expectedCountKey = testKeyPrefix+HistogramAggregateAction.COUNT_KEY;
-        final String expectedStartTimeKey = testKeyPrefix+HistogramAggregateAction.START_TIME_KEY;
+        final String expectedCountKey = histogramAggregateActionConfig.getCountKey();
+        final String expectedStartTimeKey = histogramAggregateActionConfig.getStartTimeKey();
         Map<String, Object> expectedEventMap = new HashMap<>(Collections.singletonMap("count", (long)testCount));
         expectedEventMap.put("unit", testUnits);
         expectedEventMap.put("name", HistogramAggregateAction.HISTOGRAM_METRIC_NAME);
@@ -200,7 +201,7 @@ public class HistogramAggregateActionTests {
         for (int i = 0; i < expectedBucketCounts.length; i++) {
             assertThat(expectedBucketCounts[i], equalTo(bucketCountsFromResult.get(i)));
         }
-        assertThat(result.get().toMap().get("attributes"), equalTo(Map.of("key", testKey, dataKey, dataValue)));
+        assertThat(result.get().toMap().get("attributes"), equalTo(Map.of(HistogramAggregateAction.HISTOGRAM_METRIC_NAME+"_key", testKey, dataKey, dataValue)));
         final List<Double> explicitBoundsFromResult = (ArrayList<Double>)result.get().toMap().get("explicitBounds");
         double bucketVal = TEST_VALUE_RANGE_MIN;
         for (int i = 0; i < explicitBoundsFromResult.size(); i++) {
@@ -221,21 +222,4 @@ public class HistogramAggregateActionTests {
             }
         }
     }
-
-
-/*
-        final Optional<Event> result = histogramAggregateAction.concludeGroup(aggregateActionInput);
-        assertThat(result.isPresent(), equalTo(true));
-        Map<String, Object> expectedEventMap = new HashMap<>();
-        expectedEventMap.put("value", (double)testCount);
-        expectedEventMap.put("name", "count");
-        expectedEventMap.put("description", "Number of events");
-        expectedEventMap.put("isMonotonic", true);
-        expectedEventMap.put("aggregationTemporality", "AGGREGATION_TEMPORALITY_CUMULATIVE");
-        expectedEventMap.put("unit", "1");
-        expectedEventMap.forEach((k, v) -> assertThat(result.get().toMap(), hasEntry(k,v)));
-        assertThat(result.get().toMap().get("attributes"), equalTo(eventMap));
-        assertThat(result.get().toMap(), hasKey("startTime"));
-        assertThat(result.get().toMap(), hasKey("time"));
-        */
 }


### PR DESCRIPTION
### Description
This change adds support to specify histogram as an aggregate action to generate a histogram of a key in the events over aggregation period

Histogram data model of open telemetry can be found at https://opentelemetry.io/docs/reference/specification/metrics/data-model/

Configuration for histogram is based on the information from https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md

This change is part of issue #2015
 
### Issues Resolved
#2015 
 
### Check List
- [X ] New functionality includes testing.
- [X ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
