### PR TITLE
Add robust retry strategy to AcmClients

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/certificate/CertificateProviderFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/certificate/CertificateProviderFactory.java
@@ -16,14 +16,23 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
+import software.amazon.awssdk.core.retry.backoff.EqualJitterBackoffStrategy;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.acm.AcmClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.time.Duration;
+
 public class CertificateProviderFactory {
     private static final Logger LOG = LoggerFactory.getLogger(CertificateProviderFactory.class);
+
+    private static final int ACM_CLIENT_RETRIES = 10;
+    private static final long ACM_CLIENT_BASE_BACKOFF_MILLIS = 1000l;
+    private static final long ACM_CLIENT_MAX_BACKOFF_MILLIS = 60000l;
 
     private final ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
 
@@ -40,8 +49,18 @@ public class CertificateProviderFactory {
                     .addCredentialsProvider(DefaultCredentialsProvider.create())
                     .build();
 
+            final BackoffStrategy backoffStrategy = EqualJitterBackoffStrategy.builder()
+                    .baseDelay(Duration.ofMillis(ACM_CLIENT_BASE_BACKOFF_MILLIS))
+                    .maxBackoffTime(Duration.ofMillis(ACM_CLIENT_MAX_BACKOFF_MILLIS))
+                    .build();
+            final RetryPolicy retryPolicy = RetryPolicy.builder()
+                    .numRetries(ACM_CLIENT_RETRIES)
+                    .retryCondition(RetryCondition.defaultRetryCondition())
+                    .backoffStrategy(backoffStrategy)
+                    .throttlingBackoffStrategy(backoffStrategy)
+                    .build();
             final ClientOverrideConfiguration clientConfig = ClientOverrideConfiguration.builder()
-                    .retryPolicy(RetryMode.STANDARD)
+                    .retryPolicy(retryPolicy)
                     .build();
 
             final AcmClient awsCertificateManager = AcmClient.builder()

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/certificate/CertificateProviderFactory.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/certificate/CertificateProviderFactory.java
@@ -16,13 +16,22 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
+import software.amazon.awssdk.core.retry.backoff.EqualJitterBackoffStrategy;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.acm.AcmClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.time.Duration;
+
 public class CertificateProviderFactory {
     private static final Logger LOG = LoggerFactory.getLogger(CertificateProviderFactory.class);
+
+    private static final int ACM_CLIENT_RETRIES = 10;
+    private static final long ACM_CLIENT_BASE_BACKOFF_MILLIS = 1000l;
+    private static final long ACM_CLIENT_MAX_BACKOFF_MILLIS = 60000l;
 
     final OTelMetricsSourceConfig oTelMetricsSourceConfig;
     public CertificateProviderFactory(final OTelMetricsSourceConfig oTelMetricsSourceConfig) {
@@ -35,9 +44,21 @@ public class CertificateProviderFactory {
             LOG.info("Using ACM certificate and private key for SSL/TLS.");
             final AwsCredentialsProvider credentialsProvider = AwsCredentialsProviderChain.builder()
                     .addCredentialsProvider(DefaultCredentialsProvider.create()).build();
-            final ClientOverrideConfiguration clientConfig = ClientOverrideConfiguration.builder()
-                    .retryPolicy(RetryMode.STANDARD)
+
+            final BackoffStrategy backoffStrategy = EqualJitterBackoffStrategy.builder()
+                    .baseDelay(Duration.ofMillis(ACM_CLIENT_BASE_BACKOFF_MILLIS))
+                    .maxBackoffTime(Duration.ofMillis(ACM_CLIENT_MAX_BACKOFF_MILLIS))
                     .build();
+            final RetryPolicy retryPolicy = RetryPolicy.builder()
+                    .numRetries(ACM_CLIENT_RETRIES)
+                    .retryCondition(RetryCondition.defaultRetryCondition())
+                    .backoffStrategy(backoffStrategy)
+                    .throttlingBackoffStrategy(backoffStrategy)
+                    .build();
+            final ClientOverrideConfiguration clientConfig = ClientOverrideConfiguration.builder()
+                    .retryPolicy(retryPolicy)
+                    .build();
+
             final AcmClient awsCertificateManager = AcmClient.builder()
                     .region(Region.of(oTelMetricsSourceConfig.getAwsRegion()))
                     .credentialsProvider(credentialsProvider)

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/certificate/CertificateProviderFactory.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/certificate/CertificateProviderFactory.java
@@ -16,13 +16,22 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
+import software.amazon.awssdk.core.retry.backoff.EqualJitterBackoffStrategy;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.acm.AcmClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.time.Duration;
+
 public class CertificateProviderFactory {
     private static final Logger LOG = LoggerFactory.getLogger(CertificateProviderFactory.class);
+
+    private static final int ACM_CLIENT_RETRIES = 10;
+    private static final long ACM_CLIENT_BASE_BACKOFF_MILLIS = 1000l;
+    private static final long ACM_CLIENT_MAX_BACKOFF_MILLIS = 60000l;
 
     final OTelTraceSourceConfig oTelTraceSourceConfig;
     public CertificateProviderFactory(final OTelTraceSourceConfig oTelTraceSourceConfig) {
@@ -35,9 +44,21 @@ public class CertificateProviderFactory {
             LOG.info("Using ACM certificate and private key for SSL/TLS.");
             final AwsCredentialsProvider credentialsProvider = AwsCredentialsProviderChain.builder()
                     .addCredentialsProvider(DefaultCredentialsProvider.create()).build();
-            final ClientOverrideConfiguration clientConfig = ClientOverrideConfiguration.builder()
-                    .retryPolicy(RetryMode.STANDARD)
+
+            final BackoffStrategy backoffStrategy = EqualJitterBackoffStrategy.builder()
+                    .baseDelay(Duration.ofMillis(ACM_CLIENT_BASE_BACKOFF_MILLIS))
+                    .maxBackoffTime(Duration.ofMillis(ACM_CLIENT_MAX_BACKOFF_MILLIS))
                     .build();
+            final RetryPolicy retryPolicy = RetryPolicy.builder()
+                    .numRetries(ACM_CLIENT_RETRIES)
+                    .retryCondition(RetryCondition.defaultRetryCondition())
+                    .backoffStrategy(backoffStrategy)
+                    .throttlingBackoffStrategy(backoffStrategy)
+                    .build();
+            final ClientOverrideConfiguration clientConfig = ClientOverrideConfiguration.builder()
+                    .retryPolicy(retryPolicy)
+                    .build();
+
             final AcmClient awsCertificateManager = AcmClient.builder()
                     .region(Region.of(oTelTraceSourceConfig.getAwsRegion()))
                     .credentialsProvider(credentialsProvider)


### PR DESCRIPTION
Signed-off-by: Chase Engelbrecht <engechas@amazon.com>

### Description
Adds a more robust retry strategy to the AcmClients
 
### Check List
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented.
  - [N/A] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
