### PR TITLE
Histogram Aggregate Action - Added duration and fixed end time in the aggregated output

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfig.java
@@ -20,6 +20,8 @@ public class HistogramAggregateActionConfig {
     public static final String MIN_KEY = "min";
     public static final String MAX_KEY = "max";
     public static final String START_TIME_KEY = "startTime";
+    public static final String END_TIME_KEY = "endTime";
+    public static final String DURATION_KEY = "duration";
     public static final Set<String> validOutputFormats = new HashSet<>(Set.of(OutputFormat.OTEL_METRICS.toString(), OutputFormat.RAW.toString()));
 
     @JsonProperty("key")
@@ -85,6 +87,14 @@ public class HistogramAggregateActionConfig {
 
     public String getStartTimeKey() {
         return generatedKeyPrefix + START_TIME_KEY;
+    }
+
+    public String getEndTimeKey() {
+        return generatedKeyPrefix + END_TIME_KEY;
+    }
+
+    public String getDurationKey() {
+        return generatedKeyPrefix + DURATION_KEY;
     }
 
     public List<Number> getBuckets() {

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
@@ -115,6 +115,8 @@ public class HistogramAggregateActionTests {
         expectedEventMap.put(expectedMinKey, expectedMin);
         expectedEventMap.forEach((k, v) -> assertThat(result.get().toMap(), hasEntry(k,v)));
         assertThat(result.get().toMap(), hasKey(expectedStartTimeKey));
+        final String expectedDurationKey = histogramAggregateActionConfig.getDurationKey();
+        assertThat(result.get().toMap(), hasKey(expectedDurationKey));
         final String expectedBucketCountsKey = histogramAggregateActionConfig.getBucketCountsKey();
         final List<Long> bucketCountsFromResult = (ArrayList<Long>)result.get().toMap().get(expectedBucketCountsKey);
         for (int i = 0; i < expectedBucketCounts.length; i++) {
@@ -122,9 +124,8 @@ public class HistogramAggregateActionTests {
         }
     }
 
-    //@ValueSource(ints = {10, 20, 50, 100})
     @ParameterizedTest
-    @ValueSource(ints = {10})
+    @ValueSource(ints = {10, 20, 50, 100})
     void testHistogramAggregateOTelFormat(int testCount) throws NoSuchFieldException, IllegalAccessException {
         HistogramAggregateActionConfig histogramAggregateActionConfig = new HistogramAggregateActionConfig();
         final String testKeyPrefix = RandomStringUtils.randomAlphabetic(5)+"_";
@@ -201,7 +202,10 @@ public class HistogramAggregateActionTests {
         for (int i = 0; i < expectedBucketCounts.length; i++) {
             assertThat(expectedBucketCounts[i], equalTo(bucketCountsFromResult.get(i)));
         }
-        assertThat(result.get().toMap().get("attributes"), equalTo(Map.of(HistogramAggregateAction.HISTOGRAM_METRIC_NAME+"_key", testKey, dataKey, dataValue)));
+        assertThat(((Map<String, String>)result.get().toMap().get("attributes")), hasEntry(HistogramAggregateAction.HISTOGRAM_METRIC_NAME+"_key", testKey));
+        assertThat(((Map<String, String>)result.get().toMap().get("attributes")), hasEntry(dataKey, dataValue));
+        final String expectedDurationKey = histogramAggregateActionConfig.getDurationKey();
+        assertThat(((Map<String, String>)result.get().toMap().get("attributes")), hasKey(expectedDurationKey));
         final List<Double> explicitBoundsFromResult = (ArrayList<Double>)result.get().toMap().get("explicitBounds");
         double bucketVal = TEST_VALUE_RANGE_MIN;
         for (int i = 0; i < explicitBoundsFromResult.size(); i++) {


### PR DESCRIPTION
Signed-off-by: Krishna Kondaka <krishkdk@amazon.com>

### Description
Added duration of the aggregated output as one of the attributes in the aggregated event. 
Fixed end time value.
 
### Issues Resolved
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
