### PR TITLE
updating S3 source documentation to include all codecs

### DIFF
--- a/data-prepper-plugins/s3-source/README.md
+++ b/data-prepper-plugins/s3-source/README.md
@@ -52,7 +52,7 @@ All Duration values are a string that represents a duration. They support ISO_86
 
 * `compression` (Optional) : The compression algorithm to apply. May be one of: `none`, `gzip`, or `automatic`. Defaults to `none`.
 
-* `codec` (Required) : The codec to apply. Must be either `newline` or `json`.
+* `codec` (Required) : The codec to apply. Must be either `newline`, `csv` or `json`.
 
 * `sqs` (Required) : The SQS configuration. See [SQS Configuration](#sqs_configuration) for details.
 


### PR DESCRIPTION
Signed-off-by: Christopher Manning <cmanning09@users.noreply.github.com>

### Description
Updating documentation. I noticed a gap in the codec's supported in the documentation
 
### Issues Resolved
none
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
