### PR TITLE
Fix CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,8 +146,8 @@ subprojects {
     configurations.all {
         resolutionStrategy.eachDependency { def details ->
             if (details.requested.group == 'io.netty' && !details.requested.name.startsWith('netty-tcnative')) {
-                details.useVersion '4.1.74.Final'
-                details.because 'Fixes CVE-2021-43797, CVE-2021-37136 and CVE-2021-37137. See https://netty.io/news/2021/09/09/4-1-68-Final.html'
+                details.useVersion '4.1.86.Final'
+                details.because 'Fixes CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
             }
         }
     }

--- a/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
@@ -14,8 +14,8 @@ dependencies {
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "io.opentelemetry.proto:opentelemetry-proto:${versionMap.opentelemetryProto}"
     implementation 'com.google.protobuf:protobuf-java-util:3.21.10'
-    implementation 'com.linecorp.armeria:armeria:1.9.2'
-    implementation 'com.linecorp.armeria:armeria-grpc:1.9.2'
+    implementation 'com.linecorp.armeria:armeria:${versionMap.armeria}'
+    implementation 'com.linecorp.armeria:armeria-grpc:${versionMap.armeria}'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'com.google.guava:guava:31.1-jre'


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
Fixes 3 CVE's in `io.netty` and 10 Data Prepper vulnerabilities
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
