### PR TITLE
New aggregate action - percent sampler

### DIFF
--- a/data-prepper-plugins/aggregate-processor/README.md
+++ b/data-prepper-plugins/aggregate-processor/README.md
@@ -42,6 +42,7 @@ While not necessary, a great way to set up the Aggregate Processor [identificati
     * [count](#count)
     * [histogram](#histogram)
     * [rate_limiter](#rate_limiter)
+    * [percent_sampler](#percent_sampler)
 ### <a name="group_duration"></a>
 * `group_duration` (Optional): A `String` that represents the amount of time that a group should exist before it is concluded automatically. Supports ISO_8601 notation Strings ("PT20.345S", "PT15M", etc.) as well as simple notation Strings for seconds ("60s") and milliseconds ("1500ms"). Default value is `180s`.
 
@@ -154,6 +155,23 @@ While not necessary, a great way to set up the Aggregate Processor [identificati
       ```
     * When the three events arrive with in one second and the `events_per_second` is set 1 and `when_exceeds` is set to `block`, all three events are allowed.
 
+
+### <a name="percent_sampler"></a>
+* `percent_sampler`: Processes the events and controls the number of events aggregated based on the configuration. Only specified `percent` of the events are allowed and the rest are dropped.
+    * It supports the following config options
+       * `percent`: percent of events to be allowed during aggregation window
+    * When the following three events arrive with in one second and the `percent` is set 50
+      ```json
+        { "sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "bytes": 2500 }
+        { "sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "bytes": 500 }
+        { "sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "bytes": 1000 }
+        { "sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "bytes": 3100 }
+      ```
+      The following Events will be allowed, and no event is generated when the group is concluded
+      ```json
+        { "sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "bytes": 500 }
+        { "sourceIp": "127.0.0.1", "destinationIp": "192.168.0.1", "bytes": 3100 }
+      ```
 
 ## Creating New Aggregate Actions
 

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateAction.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-Limense-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateAction;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionInput;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionResponse;
+import org.opensearch.dataprepper.plugins.processor.aggregate.GroupState;
+
+/**
+ * An AggregateAction that combines multiple Events into a single Event. This action 
+ * 
+ * @since 2.1
+ */
+@DataPrepperPlugin(name = "percent_sampler", pluginType = AggregateAction.class, pluginConfigurationType = PercentSamplerAggregateActionConfig.class)
+public class PercentSamplerAggregateAction implements AggregateAction {
+    static final String TOTAL_EVENTS_KEY = "total_events";
+    static final String TOTAL_ALLOWED_EVENTS_KEY = "total_allowed_events";
+    private final double percent;
+
+    @DataPrepperPluginConstructor
+    public PercentSamplerAggregateAction(final PercentSamplerAggregateActionConfig percentSamplerAggregateActionConfig) {
+        percent = percentSamplerAggregateActionConfig.getPercent();
+    }
+
+    @Override
+    public AggregateActionResponse handleEvent(final Event event, final AggregateActionInput aggregateActionInput) {
+        final GroupState groupState = aggregateActionInput.getGroupState();
+        Long totalEvents = 0L;
+        Long totalAllowedEvents = 0L;
+        if (groupState.get(TOTAL_EVENTS_KEY) == null) {
+            groupState.put(TOTAL_ALLOWED_EVENTS_KEY, 0L);
+        } else {
+            totalEvents = (Long)groupState.get(TOTAL_EVENTS_KEY);
+            totalAllowedEvents = (Long)groupState.get(TOTAL_ALLOWED_EVENTS_KEY);
+        }
+        groupState.put(TOTAL_EVENTS_KEY, totalEvents+1);
+        if ((((double)(totalAllowedEvents+1))/(double)(totalEvents+1)) <= percent/100.0) {
+            groupState.put(TOTAL_ALLOWED_EVENTS_KEY, totalAllowedEvents+1);
+            return new AggregateActionResponse(event);
+        }
+        return AggregateActionResponse.nullEventResponse();
+    }
+}

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionConfig.java
@@ -7,16 +7,19 @@ package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.AssertTrue;
 
 public class PercentSamplerAggregateActionConfig {
     @JsonProperty("percent")
     @NotNull
-    double percent;
+    private double percent;
     
+    @AssertTrue(message = "Percent value must be greater than 0.0 and less than 100.0")
+    boolean isPercentValid() {
+        return percent > 0.0 && percent < 100.0;
+    }
+
     public double getPercent() {
-        if (percent <= 0.0 || percent >= 100.0) {
-            throw new IllegalArgumentException("Invalid percent value. percent value must be greater than 0.0 and less than 100.0");
-        }
         return percent;
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionConfig.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-Limense-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+public class PercentSamplerAggregateActionConfig {
+    @JsonProperty("percent")
+    @NotNull
+    double percent;
+    
+    public double getPercent() {
+        if (percent <= 0.0 || percent >= 100.0) {
+            throw new IllegalArgumentException("Invalid percent value. percent value must be greater than 0.0 and less than 100.0");
+        }
+        return percent;
+    }
+}

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
@@ -56,7 +56,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.CoreMatchers.hasItem;

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
@@ -56,6 +56,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -278,7 +279,7 @@ public class AggregateProcessorIT {
         boolean allThreadsFinished = countDownLatch.await(5L, TimeUnit.SECONDS);
 
         assertThat(allThreadsFinished, equalTo(true));
-        assertThat((double)allowedEventsCount.get(), equalTo(NUM_THREADS * NUM_EVENTS_PER_BATCH * testPercent/100));
+        assertThat((double)allowedEventsCount.get(), closeTo(NUM_THREADS * NUM_EVENTS_PER_BATCH * testPercent/100, 1.0));
     }
 
     @RepeatedTest(value = 2)

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
@@ -17,6 +17,8 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -24,6 +26,8 @@ import org.opensearch.dataprepper.plugins.processor.aggregate.actions.RemoveDupl
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.PutAllAggregateAction;
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.CountAggregateAction;
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.CountAggregateActionConfig;
+import org.opensearch.dataprepper.plugins.processor.aggregate.actions.PercentSamplerAggregateAction;
+import org.opensearch.dataprepper.plugins.processor.aggregate.actions.PercentSamplerAggregateActionConfig;
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.RateLimiterMode;
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.RateLimiterAggregateAction;
 import org.opensearch.dataprepper.plugins.processor.aggregate.actions.RateLimiterAggregateActionConfig;
@@ -49,8 +53,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -242,6 +248,38 @@ public class AggregateProcessorIT {
         for (final Map<String, Object> uniqueEventMap : uniqueEventMaps) {
             assertThat(aggregatedResult, hasItem(uniqueEventMap));
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {5.0, 15.0, 33.0, 55.0, 70.0, 85.0, 92.0, 99.0})
+    void aggregateWithPercentSamplerAction(double testPercent) throws InterruptedException, NoSuchFieldException, IllegalAccessException {
+        PercentSamplerAggregateActionConfig percentSamplerAggregateActionConfig = new PercentSamplerAggregateActionConfig();
+        setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", testPercent);
+        aggregateAction = new PercentSamplerAggregateAction(percentSamplerAggregateActionConfig);
+        when(pluginFactory.loadPlugin(eq(AggregateAction.class), any(PluginSetting.class)))
+                .thenReturn(aggregateAction);
+        when(aggregateProcessorConfig.getGroupDuration()).thenReturn(Duration.ofSeconds(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE));
+        final AggregateProcessor objectUnderTest = createObjectUnderTest();
+
+        final ExecutorService executorService = Executors.newFixedThreadPool(NUM_THREADS);
+        final CountDownLatch countDownLatch = new CountDownLatch(NUM_THREADS);
+
+        objectUnderTest.doExecute(eventBatch);
+        Thread.sleep(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE * 1000);
+        AtomicInteger allowedEventsCount = new AtomicInteger(0);
+
+        for (int i = 0; i < NUM_THREADS; i++) {
+            executorService.execute(() -> {
+                final List<Record<Event>> recordsOut = (List<Record<Event>>) objectUnderTest.doExecute(eventBatch);
+                allowedEventsCount.getAndAdd(recordsOut.size());
+                countDownLatch.countDown();
+            });
+        }
+
+        boolean allThreadsFinished = countDownLatch.await(5L, TimeUnit.SECONDS);
+
+        assertThat(allThreadsFinished, equalTo(true));
+        assertThat((double)allowedEventsCount.get(), equalTo(NUM_THREADS * NUM_EVENTS_PER_BATCH * testPercent/100));
     }
 
     @RepeatedTest(value = 2)

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionConfigTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionConfigTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
+
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
+import org.junit.jupiter.api.extension.ExtendWith; 
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+public class PercentSamplerAggregateActionConfigTests {
+    private PercentSamplerAggregateActionConfig percentSamplerAggregateActionConfig;
+
+    private PercentSamplerAggregateActionConfig createObjectUnderTest() {
+        return new PercentSamplerAggregateActionConfig();
+    }
+    
+    @BeforeEach
+    void setup() {
+        percentSamplerAggregateActionConfig = createObjectUnderTest();
+    }
+
+    @Test
+    void testValidConfig() throws NoSuchFieldException, IllegalAccessException {
+        final double testPercent = ThreadLocalRandom.current().nextDouble(0.01, 99.9);
+        setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", testPercent);
+        assertThat(percentSamplerAggregateActionConfig.getPercent(), equalTo(testPercent));
+    }
+    
+    @Test
+    void testInvalidConfig() throws NoSuchFieldException, IllegalAccessException {
+        setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", 0.0);
+        assertThrows(IllegalArgumentException.class, () -> percentSamplerAggregateActionConfig.getPercent());
+        setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", 100.0);
+        assertThrows(IllegalArgumentException.class, () -> percentSamplerAggregateActionConfig.getPercent());
+        setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", -1.0);
+        assertThrows(IllegalArgumentException.class, () -> percentSamplerAggregateActionConfig.getPercent());
+        setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", 110.0);
+        assertThrows(IllegalArgumentException.class, () -> percentSamplerAggregateActionConfig.getPercent());
+    }
+}

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionConfigTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionConfigTests.java
@@ -16,6 +16,9 @@ import java.util.concurrent.ThreadLocalRandom;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
 @ExtendWith(MockitoExtension.class)
 public class PercentSamplerAggregateActionConfigTests {
     private PercentSamplerAggregateActionConfig percentSamplerAggregateActionConfig;
@@ -36,15 +39,10 @@ public class PercentSamplerAggregateActionConfigTests {
         assertThat(percentSamplerAggregateActionConfig.getPercent(), equalTo(testPercent));
     }
     
-    @Test
-    void testInvalidConfig() throws NoSuchFieldException, IllegalAccessException {
-        setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", 0.0);
-        assertThat(percentSamplerAggregateActionConfig.isPercentValid(), equalTo(false));
-        setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", 100.0);
-        assertThat(percentSamplerAggregateActionConfig.isPercentValid(), equalTo(false));
-        setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", -1.0);
-        assertThat(percentSamplerAggregateActionConfig.isPercentValid(), equalTo(false));
-        setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", 110.0);
+    @ParameterizedTest
+    @ValueSource(doubles = {0.0, 100.0, -1.0, 110.0})
+    void testInvalidConfig(double percent) throws NoSuchFieldException, IllegalAccessException {
+        setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", percent);
         assertThat(percentSamplerAggregateActionConfig.isPercentValid(), equalTo(false));
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionConfigTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionConfigTests.java
@@ -15,7 +15,6 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 public class PercentSamplerAggregateActionConfigTests {
@@ -40,12 +39,12 @@ public class PercentSamplerAggregateActionConfigTests {
     @Test
     void testInvalidConfig() throws NoSuchFieldException, IllegalAccessException {
         setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", 0.0);
-        assertThrows(IllegalArgumentException.class, () -> percentSamplerAggregateActionConfig.getPercent());
+        assertThat(percentSamplerAggregateActionConfig.isPercentValid(), equalTo(false));
         setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", 100.0);
-        assertThrows(IllegalArgumentException.class, () -> percentSamplerAggregateActionConfig.getPercent());
+        assertThat(percentSamplerAggregateActionConfig.isPercentValid(), equalTo(false));
         setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", -1.0);
-        assertThrows(IllegalArgumentException.class, () -> percentSamplerAggregateActionConfig.getPercent());
+        assertThat(percentSamplerAggregateActionConfig.isPercentValid(), equalTo(false));
         setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", 110.0);
-        assertThrows(IllegalArgumentException.class, () -> percentSamplerAggregateActionConfig.getPercent());
+        assertThat(percentSamplerAggregateActionConfig.isPercentValid(), equalTo(false));
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionTests.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
 
-import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.junit.jupiter.api.extension.ExtendWith; 
@@ -16,7 +15,9 @@ import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionInp
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionResponse;
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionTestUtils;
 
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.Map;
@@ -32,15 +33,17 @@ public class PercentSamplerAggregateActionTests {
 
     private AggregateAction percentSamplerAggregateAction;
 
+    @Mock
+    private PercentSamplerAggregateActionConfig percentSamplerAggregateActionConfig;
+
     private AggregateAction createObjectUnderTest(PercentSamplerAggregateActionConfig config) {
         return new PercentSamplerAggregateAction(config);
     }
 
     @ParameterizedTest
     @ValueSource(doubles = {1.0, 10.0, 25.0, 50.0, 66.0, 75.0, 90.0, 99.0})
-    void testPercentSamplerAggregate(double testPercent) throws NoSuchFieldException, IllegalAccessException, InterruptedException {
-        PercentSamplerAggregateActionConfig percentSamplerAggregateActionConfig = new PercentSamplerAggregateActionConfig();
-        setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", testPercent);
+    void testPercentSamplerAggregate(double testPercent) throws InterruptedException {
+        when(percentSamplerAggregateActionConfig.getPercent()).thenReturn(testPercent);
         percentSamplerAggregateAction = createObjectUnderTest(percentSamplerAggregateActionConfig);
         final String key = UUID.randomUUID().toString();
         final String value = UUID.randomUUID().toString();

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionTests.java
@@ -57,9 +57,13 @@ public class PercentSamplerAggregateActionTests {
         int allowedEvents = 0;
         final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(eventMap);
         for (int i = 0; i < totalEvents; i++) { 
-            testEvent.put(dataKey, UUID.randomUUID().toString());
+            final String dataValue = UUID.randomUUID().toString();
+            testEvent.put(dataKey, dataValue);
             final AggregateActionResponse aggregateActionResponse = percentSamplerAggregateAction.handleEvent(testEvent, aggregateActionInput);
-            if (aggregateActionResponse.getEvent() != null) {
+            Event receivedEvent = aggregateActionResponse.getEvent();
+            if (receivedEvent != null) {
+                assertThat(receivedEvent.get(dataKey, String.class), equalTo(dataValue));
+                assertThat(receivedEvent.get(key, String.class), equalTo(value));
                 allowedEvents++;
             }
         }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/PercentSamplerAggregateActionTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
+
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.junit.jupiter.api.extension.ExtendWith; 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateAction;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionInput;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionResponse;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionTestUtils;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class PercentSamplerAggregateActionTests {
+    AggregateActionInput aggregateActionInput;
+
+    private AggregateAction percentSamplerAggregateAction;
+
+    private AggregateAction createObjectUnderTest(PercentSamplerAggregateActionConfig config) {
+        return new PercentSamplerAggregateAction(config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {1.0, 10.0, 25.0, 50.0, 66.0, 75.0, 90.0, 99.0})
+    void testPercentSamplerAggregate(double testPercent) throws NoSuchFieldException, IllegalAccessException, InterruptedException {
+        PercentSamplerAggregateActionConfig percentSamplerAggregateActionConfig = new PercentSamplerAggregateActionConfig();
+        setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", testPercent);
+        percentSamplerAggregateAction = createObjectUnderTest(percentSamplerAggregateActionConfig);
+        final String key = UUID.randomUUID().toString();
+        final String value = UUID.randomUUID().toString();
+        final String dataKey = UUID.randomUUID().toString();
+        Map<Object, Object> eventMap = Collections.singletonMap(key, value);
+        Event testEvent = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(eventMap)
+                .build();
+        final int totalEvents = 1000;
+        int allowedEvents = 0;
+        final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(eventMap);
+        for (int i = 0; i < totalEvents; i++) { 
+            testEvent.put(dataKey, UUID.randomUUID().toString());
+            final AggregateActionResponse aggregateActionResponse = percentSamplerAggregateAction.handleEvent(testEvent, aggregateActionInput);
+            if (aggregateActionResponse.getEvent() != null) {
+                allowedEvents++;
+            }
+        }
+        final Optional<Event> result = percentSamplerAggregateAction.concludeGroup(aggregateActionInput);
+        assertThat(result.isPresent(), equalTo(false));
+        assertThat(allowedEvents, equalTo((int)(totalEvents * testPercent/100.0)));
+    }
+}


### PR DESCRIPTION
### Description
Added new aggregate action to sample the number of events by allowing only the specified percent number of events during the aggregation window.
Resolves the issue #2094 

Provide a new actionpercent_sampler that would limit the number of events to the specified percent in the configuration. Only percent number of events are allowed out of every 100 events.
```
processor:
  aggregate:
    identification_keys:
      - # ... Identification keys for the metric ...
      action:
        percent_sampler: 
           percent: 60
```
The above config would allow only 6 out of every 10 events received during the aggregation window.
 
### Issues Resolved
#2094 
 
### Check List
- [ X] New functionality includes testing.
- [ X] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
