### PR TITLE
Update OTelProtoCodec for InstrumentationLibrary to InstrumentationScope rename

### DIFF
--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodec.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodec.java
@@ -19,6 +19,7 @@ import io.opentelemetry.proto.metrics.v1.SummaryDataPoint;
 import io.opentelemetry.proto.resource.v1.Resource;
 import io.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
 import io.opentelemetry.proto.trace.v1.Status;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
@@ -44,6 +45,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -79,8 +81,8 @@ public class OTelProtoCodec {
     private static final String AT = "@";
     private static final String METRIC_ATTRIBUTES = "metric.attributes";
     private static final String EXEMPLAR_ATTRIBUTES = "exemplar.attributes";
-    private static final String INSTRUMENTATION_SCOPE_NAME = "instrumentationScope.name";
-    private static final String INSTRUMENTATION_SCOPE_VERSION = "instrumentationScope.version";
+    static final String INSTRUMENTATION_SCOPE_NAME = "instrumentationScope.name";
+    static final String INSTRUMENTATION_SCOPE_VERSION = "instrumentationScope.version";
 
     public static final Function<String, String> REPLACE_DOT_WITH_AT = i -> i.replace(DOT, AT);
     /**
@@ -144,20 +146,51 @@ public class OTelProtoCodec {
         }
 
         protected List<Span> parseResourceSpans(final ResourceSpans resourceSpans) {
-            final List<Span> spans = new LinkedList<>();
-
             final String serviceName = getServiceName(resourceSpans.getResource()).orElse(null);
             final Map<String, Object> resourceAttributes = getResourceAttributes(resourceSpans.getResource());
-            for (InstrumentationLibrarySpans is : resourceSpans.getInstrumentationLibrarySpansList()) {
-                for (io.opentelemetry.proto.trace.v1.Span sp : is.getSpansList()) {
-                    final Span span = parseSpan(sp, is.getInstrumentationLibrary(), serviceName, resourceAttributes);
-                    spans.add(span);
-                }
+
+            if (resourceSpans.getScopeSpansList().size() > 0) {
+                return parseScopeSpans(resourceSpans.getScopeSpansList(), serviceName, resourceAttributes);
             }
-            return spans;
+
+            if (resourceSpans.getInstrumentationLibrarySpansList().size() > 0) {
+                return parseInstrumentationLibrarySpans(resourceSpans.getInstrumentationLibrarySpansList(), serviceName, resourceAttributes);
+            }
+
+            LOG.debug("No spans found to parse from ResourceSpans object: {}", resourceSpans);
+            return Collections.emptyList();
         }
 
-        protected Span parseSpan(final io.opentelemetry.proto.trace.v1.Span sp, final InstrumentationLibrary instrumentationLibrary,
+        private List<Span> parseScopeSpans(final List<ScopeSpans> scopeSpansList, final String serviceName, final Map<String, Object> resourceAttributes) {
+            return scopeSpansList.stream()
+                    .map(scopeSpans -> parseSpans(scopeSpans.getSpansList(), scopeSpans.getScope(),
+                            OTelProtoCodec::getInstrumentationScopeAttributes, serviceName, resourceAttributes))
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toList());
+        }
+
+        private List<Span> parseInstrumentationLibrarySpans(final List<InstrumentationLibrarySpans> instrumentationLibrarySpansList,
+                                                            final String serviceName, final Map<String, Object> resourceAttributes) {
+            return instrumentationLibrarySpansList.stream()
+                    .map(instrumentationLibrarySpans -> parseSpans(instrumentationLibrarySpans.getSpansList(),
+                            instrumentationLibrarySpans.getInstrumentationLibrary(), this::getInstrumentationLibraryAttributes,
+                            serviceName, resourceAttributes))
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toList());
+        }
+
+        private <T> List<Span> parseSpans(final List<io.opentelemetry.proto.trace.v1.Span> spans, final T scope,
+                                          final Function<T, Map<String, Object>> scopeAttributesGetter,
+                                          final String serviceName, final Map<String, Object> resourceAttributes) {
+            return spans.stream()
+                    .map(span -> {
+                        final Map<String, Object> scopeAttributes = scopeAttributesGetter.apply(scope);
+                        return parseSpan(span, scopeAttributes, serviceName, resourceAttributes);
+                    })
+                    .collect(Collectors.toList());
+        }
+
+        protected Span parseSpan(final io.opentelemetry.proto.trace.v1.Span sp, final Map<String, Object> instrumentationScopeAttributes,
                                      final String serviceName, final Map<String, Object> resourceAttributes) {
             return JacksonSpan.builder()
                     .withSpanId(Hex.encodeHexString(sp.getSpanId().toByteArray()))
@@ -173,7 +206,7 @@ public class OTelProtoCodec {
                             Arrays.asList(
                                     getSpanAttributes(sp),
                                     resourceAttributes,
-                                    getInstrumentationLibraryAttributes(instrumentationLibrary),
+                                    instrumentationScopeAttributes,
                                     getSpanStatusAttributes(sp.getStatus())
                             )
                     ))
@@ -308,10 +341,10 @@ public class OTelProtoCodec {
         protected Map<String, Object> getInstrumentationLibraryAttributes(final InstrumentationLibrary instrumentationLibrary) {
             final Map<String, Object> instrumentationAttr = new HashMap<>();
             if (!instrumentationLibrary.getName().isEmpty()) {
-                instrumentationAttr.put(INSTRUMENTATION_LIBRARY_NAME, instrumentationLibrary.getName());
+                instrumentationAttr.put(INSTRUMENTATION_SCOPE_NAME, instrumentationLibrary.getName());
             }
             if (!instrumentationLibrary.getVersion().isEmpty()) {
-                instrumentationAttr.put(INSTRUMENTATION_LIBRARY_VERSION, instrumentationLibrary.getVersion());
+                instrumentationAttr.put(INSTRUMENTATION_SCOPE_VERSION, instrumentationLibrary.getVersion());
             }
             return instrumentationAttr;
         }
@@ -355,12 +388,12 @@ public class OTelProtoCodec {
             final Map<String, Object> allAttributes = span.getAttributes();
             final Resource resource = constructResource(span.getServiceName(), allAttributes);
             rsBuilder.setResource(resource);
-            final InstrumentationLibrarySpans.Builder instrumentationLibrarySpansBuilder = InstrumentationLibrarySpans.newBuilder();
-            final InstrumentationLibrary instrumentationLibrary = constructInstrumentationLibrary(allAttributes);
-            instrumentationLibrarySpansBuilder.setInstrumentationLibrary(instrumentationLibrary);
+            final ScopeSpans.Builder scopeSpansBuilder = ScopeSpans.newBuilder();
+            final InstrumentationScope instrumentationScope = constructInstrumentationScope(allAttributes);
+            scopeSpansBuilder.setScope(instrumentationScope);
             final io.opentelemetry.proto.trace.v1.Span otelProtoSpan = constructSpan(span, allAttributes);
-            instrumentationLibrarySpansBuilder.addSpans(otelProtoSpan);
-            rsBuilder.addInstrumentationLibrarySpans(instrumentationLibrarySpansBuilder);
+            scopeSpansBuilder.addSpans(otelProtoSpan);
+            rsBuilder.addScopeSpans(scopeSpansBuilder);
             return rsBuilder.build();
         }
 
@@ -411,12 +444,12 @@ public class OTelProtoCodec {
             return result;
         }
 
-        protected InstrumentationLibrary constructInstrumentationLibrary(final Map<String, Object> attributes) {
-            final InstrumentationLibrary.Builder builder = InstrumentationLibrary.newBuilder();
-            final Optional<String> instrumentationLibraryName = Optional.ofNullable((String) attributes.get(INSTRUMENTATION_LIBRARY_NAME));
-            final Optional<String> instrumentationLibraryVersion = Optional.ofNullable((String) attributes.get(INSTRUMENTATION_LIBRARY_VERSION));
-            instrumentationLibraryName.ifPresent(builder::setName);
-            instrumentationLibraryVersion.ifPresent(builder::setVersion);
+        protected InstrumentationScope constructInstrumentationScope(final Map<String, Object> attributes) {
+            final InstrumentationScope.Builder builder = InstrumentationScope.newBuilder();
+            final Optional<String> instrumentationScopeName = Optional.ofNullable((String) attributes.get(INSTRUMENTATION_SCOPE_NAME));
+            final Optional<String> instrumentationScopeVersion = Optional.ofNullable((String) attributes.get(INSTRUMENTATION_SCOPE_VERSION));
+            instrumentationScopeName.ifPresent(builder::setName);
+            instrumentationScopeVersion.ifPresent(builder::setVersion);
             return builder.build();
         }
 

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodec.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodec.java
@@ -47,7 +47,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodecTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodecTest.java
@@ -21,7 +21,6 @@ import io.opentelemetry.proto.metrics.v1.Exemplar;
 import io.opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint;
 import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
 import io.opentelemetry.proto.resource.v1.Resource;
-import io.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.proto.trace.v1.ScopeSpans;
 import io.opentelemetry.proto.trace.v1.Status;

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-both-span-types.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-both-span-types.json
@@ -240,6 +240,36 @@
             }
           ]
         }
+      ],
+      "instrumentationLibrarySpans": [
+        {
+          "instrumentationLibrary": {
+            "name": "io.opentelemetry.auto.spring-webmvc-3.1",
+            "version": ""
+          },
+          "spans": [
+            {
+              "traceId": "/6V20yEXOsbO82Acj0vedQ==",
+              "spanId": "CFrAgv/Pv40=",
+              "traceState": "",
+              "parentSpanId": "yxwHNNFJQP0=",
+              "name": "LoggingController.save",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1597902043168792500",
+              "endTimeUnixNano": "1597902043215953100",
+              "attributes": [],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "links": [],
+              "droppedLinksCount": 0,
+              "status": {
+                "code": "STATUS_CODE_OK",
+                "message": ""
+              }
+            }
+          ]
+        }
       ]
     }
   ]

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-instrumentation-library.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-instrumentation-library.json
@@ -69,9 +69,9 @@
         ],
         "droppedAttributesCount": 0
       },
-      "scopeSpans": [
+      "instrumentationLibrarySpans": [
         {
-          "scope": {
+          "instrumentationLibrary": {
             "name": "io.opentelemetry.auto.spring-webmvc-3.1",
             "version": ""
           },
@@ -99,7 +99,7 @@
           ]
         },
         {
-          "scope": {
+          "instrumentationLibrary": {
             "name": "io.opentelemetry.auto.apache-httpasyncclient-4.0",
             "version": ""
           },
@@ -146,7 +146,7 @@
           ]
         },
         {
-          "scope": {
+          "instrumentationLibrary": {
             "name": "io.opentelemetry.auto.servlet-3.0",
             "version": ""
           },

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-no-spans.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-no-spans.json
@@ -1,0 +1,74 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "analytics-service"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "java"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "0.8.0-SNAPSHOT"
+            }
+          },
+          {
+            "key": "array",
+            "value": {
+              "arrayValue": {
+                "values": [
+                  {
+                    "stringValue": "test string"
+                  },
+                  {
+                    "boolValue": false
+                  },
+                  {
+                    "intValue": 0
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "key": "kvList",
+            "value": {
+              "kvlistValue": {
+                "values": [
+                  {
+                    "key": "key1",
+                    "value": {
+                      "stringValue": "value1"
+                    }
+                  },
+                  {
+                    "key": "key2",
+                    "value": {
+                      "stringValue": "value2"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description
The InstrumentationLibrary model was renamed to InstrumentationScope as part of this PR: https://github.com/open-telemetry/opentelemetry-proto/pull/362

This PR updates the `OTelProtoDecoder` and `OTelProtoEncoder` to use the new `InstrumentationScope` model while continuing to support incoming requests using `InstrumentationLibrary` per the specification defined in the above PR.
 
### Check List
- [x] New functionality includes testing.
- [N/A] New functionality has been documented.
  - [N/A] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
