### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,15 +1,20 @@
-# Maintainers
-| Maintainer | GitHub ID | Affiliation |
-| --------------- | --------- | ----------- |
-| Steven Bayer | [sbayer55](https://github.com/sbayer55) | Amazon |
-| Qi Chen | [chenqi0805](https://github.com/chenqi0805) | Amazon |
-| Chase Engelbrecht | [engechas](https://github.com/engechas) | Amazon |
-| Taylor Gray | [graytaylor0](https://github.com/graytaylor0) | Amazon |
-| Dinu John |  [dinujoh](https://github.com/dinujoh) | Amazon |
-| Christopher Manning | [cmanning09](https://github.com/cmanning09) | Amazon |
-| Asif Sohail Mohammed | [asifsmohammed](https://github.com/asifsmohammed) | Amazon |
-| David Powers | [dapowers87](https://github.com/dapowers87) | Amazon |
-| Shivani Shukla | [sshivanii](https://github.com/sshivanii) | Amazon |
-| Phill Treddenick | [treddeni-amazon](https://github.com/treddeni-amazon) | Amazon |
-| David Venable | [dlvenable](https://github.com/dlvenable) | Amazon |
-| Hai Yan | [oeyh](https://github.com/oeyh) | Amazon |
+## Overview
+
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
+
+| Maintainer           | GitHub ID                                             | Affiliation |
+| -------------------- | ----------------------------------------------------- | ----------- |
+| Steven Bayer         | [sbayer55](https://github.com/sbayer55)               | Amazon      |
+| Qi Chen              | [chenqi0805](https://github.com/chenqi0805)           | Amazon      |
+| Chase Engelbrecht    | [engechas](https://github.com/engechas)               | Amazon      |
+| Taylor Gray          | [graytaylor0](https://github.com/graytaylor0)         | Amazon      |
+| Dinu John            | [dinujoh](https://github.com/dinujoh)                 | Amazon      |
+| Christopher Manning  | [cmanning09](https://github.com/cmanning09)           | Amazon      |
+| Asif Sohail Mohammed | [asifsmohammed](https://github.com/asifsmohammed)     | Amazon      |
+| David Powers         | [dapowers87](https://github.com/dapowers87)           | Amazon      |
+| Shivani Shukla       | [sshivanii](https://github.com/sshivanii)             | Amazon      |
+| Phill Treddenick     | [treddeni-amazon](https://github.com/treddeni-amazon) | Amazon      |
+| David Venable        | [dlvenable](https://github.com/dlvenable)             | Amazon      |
+| Hai Yan              | [oeyh](https://github.com/oeyh)                       | Amazon      |


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.