### PR TITLE
Fix for null pointer exception in remote peer forwarding (fix for issue 2123)

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
@@ -156,6 +156,7 @@ class RemotePeerForwarder implements PeerForwarder {
             }
             if (numMissingIdentificationKeys == identificationKeys.size()) {
                 recordsMissingIdentificationKeys.increment(1);
+                identificationKeyValues.clear();
             }
 
             final String dataPrepperIp = hashRing.getServerIp(identificationKeyValues).orElse(StaticPeerListProvider.LOCAL_ENDPOINT);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
@@ -144,14 +144,18 @@ class RemotePeerForwarder implements PeerForwarder {
             final Event event = record.getData();
 
             final List<String> identificationKeyValues = new LinkedList<>();
+            int numMissingIdentificationKeys = 0;
             for (final String identificationKey : identificationKeys) {
                 Object identificationKeyValue = event.get(identificationKey, Object.class);
                 if (identificationKeyValue == null) {
                     identificationKeyValues.add(null);
-                    recordsMissingIdentificationKeys.increment(1);
+                    numMissingIdentificationKeys++;
                 } else {
                     identificationKeyValues.add(identificationKeyValue.toString());
                 }
+            }
+            if (numMissingIdentificationKeys == identificationKeys.size()) {
+                recordsMissingIdentificationKeys.increment(1);
             }
 
             final String dataPrepperIp = hashRing.getServerIp(identificationKeyValues).orElse(StaticPeerListProvider.LOCAL_ENDPOINT);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
@@ -146,7 +146,7 @@ class RemotePeerForwarder implements PeerForwarder {
             final List<String> identificationKeyValues = new LinkedList<>();
             int numMissingIdentificationKeys = 0;
             for (final String identificationKey : identificationKeys) {
-                Object identificationKeyValue = event.get(identificationKey, Object.class);
+                final Object identificationKeyValue = event.get(identificationKey, Object.class);
                 if (identificationKeyValue == null) {
                     identificationKeyValues.add(null);
                     numMissingIdentificationKeys++;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
@@ -141,8 +141,17 @@ class RemotePeerForwarder implements PeerForwarder {
             final Event event = record.getData();
 
             final List<String> identificationKeyValues = new LinkedList<>();
+            boolean identificationKeysNotFound = false;
             for (final String identificationKey : identificationKeys) {
-                identificationKeyValues.add(event.get(identificationKey, Object.class).toString());
+                Object identificationKeyValue = event.get(identificationKey, Object.class);
+                if (identificationKeyValue == null) {
+                    identificationKeysNotFound = true;
+                    break;
+                }
+                identificationKeyValues.add(identificationKeyValue.toString());
+            }
+            if (identificationKeysNotFound) {
+                continue;
             }
 
             final String dataPrepperIp = hashRing.getServerIp(identificationKeyValues).orElse(StaticPeerListProvider.LOCAL_ENDPOINT);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
@@ -53,6 +53,7 @@ import static org.opensearch.dataprepper.peerforwarder.RemotePeerForwarder.RECOR
 import static org.opensearch.dataprepper.peerforwarder.RemotePeerForwarder.RECORDS_MISSING_IDENTIFICATION_KEYS;
 import static org.opensearch.dataprepper.peerforwarder.RemotePeerForwarder.REQUESTS_FAILED;
 import static org.opensearch.dataprepper.peerforwarder.RemotePeerForwarder.REQUESTS_SUCCESSFUL;
+import org.apache.commons.lang3.RandomStringUtils;
 
 @ExtendWith(MockitoExtension.class)
 class RemotePeerForwarderTest {
@@ -233,8 +234,8 @@ class RemotePeerForwarderTest {
         final Collection<Record<Event>> testRecords = generateBatchRecords(2);
         // Add an event that doesn't have identification keys in it
         final Map<String, String> eventData = new HashMap<>();
-        eventData.put("key3", "value3");
-        eventData.put("key4", "value4");
+        eventData.put(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(10));
+        eventData.put(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(10));
         final JacksonEvent event = JacksonLog.builder().withData(eventData).build();
         testRecords.add(new Record<>(event));
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
@@ -244,7 +244,7 @@ class RemotePeerForwarderTest {
 
         verify(recordsToBeProcessedLocallyCounter).increment(2.0);
         verify(recordsActuallyProcessedLocallyCounter).increment(2.0);
-        verify(recordsMissingIdentificationKeys, times(2)).increment(1.0);
+        verify(recordsMissingIdentificationKeys).increment(1.0);
         verify(recordsToBeForwardedCounter).increment(1.0);
         verify(requestsSuccessfulCounter).increment();
         verify(recordsSuccessfullyForwardedCounter).increment(1.0);


### PR DESCRIPTION
Signed-off-by: Krishna Kondaka <krishkdk@amazon.com>

### Description
Fix for null pointer exception in remote peer forwarding
 
### Issues Resolved
#2123 
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
