### PR TITLE
Add e2etest for testing log metrics

### DIFF
--- a/e2e-test/peerforwarder/build.gradle
+++ b/e2e-test/peerforwarder/build.gradle
@@ -29,6 +29,7 @@ task removeDataPrepperNetwork(type: DockerRemoveNetwork) {
 }
 
 def AGGREGATE_PIPELINE_YAML = "aggregate-e2e-pipeline.yml"
+def LOG_METRICS_PIPELINE_YAML = "log-metrics-pipeline.yml"
 def DATA_PREPPER_CONFIG_LOCAL_NODE = "data_prepper_local_node.yml"
 def DATA_PREPPER_CONFIG_STATIC = "data_prepper_static.yml"
 
@@ -63,6 +64,7 @@ def createDataPrepperDockerContainer(final String taskBaseName, final String dat
         hostConfig.portBindings = [String.format('%d:2021', sourcePort)]
         hostConfig.network = createDataPrepperNetwork.getNetworkName()
         hostConfig.binds = [(project.file("src/integrationTest/resources/${pipelineConfigYAML}").toString()):"/app/data-prepper/pipelines/pipelines.yaml",
+                            "/tmp":"/tmp",
                             (project.file("src/integrationTest/resources/${dataPrepperConfigYAML}").toString()):"/app/data-prepper/config/data-prepper-config.yaml"]
         cmd = ['java', '-Ddata-prepper.dir=/app/data-prepper', '-cp', '/app/data-prepper/lib/*', 'org.opensearch.dataprepper.DataPrepperExecute']
         targetImageId buildDataPrepperDockerImage.getImageId()
@@ -173,6 +175,17 @@ def createLocalAggregateDataPrepper2Task = createDataPrepperDockerContainer(
 
 def localAggregateEndToEndTest = createEndToEndTest("localAggregateEndToEndTest", includeLocalAggregateTestsMatchPattern,
         createLocalAggregateDataPrepper1Task, createLocalAggregateDataPrepper2Task)
+
+// Discovery mode: LOCAL_NODE
+def includeLocalLogMetricsTestsMatchPattern = "org.opensearch.dataprepper.integration.peerforwarder.EndToEndLogMetricsTest.testLogMetricsPipelineWithMultipleNodesEndToEnd*"
+
+def createLocalLogMetricsDataPrepper1Task = createDataPrepperDockerContainer(
+        "localLogMetricsDataPrepper1", "dataprepper1", 2021, "${LOG_METRICS_PIPELINE_YAML}", "${DATA_PREPPER_CONFIG_LOCAL_NODE}")
+def createLocalLogMetricsDataPrepper2Task = createDataPrepperDockerContainer(
+        "localLogMetricsDataPrepper2", "dataprepper2", 2022, "${LOG_METRICS_PIPELINE_YAML}", "${DATA_PREPPER_CONFIG_LOCAL_NODE}")
+
+def localLogMetricsEndToEndTest = createEndToEndTest("localLogMetricsEndToEndTest", includeLocalLogMetricsTestsMatchPattern,
+        createLocalLogMetricsDataPrepper1Task, createLocalLogMetricsDataPrepper2Task)
 
 // Discovery mode: STATIC with SSL & mTLS
 def includeStaticAggregateTestsMatchPattern = "org.opensearch.dataprepper.integration.peerforwarder.EndToEndPeerForwarderTest.testAggregatePipelineWithMultipleNodesEndToEnd*"

--- a/e2e-test/peerforwarder/build.gradle
+++ b/e2e-test/peerforwarder/build.gradle
@@ -176,7 +176,7 @@ def createLocalAggregateDataPrepper2Task = createDataPrepperDockerContainer(
 def localAggregateEndToEndTest = createEndToEndTest("localAggregateEndToEndTest", includeLocalAggregateTestsMatchPattern,
         createLocalAggregateDataPrepper1Task, createLocalAggregateDataPrepper2Task)
 
-// Discovery mode: LOCAL_NODE
+// Discovery mode: LOCAL_NODE - Log pipeline metrics e2e test
 def includeLocalLogMetricsTestsMatchPattern = "org.opensearch.dataprepper.integration.peerforwarder.EndToEndLogMetricsTest.testLogMetricsPipelineWithMultipleNodesEndToEnd*"
 
 def createLocalLogMetricsDataPrepper1Task = createDataPrepperDockerContainer(

--- a/e2e-test/peerforwarder/src/integrationTest/java/org/opensearch/dataprepper/integration/peerforwarder/EndToEndLogMetricsTest.java
+++ b/e2e-test/peerforwarder/src/integrationTest/java/org/opensearch/dataprepper/integration/peerforwarder/EndToEndLogMetricsTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.integration.peerforwarder;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import io.netty.util.AsciiString;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.action.admin.indices.refresh.RefreshRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration;
+import org.opensearch.dataprepper.plugins.source.loggenerator.ApacheLogFaker;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+
+public class EndToEndLogMetricsTest {
+    private static final int HTTP_SOURCE_PORT_1 = 2021;
+    private static final int HTTP_SOURCE_PORT_2 = 2022;
+    private static final String TEST_INDEX_NAME = "test-log-metrics-index";
+    private static final String CUSTOM_KEY_1 = "verb";
+    private static final String CUSTOM_KEY_2 = "bytes";
+    private static final String SOURCE_IP = "127.0.0.1";
+    private static final String DESTINATION_IP_1 = "8.8.8.8";
+    private static final String DESTINATION_IP_2 = "12.12.13.13";
+    private static final int TOTAL_EVENTS = 40;
+    private double expectedMin = Float.MAX_VALUE;
+    private double expectedMax = -Float.MAX_VALUE;
+    private double expectedSum = 0;
+
+    private final ApacheLogFaker apacheLogFaker = new ApacheLogFaker();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final Random random = new Random();
+
+    @Test
+    public void testLogMetricsPipelineWithMultipleNodesEndToEnd() throws JsonProcessingException {
+        double[] latencies = new double[TOTAL_EVENTS];
+        for (int i = 0; i < TOTAL_EVENTS; i++) {
+            latencies[i] = ThreadLocalRandom.current().nextDouble(-2, 12);
+            expectedSum += latencies[i];
+            if (latencies[i] < expectedMin) {
+                expectedMin = latencies[i];
+            }
+            if (latencies[i] > expectedMax) {
+                expectedMax = latencies[i];
+            }
+        }
+        int latencyIdx = 0;
+        for (int i = 0; i < TOTAL_EVENTS/4; i++) {
+            sendHttpRequestToSource(HTTP_SOURCE_PORT_1, generateRandomApacheLogHttpData(DESTINATION_IP_1, latencies[latencyIdx++], CUSTOM_KEY_1, "POST"));
+            sendHttpRequestToSource(HTTP_SOURCE_PORT_1, generateRandomApacheLogHttpData(DESTINATION_IP_2, latencies[latencyIdx++], CUSTOM_KEY_2, String.valueOf(random.nextInt())));
+            sendHttpRequestToSource(HTTP_SOURCE_PORT_2, generateRandomApacheLogHttpData(DESTINATION_IP_1, latencies[latencyIdx++], CUSTOM_KEY_2, String.valueOf(random.nextInt())));
+            sendHttpRequestToSource(HTTP_SOURCE_PORT_2, generateRandomApacheLogHttpData(DESTINATION_IP_2, latencies[latencyIdx++], CUSTOM_KEY_1, "GET"));
+        }
+
+        verifyDataInOpenSearch();
+    }
+
+    private void verifyDataInOpenSearch() {
+        // Verify data in OpenSearch backend
+        final RestHighLevelClient restHighLevelClient = prepareOpenSearchRestHighLevelClient();
+        final List<Map<String, Object>> retrievedDocs = new ArrayList<>();
+        // Wait for data to flow through pipeline and be indexed by ES
+        await().atMost(45, TimeUnit.SECONDS).untilAsserted(
+                () -> {
+                    refreshIndices(restHighLevelClient);
+                    final SearchRequest searchRequest = new SearchRequest(TEST_INDEX_NAME);
+                    searchRequest.source(
+                            SearchSourceBuilder.searchSource().size(100)
+                    );
+                    final SearchResponse searchResponse = restHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
+                    final List<Map<String, Object>> foundSources = getSourcesFromSearchHits(searchResponse.getHits());
+                    Assert.assertTrue(foundSources.size() >=2 && foundSources.size() <= 4);
+                    retrievedDocs.addAll(foundSources);
+                }
+        );
+
+        Assert.assertTrue(retrievedDocs.size() >=2 && retrievedDocs.size() <= 4);
+        // Verify original and aggregated keys from retrieved docs
+        final List<String> expectedDocKeys = Arrays.asList(
+                "sourceIp", "destinationIp", "histogram_key", "kind", "name", "description", "min", "max", "count", "sum", "time");
+        double receivedMin = Float.MAX_VALUE;
+        double receivedMax = -Float.MAX_VALUE;
+        double receivedSum = 0.0;
+        int receivedCount = 0;
+        for (Map<String, Object> retrievedDoc: retrievedDocs) {
+            for (String key: expectedDocKeys) {
+                assertThat(retrievedDoc, hasKey(key));
+                if (key.equals("histogram_key")) {
+                    Assert.assertThat((String)retrievedDoc.get("histogram_key"), equalTo("latency"));
+                }
+                if (key.equals("kind")) {
+                    Assert.assertThat((String)retrievedDoc.get("kind"), equalTo("HISTOGRAM"));
+                }
+                if (key.equals("explicitBoundsCount")) {
+                    Assert.assertThat((String)retrievedDoc.get("explicitBoundsCount"), equalTo(5));
+                }
+                if (key.equals("min")) {
+                    double minVal = (double)retrievedDoc.get("min");
+                    if (minVal < receivedMin) {
+                        receivedMin = minVal;
+                    }
+                }
+                if (key.equals("max")) {
+                    double maxVal = (double)retrievedDoc.get("max");
+                    if (maxVal > receivedMax) {
+                        receivedMax = maxVal;
+                    }
+                }
+                if (key.equals("sum")) {
+                    receivedSum += (double)retrievedDoc.get("sum");
+                }
+                if (key.equals("count")) {
+                    receivedCount += (int)retrievedDoc.get("count");
+                }
+            }
+        }
+        Assert.assertThat(expectedMin, equalTo(receivedMin));
+        Assert.assertThat(expectedMax, equalTo(receivedMax));
+        Assert.assertThat(TOTAL_EVENTS, equalTo(receivedCount));
+        Assert.assertThat(expectedSum, closeTo(receivedSum, 0.1));
+    }
+
+    private RestHighLevelClient prepareOpenSearchRestHighLevelClient() {
+        final ConnectionConfiguration.Builder builder = new ConnectionConfiguration.Builder(
+                Collections.singletonList("https://127.0.0.1:9200"));
+        builder.withUsername("admin");
+        builder.withPassword("admin");
+        return builder.build().createClient();
+    }
+
+    private void sendHttpRequestToSource(final int port, final HttpData httpData) {
+        WebClient.of().execute(RequestHeaders.builder()
+                                .scheme(SessionProtocol.HTTP)
+                                .authority(String.format("127.0.0.1:%d", port))
+                                .method(HttpMethod.POST)
+                                .path("/log/ingest")
+                                .contentType(MediaType.JSON_UTF_8)
+                                .build(),
+                        httpData)
+                .aggregate()
+                .whenComplete((i, ex) -> {
+                    assertThat(i.status(), is(HttpStatus.OK));
+                    final List<String> headerKeys = i.headers()
+                            .stream()
+                            .map(Map.Entry::getKey)
+                            .map(AsciiString::toString)
+                            .collect(Collectors.toList());
+                    assertThat("Response Header Keys", headerKeys, not(contains("server")));
+                }).join();
+    }
+
+    private List<Map<String, Object>> getSourcesFromSearchHits(final SearchHits searchHits) {
+        final List<Map<String, Object>> sources = new ArrayList<>();
+        searchHits.forEach(hit -> {
+            Map<String, Object> source = hit.getSourceAsMap();
+            sources.add(source);
+        });
+        return sources;
+    }
+
+    private void refreshIndices(final RestHighLevelClient restHighLevelClient) throws IOException {
+        final RefreshRequest requestAll = new RefreshRequest();
+        restHighLevelClient.indices().refresh(requestAll, RequestOptions.DEFAULT);
+    }
+
+    private HttpData generateRandomApacheLogHttpData(final String destinationIp, double latency, final String customKey, final String customValue) throws JsonProcessingException {
+        final List<Map<String, Object>> jsonArray = new ArrayList<>();
+        final Map<String, Object> logObj = new HashMap<>();
+        logObj.put("date", System.currentTimeMillis());
+        logObj.put("log", apacheLogFaker.generateRandomExtendedApacheLog());
+        logObj.put("latency", latency);
+        logObj.put("sourceIp", SOURCE_IP);
+        logObj.put("destinationIp", destinationIp);
+        logObj.put(customKey, customValue);
+        jsonArray.add(logObj);
+
+        final String jsonData = objectMapper.writeValueAsString(jsonArray);
+        return HttpData.ofUtf8(jsonData);
+    }
+}

--- a/e2e-test/peerforwarder/src/integrationTest/resources/log-metrics-pipeline.yml
+++ b/e2e-test/peerforwarder/src/integrationTest/resources/log-metrics-pipeline.yml
@@ -1,0 +1,19 @@
+aggregate-pipeline:
+  source:
+    http:
+  processor:
+    - aggregate:
+        identification_keys: [ "sourceIp", "destinationIp" ]
+        action:
+          histogram:
+            key: "latency"
+            record_minmax: true
+            units: "seconds"
+            buckets: [2.0, 4.0, 6.0, 8.0, 10.0]
+        group_duration: "15s"
+  sink:
+    - opensearch:
+        hosts: [ "https://node-0.example.com:9200" ]
+        username: "admin"
+        password: "admin"
+        index: "test-log-metrics-index"


### PR DESCRIPTION
Signed-off-by: Krishna Kondaka <krishkdk@amazon.com>

### Description
Added e2e test for testing log metrics functionality.
 
### Issues Resolved
#2126 
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
