### PR TITLE
Adds count metrics to the service_map_stateful processor

### DIFF
--- a/data-prepper-plugins/service-map-stateful/README.md
+++ b/data-prepper-plugins/service-map-stateful/README.md
@@ -17,8 +17,11 @@ processor:
 Besides common metrics in [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java), service-map-stateful processor introduces the following custom metrics.
 
 ### Gauge
-- `spansDbSize`: measures total spans byte sizes in MapDB across the current and previous window durations.
-- `traceGroupDbSize`: measures total trace group byte sizes in MapDB across the current and previous trace group window durations.
+- `spansDbSize`: measures total spans byte sizes in MapDB across the current and previous window durations. This only tracks the byte size for the file (if used).
+- `traceGroupDbSize`: measures total trace group byte sizes in MapDB across the current and previous trace group window durations. This only tracks the byte size for the file (if used).
+- `spansDbCount`: measures the total spans across the current and previous window durations.
+- `traceGroupDbCount`: measures the total trace groups across the current and previous trace group window durations.
+- `relationshipCount`: measures the total relationships stored
 
 ## Developer Guide
 This plugin is compatible with Java 8. See 

--- a/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapStatefulProcessor.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapStatefulProcessor.java
@@ -44,7 +44,7 @@ public class ServiceMapStatefulProcessor extends AbstractProcessor<Record<Event>
     static final String TRACE_GROUP_DB_SIZE = "traceGroupDbSize";
     static final String SPANS_DB_COUNT = "spansDbCount";
     static final String TRACE_GROUP_DB_COUNT = "traceGroupDbCount";
-    static final String RELATIONSHIP_COUNT = "RelationshipCount";
+    static final String RELATIONSHIP_COUNT = "relationshipCount";
 
     private static final Logger LOG = LoggerFactory.getLogger(ServiceMapStatefulProcessor.class);
     private static final String EMPTY_SUFFIX = "-empty";

--- a/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapStatefulProcessor.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/org/opensearch/dataprepper/plugins/processor/ServiceMapStatefulProcessor.java
@@ -40,8 +40,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 @DataPrepperPlugin(name = "service_map_stateful", pluginType = Processor.class)
 public class ServiceMapStatefulProcessor extends AbstractProcessor<Record<Event>, Record<Event>> implements RequiresPeerForwarding {
 
-    public static final String SPANS_DB_SIZE = "spansDbSize";
-    public static final String TRACE_GROUP_DB_SIZE = "traceGroupDbSize";
+    static final String SPANS_DB_SIZE = "spansDbSize";
+    static final String TRACE_GROUP_DB_SIZE = "traceGroupDbSize";
+    static final String SPANS_DB_COUNT = "spansDbCount";
+    static final String TRACE_GROUP_DB_COUNT = "traceGroupDbCount";
+    static final String RELATIONSHIP_COUNT = "RelationshipCount";
 
     private static final Logger LOG = LoggerFactory.getLogger(ServiceMapStatefulProcessor.class);
     private static final String EMPTY_SUFFIX = "-empty";
@@ -100,6 +103,9 @@ public class ServiceMapStatefulProcessor extends AbstractProcessor<Record<Event>
 
         pluginMetrics.gauge(SPANS_DB_SIZE, this, serviceMapStateful -> serviceMapStateful.getSpansDbSize());
         pluginMetrics.gauge(TRACE_GROUP_DB_SIZE, this, serviceMapStateful -> serviceMapStateful.getTraceGroupDbSize());
+        pluginMetrics.gauge(SPANS_DB_COUNT, this, serviceMapStateful -> serviceMapStateful.getSpansDbCount());
+        pluginMetrics.gauge(TRACE_GROUP_DB_COUNT, this, serviceMapStateful -> serviceMapStateful.getTraceGroupDbCount());
+        pluginMetrics.gauge(RELATIONSHIP_COUNT, this, serviceMapStateful -> serviceMapStateful.getRelationshipCount());
     }
 
     /**
@@ -314,11 +320,21 @@ public class ServiceMapStatefulProcessor extends AbstractProcessor<Record<Event>
         return currentWindow.sizeInBytes() + previousWindow.sizeInBytes();
     }
 
+    public double getSpansDbCount() {
+        return currentWindow.size() + previousWindow.size();
+    }
+
     /**
      * @return Trace group database size in bytes
      */
     public double getTraceGroupDbSize() {
         return currentTraceGroupWindow.sizeInBytes() + previousTraceGroupWindow.sizeInBytes();
+    }
+    public double getTraceGroupDbCount() {
+        return currentTraceGroupWindow.size() + previousTraceGroupWindow.size();
+    }
+    public double getRelationshipCount() {
+        return RELATIONSHIP_STATE.size();
     }
 
     /**


### PR DESCRIPTION
### Description

The `service_map_stateful` processor currently has two size metrics. These return 0 since Data Prepper is not using a file.

This PR adds three new metrics.

* `spansDbCount` - The count of items in both windows for spans.
* `traceGroupDbCount` - The count of items in both windows for trace groups.
* `relationshipCount` - The count of items in the static relationship map.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
