### PR TITLE
Adds ScheduledExecutorService for Polling the RSS feed

### DIFF
--- a/data-prepper-plugins/rss-source/build.gradle
+++ b/data-prepper-plugins/rss-source/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.apptasticsoftware:rssreader:3.2.5'
+    implementation 'com.google.code.gson:gson:2.8.7' // TODO: Pretty print Items for demo, remove later
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
     testImplementation project(':data-prepper-test-common')
 }

--- a/data-prepper-plugins/rss-source/build.gradle
+++ b/data-prepper-plugins/rss-source/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.apptasticsoftware:rssreader:3.2.5'
-    implementation 'com.google.code.gson:gson:2.8.7' // TODO: Pretty print Items for demo, remove later
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
     testImplementation project(':data-prepper-test-common')
 }

--- a/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RSSSource.java
+++ b/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RSSSource.java
@@ -44,7 +44,7 @@ public class RSSSource implements Source<Record<Document>> {
         if (buffer == null) {
             throw new IllegalStateException("Buffer is null");
         }
-        rssReaderTask = new RssReaderTask(rssReader, rssSourceConfig, buffer);
+        rssReaderTask = new RssReaderTask(rssReader, rssSourceConfig.getUrl(), buffer);
         scheduledExecutorService.scheduleAtFixedRate(rssReaderTask, 0, 5, TimeUnit.SECONDS);
     }
 

--- a/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RSSSource.java
+++ b/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RSSSource.java
@@ -20,6 +20,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -32,8 +36,10 @@ public class RSSSource implements Source<Record<Document>> {
 
     private final RSSSourceConfig rssSourceConfig;
 
+    private static int count = 0;
+
     @DataPrepperPluginConstructor
-    public RSSSource(final PluginMetrics pluginMetrics, final RSSSourceConfig rssSourceConfig) {
+    public RSSSource(final PluginMetrics pluginMetrics, final RSSSourceConfig rssSourceConfig) throws InterruptedException {
         this.pluginMetrics = pluginMetrics;
         this.rssSourceConfig = rssSourceConfig;
     }
@@ -51,22 +57,64 @@ public class RSSSource implements Source<Record<Document>> {
         // TODO: Stop the service
     }
 
-    void extractItemsFromRssFeed(final RSSSourceConfig rssSourceConfig) {
-        final String url = rssSourceConfig.getUrl();
+//    public void run() throws InterruptedException {
+//        ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+//
+//        Runnable task = () -> {
+//            readRssRead();
+//            count++;
+//            System.out.println("Running task to extract items from RSS feed");
+//        };
+//
+//        ScheduledFuture<?> scheduledFuture = executorService.scheduleAtFixedRate(task, 0, 5, TimeUnit.MINUTES);
+//
+//        while (true) {
+//            System.out.println("Count: "+ count);
+//            Thread.sleep(1000);
+//            if (count == 20) {
+//                System.out.println(" Count is 20 time to cancel scheduled future");
+//                scheduledFuture.cancel(true);
+//                executorService.shutdown();
+//                break;
+//            }
+//        }
+//    }
+    void extractItemsFromRssFeed(final RSSSourceConfig rssSourceConfig) throws InterruptedException {
 
+        ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+
+        final String url = rssSourceConfig.getUrl();
         if(url.isEmpty()) {
             throw new IllegalArgumentException("No path specified for the RSS Feed URL");
         }
-
         final RssReader reader = new RssReader();
-        final Stream<Item> rssFeed;
-        try {
-            rssFeed = reader.read(url);
-        } catch (IOException e) {
-            throw new RuntimeException("IO Exception when reading RSS Feed URL", e);
+
+        Runnable task = () -> {
+            final Stream<Item> rssFeed;
+            try {
+                rssFeed = reader.read(url);
+            } catch (IOException e) {
+                throw new RuntimeException("IO Exception when reading RSS Feed URL", e);
+            }
+            final List<Item> items = rssFeed.collect(Collectors.toList());
+            items.forEach(this::buildEventDocument);
+            count++;
+            System.out.println("Running task to extract items from RSS feed");
+        };
+
+        ScheduledFuture<?> scheduledFuture = executorService.scheduleAtFixedRate(task, 0, 5, TimeUnit.MINUTES);
+
+        while (true) {
+            System.out.println("Count: "+ count);
+            Thread.sleep(1000);
+            if (count == 1) {
+                System.out.println(" Count is 20 time to cancel scheduled future");
+                scheduledFuture.cancel(true);
+                executorService.shutdown();
+                break;
+            }
         }
-        final List<Item> items = rssFeed.collect(Collectors.toList());
-        items.forEach(this::buildEventDocument);
+
     }
 
     private Record<Document> buildEventDocument(final Item item) {
@@ -75,5 +123,6 @@ public class RSSSource implements Source<Record<Document>> {
                 .getThis()
                 .build();
         return new Record<>(document);
+
     }
 }

--- a/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RSSSource.java
+++ b/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RSSSource.java
@@ -44,14 +44,7 @@ public class RSSSource implements Source<Record<Document>> {
         if (buffer == null) {
             throw new IllegalStateException("Buffer is null");
         }
-
-        rssReaderTask = new RssReaderTask(rssReader, rssSourceConfig);
-        rssReaderTask.run();
-        try {
-            buffer.writeAll(rssReaderTask.collection, 500);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        rssReaderTask = new RssReaderTask(rssReader, rssSourceConfig, buffer);
         scheduledExecutorService.scheduleAtFixedRate(rssReaderTask, 0, 5, TimeUnit.SECONDS);
     }
 

--- a/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RSSSource.java
+++ b/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RSSSource.java
@@ -5,36 +5,29 @@
 
 package org.opensearch.dataprepper.plugins.source.rss;
 
-import com.apptasticsoftware.rssreader.Item;
 import com.apptasticsoftware.rssreader.RssReader;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.document.Document;
-import org.opensearch.dataprepper.model.document.JacksonDocument;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @DataPrepperPlugin(name = "rss", pluginType = Source.class, pluginConfigurationType =  RSSSourceConfig.class)
 public class RSSSource implements Source<Record<Document>> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(RSSSource.class);
-
     private final PluginMetrics pluginMetrics;
 
     private final RSSSourceConfig rssSourceConfig;
+
+    private RssReaderTask rssReaderTask;
+
+    private final RssReader rssReader = new RssReader();
 
     private final ScheduledExecutorService scheduledExecutorService;
 
@@ -51,28 +44,15 @@ public class RSSSource implements Source<Record<Document>> {
         if (buffer == null) {
             throw new IllegalStateException("Buffer is null");
         }
-        final Runnable runnable = () -> {
-            final RssReader reader = new RssReader();
-            final Stream<Item> itemStream;
-            try {
-                LOG.info("Reading RSS Feed URL");
-                itemStream = reader.read(rssSourceConfig.getUrl());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            LOG.info("RSS feed URL read successfully. Proceeding to collect Items from URL");
-            final List<Item> items = itemStream.collect(Collectors.toList());
-            for (final Item item: items) {
-                LOG.info("Converting Feed Item to an Event Document");
-                final Record<Document> document = buildEventDocument(item);
-                try {
-                    buffer.write(document, 500);
-                } catch (TimeoutException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        };
-        scheduledExecutorService.scheduleAtFixedRate(runnable, 0, 5, TimeUnit.SECONDS);
+
+        rssReaderTask = new RssReaderTask(rssReader, rssSourceConfig);
+        rssReaderTask.run();
+        try {
+            buffer.writeAll(rssReaderTask.collection, 500);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        scheduledExecutorService.scheduleAtFixedRate(rssReaderTask, 0, 5, TimeUnit.SECONDS);
     }
 
     @Override
@@ -80,11 +60,4 @@ public class RSSSource implements Source<Record<Document>> {
         scheduledExecutorService.shutdown();
     }
 
-    private Record<Document> buildEventDocument(final Item item) {
-        final JacksonDocument document = JacksonDocument.builder()
-                .withData(item)
-                .getThis()
-                .build();
-        return new Record<>(document);
-    }
 }

--- a/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RssReaderTask.java
+++ b/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RssReaderTask.java
@@ -27,16 +27,16 @@ class RssReaderTask implements Runnable {
 
     private final RssReader rssReader;
 
-    private final RSSSourceConfig rssSourceConfig;
+    private final String url;
 
     private final Buffer<Record<Document>> buffer;
 
     final Collection<Record<Document>> collection = new HashSet<>();
 
 
-    public RssReaderTask(RssReader rssReader, final RSSSourceConfig rssSourceConfig, final Buffer<Record<Document>> buffer) {
+    public RssReaderTask(RssReader rssReader, final String url, final Buffer<Record<Document>> buffer) {
         this.rssReader = rssReader;
-        this.rssSourceConfig = rssSourceConfig;
+        this.url = url;
         this.buffer = buffer;
 
     }
@@ -46,7 +46,7 @@ class RssReaderTask implements Runnable {
         final Stream<Item> itemStream;
         try {
             LOG.debug("Reading RSS Feed URL");
-            itemStream = rssReader.read(rssSourceConfig.getUrl());
+            itemStream = rssReader.read(url);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RssReaderTask.java
+++ b/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RssReaderTask.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rss;
+
+import com.apptasticsoftware.rssreader.Item;
+import com.apptasticsoftware.rssreader.RssReader;
+import org.opensearch.dataprepper.model.document.Document;
+import org.opensearch.dataprepper.model.document.JacksonDocument;
+import org.opensearch.dataprepper.model.record.Record;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class RssReaderTask implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RssReaderTask.class);
+
+    private final RssReader rssReader;
+
+    private final RSSSourceConfig rssSourceConfig;
+
+    final Collection<Record<Document>> collection = new HashSet<>();
+
+
+    public RssReaderTask(RssReader rssReader, final RSSSourceConfig rssSourceConfig) {
+        this.rssReader = rssReader;
+        this.rssSourceConfig = rssSourceConfig;
+
+    }
+
+    @Override
+    public void run() {
+        final Stream<Item> itemStream;
+        try {
+            LOG.debug("Reading RSS Feed URL");
+            itemStream = rssReader.read(rssSourceConfig.getUrl());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        final List<Item> items = itemStream.collect(Collectors.toList());
+        for (final Item item: items) {
+            LOG.debug("Converting Feed Item with ID:{} to an Event Document", item.getGuid());
+            final Record<Document> document = buildEventDocument(item);
+            collection.add(document);
+        }
+    }
+
+    private Record<Document> buildEventDocument(final Item item) {
+        final JacksonDocument document = JacksonDocument.builder()
+                .withData(item)
+                .getThis()
+                .build();
+        return new Record<>(document);
+    }
+}

--- a/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RssReaderTask.java
+++ b/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RssReaderTask.java
@@ -48,9 +48,12 @@ class RssReaderTask implements Runnable {
             LOG.debug("Reading RSS Feed URL");
             itemStream = rssReader.read(url);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Unable to read the RSS Feed URL", e);
         }
         final List<Item> items = itemStream.collect(Collectors.toList());
+        if (items.isEmpty()) {
+            return;
+        }
         for (final Item item: items) {
             LOG.debug("Converting Feed Item with ID:{} to an Event Document", item.getGuid());
             final Record<Document> document = buildEventDocument(item);

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
@@ -17,9 +17,8 @@ import org.opensearch.dataprepper.model.document.Document;
 import org.opensearch.dataprepper.model.record.Record;
 
 import java.time.Duration;
-import java.util.concurrent.TimeoutException;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
@@ -58,11 +57,11 @@ class RSSSourceTest {
     }
 
     @Test
-    void test_ExecutorService_keep_writing_Events_to_Buffer() throws InterruptedException, TimeoutException {
+    void test_ExecutorService_keep_writing_Events_to_Buffer() throws Exception {
         rssSource.start(buffer);
         Thread.sleep(5000);
-        verify(buffer, atLeastOnce()).write(any(Record.class), anyInt());
+        verify(buffer, atLeastOnce()).writeAll(anyCollection(), anyInt());
         Thread.sleep(5000);
-        verify(buffer, atLeastOnce()).write(any(Record.class), anyInt());
+        verify(buffer, atLeastOnce()).writeAll(anyCollection(), anyInt());
     }
 }

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.source.rss;
 
 import org.junit.jupiter.api.AfterEach;

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class RSSSourceTest {
+class RSSSourceTest {
 
     private final String PLUGIN_NAME = "rss";
 
@@ -36,7 +36,6 @@ public class RSSSourceTest {
     private RSSSourceConfig rssSourceConfig;
 
     private PluginMetrics pluginMetrics;
-
 
     private RSSSource rssSource;
 
@@ -56,9 +55,9 @@ public class RSSSourceTest {
     @Test
     void test_ExecutorService_keep_writing_Events_to_Buffer() throws InterruptedException, TimeoutException {
         rssSource.start(buffer);
-        Thread.sleep(1000);
+        Thread.sleep(5000);
         verify(buffer, atLeastOnce()).write(any(Record.class), anyInt());
-        Thread.sleep(1000);
+        Thread.sleep(5000);
         verify(buffer, atLeastOnce()).write(any(Record.class), anyInt());
     }
 }

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
@@ -7,10 +7,20 @@ package org.opensearch.dataprepper.plugins.source.rss;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -65,6 +75,31 @@ class RSSSourceTest {
         rssSource.extractItemsFromRssFeed(rssSourceConfig);
         verify(rssSource, times(1)).extractItemsFromRssFeed(rssSourceConfig);
 
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(RssFeedProviders.class)
+    void test_when_items_from_one_valid_rss_url_extracted(final String url) throws InterruptedException {
+        when(rssSourceConfig.getUrl()).thenReturn(url);
+        doCallRealMethod().when(rssSource).extractItemsFromRssFeed(any(RSSSourceConfig.class));
+        rssSource.extractItemsFromRssFeed(rssSourceConfig);
+        verify(rssSource, times(1)).extractItemsFromRssFeed(rssSourceConfig);
+
+    }
+
+    static class RssFeedProviders implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return provideSampleRssUrlFeeds().map(Arguments::of);
+        }
+    }
+
+    private static Stream<String> provideSampleRssUrlFeeds() {
+        final File directoryPath = new File("src/test/resources");
+        return Arrays.stream(Objects.requireNonNull(directoryPath.listFiles((dir, name) -> name.endsWith(".rss"))))
+                .filter(File::isFile)
+                .map(File::toURL).map(URL::toString);
     }
 
    @Test

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
@@ -1,40 +1,27 @@
-/*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package org.opensearch.dataprepper.plugins.source.rss;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.document.Document;
+import org.opensearch.dataprepper.model.record.Record;
 
-import java.io.File;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.Objects;
-import java.util.stream.Stream;
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-class RSSSourceTest {
+@ExtendWith(MockitoExtension.class)
+public class RSSSourceTest {
 
     private final String PLUGIN_NAME = "rss";
 
@@ -42,79 +29,36 @@ class RSSSourceTest {
 
     private final String VALID_RSS_URL = "https://forum.opensearch.org/latest.rss";
 
-    private final String INVALID_RSS_URL = "https://docs.aws.amazon.com/amazondynamodb/latest";
+    @Mock
+    private Buffer<Record<Document>> buffer;
+
+    @Mock
+    private RSSSourceConfig rssSourceConfig;
 
     private PluginMetrics pluginMetrics;
 
-    private RSSSourceConfig rssSourceConfig;
 
     private RSSSource rssSource;
 
     @BeforeEach
     void setUp() {
         pluginMetrics = PluginMetrics.fromNames(PLUGIN_NAME, PIPELINE_NAME);
-        rssSourceConfig = mock(RSSSourceConfig.class);
-        rssSource = mock(RSSSource.class);
+        lenient().when(rssSourceConfig.getUrl()).thenReturn(VALID_RSS_URL);
+        lenient().when(rssSourceConfig.getPollingFrequency()).thenReturn(Duration.ofSeconds(5));
+        rssSource = new RSSSource(pluginMetrics, rssSourceConfig);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        rssSource.stop();
     }
 
     @Test
-    void test_when_extractItemsFromRssFeed_captured() throws InterruptedException {
-        ArgumentCaptor<RSSSourceConfig> argumentCaptor = ArgumentCaptor.forClass(RSSSourceConfig.class);
-        when(rssSourceConfig.getUrl()).thenReturn(VALID_RSS_URL);
-        doNothing().when(rssSource).extractItemsFromRssFeed(argumentCaptor.capture());
-        rssSource.extractItemsFromRssFeed(rssSourceConfig);
-        assertEquals(rssSourceConfig, argumentCaptor.getValue());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = { "https://www.yahoo.com/news/rss/mostviewed", "https://forum.opensearch.org/latest.rss",
-            "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/dynamodbupdates.rss"})
-    void test_when_items_from_valid_rss_url_extracted(final String url) throws InterruptedException {
-        when(rssSourceConfig.getUrl()).thenReturn(url);
-        doCallRealMethod().when(rssSource).extractItemsFromRssFeed(any(RSSSourceConfig.class));
-        rssSource.extractItemsFromRssFeed(rssSourceConfig);
-        verify(rssSource, times(1)).extractItemsFromRssFeed(rssSourceConfig);
-
-    }
-
-    @ParameterizedTest
-    @ArgumentsSource(RssFeedProviders.class)
-    void test_when_items_from_one_valid_rss_url_extracted(final String url) throws InterruptedException {
-        when(rssSourceConfig.getUrl()).thenReturn(url);
-        doCallRealMethod().when(rssSource).extractItemsFromRssFeed(any(RSSSourceConfig.class));
-        rssSource.extractItemsFromRssFeed(rssSourceConfig);
-        verify(rssSource, times(1)).extractItemsFromRssFeed(rssSourceConfig);
-
-    }
-
-    static class RssFeedProviders implements ArgumentsProvider {
-
-        @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
-            return provideSampleRssUrlFeeds().map(Arguments::of);
-        }
-    }
-
-    private static Stream<String> provideSampleRssUrlFeeds() {
-        final File directoryPath = new File("src/test/resources");
-        return Arrays.stream(Objects.requireNonNull(directoryPath.listFiles((dir, name) -> name.endsWith(".rss"))))
-                .filter(File::isFile)
-                .map(File::toURL).map(URL::toString);
-    }
-
-   @Test
-    void test_when_empty_rss_url_provided() throws InterruptedException {
-        when(rssSourceConfig.getUrl()).thenReturn("");
-       rssSource.extractItemsFromRssFeed(rssSourceConfig);
-       doThrow(IllegalArgumentException.class).when(rssSource).extractItemsFromRssFeed(any(RSSSourceConfig.class));
-       assertThrows(IllegalArgumentException.class, () -> rssSource.extractItemsFromRssFeed(rssSourceConfig));
-    }
-
-    @Test
-    void test_when_invalid_rss_url_provided() throws InterruptedException {
-        when(rssSourceConfig.getUrl()).thenReturn(INVALID_RSS_URL);
-        rssSource.extractItemsFromRssFeed(rssSourceConfig);
-        doThrow(RuntimeException.class).when(rssSource).extractItemsFromRssFeed(isA(RSSSourceConfig.class));
-        assertThrows(RuntimeException.class, () -> rssSource.extractItemsFromRssFeed(rssSourceConfig));
+    void test_ExecutorService_keep_writing_Events_to_Buffer() throws InterruptedException, TimeoutException {
+        rssSource.start(buffer);
+        Thread.sleep(1000);
+        verify(buffer, atLeastOnce()).write(any(Record.class), anyInt());
+        Thread.sleep(1000);
+        verify(buffer, atLeastOnce()).write(any(Record.class), anyInt());
     }
 }

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
@@ -48,7 +48,7 @@ class RSSSourceTest {
     }
 
     @Test
-    void test_when_extractItemsFromRssFeed_captured() {
+    void test_when_extractItemsFromRssFeed_captured() throws InterruptedException {
         ArgumentCaptor<RSSSourceConfig> argumentCaptor = ArgumentCaptor.forClass(RSSSourceConfig.class);
         when(rssSourceConfig.getUrl()).thenReturn(VALID_RSS_URL);
         doNothing().when(rssSource).extractItemsFromRssFeed(argumentCaptor.capture());
@@ -59,7 +59,7 @@ class RSSSourceTest {
     @ParameterizedTest
     @ValueSource(strings = { "https://www.yahoo.com/news/rss/mostviewed", "https://forum.opensearch.org/latest.rss",
             "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/dynamodbupdates.rss"})
-    void test_when_items_from_valid_rss_url_extracted(final String url) {
+    void test_when_items_from_valid_rss_url_extracted(final String url) throws InterruptedException {
         when(rssSourceConfig.getUrl()).thenReturn(url);
         doCallRealMethod().when(rssSource).extractItemsFromRssFeed(any(RSSSourceConfig.class));
         rssSource.extractItemsFromRssFeed(rssSourceConfig);
@@ -68,7 +68,7 @@ class RSSSourceTest {
     }
 
    @Test
-    void test_when_empty_rss_url_provided() {
+    void test_when_empty_rss_url_provided() throws InterruptedException {
         when(rssSourceConfig.getUrl()).thenReturn("");
        rssSource.extractItemsFromRssFeed(rssSourceConfig);
        doThrow(IllegalArgumentException.class).when(rssSource).extractItemsFromRssFeed(any(RSSSourceConfig.class));
@@ -76,7 +76,7 @@ class RSSSourceTest {
     }
 
     @Test
-    void test_when_invalid_rss_url_provided() {
+    void test_when_invalid_rss_url_provided() throws InterruptedException {
         when(rssSourceConfig.getUrl()).thenReturn(INVALID_RSS_URL);
         rssSource.extractItemsFromRssFeed(rssSourceConfig);
         doThrow(RuntimeException.class).when(rssSource).extractItemsFromRssFeed(isA(RSSSourceConfig.class));

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RssReaderTaskTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RssReaderTaskTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.rss;
+
+import com.apptasticsoftware.rssreader.Item;
+import com.apptasticsoftware.rssreader.RssReader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.document.Document;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RssReaderTaskTest {
+
+    private RssReaderTask readerTask;
+
+    private String url;
+
+    private Item item1;
+
+    private Item item2;
+
+    @Mock
+    private RssReader rssReader;
+
+    @Mock
+    private Buffer<Record<Document>> buffer;
+
+    @Captor
+    ArgumentCaptor<Collection<Record<Document>>> argumentCaptor;
+
+    @BeforeEach
+    void setUp() {
+        url = UUID.randomUUID().toString();
+        item1 = new Item();
+        item2 = new Item();
+        readerTask = new RssReaderTask(rssReader, url, buffer);
+    }
+
+    @Test
+    void test_when_RssReader_throws_exception() throws IOException {
+        when(rssReader.read(url)).thenThrow(IOException.class);
+        assertThrows(RuntimeException.class, () -> readerTask.run());
+        verifyNoInteractions(buffer);
+    }
+
+    @Test
+    void test_when_itemStream_is_empty() throws IOException {
+        when(rssReader.read(url)).thenReturn(Stream.empty());
+        readerTask.run();
+        verify(rssReader, times(1)).read(url);
+        verifyNoInteractions(buffer);
+    }
+
+    @Test
+    void test_when_itemStream_contains_one_item() throws Exception {
+        when(rssReader.read(url)).thenReturn(Stream.of(item1));
+        readerTask.run();
+        verify(rssReader, times(1)).read(url);
+        verify(buffer, times(1)).writeAll(argumentCaptor.capture(), anyInt());
+        Collection<Record<Document>> collection = argumentCaptor.getValue();
+        assertEquals(collection.size(), 1);
+    }
+
+    @Test
+    void test_when_itemStream_contains_two_items() throws Exception {
+        when(rssReader.read(url)).thenReturn(Stream.of(item1, item2));
+        readerTask.run();
+        verify(rssReader, times(1)).read(url);
+        verify(buffer, times(1)).writeAll(argumentCaptor.capture(), anyInt());
+        Collection<Record<Document>> collection = argumentCaptor.getValue();
+        assertEquals(collection.size(), 2);
+    }
+}


### PR DESCRIPTION
### Description
- This PR adds the Java `ScheduledExecutorService` to schedule reading the RSS Feed URL every 5 minutes. It is a draft to gather any feedback about using the Executor service.
- Currently, the unit test is reading from a real RSS feed URL because storing the URL in local files under `test/resources` directory resulted in `Invalid URI scheme file` errors. Finding the fix for this is still underway.
- DCO is failing, working on amending the commit messages.
 
### Issues Resolved
#2081 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
