### PR TITLE
2.0 CVE cleanup

### DIFF
--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -8,7 +8,7 @@ ext.versionMap = [
         junitJupiter : '5.8.2',
         mockito : '3.11.2',
         opentelemetryProto : '1.7.1-alpha',
-        opensearchVersion : '1.3.5',
+        opensearchVersion : '1.3.6',
         armeria: '1.20.3',
         armeriaGrpc: '1.20.3',
         protobufJavaUtil: '3.21.11',

--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -9,10 +9,10 @@ ext.versionMap = [
         mockito : '3.11.2',
         opentelemetryProto : '1.7.1-alpha',
         opensearchVersion : '1.3.5',
-        armeria: '1.19.0',
-        armeriaGrpc: '1.19.0',
-        protobufJavaUtil: '3.19.6',
-        protobufJava: '3.19.6'
+        armeria: '1.20.3',
+        armeriaGrpc: '1.20.3',
+        protobufJavaUtil: '3.21.11',
+        protobufJava: '3.21.11'
 ]
 
 ext.coreProjects = [

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ subprojects {
         }
     }
     dependencies {
-        implementation platform('com.fasterxml.jackson:jackson-bom:2.13.4')
+        implementation platform('com.fasterxml.jackson:jackson-bom:2.14.1')
         implementation platform('io.micrometer:micrometer-bom:1.9.4')
         implementation 'com.google.guava:guava:31.1-jre'
         implementation 'org.slf4j:slf4j-api:1.7.36'
@@ -111,23 +111,17 @@ subprojects {
                 }
                 because 'the build fails if the Log4j API is not update along with log4j-core'
             }
-            implementation('com.fasterxml.jackson.core:jackson-databind') {
-                version {
-                    require '2.13.4.2'
-                }
-                because 'Fixes CVE-2022-42003. Keep this until Data Prepper uses 2.14.'
-            }
             implementation('com.google.code.gson:gson') {
                 version {
                     require '2.8.9'
                 }
                 because 'Fixes WS-2021-0419 DoS vulnerability'
             }
-            implementation('com.google.protobuf:protobuf-java-util') {
+            implementation('com.google.protobuf:protobuf-java') {
                 version {
-                    require '3.21.7'
+                    require '3.21.11'
                 }
-                because 'Fixes CVE-2022-3171'
+                because 'Fixes CVE-2022-3509, CVE-2022-3510'
             }
         }
         constraints {
@@ -146,8 +140,8 @@ subprojects {
     configurations.all {
         resolutionStrategy.eachDependency { def details ->
             if (details.requested.group == 'io.netty' && !details.requested.name.startsWith('netty-tcnative')) {
-                details.useVersion '4.1.74.Final'
-                details.because 'Fixes CVE-2021-43797, CVE-2021-37136 and CVE-2021-37137. See https://netty.io/news/2021/09/09/4-1-68-Final.html'
+                details.useVersion '4.1.86.Final'
+                details.because 'Fixes CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
Fix all CVE's related to protobuf-java, snakeyaml, netty.
Created to handle all failed backport PR's. 
https://advisories.aws.barahmand.com/vulnerabilities/Data%20Prepper/origin/2.0
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
