### PR TITLE
1.5 branch CVE cleanup

### DIFF
--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -8,10 +8,10 @@ ext.versionMap = [
         junitJupiter : '5.8.2',
         mockito : '3.11.2',
         opentelemetryProto : '1.7.1-alpha',
-        opensearchVersion : '1.3.1',
-        armeria: '1.16.0',
-        armeriaGrpc: '1.16.0',
-        protobufJavaUtil: '3.19.4'
+        opensearchVersion : '1.3.6',
+        armeria: '1.20.3',
+        armeriaGrpc: '1.20.3',
+        protobufJavaUtil: '3.21.11',
 ]
 
 ext.coreProjects = [

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ subprojects {
         }
     }
     dependencies {
-        implementation platform('com.fasterxml.jackson:jackson-bom:2.13.3')
+        implementation platform('com.fasterxml.jackson:jackson-bom:2.14.1')
         implementation platform('io.micrometer:micrometer-bom:1.9.0')
         implementation 'com.google.guava:guava:31.0.1-jre'
         implementation 'org.slf4j:slf4j-api:1.7.36'
@@ -124,23 +124,17 @@ subprojects {
                 }
                 because 'the build fails if the Log4j API is not update along with log4j-core'
             }
-            implementation('com.fasterxml.jackson.core:jackson-databind') {
-                version {
-                    require '2.13.4.2'
-                }
-                because 'Fixes CVE-2022-42003. Keep this until Data Prepper uses 2.14.'
-            }
             implementation('com.google.code.gson:gson') {
                 version {
                     require '2.8.9'
                 }
                 because 'Fixes WS-2021-0419 DoS vulnerability'
             }
-            implementation('com.google.protobuf:protobuf-java-util') {
+            implementation('com.google.protobuf:protobuf-java') {
                 version {
-                    require '3.21.7'
+                    require '3.21.11'
                 }
-                because 'Fixes CVE-2022-3171'
+                because 'Fixes CVE-2022-3509, CVE-2022-3510'
             }
         }
         constraints {
@@ -159,8 +153,8 @@ subprojects {
     configurations.all {
         resolutionStrategy.eachDependency { def details ->
             if (details.requested.group == 'io.netty' && !details.requested.name.startsWith('netty-tcnative')) {
-                details.useVersion '4.1.74.Final'
-                details.because 'Fixes CVE-2021-43797, CVE-2021-37136 and CVE-2021-37137. See https://netty.io/news/2021/09/09/4-1-68-Final.html'
+                details.useVersion '4.1.86.Final'
+                details.because 'Fixes CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,12 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.github.jk1:gradle-license-report:1.17'
+        classpath 'com.github.jk1:gradle-license-report:2.1'
     }
 }
 
 plugins {
-    id 'com.diffplug.spotless' version '6.7.1'
+    id 'com.diffplug.spotless' version '6.11.0'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 }
 
@@ -41,7 +41,7 @@ allprojects {
     ext {
         mavenPublicationRootFile = file("${rootProject.buildDir}/m2")
     }
-    
+
     repositories {
         mavenCentral()
         maven { url 'https://jitpack.io' }
@@ -95,9 +95,9 @@ subprojects {
     }
     dependencies {
         implementation platform('com.fasterxml.jackson:jackson-bom:2.14.1')
-        implementation platform('io.micrometer:micrometer-bom:1.9.0')
-        implementation 'com.google.guava:guava:31.0.1-jre'
-        implementation 'org.slf4j:slf4j-api:1.7.36'
+        implementation platform('io.micrometer:micrometer-bom:1.9.4')
+        implementation 'com.google.guava:guava:31.1-jre'
+        implementation 'org.slf4j:slf4j-api:2.0.5'
         testImplementation platform("org.junit:junit-bom:${versionMap.junitJupiter}")
         testImplementation 'org.junit.jupiter:junit-jupiter'
         testImplementation 'org.junit.vintage:junit-vintage-engine'
@@ -172,7 +172,7 @@ subprojects {
 
 configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
     dependencies {
-        implementation platform('software.amazon.awssdk:bom:2.17.209')
+        implementation platform('software.amazon.awssdk:bom:2.17.264')
         implementation 'jakarta.validation:jakarta.validation-api:3.0.1'
     }
 }

--- a/examples/trace-analytics-sample-app/sample-app/requirements.txt
+++ b/examples/trace-analytics-sample-app/sample-app/requirements.txt
@@ -5,4 +5,4 @@ opentelemetry-instrumentation-flask==0.19b0
 opentelemetry-instrumentation-mysql==0.19b0
 opentelemetry-instrumentation-requests==0.19b0
 opentelemetry-sdk==1.0.0
-protobuf==3.15.6
+protobuf==3.18.3

--- a/performance-test/build.gradle
+++ b/performance-test/build.gradle
@@ -5,7 +5,11 @@
 
 plugins {
     id 'java'
-    id 'io.gatling.gradle' version '3.7.4'
+    id 'io.gatling.gradle' version '3.9.0'
+}
+
+configurations.all {
+    exclude group: 'io.pebbletemplates', module: 'pebble'
 }
 
 group 'org.opensearch.dataprepper.test.performance'
@@ -16,8 +20,8 @@ repositories {
 
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 }
 
 test {

--- a/release/smoke-tests/otel-span-exporter/requirements.txt
+++ b/release/smoke-tests/otel-span-exporter/requirements.txt
@@ -12,7 +12,7 @@ opentelemetry-exporter-otlp-proto-http==1.7.1
 opentelemetry-proto==1.7.1
 opentelemetry-sdk==1.7.1
 opentelemetry-semantic-conventions==0.26b1
-protobuf==3.19.1
+protobuf==3.19.5
 requests==2.26.0
 six==1.16.0
 urllib3==1.26.7


### PR DESCRIPTION
### Description
Fix all CVE's related to protobuf-java, snakeyaml, netty, opensearch, jackson
Created to handle all failed backport PR's.
https://advisories.aws.barahmand.com/vulnerabilities/Data%20Prepper/origin/1.5
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
