### PR TITLE
Enable log metrics e2e test in the github

### DIFF
--- a/.github/workflows/data-prepper-peer-forwarder-local-node-e2e-tests.yml
+++ b/.github/workflows/data-prepper-peer-forwarder-local-node-e2e-tests.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [11, 17]
+        test: ['localAggregateEndToEndTest', 'localLogMetricsEndToEndTest']
       fail-fast: false
 
     runs-on: ubuntu-latest
@@ -26,4 +27,4 @@ jobs:
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
       - name: Run raw-span latest release compatibility end-to-end tests with Gradle
-        run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:peerforwarder:localAggregateEndToEndTest
+        run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:peerforwarder:${{ matrix.test }}

--- a/e2e-test/peerforwarder/src/integrationTest/java/org/opensearch/dataprepper/integration/peerforwarder/EndToEndLogMetricsTest.java
+++ b/e2e-test/peerforwarder/src/integrationTest/java/org/opensearch/dataprepper/integration/peerforwarder/EndToEndLogMetricsTest.java
@@ -150,8 +150,8 @@ public class EndToEndLogMetricsTest {
                 }
             }
         }
-        Assert.assertThat(expectedMin, equalTo(receivedMin));
-        Assert.assertThat(expectedMax, equalTo(receivedMax));
+        Assert.assertThat(expectedMin, closeTo(receivedMin, 0.01));
+        Assert.assertThat(expectedMax, closeTo(receivedMax, 0.01));
         Assert.assertThat(TOTAL_EVENTS, equalTo(receivedCount));
         Assert.assertThat(expectedSum, closeTo(receivedSum, 0.1));
     }


### PR DESCRIPTION
Signed-off-by: Krishna Kondaka <krishkdk@amazon.com>

### Description
Enable log metrics e2e test in the github
 
### Issues Resolved
#2126 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
