### PR TITLE
Test against multiple OTel version - Issue #1963

### DIFF
--- a/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [11, 17]
+        otelVersion: ['0.9.0-alpha', '0.16.0-alpha']
       fail-fast: false
 
     runs-on: ubuntu-latest
@@ -26,4 +27,4 @@ jobs:
       - name: Checkout Data-Prepper
         uses: actions/checkout@v2
       - name: Run raw-span end-to-end tests with Gradle
-        run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:trace:rawSpanEndToEndTest
+        run: ./gradlew -PopenTelemetryVersion=${{ matrix.otelVersion }} -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:trace:rawSpanEndToEndTest

--- a/e2e-test/build.gradle
+++ b/e2e-test/build.gradle
@@ -46,6 +46,7 @@ subprojects {
     ext {
         dataPrepperJarFilepath = "${project.buildDir.name}/bin/data-prepper/"
         targetJavaVersion = project.hasProperty('endToEndJavaVersion') ? project.getProperty('endToEndJavaVersion') : '11'
+        targetOpenTelemetryVersion = project.hasProperty('openTelemetryVersion') ? project.getProperty('openTelemetryVersion') : "${versionMap.opentelemetryProto}"
         dataPrepperBaseImage = "eclipse-temurin:${targetJavaVersion}-jre-alpine"
     }
 }

--- a/e2e-test/trace/build.gradle
+++ b/e2e-test/trace/build.gradle
@@ -233,7 +233,7 @@ dependencies {
     integrationTestImplementation project(':data-prepper-plugins:opensearch')
     integrationTestImplementation project(':data-prepper-plugins:otel-trace-group-processor')
     integrationTestImplementation 'org.awaitility:awaitility:4.2.0'
-    integrationTestImplementation "io.opentelemetry.proto:opentelemetry-proto:${versionMap.opentelemetryProto}"
+    integrationTestImplementation "io.opentelemetry.proto:opentelemetry-proto:${targetOpenTelemetryVersion}"
     integrationTestImplementation "com.google.protobuf:protobuf-java-util:${versionMap.protobufJavaUtil}"
     integrationTestImplementation "com.linecorp.armeria:armeria:${versionMap.armeria}"
     integrationTestImplementation "com.linecorp.armeria:armeria-grpc:${versionMap.armeriaGrpc}"


### PR DESCRIPTION
Signed-off-by: Krishna Kondaka <krishkdk@amazon.com>

### Description
Added e2e test workflows with different otel client library versions for testing with older opentelemetry client version and newer version.
 
### Issues Resolved
Resolves #1963 
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
