### PR TITLE
Add support to convert metrics to json strings without flattening attributes - issue #2146

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
@@ -32,6 +32,7 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
     protected static final String SCHEMA_URL_KEY = "schemaUrl";
     protected static final String EXEMPLARS_KEY = "exemplars";
     protected static final String FLAGS_KEY = "flags";
+    private boolean flattenAttributes = true;
 
     protected JacksonMetric(Builder builder) {
         super(builder);
@@ -39,6 +40,9 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
 
     @Override
     public String toJsonString() {
+        if (!flattenAttributes) {
+            return getJsonNode().toString();
+        }
         final ObjectNode attributesNode = (ObjectNode) getJsonNode().get(ATTRIBUTES_KEY);
         final ObjectNode flattenedJsonNode = getJsonNode().deepCopy();
         if (attributesNode != null) {
@@ -107,6 +111,10 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
     @Override
     public Integer getFlags() {
         return this.get(FLAGS_KEY, Integer.class);
+    }
+
+    public void disableAttributesFlattening() {
+        flattenAttributes = false;
     }
 
     /**

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
@@ -88,7 +88,7 @@ public class CountAggregateAction implements AggregateAction {
             long startTimeNanos = getTimeNanos(startTime);
             Map<String, Object> attr = new HashMap<String, Object>();
             groupState.forEach((k, v) -> attr.put((String)k, v));
-            JacksonSum js = JacksonSum.builder()
+            JacksonSum sum = JacksonSum.builder()
                 .withName(SUM_METRIC_NAME)
                 .withDescription(SUM_METRIC_DESCRIPTION)
                 .withTime(OTelProtoCodec.convertUnixNanosToISO8601(currentTimeNanos))
@@ -99,7 +99,8 @@ public class CountAggregateAction implements AggregateAction {
                 .withValue((double)countValue)
                 .withAttributes(attr)
                 .build();
-            event = (Event)js;
+            sum.disableAttributesFlattening();
+            event = (Event)sum;
         }
         
         return Optional.of(event);

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
@@ -205,6 +205,7 @@ public class HistogramAggregateAction implements AggregateAction {
                 .withExplicitBoundsList(explicitBoundsList)
                 .withAttributes(attr)
                 .build();
+            histogram.disableAttributesFlattening();
             event = (Event)histogram;
         }
         

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
 import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.metric.JacksonMetric;
 import org.junit.jupiter.api.extension.ExtendWith; 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,6 +26,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
@@ -99,6 +101,8 @@ public class CountAggregateActionTest {
         expectedEventMap.put("unit", "1");
         expectedEventMap.forEach((k, v) -> assertThat(result.get().toMap(), hasEntry(k,v)));
         assertThat(result.get().toMap().get("attributes"), equalTo(eventMap));
+        JacksonMetric metric = (JacksonMetric) result.get();
+        assertThat(metric.toJsonString().indexOf("attributes"), not(-1));
         assertThat(result.get().toMap(), hasKey("startTime"));
         assertThat(result.get().toMap(), hasKey("time"));
     }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.plugins.processor.aggregate.actions;
 import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.metric.JacksonMetric;
 import org.junit.jupiter.api.extension.ExtendWith; 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -29,6 +30,7 @@ import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
@@ -206,6 +208,8 @@ public class HistogramAggregateActionTests {
         assertThat(((Map<String, String>)result.get().toMap().get("attributes")), hasEntry(dataKey, dataValue));
         final String expectedDurationKey = histogramAggregateActionConfig.getDurationKey();
         assertThat(((Map<String, String>)result.get().toMap().get("attributes")), hasKey(expectedDurationKey));
+        JacksonMetric metric = (JacksonMetric) result.get();
+        assertThat(metric.toJsonString().indexOf("attributes"), not(-1));
         final List<Double> explicitBoundsFromResult = (ArrayList<Double>)result.get().toMap().get("explicitBounds");
         double bucketVal = TEST_VALUE_RANGE_MIN;
         for (int i = 0; i < explicitBoundsFromResult.size(); i++) {


### PR DESCRIPTION


Signed-off-by: Krishna Kondaka <krishkdk@amazon.com>

### Description
Add support to convert metrics to json strings without flattening attributes field.

Currently JacksonMetric's `toJsonString()` method flattens attributes field by moving all fields inside attributes field. to parent. But OTEL metrics format expects attributes field to be present.

Added a new flag in JacksonMetric to override the default behavior of flattening attributes field. If this flag is set, attributes field is not flattened.
 
### Issues Resolved
Resolves #2146 
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
