### PR TITLE
Add configurations and metrics to OTelTraceRawProcessor

### DIFF
--- a/data-prepper-plugins/otel-trace-raw-processor/README.md
+++ b/data-prepper-plugins/otel-trace-raw-processor/README.md
@@ -16,7 +16,7 @@ processor:
 * `trace_group_cache_max_size`: An `int` representing the total number of traces to keep in the trace group cache.
 
 ## Metrics
-In addition to the metrics from [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java):
+In addition to the metrics from [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/AbstractProcessor.java):
 
 * `traceGroupCacheCount` - (gauge) The count of trace groups in the trace group cache
 * `spanSetCount` - (gauge) The count of span sets in the span set collection

--- a/data-prepper-plugins/otel-trace-raw-processor/README.md
+++ b/data-prepper-plugins/otel-trace-raw-processor/README.md
@@ -12,9 +12,14 @@ processor:
 ## Configuration
 
 * `trace_flush_interval`: An `int` represents the time interval in seconds to flush all the descendant spans without any root span. Default to 180.
+* `trace_group_cache_ttl`: A `Duration` represents the time-to-live for traces in the trace group cache. Defaults to 15 seconds.
+* `trace_group_cache_max_size`: An `int` representing the total number of traces to keep in the trace group cache.
 
 ## Metrics
-Apart from common metrics in [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java), `otel_trace_raw` processor has not introduced any custom metrics.
+In addition to the metrics from [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java):
+
+* `traceGroupCacheCount` - (gauge) The count of trace groups in the trace group cache
+* `spanSetCount` - (gauge) The count of span sets in the span set collection
 
 ## Developer Guide
 This plugin is compatible with Java 8. See 

--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OTelTraceRawProcessor.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OTelTraceRawProcessor.java
@@ -5,8 +5,10 @@
 
 package org.opensearch.dataprepper.plugins.processor.oteltrace;
 
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.peerforwarder.RequiresPeerForwarding;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
@@ -34,10 +36,12 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 
-@DataPrepperPlugin(name = "otel_trace_raw", pluginType = Processor.class)
+@DataPrepperPlugin(name = "otel_trace_raw", pluginType = Processor.class, pluginConfigurationType = OtelTraceRawProcessorConfig.class)
 public class OTelTraceRawProcessor extends AbstractProcessor<Record<Span>, Record<Span>> implements RequiresPeerForwarding {
     private static final long SEC_TO_MILLIS = 1_000L;
     private static final Logger LOG = LoggerFactory.getLogger(OTelTraceRawProcessor.class);
+    public static final String TRACE_GROUP_CACHE_COUNT_METRIC_NAME = "traceGroupCacheCount";
+    public static final String SPAN_SET_COUNT_METRIC_NAME = "spanSetCount";
 
     private final long traceFlushInterval;
 
@@ -52,16 +56,23 @@ public class OTelTraceRawProcessor extends AbstractProcessor<Record<Span>, Recor
 
     private volatile boolean isShuttingDown = false;
 
-    public OTelTraceRawProcessor(final PluginSetting pluginSetting) {
-        super(pluginSetting);
-        traceFlushInterval = SEC_TO_MILLIS * pluginSetting.getLongOrDefault(
-                OtelTraceRawProcessorConfig.TRACE_FLUSH_INTERVAL, OtelTraceRawProcessorConfig.DEFAULT_TG_FLUSH_INTERVAL_SEC);
-        final int numProcessWorkers = pluginSetting.getNumberOfProcessWorkers();
+    @DataPrepperPluginConstructor
+    public OTelTraceRawProcessor(final OtelTraceRawProcessorConfig otelTraceRawProcessorConfig,
+                                 final PipelineDescription pipelineDescription,
+                                 final PluginMetrics pluginMetrics) {
+        super(pluginMetrics);
+        traceFlushInterval = SEC_TO_MILLIS * otelTraceRawProcessorConfig.getTraceFlushIntervalSeconds();
+        final int numProcessWorkers = pipelineDescription.getNumberOfProcessWorkers();
         traceIdTraceGroupCache = CacheBuilder.newBuilder()
                 .concurrencyLevel(numProcessWorkers)
-                .maximumSize(OtelTraceRawProcessorConfig.MAX_TRACE_ID_CACHE_SIZE)
-                .expireAfterWrite(OtelTraceRawProcessorConfig.DEFAULT_TRACE_ID_TTL_SEC, TimeUnit.SECONDS)
+                .maximumSize(otelTraceRawProcessorConfig.getMaxTraceIdCacheSize())
+                .expireAfterWrite(otelTraceRawProcessorConfig.getTraceIdTimeToLive().toMillis(), TimeUnit.MILLISECONDS)
                 .build();
+
+        pluginMetrics.gauge(TRACE_GROUP_CACHE_COUNT_METRIC_NAME, traceIdTraceGroupCache, cache -> (double) cache.size());
+        pluginMetrics.gauge(SPAN_SET_COUNT_METRIC_NAME, traceIdSpanSetMap, cache -> (double) cache.size());
+
+        LOG.info("Configured Trace Raw Processor with a trace flush interval of {} ms.", traceFlushInterval);
     }
 
     /**

--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OTelTraceRawProcessor.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OTelTraceRawProcessor.java
@@ -65,8 +65,8 @@ public class OTelTraceRawProcessor extends AbstractProcessor<Record<Span>, Recor
         final int numProcessWorkers = pipelineDescription.getNumberOfProcessWorkers();
         traceIdTraceGroupCache = CacheBuilder.newBuilder()
                 .concurrencyLevel(numProcessWorkers)
-                .maximumSize(otelTraceRawProcessorConfig.getMaxTraceIdCacheSize())
-                .expireAfterWrite(otelTraceRawProcessorConfig.getTraceIdTimeToLive().toMillis(), TimeUnit.MILLISECONDS)
+                .maximumSize(otelTraceRawProcessorConfig.getTraceGroupCacheMaxSize())
+                .expireAfterWrite(otelTraceRawProcessorConfig.getTraceGroupCacheTimeToLive().toMillis(), TimeUnit.MILLISECONDS)
                 .build();
 
         pluginMetrics.gauge(TRACE_GROUP_CACHE_COUNT_METRIC_NAME, traceIdTraceGroupCache, cache -> (double) cache.size());

--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OtelTraceRawProcessorConfig.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OtelTraceRawProcessorConfig.java
@@ -5,9 +5,32 @@
 
 package org.opensearch.dataprepper.plugins.processor.oteltrace;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Duration;
+
 public class OtelTraceRawProcessorConfig {
-    static final String TRACE_FLUSH_INTERVAL = "trace_flush_interval";
     static final long DEFAULT_TG_FLUSH_INTERVAL_SEC = 180L;
-    static final long DEFAULT_TRACE_ID_TTL_SEC = 15L;
-    static final long MAX_TRACE_ID_CACHE_SIZE = 1000_000L;
+    static final Duration DEFAULT_TRACE_ID_TTL = Duration.ofSeconds(15L);
+    static final long MAX_TRACE_ID_CACHE_SIZE = 1_000_000L;
+    @JsonProperty("trace_flush_interval")
+    private long traceFlushInterval = DEFAULT_TG_FLUSH_INTERVAL_SEC;
+
+    @JsonProperty("trace_id_ttl")
+    private Duration traceIdTimeToLive = DEFAULT_TRACE_ID_TTL;
+
+    @JsonProperty("max_trace_id_cache_size")
+    private long maxTraceIdCacheSize = MAX_TRACE_ID_CACHE_SIZE;
+
+    public long getTraceFlushIntervalSeconds() {
+        return traceFlushInterval;
+    }
+
+    public Duration getTraceIdTimeToLive() {
+        return traceIdTimeToLive;
+    }
+
+    public long getMaxTraceIdCacheSize() {
+        return maxTraceIdCacheSize;
+    }
 }

--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OtelTraceRawProcessorConfig.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OtelTraceRawProcessorConfig.java
@@ -16,21 +16,21 @@ public class OtelTraceRawProcessorConfig {
     @JsonProperty("trace_flush_interval")
     private long traceFlushInterval = DEFAULT_TG_FLUSH_INTERVAL_SEC;
 
-    @JsonProperty("trace_id_ttl")
-    private Duration traceIdTimeToLive = DEFAULT_TRACE_ID_TTL;
+    @JsonProperty("trace_group_cache_ttl")
+    private Duration traceGroupCacheTimeToLive = DEFAULT_TRACE_ID_TTL;
 
-    @JsonProperty("max_trace_id_cache_size")
-    private long maxTraceIdCacheSize = MAX_TRACE_ID_CACHE_SIZE;
+    @JsonProperty("trace_group_cache_max_size")
+    private long traceGroupCacheMaxSize = MAX_TRACE_ID_CACHE_SIZE;
 
     public long getTraceFlushIntervalSeconds() {
         return traceFlushInterval;
     }
 
-    public Duration getTraceIdTimeToLive() {
-        return traceIdTimeToLive;
+    public Duration getTraceGroupCacheTimeToLive() {
+        return traceGroupCacheTimeToLive;
     }
 
-    public long getMaxTraceIdCacheSize() {
-        return maxTraceIdCacheSize;
+    public long getTraceGroupCacheMaxSize() {
+        return traceGroupCacheMaxSize;
     }
 }

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OTelTraceRawProcessorTest.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OTelTraceRawProcessorTest.java
@@ -115,8 +115,8 @@ public class OTelTraceRawProcessorTest {
         pluginMetrics = mock(PluginMetrics.class);
 
         when(config.getTraceFlushIntervalSeconds()).thenReturn(TEST_TRACE_FLUSH_INTERVAL);
-        when(config.getMaxTraceIdCacheSize()).thenReturn(OtelTraceRawProcessorConfig.MAX_TRACE_ID_CACHE_SIZE);
-        when(config.getTraceIdTimeToLive()).thenReturn(OtelTraceRawProcessorConfig.DEFAULT_TRACE_ID_TTL);
+        when(config.getTraceGroupCacheMaxSize()).thenReturn(OtelTraceRawProcessorConfig.MAX_TRACE_ID_CACHE_SIZE);
+        when(config.getTraceGroupCacheTimeToLive()).thenReturn(OtelTraceRawProcessorConfig.DEFAULT_TRACE_ID_TTL);
 
         oTelTraceRawProcessor = new OTelTraceRawProcessor(config, pipelineDescription, pluginMetrics);
         executorService = Executors.newFixedThreadPool(TEST_CONCURRENCY_SCALE);


### PR DESCRIPTION
### Description

This PR adds two new features to `otel_trace_raw`:

* New configuration options: `trace_id_ttl` and `max_trace_id_cache_size`
* Two new metrics: `traceGroupCacheCount` and `spanSetCount`
 
### Issues Resolved

Resolves #2165
Resolves #2166 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
