### PR TITLE
Removed getObjectAttributes API call to check object size

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/InvalidS3URIException.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/InvalidS3URIException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.sink.opensearch.s3;
 
 public class InvalidS3URIException extends RuntimeException {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/InvalidS3URIException.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/InvalidS3URIException.java
@@ -1,0 +1,8 @@
+package org.opensearch.dataprepper.plugins.sink.opensearch.s3;
+
+public class InvalidS3URIException extends RuntimeException {
+
+    public InvalidS3URIException(final String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3FileReader.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3FileReader.java
@@ -31,6 +31,7 @@ public class S3FileReader implements FileReader {
     public ResponseInputStream<GetObjectResponse> readFile(final String filePath) {
         try {
             final URI fileUri = new URI(filePath);
+            validateURI(fileUri);
             validateFileType(filePath);
 
             final GetObjectRequest getObjectRequest = GetObjectRequest.builder()
@@ -46,6 +47,15 @@ public class S3FileReader implements FileReader {
         } catch (URISyntaxException ex) {
             LOG.error("Error encountered while parsing the Amazon S3 URI in OpenSearch sink.", ex);
             throw new RuntimeException(ex);
+        }
+    }
+
+    private void validateURI(URI fileUri) {
+        final String bucketName = fileUri.getHost();
+        final String objectKey = fileUri.getPath();
+
+        if (bucketName == null || objectKey.length() < 2) {
+            throw new InvalidS3URIException("S3 URi must contain valid bucket and object key name");
         }
     }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3FileReader.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3FileReader.java
@@ -21,6 +21,7 @@ public class S3FileReader implements FileReader {
     private static final Logger LOG = LoggerFactory.getLogger(S3FileReader.class);
     static final long ONE_MB = 1024L * 1024L;
     private static final long FIVE_MB = 5 * ONE_MB;
+    private static final String MAX_CONTENT_LENGTH = "5 MB";
 
     private final S3Client s3Client;
 
@@ -75,8 +76,8 @@ public class S3FileReader implements FileReader {
         final Long contentLength = responseInputStream.response().contentLength();
 
         if (contentLength > FIVE_MB) {
-            throw new S3ObjectTooLargeException(String.format("S3 object content length can't be more than 5MB. %s object size is %s bytes",
-                    uri.getPath().substring(1), contentLength));
+            throw new S3ObjectTooLargeException(String.format("S3 object content length can't be more than %s. %s object size is %s bytes",
+                    MAX_CONTENT_LENGTH, uri.getPath().substring(1), contentLength));
         }
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3FileReader.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3FileReader.java
@@ -19,7 +19,8 @@ import java.util.Objects;
 
 public class S3FileReader implements FileReader {
     private static final Logger LOG = LoggerFactory.getLogger(S3FileReader.class);
-    private static final long MAX_FILE_SIZE = 5_000_000L;
+    static final long ONE_MB = 1024L * 1024L;
+    private static final long FIVE_MB = 5 * ONE_MB;
 
     private final S3Client s3Client;
 
@@ -73,7 +74,7 @@ public class S3FileReader implements FileReader {
     private void validateS3ObjectSize(final ResponseInputStream<GetObjectResponse> responseInputStream, final URI uri) {
         final Long contentLength = responseInputStream.response().contentLength();
 
-        if (contentLength > MAX_FILE_SIZE) {
+        if (contentLength > FIVE_MB) {
             throw new S3ObjectTooLargeException(String.format("S3 object content length can't be more than 5MB. %s object size is %s bytes",
                     uri.getPath().substring(1), contentLength));
         }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -5,15 +5,19 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;
 
+import org.apache.commons.io.IOUtils;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.junit.Test;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetObjectAttributesRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectAttributesResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -84,12 +88,16 @@ public class IndexConfigurationTests {
         final String testTemplateFilePath = "s3://folder/file.json";
         final String testS3AwsRegion = "us-east-2";
         final String testS3StsRoleArn = "arn:aws:iam::123456789:user/user-role";
+        final String fileContent = "{}";
 
         final S3Client s3Client = mock(S3Client.class);
-        when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(null);
 
-        final GetObjectAttributesResponse getObjectAttributesResponse = GetObjectAttributesResponse.builder().objectSize(100L).build();
-        when(s3Client.getObjectAttributes(any(GetObjectAttributesRequest.class))).thenReturn(getObjectAttributesResponse);
+        final InputStream fileObjectStream = IOUtils.toInputStream(fileContent, StandardCharsets.UTF_8);
+        final ResponseInputStream<GetObjectResponse> fileInputStream = new ResponseInputStream<>(
+                GetObjectResponse.builder().contentLength(1_000_000L).build(),
+                AbortableInputStream.create(fileObjectStream)
+        );
+        when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fileInputStream);
 
         final String testIndexAlias = UUID.randomUUID().toString();
         IndexConfiguration indexConfiguration = new IndexConfiguration.Builder()

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import static org.apache.commons.io.FileUtils.ONE_MB;
 import static org.mockito.ArgumentMatchers.any;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -89,7 +90,7 @@ public class IndexConfigurationTests {
         final String testS3AwsRegion = "us-east-2";
         final String testS3StsRoleArn = "arn:aws:iam::123456789:user/user-role";
         final String fileContent = "{}";
-        final long CONTENT_LENGTH = 1_000_000L;
+        final long CONTENT_LENGTH = 3 * ONE_MB;
 
         final S3Client s3Client = mock(S3Client.class);
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -89,12 +89,13 @@ public class IndexConfigurationTests {
         final String testS3AwsRegion = "us-east-2";
         final String testS3StsRoleArn = "arn:aws:iam::123456789:user/user-role";
         final String fileContent = "{}";
+        final long CONTENT_LENGTH = 1_000_000L;
 
         final S3Client s3Client = mock(S3Client.class);
 
         final InputStream fileObjectStream = IOUtils.toInputStream(fileContent, StandardCharsets.UTF_8);
         final ResponseInputStream<GetObjectResponse> fileInputStream = new ResponseInputStream<>(
-                GetObjectResponse.builder().contentLength(1_000_000L).build(),
+                GetObjectResponse.builder().contentLength(CONTENT_LENGTH).build(),
                 AbortableInputStream.create(fileObjectStream)
         );
         when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fileInputStream);

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IsmPolicyManagementTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IsmPolicyManagementTests.java
@@ -18,8 +18,6 @@ import org.opensearch.client.RestHighLevelClient;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetObjectAttributesRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectAttributesResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
@@ -130,13 +128,11 @@ public class IsmPolicyManagementTests {
 
         final InputStream fileObjectStream = IOUtils.toInputStream(fileContent, StandardCharsets.UTF_8);
         final ResponseInputStream<GetObjectResponse> fileInputStream = new ResponseInputStream<>(
-                GetObjectResponse.builder().build(),
+                GetObjectResponse.builder().contentLength(1000L).build(),
                 AbortableInputStream.create(fileObjectStream)
         );
-        final GetObjectAttributesResponse getObjectAttributesResponse = GetObjectAttributesResponse.builder().objectSize(100L).build();
 
         when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fileInputStream);
-        when(s3Client.getObjectAttributes(any(GetObjectAttributesRequest.class))).thenReturn(getObjectAttributesResponse);
         when(restHighLevelClient.getLowLevelClient()).thenReturn(restClient);
         when(restClient.performRequest(any())).thenThrow(responseException).thenReturn(null);
         when(responseException.getMessage()).thenReturn("Invalid field: [ism_template]");

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IsmPolicyManagementTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IsmPolicyManagementTests.java
@@ -118,6 +118,7 @@ public class IsmPolicyManagementTests {
 
     @Test
     public void checkAndCreatePolicy_with_custom_ism_policy_from_s3() throws IOException {
+        final long CONTENT_LENGTH = 1_000_000L;
         IsmPolicyManagement ismPolicyManagementStrategyWithTemplate = new IsmPolicyManagement(restHighLevelClient,
                 POLICY_NAME,
                 TEST_ISM_FILE_PATH_S3, s3Client);
@@ -128,7 +129,7 @@ public class IsmPolicyManagementTests {
 
         final InputStream fileObjectStream = IOUtils.toInputStream(fileContent, StandardCharsets.UTF_8);
         final ResponseInputStream<GetObjectResponse> fileInputStream = new ResponseInputStream<>(
-                GetObjectResponse.builder().contentLength(1000L).build(),
+                GetObjectResponse.builder().contentLength(CONTENT_LENGTH).build(),
                 AbortableInputStream.create(fileObjectStream)
         );
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IsmPolicyManagementTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IsmPolicyManagementTests.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Objects;
 
+import static org.apache.commons.io.FileUtils.ONE_MB;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
@@ -118,7 +119,6 @@ public class IsmPolicyManagementTests {
 
     @Test
     public void checkAndCreatePolicy_with_custom_ism_policy_from_s3() throws IOException {
-        final long CONTENT_LENGTH = 1_000_000L;
         IsmPolicyManagement ismPolicyManagementStrategyWithTemplate = new IsmPolicyManagement(restHighLevelClient,
                 POLICY_NAME,
                 TEST_ISM_FILE_PATH_S3, s3Client);
@@ -129,7 +129,7 @@ public class IsmPolicyManagementTests {
 
         final InputStream fileObjectStream = IOUtils.toInputStream(fileContent, StandardCharsets.UTF_8);
         final ResponseInputStream<GetObjectResponse> fileInputStream = new ResponseInputStream<>(
-                GetObjectResponse.builder().contentLength(CONTENT_LENGTH).build(),
+                GetObjectResponse.builder().contentLength(ONE_MB).build(),
                 AbortableInputStream.create(fileObjectStream)
         );
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3FileReaderTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3FileReaderTest.java
@@ -29,8 +29,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class S3FileReaderTest {
-    private static final Long CONTENT_LENGTH_EXCEEDING_THRESHOLD = 8_000_000L;
-    private static final Long CONTENT_LENGTH_SMALLER_THAN_THRESHOLD = 1_000_000L;
+    private static final Long CONTENT_LENGTH_EXCEEDING_THRESHOLD = 8 * S3FileReader.ONE_MB;
+    private static final Long CONTENT_LENGTH_SMALLER_THAN_THRESHOLD = 3 * S3FileReader.ONE_MB;
 
     @Mock
     private S3Client s3Client;

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3FileReaderTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3FileReaderTest.java
@@ -109,4 +109,28 @@ class S3FileReaderTest {
 
         assertThrows(UnsupportedFileTypeException.class, () -> s3FileReader.readFile(s3SFile));
     }
+
+    @Test
+    void readFile_with_invalid_bucket_name() {
+        final String bucketName = "";
+        final String filePath = UUID.randomUUID().toString();
+
+        final String s3SFile = String.format("s3://%s/%s",bucketName, filePath);
+
+        s3FileReader = new S3FileReader(s3Client);
+
+        assertThrows(InvalidS3URIException.class, () -> s3FileReader.readFile(s3SFile));
+    }
+
+    @Test
+    void readFile_with_invalid_object_key() {
+        final String bucketName = UUID.randomUUID().toString();
+        final String filePath = "";
+
+        final String s3SFile = String.format("s3://%s/%s",bucketName, filePath);
+
+        s3FileReader = new S3FileReader(s3Client);
+
+        assertThrows(InvalidS3URIException.class, () -> s3FileReader.readFile(s3SFile));
+    }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3FileReaderTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3FileReaderTest.java
@@ -29,6 +29,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class S3FileReaderTest {
+    private static final Long CONTENT_LENGTH_EXCEEDING_THRESHOLD = 8_000_000L;
+    private static final Long CONTENT_LENGTH_SMALLER_THAN_THRESHOLD = 1_000_000L;
 
     @Mock
     private S3Client s3Client;
@@ -45,7 +47,7 @@ class S3FileReaderTest {
 
         final InputStream fileObjectStream = IOUtils.toInputStream(fileContent, StandardCharsets.UTF_8);
         final ResponseInputStream<GetObjectResponse> fileInputStream = new ResponseInputStream<>(
-                GetObjectResponse.builder().contentLength(1_000_000L).build(),
+                GetObjectResponse.builder().contentLength(CONTENT_LENGTH_SMALLER_THAN_THRESHOLD).build(),
                 AbortableInputStream.create(fileObjectStream)
         );
 
@@ -85,7 +87,7 @@ class S3FileReaderTest {
         final GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(bucketName).key(filePath).build();
         final InputStream fileObjectStream = IOUtils.toInputStream(fileContent, StandardCharsets.UTF_8);
         final ResponseInputStream<GetObjectResponse> fileInputStream = new ResponseInputStream<>(
-                GetObjectResponse.builder().contentLength(8_000_000L).build(),
+                GetObjectResponse.builder().contentLength(CONTENT_LENGTH_EXCEEDING_THRESHOLD).build(),
                 AbortableInputStream.create(fileObjectStream)
         );
 


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
This PR removes use of `getObjectAttributes` API and checks content length from `response().contentLength();`
 
### Issues Resolved
resolves #2177 
resolves #2178 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
