### PR TITLE
ENH: add and populate markers

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/logging/DataPrepperMarkers.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/logging/DataPrepperMarkers.java
@@ -1,0 +1,15 @@
+package org.opensearch.dataprepper.logging;
+
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+public final class DataPrepperMarkers {
+    public static final Marker EVENT_MARKER = MarkerFactory.getMarker("EVENT");
+    public static final Marker SENSITIVE_MARKER = MarkerFactory.getMarker("SENSITIVE");
+
+    static {
+        SENSITIVE_MARKER.add(EVENT_MARKER);
+    }
+
+    private DataPrepperMarkers() {}
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/logging/DataPrepperMarkers.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/logging/DataPrepperMarkers.java
@@ -4,11 +4,11 @@ import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
 public final class DataPrepperMarkers {
-    public static final Marker EVENT_MARKER = MarkerFactory.getMarker("EVENT");
-    public static final Marker SENSITIVE_MARKER = MarkerFactory.getMarker("SENSITIVE");
+    public static final Marker EVENT = MarkerFactory.getMarker("EVENT");
+    public static final Marker SENSITIVE = MarkerFactory.getMarker("SENSITIVE");
 
     static {
-        EVENT_MARKER.add(SENSITIVE_MARKER);
+        EVENT.add(SENSITIVE);
     }
 
     private DataPrepperMarkers() {}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/logging/DataPrepperMarkers.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/logging/DataPrepperMarkers.java
@@ -8,7 +8,7 @@ public final class DataPrepperMarkers {
     public static final Marker SENSITIVE_MARKER = MarkerFactory.getMarker("SENSITIVE");
 
     static {
-        SENSITIVE_MARKER.add(EVENT_MARKER);
+        EVENT_MARKER.add(SENSITIVE_MARKER);
     }
 
     private DataPrepperMarkers() {}

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/logging/DataPrepperMarkersTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/logging/DataPrepperMarkersTest.java
@@ -1,0 +1,15 @@
+package org.opensearch.dataprepper.logging;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT_MARKER;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE_MARKER;
+
+class DataPrepperMarkersTest {
+    @Test
+    void testMarkers() {
+        assertThat(SENSITIVE_MARKER.contains(EVENT_MARKER.getName()), is(true));
+    }
+}

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/logging/DataPrepperMarkersTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/logging/DataPrepperMarkersTest.java
@@ -10,6 +10,6 @@ import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE_MA
 class DataPrepperMarkersTest {
     @Test
     void testMarkers() {
-        assertThat(SENSITIVE_MARKER.contains(EVENT_MARKER.getName()), is(true));
+        assertThat(EVENT_MARKER.contains(SENSITIVE_MARKER.getName()), is(true));
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/logging/DataPrepperMarkersTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/logging/DataPrepperMarkersTest.java
@@ -4,12 +4,12 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT_MARKER;
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE_MARKER;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE;
 
 class DataPrepperMarkersTest {
     @Test
     void testMarkers() {
-        assertThat(EVENT_MARKER.contains(SENSITIVE_MARKER.getName()), is(true));
+        assertThat(EVENT.contains(SENSITIVE.getName()), is(true));
     }
 }

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/StringProcessor.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/StringProcessor.java
@@ -23,6 +23,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT_MARKER;
+
 /**
  * A simple String implementation of {@link Processor} which generates new Records with uppercase or lowercase content. The current
  * simpler implementation does not handle errors (if any).
@@ -76,7 +78,7 @@ public class StringProcessor implements Processor<Record<Event>, Record<Event>> 
                         .build();
                 modifiedRecords.add(new Record<>(newRecordEvent));
             } catch (JsonProcessingException e) {
-                LOG.error("Unable to process Event data: {}", eventJson, e);
+                LOG.error(EVENT_MARKER, "Unable to process Event data: {}", eventJson, e);
             }
         }
         return modifiedRecords;

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/StringProcessor.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/processor/StringProcessor.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT_MARKER;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
 
 /**
  * A simple String implementation of {@link Processor} which generates new Records with uppercase or lowercase content. The current
@@ -78,7 +78,7 @@ public class StringProcessor implements Processor<Record<Event>, Record<Event>> 
                         .build();
                 modifiedRecords.add(new Record<>(newRecordEvent));
             } catch (JsonProcessingException e) {
-                LOG.error(EVENT_MARKER, "Unable to process Event data: {}", eventJson, e);
+                LOG.error(EVENT, "Unable to process Event data: {}", eventJson, e);
             }
         }
         return modifiedRecords;

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/source/file/FileSource.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/source/file/FileSource.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeoutException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE_MARKER;
 
 @DataPrepperPlugin(name = "file", pluginType = Source.class, pluginConfigurationType = FileSourceConfig.class)
 public class FileSource implements Source<Record<Object>> {
@@ -96,7 +97,7 @@ public class FileSource implements Source<Record<Object>> {
         try {
             return OBJECT_MAPPER.readValue(jsonString, MAP_TYPE_REFERENCE);
         } catch (JsonProcessingException e) {
-            LOG.error("Unable to parse json data [{}], assuming plain text", jsonString, e);
+            LOG.error(SENSITIVE_MARKER, "Unable to parse json data [{}], assuming plain text", jsonString, e);
             final Map<String, Object> plainMap = new HashMap<>();
             plainMap.put(MESSAGE_KEY, jsonString);
             return plainMap;

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/source/file/FileSource.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/source/file/FileSource.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeoutException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE_MARKER;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE;
 
 @DataPrepperPlugin(name = "file", pluginType = Source.class, pluginConfigurationType = FileSourceConfig.class)
 public class FileSource implements Source<Record<Object>> {
@@ -97,7 +97,7 @@ public class FileSource implements Source<Record<Object>> {
         try {
             return OBJECT_MAPPER.readValue(jsonString, MAP_TYPE_REFERENCE);
         } catch (JsonProcessingException e) {
-            LOG.error(SENSITIVE_MARKER, "Unable to parse json data [{}], assuming plain text", jsonString, e);
+            LOG.error(SENSITIVE, "Unable to parse json data [{}], assuming plain text", jsonString, e);
             final Map<String, Object> plainMap = new HashMap<>();
             plainMap.put(MESSAGE_KEY, jsonString);
             return plainMap;

--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
@@ -26,7 +26,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT_MARKER;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
 
 /**
  * Processor to parse CSV data in Events.
@@ -77,7 +77,7 @@ public class CsvProcessor extends AbstractProcessor<Record<Event>, Record<Event>
                 }
             } catch (final IOException e) {
                 csvInvalidEventsCounter.increment();
-                LOG.error(EVENT_MARKER, "An exception occurred while reading event [{}]", event, e);
+                LOG.error(EVENT, "An exception occurred while reading event [{}]", event, e);
             }
         }
         return records;

--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
@@ -26,6 +26,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT_MARKER;
+
 /**
  * Processor to parse CSV data in Events.
  *
@@ -75,7 +77,7 @@ public class CsvProcessor extends AbstractProcessor<Record<Event>, Record<Event>
                 }
             } catch (final IOException e) {
                 csvInvalidEventsCounter.increment();
-                LOG.error("An exception occurred while reading event [{}]", event, e);
+                LOG.error(EVENT_MARKER, "An exception occurred while reading event [{}]", event, e);
             }
         }
         return records;

--- a/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/HandleFailedEventsOption.java
+++ b/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/HandleFailedEventsOption.java
@@ -13,6 +13,8 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT_MARKER;
+
 enum HandleFailedEventsOption {
     DROP("drop", true, false),
     DROP_SILENTLY("drop_silently", true, true),
@@ -37,7 +39,7 @@ enum HandleFailedEventsOption {
 
     public boolean isDropEventOption(final Event event, final Throwable cause, final Logger log) {
         if (isLogRequired) {
-            log.warn("An exception occurred while processing when expression for event {}", event, cause);
+            log.warn(EVENT_MARKER, "An exception occurred while processing when expression for event {}", event, cause);
         }
         return isDropEventOption;
     }

--- a/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/HandleFailedEventsOption.java
+++ b/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/HandleFailedEventsOption.java
@@ -13,7 +13,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT_MARKER;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
 
 enum HandleFailedEventsOption {
     DROP("drop", true, false),
@@ -39,7 +39,7 @@ enum HandleFailedEventsOption {
 
     public boolean isDropEventOption(final Event event, final Throwable cause, final Logger log) {
         if (isLogRequired) {
-            log.warn(EVENT_MARKER, "An exception occurred while processing when expression for event {}", event, cause);
+            log.warn(EVENT, "An exception occurred while processing when expression for event {}", event, cause);
         }
         return isDropEventOption;
     }

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
@@ -50,7 +50,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT_MARKER;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
 
 
 @SingleThread
@@ -124,19 +124,19 @@ public class GrokProcessor extends AbstractProcessor<Record<Event>, Record<Event
                 final Record<Event> grokkedRecord = new Record<>(event, record.getMetadata());
                 recordsOut.add(grokkedRecord);
             } catch (TimeoutException e) {
-                LOG.error(EVENT_MARKER, "Matching on record [{}] took longer than [{}] and timed out", record.getData(), grokProcessorConfig.getTimeoutMillis());
+                LOG.error(EVENT, "Matching on record [{}] took longer than [{}] and timed out", record.getData(), grokProcessorConfig.getTimeoutMillis());
                 recordsOut.add(record);
                 grokProcessingTimeoutsCounter.increment();
             } catch (ExecutionException e) {
-                LOG.error(EVENT_MARKER, "An exception occurred while matching on record [{}]", record.getData(), e);
+                LOG.error(EVENT, "An exception occurred while matching on record [{}]", record.getData(), e);
                 recordsOut.add(record);
                 grokProcessingErrorsCounter.increment();
             } catch (InterruptedException e) {
-                LOG.error(EVENT_MARKER, "Matching on record [{}] was interrupted", record.getData(), e);
+                LOG.error(EVENT, "Matching on record [{}] was interrupted", record.getData(), e);
                 recordsOut.add(record);
                 grokProcessingErrorsCounter.increment();
             } catch (RuntimeException e) {
-                LOG.error(EVENT_MARKER, "Unknown exception occurred when matching record [{}]", record.getData(), e);
+                LOG.error(EVENT, "Unknown exception occurred when matching record [{}]", record.getData(), e);
                 recordsOut.add(record);
                 grokProcessingErrorsCounter.increment();
             }

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
@@ -50,6 +50,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT_MARKER;
+
 
 @SingleThread
 @DataPrepperPlugin(name = "grok", pluginType = Processor.class)
@@ -122,19 +124,19 @@ public class GrokProcessor extends AbstractProcessor<Record<Event>, Record<Event
                 final Record<Event> grokkedRecord = new Record<>(event, record.getMetadata());
                 recordsOut.add(grokkedRecord);
             } catch (TimeoutException e) {
-                LOG.error("Matching on record [{}] took longer than [{}] and timed out", record.getData(), grokProcessorConfig.getTimeoutMillis());
+                LOG.error(EVENT_MARKER, "Matching on record [{}] took longer than [{}] and timed out", record.getData(), grokProcessorConfig.getTimeoutMillis());
                 recordsOut.add(record);
                 grokProcessingTimeoutsCounter.increment();
             } catch (ExecutionException e) {
-                LOG.error("An exception occurred while matching on record [{}]", record.getData(), e);
+                LOG.error(EVENT_MARKER, "An exception occurred while matching on record [{}]", record.getData(), e);
                 recordsOut.add(record);
                 grokProcessingErrorsCounter.increment();
             } catch (InterruptedException e) {
-                LOG.error("Matching on record [{}] was interrupted", record.getData(), e);
+                LOG.error(EVENT_MARKER, "Matching on record [{}] was interrupted", record.getData(), e);
                 recordsOut.add(record);
                 grokProcessingErrorsCounter.increment();
             } catch (RuntimeException e) {
-                LOG.error("Unknown exception occurred when matching record [{}]", record.getData(), e);
+                LOG.error(EVENT_MARKER, "Unknown exception occurred when matching record [{}]", record.getData(), e);
                 recordsOut.add(record);
                 grokProcessingErrorsCounter.increment();
             }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -46,7 +46,7 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE_MARKER;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE;
 
 @DataPrepperPlugin(name = "opensearch", pluginType = Sink.class)
 public class OpenSearchSink extends AbstractSink<Record<Event>> {
@@ -215,10 +215,10 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
         dlqWriter.write(String.format("{\"Document\": [%s], \"failure\": %s}\n",
                 BulkOperationWriter.bulkOperationToString(bulkOperation), failure.getMessage()));
       } catch (final IOException e) {
-        LOG.error(SENSITIVE_MARKER, "DLQ failed for Document [{}]", bulkOperation, e);
+        LOG.error(SENSITIVE, "DLQ failed for Document [{}]", bulkOperation, e);
       }
     } else {
-      LOG.warn(SENSITIVE_MARKER, "Document [{}] has failure.", bulkOperation.toString(), failure);
+      LOG.warn(SENSITIVE, "Document [{}] has failure.", bulkOperation.toString(), failure);
     }
   }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -46,6 +46,8 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE_MARKER;
+
 @DataPrepperPlugin(name = "opensearch", pluginType = Sink.class)
 public class OpenSearchSink extends AbstractSink<Record<Event>> {
   public static final String BULKREQUEST_LATENCY = "bulkRequestLatency";
@@ -213,10 +215,10 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
         dlqWriter.write(String.format("{\"Document\": [%s], \"failure\": %s}\n",
                 BulkOperationWriter.bulkOperationToString(bulkOperation), failure.getMessage()));
       } catch (final IOException e) {
-        LOG.error("DLQ failed for Document [{}]", bulkOperation, e);
+        LOG.error(SENSITIVE_MARKER, "DLQ failed for Document [{}]", bulkOperation, e);
       }
     } else {
-      LOG.warn("Document [{}] has failure.", bulkOperation.toString(), failure);
+      LOG.warn(SENSITIVE_MARKER, "Document [{}] has failure.", bulkOperation.toString(), failure);
     }
   }
 

--- a/data-prepper-plugins/otel-trace-group-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltracegroup/OTelTraceGroupProcessor.java
+++ b/data-prepper-plugins/otel-trace-group-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltracegroup/OTelTraceGroupProcessor.java
@@ -42,6 +42,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT_MARKER;
+
 @DataPrepperPlugin(name = "otel_trace_group", pluginType = Processor.class)
 public class OTelTraceGroupProcessor extends AbstractProcessor<Record<Span>, Record<Span>> {
 
@@ -99,7 +101,7 @@ public class OTelTraceGroupProcessor extends AbstractProcessor<Record<Span>, Rec
                 } catch (Exception e) {
                     recordsOut.add(record);
                     recordsOutMissingTraceGroupCounter.increment();
-                    LOG.error("Failed to process the span: [{}]", record.getData(), e);
+                    LOG.error(EVENT_MARKER, "Failed to process the span: [{}]", record.getData(), e);
                 }
             } else {
                 recordsOut.add(record);

--- a/data-prepper-plugins/otel-trace-group-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltracegroup/OTelTraceGroupProcessor.java
+++ b/data-prepper-plugins/otel-trace-group-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltracegroup/OTelTraceGroupProcessor.java
@@ -42,7 +42,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT_MARKER;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
 
 @DataPrepperPlugin(name = "otel_trace_group", pluginType = Processor.class)
 public class OTelTraceGroupProcessor extends AbstractProcessor<Record<Span>, Record<Span>> {
@@ -101,7 +101,7 @@ public class OTelTraceGroupProcessor extends AbstractProcessor<Record<Span>, Rec
                 } catch (Exception e) {
                     recordsOut.add(record);
                     recordsOutMissingTraceGroupCounter.increment();
-                    LOG.error(EVENT_MARKER, "Failed to process the span: [{}]", record.getData(), e);
+                    LOG.error(EVENT, "Failed to process the span: [{}]", record.getData(), e);
                 }
             } else {
                 recordsOut.add(record);

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessor.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT_MARKER;
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
 
 @DataPrepperPlugin(name = "parse_json", pluginType = Processor.class, pluginConfigurationType = ParseJsonProcessorConfig.class)
 public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
@@ -69,7 +69,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
                     event.put(destination, parsedJson);
                 }
             } catch (final JsonProcessingException jsonException) {
-                LOG.error(EVENT_MARKER, "An exception occurred due to invalid JSON while reading event [{}]", event, jsonException);
+                LOG.error(EVENT, "An exception occurred due to invalid JSON while reading event [{}]", event, jsonException);
             }
         }
         return records;
@@ -100,7 +100,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
 
         final boolean pointerIsValid = temporaryEvent.containsKey(actualPointer);
         if (!pointerIsValid) {
-            LOG.error(EVENT_MARKER, "Writing entire JSON because the pointer {} is invalid on Event {}", pointer, event);
+            LOG.error(EVENT, "Writing entire JSON because the pointer {} is invalid on Event {}", pointer, event);
             return parsedJson;
         }
 

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessor.java
@@ -27,6 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT_MARKER;
+
 @DataPrepperPlugin(name = "parse_json", pluginType = Processor.class, pluginConfigurationType = ParseJsonProcessorConfig.class)
 public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
     private static final Logger LOG = LoggerFactory.getLogger(ParseJsonProcessor.class);
@@ -67,7 +69,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
                     event.put(destination, parsedJson);
                 }
             } catch (final JsonProcessingException jsonException) {
-                LOG.error("An exception occurred due to invalid JSON while reading event [{}]", event, jsonException);
+                LOG.error(EVENT_MARKER, "An exception occurred due to invalid JSON while reading event [{}]", event, jsonException);
             }
         }
         return records;
@@ -98,7 +100,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
 
         final boolean pointerIsValid = temporaryEvent.containsKey(actualPointer);
         if (!pointerIsValid) {
-            LOG.error("Writing entire JSON because the pointer {} is invalid on Event {}", pointer, event);
+            LOG.error(EVENT_MARKER, "Writing entire JSON because the pointer {} is invalid on Event {}", pointer, event);
             return parsedJson;
         }
 


### PR DESCRIPTION
Signed-off-by: George Chen <qchea@amazon.com>

### Description
This PR 

- adds SENSITIVE and EVENT marker in data-prepper-api, where SENSITIVE is a child of EVENT
- populates markers where applicable throughout the project

smoke tested with DataPrepperExecute::main entrypoint. 

The following filter will filter out both SENSITIVE and EVENT.
```
appender.console.markerFilter1.type = MarkerFilter
appender.console.markerFilter1.marker = SENSITIVE
appender.console.markerFilter1.onMatch = DENY
appender.console.markerFilter1.onMismatch = NEUTRAL
```
The following filter will only filter out EVENT.
```
appender.console.markerFilter2.type = MarkerFilter
appender.console.markerFilter2.marker = EVENT
appender.console.markerFilter2.onMatch = DENY
appender.console.markerFilter2.onMismatch = NEUTRAL
```
 
### Issues Resolved
Resolves #1990 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
