### PR TITLE
Fixes links to use org/opensearch from com/amazon

### DIFF
--- a/data-prepper-plugins/aggregate-processor/README.md
+++ b/data-prepper-plugins/aggregate-processor/README.md
@@ -175,7 +175,7 @@ While not necessary, a great way to set up the Aggregate Processor [identificati
 
 ## Creating New Aggregate Actions
 
-It is easy to create custom Aggregate Actions to be used by the Aggregate Processor. To do so, create a new class that implements the [AggregateAction interface](src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/AggregateAction.java).
+It is easy to create custom Aggregate Actions to be used by the Aggregate Processor. To do so, create a new class that implements the [AggregateAction interface](src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateAction.java).
 The interface has the following signature:
 
 ```
@@ -194,7 +194,7 @@ public interface AggregateAction {
 ```
 
 The `AggregateActionInput` that is passed to the functions of the interface contains a method `getGroupState()`, which returns a `GroupState` Object that can be operated on like a java `Map`. 
-For actual examples, take a closer look at the code for some existing AggregateActions [here](src/main/java/com/amazon/dataprepper/plugins/processor/aggregate/actions).
+For actual examples, take a closer look at the code for some existing AggregateActions [here](src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions).
 
 ## State
 
@@ -203,7 +203,7 @@ This functionality is on the Data Prepper Roadmap.
 
 ## Metrics
 
-Apart from common metrics in [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java), the Aggregate Processor introduces the following custom metrics.
+Apart from common metrics in [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/AbstractProcessor.java), the Aggregate Processor introduces the following custom metrics.
 
 **Counter**
 

--- a/data-prepper-plugins/blocking-buffer/README.md
+++ b/data-prepper-plugins/blocking-buffer/README.md
@@ -15,7 +15,7 @@ buffer:
 - batch_size => An `int` representing max number of records the buffer returns on read. Default is `8`.
 
 ## Metrics
-This plugin inherits the common metrics defined in [AbstractBuffer](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java) and the additional customer metrics:
+This plugin inherits the common metrics defined in [AbstractBuffer](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/AbstractBuffer.java) and the additional customer metrics:
 - Gauge
   - `bufferUsage`: percent usage of the `buffer_size` based on the `recordsInBuffer`.
 

--- a/data-prepper-plugins/csv-processor/README.md
+++ b/data-prepper-plugins/csv-processor/README.md
@@ -87,7 +87,7 @@ And will parse it into the following. (Note that since `delete_header` is `true`
 
 ## Metrics
 
-Apart from common metrics in [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java), the CSV Processor includes the following custom metric.
+Apart from common metrics in [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/AbstractProcessor.java), the CSV Processor includes the following custom metric.
 
 **Counter**
 

--- a/data-prepper-plugins/http-source/README.md
+++ b/data-prepper-plugins/http-source/README.md
@@ -55,7 +55,7 @@ source:
 ```
 
 This plugin uses pluggable authentication for HTTP servers. To provide custom authentication,
-create a plugin which implements [`ArmeriaHttpAuthenticationProvider`](../armeria-common/src/main/java/com/amazon/dataprepper/armeria/authentication/ArmeriaHttpAuthenticationProvider.java)
+create a plugin which implements [`ArmeriaHttpAuthenticationProvider`](../armeria-common/src/main/java/org/opensearch/dataprepper/armeria/authentication/ArmeriaHttpAuthenticationProvider.java)
 
 
 ### SSL

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -171,7 +171,7 @@ is explicitly mapped by your index template.
 
 ## Metrics
 
-Besides common metrics in [AbstractSink](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/sink/AbstractSink.java), OpenSearch sink introduces the following custom metrics.
+Besides common metrics in [AbstractSink](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/AbstractSink.java), OpenSearch sink introduces the following custom metrics.
 
 ### Timer
 

--- a/data-prepper-plugins/otel-metrics-raw-processor/README.md
+++ b/data-prepper-plugins/otel-metrics-raw-processor/README.md
@@ -111,7 +111,7 @@ All exponential histograms that have a scale that is above the configured parame
 **Note**: the absolute scale value is used for comparison, so a scale of -11 will be treated equally to 11 and thus exceed the configured value of 10 - and be discarded.
 
 ## Metrics
-This plugin uses all common metrics in [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java), and does not currently introduce custom metrics.
+This plugin uses all common metrics in [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/AbstractProcessor.java), and does not currently introduce custom metrics.
 
 ## Developer Guide
 This plugin is compatible with Java 8. See 

--- a/data-prepper-plugins/otel-trace-group-processor/README.md
+++ b/data-prepper-plugins/otel-trace-group-processor/README.md
@@ -1,6 +1,6 @@
 # OTel Trace Group Processor
 
-This is a processor that fills in the missing trace group related fields in the collection of [Span](../../data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/Span.java) records by looking up the opensearch backend.
+This is a processor that fills in the missing trace group related fields in the collection of [Span](../../data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/Span.java) records by looking up the opensearch backend.
 It finds the missing trace group info for a spanId by looking up the relevant fields in its root span stored in OpenSearch or Amazon OpenSearch Service backend that the local data-prepper host ingest into.
 
 ## Usages

--- a/data-prepper-plugins/otel-trace-source/README.md
+++ b/data-prepper-plugins/otel-trace-source/README.md
@@ -65,7 +65,7 @@ source:
 ```
 
 This plugin uses pluggable authentication for GRPC servers. To provide custom authentication,
-create a plugin which implements [`GrpcAuthenticationProvider`](../armeria-common/src/main/java/com/amazon/dataprepper/armeria/authentication/GrpcAuthenticationProvider.java)
+create a plugin which implements [`GrpcAuthenticationProvider`](../armeria-common/src/main/java/org/opensearch/dataprepper/armeria/authentication/GrpcAuthenticationProvider.java)
 
 ### SSL
 

--- a/data-prepper-plugins/service-map-stateful/README.md
+++ b/data-prepper-plugins/service-map-stateful/README.md
@@ -14,7 +14,7 @@ processor:
 * window_duration(Optional) => An `int` represents the fixed time window in seconds to evaluate service-map relationships. Default is ```180```.
 
 ## Metrics
-Besides common metrics in [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractProcessor.java), service-map-stateful processor introduces the following custom metrics.
+Besides common metrics in [AbstractProcessor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/AbstractProcessor.java), service-map-stateful processor introduces the following custom metrics.
 
 ### Gauge
 - `spansDbSize`: measures total spans byte sizes in MapDB across the current and previous window durations. This only tracks the byte size for the file (if used).

--- a/docs/plugin_development.md
+++ b/docs/plugin_development.md
@@ -7,7 +7,7 @@ are created as Data Prepper plugins.
 
 Plugins are created as Java classes. They must conform to the following.
 
-* The class must be annotated with [`@DataPrepperPlugin`](../data-prepper-api/src/main/java/com/amazon/dataprepper/model/annotations/DataPrepperPlugin.java)
+* The class must be annotated with [`@DataPrepperPlugin`](../data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperPlugin.java)
 * The class must be in the `org.opensearch.dataprepper.plugins` package
 * The class must implement the required interface
 * The class must have a valid constructor (see below)
@@ -15,7 +15,7 @@ Plugins are created as Java classes. They must conform to the following.
 ### Plugin Constructors
 
 The preferred way to create a plugin constructor is to choose a single
-constructor and annotate it with [`@DataPrepperConstructor`](../data-prepper-api/src/main/java/com/amazon/dataprepper/model/annotations/DataPrepperPluginConstructor.java).
+constructor and annotate it with [`@DataPrepperConstructor`](../data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperPluginConstructor.java).
 The constructor can only take in class types which are supported by the plugin framework.
 
 The plugin framework can inject the following types into this constructor:

--- a/docs/trace_analytics.md
+++ b/docs/trace_analytics.md
@@ -33,8 +33,8 @@ The [OpenTelemetry source](../data-prepper-plugins/otel-trace-source/README.md) 
 ### Processor
 
 We have two processor for the Trace Analytics feature,
-* *otel_trace_raw* -  This is a processor that receives collection of [Span](../../data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/Span.java) records sent from [otel-trace-source](../dataPrepper-plugins/otel-trace-source), does stateful processing on extracting and filling-in trace group related fields.
-* *otel_trace_group* -  This is a processor that fills in the missing trace group related fields in the collection of [Span](../../data-prepper-api/src/main/java/com/amazon/dataprepper/model/trace/Span.java) records by looking up the opensearch backend.
+* *otel_trace_raw* -  This is a processor that receives collection of [Span](../data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/Span.java) records sent from [otel-trace-source](../data-prepper-plugins/otel-trace-source/README.md), does stateful processing on extracting and filling-in trace group related fields.
+* *otel_trace_group* -  This is a processor that fills in the missing trace group related fields in the collection of [Span](../data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/Span.java) records by looking up the opensearch backend.
 * *service_map_stateful* -  This processor performs the required preprocessing on the trace data and build metadata to display the service-map OpenSearch Dashboards dashboards.
 
 


### PR DESCRIPTION
### Description

This fixes broken links which have the `com/amazon/dataprepper` path. This PR updates most to use `org/opensearch/dataprepper`. It leaves out the trace-raw since that is resolved in another PR.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
