### PR TITLE
Optimize buffer reads, allow delay to be 0

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/PipelineConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/PipelineConfiguration.java
@@ -145,7 +145,11 @@ public class PipelineConfiguration {
 
     private Integer getReadBatchDelayFromPipelineModel(final PipelineModel pipelineModel) {
         final Integer configuredDelay = pipelineModel.getReadBatchDelay();
-        validateConfiguration(configuredDelay, DELAY_COMPONENT);
+
+        if (configuredDelay != null && configuredDelay < 0) {
+            throw new IllegalArgumentException(String.format("Invalid configuration, %s must be a non-negative integer.", DELAY_COMPONENT));
+        }
+
         return configuredDelay == null ? DEFAULT_READ_BATCH_DELAY : configuredDelay;
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
@@ -420,8 +420,8 @@ public class PeerForwarderConfiguration {
 
     private void setBatchDelay(final Integer batchDelay) {
         if (batchDelay != null) {
-            if (batchDelay <= 0) {
-                throw new IllegalArgumentException("Batch delay must be a positive integer.");
+            if (batchDelay < 0) {
+                throw new IllegalArgumentException("Batch delay must be a non-negative integer.");
             }
             this.batchDelay = batchDelay;
         }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderReceiveBuffer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderReceiveBuffer.java
@@ -87,21 +87,16 @@ public class PeerForwarderReceiveBuffer<T extends Record<?>> implements Buffer<T
     @Override
     public Map.Entry<Collection<T>, CheckpointState> read(final int timeoutInMillis) {
         final List<T> records = new ArrayList<>();
-        final Stopwatch stopwatch = Stopwatch.createStarted();
-        try {
+
+        if (timeoutInMillis == 0) {
+            blockingQueue.drainTo(records, batchSize);
+        } else {
+            final Stopwatch stopwatch = Stopwatch.createStarted();
             while (stopwatch.elapsed(TimeUnit.MILLISECONDS) < timeoutInMillis && records.size() < batchSize) {
-                final T record = blockingQueue.poll(timeoutInMillis, TimeUnit.MILLISECONDS);
-                if (record != null) { //record can be null, avoiding adding nulls
-                    records.add(record);
-                }
-                if (records.size() < batchSize) {
-                    blockingQueue.drainTo(records, batchSize - records.size());
-                }
+                blockingQueue.drainTo(records, batchSize - records.size());
             }
-        } catch (InterruptedException ex) {
-            LOG.info("Peer forwarder buffer - Interrupt received while reading from buffer");
-            throw new RuntimeException(ex);
         }
+
         final CheckpointState checkpointState = new CheckpointState(records.size());
         recordsInFlight += checkpointState.getNumRecordsToBeChecked();
         return new AbstractMap.SimpleEntry<>(records, checkpointState);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/PipelineConfigurationTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/PipelineConfigurationTests.java
@@ -198,9 +198,9 @@ class PipelineConfigurationTests {
         when(pipelineModel.getProcessors()).thenReturn(processors);
         when(pipelineModel.getSinks()).thenReturn(sinks);
         when(pipelineModel.getWorkers()).thenReturn(TestDataProvider.TEST_WORKERS);
-        when(pipelineModel.getReadBatchDelay()).thenReturn(0);
+        when(pipelineModel.getReadBatchDelay()).thenReturn(-1);
         final IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> new PipelineConfiguration(pipelineModel));
-        assertThat(actual.getMessage(), equalTo("Invalid configuration, delay cannot be 0"));
+        assertThat(actual.getMessage(), equalTo("Invalid configuration, delay must be a non-negative integer."));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Chase Engelbrecht <engechas@amazon.com>

### Description
Optimizes the buffer read logic by removing the poll before drainTo. A read delay of 0 is now valid as well, which makes only a single call to drainTo when reading. 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
