### PR TITLE
Add clientTimeout to peer forwarder configuration, optimize CPF seria…

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerClientPool.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerClientPool.java
@@ -36,7 +36,7 @@ public class PeerClientPool {
         peerClients = new ConcurrentHashMap<>();
     }
 
-    public void setClientTimeoutSeconds(int clientTimeoutMillis) {
+    public void setClientTimeoutMillis(int clientTimeoutMillis) {
         this.clientTimeoutMillis = clientTimeoutMillis;
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerClientPool.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerClientPool.java
@@ -25,7 +25,7 @@ public class PeerClientPool {
     private final Map<String, WebClient> peerClients;
 
     private int port;
-    private int clientTimeoutSeconds = 3;
+    private int clientTimeoutMillis = 60_000;
     private boolean ssl;
     private Certificate certificate;
     private boolean sslDisableVerification;
@@ -36,8 +36,8 @@ public class PeerClientPool {
         peerClients = new ConcurrentHashMap<>();
     }
 
-    public void setClientTimeoutSeconds(int clientTimeoutSeconds) {
-        this.clientTimeoutSeconds = clientTimeoutSeconds;
+    public void setClientTimeoutSeconds(int clientTimeoutMillis) {
+        this.clientTimeoutMillis = clientTimeoutMillis;
     }
 
     public void setSsl(boolean ssl) {
@@ -72,7 +72,8 @@ public class PeerClientPool {
         final String protocol = ssl ? HTTPS : HTTP;
 
         ClientBuilder clientBuilder = Clients.builder(String.format("%s://%s:%s/", protocol, ipAddress, port))
-                .writeTimeout(Duration.ofSeconds(clientTimeoutSeconds));
+                .writeTimeout(Duration.ofMillis(clientTimeoutMillis))
+                .responseTimeout(Duration.ofMillis(clientTimeoutMillis));
 
         if (ssl) {
             final ClientFactoryBuilder clientFactoryBuilder = ClientFactory.builder();

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactory.java
@@ -36,7 +36,7 @@ public class PeerForwarderClientFactory {
     }
 
     public PeerClientPool setPeerClientPool() {
-        peerClientPool.setClientTimeoutSeconds(peerForwarderConfiguration.getClientTimeout());
+        peerClientPool.setClientTimeoutMillis(peerForwarderConfiguration.getClientTimeout());
 
         final int targetPort = peerForwarderConfiguration.getServerPort();
         peerClientPool.setPort(targetPort);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderClientFactory.java
@@ -36,7 +36,7 @@ public class PeerForwarderClientFactory {
     }
 
     public PeerClientPool setPeerClientPool() {
-        peerClientPool.setClientTimeoutSeconds(3);
+        peerClientPool.setClientTimeoutSeconds(peerForwarderConfiguration.getClientTimeout());
 
         final int targetPort = peerForwarderConfiguration.getServerPort();
         peerClientPool.setPort(targetPort);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
@@ -30,6 +30,7 @@ public class PeerForwarderConfiguration {
 
     private Integer serverPort = 4994;
     private Integer requestTimeout = 10_000;
+    private Integer clientTimeout = 60_000;
     private Integer serverThreadCount = 200;
     private Integer maxConnectionCount = 500;
     private Integer maxPendingRequests = 1024;
@@ -64,6 +65,7 @@ public class PeerForwarderConfiguration {
     public PeerForwarderConfiguration (
             @JsonProperty("port") final Integer serverPort,
             @JsonProperty("request_timeout") final Integer requestTimeout,
+            @JsonProperty("client_timeout") final Integer clientTimeout,
             @JsonProperty("server_thread_count") final Integer serverThreadCount,
             @JsonProperty("max_connection_count") final Integer maxConnectionCount,
             @JsonProperty("max_pending_requests") final Integer maxPendingRequests,
@@ -93,6 +95,7 @@ public class PeerForwarderConfiguration {
     ) {
         setServerPort(serverPort);
         setRequestTimeout(requestTimeout);
+        setClientTimeout(clientTimeout);
         setServerThreadCount(serverThreadCount);
         setMaxConnectionCount(maxConnectionCount);
         setMaxPendingRequests(maxPendingRequests);
@@ -129,6 +132,10 @@ public class PeerForwarderConfiguration {
 
     public int getRequestTimeout() {
         return requestTimeout;
+    }
+
+    public int getClientTimeout() {
+        return clientTimeout;
     }
 
     public int getServerThreadCount() {
@@ -238,6 +245,15 @@ public class PeerForwarderConfiguration {
                 throw new IllegalArgumentException("Request timeout must be a positive integer.");
             }
             this.requestTimeout = requestTimeout;
+        }
+    }
+
+    private void setClientTimeout(final Integer clientTimeout) {
+        if (clientTimeout != null) {
+            if (clientTimeout <= 0) {
+                throw new IllegalArgumentException("Client timeout must be a positive integer.");
+            }
+            this.clientTimeout = clientTimeout;
         }
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
@@ -241,8 +241,8 @@ public class PeerForwarderConfiguration {
 
     private void setRequestTimeout(final Integer requestTimeout) {
         if (requestTimeout!= null) {
-            if (requestTimeout <= 0) {
-                throw new IllegalArgumentException("Request timeout must be a positive integer.");
+            if (requestTimeout <= 1) {
+                throw new IllegalArgumentException("Request timeout must be a positive integer greater than 1.");
             }
             this.requestTimeout = requestTimeout;
         }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClient.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClient.java
@@ -61,22 +61,22 @@ public class PeerForwarderClient {
 
         final WebClient client = peerClientPool.getClient(ipAddress);
 
-        final String serializedJsonString = getSerializedJsonString(records, pluginId, pipelineName);
+        final byte[] serializedJsonBytes = getSerializedJsonBytes(records, pluginId, pipelineName);
 
         final AggregatedHttpResponse aggregatedHttpResponse = clientRequestForwardingLatencyTimer.record(() ->
-            processHttpRequest(client, serializedJsonString)
+            processHttpRequest(client, serializedJsonBytes)
         );
         requestsCounter.increment();
 
         return aggregatedHttpResponse;
     }
 
-    private String getSerializedJsonString(final Collection<Record<Event>> records, final String pluginId, final String pipelineName) {
+    private byte[] getSerializedJsonBytes(final Collection<Record<Event>> records, final String pluginId, final String pipelineName) {
         final List<WireEvent> wireEventList = getWireEventList(records);
         final WireEvents wireEvents = new WireEvents(wireEventList, pluginId, pipelineName);
 
         try {
-            return objectMapper.writeValueAsString(wireEvents);
+            return objectMapper.writeValueAsBytes(wireEvents);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -101,7 +101,7 @@ public class PeerForwarderClient {
         );
     }
 
-    private AggregatedHttpResponse processHttpRequest(final WebClient client, final String content) {
+    private AggregatedHttpResponse processHttpRequest(final WebClient client, final byte[] content) {
         return client.post(DEFAULT_PEER_FORWARDING_URI, content).aggregate().join();
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServerProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServerProvider.java
@@ -80,8 +80,7 @@ public class PeerForwarderHttpServerProvider implements Provider<Server> {
 
 
         sb.maxNumConnections(peerForwarderConfiguration.getMaxConnectionCount());
-        // Add 1 second to the request timeout to allow for processing other than the buffer writes
-        sb.requestTimeout(Duration.ofMillis(peerForwarderConfiguration.getRequestTimeout() + 1000));
+        sb.requestTimeout(Duration.ofMillis(peerForwarderConfiguration.getRequestTimeout()));
         final int threadCount = peerForwarderConfiguration.getServerThreadCount();
         final ScheduledThreadPoolExecutor blockingTaskExecutor = new ScheduledThreadPoolExecutor(threadCount);
         sb.blockingTaskExecutor(blockingTaskExecutor, true);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServerProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServerProvider.java
@@ -80,7 +80,8 @@ public class PeerForwarderHttpServerProvider implements Provider<Server> {
 
 
         sb.maxNumConnections(peerForwarderConfiguration.getMaxConnectionCount());
-        sb.requestTimeout(Duration.ofMillis(peerForwarderConfiguration.getRequestTimeout()));
+        // Add 1 second to the request timeout to allow for processing other than the buffer writes
+        sb.requestTimeout(Duration.ofMillis(peerForwarderConfiguration.getRequestTimeout() + 1000));
         final int threadCount = peerForwarderConfiguration.getServerThreadCount();
         final ScheduledThreadPoolExecutor blockingTaskExecutor = new ScheduledThreadPoolExecutor(threadCount);
         sb.blockingTaskExecutor(blockingTaskExecutor, true);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpService.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpService.java
@@ -42,6 +42,7 @@ public class PeerForwarderHttpService {
     private static final String TRACE_EVENT_TYPE = "TRACE";
     static final String SERVER_REQUEST_PROCESSING_LATENCY = "serverRequestProcessingLatency";
     static final String RECORDS_RECEIVED_FROM_PEERS = "recordsReceivedFromPeers";
+    static final double BUFFER_TIMEOUT_FRACTION = 0.8;
 
     private final ResponseHandler responseHandler;
     private final PeerForwarderProvider peerForwarderProvider;
@@ -99,9 +100,13 @@ public class PeerForwarderHttpService {
                     .map(this::transformEvent)
                     .collect(Collectors.toList());
 
-            recordPeerForwarderReceiveBuffer.writeAll(jacksonEvents, peerForwarderConfiguration.getRequestTimeout());
+            recordPeerForwarderReceiveBuffer.writeAll(jacksonEvents, getBufferTimeoutMillis());
             recordsReceivedFromPeersCounter.increment(jacksonEvents.size());
         }
+    }
+
+    private int getBufferTimeoutMillis() {
+        return (int) (peerForwarderConfiguration.getRequestTimeout() * BUFFER_TIMEOUT_FRACTION);
     }
 
     private PeerForwarderReceiveBuffer<Record<Event>> getPeerForwarderBuffer(final WireEvents wireEvents) {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpService.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpService.java
@@ -11,7 +11,6 @@ import org.opensearch.dataprepper.model.event.DefaultEventMetadata;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.record.Record;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpData;
@@ -28,6 +27,7 @@ import org.opensearch.dataprepper.peerforwarder.model.WireEvents;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -73,8 +73,8 @@ public class PeerForwarderHttpService {
         WireEvents wireEvents;
         final HttpData content = aggregatedHttpRequest.content();
         try {
-            wireEvents = objectMapper.readValue(content.toStringUtf8(), WireEvents.class);
-        } catch (JsonProcessingException e) {
+            wireEvents = objectMapper.readValue(content.array(), WireEvents.class);
+        } catch (IOException e) {
             final String message = "Failed to write the request content due to bad request data format. Needs to be JSON object";
             LOG.error(message, e);
             return responseHandler.handleException(e, message);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpService.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpService.java
@@ -42,7 +42,7 @@ public class PeerForwarderHttpService {
     private static final String TRACE_EVENT_TYPE = "TRACE";
     static final String SERVER_REQUEST_PROCESSING_LATENCY = "serverRequestProcessingLatency";
     static final String RECORDS_RECEIVED_FROM_PEERS = "recordsReceivedFromPeers";
-    static final double BUFFER_TIMEOUT_FRACTION = 0.8;
+    private static final double BUFFER_TIMEOUT_FRACTION = 0.8;
 
     private final ResponseHandler responseHandler;
     private final PeerForwarderProvider peerForwarderProvider;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
@@ -44,6 +44,7 @@ class PeerForwarderConfigurationTest {
 
         assertThat(peerForwarderConfiguration.getServerPort(), equalTo(4994));
         assertThat(peerForwarderConfiguration.getRequestTimeout(), equalTo(10_000));
+        assertThat(peerForwarderConfiguration.getClientTimeout(), equalTo(60_000));
         assertThat(peerForwarderConfiguration.getServerThreadCount(), equalTo(200));
         assertThat(peerForwarderConfiguration.getMaxConnectionCount(), equalTo(500));
         assertThat(peerForwarderConfiguration.getMaxPendingRequests(), equalTo(1024));
@@ -68,6 +69,7 @@ class PeerForwarderConfigurationTest {
 
         assertThat(peerForwarderConfiguration.getServerPort(), equalTo(21895));
         assertThat(peerForwarderConfiguration.getRequestTimeout(), equalTo(1000));
+        assertThat(peerForwarderConfiguration.getClientTimeout(), equalTo(50));
         assertThat(peerForwarderConfiguration.getServerThreadCount(), equalTo(100));
         assertThat(peerForwarderConfiguration.getMaxConnectionCount(), equalTo(100));
         assertThat(peerForwarderConfiguration.getMaxPendingRequests(), equalTo(512));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -444,6 +444,7 @@ class PeerForwarder_ClientServerIT {
         return new PeerForwarderConfiguration(
                 4994,
                 10_000,
+                60_000,
                 200,
                 500,
                 1024,

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClientTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/client/PeerForwarderClientTest.java
@@ -53,6 +53,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -135,7 +136,7 @@ class PeerForwarderClientTest {
     @Test
     void test_serializeRecordsAndSendHttpRequest_with_bad_wireEvents_should_throw() throws JsonProcessingException {
         ObjectMapper objectMapper = mock(ObjectMapper.class);
-        when(objectMapper.writeValueAsString(isA(WireEvents.class))).thenThrow(JsonProcessingException.class);
+        when(objectMapper.writeValueAsBytes(isA(WireEvents.class))).thenThrow(JsonProcessingException.class);
 
         final PeerForwarderClient objectUnderTest = createObjectUnderTest(objectMapper);
 
@@ -155,7 +156,7 @@ class PeerForwarderClientTest {
 
         final WebClient webClient = mock(WebClient.class);
         when(peerClientPool.getClient(anyString())).thenReturn(webClient);
-        when(webClient.post(anyString(), anyString())).thenReturn(HttpResponse.ofJson(CompletableFuture.class));
+        when(webClient.post(anyString(), any(byte[].class))).thenReturn(HttpResponse.ofJson(CompletableFuture.class));
 
         final PeerForwarderClient peerForwarderClient = createObjectUnderTest(objectMapper);
         final Collection<Record<Event>> records = generateBatchRecords(1);

--- a/data-prepper-core/src/test/resources/valid_peer_forwarder_config.yml
+++ b/data-prepper-core/src/test/resources/valid_peer_forwarder_config.yml
@@ -1,5 +1,6 @@
 port: 21895
 request_timeout: 1000
+client_timeout: 50
 server_thread_count: 100
 max_connection_count: 100
 max_pending_requests: 512


### PR DESCRIPTION
…lization

Signed-off-by: Chase Engelbrecht <engechas@amazon.com>

### Description
This PR adds a new CPF configuration option for client timeout. This aimed at reducing the ResponseTimeoutExceptions received when the CPF server is overloaded with requests.

The server requestTimeout is set to 1s above the configured value to give overhead for the processing time outside of the buffer write.

The serialization on the client side is change from a String to byte[] for a slight performance boost and less memory consumption.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
