### PR TITLE
Updated guava version to 31.1-jre

### DIFF
--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -12,7 +12,8 @@ ext.versionMap = [
         armeria: '1.20.3',
         armeriaGrpc: '1.20.3',
         protobufJavaUtil: '3.21.11',
-        protobufJava: '3.21.11'
+        protobufJava: '3.21.11',
+        guava: '31.1-jre'
 ]
 
 ext.coreProjects = [

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ subprojects {
     dependencies {
         implementation platform('com.fasterxml.jackson:jackson-bom:2.14.1')
         implementation platform('io.micrometer:micrometer-bom:1.9.4')
-        implementation 'com.google.guava:guava:31.1-jre'
+        implementation "com.google.guava:guava:${versionMap.guava}"
         implementation 'org.slf4j:slf4j-api:2.0.5'
         testImplementation platform("org.junit:junit-bom:${versionMap.junitJupiter}")
         testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/data-prepper-plugins/aggregate-processor/build.gradle
+++ b/data-prepper-plugins/aggregate-processor/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation project(':data-prepper-expression')
     implementation project(':data-prepper-plugins:otel-proto-common')
     implementation project(':data-prepper-plugins:otel-metrics-raw-processor')
-    implementation 'com.google.guava:guava:10.0.1'
+    implementation "com.google.guava:guava:${versionMap.guava}"
     implementation "org.apache.commons:commons-lang3:3.12.0"
     implementation "io.opentelemetry.proto:opentelemetry-proto:${versionMap.opentelemetryProto}"
     implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation 'org.opensearch.client:opensearch-java:2.1.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation 'com.google.guava:guava:23.0'
+    implementation "com.google.guava:guava:${versionMap.guava}"
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     implementation 'software.amazon.awssdk:auth'
     implementation 'software.amazon.awssdk:http-client-spi'

--- a/data-prepper-plugins/otel-metrics-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-metrics-raw-processor/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation "com.linecorp.armeria:armeria-grpc:${versionMap.armeriaGrpc}"
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
+    implementation "com.google.guava:guava:${versionMap.guava}"
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
 }

--- a/data-prepper-plugins/otel-trace-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-processor/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation "com.linecorp.armeria:armeria-grpc:${versionMap.armeriaGrpc}"
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation 'com.google.guava:guava:31.1-jre'
+    implementation "com.google.guava:guava:${versionMap.guava}"
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
 }


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
- Updates Guava dependency
- Fixes CVE-2020-8908, CVE-2018-10237

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
