### PR TITLE
Implement batching for peer forwarder request documents

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
@@ -176,7 +176,7 @@ public class PipelineParser {
                         final List<Processor> processors = processorComponentList.stream().map(IdentifiedComponent::getComponent).collect(Collectors.toList());
                         if (!processors.isEmpty() && processors.get(0) instanceof RequiresPeerForwarding) {
                             return PeerForwardingProcessorDecorator.decorateProcessors(
-                                    processors, peerForwarderProvider, pipelineName, processorComponentList.get(0).getName()
+                                    processors, peerForwarderProvider, pipelineName, processorComponentList.get(0).getName(), pipelineConfiguration.getWorkers()
                             );
                         }
                         return processors;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderAppConfig.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.yaml.snakeyaml.LoaderOptions;
 
 @Configuration
 class PeerForwarderAppConfig {
@@ -33,8 +34,13 @@ class PeerForwarderAppConfig {
     }
 
     @Bean(name = "peerForwarderObjectMapper")
-    public ObjectMapper objectMapper(final YAMLFactory yamlFactory) {
+    public ObjectMapper objectMapper() {
         final JavaTimeModule javaTimeModule = new JavaTimeModule();
+        final LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(10 * 1024 * 1024); // 10MB
+        final YAMLFactory yamlFactory = YAMLFactory.builder()
+                .loaderOptions(loaderOptions)
+                .build();
         return new ObjectMapper(yamlFactory).registerModule(javaTimeModule);
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
@@ -24,6 +24,7 @@ import java.util.Map;
 public class PeerForwarderConfiguration {
     public static final String DEFAULT_PEER_FORWARDING_URI = "/event/forward";
     public static final Duration DEFAULT_DRAIN_TIMEOUT = Duration.ofSeconds(10L);
+    public static final Duration DEFAULT_FORWARDING_BATCH_TIMEOUT = Duration.ofSeconds(3L);
     public static final String DEFAULT_CERTIFICATE_FILE_PATH = "config/default_certificate.pem";
     public static final String DEFAULT_PRIVATE_KEY_FILE_PATH = "config/default_private_key.pem";
     private static final String S3_PREFIX = "s3://";
@@ -59,6 +60,7 @@ public class PeerForwarderConfiguration {
     private Duration drainTimeout = DEFAULT_DRAIN_TIMEOUT;
     private Integer failedForwardingRequestLocalWriteTimeout = 500;
     private Integer forwardingBatchSize = 1500;
+    private Duration forwardingBatchTimeout = DEFAULT_FORWARDING_BATCH_TIMEOUT;
 
     public PeerForwarderConfiguration() {}
 
@@ -92,7 +94,8 @@ public class PeerForwarderConfiguration {
             @JsonProperty("buffer_size") final Integer bufferSize,
             @JsonProperty("drain_timeout") final Duration drainTimeout,
             @JsonProperty("failed_forwarding_requests_local_write_timeout") final Integer failedForwardingRequestLocalWriteTimeout,
-            @JsonProperty("forwarding_batch_size") final Integer forwardingBatchSize
+            @JsonProperty("forwarding_batch_size") final Integer forwardingBatchSize,
+            @JsonProperty("forwarding_batch_timeout") final Duration forwardingBatchTimeout
     ) {
         setServerPort(serverPort);
         setRequestTimeout(requestTimeout);
@@ -123,6 +126,7 @@ public class PeerForwarderConfiguration {
         setDrainTimeout(drainTimeout);
         setFailedForwardingRequestLocalWriteTimeout(failedForwardingRequestLocalWriteTimeout);
         setForwardingBatchSize(forwardingBatchSize);
+        setForwardingBatchTimeout(forwardingBatchTimeout);
         checkForCertAndKeyFileInS3();
         validateSslAndAuthentication();
     }
@@ -229,6 +233,10 @@ public class PeerForwarderConfiguration {
 
     public Integer getForwardingBatchSize() {
         return forwardingBatchSize;
+    }
+
+    public Duration getForwardingBatchTimeout() {
+        return forwardingBatchTimeout;
     }
 
     private void setServerPort(final Integer serverPort) {
@@ -491,6 +499,15 @@ public class PeerForwarderConfiguration {
                 throw new IllegalArgumentException("Forwarding batch size must be between 1 and 3000 inclusive.");
             }
             this.forwardingBatchSize = forwardingBatchSize;
+        }
+    }
+
+    private void setForwardingBatchTimeout(final Duration forwardingBatchTimeout) {
+        if (forwardingBatchTimeout != null) {
+            if (forwardingBatchTimeout.isNegative()) {
+                throw new IllegalArgumentException("Forwarding batch timeout must be non-negative.");
+            }
+            this.forwardingBatchTimeout = forwardingBatchTimeout;
         }
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
@@ -28,7 +28,7 @@ public class PeerForwarderConfiguration {
     public static final String DEFAULT_CERTIFICATE_FILE_PATH = "config/default_certificate.pem";
     public static final String DEFAULT_PRIVATE_KEY_FILE_PATH = "config/default_private_key.pem";
     private static final String S3_PREFIX = "s3://";
-    private static final int MAX_FORWADING_BATCH_SIZE = 3000;
+    private static final int MAX_FORWARDING_BATCH_SIZE = 3000;
 
     private Integer serverPort = 4994;
     private Integer requestTimeout = 10_000;
@@ -495,7 +495,7 @@ public class PeerForwarderConfiguration {
 
     private void setForwardingBatchSize(final Integer forwardingBatchSize) {
         if (forwardingBatchSize != null) {
-            if (forwardingBatchSize <= 0 || forwardingBatchSize > MAX_FORWADING_BATCH_SIZE) {
+            if (forwardingBatchSize <= 0 || forwardingBatchSize > MAX_FORWARDING_BATCH_SIZE) {
                 throw new IllegalArgumentException("Forwarding batch size must be between 1 and 3000 inclusive.");
             }
             this.forwardingBatchSize = forwardingBatchSize;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
@@ -27,6 +27,7 @@ public class PeerForwarderConfiguration {
     public static final String DEFAULT_CERTIFICATE_FILE_PATH = "config/default_certificate.pem";
     public static final String DEFAULT_PRIVATE_KEY_FILE_PATH = "config/default_private_key.pem";
     private static final String S3_PREFIX = "s3://";
+    private static final int MAX_FORWADING_BATCH_SIZE = 3000;
 
     private Integer serverPort = 4994;
     private Integer requestTimeout = 10_000;
@@ -57,6 +58,7 @@ public class PeerForwarderConfiguration {
     private boolean sslCertAndKeyFileInS3 = false;
     private Duration drainTimeout = DEFAULT_DRAIN_TIMEOUT;
     private Integer failedForwardingRequestLocalWriteTimeout = 500;
+    private Integer forwardingBatchSize = 1500;
 
     public PeerForwarderConfiguration() {}
 
@@ -89,7 +91,8 @@ public class PeerForwarderConfiguration {
             @JsonProperty("batch_delay") final Integer batchDelay,
             @JsonProperty("buffer_size") final Integer bufferSize,
             @JsonProperty("drain_timeout") final Duration drainTimeout,
-            @JsonProperty("failed_forwarding_requests_local_write_timeout") final Integer failedForwardingRequestLocalWriteTimeout
+            @JsonProperty("failed_forwarding_requests_local_write_timeout") final Integer failedForwardingRequestLocalWriteTimeout,
+            @JsonProperty("forwarding_batch_size") final Integer forwardingBatchSize
     ) {
         setServerPort(serverPort);
         setRequestTimeout(requestTimeout);
@@ -119,6 +122,7 @@ public class PeerForwarderConfiguration {
         setBufferSize(bufferSize);
         setDrainTimeout(drainTimeout);
         setFailedForwardingRequestLocalWriteTimeout(failedForwardingRequestLocalWriteTimeout);
+        setForwardingBatchSize(forwardingBatchSize);
         checkForCertAndKeyFileInS3();
         validateSslAndAuthentication();
     }
@@ -221,6 +225,10 @@ public class PeerForwarderConfiguration {
 
     public Integer getFailedForwardingRequestLocalWriteTimeout() {
         return failedForwardingRequestLocalWriteTimeout;
+    }
+
+    public Integer getForwardingBatchSize() {
+        return forwardingBatchSize;
     }
 
     private void setServerPort(final Integer serverPort) {
@@ -474,6 +482,15 @@ public class PeerForwarderConfiguration {
                 throw new IllegalArgumentException("Failed forwarding requests local write timeout must be a positive integer.");
             }
             this.failedForwardingRequestLocalWriteTimeout = failedForwardingRequestLocalWriteTimeout;
+        }
+    }
+
+    private void setForwardingBatchSize(final Integer forwardingBatchSize) {
+        if (forwardingBatchSize != null) {
+            if (forwardingBatchSize <= 0 || forwardingBatchSize > MAX_FORWADING_BATCH_SIZE) {
+                throw new IllegalArgumentException("Forwarding batch size must be between 1 and 3000 inclusive.");
+            }
+            this.forwardingBatchSize = forwardingBatchSize;
         }
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
@@ -57,7 +57,8 @@ public class PeerForwarderProvider {
                     pluginMetrics,
                     peerForwarderConfiguration.getBatchDelay(),
                     peerForwarderConfiguration.getFailedForwardingRequestLocalWriteTimeout(),
-                    Executors.newFixedThreadPool(peerForwarderConfiguration.getClientThreadCount())
+                    Executors.newFixedThreadPool(peerForwarderConfiguration.getClientThreadCount()),
+                    peerForwarderConfiguration.getForwardingBatchSize()
             );
         }
         else {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
@@ -35,7 +35,8 @@ public class PeerForwarderProvider {
         this.pluginMetrics = pluginMetrics;
     }
 
-    public PeerForwarder register(final String pipelineName, final String pluginId, final Set<String> identificationKeys) {
+    public PeerForwarder register(final String pipelineName, final String pluginId, final Set<String> identificationKeys,
+                                  final Integer pipelineWorkerThreads) {
         if (pipelinePeerForwarderReceiveBufferMap.containsKey(pipelineName) &&
                 pipelinePeerForwarderReceiveBufferMap.get(pipelineName).containsKey(pluginId)) {
             throw new RuntimeException("Data Prepper 2.0 will only support a single peer-forwarder per pipeline/plugin type");
@@ -58,7 +59,9 @@ public class PeerForwarderProvider {
                     peerForwarderConfiguration.getBatchDelay(),
                     peerForwarderConfiguration.getFailedForwardingRequestLocalWriteTimeout(),
                     Executors.newFixedThreadPool(peerForwarderConfiguration.getClientThreadCount()),
-                    peerForwarderConfiguration.getForwardingBatchSize()
+                    peerForwarderConfiguration.getForwardingBatchSize(),
+                    peerForwarderConfiguration.getForwardingBatchTimeout(),
+                    pipelineWorkerThreads
             );
         }
         else {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
@@ -28,7 +28,8 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
             final List<Processor> processors,
             final PeerForwarderProvider peerForwarderProvider,
             final String pipelineName,
-            final String pluginId) {
+            final String pluginId,
+            final Integer pipelineWorkerThreads) {
 
         Set<String> identificationKeys;
         Processor firstInnerProcessor;
@@ -65,7 +66,7 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
                     "Peer Forwarder Plugin: %s cannot have empty identification keys." + pluginId);
         }
 
-        final PeerForwarder peerForwarder = peerForwarderProvider.register(pipelineName, pluginId, identificationKeys);
+        final PeerForwarder peerForwarder = peerForwarderProvider.register(pipelineName, pluginId, identificationKeys, pipelineWorkerThreads);
 
         return processors.stream().map(processor -> new PeerForwardingProcessorDecorator(peerForwarder, processor))
                 .collect(Collectors.toList());

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
@@ -265,7 +265,7 @@ class RemotePeerForwarder implements PeerForwarder {
 
     private boolean shouldFlushBatch(final String destinationIp) {
         final long currentTime = System.currentTimeMillis();
-        final long millisSinceLastFlush = currentTime - peerBatchingLastFlushTimeMap.get(destinationIp);
+        final long millisSinceLastFlush = currentTime - peerBatchingLastFlushTimeMap.getOrDefault(destinationIp, System.currentTimeMillis());
         final Duration durationSinceLastFlush = Duration.of(millisSinceLastFlush, ChronoUnit.MILLIS);
 
         final boolean shouldFlushDueToTimeout = durationSinceLastFlush.compareTo(forwardingBatchTimeout) >= 0;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
@@ -22,11 +22,13 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration.DEFAULT_FORWARDING_BATCH_TIMEOUT;
 import static org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration.DEFAULT_PRIVATE_KEY_FILE_PATH;
 
 class PeerForwarderConfigurationTest {
@@ -61,6 +63,7 @@ class PeerForwarderConfigurationTest {
         assertThat(peerForwarderConfiguration.getDrainTimeout(), equalTo(DEFAULT_DRAIN_TIMEOUT));
         assertThat(peerForwarderConfiguration.getFailedForwardingRequestLocalWriteTimeout(), equalTo(500));
         assertThat(peerForwarderConfiguration.getForwardingBatchSize(), equalTo(1500));
+        assertThat(peerForwarderConfiguration.getForwardingBatchTimeout(), equalTo(DEFAULT_FORWARDING_BATCH_TIMEOUT));
     }
 
     @Test
@@ -90,6 +93,7 @@ class PeerForwarderConfigurationTest {
         assertThat(peerForwarderConfiguration.getDrainTimeout(), equalTo(DEFAULT_DRAIN_TIMEOUT));
         assertThat(peerForwarderConfiguration.getFailedForwardingRequestLocalWriteTimeout(), equalTo(15));
         assertThat(peerForwarderConfiguration.getForwardingBatchSize(), equalTo(2500));
+        assertThat(peerForwarderConfiguration.getForwardingBatchTimeout(), equalTo(Duration.of(5, ChronoUnit.SECONDS)));
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
@@ -60,6 +60,7 @@ class PeerForwarderConfigurationTest {
         assertThat(peerForwarderConfiguration.getAuthentication(), equalTo(ForwardingAuthentication.UNAUTHENTICATED));
         assertThat(peerForwarderConfiguration.getDrainTimeout(), equalTo(DEFAULT_DRAIN_TIMEOUT));
         assertThat(peerForwarderConfiguration.getFailedForwardingRequestLocalWriteTimeout(), equalTo(500));
+        assertThat(peerForwarderConfiguration.getForwardingBatchSize(), equalTo(1500));
     }
 
     @Test
@@ -88,6 +89,7 @@ class PeerForwarderConfigurationTest {
         assertThat(peerForwarderConfiguration.getAuthentication(), equalTo(ForwardingAuthentication.UNAUTHENTICATED));
         assertThat(peerForwarderConfiguration.getDrainTimeout(), equalTo(DEFAULT_DRAIN_TIMEOUT));
         assertThat(peerForwarderConfiguration.getFailedForwardingRequestLocalWriteTimeout(), equalTo(15));
+        assertThat(peerForwarderConfiguration.getForwardingBatchSize(), equalTo(2500));
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProviderTest.java
@@ -19,6 +19,7 @@ import org.opensearch.dataprepper.peerforwarder.discovery.DiscoveryMode;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
@@ -35,6 +36,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PeerForwarderProviderTest {
+    private static final int PIPELINE_WORKER_THREADS = new Random().nextInt(10) + 1;
 
     @Mock
     private PeerForwarderClientFactory peerForwarderClientFactory;
@@ -76,7 +78,7 @@ class PeerForwarderProviderTest {
     @Test
     void register_creates_a_new_RemotePeerForwarder_with_cloud_map_discovery_mode() {
         when(peerForwarderConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.AWS_CLOUD_MAP);
-        final PeerForwarder peerForwarder = createObjectUnderTest().register(pipelineName, pluginId, identificationKeys);
+        final PeerForwarder peerForwarder = createObjectUnderTest().register(pipelineName, pluginId, identificationKeys, PIPELINE_WORKER_THREADS);
 
         assertThat(peerForwarder, instanceOf(RemotePeerForwarder.class));
     }
@@ -85,7 +87,7 @@ class PeerForwarderProviderTest {
     void register_creates_a_new_RemotePeerForwarder_with_static_discovery_mode_of_size_grater_than_one() {
         when(peerForwarderConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.STATIC);
         when(peerForwarderConfiguration.getStaticEndpoints()).thenReturn(List.of("endpoint1", "endpoint2"));
-        final PeerForwarder peerForwarder = createObjectUnderTest().register(pipelineName, pluginId, identificationKeys);
+        final PeerForwarder peerForwarder = createObjectUnderTest().register(pipelineName, pluginId, identificationKeys, PIPELINE_WORKER_THREADS);
 
         assertThat(peerForwarder, instanceOf(RemotePeerForwarder.class));
     }
@@ -94,14 +96,14 @@ class PeerForwarderProviderTest {
     void register_creates_a_new_RemotePeerForwarder_with_static_discovery_mode_of_size_one() {
         when(peerForwarderConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.STATIC);
         when(peerForwarderConfiguration.getStaticEndpoints()).thenReturn(List.of("endpoint1"));
-        final PeerForwarder peerForwarder = createObjectUnderTest().register(pipelineName, pluginId, identificationKeys);
+        final PeerForwarder peerForwarder = createObjectUnderTest().register(pipelineName, pluginId, identificationKeys, PIPELINE_WORKER_THREADS);
 
         assertThat(peerForwarder, instanceOf(LocalPeerForwarder.class));
     }
 
     @Test
     void register_creates_a_new_LocalPeerForwarder_with_local_discovery_mode() {
-        final PeerForwarder peerForwarder = createObjectUnderTest().register(pipelineName, pluginId, identificationKeys);
+        final PeerForwarder peerForwarder = createObjectUnderTest().register(pipelineName, pluginId, identificationKeys, PIPELINE_WORKER_THREADS);
 
         assertThat(peerForwarder, instanceOf(LocalPeerForwarder.class));
     }
@@ -109,7 +111,7 @@ class PeerForwarderProviderTest {
     @Test
     void register_creates_HashRing_if_peer_forwarding_is_required() {
         when(peerForwarderConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.AWS_CLOUD_MAP);
-        createObjectUnderTest().register(pipelineName, pluginId, identificationKeys);
+        createObjectUnderTest().register(pipelineName, pluginId, identificationKeys, PIPELINE_WORKER_THREADS);
 
         verify(peerForwarderClientFactory).createHashRing();
     }
@@ -120,7 +122,7 @@ class PeerForwarderProviderTest {
         final PeerForwarderProvider objectUnderTest = createObjectUnderTest();
 
         for (int i = 0; i < 10; i++)
-            objectUnderTest.register(pipelineName, UUID.randomUUID().toString(), identificationKeys);
+            objectUnderTest.register(pipelineName, UUID.randomUUID().toString(), identificationKeys, PIPELINE_WORKER_THREADS);
 
         verify(peerForwarderClientFactory, times(1)).createHashRing();
     }
@@ -136,17 +138,17 @@ class PeerForwarderProviderTest {
     void isAtLeastOnePeerForwarderRegistered_should_throw_when_register_is_called_with_same_pipeline_and_plugin() {
         final PeerForwarderProvider objectUnderTest = createObjectUnderTest();
 
-        objectUnderTest.register(pipelineName, pluginId, identificationKeys);
+        objectUnderTest.register(pipelineName, pluginId, identificationKeys, PIPELINE_WORKER_THREADS);
 
         assertThrows(RuntimeException.class, () ->
-                objectUnderTest.register(pipelineName, pluginId, identificationKeys));
+                objectUnderTest.register(pipelineName, pluginId, identificationKeys, PIPELINE_WORKER_THREADS));
     }
 
     @Test
     void isAtLeastOnePeerForwarderRegistered_should_return_false_if_register_is_called_with_local_discovery_mode() {
         final PeerForwarderProvider objectUnderTest = createObjectUnderTest();
 
-        objectUnderTest.register(pipelineName, pluginId, identificationKeys);
+        objectUnderTest.register(pipelineName, pluginId, identificationKeys, PIPELINE_WORKER_THREADS);
 
         assertThat(objectUnderTest.isPeerForwardingRequired(), equalTo(false));
     }
@@ -156,7 +158,7 @@ class PeerForwarderProviderTest {
         when(peerForwarderConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.AWS_CLOUD_MAP);
         final PeerForwarderProvider objectUnderTest = createObjectUnderTest();
 
-        objectUnderTest.register(pipelineName, pluginId, identificationKeys);
+        objectUnderTest.register(pipelineName, pluginId, identificationKeys, PIPELINE_WORKER_THREADS);
 
         assertThat(objectUnderTest.isPeerForwardingRequired(), equalTo(true));
     }
@@ -178,7 +180,7 @@ class PeerForwarderProviderTest {
     void getPipelinePeerForwarderReceiveBufferMap_should_return_non_empty_map_when_register_is_called() {
         final PeerForwarderProvider objectUnderTest = createObjectUnderTest();
 
-        objectUnderTest.register(pipelineName, UUID.randomUUID().toString(), identificationKeys);
+        objectUnderTest.register(pipelineName, UUID.randomUUID().toString(), identificationKeys, PIPELINE_WORKER_THREADS);
 
         final Map<String, Map<String, PeerForwarderReceiveBuffer<Record<Event>>>> pipelinePeerForwarderReceiveBufferMap = objectUnderTest
                 .getPipelinePeerForwarderReceiveBufferMap();

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -469,6 +469,7 @@ class PeerForwarder_ClientServerIT {
                 3000,
                 512,
                 null,
+                null,
                 null
         );
     }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
@@ -57,7 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * works.
  */
 class PeerForwarder_ClientServerIT {
-
+    private static final int PIPELINE_WORKER_THREADS = new Random().nextInt(10) + 1;
     private static final String LOCALHOST = "127.0.0.1";
     private static final String SSL_CERTIFICATE_FILE = "src/test/resources/test-crt.crt";
     private static final String SSL_KEY_FILE = "src/test/resources/test-key.key";
@@ -146,7 +147,7 @@ class PeerForwarder_ClientServerIT {
 
             final CertificateProviderFactory certificateProviderFactory = new CertificateProviderFactory(peerForwarderConfiguration);
             peerForwarderProvider = createPeerForwarderProvider(peerForwarderConfiguration, certificateProviderFactory);
-            peerForwarderProvider.register(pipelineName, pluginId, Collections.singleton(UUID.randomUUID().toString()));
+            peerForwarderProvider.register(pipelineName, pluginId, Collections.singleton(UUID.randomUUID().toString()), PIPELINE_WORKER_THREADS);
             server = createServer(peerForwarderConfiguration, certificateProviderFactory, peerForwarderProvider);
             server.start();
         }
@@ -250,7 +251,7 @@ class PeerForwarder_ClientServerIT {
 
             final CertificateProviderFactory certificateProviderFactory = new CertificateProviderFactory(peerForwarderConfiguration);
             peerForwarderProvider = createPeerForwarderProvider(peerForwarderConfiguration, certificateProviderFactory);
-            peerForwarderProvider.register(pipelineName, pluginId, Collections.singleton(UUID.randomUUID().toString()));
+            peerForwarderProvider.register(pipelineName, pluginId, Collections.singleton(UUID.randomUUID().toString()), PIPELINE_WORKER_THREADS);
             server = createServer(peerForwarderConfiguration, certificateProviderFactory, peerForwarderProvider);
             server.start();
         }
@@ -303,7 +304,7 @@ class PeerForwarder_ClientServerIT {
 
             final CertificateProviderFactory certificateProviderFactory = new CertificateProviderFactory(peerForwarderConfiguration);
             peerForwarderProvider = createPeerForwarderProvider(peerForwarderConfiguration, certificateProviderFactory);
-            peerForwarderProvider.register(pipelineName, pluginId, Collections.singleton(UUID.randomUUID().toString()));
+            peerForwarderProvider.register(pipelineName, pluginId, Collections.singleton(UUID.randomUUID().toString()), PIPELINE_WORKER_THREADS);
             server = createServer(peerForwarderConfiguration, certificateProviderFactory, peerForwarderProvider);
             server.start();
         }
@@ -468,6 +469,7 @@ class PeerForwarder_ClientServerIT {
                 48,
                 3000,
                 512,
+                null,
                 null,
                 null,
                 null

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
@@ -39,6 +40,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PeerForwardingProcessingDecoratorTest {
+    private static final int PIPELINE_WORKER_THREADS = new Random().nextInt(10) + 1;
     private static final String TEST_IDENTIFICATION_KEY = "identification_key";
 
     private Record<Event> record;
@@ -66,7 +68,7 @@ class PeerForwardingProcessingDecoratorTest {
     }
 
     private List<Processor> createObjectUnderTesDecoratedProcessors(final List<Processor> processors) {
-        return PeerForwardingProcessorDecorator.decorateProcessors(processors, peerForwarderProvider, pipelineName, pluginId);
+        return PeerForwardingProcessorDecorator.decorateProcessors(processors, peerForwarderProvider, pipelineName, pluginId, PIPELINE_WORKER_THREADS);
     }
 
     @Test
@@ -113,7 +115,7 @@ class PeerForwardingProcessingDecoratorTest {
         void setUp() {
             identificationKeys = Set.of(TEST_IDENTIFICATION_KEY);
 
-            when(peerForwarderProvider.register(pipelineName, pluginId, identificationKeys)).thenReturn(peerForwarder);
+            when(peerForwarderProvider.register(pipelineName, pluginId, identificationKeys, PIPELINE_WORKER_THREADS)).thenReturn(peerForwarder);
             when(requiresPeerForwarding.getIdentificationKeys()).thenReturn(identificationKeys);
             processor = (Processor) requiresPeerForwarding;
         }
@@ -122,7 +124,7 @@ class PeerForwardingProcessingDecoratorTest {
         void PeerForwardingProcessingDecorator_should_have_interaction_with_getIdentificationKeys() {
             createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
             verify(requiresPeerForwarding, times(2)).getIdentificationKeys();
-            verify(peerForwarderProvider).register(pipelineName, pluginId, identificationKeys);
+            verify(peerForwarderProvider).register(pipelineName, pluginId, identificationKeys, PIPELINE_WORKER_THREADS);
         }
 
         @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
@@ -252,7 +252,7 @@ class RemotePeerForwarderTest {
 
         final RemotePeerForwarder peerForwarder = createObjectUnderTest();
 
-        final int recordsSetsToGenerate = new Random().nextInt(FORWARDING_BATCH_SIZE) + FORWARDING_BATCH_SIZE + 1;
+        final int recordsSetsToGenerate = new Random().nextInt(FORWARDING_BATCH_SIZE - 1) + FORWARDING_BATCH_SIZE;
         final Collection<Record<Event>> inputRecords = generateSetsofBatchRecords(recordsSetsToGenerate, 2);
 
         // Send first forwarding request with record count under the batch size

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
@@ -60,6 +60,7 @@ class RemotePeerForwarderTest {
     private static final int TEST_BATCH_DELAY = 3_000;
     private static final int TEST_LOCAL_WRITE_TIMEOUT = 500;
     private static final int TEST_TIMEOUT_IN_MILLIS = 500;
+    private static final int FORWARDING_BATCH_SIZE = 5;
 
     @Mock
     private PeerForwarderClient peerForwarderClient;
@@ -135,7 +136,7 @@ class RemotePeerForwarderTest {
 
     private RemotePeerForwarder createObjectUnderTest() {
         return new RemotePeerForwarder(peerForwarderClient, hashRing, peerForwarderReceiveBuffer, pipelineName, pluginId,
-                identificationKeys, pluginMetrics, TEST_BATCH_DELAY, TEST_LOCAL_WRITE_TIMEOUT, executorService);
+                identificationKeys, pluginMetrics, TEST_BATCH_DELAY, TEST_LOCAL_WRITE_TIMEOUT, executorService, FORWARDING_BATCH_SIZE);
     }
 
     @Test

--- a/data-prepper-core/src/test/resources/valid_peer_forwarder_config.yml
+++ b/data-prepper-core/src/test/resources/valid_peer_forwarder_config.yml
@@ -11,3 +11,4 @@ batch_size: 100
 buffer_size: 100
 batch_delay: 10
 failed_forwarding_requests_local_write_timeout: 15
+forwarding_batch_size: 2500

--- a/data-prepper-core/src/test/resources/valid_peer_forwarder_config.yml
+++ b/data-prepper-core/src/test/resources/valid_peer_forwarder_config.yml
@@ -12,3 +12,4 @@ buffer_size: 100
 batch_delay: 10
 failed_forwarding_requests_local_write_timeout: 15
 forwarding_batch_size: 2500
+forwarding_batch_timeout: 5s


### PR DESCRIPTION
Signed-off-by: Chase Engelbrecht <engechas@amazon.com>

### Description
Adds implementation for batching the content of requests sent to a peer. This is aimed at reducing the number of network calls needed by the CPF.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
