### PR TITLE
Add configurable bound to CPF executor service

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
@@ -51,6 +51,7 @@ public class PeerForwarderConfiguration {
     private String domainName;
     private List<String> staticEndpoints = new ArrayList<>();
     private Integer clientThreadCount = 200;
+    private Integer clientThreadPoolBound = 500;
     private Integer batchSize = 48;
     private Integer batchDelay = 3_000;
     private Integer bufferSize = 512;
@@ -85,6 +86,7 @@ public class PeerForwarderConfiguration {
             @JsonProperty("domain_name") final String domainName,
             @JsonProperty("static_endpoints") final List<String> staticEndpoints,
             @JsonProperty("client_thread_count") final Integer clientThreadCount,
+            @JsonProperty("client_thread_pool_bound") final Integer clientThreadPoolBound,
             @JsonProperty("batch_size") final Integer batchSize,
             @JsonProperty("batch_delay") final Integer batchDelay,
             @JsonProperty("buffer_size") final Integer bufferSize,
@@ -114,6 +116,7 @@ public class PeerForwarderConfiguration {
         setDomainName(domainName);
         setStaticEndpoints(staticEndpoints);
         setClientThreadCount(clientThreadCount);
+        setClientThreadPoolBound(clientThreadPoolBound);
         setBatchSize(batchSize);
         setBatchDelay(batchDelay);
         setBufferSize(bufferSize);
@@ -201,6 +204,10 @@ public class PeerForwarderConfiguration {
 
     public Integer getClientThreadCount() {
         return clientThreadCount;
+    }
+
+    public Integer getClientThreadPoolBound() {
+        return clientThreadPoolBound;
     }
 
     public int getBatchSize() {
@@ -413,6 +420,15 @@ public class PeerForwarderConfiguration {
                 throw new IllegalArgumentException("Client thread count must be a positive integer.");
             }
             this.clientThreadCount = clientThreadCount;
+        }
+    }
+
+    public void setClientThreadPoolBound(final Integer clientThreadPoolBound) {
+        if (clientThreadPoolBound != null) {
+            if (clientThreadPoolBound <= 0) {
+                throw new IllegalArgumentException("Client thread count must be a positive integer.");
+            }
+            this.clientThreadPoolBound = clientThreadPoolBound;
         }
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
@@ -14,7 +14,10 @@ import org.opensearch.dataprepper.peerforwarder.discovery.DiscoveryMode;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class PeerForwarderProvider {
 
@@ -57,7 +60,7 @@ public class PeerForwarderProvider {
                     pluginMetrics,
                     peerForwarderConfiguration.getBatchDelay(),
                     peerForwarderConfiguration.getFailedForwardingRequestLocalWriteTimeout(),
-                    Executors.newFixedThreadPool(peerForwarderConfiguration.getClientThreadCount())
+                    getClientExecutorService()
             );
         }
         else {
@@ -94,5 +97,11 @@ public class PeerForwarderProvider {
 
     public Map<String, Map<String, PeerForwarderReceiveBuffer<Record<Event>>>> getPipelinePeerForwarderReceiveBufferMap() {
         return pipelinePeerForwarderReceiveBufferMap;
+    }
+
+    private ExecutorService getClientExecutorService() {
+        return new ThreadPoolExecutor(peerForwarderConfiguration.getClientThreadCount(),
+                peerForwarderConfiguration.getClientThreadCount(), 0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(peerForwarderConfiguration.getClientThreadPoolBound()));
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfigurationTest.java
@@ -54,6 +54,7 @@ class PeerForwarderConfigurationTest {
         assertThat(peerForwarderConfiguration.isUseAcmCertificateForSsl(), equalTo(false));
         assertThat(peerForwarderConfiguration.getDiscoveryMode(), equalTo(DiscoveryMode.LOCAL_NODE));
         assertThat(peerForwarderConfiguration.getClientThreadCount(), equalTo(200));
+        assertThat(peerForwarderConfiguration.getClientThreadPoolBound(), equalTo(500));
         assertThat(peerForwarderConfiguration.getBatchSize(), equalTo(48));
         assertThat(peerForwarderConfiguration.getBatchDelay(), equalTo(3_000));
         assertThat(peerForwarderConfiguration.getBufferSize(), equalTo(512));
@@ -82,6 +83,7 @@ class PeerForwarderConfigurationTest {
         assertThat(peerForwarderConfiguration.getAwsCloudMapNamespaceName(), equalTo(null));
         assertThat(peerForwarderConfiguration.getAwsCloudMapServiceName(), equalTo(null));
         assertThat(peerForwarderConfiguration.getClientThreadCount(), equalTo(100));
+        assertThat(peerForwarderConfiguration.getClientThreadPoolBound(), equalTo(50));
         assertThat(peerForwarderConfiguration.getBatchSize(), equalTo(100));
         assertThat(peerForwarderConfiguration.getBatchDelay(), equalTo(10));
         assertThat(peerForwarderConfiguration.getBufferSize(), equalTo(100));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProviderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProviderTest.java
@@ -66,6 +66,7 @@ class PeerForwarderProviderTest {
         lenient().when(peerForwarderConfiguration.getBatchSize()).thenReturn(48);
         lenient().when(peerForwarderConfiguration.getFailedForwardingRequestLocalWriteTimeout()).thenReturn(500);
         lenient().when(peerForwarderConfiguration.getClientThreadCount()).thenReturn(8);
+        lenient().when(peerForwarderConfiguration.getClientThreadPoolBound()).thenReturn(16);
         when(peerForwarderConfiguration.getDiscoveryMode()).thenReturn(DiscoveryMode.LOCAL_NODE);
     }
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -465,6 +465,7 @@ class PeerForwarder_ClientServerIT {
                 null,
                 List.of("127.0.0.1"),
                 200,
+                500,
                 48,
                 3000,
                 512,

--- a/data-prepper-core/src/test/resources/valid_peer_forwarder_config.yml
+++ b/data-prepper-core/src/test/resources/valid_peer_forwarder_config.yml
@@ -7,6 +7,7 @@ ssl: false
 use_acm_certificate_for_ssl: false
 discovery_mode: static
 client_thread_count: 100
+client_thread_pool_bound: 50
 batch_size: 100
 buffer_size: 100
 batch_delay: 10


### PR DESCRIPTION
Signed-off-by: Chase Engelbrecht <engechas@amazon.com>

### Description
Adds a configurable bound to the ExecutorService used in the RemotePeerForwarder to prevent excessive GC when the CPF cannot keep up with the incoming traffic
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
