### PR TITLE
Abstract sink should not create a new retry thread everytime initialization fails

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/AbstractSink.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/AbstractSink.java
@@ -38,7 +38,7 @@ public abstract class AbstractSink<T extends Record<?>> implements Sink<T> {
             doInitialize();
         } catch (Exception e) {
         }
-        if (!isReady()) {
+        if (!isReady() && retryThread == null) {
             retryThread = new Thread(new SinkThread(this, NUMBER_OF_RETRIES));
             retryThread.start();
         }


### PR DESCRIPTION
Signed-off-by: Krishna Kondaka <krishkdk@amazon.com>

### Description
In the code changes made to support retries of Sink initialization, retry thread is being created every time initialization failed.
This changes fixes it checking to make sure retry thread is not already created before creating it.
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
