### PR TITLE
Update default values in buffer documentation

### DIFF
--- a/data-prepper-plugins/blocking-buffer/README.md
+++ b/data-prepper-plugins/blocking-buffer/README.md
@@ -11,8 +11,8 @@ buffer:
 *Note*: *By default, Data Prepper uses only one buffer. the `bounded_blocking` buffer, so this section in the `.yaml` need not be defined unless one wants to mention a custom buffer or tune the buffer settings*
 
 ## Configuration
-- buffer_size => An `int` representing max number of unchecked records the buffer accepts (num of unchecked records = num of records written into the buffer + num of in-flight records not yet checked by the Checkpointing API). Default is `512`.
-- batch_size => An `int` representing max number of records the buffer returns on read. Default is `8`.
+- buffer_size => An `int` representing max number of unchecked records the buffer accepts (num of unchecked records = num of records written into the buffer + num of in-flight records not yet checked by the Checkpointing API). Default is `12800`.
+- batch_size => An `int` representing max number of records the buffer returns on read. Default is `200`.
 
 ## Metrics
 This plugin inherits the common metrics defined in [AbstractBuffer](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/AbstractBuffer.java) and the additional customer metrics:

--- a/docs/trace_analytics.md
+++ b/docs/trace_analytics.md
@@ -87,12 +87,12 @@ otel-trace-pipeline:
        # buffer_size is the number of ExportTraceRequest from otel-collector the data prepper should hold in memeory. 
        # We recommend to keep the same buffer_size for all pipelines. 
        # Make sure you configure sufficient heap
-       # default value is 512
-       buffer_size: 512
+       # default value is 12800
+       buffer_size: 25600
        # This is the maximum number of request each worker thread will process within the delay.
-       # Default is 8.
+       # Default is 200.
        # Make sure buffer_size >= workers * batch_size
-       batch_size: 8
+       batch_size: 400
   sink:
     - pipeline:
         name: "raw-pipeline"
@@ -110,12 +110,13 @@ raw-pipeline:
       bounded_blocking:
          # Configure the same value as in otel-trace-pipeline
          # Make sure you configure sufficient heap
-         # default value is 512
-         buffer_size: 512
+         # default value is 12800
+         buffer_size: 25600
+         # This is the maximum number of request each worker thread will process within the delay.
+         # Default is 200.
+         # Make sure buffer_size >= workers * batch_size
          # The raw processor does bulk request to your OpenSearch sink, so configure the batch_size higher.
-         # If you use the recommended otel-collector setup each ExportTraceRequest could contain max 50 spans. https://github.com/opensearch-project/data-prepper/tree/v0.7.x/deployment/aws
-         # With 64 as batch size each worker thread could process upto 3200 spans (64 * 50)
-         batch_size: 64
+         batch_size: 3200
   processor:
     - otel_trace_raw:
     - otel_trace_group:
@@ -161,12 +162,12 @@ service-map-pipeline:
          # buffer_size is the number of ExportTraceRequest from otel-collector the data prepper should hold in memeory. 
          # We recommend to keep the same buffer_size for all pipelines. 
          # Make sure you configure sufficient heap
-         # default value is 512
-         buffer_size: 512
+         # default value is 12800
+         buffer_size: 25600
          # This is the maximum number of request each worker thread will process within the delay.
-         # Default is 8.
+         # Default is 200.
          # Make sure buffer_size >= workers * batch_size
-         batch_size: 8
+         batch_size: 400
   sink:
     - opensearch:
         hosts: [ "https://localhost:9200" ]


### PR DESCRIPTION
Signed-off-by: Jannik Brand <jannik.brand@sap.com>

### Description
This PR updates the default buffer values (`buffer_size`, `batch_size`) in the documentation. There are new default values due to #1906 (since version [2.0.0](https://github.com/opensearch-project/data-prepper/releases/tag/2.0.0)). The default `buffer_size` (previously: 512) and default `batch_size` (previously: 8) were increased by the factor 25. The new default values are: `buffer_size`: 12800 and `batch_size`: 200.
Within the `trace_analytics.md` file an example for a possible trace pipeline setup is given. I increased the new default values by a factor of 2, so that it will match the 3200 spans each raw-pipeline worker thread could process before.

### Issues Resolved
Resolves #1983 (in combination with https://github.com/opensearch-project/documentation-website/pull/2574)
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
