### PR TITLE
Use Armeria's BlockingTaskExecutor to configure thread names

### DIFF
--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
@@ -40,7 +40,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.function.Function;
 
 @DataPrepperPlugin(name = "otel_trace_source", pluginType = Source.class, pluginConfigurationType = OTelTraceSourceConfig.class)

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.oteltrace;
 
+import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -52,15 +53,12 @@ public class OTelTraceSource implements Source<Record<Object>> {
     private final PluginMetrics pluginMetrics;
     private final GrpcAuthenticationProvider authenticationProvider;
     private final CertificateProviderFactory certificateProviderFactory;
+    private final String pipelineName;
 
     @DataPrepperPluginConstructor
     public OTelTraceSource(final OTelTraceSourceConfig oTelTraceSourceConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory,
                            final PipelineDescription pipelineDescription) {
-        oTelTraceSourceConfig.validateAndInitializeCertAndKeyFileInS3();
-        this.oTelTraceSourceConfig = oTelTraceSourceConfig;
-        this.pluginMetrics = pluginMetrics;
-        this.certificateProviderFactory = new CertificateProviderFactory(oTelTraceSourceConfig);
-        this.authenticationProvider = createAuthenticationProvider(pluginFactory, pipelineDescription);
+        this(oTelTraceSourceConfig, pluginMetrics, pluginFactory, new CertificateProviderFactory(oTelTraceSourceConfig), pipelineDescription);
     }
 
     // accessible only in the same package for unit test
@@ -71,6 +69,7 @@ public class OTelTraceSource implements Source<Record<Object>> {
         this.pluginMetrics = pluginMetrics;
         this.certificateProviderFactory = certificateProviderFactory;
         this.authenticationProvider = createAuthenticationProvider(pluginFactory, pipelineDescription);
+        this.pipelineName = pipelineDescription.getPipelineName();
     }
 
     @Override
@@ -147,9 +146,11 @@ public class OTelTraceSource implements Source<Record<Object>> {
             }
 
             sb.maxNumConnections(oTelTraceSourceConfig.getMaxConnectionCount());
-            sb.blockingTaskExecutor(
-                    Executors.newScheduledThreadPool(oTelTraceSourceConfig.getThreadCount()),
-                    true);
+            final BlockingTaskExecutor blockingTaskExecutor = BlockingTaskExecutor.builder()
+                    .numThreads(oTelTraceSourceConfig.getThreadCount())
+                    .threadNamePrefix(pipelineName + "-otel_trace")
+                    .build();
+            sb.blockingTaskExecutor(blockingTaskExecutor, true);
 
             server = sb.build();
         }


### PR DESCRIPTION
### Description

This PR makes a few changes to the OTel Trace Source:
* Use Armeria's `BlockingTaskExecutor` class which wraps a ScheduledThreadPool.
* Give each OTel Trace thread a name which uses the pipeline name and "-otel_trace" to make tracking threads easier.
* Improved constructor use for maintainability
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
