### PR TITLE
Re-use the default RecordMetadata

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/record/RecordMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/record/RecordMetadata.java
@@ -15,6 +15,8 @@ import java.util.Map;
  */
 @Deprecated
 public class RecordMetadata {
+    private static final RecordMetadata DEFAULT_METADATA = new RecordMetadata();
+
     //forcing it to a concrete type to show that I want it to be Immutable
     private final ImmutableMap<String, Object> metadata;
 
@@ -62,7 +64,7 @@ public class RecordMetadata {
      * @return an empty MetadataRecords object.
      */
     public static RecordMetadata defaultMetadata() {
-        return new RecordMetadata();
+        return DEFAULT_METADATA;
     }
 
     /**

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/record/RecordMetadataTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/record/RecordMetadataTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.record;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class RecordMetadataTest {
+    @Test
+    void defaultMetadata_returns_the_same_instance_when_called_multiple_times() {
+        assertThat(RecordMetadata.defaultMetadata(), sameInstance(RecordMetadata.defaultMetadata()));
+    }
+    @Test
+    void getMetadataObject_on_defaultMetadata_is_expected_value() {
+        final RecordMetadata objectUnderTest = RecordMetadata.defaultMetadata();
+        assertThat(objectUnderTest, notNullValue());
+        assertThat(objectUnderTest.getMetadataObject(), notNullValue());
+        assertThat(objectUnderTest.getMetadataObject().size(), equalTo(1));
+        assertThat(objectUnderTest.getMetadataObject().get(RecordMetadata.RECORD_TYPE), equalTo("unknown"));
+    }
+}


### PR DESCRIPTION
### Description

Each time a source creates a new Record, it also creates a new `RecordMetadata`. Most of these are also using the default. This class is immutable so the default value can be re-used across `Record` objects. This PR uses a private static shared default that is re-used.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
