### PR TITLE
Use ImmutableMap.of() in DefaultEventMetadata

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventMetadata.java
@@ -35,7 +35,7 @@ public class DefaultEventMetadata implements EventMetadata {
 
         this.timeReceived = builder.timeReceived == null ? Instant.now() : builder.timeReceived;
 
-        this.attributes = builder.attributes == null ? new ImmutableMap.Builder<String, Object>().build() : ImmutableMap.copyOf(builder.attributes);
+        this.attributes = builder.attributes == null ? ImmutableMap.of() : ImmutableMap.copyOf(builder.attributes);
     }
 
     @Override

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
@@ -81,6 +81,30 @@ public class DefaultEventMetadataTest {
     }
 
     @Test
+    public void testAttributesMutation_without_attributes_throwsAnException() {
+        eventMetadata = DefaultEventMetadata.builder()
+                .withEventType(testEventType)
+                .withTimeReceived(testTimeReceived)
+                .build();
+        final Map<String, Object> attributes = eventMetadata.getAttributes();
+
+        assertThrows(UnsupportedOperationException.class, () -> attributes.put("foo", "bar"));
+    }
+
+    @Test
+    public void testAttributes_without_attributes_is_empty() {
+        eventMetadata = DefaultEventMetadata.builder()
+                .withEventType(testEventType)
+                .withTimeReceived(testTimeReceived)
+                .build();
+        final Map<String, Object> attributes = eventMetadata.getAttributes();
+        assertThat(attributes, notNullValue());
+        assertThat(attributes.size(), equalTo(0));
+
+        assertThrows(UnsupportedOperationException.class, () -> attributes.put("foo", "bar"));
+    }
+
+    @Test
     public void testBuild_withoutTimeReceived() {
 
         final Instant before = Instant.now();


### PR DESCRIPTION
### Description

From looking at the code, I see that most Events do not have metadata attributes. Each of these calls was creating a new `ImmutableMap`. This PR calls `ImmutableMap.of()` which will use a shared empty map. This should help reduce the object churn for Events.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
