### PR TITLE
Reduce task dependencies in :release:archives:linux:linuxTar build

### DIFF
--- a/release/archives/build.gradle
+++ b/release/archives/build.gradle
@@ -74,15 +74,11 @@ subprojects {
         assemble.dependsOn(installTaskName)
 
         //Adds one task per supported architecture for downloading appropriate JDK e.g. downloadarm64JDK
-        tasks.create("${downloadJDKTask}") {
-            doLast {
-                download {
-                    src jdkSources.get(platform + '_' + architecture)
-                    dest "${buildDir}/${platform}${architecture}/openjdk/openjdk.tar.gz"
-                    overwrite false
-                }
-            }
-        }
+        tasks.create("${downloadJDKTask}", Download, {
+            src jdkSources.get(platform + '_' + architecture)
+            dest "${buildDir}/${platform}${architecture}/openjdk/openjdk.tar.gz"
+            overwrite false
+        })
     }
 
     tasks.withType(Zip) {
@@ -172,7 +168,6 @@ task uploadArchives {
 
 task buildTar {
     subprojects.each { dependsOn ':release:archives:' + it.name + ':' + it.name + 'Tar' }
-
 }
 
 task buildArchives {

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -36,12 +36,14 @@ task benchmarkTests {
     // TODO add benchmark test and enable
 }
 
-task buildMain {
-    dependsOn ':data-prepper-main:build'
+task assembleMain {
+    dependsOn ':data-prepper-core:assemble'
+    dependsOn ':data-prepper-plugins:assemble'
+    dependsOn ':data-prepper-main:assemble'
 }
 
 task releasePrerequisites {
-    dependsOn 'buildMain'
+    dependsOn 'assembleMain'
     dependsOn 'endToEndTests'
     dependsOn 'benchmarkTests'
 }


### PR DESCRIPTION
### Description

This change reduces some of the task dependencies when building tar.gz distributions. It doesn't need to run the data-prepper-main tests, just assemble. And it uses the correct configuration for downloading OpenJDK.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
