### PR TITLE
Improved PipelineConnector copy using JsonNode.deepCopy

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventMetadata.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableMap;
 
 import java.time.Instant;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -38,6 +39,12 @@ public class DefaultEventMetadata implements EventMetadata {
         this.attributes = builder.attributes == null ? ImmutableMap.of() : ImmutableMap.copyOf(builder.attributes);
     }
 
+    private DefaultEventMetadata(final EventMetadata eventMetadata) {
+        this.eventType = eventMetadata.getEventType();
+        this.timeReceived = eventMetadata.getTimeReceived();
+        this.attributes = ImmutableMap.copyOf(eventMetadata.getAttributes());
+    }
+
     @Override
     public String getEventType() {
         return eventType;
@@ -53,6 +60,30 @@ public class DefaultEventMetadata implements EventMetadata {
         return attributes;
     }
 
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final DefaultEventMetadata that = (DefaultEventMetadata) o;
+        return Objects.equals(eventType, that.eventType)
+                && Objects.equals(timeReceived, that.timeReceived)
+                && Objects.equals(attributes, that.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventType, timeReceived, attributes);
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultEventMetadata{" +
+                "eventType='" + eventType + '\'' +
+                ", timeReceived=" + timeReceived +
+                ", attributes=" + attributes +
+                '}';
+    }
+
     /**
      * Constructs an empty builder.
      * @return a builder
@@ -60,6 +91,10 @@ public class DefaultEventMetadata implements EventMetadata {
      */
     public static Builder builder() {
         return new Builder();
+    }
+
+    static EventMetadata fromEventMetadata(final EventMetadata eventMetadata) {
+        return new DefaultEventMetadata(eventMetadata);
     }
 
     /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
@@ -7,13 +7,13 @@ package org.opensearch.dataprepper.model.trace;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.opensearch.dataprepper.model.event.EventMetadata;
 import org.opensearch.dataprepper.model.event.EventType;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -59,12 +59,17 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
     private static final ObjectMapper mapper = new ObjectMapper()
             .registerModule(new JavaTimeModule());
-    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {};
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {
+    };
 
     protected JacksonSpan(final Builder builder) {
         super(builder);
 
         checkArgument(this.getMetadata().getEventType().equals("TRACE"), "eventType must be of type Trace");
+    }
+
+    private JacksonSpan(final JacksonSpan otherSpan) {
+        super(otherSpan);
     }
 
     @Override
@@ -171,6 +176,17 @@ public class JacksonSpan extends JacksonEvent implements Span {
         return new Builder();
     }
 
+    public static JacksonSpan fromSpan(final Span span) {
+        if (span instanceof JacksonSpan) {
+            return new JacksonSpan((JacksonSpan) span);
+        } else {
+            return JacksonSpan.builder()
+                    .withData(span.toMap())
+                    .withEventMetadata(span.getMetadata())
+                    .build();
+        }
+    }
+
     @Override
     public String toJsonString() {
         final ObjectNode attributesNode = (ObjectNode) getJsonNode().get("attributes");
@@ -190,6 +206,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
     /**
      * Builder for creating {@link JacksonSpan}
+     *
      * @since 1.2
      */
     public static class Builder extends JacksonEvent.Builder<Builder> {
@@ -207,6 +224,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the data of the event.
+         *
          * @param data JSON representation of the data
          * @since 2.0
          */
@@ -221,6 +239,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the data of the event.
+         *
          * @param data the data
          * @since 2.0
          */
@@ -232,6 +251,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the metadata.
+         *
          * @param eventMetadata the metadata
          * @since 2.0
          */
@@ -243,6 +263,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the span id.
+         *
          * @param spanId
          * @since 1.2
          */
@@ -253,6 +274,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the trace id for the span.
+         *
          * @param traceId
          * @since 1.2
          */
@@ -263,6 +285,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the trace state
+         *
          * @param traceState
          * @since 1.2
          */
@@ -273,6 +296,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the parent span id.
+         *
          * @param parentSpanId
          * @since 1.2
          */
@@ -283,6 +307,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the span name
+         *
          * @param name
          * @since 1.2
          */
@@ -293,6 +318,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the type of span
+         *
          * @param kind
          * @since 1.2
          */
@@ -303,6 +329,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the start time of the span
+         *
          * @param startTime
          * @since 1.2
          */
@@ -313,6 +340,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the end time of the span
+         *
          * @param endTime
          * @since 1.2
          */
@@ -323,6 +351,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Optional - sets the attributes for {@link JacksonSpan}. Default is an empty map.
+         *
          * @param attributes the attributes to associate with this event.
          * @since 1.2
          */
@@ -333,6 +362,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Optional - sets the dropped attribute count for {@link JacksonSpan}. Default is 0.
+         *
          * @param droppedAttributesCount the total number of dropped attributes
          * @since 1.2
          */
@@ -343,6 +373,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Optional - sets the events for {@link JacksonSpan}. Default is an empty list.
+         *
          * @param events the events to associate.
          * @since 1.2
          */
@@ -353,6 +384,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Optional - sets the dropped events count for {@link JacksonSpan}. Default is 0.
+         *
          * @param droppedEventsCount the total number of dropped events
          * @since 1.2
          */
@@ -363,6 +395,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Optional - sets the links for {@link JacksonSpan}. Default is an empty list.
+         *
          * @param links the links to associate.
          * @since 1.2
          */
@@ -373,6 +406,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Optional - sets the dropped links count for {@link JacksonSpan}. Default is 0.
+         *
          * @param droppedLinksCount the total number of dropped links
          * @since 1.2
          */
@@ -383,6 +417,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the trace group name
+         *
          * @param traceGroup
          * @since 1.2
          */
@@ -393,6 +428,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the duration of the span
+         *
          * @param durationInNanos
          * @since 1.2
          */
@@ -403,6 +439,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the trace group fields
+         *
          * @param traceGroupFields
          * @since 1.2
          */
@@ -413,6 +450,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Sets the service name of the span
+         *
          * @param serviceName
          * @since 1.3
          */
@@ -423,6 +461,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
 
         /**
          * Returns a newly created {@link JacksonSpan}
+         *
          * @return a JacksonSpan
          * @since 1.2
          */
@@ -443,7 +482,7 @@ public class JacksonSpan extends JacksonEvent implements Span {
             REQUIRED_NON_EMPTY_KEYS.forEach(key -> {
                 final String value = (String) data.get(key);
                 checkNotNull(value, key + " cannot be null");
-                checkArgument(!value.isEmpty(),  key + " cannot be an empty string");
+                checkArgument(!value.isEmpty(), key + " cannot be an empty string");
             });
 
             REQUIRED_NON_NULL_KEYS.forEach(key -> {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/PipelineConnector.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/PipelineConnector.java
@@ -67,31 +67,25 @@ public final class PipelineConnector<T extends Record<?>> implements Source<T>, 
     public void output(final Collection<T> records) {
         if (buffer != null && !isStopRequested.get()) {
             for (T record : records) {
-		if(record.getData() instanceof JacksonSpan) {
-		    try {
-		        final Span spanEvent = (Span)record.getData();
-			Span newSpanEvent = JacksonSpan.builder()
-				  .withData(spanEvent.toMap())
-				  .withEventMetadata(spanEvent.getMetadata())
-			          .build(); 
-			record = (T) (new Record<>(newSpanEvent));
-		    } catch (Exception ex) {
+                if (record.getData() instanceof JacksonSpan) {
+                    try {
+                        final Span spanEvent = (Span) record.getData();
+                        Span newSpanEvent = JacksonSpan.fromSpan(spanEvent);
+                        record = (T) (new Record<>(newSpanEvent));
+                    } catch (Exception ex) {
                         LOG.error("PipelineConnector [{}-{}]:  exception while duplicating the event [{}]",
                                 sinkPipelineName, sourcePipelineName, ex);
                     }
-		} else if(record.getData() instanceof Event) {
-		    try {
-		        final Event recordEvent = (Event)record.getData();
-			Event newRecordEvent = JacksonEvent.builder() 
-			          .withData(recordEvent.toMap()) 
-				  .withEventMetadata(recordEvent.getMetadata()) 
-			          .build(); 
-			record = (T) (new Record<>(newRecordEvent));
-		    } catch (Exception ex) {
+                } else if (record.getData() instanceof Event) {
+                    try {
+                        final Event recordEvent = (Event) record.getData();
+                        Event newRecordEvent = JacksonEvent.fromEvent(recordEvent);
+                        record = (T) (new Record<>(newRecordEvent));
+                    } catch (Exception ex) {
                         LOG.error("PipelineConnector [{}-{}]:  exception while duplicating the event [{}]",
                                 sinkPipelineName, sourcePipelineName, ex);
                     }
-		}
+                }
 
                 while (true) {
                     try {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineConnectorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineConnectorTest.java
@@ -40,11 +40,14 @@ import java.util.Map;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.concurrent.TimeoutException;
+
 import com.google.common.collect.ImmutableMap;
 
 
 import static org.junit.Assert.assertTrue;
+
 import org.junit.jupiter.api.Assertions;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -63,20 +66,20 @@ public class PipelineConnectorTest {
     private static final String SINK_PIPELINE_NAME = "SINK_PIPELINE_NAME";
     private final String testKey = UUID.randomUUID().toString();
     private final String testValue = UUID.randomUUID().toString();
-    private static final String TEST_TRACE_ID =  UUID.randomUUID().toString();
-    private static final String TEST_SPAN_ID =  UUID.randomUUID().toString();
-    private static final String TEST_TRACE_STATE =  UUID.randomUUID().toString();
-    private static final String TEST_PARENT_SPAN_ID =  UUID.randomUUID().toString();
-    private static final String TEST_NAME =  UUID.randomUUID().toString();
-    private static final String TEST_KIND =  UUID.randomUUID().toString();
-    private static final String TEST_START_TIME =  UUID.randomUUID().toString();
-    private static final String TEST_END_TIME =  UUID.randomUUID().toString();
+    private static final String TEST_TRACE_ID = UUID.randomUUID().toString();
+    private static final String TEST_SPAN_ID = UUID.randomUUID().toString();
+    private static final String TEST_TRACE_STATE = UUID.randomUUID().toString();
+    private static final String TEST_PARENT_SPAN_ID = UUID.randomUUID().toString();
+    private static final String TEST_NAME = UUID.randomUUID().toString();
+    private static final String TEST_KIND = UUID.randomUUID().toString();
+    private static final String TEST_START_TIME = UUID.randomUUID().toString();
+    private static final String TEST_END_TIME = UUID.randomUUID().toString();
     private static final Map<String, Object> TEST_ATTRIBUTES = ImmutableMap.of("key1", new Date().getTime(), "key2", UUID.randomUUID().toString());
     private static final Integer TEST_DROPPED_ATTRIBUTES_COUNT = 8;
-    private static final Integer TEST_DROPPED_EVENTS_COUNT =  45;
-    private static final Integer TEST_DROPPED_LINKS_COUNT =  21;
-    private static final String TEST_TRACE_GROUP =  UUID.randomUUID().toString();
-    private static final Long TEST_DURATION_IN_NANOS =  537L;
+    private static final Integer TEST_DROPPED_EVENTS_COUNT = 45;
+    private static final Integer TEST_DROPPED_LINKS_COUNT = 21;
+    private static final String TEST_TRACE_GROUP = UUID.randomUUID().toString();
+    private static final Long TEST_DURATION_IN_NANOS = 537L;
     private static final String TEST_SERVICE_NAME = UUID.randomUUID().toString();
 
     @Mock
@@ -96,20 +99,19 @@ public class PipelineConnectorTest {
     private DefaultSpanEvent defaultSpanEvent;
 
 
-
     @Before
     public void setup() {
         recordList = Collections.singletonList(RECORD);
         sut = new PipelineConnector<>();
 
-	final Event event = JacksonEvent.builder()
-			.withEventType("event")
-			.withData(Collections.singletonMap(testKey, testValue))
-			.build();
-	EVENT_RECORD = new Record<>(event);
+        final Event event = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(Collections.singletonMap(testKey, testValue))
+                .build();
+        EVENT_RECORD = new Record<>(event);
         eventRecordList = Collections.singletonList(EVENT_RECORD);
-	final Queue<Record<Event>> bufferQueue = new LinkedList<>();
-	eventBuffer = new TestBuffer(bufferQueue, 1);
+        final Queue<Record<Event>> bufferQueue = new LinkedList<>();
+        eventBuffer = new TestBuffer(bufferQueue, 1);
         eut = new PipelineConnector<>();
 
         defaultSpanEvent = DefaultSpanEvent.builder()
@@ -128,7 +130,7 @@ public class PipelineConnectorTest {
                 .withStatusCode(201)
                 .withEndTime("the End")
                 .build();
-	final JacksonSpan span = JacksonSpan.builder()
+        final JacksonSpan span = JacksonSpan.builder()
                 .withSpanId(TEST_SPAN_ID)
                 .withTraceId(TEST_TRACE_ID)
                 .withTraceState(TEST_TRACE_STATE)
@@ -147,11 +149,11 @@ public class PipelineConnectorTest {
                 .withTraceGroup(TEST_TRACE_GROUP)
                 .withDurationInNanos(TEST_DURATION_IN_NANOS)
                 .withTraceGroupFields(defaultTraceGroupFields)
-		.build();
+                .build();
 
-	SPAN_RECORD = new Record<>(span);
+        SPAN_RECORD = new Record<>(span);
         spanRecordList = Collections.singletonList(SPAN_RECORD);
-	spanBuffer = new BlockingBuffer<>("Pipeline1");
+        spanBuffer = new BlockingBuffer<>("Pipeline1");
         sput = new PipelineConnector<>();
 
     }
@@ -195,18 +197,18 @@ public class PipelineConnectorTest {
 
         eut.output(eventRecordList);
 
-	Map.Entry<Collection<Record<Event>>, CheckpointState> ent = eventBuffer.read(1);
-	ArrayList<Record<Event>> records = new ArrayList<>(ent.getKey());
-	// Make sure the records are different
-	assertThat(eventRecordList.get(0), not(sameInstance(records.get(0))));
-	// Make sure the events are different
-	Event event1 = eventRecordList.get(0).getData();
-	Event event2 = records.get(0).getData();
-	assertThat(event1, not(sameInstance(event2)));
-	event1.toMap().forEach((k, v)-> Assertions.assertEquals(event2.get(k, String.class), v));
-	event1.toMap().forEach((k, v)-> Assertions.assertEquals(k, testKey));
-	event1.toMap().forEach((k, v)-> Assertions.assertEquals(v, testValue));
-	
+        Map.Entry<Collection<Record<Event>>, CheckpointState> ent = eventBuffer.read(1);
+        ArrayList<Record<Event>> records = new ArrayList<>(ent.getKey());
+        // Make sure the records are different
+        assertThat(eventRecordList.get(0), not(sameInstance(records.get(0))));
+        // Make sure the events are different
+        Event event1 = eventRecordList.get(0).getData();
+        Event event2 = records.get(0).getData();
+        assertThat(event1, not(sameInstance(event2)));
+        event1.toMap().forEach((k, v) -> Assertions.assertEquals(event2.get(k, String.class), v));
+        event1.toMap().forEach((k, v) -> Assertions.assertEquals(k, testKey));
+        event1.toMap().forEach((k, v) -> Assertions.assertEquals(v, testValue));
+
     }
 
     @Test
@@ -215,15 +217,15 @@ public class PipelineConnectorTest {
 
         sput.output(spanRecordList);
 
-	Map.Entry<Collection<Record<JacksonSpan>>, CheckpointState> ent = spanBuffer.doRead(10000);
-	ArrayList<Record<JacksonSpan>> records = new ArrayList<>(ent.getKey());
-	// Make sure the records are different
-	assertThat(spanRecordList.get(0), not(sameInstance(records.get(0))));
-	// Make sure the spans are different
-	JacksonSpan span1 = spanRecordList.get(0).getData();
-	JacksonSpan span2 = records.get(0).getData();
-	assertThat(span1, not(sameInstance(span2)));
-	span1.toMap().forEach((k, v) -> Assertions.assertEquals(span2.toMap().get(k), v));
+        Map.Entry<Collection<Record<JacksonSpan>>, CheckpointState> ent = spanBuffer.doRead(10000);
+        ArrayList<Record<JacksonSpan>> records = new ArrayList<>(ent.getKey());
+        // Make sure the records are different
+        assertThat(spanRecordList.get(0), not(sameInstance(records.get(0))));
+        // Make sure the spans are different
+        JacksonSpan span1 = spanRecordList.get(0).getData();
+        JacksonSpan span2 = records.get(0).getData();
+        assertThat(span1, not(sameInstance(span2)));
+        span1.toMap().forEach((k, v) -> Assertions.assertEquals(span2.toMap().get(k), v));
     }
 
     @Test


### PR DESCRIPTION
### Description

The previous method of copying took a few steps: 1) Create a new `Map`; 2) Create a new `JsonNode`; 3) Perform a `convertValue` to get the data back into the `JsonNode` from the `Map`.

This PR adds a static method in `JacksonEvent` and `JacksonSpan` which performs a copy. If the incoming `Event`/`Span` is a Jackson-based one, then it performs a `deepCopy()` on the `JsonNode`. Otherwise, it performs the slower version above. That second is a fallback as all `Event` objects by default are the Jackson kind.
 
In some local and isolated testing, I found that this reduces the time to perform `PipelineConnector.output` is reduced by about one-third.

Also, some of these files had bad formatting so I ran IntelliJ's format on them to clean them up some.

n.b. I believe #1915 will be a better solution, but this one is fairly quick to implement.

### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
