### PR TITLE
Sink doInitialize() should be able throw exception to stop execution

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/AbstractSink.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/AbstractSink.java
@@ -30,14 +30,13 @@ public abstract class AbstractSink<T extends Record<?>> implements Sink<T> {
         retryThread = null;
     }
 
-    public abstract void doInitialize() throws Exception;
+    public abstract void doInitialize();
 
     @Override
     public void initialize() {
-        try {
-            doInitialize();
-        } catch (Exception e) {
-        }
+        // Derived class supposed to catch retryable exceptions and throw
+        // the exceptions which are not retryable.
+        doInitialize();
         if (!isReady() && retryThread == null) {
             retryThread = new Thread(new SinkThread(this, NUMBER_OF_RETRIES));
             retryThread.start();

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkThread.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkThread.java
@@ -21,7 +21,7 @@ class SinkThread implements Runnable {
             try {
                 Thread.sleep(1000);
                 sink.doInitialize();
-            } catch (Exception e){}
+            } catch (InterruptedException e){}
         }
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/AbstractSinkTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/AbstractSinkTest.java
@@ -134,12 +134,10 @@ public class AbstractSinkTest {
         }
 
         @Override
-        public void doInitialize() throws Exception {
+        public void doInitialize() {
             // make this check for smaller number so that test finishes sooner
             if (++initCount == NUMBER_OF_RETRIES/200) {
                 initialized = true;
-            } else {
-                throw new RuntimeException("Not initialized");
             }
         }
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/AbstractSinkTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/AbstractSinkTest.java
@@ -67,6 +67,9 @@ public class AbstractSinkTest {
         abstractSink.initialize();
         Assert.assertEquals(abstractSink.isReady(), false);
         Assert.assertEquals(abstractSink.getRetryThreadState(), Thread.State.RUNNABLE);
+        // Do another intialize to make sure the sink is still not ready
+        abstractSink.initialize();
+        Assert.assertEquals(abstractSink.isReady(), false);
         while (!abstractSink.isReady()) {
             try {
                 Thread.sleep(1000);
@@ -136,7 +139,7 @@ public class AbstractSinkTest {
         @Override
         public void doInitialize() {
             // make this check for smaller number so that test finishes sooner
-            if (++initCount == NUMBER_OF_RETRIES/200) {
+            if (initCount++ == NUMBER_OF_RETRIES/200) {
                 initialized = true;
             }
         }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkThreadTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkThreadTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -45,5 +46,13 @@ public class SinkThreadTest {
         when(sink.isReady()).thenReturn(false).thenReturn(true);
         sinkThread.run();
         verify(sink, times(8)).isReady();
+        when(sink.isReady()).thenReturn(false).thenReturn(true);
+        try {
+            lenient().doAnswer((i) -> {
+                throw new InterruptedException("Fake interrupt");
+            }).when(sink).doInitialize();
+            sinkThread.run();
+            verify(sink, times(7)).doInitialize();
+        } catch (Exception e){}
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -102,19 +102,22 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
   }
 
   @Override
-  public void doInitialize() throws IOException {
+  public void doInitialize() {
     try {
         doInitializeInternal();
     } catch (IOException e) {
-        LOG.warn("Failed to initialize OpenSearch sink " + e.getMessage());
+        LOG.warn("Failed to initialize OpenSearch sink, retrying. Error - " + e.getCause());
     } catch (InvalidPluginConfigurationException e) {
+        LOG.error("Failed to initialize OpenSearch sink.");
         this.shutdown();
         throw new RuntimeException(e.getMessage(), e);
     } catch (Exception e) {
         if (!BulkRetryStrategy.canRetry(e)) {
+            LOG.error("Failed to initialize OpenSearch sink.");
             this.shutdown();
             throw e;
         }
+        LOG.warn("Failed to initialize OpenSearch sink, retrying. Error - " + e.getCause());
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Krishna Kondaka <krishkdk@amazon.com>

### Description
Abstract sink initialize() catches all exceptions from doInitialize and ignores them. Abstract sink should let individual sinks to decide what exceptions to catch and what exceptions to throw.

Modified the code to remove exception catching from both Abstract sink `initialize` and SinkThread's `run` methods. OpenSearch sink is modified to log failure message in all cases.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
