### PR TITLE
Refactor to remove stream in RemotePeerForwarder as micro optimization

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
@@ -35,7 +35,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.stream.Collectors;
 
 class RemotePeerForwarder implements PeerForwarder {
     private static final Logger LOG = LoggerFactory.getLogger(RemotePeerForwarder.class);
@@ -229,8 +228,7 @@ class RemotePeerForwarder implements PeerForwarder {
     private void forwardBatchedRecords() {
         final Map<CompletableFuture<AggregatedHttpResponse>, List<Record<Event>>> futuresMap = new HashMap<>();
         peerBatchingQueueMap.forEach((ipAddress, records) -> {
-            final Map<CompletableFuture<AggregatedHttpResponse>, List<Record<Event>>> futuresForIp = forwardRecordsForIp(ipAddress);
-            futuresMap.putAll(futuresForIp);
+            futuresMap.putAll(forwardRecordsForIp(ipAddress));
         });
 
         final CompletableFuture<Void> compositeFuture = CompletableFuture.allOf(futuresMap.keySet().toArray(CompletableFuture[]::new));

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
@@ -227,10 +227,11 @@ class RemotePeerForwarder implements PeerForwarder {
     }
 
     private void forwardBatchedRecords() {
-        final Map<CompletableFuture<AggregatedHttpResponse>, List<Record<Event>>> futuresMap = peerBatchingQueueMap.keySet().stream()
-                .map(this::forwardRecordsForIp)
-                .flatMap(map -> map.entrySet().stream())
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        final Map<CompletableFuture<AggregatedHttpResponse>, List<Record<Event>>> futuresMap = new HashMap<>();
+        peerBatchingQueueMap.forEach((ipAddress, records) -> {
+            final Map<CompletableFuture<AggregatedHttpResponse>, List<Record<Event>>> futuresForIp = forwardRecordsForIp(ipAddress);
+            futuresMap.putAll(futuresForIp);
+        });
 
         final CompletableFuture<Void> compositeFuture = CompletableFuture.allOf(futuresMap.keySet().toArray(CompletableFuture[]::new));
         try {


### PR DESCRIPTION
### Description
Streams are less efficient than ordinary collection methods. Since `forwardBatchedRecords` is executed many times, the slight optimization of using ordinary collection methods makes a non-negligible difference in CPU utilization

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
