### PR TITLE
Use the Gradle version catalog for common software versions

### DIFF
--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -3,18 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//preferably try to maintain the alphabetical order
-ext.versionMap = [
-        junitJupiter : '5.8.2',
-        mockito : '3.11.2',
-        opentelemetryProto : '0.16.0-alpha',
-        opensearchVersion : '1.3.7',
-        armeria: '1.20.3',
-        armeriaGrpc: '1.20.3',
-        protobufJavaUtil: '3.21.11',
-        protobufJava: '3.21.11'
-]
-
 ext.coreProjects = [
         project(':data-prepper-api'),
         project(':data-prepper-core'),

--- a/build.gradle
+++ b/build.gradle
@@ -85,12 +85,8 @@ subprojects {
         implementation platform('io.micrometer:micrometer-bom:1.9.4')
         implementation 'com.google.guava:guava:31.1-jre'
         implementation 'org.slf4j:slf4j-api:2.0.5'
-        testImplementation platform("org.junit:junit-bom:${versionMap.junitJupiter}")
-        testImplementation 'org.junit.jupiter:junit-jupiter'
-        testImplementation 'org.junit.vintage:junit-vintage-engine'
-        testImplementation "org.mockito:mockito-core:${versionMap.mockito}"
-        testImplementation "org.mockito:mockito-junit-jupiter:${versionMap.mockito}"
-
+        testImplementation testLibs.bundles.junit
+        testImplementation testLibs.bundles.mockito
         testImplementation 'org.hamcrest:hamcrest:2.2'
         testImplementation 'org.awaitility:awaitility:4.2.0'
         constraints {

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -39,16 +39,16 @@ dependencies {
     }
     implementation 'software.amazon.cloudwatchlogs:aws-embedded-metrics:2.0.0-beta-1'
     testImplementation 'org.springframework:spring-test:5.3.25'
-    implementation "com.linecorp.armeria:armeria:${versionMap.armeria}"
+    implementation libs.armeria.core
+    implementation libs.armeria.grpc
     implementation 'org.apache.commons:commons-lang3:3.12.0'
-    implementation "com.linecorp.armeria:armeria-grpc:${versionMap.armeriaGrpc}"
     implementation 'software.amazon.awssdk:acm'
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:apache-client'
     implementation 'commons-validator:commons-validator:1.7'
     implementation 'software.amazon.awssdk:servicediscovery'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
+    testImplementation testLibs.mockito.inline
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
     testImplementation project(':data-prepper-api').sourceSets.test.output
 }

--- a/data-prepper-logstash-configuration/build.gradle
+++ b/data-prepper-logstash-configuration/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation "org.apache.commons:commons-lang3:3.12.0"
     testImplementation 'org.slf4j:slf4j-simple:2.0.5'
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
+    testImplementation testLibs.mockito.inline
 }
 
 generateGrammarSource {

--- a/data-prepper-plugins/aggregate-processor/build.gradle
+++ b/data-prepper-plugins/aggregate-processor/build.gradle
@@ -16,10 +16,10 @@ dependencies {
     implementation project(':data-prepper-plugins:otel-metrics-raw-processor')
     implementation 'com.google.guava:guava:23.0'
     implementation "org.apache.commons:commons-lang3:3.12.0"
-    implementation "io.opentelemetry.proto:opentelemetry-proto:${versionMap.opentelemetryProto}"
+    implementation libs.opentelemetry.proto
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
+    testImplementation testLibs.mockito.inline
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/armeria-common/build.gradle
+++ b/data-prepper-plugins/armeria-common/build.gradle
@@ -6,7 +6,7 @@
 
 dependencies {
     implementation project(':data-prepper-api')
-    implementation "com.linecorp.armeria:armeria:${versionMap.armeria}"
-    implementation "com.linecorp.armeria:armeria-grpc:${versionMap.armeriaGrpc}"
-    testImplementation "com.linecorp.armeria:armeria-junit5:${versionMap.armeria}"
+    implementation libs.armeria.core
+    implementation libs.armeria.grpc
+    testImplementation libs.armeria.junit
 }

--- a/data-prepper-plugins/common/build.gradle
+++ b/data-prepper-plugins/common/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation 'io.micrometer:micrometer-core'
     testImplementation project(':data-prepper-plugins:blocking-buffer')
     testImplementation 'commons-io:commons-io:2.11.0'
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
+    testImplementation testLibs.mockito.inline
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/grok-processor/build.gradle
+++ b/data-prepper-plugins/grok-processor/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation "io.krakens:java-grok:0.1.9"
     implementation 'io.micrometer:micrometer-core'
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
+    testImplementation testLibs.mockito.inline
     testImplementation project(':data-prepper-test-common')
 }
 

--- a/data-prepper-plugins/http-source/build.gradle
+++ b/data-prepper-plugins/http-source/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(':data-prepper-plugins:blocking-buffer')
     implementation project(':data-prepper-plugins:common')
     implementation project(':data-prepper-plugins:armeria-common')
-    implementation "com.linecorp.armeria:armeria:${versionMap.armeria}"
+    implementation libs.armeria.core
     implementation 'commons-io:commons-io:2.11.0'
     implementation 'software.amazon.awssdk:acm'
     implementation 'software.amazon.awssdk:s3'

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -5,7 +5,7 @@
 
 buildscript {
     ext {
-        opensearchVersion = System.getProperty('opensearch.version', "${versionMap.opensearchVersion}")
+        opensearchVersion = System.getProperty('opensearch.version', "${libs.versions.opensearch.get()}")
     }
 
     repositories {

--- a/data-prepper-plugins/otel-logs-source/build.gradle
+++ b/data-prepper-plugins/otel-logs-source/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'commons-codec:commons-codec:1.15'
     implementation project(':data-prepper-plugins:armeria-common')
     testImplementation project(':data-prepper-api').sourceSets.test.output
-    implementation "io.opentelemetry.proto:opentelemetry-proto:${versionMap.opentelemetryProto}"
+    implementation libs.opentelemetry.proto
     implementation "commons-io:commons-io:2.11.0"
     implementation 'software.amazon.awssdk:acm'
     implementation 'software.amazon.awssdk:auth'
@@ -30,7 +30,7 @@ dependencies {
     implementation "org.bouncycastle:bcprov-jdk15on:1.69"
     implementation "org.bouncycastle:bcpkix-jdk15on:1.69"
     testImplementation 'org.assertj:assertj-core:3.21.0'
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
+    testImplementation testLibs.mockito.inline
     testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation("commons-io:commons-io:2.10.0")
 }

--- a/data-prepper-plugins/otel-metrics-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-metrics-raw-processor/build.gradle
@@ -14,15 +14,15 @@ dependencies {
     implementation 'commons-codec:commons-codec:1.15'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     testImplementation project(':data-prepper-api').sourceSets.test.output
-    implementation "io.opentelemetry.proto:opentelemetry-proto:${versionMap.opentelemetryProto}"
-    implementation "com.google.protobuf:protobuf-java-util:${versionMap.protobufJavaUtil}"
-    implementation "com.linecorp.armeria:armeria:${versionMap.armeria}"
-    implementation "com.linecorp.armeria:armeria-grpc:${versionMap.armeriaGrpc}"
+    implementation libs.opentelemetry.proto
+    implementation libs.protobuf.util
+    implementation libs.armeria.core
+    implementation libs.armeria.grpc
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
+    testImplementation testLibs.mockito.inline
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/otel-metrics-source/build.gradle
+++ b/data-prepper-plugins/otel-metrics-source/build.gradle
@@ -14,22 +14,22 @@ dependencies {
     implementation 'commons-codec:commons-codec:1.15'
     implementation project(':data-prepper-plugins:armeria-common')
     testImplementation project(':data-prepper-api').sourceSets.test.output
-    implementation "io.opentelemetry.proto:opentelemetry-proto:${versionMap.opentelemetryProto}"
+    implementation libs.opentelemetry.proto
     implementation "commons-io:commons-io:2.11.0"
     implementation 'software.amazon.awssdk:acm'
     implementation 'software.amazon.awssdk:auth'
     implementation 'software.amazon.awssdk:regions'
     implementation 'software.amazon.awssdk:s3'
-    implementation "com.google.protobuf:protobuf-java-util:${versionMap.protobufJavaUtil}"
-    implementation "com.linecorp.armeria:armeria:${versionMap.armeria}"
-    implementation "com.linecorp.armeria:armeria-grpc:${versionMap.armeriaGrpc}"
+    implementation libs.protobuf.util
+    implementation libs.armeria.core
+    implementation libs.armeria.grpc
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation "org.apache.commons:commons-lang3:3.12.0"
     implementation "org.bouncycastle:bcprov-jdk15on:1.70"
     implementation "org.bouncycastle:bcpkix-jdk15on:1.70"
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
+    testImplementation testLibs.mockito.inline
     testImplementation("commons-io:commons-io:2.10.0")
 }
 

--- a/data-prepper-plugins/otel-proto-common/build.gradle
+++ b/data-prepper-plugins/otel-proto-common/build.gradle
@@ -9,8 +9,8 @@ plugins {
 
 dependencies {
     implementation project(':data-prepper-api')
-    implementation "io.opentelemetry.proto:opentelemetry-proto:${versionMap.opentelemetryProto}"
-    implementation "com.google.protobuf:protobuf-java-util:${versionMap.protobufJavaUtil}"
+    implementation libs.opentelemetry.proto
+    implementation libs.protobuf.util
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation "org.apache.commons:commons-lang3:3.12.0"

--- a/data-prepper-plugins/otel-trace-group-processor/build.gradle
+++ b/data-prepper-plugins/otel-trace-group-processor/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 ext {
-    opensearchVersion = System.getProperty("opensearch.version", "${versionMap.opensearchVersion}")
+    opensearchVersion = System.getProperty("opensearch.version", "${libs.versions.opensearch.get()}")
 }
 
 dependencies {

--- a/data-prepper-plugins/otel-trace-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-processor/build.gradle
@@ -12,15 +12,15 @@ dependencies {
     implementation project(':data-prepper-plugins:common')
     implementation 'commons-codec:commons-codec:1.15'
     testImplementation project(':data-prepper-api').sourceSets.test.output
-    implementation "io.opentelemetry.proto:opentelemetry-proto:${versionMap.opentelemetryProto}"
-    implementation "com.google.protobuf:protobuf-java-util:${versionMap.protobufJavaUtil}"
-    implementation "com.linecorp.armeria:armeria:${versionMap.armeria}"
-    implementation "com.linecorp.armeria:armeria-grpc:${versionMap.armeriaGrpc}"
+    implementation libs.opentelemetry.proto
+    implementation libs.protobuf.util
+    implementation libs.armeria.core
+    implementation libs.armeria.grpc
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'com.google.guava:guava:31.1-jre'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
+    testImplementation testLibs.mockito.inline
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -15,20 +15,20 @@ dependencies {
     implementation project(':data-prepper-plugins:otel-proto-common')
     implementation 'commons-codec:commons-codec:1.15'
     testImplementation project(':data-prepper-api').sourceSets.test.output
-    implementation "io.opentelemetry.proto:opentelemetry-proto:${versionMap.opentelemetryProto}"
+    implementation libs.opentelemetry.proto
     implementation "commons-io:commons-io:2.11.0"
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:acm'
-    implementation "com.google.protobuf:protobuf-java-util:${versionMap.protobufJavaUtil}"
-    implementation "com.linecorp.armeria:armeria:${versionMap.armeria}"
-    implementation "com.linecorp.armeria:armeria-grpc:${versionMap.armeriaGrpc}"
+    implementation libs.protobuf.util
+    implementation libs.armeria.core
+    implementation libs.armeria.grpc
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation "org.apache.commons:commons-lang3:3.12.0"
     implementation "org.bouncycastle:bcprov-jdk15on:1.70"
     implementation "org.bouncycastle:bcpkix-jdk15on:1.70"
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
+    testImplementation testLibs.mockito.inline
     testImplementation("commons-io:commons-io:2.10.0")
 }
 

--- a/data-prepper-plugins/peer-forwarder/build.gradle
+++ b/data-prepper-plugins/peer-forwarder/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:otel-proto-common')
     testImplementation project(':data-prepper-api').sourceSets.test.output
-    implementation "io.opentelemetry.proto:opentelemetry-proto:${versionMap.opentelemetryProto}"
+    implementation libs.opentelemetry.proto
     implementation "com.linecorp.armeria:armeria:1.9.2"
     implementation "com.linecorp.armeria:armeria-grpc:1.9.2"
     implementation 'com.amazonaws:aws-java-sdk-s3'
@@ -28,7 +28,7 @@ dependencies {
     implementation "org.apache.commons:commons-lang3:3.12.0"
     implementation "commons-validator:commons-validator:1.7"
     testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
+    testImplementation testLibs.mockito.inline
     testImplementation "commons-io:commons-io:2.10.0"
     testImplementation 'org.awaitility:awaitility:4.1.1'
 }

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -19,11 +19,11 @@ dependencies {
     implementation 'commons-codec:commons-codec:1.15'
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation("io.opentelemetry.proto:opentelemetry-proto:${versionMap.opentelemetryProto}") {
+    implementation(libs.opentelemetry.proto) {
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
     }
-    implementation "com.google.protobuf:protobuf-java:${versionMap.protobufJava}"
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito}"
+    implementation libs.protobuf.core
+    testImplementation testLibs.mockito.inline
 }
 
 jacocoTestCoverageVerification {

--- a/e2e-test/build.gradle
+++ b/e2e-test/build.gradle
@@ -46,7 +46,7 @@ subprojects {
     ext {
         dataPrepperJarFilepath = "${project.buildDir.name}/bin/data-prepper/"
         targetJavaVersion = project.hasProperty('endToEndJavaVersion') ? project.getProperty('endToEndJavaVersion') : '11'
-        targetOpenTelemetryVersion = project.hasProperty('openTelemetryVersion') ? project.getProperty('openTelemetryVersion') : "${versionMap.opentelemetryProto}"
+        targetOpenTelemetryVersion = project.hasProperty('openTelemetryVersion') ? project.getProperty('openTelemetryVersion') : "${libs.versions.opentelemetry.get()}"
         dataPrepperBaseImage = "eclipse-temurin:${targetJavaVersion}-jre-alpine"
     }
 }

--- a/e2e-test/log/build.gradle
+++ b/e2e-test/log/build.gradle
@@ -92,7 +92,7 @@ def removeDataPrepperDockerContainer(final DockerStopContainer stopDataPrepperDo
  * OpenSearch Docker tasks
  */
 task pullOpenSearchDockerImage(type: DockerPullImage) {
-    image = "opensearchproject/opensearch:${versionMap.opensearchVersion}"
+    image = "opensearchproject/opensearch:${libs.versions.opensearch.get()}"
 }
 
 task createOpenSearchDockerContainer(type: DockerCreateContainer) {
@@ -190,7 +190,7 @@ dependencies {
     integrationTestImplementation project(':data-prepper-plugins:common')
     integrationTestImplementation project(':data-prepper-plugins:log-generator-source')
     integrationTestImplementation project(':data-prepper-plugins:opensearch')
-    integrationTestImplementation "com.linecorp.armeria:armeria:${versionMap.armeria}"
+    integrationTestImplementation libs.armeria.core
     integrationTestImplementation "org.awaitility:awaitility:4.1.1"
-    integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${versionMap.opensearchVersion}"
+    integrationTestImplementation libs.opensearch.rhlc
 }

--- a/e2e-test/peerforwarder/build.gradle
+++ b/e2e-test/peerforwarder/build.gradle
@@ -94,7 +94,7 @@ def removeDataPrepperDockerContainer(final DockerStopContainer stopDataPrepperDo
  * OpenSearch Docker tasks
  */
 task pullOpenSearchDockerImage(type: DockerPullImage) {
-    image = "opensearchproject/opensearch:${versionMap.opensearchVersion}"
+    image = "opensearchproject/opensearch:${libs.versions.opensearch.get()}"
 }
 
 task createOpenSearchDockerContainer(type: DockerCreateContainer) {
@@ -205,10 +205,10 @@ dependencies {
     integrationTestImplementation project(':data-prepper-plugins:opensearch')
     integrationTestImplementation project(':data-prepper-plugins:otel-trace-group-processor')
     integrationTestImplementation 'org.awaitility:awaitility:4.2.0'
-    integrationTestImplementation "io.opentelemetry.proto:opentelemetry-proto:${versionMap.opentelemetryProto}"
-    integrationTestImplementation "com.google.protobuf:protobuf-java-util:${versionMap.protobufJavaUtil}"
-    integrationTestImplementation "com.linecorp.armeria:armeria:${versionMap.armeria}"
-    integrationTestImplementation "com.linecorp.armeria:armeria-grpc:${versionMap.armeriaGrpc}"
-    integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${versionMap.opensearchVersion}"
+    integrationTestImplementation libs.opentelemetry.proto
+    integrationTestImplementation libs.protobuf.util
+    integrationTestImplementation libs.armeria.core
+    integrationTestImplementation libs.armeria.grpc
+    integrationTestImplementation libs.opensearch.rhlc
     integrationTestImplementation 'com.fasterxml.jackson.core:jackson-databind'
 }

--- a/e2e-test/trace/build.gradle
+++ b/e2e-test/trace/build.gradle
@@ -114,7 +114,7 @@ def createDataPrepperDockerContainerFromPullImage(final String taskBaseName, fin
  * OpenSearch Docker tasks
  */
 task pullOpenSearchDockerImage(type: DockerPullImage) {
-    image = "opensearchproject/opensearch:${versionMap.opensearchVersion}"
+    image = "opensearchproject/opensearch:${libs.versions.opensearch.get()}"
 }
 
 task createOpenSearchDockerContainer(type: DockerCreateContainer) {
@@ -234,9 +234,9 @@ dependencies {
     integrationTestImplementation project(':data-prepper-plugins:otel-trace-group-processor')
     integrationTestImplementation 'org.awaitility:awaitility:4.2.0'
     integrationTestImplementation "io.opentelemetry.proto:opentelemetry-proto:${targetOpenTelemetryVersion}"
-    integrationTestImplementation "com.google.protobuf:protobuf-java-util:${versionMap.protobufJavaUtil}"
-    integrationTestImplementation "com.linecorp.armeria:armeria:${versionMap.armeria}"
-    integrationTestImplementation "com.linecorp.armeria:armeria-grpc:${versionMap.armeriaGrpc}"
-    integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${versionMap.opensearchVersion}"
+    integrationTestImplementation libs.protobuf.util
+    integrationTestImplementation libs.armeria.core
+    integrationTestImplementation libs.armeria.grpc
+    integrationTestImplementation libs.opensearch.rhlc
     integrationTestImplementation 'com.fasterxml.jackson.core:jackson-databind'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,36 @@ pluginManagement {
 
 rootProject.name = 'opensearch-data-prepper'
 
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            version('armeria', '1.20.3')
+            library('armeria-core', 'com.linecorp.armeria', 'armeria').versionRef('armeria')
+            library('armeria-grpc', 'com.linecorp.armeria', 'armeria-grpc').versionRef('armeria')
+            library('armeria-junit', 'com.linecorp.armeria', 'armeria-junit5').versionRef('armeria')
+            version('protobuf', '3.21.11')
+            library('protobuf-core', 'com.google.protobuf', 'protobuf-java').versionRef('protobuf')
+            library('protobuf-util', 'com.google.protobuf', 'protobuf-java-util').versionRef('protobuf')
+            version('opentelemetry', '0.16.0-alpha')
+            library('opentelemetry-proto', 'io.opentelemetry.proto', 'opentelemetry-proto').versionRef('opentelemetry')
+            version('opensearch', '1.3.7')
+            library('opensearch-rhlc', 'org.opensearch.client', 'opensearch-rest-high-level-client').versionRef('opensearch')
+        }
+        testLibs {
+            version('junit', '5.8.2')
+            version('mockito', '3.11.2')
+            library('junit-core', 'org.junit.jupiter', 'junit-jupiter').versionRef('junit')
+            library('junit-params', 'org.junit.jupiter', 'junit-jupiter-params').versionRef('junit')
+            library('junit-vintage', 'org.junit.vintage', 'junit-vintage-engine').versionRef('junit')
+            bundle('junit', ['junit-core', 'junit-params', 'junit-vintage'])
+            library('mockito-core', 'org.mockito', 'mockito-core').versionRef('mockito')
+            library('mockito-junit', 'org.mockito', 'mockito-junit-jupiter').versionRef('mockito')
+            library('mockito-inline', 'org.mockito', 'mockito-inline').versionRef('mockito')
+            bundle('mockito', ['mockito-core', 'mockito-junit'])
+        }
+    }
+}
+
 include 'data-prepper-api'
 include 'data-prepper-plugins'
 include 'data-prepper-core'


### PR DESCRIPTION
### Description

This introduces a Gradle version catalog. So far it only goes so far as adding enough to replace the old `ext.versionMap`.

I think we can expand our use of these catalogs in future PRs, but to start I was just removing the `ext.versionMap`.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
