### PR TITLE
OpenSearchSink should close open files before retrying initialization

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/DataPrepper.java
@@ -94,7 +94,8 @@ public class DataPrepper {
             }
         }
         if (waitingPipelineNames.size() > 0) {
-            LOG.info("One or more Pipelines are not ready even after {} retries.", numRetries);
+            LOG.info("One or more Pipelines are not ready even after {} retries. Shutting down pipelines", numRetries);
+            shutdown();
             throw new RuntimeException("Failed to start pipelines");
         }
         transformationPipelines.forEach((name, pipeline) -> {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -107,6 +107,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
         doInitializeInternal();
     } catch (IOException e) {
         LOG.warn("Failed to initialize OpenSearch sink, retrying. Error - " + e.getCause());
+        closeFiles();
     } catch (InvalidPluginConfigurationException e) {
         LOG.error("Failed to initialize OpenSearch sink.");
         this.shutdown();
@@ -118,6 +119,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
             throw e;
         }
         LOG.warn("Failed to initialize OpenSearch sink, retrying. Error - " + e.getCause());
+        closeFiles();
     }
   }
 
@@ -252,9 +254,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     }
   }
 
-  @Override
-  public void shutdown() {
-    super.shutdown();
+  private void closeFiles() {
     // Close the client. This closes the low-level client which will close it for both high-level clients.
     if (restHighLevelClient != null) {
       try {
@@ -270,5 +270,11 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
         LOG.error(e.getMessage(), e);
       }
     }
+  }
+
+  @Override
+  public void shutdown() {
+    super.shutdown();
+    closeFiles();
   }
 }


### PR DESCRIPTION
Signed-off-by: Krishna Kondaka <krishkdk@amazon.com>

### Description
OpenSearchSink should close open files before retrying initialization. Failing to close files would result in failure in retry due reaching file descriptor limit.

Tested manually to make sure open file descriptor limit is not reached with the fix.
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
