### PR TITLE
OTel Trace Source: Logging and integration tests

### DIFF
--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation "org.bouncycastle:bcpkix-jdk15on:1.70"
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation testLibs.mockito.inline
+    testImplementation 'org.slf4j:slf4j-simple:2.0.5'
     testImplementation("commons-io:commons-io:2.10.0")
 }
 

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
@@ -14,6 +14,7 @@ import io.micrometer.core.instrument.Timer;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
+import org.opensearch.dataprepper.logging.DataPrepperMarkers;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
@@ -89,12 +90,12 @@ public class OTelTraceGrpcService extends TraceServiceGrpc.TraceServiceImplBase 
             return;
         }
 
-        Collection<Span> spans;
+        final Collection<Span> spans;
 
         try {
             spans = oTelProtoDecoder.parseExportTraceServiceRequest(request);
-        } catch (Exception e) {
-            LOG.error("Failed to parse the request due to:", request, e);
+        } catch (final Exception e) {
+            LOG.warn(DataPrepperMarkers.SENSITIVE, "Failed to parse request with error '{}'. Request body: {}.", e.getMessage(), request);
             badRequestsCounter.increment();
             responseObserver.onError(Status.INVALID_ARGUMENT.withDescription(e.getMessage()).asException());
             return;

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -5,16 +5,12 @@
 
 package org.opensearch.dataprepper.plugins.source.oteltrace;
 
-import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.model.configuration.PipelineDescription;
-import org.opensearch.dataprepper.model.configuration.PluginModel;
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
-import org.opensearch.dataprepper.model.plugin.PluginFactory;
-import org.opensearch.dataprepper.model.record.Record;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
@@ -31,24 +27,41 @@ import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import io.grpc.BindableService;
 import io.grpc.ServerServiceDefinition;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.netty.util.AsciiString;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.Span;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginModel;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.GrpcBasicAuthenticationProvider;
-import org.opensearch.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
 import org.opensearch.dataprepper.plugins.certificate.CertificateProvider;
 import org.opensearch.dataprepper.plugins.certificate.model.Certificate;
 import org.opensearch.dataprepper.plugins.health.HealthGrpcService;
@@ -59,41 +72,52 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.oteltrace.OTelTraceSourceConfig.SSL;
 
 @ExtendWith(MockitoExtension.class)
 public class OTelTraceSourceTest {
 
+    private static final String GRPC_ENDPOINT = "gproto+http://127.0.0.1:21890/";
     @Mock
     private ServerBuilder serverBuilder;
 
@@ -132,7 +156,8 @@ public class OTelTraceSourceTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    private BlockingBuffer<Record<Object>> buffer;
+    @Mock
+    private Buffer<Record<Object>> buffer;
 
     private static final String TEST_PIPELINE_NAME = "test_pipeline";
     private static final ExportTraceServiceRequest SUCCESS_REQUEST = ExportTraceServiceRequest.newBuilder()
@@ -155,13 +180,6 @@ public class OTelTraceSourceTest {
                 .map(AsciiString::toString)
                 .collect(Collectors.toList());
         assertThat("Response Header Keys", headerKeys, not(contains("server")));
-    }
-
-    private BlockingBuffer<Record<Object>> getBuffer() {
-        final HashMap<String, Object> integerHashMap = new HashMap<>();
-        integerHashMap.put("buffer_size", 1);
-        integerHashMap.put("batch_size", 1);
-        return new BlockingBuffer<>(new PluginSetting("blocking_buffer", integerHashMap));
     }
 
     private void configureObjectUnderTest() {
@@ -197,7 +215,6 @@ public class OTelTraceSourceTest {
         when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))
                 .thenReturn(authenticationProvider);
         configureObjectUnderTest();
-        buffer = getBuffer();
         pipelineDescription = mock(PipelineDescription.class);
         lenient().when(pipelineDescription.getPipelineName()).thenReturn(TEST_PIPELINE_NAME);
     }
@@ -250,7 +267,6 @@ public class OTelTraceSourceTest {
         oTelTraceSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelTraceSourceConfig.class);
         SOURCE = new OTelTraceSource(oTelTraceSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
 
-        buffer = getBuffer();
         SOURCE.start(buffer);
 
         WebClient.builder().factory(ClientFactory.insecure()).build().execute(RequestHeaders.builder()
@@ -814,4 +830,101 @@ public class OTelTraceSourceTest {
             assertTrue(Thread.interrupted());
         }
     }
+
+    @Test
+    void gRPC_request_writes_to_buffer_with_successful_response() throws Exception {
+        configureObjectUnderTest();
+        SOURCE.start(buffer);
+
+        final TraceServiceGrpc.TraceServiceBlockingStub client = Clients.builder(GRPC_ENDPOINT)
+                .build(TraceServiceGrpc.TraceServiceBlockingStub.class);
+        final ExportTraceServiceResponse exportResponse = client.export(createExportTraceRequest());
+        assertThat(exportResponse, notNullValue());
+
+        final ArgumentCaptor<Collection<Record<Object>>> bufferWriteArgumentCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(buffer).writeAll(bufferWriteArgumentCaptor.capture(), anyInt());
+
+        final Collection<Record<Object>> actualBufferWrites = bufferWriteArgumentCaptor.getValue();
+        assertThat(actualBufferWrites, notNullValue());
+        assertThat(actualBufferWrites, hasSize(1));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(BufferExceptionToStatusArgumentsProvider.class)
+    void gRPC_request_returns_expected_status_for_exceptions_from_buffer(
+            final Class<Exception> bufferExceptionClass,
+            final Status.Code expectedStatusCode) throws Exception {
+        configureObjectUnderTest();
+        SOURCE.start(buffer);
+
+        final TraceServiceGrpc.TraceServiceBlockingStub client = Clients.builder(GRPC_ENDPOINT)
+                .build(TraceServiceGrpc.TraceServiceBlockingStub.class);
+
+        doThrow(bufferExceptionClass)
+                .when(buffer)
+                .writeAll(anyCollection(), anyInt());
+        final ExportTraceServiceRequest exportTraceRequest = createExportTraceRequest();
+        final StatusRuntimeException actualException = assertThrows(StatusRuntimeException.class, () -> client.export(exportTraceRequest));
+
+        assertThat(actualException.getStatus(), notNullValue());
+        assertThat(actualException.getStatus().getCode(), equalTo(expectedStatusCode));
+    }
+
+    @Test
+    void gRPC_request_throws_InvalidArgument_for_malformed_trace_data() {
+        configureObjectUnderTest();
+        SOURCE.start(buffer);
+
+        final TraceServiceGrpc.TraceServiceBlockingStub client = Clients.builder(GRPC_ENDPOINT)
+                .build(TraceServiceGrpc.TraceServiceBlockingStub.class);
+
+        final ExportTraceServiceRequest exportTraceRequest = createInvalidExportTraceRequest();
+        final StatusRuntimeException actualException = assertThrows(StatusRuntimeException.class, () -> client.export(exportTraceRequest));
+
+        assertThat(actualException.getStatus(), notNullValue());
+        assertThat(actualException.getStatus().getCode(), equalTo(Status.Code.INVALID_ARGUMENT));
+
+        verifyNoInteractions(buffer);
+    }
+
+    static class BufferExceptionToStatusArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
+            return Stream.of(
+                    arguments(TimeoutException.class, Status.Code.RESOURCE_EXHAUSTED),
+                    arguments(SizeOverflowException.class, Status.Code.RESOURCE_EXHAUSTED),
+                    arguments(Exception.class, Status.Code.INTERNAL),
+                    arguments(RuntimeException.class, Status.Code.INTERNAL)
+            );
+        }
+    }
+
+    private ExportTraceServiceRequest createInvalidExportTraceRequest() {
+        final io.opentelemetry.proto.trace.v1.Span testSpan = Span.newBuilder()
+                .setTraceState("SUCCESS").build();
+        final ExportTraceServiceRequest successRequest = ExportTraceServiceRequest.newBuilder()
+                .addResourceSpans(ResourceSpans.newBuilder()
+                        .addInstrumentationLibrarySpans(InstrumentationLibrarySpans.newBuilder().addSpans(testSpan)).build())
+                .build();
+
+        return successRequest;
+    }
+
+    private ExportTraceServiceRequest createExportTraceRequest() {
+        final io.opentelemetry.proto.trace.v1.Span testSpan = Span.newBuilder()
+                .setTraceId(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
+                .setSpanId(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
+                .setName(UUID.randomUUID().toString())
+                .setKind(Span.SpanKind.SPAN_KIND_SERVER)
+                .setStartTimeUnixNano(100)
+                .setEndTimeUnixNano(101)
+                .setTraceState("SUCCESS").build();
+        final ExportTraceServiceRequest successRequest = ExportTraceServiceRequest.newBuilder()
+                .addResourceSpans(ResourceSpans.newBuilder()
+                        .addInstrumentationLibrarySpans(InstrumentationLibrarySpans.newBuilder().addSpans(testSpan)).build())
+                .build();
+
+        return successRequest;
+    }
+
 }

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -112,6 +112,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.oteltrace.OTelTraceSourceConfig.DEFAULT_PORT;
+import static org.opensearch.dataprepper.plugins.source.oteltrace.OTelTraceSourceConfig.DEFAULT_REQUEST_TIMEOUT_MS;
 import static org.opensearch.dataprepper.plugins.source.oteltrace.OTelTraceSourceConfig.SSL;
 
 @ExtendWith(MockitoExtension.class)
@@ -150,6 +152,7 @@ public class OTelTraceSourceTest {
 
     private PluginSetting pluginSetting;
     private PluginSetting testPluginSetting;
+    @Mock(lenient = true)
     private OTelTraceSourceConfig oTelTraceSourceConfig;
     private PluginMetrics pluginMetrics;
     private PipelineDescription pipelineDescription;
@@ -183,14 +186,8 @@ public class OTelTraceSourceTest {
     }
 
     private void configureObjectUnderTest() {
-        final Map<String, Object> settingsMap = new HashMap<>();
-        settingsMap.put("request_timeout", 5);
-        settingsMap.put(SSL, false);
-        pluginSetting = new PluginSetting("otel_trace", settingsMap);
-        pluginSetting.setPipelineName("pipeline");
         pluginMetrics = PluginMetrics.fromNames("otel_trace", "pipeline");
 
-        oTelTraceSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelTraceSourceConfig.class);
         pipelineDescription = mock(PipelineDescription.class);
         when(pipelineDescription.getPipelineName()).thenReturn(TEST_PIPELINE_NAME);
         SOURCE = new OTelTraceSource(oTelTraceSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
@@ -211,6 +208,12 @@ public class OTelTraceSourceTest {
         lenient().when(grpcServiceBuilder.build()).thenReturn(grpcService);
 
         lenient().when(authenticationProvider.getHttpAuthenticationService()).thenCallRealMethod();
+
+        when(oTelTraceSourceConfig.getPort()).thenReturn(DEFAULT_PORT);
+        when(oTelTraceSourceConfig.isSsl()).thenReturn(false);
+        when(oTelTraceSourceConfig.getRequestTimeoutInMillis()).thenReturn(DEFAULT_REQUEST_TIMEOUT_MS);
+        when(oTelTraceSourceConfig.getMaxConnectionCount()).thenReturn(10);
+        when(oTelTraceSourceConfig.getThreadCount()).thenReturn(5);
 
         when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))
                 .thenReturn(authenticationProvider);


### PR DESCRIPTION
### Description

Changes to OTel Trace Source

Logging improvements when traces fail to parse. These are related to #2185.
* Logs only the exception message. The whole stack trace is not necessary since this is not a bug in Data Prepper.
* Include the Trace in the message.
* Adds the SENSITIVE marker so that this logging can be disabled.
* Move to WARN from ERROR. Again, this is not a bug in Data Prepper.

Adds new integration tests. The test for this did not actually verify correct behavior for gRPC calls. This adds a few new tests to verify this behavior.
 
### Issues Resolved

Related to #2185.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
