### PR TITLE
Created a metric for the overall JVM memory usage - both heap and non-heap

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/meter/JvmMemoryAggregateMetrics.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/meter/JvmMemoryAggregateMetrics.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.meter;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.BaseUnits;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+
+/**
+ * Provides JVM metrics
+ */
+public class JvmMemoryAggregateMetrics implements MeterBinder {
+    static final String AREA_TAG_NAME = "area";
+    static final String JVM_MEMORY_USED = "jvm.memory.used";
+    private final MemoryMXBean memoryMXBean;
+
+    public JvmMemoryAggregateMetrics() {
+        memoryMXBean = ManagementFactory.getMemoryMXBean();
+    }
+
+    @Override
+    public void bindTo(final MeterRegistry registry) {
+        final MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+
+        Gauge.builder(JVM_MEMORY_USED, memoryMXBean, (mem) -> mem.getHeapMemoryUsage().getUsed())
+                .tags(Tags.of(Tag.of(AREA_TAG_NAME, "heap")))
+                .description("The amount of used heap memory")
+                .baseUnit(BaseUnits.BYTES)
+                .register(registry);
+        Gauge.builder(JVM_MEMORY_USED, memoryMXBean, (mem) -> mem.getNonHeapMemoryUsage().getUsed())
+                .tags(Tags.of(Tag.of(AREA_TAG_NAME, "nonheap")))
+                .description("The amount of used non-heap memory")
+                .baseUnit(BaseUnits.BYTES)
+                .register(registry);
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/config/MetricsConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/config/MetricsConfig.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.parser.config;
 
 import org.opensearch.dataprepper.meter.EMFLoggingMeterRegistry;
+import org.opensearch.dataprepper.meter.JvmMemoryAggregateMetrics;
 import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
 import org.opensearch.dataprepper.parser.model.MetricRegistryType;
 import org.opensearch.dataprepper.pipeline.server.CloudWatchMeterRegistryProvider;
@@ -72,6 +73,11 @@ public class MetricsConfig {
     @Bean
     public JvmThreadMetrics jvmThreadMetrics() {
         return new JvmThreadMetrics();
+    }
+
+    @Bean
+    public JvmMemoryAggregateMetrics jvmMemoryAggregateMetrics() {
+        return new JvmMemoryAggregateMetrics();
     }
 
     private void configureMetricRegistry(final Map<String, String> metricTags,

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/meter/JvmMemoryAggregateMetricsTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/meter/JvmMemoryAggregateMetricsTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.meter;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.BaseUnits;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.opensearch.dataprepper.meter.JvmMemoryAggregateMetrics.AREA_TAG_NAME;
+import static org.opensearch.dataprepper.meter.JvmMemoryAggregateMetrics.JVM_MEMORY_USED;
+
+@ExtendWith(MockitoExtension.class)
+class JvmMemoryAggregateMetricsTest {
+    @Mock
+    private MemoryMXBean memoryMXBean;
+
+    private MeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+    }
+
+    private JvmMemoryAggregateMetrics createObjectUnderTest() {
+        try (final MockedStatic<ManagementFactory> managementFactoryMockedStatic = mockStatic(ManagementFactory.class)) {
+            managementFactoryMockedStatic.when(ManagementFactory::getMemoryMXBean).thenReturn(memoryMXBean);
+            return new JvmMemoryAggregateMetrics();
+        }
+    }
+
+    @Test
+    void bindTo_registers_heap_Meter_with_MeterRegistry() {
+        createObjectUnderTest().bindTo(meterRegistry);
+
+        assertThat(meterRegistry.getMeters().size(), equalTo(2));
+
+        final Meter heapMeter = meterRegistry.getMeters().stream()
+                .filter(m -> m.getId().getTag(AREA_TAG_NAME).equals("heap"))
+                .findFirst()
+                .orElse(null);
+
+        assertThat(heapMeter, notNullValue());
+        assertThat(heapMeter.getId().getName(), equalTo(JVM_MEMORY_USED));
+        assertThat(heapMeter.getId().getBaseUnit(), equalTo(BaseUnits.BYTES));
+        assertThat(heapMeter.getId().getDescription(), allOf(notNullValue(), not(emptyString())));
+    }
+
+    @Test
+    void bindTo_registers_nonheap_Meter_with_MeterRegistry() {
+        createObjectUnderTest().bindTo(meterRegistry);
+
+        assertThat(meterRegistry.getMeters().size(), equalTo(2));
+
+        final Meter nonHeapMeter = meterRegistry.getMeters().stream()
+                .filter(m -> m.getId().getTag(AREA_TAG_NAME).equals("nonheap"))
+                .findFirst()
+                .orElse(null);
+
+        assertThat(nonHeapMeter, notNullValue());
+        assertThat(nonHeapMeter.getId().getName(), equalTo(JVM_MEMORY_USED));
+        assertThat(nonHeapMeter.getId().getBaseUnit(), equalTo(BaseUnits.BYTES));
+        assertThat(nonHeapMeter.getId().getDescription(), allOf(notNullValue(), not(emptyString())));
+    }
+}


### PR DESCRIPTION
### Description

By default, the Micrometer memory metrics break the memory metrics into pools. This PR uses the aggregate heap and non-heap usage for a clearer view.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
