### PR TITLE
Updated Data Prepper base image for e2e tests

### DIFF
--- a/e2e-test/build.gradle
+++ b/e2e-test/build.gradle
@@ -47,6 +47,6 @@ subprojects {
         dataPrepperJarFilepath = "${project.buildDir.name}/bin/data-prepper/"
         targetJavaVersion = project.hasProperty('endToEndJavaVersion') ? project.getProperty('endToEndJavaVersion') : '11'
         targetOpenTelemetryVersion = project.hasProperty('openTelemetryVersion') ? project.getProperty('openTelemetryVersion') : "${libs.versions.opentelemetry.get()}"
-        dataPrepperBaseImage = "eclipse-temurin:${targetJavaVersion}-jre-alpine"
+        dataPrepperBaseImage = "eclipse-temurin:${targetJavaVersion}-jre"
     }
 }


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
- Removes use of alpine image to run e2e tests on ARM architecture
 
### Issues Resolved
Contributes towards #640 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
