### PR TITLE
Use a factory method in trace raw processor

### DIFF
--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OTelTraceRawProcessor.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/OTelTraceRawProcessor.java
@@ -124,7 +124,7 @@ public class OTelTraceRawProcessor extends AbstractProcessor<Record<Span>, Recor
      * @return List containing root span, along with any child spans that have already been processed.
      */
     private List<Span> processRootSpan(final Span parentSpan) {
-        final TraceGroup traceGroup = new TraceGroup.TraceGroupBuilder().setFromSpan(parentSpan).build();
+        final TraceGroup traceGroup = TraceGroup.fromSpan(parentSpan);
         final String parentSpanTraceId = parentSpan.getTraceId();
         traceIdTraceGroupCache.put(parentSpanTraceId, traceGroup);
 

--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/model/TraceGroup.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltrace/model/TraceGroup.java
@@ -13,6 +13,11 @@ public class TraceGroup {
 
     private final TraceGroupFields traceGroupFields;
 
+    private TraceGroup(final String traceGroup, final TraceGroupFields traceGroupFields) {
+        this.traceGroup = traceGroup;
+        this.traceGroupFields = traceGroupFields;
+    }
+
     public String getTraceGroup() {
         return traceGroup;
     }
@@ -21,33 +26,7 @@ public class TraceGroup {
         return traceGroupFields;
     }
 
-    TraceGroup(final TraceGroupBuilder traceGroupBuilder) {
-        traceGroup = traceGroupBuilder.traceGroup;
-        traceGroupFields = traceGroupBuilder.traceGroupFields;
-    }
-
-    public static class TraceGroupBuilder {
-        private String traceGroup;
-        private TraceGroupFields traceGroupFields;
-
-        public TraceGroupBuilder setTraceGroup(final String traceGroup) {
-            this.traceGroup = traceGroup;
-            return this;
-        }
-
-        public TraceGroupBuilder setTraceGroupFields(final TraceGroupFields traceGroupFields) {
-            this.traceGroupFields = traceGroupFields;
-            return this;
-        }
-
-        public TraceGroup build() {
-            return new TraceGroup(this);
-        }
-
-        public TraceGroupBuilder setFromSpan(final Span span) {
-            return this
-                    .setTraceGroup(span.getTraceGroup())
-                    .setTraceGroupFields(span.getTraceGroupFields());
-        }
+    public static TraceGroup fromSpan(final Span span) {
+        return new TraceGroup(span.getTraceGroup(), span.getTraceGroupFields());
     }
 }

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/oteltrace/model/TraceGroupTest.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/oteltrace/model/TraceGroupTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.oteltrace.model;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.trace.Span;
+import org.opensearch.dataprepper.model.trace.TraceGroupFields;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TraceGroupTest {
+    @Test
+    void fromSpan_creates_expected_TraceGroup() {
+        final String traceGroup = UUID.randomUUID().toString();
+        final TraceGroupFields traceGroupFields = mock(TraceGroupFields.class);
+        final Span span = mock(Span.class);
+        when(span.getTraceGroup()).thenReturn(traceGroup);
+        when(span.getTraceGroupFields()).thenReturn(traceGroupFields);
+
+        final TraceGroup objectUnderTest = TraceGroup.fromSpan(span);
+
+        assertThat(objectUnderTest, notNullValue());
+        assertThat(objectUnderTest.getTraceGroup(), equalTo(traceGroup));
+        assertThat(objectUnderTest.getTraceGroupFields(), equalTo(traceGroupFields));
+    }
+}


### PR DESCRIPTION
### Description

The `otel_trace_raw` processor was using a builder pattern to create a `TraceGroup` object for each parent span. This is used rather rigidly, so we can replace it with a factory method. This is a small optimization to reduce object creation (specifically removes the call to create a new builder object).
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
