### PR TITLE
Added path support for HTTP source

### DIFF
--- a/data-prepper-plugins/http-source/README.md
+++ b/data-prepper-plugins/http-source/README.md
@@ -22,7 +22,7 @@ source:
 ## Configurations
 
 * port (Optional) => An `int` between 0 and 65535 represents the port source is running on. Default is ```2021```.
-* path (Optional) => A `string` which represents the URI path for log ingestion, and it should start with `/`. Path can contain `${PIPELINE_NAME}` placeholder which will be replaced with pipeline name. Default value is `/log/ingest`.
+* path (Optional) => A `string` which represents the URI path for log ingestion, and it should start with `/`. Path can contain `${pipelineName}` placeholder which will be replaced with pipeline name. Default value is `/log/ingest`.
 * health_check_service (Optional) => A `boolean` that determines if a `/health` endpoint on the defined port will be home to a health check. Default is `false`
 * unauthenticated_health_check (Optional) => A `boolean` that determines if the health endpoint will require authentication. This option is ignored if no authentication is defined. Default is `false`
 * request_timeout (Optional) => An `int` larger than 0 represents request timeout in millis. Default is ```10_000```. 

--- a/data-prepper-plugins/http-source/README.md
+++ b/data-prepper-plugins/http-source/README.md
@@ -5,7 +5,7 @@ This is a source plugin that supports HTTP protocol. Currently ONLY support Json
 
 
 ## Usages
-Currently, we are exposing `/log/ingest` URI path for http log ingestion. Example `.yaml` configuration:
+To get started with HTTP source, create the following `pipeline.yaml` configuration:
 ```yaml
 source:
    http:
@@ -22,6 +22,7 @@ source:
 ## Configurations
 
 * port (Optional) => An `int` between 0 and 65535 represents the port source is running on. Default is ```2021```.
+* path (Optional) => A `string` which represents the URI path for log ingestion, and it should start with `/`. Path can contain `${PIPELINE_NAME}` placeholder which will be replaced with pipeline name. Default value is `/log/ingest`.
 * health_check_service (Optional) => A `boolean` that determines if a `/health` endpoint on the defined port will be home to a health check. Default is `false`
 * unauthenticated_health_check (Optional) => A `boolean` that determines if the health endpoint will require authentication. This option is ignored if no authentication is defined. Default is `false`
 * request_timeout (Optional) => An `int` larger than 0 represents request timeout in millis. Default is ```10_000```. 

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
@@ -40,6 +40,7 @@ import java.util.function.Function;
 @DataPrepperPlugin(name = "http", pluginType = Source.class, pluginConfigurationType = HTTPSourceConfig.class)
 public class HTTPSource implements Source<Record<Log>> {
     private static final Logger LOG = LoggerFactory.getLogger(HTTPSource.class);
+    private static final String PIPELINE_NAME_PLACEHOLDER = "${pipelineName}";
     public static final String REGEX_HEALTH = "regex:^/(?!health$).*$";
 
     private final HTTPSourceConfig sourceConfig;
@@ -122,7 +123,7 @@ public class HTTPSource implements Source<Record<Log>> {
                     maxPendingRequests, blockingTaskExecutor.getQueue());
             final LogThrottlingRejectHandler logThrottlingRejectHandler = new LogThrottlingRejectHandler(maxPendingRequests, pluginMetrics);
 
-            final String httpSourcePath = sourceConfig.getPath().replace("${PIPELINE_NAME}", pipelineName);
+            final String httpSourcePath = sourceConfig.getPath().replace(PIPELINE_NAME_PLACEHOLDER, pipelineName);
             sb.decorator(httpSourcePath, ThrottlingService.newDecorator(logThrottlingStrategy, logThrottlingRejectHandler));
             final LogHTTPService logHTTPService = new LogHTTPService(sourceConfig.getBufferTimeoutInMillis(), buffer, pluginMetrics);
             sb.annotatedService(httpSourcePath, logHTTPService);

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
@@ -45,6 +45,7 @@ public class HTTPSource implements Source<Record<Log>> {
     private final HTTPSourceConfig sourceConfig;
     private final CertificateProviderFactory certificateProviderFactory;
     private final ArmeriaHttpAuthenticationProvider authenticationProvider;
+    private final String pipelineName;
     private Server server;
     private final PluginMetrics pluginMetrics;
     private static final String HTTP_HEALTH_CHECK_PATH = "/health";
@@ -54,7 +55,8 @@ public class HTTPSource implements Source<Record<Log>> {
                       final PipelineDescription pipelineDescription) {
         this.sourceConfig = sourceConfig;
         this.pluginMetrics = pluginMetrics;
-        certificateProviderFactory = new CertificateProviderFactory(sourceConfig);
+        this.pipelineName = pipelineDescription.getPipelineName();
+        this.certificateProviderFactory = new CertificateProviderFactory(sourceConfig);
         final PluginModel authenticationConfiguration = sourceConfig.getAuthentication();
         final PluginSetting authenticationPluginSetting;
 
@@ -70,7 +72,7 @@ public class HTTPSource implements Source<Record<Log>> {
             authenticationPluginSetting =
                     new PluginSetting(ArmeriaHttpAuthenticationProvider.UNAUTHENTICATED_PLUGIN_NAME, Collections.emptyMap());
         }
-        authenticationPluginSetting.setPipelineName(pipelineDescription.getPipelineName());
+        authenticationPluginSetting.setPipelineName(pipelineName);
         authenticationProvider = pluginFactory.loadPlugin(ArmeriaHttpAuthenticationProvider.class, authenticationPluginSetting);
     }
 
@@ -119,10 +121,11 @@ public class HTTPSource implements Source<Record<Log>> {
             final LogThrottlingStrategy logThrottlingStrategy = new LogThrottlingStrategy(
                     maxPendingRequests, blockingTaskExecutor.getQueue());
             final LogThrottlingRejectHandler logThrottlingRejectHandler = new LogThrottlingRejectHandler(maxPendingRequests, pluginMetrics);
-            // TODO: allow customization on URI path for log ingestion
-            sb.decorator(HTTPSourceConfig.DEFAULT_LOG_INGEST_URI, ThrottlingService.newDecorator(logThrottlingStrategy, logThrottlingRejectHandler));
+
+            final String httpSourcePath = sourceConfig.getPath().replace("${PIPELINE_NAME}", pipelineName);
+            sb.decorator(httpSourcePath, ThrottlingService.newDecorator(logThrottlingStrategy, logThrottlingRejectHandler));
             final LogHTTPService logHTTPService = new LogHTTPService(sourceConfig.getBufferTimeoutInMillis(), buffer, pluginMetrics);
-            sb.annotatedService(HTTPSourceConfig.DEFAULT_LOG_INGEST_URI, logHTTPService);
+            sb.annotatedService(httpSourcePath, logHTTPService);
 
             if (sourceConfig.hasHealthCheckService()) {
                 LOG.info("HTTP source health check is enabled");

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
@@ -35,6 +35,9 @@ public class HTTPSourceConfig {
     @Max(65535)
     private int port = DEFAULT_PORT;
 
+    @JsonProperty("path")
+    private String path = DEFAULT_LOG_INGEST_URI;
+
     @JsonProperty("request_timeout")
     @Min(2)
     private int requestTimeoutInMillis = DEFAULT_REQUEST_TIMEOUT_MS;
@@ -89,6 +92,11 @@ public class HTTPSourceConfig {
                 sslKeyFile.toLowerCase().startsWith(S3_PREFIX);
     }
 
+    @AssertTrue(message = "path should start with /")
+    boolean isPathValid() {
+        return path.startsWith("/");
+    }
+
     @AssertTrue(message = "ssl_certificate_file cannot be a empty or null when ssl is enabled")
     boolean isSslCertificateFileValid() {
         if (ssl && !useAcmCertificateForSsl) {
@@ -129,6 +137,10 @@ public class HTTPSourceConfig {
 
     public int getPort() {
         return port;
+    }
+
+    public String getPath() {
+        return path;
     }
 
     public int getRequestTimeoutInMillis() {

--- a/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfigTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfigTest.java
@@ -24,6 +24,7 @@ public class HTTPSourceConfigTest {
 
         // When/Then
         assertEquals(HTTPSourceConfig.DEFAULT_PORT, sourceConfig.getPort());
+        assertEquals(HTTPSourceConfig.DEFAULT_LOG_INGEST_URI, sourceConfig.getPath());
         assertEquals(HTTPSourceConfig.DEFAULT_REQUEST_TIMEOUT_MS, sourceConfig.getRequestTimeoutInMillis());
         assertEquals(HTTPSourceConfig.DEFAULT_THREAD_COUNT, sourceConfig.getThreadCount());
         assertEquals(HTTPSourceConfig.DEFAULT_MAX_CONNECTION_COUNT, sourceConfig.getMaxConnectionCount());
@@ -224,6 +225,25 @@ public class HTTPSourceConfigTest {
 
             assertThat(objectUnderTest.isAcmCertificateArnValid(), equalTo(true));
         }
+    }
+
+    @Test
+    void getPath_should_return_correct_path() throws NoSuchFieldException, IllegalAccessException {
+        final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+        reflectivelySetField(objectUnderTest, "path", "/my/custom/path");
+
+        assertThat(objectUnderTest.isPathValid(), equalTo(true));
+        assertThat(objectUnderTest.getPath(), equalTo("/my/custom/path"));
+    }
+
+    @Test
+    void isPathValid_should_return_false_for_invalid_path() throws NoSuchFieldException, IllegalAccessException {
+        final HTTPSourceConfig objectUnderTest = new HTTPSourceConfig();
+
+        reflectivelySetField(objectUnderTest, "path", "my/custom/path");
+
+        assertThat(objectUnderTest.isPathValid(), equalTo(false));
     }
 
         private void reflectivelySetField(final HTTPSourceConfig httpSourceConfig, final String fieldName, final Object value) throws NoSuchFieldException, IllegalAccessException {

--- a/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
@@ -542,7 +542,7 @@ class HTTPSourceTest {
     void testHTTPSJsonResponse_with_custom_path_along_with_placeholder() {
         reset(sourceConfig);
         when(sourceConfig.getPort()).thenReturn(2021);
-        when(sourceConfig.getPath()).thenReturn("/${PIPELINE_NAME}/test");
+        when(sourceConfig.getPath()).thenReturn("/${pipelineName}/test");
         when(sourceConfig.getThreadCount()).thenReturn(200);
         when(sourceConfig.getMaxConnectionCount()).thenReturn(500);
         when(sourceConfig.getMaxPendingRequests()).thenReturn(1024);

--- a/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
@@ -170,6 +170,7 @@ class HTTPSourceTest {
 
         sourceConfig = mock(HTTPSourceConfig.class);
         lenient().when(sourceConfig.getPort()).thenReturn(2021);
+        lenient().when(sourceConfig.getPath()).thenReturn(HTTPSourceConfig.DEFAULT_LOG_INGEST_URI);
         lenient().when(sourceConfig.getRequestTimeoutInMillis()).thenReturn(10_000);
         lenient().when(sourceConfig.getThreadCount()).thenReturn(200);
         lenient().when(sourceConfig.getMaxConnectionCount()).thenReturn(500);
@@ -512,6 +513,7 @@ class HTTPSourceTest {
     void testHTTPSJsonResponse() {
         reset(sourceConfig);
         when(sourceConfig.getPort()).thenReturn(2021);
+        when(sourceConfig.getPath()).thenReturn(HTTPSourceConfig.DEFAULT_LOG_INGEST_URI);
         when(sourceConfig.getThreadCount()).thenReturn(200);
         when(sourceConfig.getMaxConnectionCount()).thenReturn(500);
         when(sourceConfig.getMaxPendingRequests()).thenReturn(1024);
@@ -532,6 +534,38 @@ class HTTPSourceTest {
                         .contentType(MediaType.JSON_UTF_8)
                         .build(),
                 HttpData.ofUtf8("[{\"log\": \"somelog\"}]"))
+                .aggregate()
+                .whenComplete((i, ex) -> assertSecureResponseWithStatusCode(i, HttpStatus.OK)).join();
+    }
+
+    @Test
+    void testHTTPSJsonResponse_with_custom_path_along_with_placeholder() {
+        reset(sourceConfig);
+        when(sourceConfig.getPort()).thenReturn(2021);
+        when(sourceConfig.getPath()).thenReturn("/${PIPELINE_NAME}/test");
+        when(sourceConfig.getThreadCount()).thenReturn(200);
+        when(sourceConfig.getMaxConnectionCount()).thenReturn(500);
+        when(sourceConfig.getMaxPendingRequests()).thenReturn(1024);
+        when(sourceConfig.getRequestTimeoutInMillis()).thenReturn(200);
+        when(sourceConfig.isSsl()).thenReturn(true);
+
+        when(sourceConfig.getSslCertificateFile()).thenReturn(TEST_SSL_CERTIFICATE_FILE);
+        when(sourceConfig.getSslKeyFile()).thenReturn(TEST_SSL_KEY_FILE);
+        HTTPSourceUnderTest = new HTTPSource(sourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
+
+        testBuffer = getBuffer();
+        HTTPSourceUnderTest.start(testBuffer);
+
+        final String path = "/" + TEST_PIPELINE_NAME + "/test";
+
+        WebClient.builder().factory(ClientFactory.insecure()).build().execute(RequestHeaders.builder()
+                                .scheme(SessionProtocol.HTTPS)
+                                .authority("127.0.0.1:2021")
+                                .method(HttpMethod.POST)
+                                .path(path)
+                                .contentType(MediaType.JSON_UTF_8)
+                                .build(),
+                        HttpData.ofUtf8("[{\"log\": \"somelog\"}]"))
                 .aggregate()
                 .whenComplete((i, ex) -> assertSecureResponseWithStatusCode(i, HttpStatus.OK)).join();
     }

--- a/e2e-test/log/src/integrationTest/java/org/opensearch/dataprepper/integration/log/EndToEndBasicLogTest.java
+++ b/e2e-test/log/src/integrationTest/java/org/opensearch/dataprepper/integration/log/EndToEndBasicLogTest.java
@@ -96,7 +96,7 @@ public class EndToEndBasicLogTest {
                         .scheme(SessionProtocol.HTTP)
                         .authority(String.format("127.0.0.1:%d", port))
                         .method(HttpMethod.POST)
-                        .path("/log/ingest")
+                        .path("/grok-pipeline/logs")
                         .contentType(MediaType.JSON_UTF_8)
                         .build(),
                 httpData)

--- a/e2e-test/log/src/integrationTest/resources/basic-grok-e2e-pipeline.yml
+++ b/e2e-test/log/src/integrationTest/resources/basic-grok-e2e-pipeline.yml
@@ -1,7 +1,7 @@
 grok-pipeline:
   source:
     http:
-      path: "/${PIPELINE_NAME}/logs"
+      path: "/${pipelineName}/logs"
   processor:
     - grok:
         match:

--- a/e2e-test/log/src/integrationTest/resources/basic-grok-e2e-pipeline.yml
+++ b/e2e-test/log/src/integrationTest/resources/basic-grok-e2e-pipeline.yml
@@ -1,6 +1,7 @@
 grok-pipeline:
   source:
     http:
+      path: "/${PIPELINE_NAME}/logs"
   processor:
     - grok:
         match:


### PR DESCRIPTION
### Description
- Adds `path` option to HTTP source
- Updated grok e2e to verify the change
 
### Issues Resolved
Resolves #2258 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
