### PR TITLE
Create DataPrepper server after pipeline initialization

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/DataPrepperServer.java
@@ -5,10 +5,16 @@
 
 package org.opensearch.dataprepper.pipeline.server;
 
+import com.sun.net.httpserver.Authenticator;
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.concurrent.ExecutorService;
@@ -22,23 +28,66 @@ import java.util.concurrent.Executors;
 @Named
 public class DataPrepperServer {
     private static final Logger LOG = LoggerFactory.getLogger(DataPrepperServer.class);
-    private final HttpServer server;
+    private final HttpServerProvider serverProvider;
+    private final ListPipelinesHandler listPipelinesHandler;
+    private final ShutdownHandler shutdownHandler;
+    private final PrometheusMeterRegistry prometheusMeterRegistry;
+    private final Authenticator authenticator;
+    private HttpServer server;
     static final ExecutorService EXECUTOR_SERVICE = Executors.newFixedThreadPool(3);
 
     @Inject
     public DataPrepperServer(
-            final HttpServer server
+            final HttpServerProvider serverProvider,
+            final ListPipelinesHandler listPipelinesHandler,
+            final ShutdownHandler shutdownHandler,
+            @Autowired(required = false) @Nullable final PrometheusMeterRegistry prometheusMeterRegistry,
+            @Autowired(required = false) @Nullable final Authenticator authenticator
     ) {
-        this.server = server;
+        this.serverProvider = serverProvider;
+        this.listPipelinesHandler = listPipelinesHandler;
+        this.shutdownHandler = shutdownHandler;
+        this.prometheusMeterRegistry = prometheusMeterRegistry;
+        this.authenticator = authenticator;
     }
 
     /**
      * Start the DataPrepperServer
      */
     public void start() {
+        server = createServer();
         server.setExecutor(EXECUTOR_SERVICE);
         server.start();
         LOG.info("Data Prepper server running at :{}", server.getAddress().getPort());
+    }
+
+    private HttpServer createServer() {
+        final HttpServer server = serverProvider.get();
+
+        createContext(server, listPipelinesHandler, authenticator, "/list");
+        createContext(server, shutdownHandler, authenticator, "/shutdown");
+
+        if (prometheusMeterRegistry != null) {
+            final PrometheusMetricsHandler prometheusMetricsHandler = new PrometheusMetricsHandler(prometheusMeterRegistry);
+            createContext(server, prometheusMetricsHandler, authenticator, "/metrics/prometheus", "/metrics/sys");
+        }
+
+        return server;
+    }
+
+    private void createContext(
+            final HttpServer httpServer,
+            final HttpHandler httpHandler,
+            @Nullable final Authenticator authenticator,
+            final String ... paths
+    ) {
+        for (final String path : paths) {
+            final HttpContext context = httpServer.createContext(path, httpHandler);
+
+            if (authenticator != null) {
+                context.setAuthenticator(authenticator);
+            }
+        }
     }
 
     /**

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/HttpServerProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/HttpServerProvider.java
@@ -15,14 +15,13 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Provider;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
 @Named
-public class HttpServerProvider implements Provider<HttpServer> {
+public class HttpServerProvider {
     private static final Logger LOG = LoggerFactory.getLogger(HttpServerProvider.class);
 
     private final DataPrepperConfiguration dataPrepperConfiguration;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/HttpServerProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/HttpServerProvider.java
@@ -32,7 +32,6 @@ public class HttpServerProvider implements Provider<HttpServer> {
         this.dataPrepperConfiguration = dataPrepperConfiguration;
     }
 
-    @Override
     public HttpServer get() {
         final InetSocketAddress socketAddress = new InetSocketAddress(dataPrepperConfiguration.getServerPort());
         try {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/config/DataPrepperServerConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/config/DataPrepperServerConfiguration.java
@@ -10,64 +10,20 @@ import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.pipeline.server.DataPrepperCoreAuthenticationProvider;
-import org.opensearch.dataprepper.pipeline.server.HttpServerProvider;
 import org.opensearch.dataprepper.pipeline.server.ListPipelinesHandler;
-import org.opensearch.dataprepper.pipeline.server.PrometheusMetricsHandler;
 import org.opensearch.dataprepper.pipeline.server.ShutdownHandler;
 import com.sun.net.httpserver.Authenticator;
-import com.sun.net.httpserver.HttpContext;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 
 @Configuration
 public class DataPrepperServerConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(DataPrepperServerConfiguration.class);
-
-    private void createContext(
-            final HttpServer httpServer,
-            final HttpHandler httpHandler,
-            @Nullable final Authenticator authenticator,
-            final String ... paths
-    ) {
-        for (final String path : paths) {
-            final HttpContext context = httpServer.createContext(path, httpHandler);
-
-            if (authenticator != null) {
-                context.setAuthenticator(authenticator);
-            }
-        }
-    }
-
-    @Bean
-    public HttpServer httpServer(
-            final HttpServerProvider httpServerProvider,
-            final ListPipelinesHandler listPipelinesHandler,
-            final ShutdownHandler shutdownHandler,
-            @Autowired(required = false) @Nullable final PrometheusMeterRegistry prometheusMeterRegistry,
-            @Autowired(required = false) @Nullable final Authenticator authenticator
-            ) {
-
-        final HttpServer server = httpServerProvider.get();
-
-        createContext(server, listPipelinesHandler, authenticator, "/list");
-        createContext(server, shutdownHandler, authenticator, "/shutdown");
-
-        if (prometheusMeterRegistry != null) {
-            final PrometheusMetricsHandler prometheusMetricsHandler = new PrometheusMetricsHandler(prometheusMeterRegistry);
-            createContext(server, prometheusMetricsHandler, authenticator, "/metrics/prometheus", "/metrics/sys");
-        }
-
-        return server;
-    }
 
     private void printInsecurePluginModelWarning() {
         LOG.warn("Creating data prepper server without authentication. This is not secure.");

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/DataPrepperServerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/DataPrepperServerTest.java
@@ -5,10 +5,14 @@
 
 package org.opensearch.dataprepper.pipeline.server;
 
+import com.sun.net.httpserver.Authenticator;
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -17,9 +21,11 @@ import java.net.InetSocketAddress;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 
@@ -28,33 +34,119 @@ public class DataPrepperServerTest {
     @Mock
     private HttpServer server;
 
-    @InjectMocks
-    private DataPrepperServer dataPrepperServer;
+    @Mock
+    private HttpServerProvider httpServerProvider;
+
+    @Mock
+    private ListPipelinesHandler listPipelinesHandler;
+
+    @Mock
+    private ShutdownHandler shutdownHandler;
+
+    @Mock
+    private PrometheusMeterRegistry prometheusMeterRegistry;
+
+    @Mock
+    private HttpContext context;
+
+    @Mock
+    private InetSocketAddress socketAddress;
+
+    @Mock
+    private Authenticator authenticator;
+
+    @AfterEach
+    public void tearDown() {
+        verifyNoMoreInteractions(server, httpServerProvider, listPipelinesHandler, shutdownHandler,
+                prometheusMeterRegistry, authenticator, context, socketAddress);
+    }
 
     @Test
     public void testDataPrepperServerConstructor() {
+        final DataPrepperServer dataPrepperServer = createObjectUnderTest(prometheusMeterRegistry, authenticator);
         assertThat(dataPrepperServer, is(notNullValue()));
     }
 
     @Test
     public void testGivenValidServerWhenStartThenShouldCallServerStart() {
-        final InetSocketAddress socketAddress = mock(InetSocketAddress.class);
+        mockServerStart();
+
+        final DataPrepperServer dataPrepperServer = createObjectUnderTest(prometheusMeterRegistry, authenticator);
+        dataPrepperServer.start();
+
+        verifyServerStart();
+        verify(server).createContext(eq("/metrics/prometheus"), any(PrometheusMetricsHandler.class));
+        verify(server).createContext(eq("/metrics/sys"), any(PrometheusMetricsHandler.class));
+        verify(context, times(4)).setAuthenticator(eq(authenticator));
+    }
+
+    @Test
+    public void testGivenValidServerWhenStartThenShouldCallServerStart_NullPrometheus() {
+        mockServerStart();
+
+        final DataPrepperServer dataPrepperServer = createObjectUnderTest(null, authenticator);
+        dataPrepperServer.start();
+
+        verifyServerStart();
+        verify(context, times(2)).setAuthenticator(eq(authenticator));
+    }
+
+    @Test
+    public void testGivenValidServerWhenStartThenShouldCallServerStart_NullAuthenticator() {
+        mockServerStart();
+
+        final DataPrepperServer dataPrepperServer = createObjectUnderTest(prometheusMeterRegistry, null);
+        dataPrepperServer.start();
+
+        verifyServerStart();
+        verify(server).createContext(eq("/metrics/prometheus"), any(PrometheusMetricsHandler.class));
+        verify(server).createContext(eq("/metrics/sys"), any(PrometheusMetricsHandler.class));
+    }
+
+    @Test
+    public void testGivenValidServerWhenStartThenShouldCallServerStart_NullPrometheusAndAuthenticator() {
+        mockServerStart();
+
+        final DataPrepperServer dataPrepperServer = createObjectUnderTest(null, null);
+        dataPrepperServer.start();
+
+        verifyServerStart();
+
+    }
+
+    @Test
+    public void testGivenValidServerWhenStopThenShouldCallServerStopWithNoDelay() {
+        mockServerStart();
+
+        final DataPrepperServer dataPrepperServer = createObjectUnderTest(null, null);
+        dataPrepperServer.start();
+        dataPrepperServer.stop();
+
+        verifyServerStart();
+        verify(server).stop(eq(0));
+    }
+
+    private void mockServerStart() {
+        when(httpServerProvider.get())
+                .thenReturn(server);
 
         when(server.getAddress())
                 .thenReturn(socketAddress);
+        when(server.createContext(any(String.class), any(HttpHandler.class)))
+                .thenReturn(context);
+    }
 
-        dataPrepperServer.start();
-
+    private void verifyServerStart() {
+        verify(httpServerProvider).get();
+        verify(server).createContext("/list", listPipelinesHandler);
+        verify(server).createContext(eq("/shutdown"), eq(shutdownHandler));
         verify(server).setExecutor(DataPrepperServer.EXECUTOR_SERVICE);
         verify(server).start();
         verify(server).getAddress();
         verify(socketAddress).getPort();
     }
 
-    @Test
-    public void testGivenValidServerWhenStopThenShouldCallServerStopWithNoDely() {
-        dataPrepperServer.stop();
-
-        verify(server).stop(eq(0));
+    private DataPrepperServer createObjectUnderTest(final PrometheusMeterRegistry prometheusMeterRegistry, final Authenticator authenticator) {
+        return new DataPrepperServer(httpServerProvider, listPipelinesHandler, shutdownHandler, prometheusMeterRegistry, authenticator);
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/config/DataPrepperServerConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/config/DataPrepperServerConfigurationTest.java
@@ -10,18 +10,11 @@ import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.pipeline.server.DataPrepperCoreAuthenticationProvider;
-import org.opensearch.dataprepper.pipeline.server.HttpServerProvider;
 import org.opensearch.dataprepper.pipeline.server.ListPipelinesHandler;
-import org.opensearch.dataprepper.pipeline.server.PrometheusMetricsHandler;
 import org.opensearch.dataprepper.pipeline.server.ShutdownHandler;
 import com.sun.net.httpserver.Authenticator;
-import com.sun.net.httpserver.HttpContext;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
@@ -30,92 +23,13 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DataPrepperServerConfigurationTest {
-    @Mock
-    private HttpContext context;
-
-    @Mock
-    private HttpServer httpServer;
-
-    @Mock
-    private HttpServerProvider httpServerProvider;
-
-    @Mock
-    private ListPipelinesHandler listPipelinesHandler;
-
-    @Mock
-    private ShutdownHandler shutdownHandler;
-
     private final DataPrepperServerConfiguration serverConfiguration = new DataPrepperServerConfiguration();
-
-    @Test
-    public void testGivenNullPrometheusMeterRegistryAndNullAuthenticatorThenServerIsCreated() {
-        when(httpServerProvider.get())
-                .thenReturn(httpServer);
-        final HttpServer server = serverConfiguration.httpServer(httpServerProvider, listPipelinesHandler, shutdownHandler, null, null);
-
-        assertThat(server, is(httpServer));
-        verify(server).createContext("/list", listPipelinesHandler);
-        verify(server).createContext(eq("/shutdown"), eq(shutdownHandler));
-    }
-
-    @Test
-    public void testGivenPrometheusMeterRegistryAndNullAuthenticatorThenServerIsCreated() {
-        final PrometheusMeterRegistry meterRegistry = mock(PrometheusMeterRegistry.class);
-
-        when(httpServerProvider.get())
-                .thenReturn(httpServer);
-        when(httpServer.createContext(any(String.class), any(HttpHandler.class)))
-                .thenReturn(context);
-
-        final HttpServer server = serverConfiguration.httpServer(
-                httpServerProvider,
-                listPipelinesHandler,
-                shutdownHandler,
-                meterRegistry,
-                null);
-
-        assertThat(server, is(httpServer));
-        verify(server).createContext(eq("/list"), eq(listPipelinesHandler));
-        verify(server).createContext(eq("/shutdown"), eq(shutdownHandler));
-        verify(server).createContext(eq("/metrics/prometheus"), any(PrometheusMetricsHandler.class));
-        verify(server).createContext(eq("/metrics/sys"), any(PrometheusMetricsHandler.class));
-        verifyNoInteractions(context);
-    }
-
-    @Test
-    public void testGivenPrometheusMeterRegistryAndAuthenticatorThenServerIsCreated() {
-        final PrometheusMeterRegistry meterRegistry = mock(PrometheusMeterRegistry.class);
-        final Authenticator authenticator = mock(Authenticator.class);
-
-        when(httpServerProvider.get())
-                .thenReturn(httpServer);
-        when(httpServer.createContext(any(String.class), any(HttpHandler.class)))
-                .thenReturn(context);
-
-        final HttpServer server = serverConfiguration.httpServer(
-                httpServerProvider,
-                listPipelinesHandler,
-                shutdownHandler,
-                meterRegistry,
-                authenticator);
-
-        assertThat(server, is(httpServer));
-        verify(server).createContext(eq("/list"), eq(listPipelinesHandler));
-        verify(server).createContext(eq("/shutdown"), eq(shutdownHandler));
-        verify(server).createContext(eq("/metrics/prometheus"), any(PrometheusMetricsHandler.class));
-        verify(server).createContext(eq("/metrics/sys"), any(PrometheusMetricsHandler.class));
-        verify(context, times(4)).setAuthenticator(eq(authenticator));
-    }
 
     @Test
     public void testGivingNoConfigThenCreateInsecureSettings() {


### PR DESCRIPTION
### Description
This PR moves the DataPrepper server creation to the DataPrepperServer class rather than creating the server through injection. This allows the pipeline initialization logic to happen before the server port is opened. 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
