### PR TITLE
Refactor PeerForwarderReceiveBuffer to extend AbstractBuffer to pick up metric logic

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderProvider.java
@@ -69,7 +69,7 @@ public class PeerForwarderProvider {
 
     private PeerForwarderReceiveBuffer<Record<Event>> createBufferPerPipelineProcessor(final String pipelineName, final String pluginId) {
         final PeerForwarderReceiveBuffer<Record<Event>> peerForwarderReceiveBuffer = new
-                PeerForwarderReceiveBuffer<>(peerForwarderConfiguration.getBufferSize(), peerForwarderConfiguration.getBatchSize());
+                PeerForwarderReceiveBuffer<>(peerForwarderConfiguration.getBufferSize(), peerForwarderConfiguration.getBatchSize(), pipelineName, pluginId);
 
         final Map<String, PeerForwarderReceiveBuffer<Record<Event>>> pluginsBufferMap =
                 pipelinePeerForwarderReceiveBufferMap.computeIfAbsent(pipelineName, k -> new HashMap<>());

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderReceiveBuffer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderReceiveBuffer.java
@@ -5,8 +5,9 @@
 
 package org.opensearch.dataprepper.peerforwarder;
 
+import com.google.common.util.concurrent.AtomicDouble;
 import org.opensearch.dataprepper.model.CheckpointState;
-import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.buffer.AbstractBuffer;
 import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
 import org.opensearch.dataprepper.model.record.Record;
 import com.google.common.base.Stopwatch;
@@ -31,24 +32,32 @@ import static java.lang.String.format;
  *
  * @since 2.0
  */
-public class PeerForwarderReceiveBuffer<T extends Record<?>> implements Buffer<T> {
+public class PeerForwarderReceiveBuffer<T extends Record<?>> extends AbstractBuffer<T> {
     private static final Logger LOG = LoggerFactory.getLogger(PeerForwarderReceiveBuffer.class);
+
+    private static final String CORE_PEER_FORWARDER_COMPONENT = "core.peerForwarder";
+    private static final String BUFFER_ID_FORMAT = "%s.%s";
+    private static final String BUFFER_USAGE_METRIC = "bufferUsage";
 
     private final int bufferSize;
     private final int batchSize;
     private final Semaphore capacitySemaphore;
     private final LinkedBlockingQueue<T> blockingQueue;
     private int recordsInFlight = 0;
+    private final AtomicDouble bufferUsage;
 
-    public PeerForwarderReceiveBuffer(final int bufferSize, final int batchSize) {
+    public PeerForwarderReceiveBuffer(final int bufferSize, final int batchSize, final String pipelineName, final String pluginId) {
+        super(String.format(BUFFER_ID_FORMAT, pipelineName, pluginId), CORE_PEER_FORWARDER_COMPONENT);
         this.bufferSize = bufferSize;
         this.batchSize = batchSize;
         this.blockingQueue = new LinkedBlockingQueue<>(bufferSize);
         this.capacitySemaphore = new Semaphore(bufferSize);
+
+        bufferUsage = pluginMetrics.gauge(BUFFER_USAGE_METRIC, new AtomicDouble());
     }
 
     @Override
-    public void write(final T record, final int timeoutInMillis) throws TimeoutException {
+    public void doWrite(final T record, final int timeoutInMillis) throws TimeoutException {
         try {
             final boolean permitAcquired = capacitySemaphore.tryAcquire(timeoutInMillis, TimeUnit.MILLISECONDS);
             if (!permitAcquired) {
@@ -62,7 +71,7 @@ public class PeerForwarderReceiveBuffer<T extends Record<?>> implements Buffer<T
     }
 
     @Override
-    public void writeAll(final Collection<T> records, final int timeoutInMillis) throws Exception {
+    public void doWriteAll(final Collection<T> records, final int timeoutInMillis) throws Exception {
         final int size = records.size();
         if (size > bufferSize) {
             throw new SizeOverflowException(format("Peer forwarder buffer capacity too small for the size of records: %d", size));
@@ -86,7 +95,7 @@ public class PeerForwarderReceiveBuffer<T extends Record<?>> implements Buffer<T
 
     // TODO - consolidate duplicate logic in BlockingBuffer
     @Override
-    public Map.Entry<Collection<T>, CheckpointState> read(final int timeoutInMillis) {
+    public Map.Entry<Collection<T>, CheckpointState> doRead(final int timeoutInMillis) {
         final List<T> records = new ArrayList<>(batchSize);
         int recordsRead = 0;
 
@@ -128,7 +137,16 @@ public class PeerForwarderReceiveBuffer<T extends Record<?>> implements Buffer<T
     }
 
     @Override
-    public void checkpoint(final CheckpointState checkpointState) {
+    protected void postProcess(final Long recordsInBuffer) {
+        // adding bounds to address race conditions and reporting negative buffer usage
+        final Double nonNegativeTotalRecords = recordsInBuffer.doubleValue() < 0 ? 0 : recordsInBuffer.doubleValue();
+        final Double boundedTotalRecords = nonNegativeTotalRecords > bufferSize ? bufferSize : nonNegativeTotalRecords;
+        final Double usage = boundedTotalRecords / bufferSize * 100;
+        bufferUsage.set(usage);
+    }
+
+    @Override
+    public void doCheckpoint(final CheckpointState checkpointState) {
         final int numCheckedRecords = checkpointState.getNumRecordsToBeChecked();
         capacitySemaphore.release(numCheckedRecords);
         recordsInFlight -= checkpointState.getNumRecordsToBeChecked();

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderReceiveBufferTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderReceiveBufferTest.java
@@ -34,9 +34,11 @@ class PeerForwarderReceiveBufferTest {
     private static final int TEST_WRITE_TIMEOUT = 100;
     private static final int TEST_BATCH_READ_TIMEOUT = 5_000;
     private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
+    private static final String PIPELINE_NAME = UUID.randomUUID().toString();
+    private static final String PLUGIN_ID = UUID.randomUUID().toString();
 
     PeerForwarderReceiveBuffer<Record<String>> createObjectUnderTest(final int bufferSize) {
-        return new PeerForwarderReceiveBuffer<>(bufferSize, TEST_BATCH_SIZE);
+        return new PeerForwarderReceiveBuffer<>(bufferSize, TEST_BATCH_SIZE, PIPELINE_NAME, PLUGIN_ID);
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
@@ -72,6 +72,8 @@ class RemotePeerForwarderTest {
     private static final int FORWARDING_BATCH_SIZE = 5;
     private static final Duration FORWARDING_BATCH_TIMEOUT = Duration.of(3, ChronoUnit.SECONDS);
     private static final int PIPELINE_WORKER_THREADS = 3;
+    private static final String PIPELINE_NAME = UUID.randomUUID().toString();
+    private static final String PLUGIN_ID = UUID.randomUUID().toString();
 
     @Mock
     private PeerForwarderClient peerForwarderClient;
@@ -116,7 +118,7 @@ class RemotePeerForwarderTest {
         pipelineName = UUID.randomUUID().toString();
         pluginId = UUID.randomUUID().toString();
         identificationKeys = generateIdentificationKeys();
-        peerForwarderReceiveBuffer = new PeerForwarderReceiveBuffer<>(TEST_BUFFER_CAPACITY, TEST_BATCH_SIZE);
+        peerForwarderReceiveBuffer = new PeerForwarderReceiveBuffer<>(TEST_BUFFER_CAPACITY, TEST_BATCH_SIZE, PIPELINE_NAME, PLUGIN_ID);
 
         when(pluginMetrics.counter(RECORDS_TO_BE_PROCESSED_LOCALLY)).thenReturn(recordsToBeProcessedLocallyCounter);
         when(pluginMetrics.counter(RECORDS_ACTUALLY_PROCESSED_LOCALLY)).thenReturn(recordsActuallyProcessedLocallyCounter);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServiceTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/server/PeerForwarderHttpServiceTest.java
@@ -60,7 +60,7 @@ class PeerForwarderHttpServiceTest {
 
 
     private final PeerForwarderReceiveBuffer peerForwarderReceiveBuffer =
-            new PeerForwarderReceiveBuffer(TEST_BATCH_SIZE, TEST_BUFFER_CAPACITY);
+            new PeerForwarderReceiveBuffer(TEST_BATCH_SIZE, TEST_BUFFER_CAPACITY, PIPELINE_NAME, PLUGIN_ID);
 
     @Mock
     private PeerForwarderCodec peerForwarderCodec;


### PR DESCRIPTION
### Description
Refactor the PeerForwarderReceiveBuffer to extend `AbstractBuffer`. This allows the CPF buffers to leverage the metrics implementation from `AbstractBuffer`. Metrics for the CPF buffers are of the format `core.peerForwarder.<pipelineName>.<pluginName>.<metricName>` i.e. `core.peerForwarder.raw-pipeline.otel_trace_raw.usage`
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
