### PR TITLE
[2263] adding versioning property to pipeline yaml configuration

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersion.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersion.java
@@ -98,4 +98,9 @@ public class DataPrepperVersion {
 
         return String.format(FULL_FORMAT, this.majorVersion, this.minorVersion);
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.majorVersion, this.minorVersion);
+    }
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersion.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersion.java
@@ -1,0 +1,101 @@
+package org.opensearch.dataprepper.model.configuration;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DataPrepperVersion {
+    private static final String CURRENT_VERSION = "2.1";
+
+    private static final String FULL_FORMAT = "%d.%d";
+    private static final String SHORTHAND_FORMAT = "%d";
+    private static final String VERSION_PATTERN_STRING = "^((\\d+)(\\.(\\d+))?)$";
+    private static final Pattern VERSION_PATTERN = Pattern.compile(VERSION_PATTERN_STRING);
+    private static final int MAJOR_VERSION_PATTERN_POSITION = 2;
+    private static final int MINOR_VERSION_PATTERN_POSITION = 4;
+
+    private final int majorVersion;
+    private final Integer minorVersion;
+
+    private static DataPrepperVersion instance;
+
+    private DataPrepperVersion(int majorVersion, Integer minorVersion) {
+        this.minorVersion = minorVersion;
+        this.majorVersion = majorVersion;
+    }
+
+    public static DataPrepperVersion getCurrentVersion() {
+        if (Objects.isNull(instance)) {
+            instance = parse(CURRENT_VERSION);
+        }
+        return instance;
+    }
+
+    public static DataPrepperVersion parse(final String version) {
+
+        final Matcher result = VERSION_PATTERN.matcher(version);
+        if(result.find()) {
+            String major = result.group(MAJOR_VERSION_PATTERN_POSITION);
+            final int foundMajorVersion = Integer.parseInt(major);
+            final String potentialMinorVersion = result.group(MINOR_VERSION_PATTERN_POSITION);
+            final Integer foundMinorVersion = potentialMinorVersion == null ? null : Integer.parseInt(potentialMinorVersion);
+
+            return new DataPrepperVersion(foundMajorVersion, foundMinorVersion);
+        }
+
+        throw new IllegalArgumentException("Invalid Data Prepper Version provided: " + version);
+    }
+
+    public int getMajorVersion() {
+        return majorVersion;
+    }
+
+    public Optional<Integer> getMinorVersion() {
+        return Optional.ofNullable(minorVersion);
+    }
+
+    /**
+     * Determines if the provided Data Prepper Version is compatible with this.
+     *
+     * The initial implementation is a basic implementation that enforces equivalent versions, any shorthand format version
+     * compared with full format with equivalent major versions and equivalent major version but the comparing minor version
+     * is less than this minor version are compatible.
+     *
+     * @param o - the other DataPrepperVersion to compare with
+     * @return return true if the versions are compatible, otherwise false
+     * @since 2.1
+     */
+    public boolean compatibleWith(DataPrepperVersion o) {
+
+        if (this.majorVersion != o.getMajorVersion()) {
+            return false;
+        }
+
+        if (this.minorVersion != null && o.getMinorVersion().isPresent()) {
+            if (!this.minorVersion.equals(o.getMinorVersion().get())) {
+                return this.minorVersion > o.getMinorVersion().get();
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof DataPrepperVersion) {
+            final DataPrepperVersion other = (DataPrepperVersion) o;
+            return this.majorVersion == other.majorVersion && Objects.equals(this.minorVersion, other.getMinorVersion().orElse(null));
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        if (this.minorVersion == null) {
+            return String.format(SHORTHAND_FORMAT, this.majorVersion);
+        }
+
+        return String.format(FULL_FORMAT, this.majorVersion, this.minorVersion);
+    }
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PipelinesDataFlowModel.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PipelinesDataFlowModel.java
@@ -8,9 +8,14 @@ package org.opensearch.dataprepper.model.configuration;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSetter;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Model for the Pipelines data flow. This has the format of the Data Prepper
@@ -19,6 +24,9 @@ import java.util.Map;
  * @since 1.2
  */
 public class PipelinesDataFlowModel {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private DataPrepperVersion version;
 
     @JsonAnySetter
     private Map<String, PipelineModel> pipelines = new HashMap<>();
@@ -34,8 +42,28 @@ public class PipelinesDataFlowModel {
         this.pipelines = pipelines;
     }
 
+    public PipelinesDataFlowModel(final DataPrepperVersion version, final Map<String, PipelineModel> pipelines) {
+        this.version = version;
+        this.pipelines = pipelines;
+    }
+
     @JsonAnyGetter
     public Map<String, PipelineModel> getPipelines() {
         return pipelines;
+    }
+
+    @JsonGetter
+    public String getVersion() {
+        return Objects.isNull(this.version) ? null : version.toString();
+    }
+
+    @JsonIgnore
+    public DataPrepperVersion getDataPrepperVersion() {
+        return version;
+    }
+
+    @JsonSetter
+    public void setVersion(final String version) {
+        this.version = DataPrepperVersion.parse(version);
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersionTest.java
@@ -1,0 +1,180 @@
+package org.opensearch.dataprepper.model.configuration;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DataPrepperVersionTest {
+
+    @ParameterizedTest
+    @MethodSource("validDataPrepperVersions")
+    public void testValidVersionsCanBeParsedSuccessfully(final String version, final int expectedMajorVersion, final Optional<Integer> expectedMinorVersion) {
+        final DataPrepperVersion result = DataPrepperVersion.parse(version);
+        assertThat(result, notNullValue());
+        assertThat(result.getMajorVersion(), is(equalTo(expectedMajorVersion)));
+        assertThat(result.getMinorVersion(), is(equalTo(expectedMinorVersion)));
+    }
+
+    private static Stream<Arguments> validDataPrepperVersions() {
+        return Stream.of(
+            Arguments.of("1", 1, Optional.empty()),
+            Arguments.of("1.0", 1, Optional.of(0)),
+            Arguments.of("123423.0", 123423, Optional.of(0)),
+            Arguments.of("2.325", 2, Optional.of(325)),
+            Arguments.of("3.14", 3, Optional.of(14))
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"*", "1.*", ".0", "alpha", "4.text", "foo.645", "\\a323"})
+    public void testInvalidVersionsCannotBeParsed(final String version) {
+        assertThrows(IllegalArgumentException.class, () -> DataPrepperVersion.parse(version));
+    }
+
+    @ParameterizedTest
+    @MethodSource("compatibleDataPrepperVersions")
+    public void testCompatibleWith_equalVersions(final String versionA, final String versionB) {
+        final DataPrepperVersion resultA = DataPrepperVersion.parse(versionA);
+        final DataPrepperVersion resultB = DataPrepperVersion.parse(versionB);
+        assertThat(resultA, notNullValue());
+        assertThat(resultB, notNullValue());
+        assertThat(resultA.compatibleWith(resultB), is(equalTo(true)));
+    }
+
+    private static Stream<Arguments> compatibleDataPrepperVersions() {
+        return Stream.of(
+            Arguments.of("1", "1.6"),
+            Arguments.of("1.4", "1"),
+            Arguments.of("1.4", "1.2"),
+            Arguments.of("342.0", "342.0"),
+            Arguments.of("342.8", "342.8"),
+            Arguments.of("13", "13")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonCompatibleDataPrepperVersions")
+    public void testCompatibleWith_lessThanVersions(final String versionA, final String versionB) {
+        final DataPrepperVersion resultA = DataPrepperVersion.parse(versionA);
+        final DataPrepperVersion resultB = DataPrepperVersion.parse(versionB);
+        assertThat(resultA, notNullValue());
+        assertThat(resultB, notNullValue());
+        assertThat(resultA.compatibleWith(resultB), is(false));
+    }
+
+    private static Stream<Arguments> nonCompatibleDataPrepperVersions() {
+        return Stream.of(
+            Arguments.of("1.2", "1.6"),
+            Arguments.of("1", "2.0"),
+            Arguments.of("2.0", "5"),
+            Arguments.of("42.0", "343.0"),
+            Arguments.of("42.0", "42.1"),
+            Arguments.of("13", "15"),
+            Arguments.of("13", "2.0"),
+            Arguments.of("7.0", "5"),
+            Arguments.of("42.0", "34.0"),
+            Arguments.of("13", "11")
+        );
+    }
+
+    @Test
+    public void testEquals_withEqualShorthandVersions() {
+        final String randVersion = RandomStringUtils.randomNumeric(4);
+        final DataPrepperVersion resultA = DataPrepperVersion.parse(randVersion);
+        final DataPrepperVersion resultB = DataPrepperVersion.parse(randVersion);
+        assertThat(resultA.equals(resultB), is(equalTo(true)));
+    }
+
+    @Test
+    public void testEquals_withEqualVersions() {
+        final Random random = new Random();
+        final int randMajorVersion = random.nextInt(100000);
+        final int randMinorVersion = random.nextInt(100000);
+        final String randVersion = String.format("%d.%d", randMajorVersion, randMinorVersion);
+        final DataPrepperVersion resultA = DataPrepperVersion.parse(randVersion);
+        final DataPrepperVersion resultB = DataPrepperVersion.parse(randVersion);
+        assertThat(resultA.equals(resultB), is(equalTo(true)));
+    }
+
+    @Test
+    public void testEquals_withNonEquivalentShorthandVersions() {
+        final String randVersionA = RandomStringUtils.randomNumeric(4);
+        final String randVersionB = RandomStringUtils.randomNumeric(2);
+        final DataPrepperVersion resultA = DataPrepperVersion.parse(randVersionA);
+        final DataPrepperVersion resultB = DataPrepperVersion.parse(randVersionB);
+        assertThat(resultA.equals(resultB), is(equalTo(false)));
+    }
+
+    @Test
+    public void testEquals_withRandomNonEquivalentVersions() {
+        final Random random = new Random();
+        final int randMajorVersionA = random.nextInt(50000);
+        int randMajorVersionB = random.nextInt(50000);
+        if (randMajorVersionA == randMajorVersionB) {
+            randMajorVersionB--;
+        }
+        final int randMinorVersionA = random.nextInt( 50000);
+        final int randMinorVersionB = random.nextInt(50000);
+        final String randVersionA = String.format("%d.%d", randMajorVersionA, randMinorVersionA);
+        final String randVersionB = String.format("%d.%d", randMajorVersionB, randMinorVersionB);
+        final DataPrepperVersion resultA = DataPrepperVersion.parse(randVersionA);
+        final DataPrepperVersion resultB = DataPrepperVersion.parse(randVersionB);
+        assertThat(resultA.equals(resultB), is(equalTo(false)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonCompatibleDataPrepperVersions")
+    public void testEquals_withNonEquivalentVersions(final String versionA, final String versionB) {
+        final DataPrepperVersion resultA = DataPrepperVersion.parse(versionA);
+        final DataPrepperVersion resultB = DataPrepperVersion.parse(versionB);
+        assertThat(resultA, notNullValue());
+        assertThat(resultB, notNullValue());
+        assertThat(resultA.equals(resultB), is(false));
+    }
+
+    @Test
+    public void testEquals_withDifferentObject() {
+        final DataPrepperVersion currentVersion = DataPrepperVersion.getCurrentVersion();
+        assertThat(currentVersion.equals("foo"), is(false));
+    }
+
+    @Test
+    public void testGetCurrentVersionIsNotNull() {
+        final DataPrepperVersion currentVersion = DataPrepperVersion.getCurrentVersion();
+        assertThat(currentVersion, notNullValue());
+    }
+
+    @Test
+    public void testGetCurrentVersionAreAlwaysEqual() {
+        final DataPrepperVersion currentVersion = DataPrepperVersion.getCurrentVersion();
+        assertThat(currentVersion, notNullValue());
+        final DataPrepperVersion currentVersion2 = DataPrepperVersion.getCurrentVersion();
+        assertThat(currentVersion2, notNullValue());
+        assertThat(currentVersion, is(equalTo(currentVersion2)));
+    }
+
+    @Test
+    public void testToString_shorthandVersion() {
+        final DataPrepperVersion result = DataPrepperVersion.parse("2");
+        assertThat(result.toString(), is(equalTo("2")));
+    }
+
+    @Test
+    public void testToString_fullVersion() {
+        final DataPrepperVersion result = DataPrepperVersion.parse("7.0");
+        assertThat(result.toString(), is(equalTo("7.0")));
+    }
+}

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersionTest.java
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -176,5 +177,16 @@ public class DataPrepperVersionTest {
     public void testToString_fullVersion() {
         final DataPrepperVersion result = DataPrepperVersion.parse("7.0");
         assertThat(result.toString(), is(equalTo("7.0")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1", "2.0", "3.14", "105435"})
+    public void testHashCode_areEqualForSameVersion(final String version) {
+
+        final DataPrepperVersion dpVersionA = DataPrepperVersion.parse(version);
+        final int hashCodeA = dpVersionA.hashCode();
+        final DataPrepperVersion dpVersionB = DataPrepperVersion.parse(version);
+        final int hashCodeB = dpVersionB.hashCode();
+        assertThat(hashCodeA, is(equalTo(hashCodeB)));
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
@@ -17,7 +17,9 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -29,6 +31,8 @@ class PipelinesDataFlowModelTest {
 
     private static final String RESOURCE_PATH = "/pipelines_data_flow_serialized.yaml";
     private static final String RESOURCE_PATH_WITH_ROUTE = "/pipelines_data_flow_route.yaml";
+    private static final String RESOURCE_PATH_WITH_SHORT_HAND_VERSION = "/pipeline_with_short_hand_version.yaml";
+    private static final String RESOURCE_PATH_WITH_VERSION = "/pipeline_with_version.yaml";
     private ObjectMapper objectMapper;
 
     @BeforeEach
@@ -53,6 +57,28 @@ class PipelinesDataFlowModelTest {
         final String serializedString = objectMapper.writeValueAsString(pipelinesDataFlowModel);
 
         InputStream inputStream = this.getClass().getResourceAsStream(RESOURCE_PATH);
+
+        final String expectedYaml = PluginModelTests.convertInputStreamToString(inputStream);
+
+        assertThat(serializedString, notNullValue());
+        assertThat(serializedString, equalTo(expectedYaml));
+    }
+
+    @Test
+    void testSerializing_PipelinesDataFlowModel_with_Version() throws JsonProcessingException {
+        String pipelineName = "test-pipeline";
+
+        final DataPrepperVersion version = DataPrepperVersion.parse("2.0");
+        final PluginModel source = new PluginModel("testSource", (Map<String, Object>) null);
+        final List<PluginModel> processors = Collections.singletonList(new PluginModel("testProcessor", (Map<String, Object>) null));
+        final List<SinkModel> sinks = Collections.singletonList(new SinkModel("testSink", Collections.emptyList(), null));
+        final PipelineModel pipelineModel = new PipelineModel(source, null, processors, null, sinks, 8, 50);
+
+        final PipelinesDataFlowModel pipelinesDataFlowModel = new PipelinesDataFlowModel(version, Collections.singletonMap(pipelineName, pipelineModel));
+
+        final String serializedString = objectMapper.writeValueAsString(pipelinesDataFlowModel);
+
+        InputStream inputStream = this.getClass().getResourceAsStream(RESOURCE_PATH_WITH_VERSION);
 
         final String expectedYaml = PluginModelTests.convertInputStreamToString(inputStream);
 
@@ -157,6 +183,24 @@ class PipelinesDataFlowModelTest {
         assertThat(pipelineModel.getRoutes().get(0), notNullValue());
         assertThat(pipelineModel.getRoutes().get(0).getName(), equalTo("my-route"));
         assertThat(pipelineModel.getRoutes().get(0).getCondition(), equalTo("/a==b"));
+    }
 
+    @Test
+    void deserialize_PipelinesDataFlowModel_with_shorthand_version() throws IOException {
+
+        final InputStream inputStream = this.getClass().getResourceAsStream(RESOURCE_PATH_WITH_SHORT_HAND_VERSION);
+
+        final PipelinesDataFlowModel actualModel = objectMapper.readValue(inputStream, PipelinesDataFlowModel.class);
+
+        final String pipelineName = "test-pipeline";
+
+        assertThat(actualModel, notNullValue());
+        assertThat(actualModel.getPipelines(), notNullValue());
+        assertThat(actualModel.getPipelines().size(), equalTo(1));
+        assertThat(actualModel.getPipelines(), hasKey(pipelineName));
+
+        final DataPrepperVersion version = actualModel.getDataPrepperVersion();
+        assertThat(version.getMajorVersion(), is(equalTo(2)));
+        assertThat(version.getMinorVersion(), is(equalTo(Optional.empty())));
     }
 }

--- a/data-prepper-api/src/test/resources/pipeline_with_short_hand_version.yaml
+++ b/data-prepper-api/src/test/resources/pipeline_with_short_hand_version.yaml
@@ -1,0 +1,10 @@
+version: "2"
+test-pipeline:
+  source:
+    testSource: null
+  processor:
+    - testProcessor: null
+  sink:
+    - testSink: null
+  workers: 8
+  delay: 50

--- a/data-prepper-api/src/test/resources/pipeline_with_version.yaml
+++ b/data-prepper-api/src/test/resources/pipeline_with_version.yaml
@@ -1,0 +1,10 @@
+version: "2.0"
+test-pipeline:
+  source:
+    testSource: null
+  processor:
+  - testProcessor: null
+  sink:
+  - testSink: null
+  workers: 8
+  delay: 50

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
@@ -47,6 +47,8 @@ public class TestDataProvider {
     public static final String SINGLE_FILE_PIPELINE_DIRECTOTRY = "src/test/resources/single-pipeline";
     public static final String EMPTY_PIPELINE_DIRECTOTRY = "src/test/resources/no-pipelines";
     public static final String VALID_MULTIPLE_SINKS_CONFIG_FILE = "src/test/resources/valid_multiple_sinks.yml";
+    public static final String INCOMPATIBLE_VERSION_CONFIG_FILE = "src/test/resources/incompatible_version.yml";
+    public static final String COMPATIBLE_VERSION_CONFIG_FILE = "src/test/resources/compatible_version.yml";
     public static final String VALID_MULTIPLE_PROCESSERS_CONFIG_FILE = "src/test/resources/valid_multiple_processors.yml";
     public static final String NO_PIPELINES_EXECUTE_CONFIG_FILE = "src/test/resources/no_pipelines_to_execute.yml";
     public static final String VALID_DATA_PREPPER_CONFIG_FILE = "src/test/resources/valid_data_prepper_config.yml";

--- a/data-prepper-core/src/test/resources/compatible_version.yml
+++ b/data-prepper-core/src/test/resources/compatible_version.yml
@@ -1,0 +1,8 @@
+version: "2" # update with every major version change
+test-pipeline-1:
+  source:
+    stdin:
+  buffer:
+    bounded_blocking: #to check non object nodes for plugins
+  sink:
+    - stdout:

--- a/data-prepper-core/src/test/resources/incompatible_version.yml
+++ b/data-prepper-core/src/test/resources/incompatible_version.yml
@@ -1,0 +1,9 @@
+
+version: "1.0" #outdated version since the compatibility check was introduced.
+test-pipeline-1:
+  source:
+    stdin:
+  buffer:
+    bounded_blocking: #to check non object nodes for plugins
+  sink:
+    - stdout:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,7 @@ Additionally, Log4j 2 configuration file is read from `config/log4j2.properties`
 Example Pipeline configuration file (pipelines.yaml):
 
 ```yaml
+version: 2
 entry-pipeline:
   workers: 4
   delay: "100"
@@ -69,6 +70,28 @@ This sample pipeline creates a source to receive trace data and outputs transfor
 
 * `delay`(Optional): An `int` representing the maximum duration in milliseconds to retrieve records from the buffer. If the buffer's specified batch_size has not been reached before this duration is exceeded, a partial batch is used. If this value is set to 0, all available records up to the batch size will be immediately returned. If the buffer is empty, the buffer will block for up to 5 milliseconds to wait for records. Default value is `3000`.
 * `workers`(Optional): An `int` representing the number of ProcessWorker threads for the pipeline.  Default value is `1`.
+
+### Versioning
+
+The pipeline configuration file now supports an optional `version` attribute. This can help users ensure the pipeline configuration
+used is compatible with the running data prepper version. Data Prepper now compares the version supplied in the confirmation at start
+time and will throw an exception if the version in the pipeline is not compatible with the running Data Prepper version. 
+This attribute can be specified with a shorthand format with only the major version (i.e. `2`) or major and minor version
+(i.e. `2.1`). Data prepper will conclude equivalent versions, any shorthand format version with equivalent major version, 
+and an equivalent major version with a previously released minor version are compatible.
+
+#### Version Compatibility Matrix
+
+| Data Prepper Version | Pipeline Configuration Version | Compatible |
+|----------------------| ---- |------------|
+| 2.1                  | 2 | true       |
+| 2.1                  | 2.1 | true       |
+| 2.1                  | 2.0 | true       |
+| 2.1                  | null | true       |
+| 2.1                  | 1.5 | false      |
+| 2.1                  | 1 | false      |
+| 2.1                  | 3.0 | false      |
+| 2.1                  | 3 | false      |
 
 ## Server Configuration
 Data Prepper allows the following properties to be configured:

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# ATTENTION: If you are changing the version, please change the DataPrepperVersion whenever the major or minor version changes.
+# See: https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersion.java#L9
 version=2.1.0-SNAPSHOT


### PR DESCRIPTION
### Description
Adding data prepper version as part of the pipeline configuration file. This PR creates a new `DataPrepperVersion` model in the API that is used in the `PipelinesDataFlowModel`. Added support for validating the current version is compatible with the current version of data prepper. Updated the documentation.
 
### Issues Resolved
- resolves #2263 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
