### PR TITLE
adding backwards compatibility support in versioning check

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersion.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersion.java
@@ -58,9 +58,8 @@ public class DataPrepperVersion {
     /**
      * Determines if the provided Data Prepper Version is compatible with this.
      *
-     * The initial implementation is a basic implementation that enforces equivalent versions, any shorthand format version
-     * compared with full format with equivalent major versions and equivalent major version but the comparing minor version
-     * is less than this minor version are compatible.
+     * The initial implementation is a basic implementation that will return true only when the comparing version is
+     * less than or equal to this version.
      *
      * @param o - the other DataPrepperVersion to compare with
      * @return return true if the versions are compatible, otherwise false
@@ -68,11 +67,11 @@ public class DataPrepperVersion {
      */
     public boolean compatibleWith(DataPrepperVersion o) {
 
-        if (this.majorVersion != o.getMajorVersion()) {
+        if (this.majorVersion < o.getMajorVersion()) {
             return false;
         }
 
-        if (this.minorVersion != null && o.getMinorVersion().isPresent()) {
+        if ((this.majorVersion == o.majorVersion) && (this.minorVersion != null && o.getMinorVersion().isPresent())) {
             if (!this.minorVersion.equals(o.getMinorVersion().get())) {
                 return this.minorVersion > o.getMinorVersion().get();
             }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersionTest.java
@@ -13,7 +13,6 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -62,7 +61,11 @@ public class DataPrepperVersionTest {
             Arguments.of("1.4", "1.2"),
             Arguments.of("342.0", "342.0"),
             Arguments.of("342.8", "342.8"),
-            Arguments.of("13", "13")
+            Arguments.of("13", "13"),
+            Arguments.of("13", "2.0"),
+            Arguments.of("7.0", "5"),
+            Arguments.of("42.0", "34.0"),
+            Arguments.of("13", "11")
         );
     }
 
@@ -83,11 +86,7 @@ public class DataPrepperVersionTest {
             Arguments.of("2.0", "5"),
             Arguments.of("42.0", "343.0"),
             Arguments.of("42.0", "42.1"),
-            Arguments.of("13", "15"),
-            Arguments.of("13", "2.0"),
-            Arguments.of("7.0", "5"),
-            Arguments.of("42.0", "34.0"),
-            Arguments.of("13", "11")
+            Arguments.of("13", "15")
         );
     }
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineParserTests.java
@@ -160,7 +160,7 @@ class PipelineParserTests {
 
         final RuntimeException actualException = assertThrows(RuntimeException.class, pipelineParser::parseConfiguration);
         assertThat(actualException.getMessage(),
-            equalTo(String.format("The version: 1.0 is not compatible with the current version: %s", DataPrepperVersion.getCurrentVersion())));
+            equalTo(String.format("The version: 3005.0 is not compatible with the current version: %s", DataPrepperVersion.getCurrentVersion())));
     }
 
     @Test

--- a/data-prepper-core/src/test/resources/incompatible_version.yml
+++ b/data-prepper-core/src/test/resources/incompatible_version.yml
@@ -1,5 +1,5 @@
 
-version: "1.0" #outdated version since the compatibility check was introduced.
+version: "3005.0" #far out future version.
 test-pipeline-1:
   source:
     stdin:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,10 +75,9 @@ This sample pipeline creates a source to receive trace data and outputs transfor
 
 The pipeline configuration file now supports an optional `version` attribute. This can help users ensure the pipeline configuration
 used is compatible with the running data prepper version. Data Prepper now compares the version supplied in the confirmation at start
-time and will throw an exception if the version in the pipeline is not compatible with the running Data Prepper version. 
+time and will throw an exception if the version in the pipeline is greater than the running Data Prepper version. 
 This attribute can be specified with a shorthand format with only the major version (i.e. `2`) or major and minor version
-(i.e. `2.1`). Data prepper will conclude equivalent versions, any shorthand format version with equivalent major version, 
-and an equivalent major version with a previously released minor version are compatible.
+(i.e. `2.1`).
 
 #### Version Compatibility Matrix
 
@@ -88,8 +87,8 @@ and an equivalent major version with a previously released minor version are com
 | 2.1                  | 2.1 | true       |
 | 2.1                  | 2.0 | true       |
 | 2.1                  | null | true       |
-| 2.1                  | 1.5 | false      |
-| 2.1                  | 1 | false      |
+| 2.1                  | 1.5 | true       |
+| 2.1                  | 1 | true       |
 | 2.1                  | 3.0 | false      |
 | 2.1                  | 3 | false      |
 


### PR DESCRIPTION
### Description
This is a follow on of #2292

Adds backward compatibility support to version check. In any major version, we should have migration fields to help with migrations. So a pipeline created for 1.5 could be compatible for 2.0. But, not always. This change will make it easier for migrating between major versions.

### Issues Resolved
None
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
