### PR TITLE
Fix error message printed when OpenSearch Sink fails to initialize

### DIFF
--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersionTest.java
@@ -13,7 +13,6 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -46,6 +46,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -106,7 +107,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     try {
         doInitializeInternal();
     } catch (IOException e) {
-        LOG.warn("Failed to initialize OpenSearch sink, retrying. Error - " + e.getCause());
+        LOG.warn("Failed to initialize OpenSearch sink, retrying. Error - " + (Objects.isNull(e.getCause()) ? e : e.getCause()));
         closeFiles();
     } catch (InvalidPluginConfigurationException e) {
         LOG.error("Failed to initialize OpenSearch sink.");
@@ -118,7 +119,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
             this.shutdown();
             throw e;
         }
-        LOG.warn("Failed to initialize OpenSearch sink, retrying. Error - " + e.getCause());
+        LOG.warn("Failed to initialize OpenSearch sink, retrying. Error - " + (Objects.isNull(e.getCause()) ? e : e.getCause()));
         closeFiles();
     }
   }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -107,7 +107,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     try {
         doInitializeInternal();
     } catch (IOException e) {
-        LOG.warn("Failed to initialize OpenSearch sink, retrying. Error - " + (Objects.isNull(e.getCause()) ? e : e.getCause()));
+        LOG.warn("Failed to initialize OpenSearch sink, retrying. Error {}", (Objects.isNull(e.getCause()) ? e : e.getCause()));
         closeFiles();
     } catch (InvalidPluginConfigurationException e) {
         LOG.error("Failed to initialize OpenSearch sink.");
@@ -119,7 +119,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
             this.shutdown();
             throw e;
         }
-        LOG.warn("Failed to initialize OpenSearch sink, retrying. Error - " + (Objects.isNull(e.getCause()) ? e : e.getCause()));
+        LOG.warn("Failed to initialize OpenSearch sink, retrying. Error {}", (Objects.isNull(e.getCause()) ? e : e.getCause()));
         closeFiles();
     }
   }


### PR DESCRIPTION
### Description
Fix error message printed when OpenSearch Sink fails to initialize.
Currently, when an exception is caused during initialization, the getCause() may be null. If it is null, we should print the entire exception.

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
