### PR TITLE
Support for path in OTel sources

### DIFF
--- a/data-prepper-plugins/otel-logs-source/README.md
+++ b/data-prepper-plugins/otel-logs-source/README.md
@@ -15,6 +15,7 @@ source:
 ## Configurations
 
 * port(Optional) => An `int` represents the port OTel logs source is running on. Default is ```21892```.
+* path(Optional) => A `String` which represents the path for sending unframed HTTP requests. This will add a new service which can be used for supporting unframed gRPC with HTTP idiomatic path to a configurable path other than `/opentelemetry.proto.collector.logs.v1.LogsService/Export` which can still be used. Path can contain `${pipelineName}` placeholder which will be replaced with pipeline name.
 * request_timeout(Optional) => An `int` represents request timeout in millis. Default is ```10_000```.
 * health_check_service(Optional) => A boolean enables a gRPC health check service under ```grpc.health.v1 / Health / Check```. Default is ```false```.
 * proto_reflection_service(Optional) => A boolean enables a reflection service for Protobuf services (see [ProtoReflectionService](https://grpc.github.io/grpc-java/javadoc/io/grpc/protobuf/services/ProtoReflectionService.html) and [gRPC reflection](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md) docs). Default is ```false```.

--- a/data-prepper-plugins/otel-logs-source/src/main/java/com/amazon/dataprepper/plugins/source/otellogs/OTelLogsSource.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/com/amazon/dataprepper/plugins/source/otellogs/OTelLogsSource.java
@@ -11,10 +11,14 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
+import io.grpc.MethodDescriptor;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
 import io.grpc.protobuf.services.ProtoReflectionService;
 
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse;
+import io.opentelemetry.proto.collector.logs.v1.LogsServiceGrpc;
 import org.opensearch.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
@@ -42,22 +46,21 @@ import java.util.concurrent.Executors;
 @DataPrepperPlugin(name = "otel_logs_source", pluginType = Source.class, pluginConfigurationType = OTelLogsSourceConfig.class)
 public class OTelLogsSource implements Source<Record<Object>> {
     private static final Logger LOG = LoggerFactory.getLogger(OTelLogsSource.class);
+    private static final String PIPELINE_NAME_PLACEHOLDER = "${pipelineName}";
+
     private final OTelLogsSourceConfig oTelLogsSourceConfig;
-    private Server server;
+    private final String pipelineName;
     private final PluginMetrics pluginMetrics;
     private final GrpcAuthenticationProvider authenticationProvider;
     private final CertificateProviderFactory certificateProviderFactory;
+    private Server server;
 
     @DataPrepperPluginConstructor
     public OTelLogsSource(final OTelLogsSourceConfig oTelLogsSourceConfig,
                           final PluginMetrics pluginMetrics,
                           final PluginFactory pluginFactory,
                           final PipelineDescription pipelineDescription) {
-        oTelLogsSourceConfig.validateAndInitializeCertAndKeyFileInS3();
-        this.oTelLogsSourceConfig = oTelLogsSourceConfig;
-        this.pluginMetrics = pluginMetrics;
-        this.certificateProviderFactory = new CertificateProviderFactory(oTelLogsSourceConfig);
-        this.authenticationProvider = createAuthenticationProvider(pluginFactory, pipelineDescription);
+        this(oTelLogsSourceConfig, pluginMetrics, pluginFactory, new CertificateProviderFactory(oTelLogsSourceConfig), pipelineDescription);
     }
 
     // accessible only in the same package for unit test
@@ -68,6 +71,7 @@ public class OTelLogsSource implements Source<Record<Object>> {
         this.pluginMetrics = pluginMetrics;
         this.certificateProviderFactory = certificateProviderFactory;
         this.authenticationProvider = createAuthenticationProvider(pluginFactory, pipelineDescription);
+        this.pipelineName = pipelineDescription.getPipelineName();
     }
 
     @Override
@@ -92,6 +96,14 @@ public class OTelLogsSource implements Source<Record<Object>> {
                     .addService(ServerInterceptors.intercept(oTelLogsGrpcService, serverInterceptors))
                     .useClientTimeoutHeader(false)
                     .useBlockingTaskExecutor(true);
+
+            final MethodDescriptor<ExportLogsServiceRequest, ExportLogsServiceResponse> methodDescriptor = LogsServiceGrpc.getExportMethod();
+            final String oTelLogsSourcePath = oTelLogsSourceConfig.getPath();
+            if (oTelLogsSourcePath != null) {
+                final String transformedOTelLogsSourcePath = oTelLogsSourcePath.replace(PIPELINE_NAME_PLACEHOLDER, pipelineName);
+                grpcServiceBuilder.addService(transformedOTelLogsSourcePath,
+                        ServerInterceptors.intercept(oTelLogsGrpcService, serverInterceptors), methodDescriptor);
+            }
 
             if (oTelLogsSourceConfig.hasHealthCheck()) {
                 LOG.info("Health check is enabled");
@@ -189,7 +201,7 @@ public class OTelLogsSource implements Source<Record<Object>> {
         } else {
             authenticationPluginSetting = new PluginSetting(GrpcAuthenticationProvider.UNAUTHENTICATED_PLUGIN_NAME, Collections.emptyMap());
         }
-        authenticationPluginSetting.setPipelineName(pipelineDescription.getPipelineName());
+        authenticationPluginSetting.setPipelineName(pipelineName);
         return pluginFactory.loadPlugin(GrpcAuthenticationProvider.class, authenticationPluginSetting);
     }
 }

--- a/data-prepper-plugins/otel-logs-source/src/main/java/com/amazon/dataprepper/plugins/source/otellogs/OTelLogsSourceConfig.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/com/amazon/dataprepper/plugins/source/otellogs/OTelLogsSourceConfig.java
@@ -13,6 +13,7 @@ import org.opensearch.dataprepper.model.configuration.PluginModel;
 public class OTelLogsSourceConfig {
     static final String REQUEST_TIMEOUT = "request_timeout";
     static final String PORT = "port";
+    static final String PATH = "path";
     static final String SSL = "ssl";
     static final String USE_ACM_CERT_FOR_SSL = "useAcmCertForSSL";
     static final String ACM_CERT_ISSUE_TIME_OUT_MILLIS = "acmCertIssueTimeOutMillis";
@@ -43,6 +44,9 @@ public class OTelLogsSourceConfig {
 
     @JsonProperty(PORT)
     private int port = DEFAULT_PORT;
+
+    @JsonProperty(PATH)
+    private String path;
 
     @JsonProperty(HEALTH_CHECK_SERVICE)
     private boolean healthCheck = DEFAULT_HEALTH_CHECK;
@@ -125,6 +129,10 @@ public class OTelLogsSourceConfig {
 
     public int getPort() {
         return port;
+    }
+
+    public String getPath() {
+        return path;
     }
 
     public boolean hasHealthCheck() {

--- a/data-prepper-plugins/otel-logs-source/src/test/java/com/amazon/dataprepper/plugins/source/otellogs/OTelLogsSourceTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/com/amazon/dataprepper/plugins/source/otellogs/OTelLogsSourceTest.java
@@ -5,13 +5,13 @@
 
 package com.amazon.dataprepper.plugins.source.otellogs;
 
-
 import com.amazon.dataprepper.plugins.health.HealthGrpcService;
 import com.amazon.dataprepper.plugins.source.otellogs.certificate.CertificateProviderFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
@@ -26,23 +26,40 @@ import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
 import io.grpc.BindableService;
 import io.grpc.ServerServiceDefinition;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.netty.util.AsciiString;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse;
+import io.opentelemetry.proto.collector.logs.v1.LogsServiceGrpc;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.logs.v1.LogRecord;
 import io.opentelemetry.proto.logs.v1.ResourceLogs;
+import io.opentelemetry.proto.logs.v1.ScopeLogs;
+import io.opentelemetry.proto.resource.v1.Resource;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
+import org.opensearch.dataprepper.armeria.authentication.HttpBasicAuthenticationConfig;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
+import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
@@ -56,28 +73,40 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.DEFAULT_PORT;
+import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.DEFAULT_REQUEST_TIMEOUT_MS;
 import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.SSL;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -86,7 +115,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class OTelLogsSourceTest {
+class OTelLogsSourceTest {
+    private static final String GRPC_ENDPOINT = "gproto+http://127.0.0.1:21892/";
+    private static final String TEST_PIPELINE_NAME = "test_pipeline";
+    private static final String USERNAME = "test_user";
+    private static final String PASSWORD = "test_password";
+    private static final String TEST_PATH = "${pipelineName}/v1/logs";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ExportLogsServiceRequest LOGS_REQUEST = ExportLogsServiceRequest.newBuilder()
+            .addResourceLogs(ResourceLogs.newBuilder().build()).build();
 
     @Mock
     private ServerBuilder serverBuilder;
@@ -118,41 +155,20 @@ public class OTelLogsSourceTest {
     @Mock
     private GrpcBasicAuthenticationProvider authenticationProvider;
 
+    @Mock
+    private HttpBasicAuthenticationConfig httpBasicAuthenticationConfig;
+
+    @Mock
     private BlockingBuffer<Record<Object>> buffer;
+
+    @Mock(lenient = true)
+    private OTelLogsSourceConfig oTelLogsSourceConfig;
+
     private PluginSetting pluginSetting;
     private PluginSetting testPluginSetting;
-    private OTelLogsSourceConfig oTelLogsSourceConfig;
     private PluginMetrics pluginMetrics;
     private PipelineDescription pipelineDescription;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-
-
     private OTelLogsSource SOURCE;
-
-    private static final String TEST_PIPELINE_NAME = "test_pipeline";
-
-    private static final ExportLogsServiceRequest LOGS_REQUEST = ExportLogsServiceRequest.newBuilder()
-            .addResourceLogs(ResourceLogs.newBuilder().build()).build();
-
-    private static void assertStatusCode415AndNoServerHeaders(final AggregatedHttpResponse response, final Throwable throwable) {
-        assertThat("Http Status", response.status(), is(HttpStatus.UNSUPPORTED_MEDIA_TYPE));
-        assertThat("Http Response Throwable", throwable, is(nullValue()));
-
-        final List<String> headerKeys = response.headers()
-                .stream()
-                .map(Map.Entry::getKey)
-                .map(AsciiString::toString)
-                .collect(Collectors.toList());
-        assertThat("Response Header Keys", headerKeys, not(contains("server")));
-    }
-
-    private BlockingBuffer<Record<Object>> getBuffer() {
-        final HashMap<String, Object> integerHashMap = new HashMap<>();
-        integerHashMap.put("buffer_size", 1);
-        integerHashMap.put("batch_size", 1);
-        return new BlockingBuffer<>(new PluginSetting("blocking_buffer", integerHashMap));
-    }
 
     @BeforeEach
     public void beforeEach() {
@@ -167,21 +183,18 @@ public class OTelLogsSourceTest {
         lenient().when(grpcServiceBuilder.useBlockingTaskExecutor(anyBoolean())).thenReturn(grpcServiceBuilder);
         lenient().when(grpcServiceBuilder.build()).thenReturn(grpcService);
 
-        final Map<String, Object> settingsMap = new HashMap<>();
-        settingsMap.put("request_timeout", 5);
-        settingsMap.put(SSL, false);
-        pluginSetting = new PluginSetting("otel_logs", settingsMap);
-        pluginSetting.setPipelineName("pipeline");
+        when(oTelLogsSourceConfig.getPort()).thenReturn(DEFAULT_PORT);
+        when(oTelLogsSourceConfig.isSsl()).thenReturn(false);
+        when(oTelLogsSourceConfig.getRequestTimeoutInMillis()).thenReturn(DEFAULT_REQUEST_TIMEOUT_MS);
+        when(oTelLogsSourceConfig.getMaxConnectionCount()).thenReturn(10);
+        when(oTelLogsSourceConfig.getThreadCount()).thenReturn(5);
         pluginMetrics = PluginMetrics.fromNames("otel_logs", "pipeline");
-
-        oTelLogsSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelLogsSourceConfig.class);
 
         when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))
                 .thenReturn(authenticationProvider);
         pipelineDescription = mock(PipelineDescription.class);
         when(pipelineDescription.getPipelineName()).thenReturn(TEST_PIPELINE_NAME);
         SOURCE = new OTelLogsSource(oTelLogsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
-        buffer = getBuffer();
     }
 
     @AfterEach
@@ -189,8 +202,12 @@ public class OTelLogsSourceTest {
         SOURCE.stop();
     }
 
+    private void configureObjectUnderTest() {
+        SOURCE = new OTelLogsSource(oTelLogsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
+    }
+
     @Test
-    void testHttpFullJson() throws InvalidProtocolBufferException {
+    void testHttpFullJsonWithNonUnframedRequests() throws InvalidProtocolBufferException {
         SOURCE.start(buffer);
         WebClient.of().execute(RequestHeaders.builder()
                         .scheme(SessionProtocol.HTTP)
@@ -201,12 +218,12 @@ public class OTelLogsSourceTest {
                         .build(),
                 HttpData.copyOf(JsonFormat.printer().print(LOGS_REQUEST).getBytes()))
                 .aggregate()
-                .whenComplete(OTelLogsSourceTest::assertStatusCode415AndNoServerHeaders)
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNSUPPORTED_MEDIA_TYPE, throwable))
                 .join();
     }
 
     @Test
-    void testHttpsFullJson() throws InvalidProtocolBufferException {
+    void testHttpsFullJsonWithNonUnframedRequests() throws InvalidProtocolBufferException {
 
         final Map<String, Object> settingsMap = new HashMap<>();
         settingsMap.put("request_timeout", 5);
@@ -220,7 +237,6 @@ public class OTelLogsSourceTest {
         oTelLogsSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelLogsSourceConfig.class);
         SOURCE = new OTelLogsSource(oTelLogsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
 
-        buffer = getBuffer();
         SOURCE.start(buffer);
 
         WebClient.builder().factory(ClientFactory.insecure()).build().execute(RequestHeaders.builder()
@@ -232,12 +248,12 @@ public class OTelLogsSourceTest {
                         .build(),
                 HttpData.copyOf(JsonFormat.printer().print(LOGS_REQUEST).getBytes()))
                 .aggregate()
-                .whenComplete(OTelLogsSourceTest::assertStatusCode415AndNoServerHeaders)
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNSUPPORTED_MEDIA_TYPE, throwable))
                 .join();
     }
 
     @Test
-    void testHttpFullBytes() {
+    void testHttpFullBytesWithNonUnframedRequests() {
         SOURCE.start(buffer);
         WebClient.of().execute(RequestHeaders.builder()
                         .scheme(SessionProtocol.HTTP)
@@ -248,12 +264,50 @@ public class OTelLogsSourceTest {
                         .build(),
                 HttpData.copyOf(LOGS_REQUEST.toByteArray()))
                 .aggregate()
-                .whenComplete(OTelLogsSourceTest::assertStatusCode415AndNoServerHeaders)
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNSUPPORTED_MEDIA_TYPE, throwable))
                 .join();
     }
 
     @Test
-    public void testServerStartCertFileSuccess() throws IOException {
+    void testHttpFullJsonWithUnframedRequests() throws InvalidProtocolBufferException {
+        when(oTelLogsSourceConfig.enableUnframedRequests()).thenReturn(true);
+        SOURCE.start(buffer);
+
+        WebClient.of().execute(RequestHeaders.builder()
+                                .scheme(SessionProtocol.HTTP)
+                                .authority("127.0.0.1:21892")
+                                .method(HttpMethod.POST)
+                                .path("/opentelemetry.proto.collector.logs.v1.LogsService/Export")
+                                .contentType(MediaType.JSON_UTF_8)
+                                .build(),
+                        HttpData.copyOf(JsonFormat.printer().print(LOGS_REQUEST).getBytes()))
+                .aggregate()
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.OK, throwable))
+                .join();
+    }
+
+    @Test
+    void testHttpFullJsonWithCustomPathAndUnframedRequests() throws InvalidProtocolBufferException {
+        when(oTelLogsSourceConfig.enableUnframedRequests()).thenReturn(true);
+        when(oTelLogsSourceConfig.getPath()).thenReturn(TEST_PATH);
+        SOURCE.start(buffer);
+
+        final String transformedPath = "/" + TEST_PIPELINE_NAME + "/v1/logs";
+        WebClient.of().execute(RequestHeaders.builder()
+                                .scheme(SessionProtocol.HTTP)
+                                .authority("127.0.0.1:21892")
+                                .method(HttpMethod.POST)
+                                .path(transformedPath)
+                                .contentType(MediaType.JSON_UTF_8)
+                                .build(),
+                        HttpData.copyOf(JsonFormat.printer().print(LOGS_REQUEST).getBytes()))
+                .aggregate()
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.OK, throwable))
+                .join();
+    }
+
+    @Test
+    void testServerStartCertFileSuccess() throws IOException {
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
             armeriaServerMock.when(Server::builder).thenReturn(serverBuilder);
             when(server.stop()).thenReturn(completableFuture);
@@ -287,7 +341,7 @@ public class OTelLogsSourceTest {
     }
 
     @Test
-    public void testServerStartACMCertSuccess() throws IOException {
+    void testServerStartACMCertSuccess() throws IOException {
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
             armeriaServerMock.when(Server::builder).thenReturn(serverBuilder);
             when(server.stop()).thenReturn(completableFuture);
@@ -406,7 +460,7 @@ public class OTelLogsSourceTest {
     }
 
     @Test
-    public void testDoubleStart() {
+    void testDoubleStart() {
         // starting server
         SOURCE.start(buffer);
         // double start server
@@ -414,7 +468,7 @@ public class OTelLogsSourceTest {
     }
 
     @Test
-    public void testRunAnotherSourceWithSamePort() {
+    void testRunAnotherSourceWithSamePort() {
         // starting server
         SOURCE.start(buffer);
 
@@ -427,7 +481,7 @@ public class OTelLogsSourceTest {
     }
 
     @Test
-    public void testStartWithEmptyBuffer() {
+    void testStartWithEmptyBuffer() {
         testPluginSetting = new PluginSetting(null, Collections.singletonMap(SSL, false));
         testPluginSetting.setPipelineName("pipeline");
         oTelLogsSourceConfig = OBJECT_MAPPER.convertValue(testPluginSetting.getSettings(), OTelLogsSourceConfig.class);
@@ -436,7 +490,7 @@ public class OTelLogsSourceTest {
     }
 
     @Test
-    public void testStartWithServerExecutionExceptionNoCause() throws ExecutionException, InterruptedException {
+    void testStartWithServerExecutionExceptionNoCause() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelLogsSource source = new OTelLogsSource(oTelLogsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -449,7 +503,7 @@ public class OTelLogsSourceTest {
     }
 
     @Test
-    public void testStartWithServerExecutionExceptionWithCause() throws ExecutionException, InterruptedException {
+    void testStartWithServerExecutionExceptionWithCause() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelLogsSource source = new OTelLogsSource(oTelLogsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -464,7 +518,7 @@ public class OTelLogsSourceTest {
     }
 
     @Test
-    public void testStopWithServerExecutionExceptionNoCause() throws ExecutionException, InterruptedException {
+    void testStopWithServerExecutionExceptionNoCause() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelLogsSource source = new OTelLogsSource(oTelLogsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -479,7 +533,7 @@ public class OTelLogsSourceTest {
     }
 
     @Test
-    public void testStartWithInterruptedException() throws ExecutionException, InterruptedException {
+    void testStartWithInterruptedException() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelLogsSource source = new OTelLogsSource(oTelLogsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -493,7 +547,7 @@ public class OTelLogsSourceTest {
     }
 
     @Test
-    public void testStopWithServerExecutionExceptionWithCause() throws ExecutionException, InterruptedException {
+    void testStopWithServerExecutionExceptionWithCause() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelLogsSource source = new OTelLogsSource(oTelLogsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -510,7 +564,7 @@ public class OTelLogsSourceTest {
     }
 
     @Test
-    public void testStopWithInterruptedException() throws ExecutionException, InterruptedException {
+    void testStopWithInterruptedException() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelLogsSource source = new OTelLogsSource(oTelLogsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -524,4 +578,144 @@ public class OTelLogsSourceTest {
             assertTrue(Thread.interrupted());
         }
     }
+
+    @Test
+    void gRPC_request_writes_to_buffer_with_successful_response() throws Exception {
+        SOURCE.start(buffer);
+
+        final LogsServiceGrpc.LogsServiceBlockingStub client = Clients.builder(GRPC_ENDPOINT)
+                .build(LogsServiceGrpc.LogsServiceBlockingStub.class);
+
+        final ExportLogsServiceResponse exportResponse = client.export(createExportLogsRequest());
+        assertThat(exportResponse, notNullValue());
+
+        final ArgumentCaptor<Collection<Record<Object>>> bufferWriteArgumentCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(buffer).writeAll(bufferWriteArgumentCaptor.capture(), anyInt());
+
+        final Collection<Record<Object>> actualBufferWrites = bufferWriteArgumentCaptor.getValue();
+        assertThat(actualBufferWrites, notNullValue());
+        assertThat(actualBufferWrites, hasSize(1));
+    }
+
+    @Test
+    void gRPC_with_auth_request_writes_to_buffer_with_successful_response() throws Exception {
+        when(httpBasicAuthenticationConfig.getUsername()).thenReturn(USERNAME);
+        when(httpBasicAuthenticationConfig.getPassword()).thenReturn(PASSWORD);
+        final GrpcAuthenticationProvider grpcAuthenticationProvider = new GrpcBasicAuthenticationProvider(httpBasicAuthenticationConfig);
+
+        when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))
+                .thenReturn(grpcAuthenticationProvider);
+        when(oTelLogsSourceConfig.enableUnframedRequests()).thenReturn(true);
+        when(oTelLogsSourceConfig.getAuthentication()).thenReturn(new PluginModel("http_basic",
+                Map.of(
+                        "username", USERNAME,
+                        "password", PASSWORD
+                )));
+        configureObjectUnderTest();
+        SOURCE.start(buffer);
+
+        final String encodeToString = Base64.getEncoder()
+                .encodeToString(String.format("%s:%s", USERNAME, PASSWORD).getBytes(StandardCharsets.UTF_8));
+
+        final LogsServiceGrpc.LogsServiceBlockingStub client = Clients.builder(GRPC_ENDPOINT)
+                .addHeader("Authorization", "Basic " + encodeToString)
+                .build(LogsServiceGrpc.LogsServiceBlockingStub.class);
+        final ExportLogsServiceResponse exportResponse = client.export(createExportLogsRequest());
+        assertThat(exportResponse, notNullValue());
+
+        final ArgumentCaptor<Collection<Record<Object>>> bufferWriteArgumentCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(buffer).writeAll(bufferWriteArgumentCaptor.capture(), anyInt());
+
+        final Collection<Record<Object>> actualBufferWrites = bufferWriteArgumentCaptor.getValue();
+        assertThat(actualBufferWrites, notNullValue());
+        assertThat(actualBufferWrites, hasSize(1));
+    }
+
+    @Test
+    void gRPC_request_writes_to_buffer_with_successful_response_with_custom_path() throws Exception {
+        when(oTelLogsSourceConfig.getPath()).thenReturn(TEST_PATH);
+        when(oTelLogsSourceConfig.enableUnframedRequests()).thenReturn(true);
+
+        configureObjectUnderTest();
+        SOURCE.start(buffer);
+
+        final LogsServiceGrpc.LogsServiceBlockingStub client = Clients.builder(GRPC_ENDPOINT)
+                .build(LogsServiceGrpc.LogsServiceBlockingStub.class);
+        final ExportLogsServiceResponse exportResponse = client.export(createExportLogsRequest());
+        assertThat(exportResponse, notNullValue());
+
+        final ArgumentCaptor<Collection<Record<Object>>> bufferWriteArgumentCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(buffer).writeAll(bufferWriteArgumentCaptor.capture(), anyInt());
+
+        final Collection<Record<Object>> actualBufferWrites = bufferWriteArgumentCaptor.getValue();
+        assertThat(actualBufferWrites, notNullValue());
+        assertThat(actualBufferWrites, hasSize(1));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(BufferExceptionToStatusArgumentsProvider.class)
+    void gRPC_request_returns_expected_status_for_exceptions_from_buffer(
+            final Class<Exception> bufferExceptionClass,
+            final Status.Code expectedStatusCode) throws Exception {
+        configureObjectUnderTest();
+        SOURCE.start(buffer);
+
+        final LogsServiceGrpc.LogsServiceBlockingStub client = Clients.builder(GRPC_ENDPOINT)
+                .build(LogsServiceGrpc.LogsServiceBlockingStub.class);
+
+        doThrow(bufferExceptionClass)
+                .when(buffer)
+                .writeAll(anyCollection(), anyInt());
+        final ExportLogsServiceRequest exportTraceRequest = createExportLogsRequest();
+        final StatusRuntimeException actualException = assertThrows(StatusRuntimeException.class, () -> client.export(exportTraceRequest));
+
+        assertThat(actualException.getStatus(), notNullValue());
+        assertThat(actualException.getStatus().getCode(), equalTo(expectedStatusCode));
+    }
+
+    static class BufferExceptionToStatusArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
+            return Stream.of(
+                    arguments(TimeoutException.class, Status.Code.RESOURCE_EXHAUSTED),
+                    arguments(SizeOverflowException.class, Status.Code.RESOURCE_EXHAUSTED),
+                    arguments(Exception.class, Status.Code.INTERNAL),
+                    arguments(RuntimeException.class, Status.Code.INTERNAL)
+            );
+        }
+    }
+
+    private ExportLogsServiceRequest createExportLogsRequest() {
+        final Resource resource = Resource.newBuilder()
+                .addAttributes(KeyValue.newBuilder()
+                        .setKey("service.name")
+                        .setValue(AnyValue.newBuilder().setStringValue("service").build())
+                ).build();
+
+        final ResourceLogs resourceLogs = ResourceLogs.newBuilder()
+                .addScopeLogs(ScopeLogs.newBuilder()
+                        .addLogRecords(LogRecord.newBuilder().setSeverityNumberValue(1))
+                        .build())
+                .setResource(resource)
+                .build();
+
+        return ExportLogsServiceRequest.newBuilder()
+                .addResourceLogs(resourceLogs)
+                .build();
+    }
+
+    private void assertSecureResponseWithStatusCode(final AggregatedHttpResponse response,
+                                                    final HttpStatus expectedStatus,
+                                                    final Throwable throwable) {
+        assertThat("Http Status", response.status(), equalTo(expectedStatus));
+        assertThat("Http Response Throwable", throwable, is(nullValue()));
+
+        final List<String> headerKeys = response.headers()
+                .stream()
+                .map(Map.Entry::getKey)
+                .map(AsciiString::toString)
+                .collect(Collectors.toList());
+        assertThat("Response Header Keys", headerKeys, not(contains("server")));
+    }
+
 }

--- a/data-prepper-plugins/otel-logs-source/src/test/java/com/amazon/dataprepper/plugins/source/otellogs/OtelLogsSourceConfigTests.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/com/amazon/dataprepper/plugins/source/otellogs/OtelLogsSourceConfigTests.java
@@ -20,6 +20,7 @@ import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfi
 import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.ENABLE_UNFRAMED_REQUESTS;
 import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.HEALTH_CHECK_SERVICE;
 import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.MAX_CONNECTION_COUNT;
+import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.PATH;
 import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.PORT;
 import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.PROTO_REFLECTION_SERVICE;
 import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.REQUEST_TIMEOUT;
@@ -27,13 +28,15 @@ import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfi
 import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.SSL_KEY_CERT_FILE;
 import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.SSL_KEY_FILE;
 import static com.amazon.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.THREAD_COUNT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-public class OtelLogsSourceConfigTests {
+class OtelLogsSourceConfigTests {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String PLUGIN_NAME = "otel_logs_source";
     private static final String TEST_KEY_CERT = "test.crt";
@@ -47,7 +50,7 @@ public class OtelLogsSourceConfigTests {
     private static final int TEST_MAX_CONNECTION_COUNT = 999;
 
     @Test
-    public void testDefault() {
+    void testDefault() {
 
         // Prepare
         final OTelLogsSourceConfig otelLogsSourceConfig = new OTelLogsSourceConfig();
@@ -67,11 +70,12 @@ public class OtelLogsSourceConfigTests {
     }
 
     @Test
-    public void testValidConfigWithoutS3CertAndKey() {
+    void testValidConfigWithoutS3CertAndKey() {
         // Prepare
         final PluginSetting validPluginSetting = completePluginSettingForOtelLogsSource(
                 TEST_REQUEST_TIMEOUT_MS,
                 TEST_PORT,
+                null,
                 true,
                 true,
                 false,
@@ -99,11 +103,12 @@ public class OtelLogsSourceConfigTests {
     }
 
     @Test
-    public void testValidConfigWithS3CertAndKey() {
+    void testValidConfigWithS3CertAndKey() {
         // Prepare
         final PluginSetting validPluginSettingWithS3CertAndKey = completePluginSettingForOtelLogsSource(
                 TEST_REQUEST_TIMEOUT_MS,
                 TEST_PORT,
+                null,
                 false,
                 false,
                 false,
@@ -132,11 +137,13 @@ public class OtelLogsSourceConfigTests {
     }
 
     @Test
-    public void testInvalidConfigWithNullKeyCert() {
+    void testInvalidConfigWithNullKeyCert() {
         // Prepare
         final PluginSetting sslNullKeyCertPluginSetting = completePluginSettingForOtelLogsSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
-                DEFAULT_PORT, false,
+                DEFAULT_PORT,
+                null,
+                false,
                 false,
                 false,
                 true, null,
@@ -152,11 +159,12 @@ public class OtelLogsSourceConfigTests {
     }
 
     @Test
-    public void testInvalidConfigWithEmptyKeyCert() {
+    void testInvalidConfigWithEmptyKeyCert() {
         // Prepare
         final PluginSetting sslEmptyKeyCertPluginSetting = completePluginSettingForOtelLogsSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
                 DEFAULT_PORT,
+                null,
                 false,
                 false,
                 false,
@@ -174,11 +182,12 @@ public class OtelLogsSourceConfigTests {
     }
 
     @Test
-    public void testInvalidConfigWithEmptyKeyFile() {
+    void testInvalidConfigWithEmptyKeyFile() {
         // Prepare
         final PluginSetting sslEmptyKeyFilePluginSetting = completePluginSettingForOtelLogsSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
                 DEFAULT_PORT,
+                null,
                 false,
                 false,
                 false,
@@ -194,8 +203,32 @@ public class OtelLogsSourceConfigTests {
         assertThrows(IllegalArgumentException.class, otelLogsSourceConfig::validateAndInitializeCertAndKeyFileInS3);
     }
 
+    @Test
+    void testValidConfigWithCustomPath() {
+        final String testPath = "testPath";
+        // Prepare
+        final PluginSetting customPathPluginSetting = completePluginSettingForOtelLogsSource(
+                DEFAULT_REQUEST_TIMEOUT_MS,
+                DEFAULT_PORT,
+                testPath,
+                false,
+                false,
+                false,
+                true,
+                TEST_KEY_CERT,
+                "",
+                DEFAULT_THREAD_COUNT,
+                DEFAULT_MAX_CONNECTION_COUNT);
+
+        final OTelLogsSourceConfig oTelLogsSourceConfig = OBJECT_MAPPER.convertValue(customPathPluginSetting.getSettings(), OTelLogsSourceConfig.class);
+
+        // When/Then
+        assertThat(oTelLogsSourceConfig.getPath(), equalTo(testPath));
+    }
+
     private PluginSetting completePluginSettingForOtelLogsSource(final int requestTimeoutInMillis,
                                                                  final int port,
+                                                                 final String path,
                                                                  final boolean healthCheck,
                                                                  final boolean protoReflectionService,
                                                                  final boolean enableUnframedRequests,
@@ -207,6 +240,7 @@ public class OtelLogsSourceConfigTests {
         final Map<String, Object> settings = new HashMap<>();
         settings.put(REQUEST_TIMEOUT, requestTimeoutInMillis);
         settings.put(PORT, port);
+        settings.put(PATH, path);
         settings.put(HEALTH_CHECK_SERVICE, healthCheck);
         settings.put(PROTO_REFLECTION_SERVICE, protoReflectionService);
         settings.put(ENABLE_UNFRAMED_REQUESTS, enableUnframedRequests);

--- a/data-prepper-plugins/otel-metrics-source/README.md
+++ b/data-prepper-plugins/otel-metrics-source/README.md
@@ -15,6 +15,7 @@ source:
 ## Configurations
 
 * port(Optional) => An `int` represents the port Otel metrics source is running on. Default is ```21891```.
+* path(Optional) => A `String` which represents the path for sending unframed HTTP requests. This will add a new service which can be used for supporting unframed gRPC with HTTP idiomatic path to a configurable path other than `/opentelemetry.proto.collector.metrics.v1.MetricsService/Export` which can still be used. Path can contain `${pipelineName}` placeholder which will be replaced with pipeline name. 
 * request_timeout(Optional) => An `int` represents request timeout in millis. Default is ```10_000```.
 * health_check_service(Optional) => A boolean enables health check service. When ```true``` enables a gRPC health check service under ```grpc.health.v1.Health/Check```. Default is ```false```. In order to use the health check service, you must also enable ```proto_reflection_service```.
 * proto_reflection_service(Optional) => A boolean enables a reflection service for Protobuf services (see [ProtoReflectionService](https://grpc.github.io/grpc-java/javadoc/io/grpc/protobuf/services/ProtoReflectionService.html) and [gRPC reflection](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md) docs). Default is ```false```.

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
@@ -11,10 +11,13 @@ import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
+import io.grpc.MethodDescriptor;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
 import io.grpc.protobuf.services.ProtoReflectionService;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
+import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
 import org.opensearch.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
@@ -47,20 +50,19 @@ public class OTelMetricsSource implements Source<Record<ExportMetricsServiceRequ
     private static final Logger LOG = LoggerFactory.getLogger(OTelMetricsSource.class);
     private static final String HTTP_HEALTH_CHECK_PATH = "/health";
     private static final String REGEX_HEALTH = "regex:^/(?!health$).*$";
+    private static final String PIPELINE_NAME_PLACEHOLDER = "${pipelineName}";
+
     private final OTelMetricsSourceConfig oTelMetricsSourceConfig;
-    private Server server;
+    private final String pipelineName;
     private final PluginMetrics pluginMetrics;
     private final GrpcAuthenticationProvider authenticationProvider;
     private final CertificateProviderFactory certificateProviderFactory;
+    private Server server;
 
     @DataPrepperPluginConstructor
     public OTelMetricsSource(final OTelMetricsSourceConfig oTelMetricsSourceConfig, final PluginMetrics pluginMetrics,
                              final PluginFactory pluginFactory, final PipelineDescription pipelineDescription) {
-        oTelMetricsSourceConfig.validateAndInitializeCertAndKeyFileInS3();
-        this.oTelMetricsSourceConfig = oTelMetricsSourceConfig;
-        this.pluginMetrics = pluginMetrics;
-        this.certificateProviderFactory = new CertificateProviderFactory(oTelMetricsSourceConfig);
-        this.authenticationProvider = createAuthenticationProvider(pluginFactory, pipelineDescription);
+        this(oTelMetricsSourceConfig, pluginMetrics, pluginFactory, new CertificateProviderFactory(oTelMetricsSourceConfig), pipelineDescription);
     }
 
     // accessible only in the same package for unit test
@@ -71,6 +73,7 @@ public class OTelMetricsSource implements Source<Record<ExportMetricsServiceRequ
         this.pluginMetrics = pluginMetrics;
         this.certificateProviderFactory = certificateProviderFactory;
         this.authenticationProvider = createAuthenticationProvider(pluginFactory, pipelineDescription);
+        this.pipelineName = pipelineDescription.getPipelineName();
     }
 
     @Override
@@ -94,6 +97,14 @@ public class OTelMetricsSource implements Source<Record<ExportMetricsServiceRequ
                     .addService(ServerInterceptors.intercept(oTelMetricsGrpcService, serverInterceptors))
                     .useClientTimeoutHeader(false)
                     .useBlockingTaskExecutor(true);
+
+            final MethodDescriptor<ExportMetricsServiceRequest, ExportMetricsServiceResponse> methodDescriptor = MetricsServiceGrpc.getExportMethod();
+            final String oTelMetricsSourcePath = oTelMetricsSourceConfig.getPath();
+            if (oTelMetricsSourcePath != null) {
+                final String transformedOTelMetricsSourcePath = oTelMetricsSourcePath.replace(PIPELINE_NAME_PLACEHOLDER, pipelineName);
+                grpcServiceBuilder.addService(transformedOTelMetricsSourcePath,
+                        ServerInterceptors.intercept(oTelMetricsGrpcService, serverInterceptors), methodDescriptor);
+            }
 
             if (oTelMetricsSourceConfig.hasHealthCheck()) {
                 LOG.info("Health check is enabled");
@@ -208,7 +219,7 @@ public class OTelMetricsSource implements Source<Record<ExportMetricsServiceRequ
         } else {
             authenticationPluginSetting = new PluginSetting(GrpcAuthenticationProvider.UNAUTHENTICATED_PLUGIN_NAME, Collections.emptyMap());
         }
-        authenticationPluginSetting.setPipelineName(pipelineDescription.getPipelineName());
+        authenticationPluginSetting.setPipelineName(pipelineName);
         return pluginFactory.loadPlugin(GrpcAuthenticationProvider.class, authenticationPluginSetting);
     }
 }

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceConfig.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceConfig.java
@@ -12,6 +12,7 @@ import org.opensearch.dataprepper.model.configuration.PluginModel;
 public class OTelMetricsSourceConfig {
     static final String REQUEST_TIMEOUT = "request_timeout";
     static final String PORT = "port";
+    static final String PATH = "path";
     static final String SSL = "ssl";
     static final String USE_ACM_CERT_FOR_SSL = "useAcmCertForSSL";
     static final String ACM_CERT_ISSUE_TIME_OUT_MILLIS = "acmCertIssueTimeOutMillis";
@@ -43,6 +44,9 @@ public class OTelMetricsSourceConfig {
 
     @JsonProperty(PORT)
     private int port = DEFAULT_PORT;
+
+    @JsonProperty(PATH)
+    private String path;
 
     @JsonProperty(HEALTH_CHECK_SERVICE)
     private boolean healthCheck = DEFAULT_HEALTH_CHECK;
@@ -128,6 +132,10 @@ public class OTelMetricsSourceConfig {
 
     public int getPort() {
         return port;
+    }
+
+    public String getPath() {
+        return path;
     }
 
     public boolean hasHealthCheck() {

--- a/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceTest.java
+++ b/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
@@ -25,9 +26,16 @@ import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import io.grpc.BindableService;
 import io.grpc.ServerServiceDefinition;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.netty.util.AsciiString;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
+import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
+import io.opentelemetry.proto.resource.v1.Resource;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -35,12 +43,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
+import org.opensearch.dataprepper.armeria.authentication.HttpBasicAuthenticationConfig;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
@@ -59,39 +73,55 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.otelmetrics.OTelMetricsSourceConfig.DEFAULT_PORT;
+import static org.opensearch.dataprepper.plugins.source.otelmetrics.OTelMetricsSourceConfig.DEFAULT_REQUEST_TIMEOUT_MS;
 import static org.opensearch.dataprepper.plugins.source.otelmetrics.OTelMetricsSourceConfig.SSL;
 
 @ExtendWith(MockitoExtension.class)
-public class OTelMetricsSourceTest {
+class OTelMetricsSourceTest {
+    private static final String GRPC_ENDPOINT = "gproto+http://127.0.0.1:21891/";
+    private static final String TEST_PIPELINE_NAME = "test_pipeline";
+    private static final String USERNAME = "test_user";
+    private static final String PASSWORD = "test_password";
+    private static final String TEST_PATH = "${pipelineName}/v1/metrics";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ExportMetricsServiceRequest METRICS_REQUEST = ExportMetricsServiceRequest.newBuilder()
+            .addResourceMetrics(ResourceMetrics.newBuilder().build()).build();
 
     @Mock
     private ServerBuilder serverBuilder;
@@ -123,39 +153,20 @@ public class OTelMetricsSourceTest {
     @Mock
     private GrpcBasicAuthenticationProvider authenticationProvider;
 
-    private PluginSetting pluginSetting;
-    private PluginSetting testPluginSetting;
+    @Mock(lenient = true)
     private OTelMetricsSourceConfig oTelMetricsSourceConfig;
-    private PluginMetrics pluginMetrics;
-    private PipelineDescription pipelineDescription;
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
+    @Mock
     private BlockingBuffer<Record<ExportMetricsServiceRequest>> buffer;
 
+    @Mock
+    private HttpBasicAuthenticationConfig httpBasicAuthenticationConfig;
+
+    private PluginSetting pluginSetting;
+    private PluginSetting testPluginSetting;
+    private PluginMetrics pluginMetrics;
+    private PipelineDescription pipelineDescription;
     private OTelMetricsSource SOURCE;
-    private static final String TEST_PIPELINE_NAME = "test_pipeline";
-    private static final ExportMetricsServiceRequest METRICS_REQUEST = ExportMetricsServiceRequest.newBuilder()
-            .addResourceMetrics(ResourceMetrics.newBuilder().build()).build();
-
-    private static void assertStatusCode415AndNoServerHeaders(final AggregatedHttpResponse response, final Throwable throwable) {
-        assertThat("Http Status", response.status(), is(HttpStatus.UNSUPPORTED_MEDIA_TYPE));
-        assertThat("Http Response Throwable", throwable, is(nullValue()));
-
-        final List<String> headerKeys = response.headers()
-                .stream()
-                .map(Map.Entry::getKey)
-                .map(AsciiString::toString)
-                .collect(Collectors.toList());
-        assertThat("Response Header Keys", headerKeys, not(contains("server")));
-    }
-
-    private BlockingBuffer<Record<ExportMetricsServiceRequest>> getBuffer() {
-        final HashMap<String, Object> integerHashMap = new HashMap<>();
-        integerHashMap.put("buffer_size", 1);
-        integerHashMap.put("batch_size", 1);
-        return new BlockingBuffer<>(new PluginSetting("blocking_buffer", integerHashMap));
-    }
 
     @BeforeEach
     public void beforeEach() {
@@ -169,22 +180,19 @@ public class OTelMetricsSourceTest {
         lenient().when(grpcServiceBuilder.useClientTimeoutHeader(anyBoolean())).thenReturn(grpcServiceBuilder);
         lenient().when(grpcServiceBuilder.useBlockingTaskExecutor(anyBoolean())).thenReturn(grpcServiceBuilder);
         lenient().when(grpcServiceBuilder.build()).thenReturn(grpcService);
-
-        final Map<String, Object> settingsMap = new HashMap<>();
-        settingsMap.put("request_timeout", 5);
-        settingsMap.put(SSL, false);
-        pluginSetting = new PluginSetting("otel_metrics", settingsMap);
-        pluginSetting.setPipelineName("pipeline");
         pluginMetrics = PluginMetrics.fromNames("otel_metrics", "pipeline");
 
-        oTelMetricsSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelMetricsSourceConfig.class);
+        when(oTelMetricsSourceConfig.getPort()).thenReturn(DEFAULT_PORT);
+        when(oTelMetricsSourceConfig.isSsl()).thenReturn(false);
+        when(oTelMetricsSourceConfig.getRequestTimeoutInMillis()).thenReturn(DEFAULT_REQUEST_TIMEOUT_MS);
+        when(oTelMetricsSourceConfig.getMaxConnectionCount()).thenReturn(10);
+        when(oTelMetricsSourceConfig.getThreadCount()).thenReturn(5);
 
         when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))
                 .thenReturn(authenticationProvider);
         pipelineDescription = mock(PipelineDescription.class);
         when(pipelineDescription.getPipelineName()).thenReturn(TEST_PIPELINE_NAME);
         SOURCE = new OTelMetricsSource(oTelMetricsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
-        buffer = getBuffer();
     }
 
     @AfterEach
@@ -192,8 +200,12 @@ public class OTelMetricsSourceTest {
         SOURCE.stop();
     }
 
+    private void configureObjectUnderTest() {
+        SOURCE = new OTelMetricsSource(oTelMetricsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
+    }
+
     @Test
-    void testHttpFullJson() throws InvalidProtocolBufferException {
+    void testHttpFullJsonWithNonUnframedRequests() throws InvalidProtocolBufferException {
         SOURCE.start(buffer);
         WebClient.of().execute(RequestHeaders.builder()
                         .scheme(SessionProtocol.HTTP)
@@ -204,12 +216,12 @@ public class OTelMetricsSourceTest {
                         .build(),
                 HttpData.copyOf(JsonFormat.printer().print(METRICS_REQUEST).getBytes()))
                 .aggregate()
-                .whenComplete(OTelMetricsSourceTest::assertStatusCode415AndNoServerHeaders)
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNSUPPORTED_MEDIA_TYPE, throwable))
                 .join();
     }
 
     @Test
-    void testHttpsFullJson() throws InvalidProtocolBufferException {
+    void testHttpsFullJsonWithNonUnframedRequests() throws InvalidProtocolBufferException {
 
         final Map<String, Object> settingsMap = new HashMap<>();
         settingsMap.put("request_timeout", 5);
@@ -222,8 +234,6 @@ public class OTelMetricsSourceTest {
 
         oTelMetricsSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelMetricsSourceConfig.class);
         SOURCE = new OTelMetricsSource(oTelMetricsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
-
-        buffer = getBuffer();
         SOURCE.start(buffer);
 
         WebClient.builder().factory(ClientFactory.insecure()).build().execute(RequestHeaders.builder()
@@ -235,12 +245,12 @@ public class OTelMetricsSourceTest {
                         .build(),
                 HttpData.copyOf(JsonFormat.printer().print(METRICS_REQUEST).getBytes()))
                 .aggregate()
-                .whenComplete(OTelMetricsSourceTest::assertStatusCode415AndNoServerHeaders)
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNSUPPORTED_MEDIA_TYPE, throwable))
                 .join();
     }
 
     @Test
-    void testHttpFullBytes() {
+    void testHttpFullBytesWithNonUnframedRequests() {
         SOURCE.start(buffer);
         WebClient.of().execute(RequestHeaders.builder()
                         .scheme(SessionProtocol.HTTP)
@@ -251,12 +261,50 @@ public class OTelMetricsSourceTest {
                         .build(),
                 HttpData.copyOf(METRICS_REQUEST.toByteArray()))
                 .aggregate()
-                .whenComplete(OTelMetricsSourceTest::assertStatusCode415AndNoServerHeaders)
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNSUPPORTED_MEDIA_TYPE, throwable))
                 .join();
     }
 
     @Test
-    public void testServerStartCertFileSuccess() throws IOException {
+    void testHttpFullJsonWithUnframedRequests() throws InvalidProtocolBufferException {
+        when(oTelMetricsSourceConfig.enableUnframedRequests()).thenReturn(true);
+        SOURCE.start(buffer);
+
+        WebClient.of().execute(RequestHeaders.builder()
+                                .scheme(SessionProtocol.HTTP)
+                                .authority("127.0.0.1:21891")
+                                .method(HttpMethod.POST)
+                                .path("/opentelemetry.proto.collector.metrics.v1.MetricsService/Export")
+                                .contentType(MediaType.JSON_UTF_8)
+                                .build(),
+                        HttpData.copyOf(JsonFormat.printer().print(METRICS_REQUEST).getBytes()))
+                .aggregate()
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.OK, throwable))
+                .join();
+    }
+
+    @Test
+    void testHttpFullJsonWithCustomPathAndUnframedRequests() throws InvalidProtocolBufferException {
+        when(oTelMetricsSourceConfig.enableUnframedRequests()).thenReturn(true);
+        when(oTelMetricsSourceConfig.getPath()).thenReturn(TEST_PATH);
+        SOURCE.start(buffer);
+
+        final String transformedPath = "/" + TEST_PIPELINE_NAME + "/v1/metrics";
+        WebClient.of().execute(RequestHeaders.builder()
+                                .scheme(SessionProtocol.HTTP)
+                                .authority("127.0.0.1:21891")
+                                .method(HttpMethod.POST)
+                                .path(transformedPath)
+                                .contentType(MediaType.JSON_UTF_8)
+                                .build(),
+                        HttpData.copyOf(JsonFormat.printer().print(METRICS_REQUEST).getBytes()))
+                .aggregate()
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.OK, throwable))
+                .join();
+    }
+
+    @Test
+    void testServerStartCertFileSuccess() throws IOException {
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
             armeriaServerMock.when(Server::builder).thenReturn(serverBuilder);
             when(server.stop()).thenReturn(completableFuture);
@@ -290,7 +338,7 @@ public class OTelMetricsSourceTest {
     }
 
     @Test
-    public void testServerStartACMCertSuccess() throws IOException {
+    void testServerStartACMCertSuccess() throws IOException {
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
             armeriaServerMock.when(Server::builder).thenReturn(serverBuilder);
             when(server.stop()).thenReturn(completableFuture);
@@ -454,9 +502,8 @@ public class OTelMetricsSourceTest {
                             .path("/health")
                             .build())
                     .aggregate()
-                    .whenComplete((i, ex) -> assertSecureResponseWithStatusCode(i, HttpStatus.UNAUTHORIZED)).join();
-
-            SOURCE.stop();
+                    .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNAUTHORIZED, throwable))
+                    .join();
         }
 
         @Test
@@ -474,21 +521,9 @@ public class OTelMetricsSourceTest {
                             .path("/health")
                             .build())
                     .aggregate()
-                    .whenComplete((i, ex) -> assertSecureResponseWithStatusCode(i, HttpStatus.OK)).join();
-
-            SOURCE.stop();
+                    .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.OK, throwable))
+                    .join();
         }
-    }
-
-    private void assertSecureResponseWithStatusCode(final AggregatedHttpResponse response, final HttpStatus expectedStatus) {
-        assertThat("Http Status", response.status(), equalTo(expectedStatus));
-
-        final List<String> headerKeys = response.headers()
-                .stream()
-                .map(Map.Entry::getKey)
-                .map(AsciiString::toString)
-                .collect(Collectors.toList());
-        assertThat("Response Header Keys", headerKeys, not(contains("server")));
     }
 
     @Test
@@ -618,7 +653,7 @@ public class OTelMetricsSourceTest {
     }
 
     @Test
-    public void testDoubleStart() {
+    void testDoubleStart() {
         // starting server
         SOURCE.start(buffer);
         // double start server
@@ -626,7 +661,7 @@ public class OTelMetricsSourceTest {
     }
 
     @Test
-    public void testRunAnotherSourceWithSamePort() {
+    void testRunAnotherSourceWithSamePort() {
         // starting server
         SOURCE.start(buffer);
 
@@ -639,7 +674,7 @@ public class OTelMetricsSourceTest {
     }
 
     @Test
-    public void testStartWithEmptyBuffer() {
+    void testStartWithEmptyBuffer() {
         testPluginSetting = new PluginSetting(null, Collections.singletonMap(SSL, false));
         testPluginSetting.setPipelineName("pipeline");
         oTelMetricsSourceConfig = OBJECT_MAPPER.convertValue(testPluginSetting.getSettings(), OTelMetricsSourceConfig.class);
@@ -648,7 +683,7 @@ public class OTelMetricsSourceTest {
     }
 
     @Test
-    public void testStartWithServerExecutionExceptionNoCause() throws ExecutionException, InterruptedException {
+    void testStartWithServerExecutionExceptionNoCause() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelMetricsSource source = new OTelMetricsSource(oTelMetricsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -661,7 +696,7 @@ public class OTelMetricsSourceTest {
     }
 
     @Test
-    public void testStartWithServerExecutionExceptionWithCause() throws ExecutionException, InterruptedException {
+    void testStartWithServerExecutionExceptionWithCause() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelMetricsSource source = new OTelMetricsSource(oTelMetricsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -676,7 +711,7 @@ public class OTelMetricsSourceTest {
     }
 
     @Test
-    public void testOptionalHttpAuthServiceNotInPlace() {
+    void testOptionalHttpAuthServiceNotInPlace() {
         when(server.stop()).thenReturn(completableFuture);
 
         try (final MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -689,7 +724,7 @@ public class OTelMetricsSourceTest {
     }
 
     @Test
-    public void testOptionalHttpAuthServiceInPlace() {
+    void testOptionalHttpAuthServiceInPlace() {
         when(server.stop()).thenReturn(completableFuture);
 
         try (final MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -701,7 +736,7 @@ public class OTelMetricsSourceTest {
     }
 
     @Test
-    public void testStopWithServerExecutionExceptionNoCause() throws ExecutionException, InterruptedException {
+    void testStopWithServerExecutionExceptionNoCause() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelMetricsSource source = new OTelMetricsSource(oTelMetricsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -716,7 +751,7 @@ public class OTelMetricsSourceTest {
     }
 
     @Test
-    public void testStartWithInterruptedException() throws ExecutionException, InterruptedException {
+    void testStartWithInterruptedException() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelMetricsSource source = new OTelMetricsSource(oTelMetricsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -730,7 +765,7 @@ public class OTelMetricsSourceTest {
     }
 
     @Test
-    public void testStopWithServerExecutionExceptionWithCause() throws ExecutionException, InterruptedException {
+    void testStopWithServerExecutionExceptionWithCause() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelMetricsSource source = new OTelMetricsSource(oTelMetricsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -747,7 +782,7 @@ public class OTelMetricsSourceTest {
     }
 
     @Test
-    public void testStopWithInterruptedException() throws ExecutionException, InterruptedException {
+    void testStopWithInterruptedException() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelMetricsSource source = new OTelMetricsSource(oTelMetricsSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -760,5 +795,135 @@ public class OTelMetricsSourceTest {
             assertThrows(RuntimeException.class, source::stop);
             assertTrue(Thread.interrupted());
         }
+    }
+
+    @Test
+    void gRPC_request_writes_to_buffer_with_successful_response() throws Exception {
+        SOURCE.start(buffer);
+
+        final MetricsServiceGrpc.MetricsServiceBlockingStub client = Clients.builder(GRPC_ENDPOINT)
+                .build(MetricsServiceGrpc.MetricsServiceBlockingStub.class);
+        final ExportMetricsServiceResponse exportResponse = client.export(createExportMetricsRequest());
+        assertThat(exportResponse, notNullValue());
+
+        final ArgumentCaptor<Record<ExportMetricsServiceRequest>> bufferWriteArgumentCaptor = ArgumentCaptor.forClass(Record.class);
+        verify(buffer).write(bufferWriteArgumentCaptor.capture(), anyInt());
+
+        final Record<ExportMetricsServiceRequest> actualBufferWrites = bufferWriteArgumentCaptor.getValue();
+        assertThat(actualBufferWrites, notNullValue());
+        assertThat(actualBufferWrites.getData().getResourceMetricsCount(), equalTo(1));
+    }
+
+    @Test
+    void gRPC_with_auth_request_writes_to_buffer_with_successful_response() throws Exception {
+        when(httpBasicAuthenticationConfig.getUsername()).thenReturn(USERNAME);
+        when(httpBasicAuthenticationConfig.getPassword()).thenReturn(PASSWORD);
+        final GrpcAuthenticationProvider grpcAuthenticationProvider = new GrpcBasicAuthenticationProvider(httpBasicAuthenticationConfig);
+
+        lenient().when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))
+                .thenReturn(grpcAuthenticationProvider);
+        when(oTelMetricsSourceConfig.enableUnframedRequests()).thenReturn(true);
+        when(oTelMetricsSourceConfig.getAuthentication()).thenReturn(new PluginModel("http_basic",
+                Map.of(
+                        "username", USERNAME,
+                        "password", PASSWORD
+                )));
+        configureObjectUnderTest();
+        SOURCE.start(buffer);
+
+        final String encodeToString = Base64.getEncoder()
+                .encodeToString(String.format("%s:%s", USERNAME, PASSWORD).getBytes(StandardCharsets.UTF_8));
+
+        final MetricsServiceGrpc.MetricsServiceBlockingStub client = Clients.builder(GRPC_ENDPOINT)
+                .addHeader("Authorization", "Basic " + encodeToString)
+                .build(MetricsServiceGrpc.MetricsServiceBlockingStub.class);
+        final ExportMetricsServiceResponse exportResponse = client.export(createExportMetricsRequest());
+        assertThat(exportResponse, notNullValue());
+
+        final ArgumentCaptor<Record<ExportMetricsServiceRequest>> bufferWriteArgumentCaptor = ArgumentCaptor.forClass(Record.class);
+        verify(buffer).write(bufferWriteArgumentCaptor.capture(), anyInt());
+
+        final Record<ExportMetricsServiceRequest> actualBufferWrites = bufferWriteArgumentCaptor.getValue();
+        assertThat(actualBufferWrites, notNullValue());
+        assertThat(actualBufferWrites.getData().getResourceMetricsCount(), equalTo(1));
+    }
+
+    @Test
+    void gRPC_request_writes_to_buffer_with_successful_response_with_custom_path() throws Exception {
+        when(oTelMetricsSourceConfig.getPath()).thenReturn(TEST_PATH);
+        when(oTelMetricsSourceConfig.enableUnframedRequests()).thenReturn(true);
+
+        SOURCE.start(buffer);
+
+        final MetricsServiceGrpc.MetricsServiceBlockingStub client = Clients.builder(GRPC_ENDPOINT)
+                .build(MetricsServiceGrpc.MetricsServiceBlockingStub.class);
+        final ExportMetricsServiceResponse exportResponse = client.export(createExportMetricsRequest());
+        assertThat(exportResponse, notNullValue());
+
+        final ArgumentCaptor<Record<ExportMetricsServiceRequest>> bufferWriteArgumentCaptor = ArgumentCaptor.forClass(Record.class);
+        verify(buffer).write(bufferWriteArgumentCaptor.capture(), anyInt());
+
+        final Record<ExportMetricsServiceRequest> actualBufferWrites = bufferWriteArgumentCaptor.getValue();
+        assertThat(actualBufferWrites, notNullValue());
+        assertThat(actualBufferWrites.getData().getResourceMetricsCount(), equalTo(1));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(BufferExceptionToStatusArgumentsProvider.class)
+    void gRPC_request_returns_expected_status_for_exceptions_from_buffer(
+            final Class<Exception> bufferExceptionClass,
+            final Status.Code expectedStatusCode) throws Exception {
+        SOURCE.start(buffer);
+
+        final MetricsServiceGrpc.MetricsServiceBlockingStub client = Clients.builder(GRPC_ENDPOINT)
+                .build(MetricsServiceGrpc.MetricsServiceBlockingStub.class);
+
+        doThrow(bufferExceptionClass)
+                .when(buffer)
+                .write(any(Record.class), anyInt());
+        final ExportMetricsServiceRequest exportMetricsRequest = createExportMetricsRequest();
+        final StatusRuntimeException actualException = assertThrows(StatusRuntimeException.class, () -> client.export(exportMetricsRequest));
+
+        assertThat(actualException.getStatus(), notNullValue());
+        assertThat(actualException.getStatus().getCode(), equalTo(expectedStatusCode));
+    }
+
+    static class BufferExceptionToStatusArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
+            return Stream.of(
+                    arguments(TimeoutException.class, Status.Code.RESOURCE_EXHAUSTED),
+                    arguments(RuntimeException.class, Status.Code.UNKNOWN)
+            );
+        }
+    }
+
+    private ExportMetricsServiceRequest createExportMetricsRequest() {
+        final Resource resource = Resource.newBuilder()
+                .addAttributes(KeyValue.newBuilder()
+                        .setKey("service.name")
+                        .setValue(AnyValue.newBuilder().setStringValue("service").build())
+                ).build();
+
+        final ResourceMetrics resourceMetrics = ResourceMetrics.newBuilder()
+                .setResource(resource)
+                .build();
+
+        return ExportMetricsServiceRequest.newBuilder()
+                .addResourceMetrics(resourceMetrics).build();
+    }
+
+    private void assertSecureResponseWithStatusCode(final AggregatedHttpResponse response,
+                                                    final HttpStatus expectedStatus,
+                                                    final Throwable throwable) {
+        assertThat("Http Status", response.status(), equalTo(expectedStatus));
+        assertThat("Http Response Throwable", throwable, is(nullValue()));
+
+        final List<String> headerKeys = response.headers()
+                .stream()
+                .map(Map.Entry::getKey)
+                .map(AsciiString::toString)
+                .collect(Collectors.toList());
+        assertThat("Response Header Keys", headerKeys, not(contains("server")));
     }
 }

--- a/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OtelMetricsSourceConfigTests.java
+++ b/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OtelMetricsSourceConfigTests.java
@@ -12,6 +12,8 @@ import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -22,7 +24,7 @@ import static org.opensearch.dataprepper.plugins.source.otelmetrics.OTelMetricsS
 import static org.opensearch.dataprepper.plugins.source.otelmetrics.OTelMetricsSourceConfig.DEFAULT_REQUEST_TIMEOUT_MS;
 import static org.opensearch.dataprepper.plugins.source.otelmetrics.OTelMetricsSourceConfig.DEFAULT_THREAD_COUNT;
 
-public class OtelMetricsSourceConfigTests {
+class OtelMetricsSourceConfigTests {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String PLUGIN_NAME = "otel_metrics_source";
     private static final String TEST_KEY_CERT = "test.crt";
@@ -36,7 +38,7 @@ public class OtelMetricsSourceConfigTests {
     private static final int TEST_MAX_CONNECTION_COUNT = 999;
 
     @Test
-    public void testDefault() {
+    void testDefault() {
 
         // Prepare
         final OTelMetricsSourceConfig otelMetricsSourceConfig = new OTelMetricsSourceConfig();
@@ -57,7 +59,7 @@ public class OtelMetricsSourceConfigTests {
     }
 
     @Test
-    public void testHttpHealthCheckWithUnframedRequestEnabled() {
+    void testHttpHealthCheckWithUnframedRequestEnabled() {
         // Prepare
         final Map<String, Object> settings = new HashMap<>();
         settings.put(OTelMetricsSourceConfig.ENABLE_UNFRAMED_REQUESTS, "true");
@@ -75,7 +77,7 @@ public class OtelMetricsSourceConfigTests {
     }
 
     @Test
-    public void testHttpHealthCheckWithUnframedRequestDisabled() {
+    void testHttpHealthCheckWithUnframedRequestDisabled() {
         // Prepare
         final Map<String, Object> settings = new HashMap<>();
         settings.put(OTelMetricsSourceConfig.ENABLE_UNFRAMED_REQUESTS, "false");
@@ -93,11 +95,12 @@ public class OtelMetricsSourceConfigTests {
     }
 
     @Test
-    public void testValidConfigWithoutS3CertAndKey() {
+    void testValidConfigWithoutS3CertAndKey() {
         // Prepare
         final PluginSetting validPluginSetting = completePluginSettingForOtelMetricsSource(
                 TEST_REQUEST_TIMEOUT_MS,
                 TEST_PORT,
+                null,
                 true,
                 true,
                 false,
@@ -126,11 +129,12 @@ public class OtelMetricsSourceConfigTests {
     }
 
     @Test
-    public void testValidConfigWithS3CertAndKey() {
+    void testValidConfigWithS3CertAndKey() {
         // Prepare
         final PluginSetting validPluginSettingWithS3CertAndKey = completePluginSettingForOtelMetricsSource(
                 TEST_REQUEST_TIMEOUT_MS,
                 TEST_PORT,
+                null,
                 false,
                 false,
                 false,
@@ -160,11 +164,13 @@ public class OtelMetricsSourceConfigTests {
     }
 
     @Test
-    public void testInvalidConfigWithNullKeyCert() {
+    void testInvalidConfigWithNullKeyCert() {
         // Prepare
         final PluginSetting sslNullKeyCertPluginSetting = completePluginSettingForOtelMetricsSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
-                DEFAULT_PORT, false,
+                DEFAULT_PORT,
+                null,
+                false,
                 false,
                 false,
                 true, null,
@@ -180,11 +186,12 @@ public class OtelMetricsSourceConfigTests {
     }
 
     @Test
-    public void testInvalidConfigWithEmptyKeyCert() {
+    void testInvalidConfigWithEmptyKeyCert() {
         // Prepare
         final PluginSetting sslEmptyKeyCertPluginSetting = completePluginSettingForOtelMetricsSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
                 DEFAULT_PORT,
+                null,
                 false,
                 false,
                 false,
@@ -202,11 +209,12 @@ public class OtelMetricsSourceConfigTests {
     }
 
     @Test
-    public void testInvalidConfigWithEmptyKeyFile() {
+    void testInvalidConfigWithEmptyKeyFile() {
         // Prepare
         final PluginSetting sslEmptyKeyFilePluginSetting = completePluginSettingForOtelMetricsSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
                 DEFAULT_PORT,
+                null,
                 false,
                 false,
                 false,
@@ -222,8 +230,32 @@ public class OtelMetricsSourceConfigTests {
         assertThrows(IllegalArgumentException.class, otelMetricsSourceConfig::validateAndInitializeCertAndKeyFileInS3);
     }
 
+    @Test
+    void testValidConfigWithCustomPath() {
+        final String testPath = "testPath";
+        // Prepare
+        final PluginSetting customPathPluginSetting = completePluginSettingForOtelMetricsSource(
+                DEFAULT_REQUEST_TIMEOUT_MS,
+                DEFAULT_PORT,
+                testPath,
+                false,
+                false,
+                false,
+                true,
+                TEST_KEY_CERT,
+                "",
+                DEFAULT_THREAD_COUNT,
+                DEFAULT_MAX_CONNECTION_COUNT);
+
+        final OTelMetricsSourceConfig oTelMetricsSourceConfig = OBJECT_MAPPER.convertValue(customPathPluginSetting.getSettings(), OTelMetricsSourceConfig.class);
+
+        // When/Then
+        assertThat(oTelMetricsSourceConfig.getPath(), equalTo(testPath));
+    }
+
     private PluginSetting completePluginSettingForOtelMetricsSource(final int requestTimeoutInMillis,
                                                                     final int port,
+                                                                    final String path,
                                                                     final boolean healthCheck,
                                                                     final boolean protoReflectionService,
                                                                     final boolean enableUnframedRequests,
@@ -235,6 +267,7 @@ public class OtelMetricsSourceConfigTests {
         final Map<String, Object> settings = new HashMap<>();
         settings.put(OTelMetricsSourceConfig.REQUEST_TIMEOUT, requestTimeoutInMillis);
         settings.put(OTelMetricsSourceConfig.PORT, port);
+        settings.put(OTelMetricsSourceConfig.PATH, path);
         settings.put(OTelMetricsSourceConfig.HEALTH_CHECK_SERVICE, healthCheck);
         settings.put(OTelMetricsSourceConfig.PROTO_REFLECTION_SERVICE, protoReflectionService);
         settings.put(OTelMetricsSourceConfig.ENABLE_UNFRAMED_REQUESTS, enableUnframedRequests);

--- a/data-prepper-plugins/otel-trace-source/README.md
+++ b/data-prepper-plugins/otel-trace-source/README.md
@@ -28,6 +28,7 @@ For more information on migrating from Data Prepper 1.x to Data Prepper 2.x, see
 ## Configurations
 
 * port(Optional) => An `int` represents the port Otel trace source is running on. Default is ```21890```.
+* path(Optional) => A `String` which represents the path for sending unframed HTTP requests. This will add a new service which can be used for supporting unframed gRPC with HTTP idiomatic path to a configurable path other than `/opentelemetry.proto.collector.trace.v1.TraceService/Export` which can still be used. Path can contain `${pipelineName}` placeholder which will be replaced with pipeline name.
 * request_timeout(Optional) => An `int` represents request timeout in millis. Default is ```10_000```.
 * health_check_service(Optional) => A boolean enables health check service. When ```true``` enables a gRPC health check service under ```grpc.health.v1.Health/Check```. Default is ```false```. In order to use the health check service, you must also enable ```proto_reflection_service```.
 * unauthenticated_health_check (Optional) => A `boolean` that determines if the health endpoint will require authentication. This option is ignored if no authentication is defined. Default is `false`
@@ -103,6 +104,11 @@ Send a sample span with the following https curl command:
 
 ```
 curl -k -H 'Content-Type: application/json; charset=utf-8'  -d '{"resourceSpans":[{"instrumentationLibrarySpans":[{"spans":[{"spanId":"AAAAAAAAAAM=","name":"test-span"}]}]}]}' https://localhost:21890/opentelemetry.proto.collector.trace.v1.TraceService/Export
+```
+
+If `path` option is configured you can send a sample span with the following https curl command:
+```
+curl -k -H 'Content-Type: application/json; charset=utf-8'  -d '{"resourceSpans":[{"instrumentationLibrarySpans":[{"spans":[{"spanId":"AAAAAAAAAAM=","name":"test-span"}]}]}]}' https://localhost:21890/<path>
 ```
 
 ## Metrics

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.StringUtils;
 public class OTelTraceSourceConfig {
     static final String REQUEST_TIMEOUT = "request_timeout";
     static final String PORT = "port";
+    static final String PATH = "path";
     static final String SSL = "ssl";
     static final String USE_ACM_CERT_FOR_SSL = "useAcmCertForSSL";
     static final String ACM_CERT_ISSUE_TIME_OUT_MILLIS = "acmCertIssueTimeOutMillis";
@@ -43,6 +44,9 @@ public class OTelTraceSourceConfig {
 
     @JsonProperty(PORT)
     private int port = DEFAULT_PORT;
+
+    @JsonProperty(PATH)
+    private String path;
 
     @JsonProperty(HEALTH_CHECK_SERVICE)
     private boolean healthCheck = DEFAULT_HEALTH_CHECK;
@@ -128,6 +132,10 @@ public class OTelTraceSourceConfig {
 
     public int getPort() {
         return port;
+    }
+
+    public String getPath() {
+        return path;
     }
 
     public boolean hasHealthCheck() {

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -53,6 +53,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
+import org.opensearch.dataprepper.armeria.authentication.HttpBasicAuthenticationConfig;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
@@ -72,6 +73,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -117,9 +119,22 @@ import static org.opensearch.dataprepper.plugins.source.oteltrace.OTelTraceSourc
 import static org.opensearch.dataprepper.plugins.source.oteltrace.OTelTraceSourceConfig.SSL;
 
 @ExtendWith(MockitoExtension.class)
-public class OTelTraceSourceTest {
-
+class OTelTraceSourceTest {
     private static final String GRPC_ENDPOINT = "gproto+http://127.0.0.1:21890/";
+    private static final String USERNAME = "test_user";
+    private static final String PASSWORD = "test_password";
+    private static final String TEST_PATH = "${pipelineName}/v1/traces";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String TEST_PIPELINE_NAME = "test_pipeline";
+    private static final ExportTraceServiceRequest SUCCESS_REQUEST = ExportTraceServiceRequest.newBuilder()
+            .addResourceSpans(ResourceSpans.newBuilder()
+                    .addInstrumentationLibrarySpans(InstrumentationLibrarySpans.newBuilder()
+                            .addSpans(io.opentelemetry.proto.trace.v1.Span.newBuilder().setTraceState("SUCCESS").build())).build()).build();
+    private static final ExportTraceServiceRequest FAILURE_REQUEST = ExportTraceServiceRequest.newBuilder()
+            .addResourceSpans(ResourceSpans.newBuilder()
+                    .addInstrumentationLibrarySpans(InstrumentationLibrarySpans.newBuilder()
+                            .addSpans(io.opentelemetry.proto.trace.v1.Span.newBuilder().setTraceState("FAILURE").build())).build()).build();
+
     @Mock
     private ServerBuilder serverBuilder;
 
@@ -150,60 +165,20 @@ public class OTelTraceSourceTest {
     @Mock
     private GrpcBasicAuthenticationProvider authenticationProvider;
 
-    private PluginSetting pluginSetting;
-    private PluginSetting testPluginSetting;
     @Mock(lenient = true)
     private OTelTraceSourceConfig oTelTraceSourceConfig;
-    private PluginMetrics pluginMetrics;
-    private PipelineDescription pipelineDescription;
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Mock
     private Buffer<Record<Object>> buffer;
 
-    private static final String TEST_PIPELINE_NAME = "test_pipeline";
-    private static final ExportTraceServiceRequest SUCCESS_REQUEST = ExportTraceServiceRequest.newBuilder()
-            .addResourceSpans(ResourceSpans.newBuilder()
-                    .addInstrumentationLibrarySpans(InstrumentationLibrarySpans.newBuilder()
-                            .addSpans(io.opentelemetry.proto.trace.v1.Span.newBuilder().setTraceState("SUCCESS").build())).build()).build();
+    @Mock
+    private HttpBasicAuthenticationConfig httpBasicAuthenticationConfig;
+
+    private PluginSetting pluginSetting;
+    private PluginSetting testPluginSetting;
+    private PluginMetrics pluginMetrics;
+    private PipelineDescription pipelineDescription;
     private OTelTraceSource SOURCE;
-    private static final ExportTraceServiceRequest FAILURE_REQUEST = ExportTraceServiceRequest.newBuilder()
-            .addResourceSpans(ResourceSpans.newBuilder()
-                    .addInstrumentationLibrarySpans(InstrumentationLibrarySpans.newBuilder()
-                            .addSpans(io.opentelemetry.proto.trace.v1.Span.newBuilder().setTraceState("FAILURE").build())).build()).build();
-
-    private static void assertStatusCode415AndNoServerHeaders(final AggregatedHttpResponse response, final Throwable throwable) {
-        assertThat("Http Status", response.status(), is(HttpStatus.UNSUPPORTED_MEDIA_TYPE));
-        assertThat("Http Response Throwable", throwable, is(nullValue()));
-
-        final List<String> headerKeys = response.headers()
-                .stream()
-                .map(Map.Entry::getKey)
-                .map(AsciiString::toString)
-                .collect(Collectors.toList());
-        assertThat("Response Header Keys", headerKeys, not(contains("server")));
-    }
-
-    private static void assertStatusCode200AndNoServerHeaders(final AggregatedHttpResponse response, final Throwable throwable) {
-        assertThat("Http Status", response.status(), is(HttpStatus.OK));
-        assertThat("Http Response Throwable", throwable, is(nullValue()));
-
-        final List<String> headerKeys = response.headers()
-                .stream()
-                .map(Map.Entry::getKey)
-                .map(AsciiString::toString)
-                .collect(Collectors.toList());
-        assertThat("Response Header Keys", headerKeys, not(contains("server")));
-    }
-
-    private void configureObjectUnderTest() {
-        pluginMetrics = PluginMetrics.fromNames("otel_trace", "pipeline");
-
-        pipelineDescription = mock(PipelineDescription.class);
-        when(pipelineDescription.getPipelineName()).thenReturn(TEST_PIPELINE_NAME);
-        SOURCE = new OTelTraceSource(oTelTraceSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
-    }
 
     @BeforeEach
     public void beforeEach() {
@@ -239,6 +214,14 @@ public class OTelTraceSourceTest {
         SOURCE.stop();
     }
 
+    private void configureObjectUnderTest() {
+        pluginMetrics = PluginMetrics.fromNames("otel_trace", "pipeline");
+
+        pipelineDescription = mock(PipelineDescription.class);
+        when(pipelineDescription.getPipelineName()).thenReturn(TEST_PIPELINE_NAME);
+        SOURCE = new OTelTraceSource(oTelTraceSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
+    }
+
     @Test
     void testHttpFullJsonWithNonUnframedRequests() throws InvalidProtocolBufferException {
         configureObjectUnderTest();
@@ -252,7 +235,7 @@ public class OTelTraceSourceTest {
                         .build(),
                 HttpData.copyOf(JsonFormat.printer().print(SUCCESS_REQUEST).getBytes()))
                 .aggregate()
-                .whenComplete(OTelTraceSourceTest::assertStatusCode415AndNoServerHeaders)
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNSUPPORTED_MEDIA_TYPE, throwable))
                 .join();
         WebClient.of().execute(RequestHeaders.builder()
                         .scheme(SessionProtocol.HTTP)
@@ -263,28 +246,7 @@ public class OTelTraceSourceTest {
                         .build(),
                 HttpData.copyOf(JsonFormat.printer().print(FAILURE_REQUEST).getBytes()))
                 .aggregate()
-                .whenComplete(OTelTraceSourceTest::assertStatusCode415AndNoServerHeaders)
-                .join();
-    }
-
-    @Test
-    void testHttpFullJsonWithCustomPathAndUnframedRequests() throws InvalidProtocolBufferException {
-        when(oTelTraceSourceConfig.enableUnframedRequests()).thenReturn(true);
-        when(oTelTraceSourceConfig.getPath()).thenReturn("${pipelineName}/v1/traces");
-        configureObjectUnderTest();
-        SOURCE.start(buffer);
-
-        final String transformedPath = "/" + TEST_PIPELINE_NAME + "/v1/traces";
-        WebClient.of().execute(RequestHeaders.builder()
-                                .scheme(SessionProtocol.HTTP)
-                                .authority("127.0.0.1:21890")
-                                .method(HttpMethod.POST)
-                                .path(transformedPath)
-                                .contentType(MediaType.JSON_UTF_8)
-                                .build(),
-                        HttpData.copyOf(JsonFormat.printer().print(createExportTraceRequest()).getBytes()))
-                .aggregate()
-                .whenComplete(OTelTraceSourceTest::assertStatusCode200AndNoServerHeaders)
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNSUPPORTED_MEDIA_TYPE, throwable))
                 .join();
     }
 
@@ -314,7 +276,7 @@ public class OTelTraceSourceTest {
                         .build(),
                 HttpData.copyOf(JsonFormat.printer().print(SUCCESS_REQUEST).getBytes()))
                 .aggregate()
-                .whenComplete(OTelTraceSourceTest::assertStatusCode415AndNoServerHeaders)
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNSUPPORTED_MEDIA_TYPE, throwable))
                 .join();
         WebClient.builder().factory(ClientFactory.insecure()).build().execute(RequestHeaders.builder()
                         .scheme(SessionProtocol.HTTPS)
@@ -325,12 +287,12 @@ public class OTelTraceSourceTest {
                         .build(),
                 HttpData.copyOf(JsonFormat.printer().print(FAILURE_REQUEST).getBytes()))
                 .aggregate()
-                .whenComplete(OTelTraceSourceTest::assertStatusCode415AndNoServerHeaders)
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNSUPPORTED_MEDIA_TYPE, throwable))
                 .join();
     }
 
     @Test
-    void testHttpFullBytes() {
+    void testHttpFullBytesWithNonUnframedRequests() {
         configureObjectUnderTest();
         SOURCE.start(buffer);
         WebClient.of().execute(RequestHeaders.builder()
@@ -342,7 +304,7 @@ public class OTelTraceSourceTest {
                         .build(),
                 HttpData.copyOf(SUCCESS_REQUEST.toByteArray()))
                 .aggregate()
-                .whenComplete(OTelTraceSourceTest::assertStatusCode415AndNoServerHeaders)
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNSUPPORTED_MEDIA_TYPE, throwable))
                 .join();
         WebClient.of().execute(RequestHeaders.builder()
                         .scheme(SessionProtocol.HTTP)
@@ -353,12 +315,52 @@ public class OTelTraceSourceTest {
                         .build(),
                 HttpData.copyOf(FAILURE_REQUEST.toByteArray()))
                 .aggregate()
-                .whenComplete(OTelTraceSourceTest::assertStatusCode415AndNoServerHeaders)
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNSUPPORTED_MEDIA_TYPE, throwable))
                 .join();
     }
 
     @Test
-    public void testServerStartCertFileSuccess() throws IOException {
+    void testHttpFullJsonWithUnframedRequests() throws InvalidProtocolBufferException {
+        when(oTelTraceSourceConfig.enableUnframedRequests()).thenReturn(true);
+        configureObjectUnderTest();
+        SOURCE.start(buffer);
+
+        WebClient.of().execute(RequestHeaders.builder()
+                                .scheme(SessionProtocol.HTTP)
+                                .authority("127.0.0.1:21890")
+                                .method(HttpMethod.POST)
+                                .path("/opentelemetry.proto.collector.trace.v1.TraceService/Export")
+                                .contentType(MediaType.JSON_UTF_8)
+                                .build(),
+                        HttpData.copyOf(JsonFormat.printer().print(createExportTraceRequest()).getBytes()))
+                .aggregate()
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.OK, throwable))
+                .join();
+    }
+
+    @Test
+    void testHttpFullJsonWithCustomPathAndUnframedRequests() throws InvalidProtocolBufferException {
+        when(oTelTraceSourceConfig.enableUnframedRequests()).thenReturn(true);
+        when(oTelTraceSourceConfig.getPath()).thenReturn(TEST_PATH);
+        configureObjectUnderTest();
+        SOURCE.start(buffer);
+
+        final String transformedPath = "/" + TEST_PIPELINE_NAME + "/v1/traces";
+        WebClient.of().execute(RequestHeaders.builder()
+                                .scheme(SessionProtocol.HTTP)
+                                .authority("127.0.0.1:21890")
+                                .method(HttpMethod.POST)
+                                .path(transformedPath)
+                                .contentType(MediaType.JSON_UTF_8)
+                                .build(),
+                        HttpData.copyOf(JsonFormat.printer().print(createExportTraceRequest()).getBytes()))
+                .aggregate()
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.OK, throwable))
+                .join();
+    }
+
+    @Test
+    void testServerStartCertFileSuccess() throws IOException {
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
             armeriaServerMock.when(Server::builder).thenReturn(serverBuilder);
             when(server.stop()).thenReturn(completableFuture);
@@ -392,7 +394,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    public void testServerStartACMCertSuccess() throws IOException {
+    void testServerStartACMCertSuccess() throws IOException {
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
             armeriaServerMock.when(Server::builder).thenReturn(serverBuilder);
             when(server.stop()).thenReturn(completableFuture);
@@ -598,7 +600,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    public void testHealthCheckUnauthNotAllowed() {
+    void testHealthCheckUnauthNotAllowed() {
         // Prepare
         final Map<String, Object> settingsMap = new HashMap<>();
         settingsMap.put(SSL, false);
@@ -628,13 +630,14 @@ public class OTelTraceSourceTest {
                         .path("/health")
                         .build())
                 .aggregate()
-                .whenComplete((i, ex) -> assertSecureResponseWithStatusCode(i, HttpStatus.UNAUTHORIZED)).join();
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNAUTHORIZED, throwable))
+                .join();
 
         source.stop();
     }
 
     @Test
-    public void testHealthCheckUnauthAllowed() {
+    void testHealthCheckUnauthAllowed() {
         // Prepare
         final Map<String, Object> settingsMap = new HashMap<>();
         settingsMap.put(SSL, false);
@@ -664,24 +667,13 @@ public class OTelTraceSourceTest {
                         .path("/health")
                         .build())
                 .aggregate()
-                .whenComplete((i, ex) -> assertSecureResponseWithStatusCode(i, HttpStatus.OK)).join();
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.OK, throwable)).join();
 
         source.stop();
     }
 
-    private void assertSecureResponseWithStatusCode(final AggregatedHttpResponse response, final HttpStatus expectedStatus) {
-        assertThat("Http Status", response.status(), equalTo(expectedStatus));
-
-        final List<String> headerKeys = response.headers()
-                .stream()
-                .map(Map.Entry::getKey)
-                .map(AsciiString::toString)
-                .collect(Collectors.toList());
-        assertThat("Response Header Keys", headerKeys, not(contains("server")));
-    }
-
     @Test
-    public void testOptionalHttpAuthServiceNotInPlace() {
+    void testOptionalHttpAuthServiceNotInPlace() {
         when(server.stop()).thenReturn(completableFuture);
 
         try (final MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -694,7 +686,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    public void testOptionalHttpAuthServiceInPlace() {
+    void testOptionalHttpAuthServiceInPlace() {
         final Optional<Function<? super HttpService, ? extends HttpService>> function = Optional.of(httpService -> httpService);
 
         final Map<String, Object> settingsMap = new HashMap<>();
@@ -721,7 +713,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    public void testOptionalHttpAuthServiceInPlaceWithUnauthenticatedDisabled() {
+    void testOptionalHttpAuthServiceInPlaceWithUnauthenticatedDisabled() {
         final Optional<Function<? super HttpService, ? extends HttpService>> function = Optional.of(httpService -> httpService);
 
         final Map<String, Object> settingsMap = new HashMap<>();
@@ -748,7 +740,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    public void testDoubleStart() {
+    void testDoubleStart() {
         // starting server
         SOURCE.start(buffer);
         // double start server
@@ -756,7 +748,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    public void testRunAnotherSourceWithSamePort() {
+    void testRunAnotherSourceWithSamePort() {
         // starting server
         SOURCE.start(buffer);
 
@@ -769,7 +761,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    public void testStartWithEmptyBuffer() {
+    void testStartWithEmptyBuffer() {
         testPluginSetting = new PluginSetting(null, Collections.singletonMap(SSL, false));
         testPluginSetting.setPipelineName("pipeline");
         oTelTraceSourceConfig = OBJECT_MAPPER.convertValue(testPluginSetting.getSettings(), OTelTraceSourceConfig.class);
@@ -778,7 +770,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    public void testStartWithServerExecutionExceptionNoCause() throws ExecutionException, InterruptedException {
+    void testStartWithServerExecutionExceptionNoCause() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelTraceSource source = new OTelTraceSource(oTelTraceSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -791,7 +783,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    public void testStartWithServerExecutionExceptionWithCause() throws ExecutionException, InterruptedException {
+    void testStartWithServerExecutionExceptionWithCause() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelTraceSource source = new OTelTraceSource(oTelTraceSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -806,7 +798,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    public void testStopWithServerExecutionExceptionNoCause() throws ExecutionException, InterruptedException {
+    void testStopWithServerExecutionExceptionNoCause() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelTraceSource source = new OTelTraceSource(oTelTraceSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -821,7 +813,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    public void testStartWithInterruptedException() throws ExecutionException, InterruptedException {
+    void testStartWithInterruptedException() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelTraceSource source = new OTelTraceSource(oTelTraceSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -835,7 +827,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    public void testStopWithServerExecutionExceptionWithCause() throws ExecutionException, InterruptedException {
+    void testStopWithServerExecutionExceptionWithCause() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelTraceSource source = new OTelTraceSource(oTelTraceSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -852,7 +844,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    public void testStopWithInterruptedException() throws ExecutionException, InterruptedException {
+    void testStopWithInterruptedException() throws ExecutionException, InterruptedException {
         // Prepare
         final OTelTraceSource source = new OTelTraceSource(oTelTraceSourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
@@ -886,8 +878,42 @@ public class OTelTraceSourceTest {
     }
 
     @Test
+    void gRPC_with_auth_request_writes_to_buffer_with_successful_response() throws Exception {
+        when(httpBasicAuthenticationConfig.getUsername()).thenReturn(USERNAME);
+        when(httpBasicAuthenticationConfig.getPassword()).thenReturn(PASSWORD);
+        final GrpcAuthenticationProvider grpcAuthenticationProvider = new GrpcBasicAuthenticationProvider(httpBasicAuthenticationConfig);
+
+        when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))
+                .thenReturn(grpcAuthenticationProvider);
+        when(oTelTraceSourceConfig.enableUnframedRequests()).thenReturn(true);
+        when(oTelTraceSourceConfig.getAuthentication()).thenReturn(new PluginModel("http_basic",
+                Map.of(
+                        "username", USERNAME,
+                        "password", PASSWORD
+                )));
+        configureObjectUnderTest();
+        SOURCE.start(buffer);
+
+        final String encodeToString = Base64.getEncoder()
+                .encodeToString(String.format("%s:%s", USERNAME, PASSWORD).getBytes(StandardCharsets.UTF_8));
+
+        final TraceServiceGrpc.TraceServiceBlockingStub client = Clients.builder(GRPC_ENDPOINT)
+                .addHeader("Authorization", "Basic " + encodeToString)
+                .build(TraceServiceGrpc.TraceServiceBlockingStub.class);
+        final ExportTraceServiceResponse exportResponse = client.export(createExportTraceRequest());
+        assertThat(exportResponse, notNullValue());
+
+        final ArgumentCaptor<Collection<Record<Object>>> bufferWriteArgumentCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(buffer).writeAll(bufferWriteArgumentCaptor.capture(), anyInt());
+
+        final Collection<Record<Object>> actualBufferWrites = bufferWriteArgumentCaptor.getValue();
+        assertThat(actualBufferWrites, notNullValue());
+        assertThat(actualBufferWrites, hasSize(1));
+    }
+
+    @Test
     void gRPC_request_writes_to_buffer_with_successful_response_with_custom_path() throws Exception {
-        when(oTelTraceSourceConfig.getPath()).thenReturn("testPath");
+        when(oTelTraceSourceConfig.getPath()).thenReturn(TEST_PATH);
         when(oTelTraceSourceConfig.enableUnframedRequests()).thenReturn(true);
 
         configureObjectUnderTest();
@@ -976,12 +1002,25 @@ public class OTelTraceSourceTest {
                 .setStartTimeUnixNano(100)
                 .setEndTimeUnixNano(101)
                 .setTraceState("SUCCESS").build();
-        final ExportTraceServiceRequest successRequest = ExportTraceServiceRequest.newBuilder()
+
+        return ExportTraceServiceRequest.newBuilder()
                 .addResourceSpans(ResourceSpans.newBuilder()
                         .addInstrumentationLibrarySpans(InstrumentationLibrarySpans.newBuilder().addSpans(testSpan)).build())
                 .build();
+    }
 
-        return successRequest;
+    private void assertSecureResponseWithStatusCode(final AggregatedHttpResponse response,
+                                                    final HttpStatus expectedStatus,
+                                                    final Throwable throwable) {
+        assertThat("Http Status", response.status(), equalTo(expectedStatus));
+        assertThat("Http Response Throwable", throwable, is(nullValue()));
+
+        final List<String> headerKeys = response.headers()
+                .stream()
+                .map(Map.Entry::getKey)
+                .map(AsciiString::toString)
+                .collect(Collectors.toList());
+        assertThat("Response Header Keys", headerKeys, not(contains("server")));
     }
 
 }

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -360,6 +360,70 @@ class OTelTraceSourceTest {
     }
 
     @Test
+    void testHttpFullJsonWithCustomPathAndAuthHeader_with_successful_response() throws InvalidProtocolBufferException {
+        when(httpBasicAuthenticationConfig.getUsername()).thenReturn(USERNAME);
+        when(httpBasicAuthenticationConfig.getPassword()).thenReturn(PASSWORD);
+        final GrpcAuthenticationProvider grpcAuthenticationProvider = new GrpcBasicAuthenticationProvider(httpBasicAuthenticationConfig);
+
+        when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))
+                .thenReturn(grpcAuthenticationProvider);
+        when(oTelTraceSourceConfig.getAuthentication()).thenReturn(new PluginModel("http_basic",
+                Map.of(
+                        "username", USERNAME,
+                        "password", PASSWORD
+                )));
+        when(oTelTraceSourceConfig.enableUnframedRequests()).thenReturn(true);
+        when(oTelTraceSourceConfig.getPath()).thenReturn(TEST_PATH);
+
+        configureObjectUnderTest();
+        SOURCE.start(buffer);
+
+        final String encodeToString = Base64.getEncoder()
+                .encodeToString(String.format("%s:%s", USERNAME, PASSWORD).getBytes(StandardCharsets.UTF_8));
+
+        final String transformedPath = "/" + TEST_PIPELINE_NAME + "/v1/traces";
+
+        WebClient.of().prepare()
+                .post("http://127.0.0.1:21890" + transformedPath)
+                .content(MediaType.JSON_UTF_8, JsonFormat.printer().print(createExportTraceRequest()).getBytes())
+                .header("Authorization", "Basic " + encodeToString)
+                .execute()
+                .aggregate()
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.OK, throwable))
+                .join();
+    }
+
+    @Test
+    void testHttpFullJsonWithCustomPathAndAuthHeader_with_unsuccessful_response() throws InvalidProtocolBufferException {
+        when(httpBasicAuthenticationConfig.getUsername()).thenReturn(USERNAME);
+        when(httpBasicAuthenticationConfig.getPassword()).thenReturn(PASSWORD);
+        final GrpcAuthenticationProvider grpcAuthenticationProvider = new GrpcBasicAuthenticationProvider(httpBasicAuthenticationConfig);
+
+        when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))
+                .thenReturn(grpcAuthenticationProvider);
+        when(oTelTraceSourceConfig.getAuthentication()).thenReturn(new PluginModel("http_basic",
+                Map.of(
+                        "username", USERNAME,
+                        "password", PASSWORD
+                )));
+        when(oTelTraceSourceConfig.enableUnframedRequests()).thenReturn(true);
+        when(oTelTraceSourceConfig.getPath()).thenReturn(TEST_PATH);
+
+        configureObjectUnderTest();
+        SOURCE.start(buffer);
+
+        final String transformedPath = "/" + TEST_PIPELINE_NAME + "/v1/traces";
+
+        WebClient.of().prepare()
+                .post("http://127.0.0.1:21890" + transformedPath)
+                .content(MediaType.JSON_UTF_8, JsonFormat.printer().print(createExportTraceRequest()).getBytes())
+                .execute()
+                .aggregate()
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.UNAUTHORIZED, throwable))
+                .join();
+    }
+
+    @Test
     void testServerStartCertFileSuccess() throws IOException {
         try (MockedStatic<Server> armeriaServerMock = Mockito.mockStatic(Server.class)) {
             armeriaServerMock.when(Server::builder).thenReturn(serverBuilder);

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
@@ -24,7 +24,7 @@ import static org.opensearch.dataprepper.plugins.source.oteltrace.OTelTraceSourc
 import static org.opensearch.dataprepper.plugins.source.oteltrace.OTelTraceSourceConfig.DEFAULT_REQUEST_TIMEOUT_MS;
 import static org.opensearch.dataprepper.plugins.source.oteltrace.OTelTraceSourceConfig.DEFAULT_THREAD_COUNT;
 
-public class OtelTraceSourceConfigTests {
+class OtelTraceSourceConfigTests {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String PLUGIN_NAME = "otel_trace_source";
     private static final String TEST_KEY_CERT = "test.crt";
@@ -38,7 +38,7 @@ public class OtelTraceSourceConfigTests {
     private static final int TEST_MAX_CONNECTION_COUNT = 999;
 
     @Test
-    public void testDefault() {
+    void testDefault() {
 
         // Prepare
         final OTelTraceSourceConfig otelTraceSourceConfig = new OTelTraceSourceConfig();
@@ -59,7 +59,7 @@ public class OtelTraceSourceConfigTests {
     }
 
     @Test
-    public void testHttpHealthCheckWithUnframedRequestEnabled() {
+    void testHttpHealthCheckWithUnframedRequestEnabled() {
         // Prepare
         final Map<String, Object> settings = new HashMap<>();
         settings.put(OTelTraceSourceConfig.ENABLE_UNFRAMED_REQUESTS, "true");
@@ -77,7 +77,7 @@ public class OtelTraceSourceConfigTests {
     }
 
     @Test
-    public void testHttpHealthCheckWithUnframedRequestDisabled() {
+    void testHttpHealthCheckWithUnframedRequestDisabled() {
         // Prepare
         final Map<String, Object> settings = new HashMap<>();
         settings.put(OTelTraceSourceConfig.ENABLE_UNFRAMED_REQUESTS, "false");
@@ -95,7 +95,7 @@ public class OtelTraceSourceConfigTests {
     }
 
     @Test
-    public void testValidConfigWithoutS3CertAndKey() {
+    void testValidConfigWithoutS3CertAndKey() {
         // Prepare
         final PluginSetting validPluginSetting = completePluginSettingForOtelTraceSource(
                 TEST_REQUEST_TIMEOUT_MS,
@@ -129,7 +129,7 @@ public class OtelTraceSourceConfigTests {
     }
 
     @Test
-    public void testValidConfigWithS3CertAndKey() {
+    void testValidConfigWithS3CertAndKey() {
         // Prepare
         final PluginSetting validPluginSettingWithS3CertAndKey = completePluginSettingForOtelTraceSource(
                 TEST_REQUEST_TIMEOUT_MS,
@@ -164,7 +164,7 @@ public class OtelTraceSourceConfigTests {
     }
 
     @Test
-    public void testInvalidConfigWithNullKeyCert() {
+    void testInvalidConfigWithNullKeyCert() {
         // Prepare
         final PluginSetting sslNullKeyCertPluginSetting = completePluginSettingForOtelTraceSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
@@ -186,7 +186,7 @@ public class OtelTraceSourceConfigTests {
     }
 
     @Test
-    public void testInvalidConfigWithEmptyKeyCert() {
+    void testInvalidConfigWithEmptyKeyCert() {
         // Prepare
         final PluginSetting sslEmptyKeyCertPluginSetting = completePluginSettingForOtelTraceSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
@@ -209,7 +209,7 @@ public class OtelTraceSourceConfigTests {
     }
 
     @Test
-    public void testInvalidConfigWithEmptyKeyFile() {
+    void testInvalidConfigWithEmptyKeyFile() {
         // Prepare
         final PluginSetting sslEmptyKeyFilePluginSetting = completePluginSettingForOtelTraceSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
@@ -234,7 +234,7 @@ public class OtelTraceSourceConfigTests {
     void testValidConfigWithCustomPath() {
         final String testPath = "testPath";
         // Prepare
-        final PluginSetting sslEmptyKeyFilePluginSetting = completePluginSettingForOtelTraceSource(
+        final PluginSetting customPathPluginSetting = completePluginSettingForOtelTraceSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
                 DEFAULT_PORT,
                 testPath,
@@ -247,7 +247,7 @@ public class OtelTraceSourceConfigTests {
                 DEFAULT_THREAD_COUNT,
                 DEFAULT_MAX_CONNECTION_COUNT);
 
-        final OTelTraceSourceConfig otelTraceSourceConfig = OBJECT_MAPPER.convertValue(sslEmptyKeyFilePluginSetting.getSettings(), OTelTraceSourceConfig.class);
+        final OTelTraceSourceConfig otelTraceSourceConfig = OBJECT_MAPPER.convertValue(customPathPluginSetting.getSettings(), OTelTraceSourceConfig.class);
 
         // When/Then
         assertThat(otelTraceSourceConfig.getPath(), equalTo(testPath));

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -98,6 +100,7 @@ public class OtelTraceSourceConfigTests {
         final PluginSetting validPluginSetting = completePluginSettingForOtelTraceSource(
                 TEST_REQUEST_TIMEOUT_MS,
                 TEST_PORT,
+                null,
                 true,
                 true,
                 false,
@@ -131,6 +134,7 @@ public class OtelTraceSourceConfigTests {
         final PluginSetting validPluginSettingWithS3CertAndKey = completePluginSettingForOtelTraceSource(
                 TEST_REQUEST_TIMEOUT_MS,
                 TEST_PORT,
+                null,
                 false,
                 false,
                 false,
@@ -164,7 +168,9 @@ public class OtelTraceSourceConfigTests {
         // Prepare
         final PluginSetting sslNullKeyCertPluginSetting = completePluginSettingForOtelTraceSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
-                DEFAULT_PORT, false,
+                DEFAULT_PORT,
+                null,
+                false,
                 false,
                 false,
                 true, null,
@@ -185,6 +191,7 @@ public class OtelTraceSourceConfigTests {
         final PluginSetting sslEmptyKeyCertPluginSetting = completePluginSettingForOtelTraceSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
                 DEFAULT_PORT,
+                null,
                 false,
                 false,
                 false,
@@ -207,6 +214,7 @@ public class OtelTraceSourceConfigTests {
         final PluginSetting sslEmptyKeyFilePluginSetting = completePluginSettingForOtelTraceSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
                 DEFAULT_PORT,
+                null,
                 false,
                 false,
                 false,
@@ -222,8 +230,32 @@ public class OtelTraceSourceConfigTests {
         assertThrows(IllegalArgumentException.class, otelTraceSourceConfig::validateAndInitializeCertAndKeyFileInS3);
     }
 
+    @Test
+    void testValidConfigWithCustomPath() {
+        final String testPath = "testPath";
+        // Prepare
+        final PluginSetting sslEmptyKeyFilePluginSetting = completePluginSettingForOtelTraceSource(
+                DEFAULT_REQUEST_TIMEOUT_MS,
+                DEFAULT_PORT,
+                testPath,
+                false,
+                false,
+                false,
+                true,
+                TEST_KEY_CERT,
+                "",
+                DEFAULT_THREAD_COUNT,
+                DEFAULT_MAX_CONNECTION_COUNT);
+
+        final OTelTraceSourceConfig otelTraceSourceConfig = OBJECT_MAPPER.convertValue(sslEmptyKeyFilePluginSetting.getSettings(), OTelTraceSourceConfig.class);
+
+        // When/Then
+        assertThat(otelTraceSourceConfig.getPath(), equalTo(testPath));
+    }
+
     private PluginSetting completePluginSettingForOtelTraceSource(final int requestTimeoutInMillis,
                                                                   final int port,
+                                                                  final String path,
                                                                   final boolean healthCheck,
                                                                   final boolean protoReflectionService,
                                                                   final boolean enableUnframedRequests,
@@ -235,6 +267,7 @@ public class OtelTraceSourceConfigTests {
         final Map<String, Object> settings = new HashMap<>();
         settings.put(OTelTraceSourceConfig.REQUEST_TIMEOUT, requestTimeoutInMillis);
         settings.put(OTelTraceSourceConfig.PORT, port);
+        settings.put(OTelTraceSourceConfig.PATH, path);
         settings.put(OTelTraceSourceConfig.HEALTH_CHECK_SERVICE, healthCheck);
         settings.put(OTelTraceSourceConfig.PROTO_REFLECTION_SERVICE, protoReflectionService);
         settings.put(OTelTraceSourceConfig.ENABLE_UNFRAMED_REQUESTS, enableUnframedRequests);


### PR DESCRIPTION
### Description
Adds path to oTel source. With this change the following are possible
gRPC, HTTP - `/opentelemetry.proto.collector.trace.v1.TraceService/Export`
HTTP - `<path>`
 
### Issues Resolved
Partially resolves #2257 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
