### PR TITLE
Loop until interrupted in SqsWorker

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
@@ -69,7 +69,7 @@ public class SqsWorker implements Runnable {
     @Override
     public void run() {
 
-        while (true) {
+        while (!Thread.currentThread().isInterrupted()) {
             int messagesProcessed = 0;
             try {
                 messagesProcessed = processSqsMessages();


### PR DESCRIPTION
### Description
The S3 source performs its shutdown work by [interrupting the SqsWorker thread](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsService.java#L51). Sometimes this works as intended, but it often fails to stop the SqsWorker. This PR changes the while loop in the SqsWorker's run method to be conditional on interruption instead of looping infinitely.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
