### PR TITLE
Fix grok processor to not create a new record

### DIFF
--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
@@ -109,8 +109,6 @@ public class GrokProcessor extends AbstractProcessor<Record<Event>, Record<Event
      */
     @Override
     public Collection<Record<Event>> doExecute(final Collection<Record<Event>> records) {
-        final List<Record<Event>> recordsOut = new LinkedList<>();
-
         for (final Record<Event> record : records) {
             try {
                 final Event event = record.getData();
@@ -121,27 +119,21 @@ public class GrokProcessor extends AbstractProcessor<Record<Event>, Record<Event
                     runWithTimeout(() -> grokProcessingTime.record(() -> matchAndMerge(event)));
                 }
 
-                final Record<Event> grokkedRecord = new Record<>(event, record.getMetadata());
-                recordsOut.add(grokkedRecord);
             } catch (TimeoutException e) {
                 LOG.error(EVENT, "Matching on record [{}] took longer than [{}] and timed out", record.getData(), grokProcessorConfig.getTimeoutMillis());
-                recordsOut.add(record);
                 grokProcessingTimeoutsCounter.increment();
             } catch (ExecutionException e) {
                 LOG.error(EVENT, "An exception occurred while matching on record [{}]", record.getData(), e);
-                recordsOut.add(record);
                 grokProcessingErrorsCounter.increment();
             } catch (InterruptedException e) {
                 LOG.error(EVENT, "Matching on record [{}] was interrupted", record.getData(), e);
-                recordsOut.add(record);
                 grokProcessingErrorsCounter.increment();
             } catch (RuntimeException e) {
                 LOG.error(EVENT, "Unknown exception occurred when matching record [{}]", record.getData(), e);
-                recordsOut.add(record);
                 grokProcessingErrorsCounter.increment();
             }
          }
-        return recordsOut;
+        return records;
     }
 
     @Override


### PR DESCRIPTION
### Description
Grok processor's `doExecute()` is unnecessarily creating a new record. Modified the code to return the existing records instead of creating new records.
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
