### PR TITLE
Added backoff for SQS to reduce logging

### DIFF
--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -13,6 +13,7 @@ repositories {
 
 dependencies {
     implementation project(':data-prepper-api')
+    implementation libs.armeria.core
     implementation 'io.micrometer:micrometer-core'
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:sts'

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/SqsWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/SqsWorkerIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source;
 
+import com.linecorp.armeria.client.retry.Backoff;
 import io.micrometer.core.instrument.DistributionSummary;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.plugins.source.configuration.OnErrorOption;
@@ -44,6 +45,7 @@ class SqsWorkerIT {
     private PluginMetrics pluginMetrics;
     private S3ObjectGenerator s3ObjectGenerator;
     private String bucket;
+    private Backoff backoff;
 
     @BeforeEach
     void setUp() {
@@ -56,6 +58,9 @@ class SqsWorkerIT {
         sqsClient = SqsClient.builder()
                 .region(Region.of(System.getProperty("tests.s3source.region")))
                 .build();
+
+        backoff = Backoff.exponential(SqsService.ONE_SECOND, SqsService.THIRTY_MINUTES).withJitter(SqsService.TWENTY_PERCENT)
+                .withMaxAttempts(Integer.MAX_VALUE);
 
         s3SourceConfig = mock(S3SourceConfig.class);
         s3Service = mock(S3Service.class);
@@ -79,7 +84,7 @@ class SqsWorkerIT {
     }
 
     private SqsWorker createObjectUnderTest() {
-        return new SqsWorker(sqsClient, s3Service, s3SourceConfig, pluginMetrics);
+        return new SqsWorker(sqsClient, s3Service, s3SourceConfig, pluginMetrics, backoff);
     }
 
     @AfterEach

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
@@ -6,11 +6,13 @@
 package org.opensearch.dataprepper.plugins.source;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.linecorp.armeria.client.retry.Backoff;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.plugins.source.configuration.OnErrorOption;
 import org.opensearch.dataprepper.plugins.source.configuration.SqsOptions;
+import org.opensearch.dataprepper.plugins.source.exception.SqsRetriesExhaustedException;
 import org.opensearch.dataprepper.plugins.source.filter.ObjectCreatedFilter;
 import org.opensearch.dataprepper.plugins.source.filter.S3EventFilter;
 import org.slf4j.Logger;
@@ -49,16 +51,21 @@ public class SqsWorker implements Runnable {
     private final Counter sqsMessagesDeletedCounter;
     private final Counter sqsMessagesFailedCounter;
     private final Timer sqsMessageDelayTimer;
+    private final Backoff standardBackoff;
+    private int failedAttemptCount;
 
     public SqsWorker(final SqsClient sqsClient,
                      final S3Service s3Service,
                      final S3SourceConfig s3SourceConfig,
-                     final PluginMetrics pluginMetrics) {
+                     final PluginMetrics pluginMetrics,
+                     final Backoff backoff) {
         this.sqsClient = sqsClient;
         this.s3Service = s3Service;
         this.s3SourceConfig = s3SourceConfig;
+        this.standardBackoff = backoff;
         sqsOptions = s3SourceConfig.getSqsOptions();
         objectCreatedFilter = new ObjectCreatedFilter();
+        failedAttemptCount = 0;
 
         sqsMessagesReceivedCounter = pluginMetrics.counter(SQS_MESSAGES_RECEIVED_METRIC_NAME);
         sqsMessagesDeletedCounter = pluginMetrics.counter(SQS_MESSAGES_DELETED_METRIC_NAME);
@@ -108,10 +115,26 @@ public class SqsWorker implements Runnable {
     private List<Message> getMessagesFromSqs() {
         try {
             final ReceiveMessageRequest receiveMessageRequest = createReceiveMessageRequest();
-            return sqsClient.receiveMessage(receiveMessageRequest).messages();
-        } catch (SqsException e) {
-            LOG.error("Error reading from SQS: {}", e.getMessage());
+            final List<Message> messages = sqsClient.receiveMessage(receiveMessageRequest).messages();
+            failedAttemptCount = 0;
+            return messages;
+        } catch (final SqsException e) {
+            retryWithBackoff(e);
             return Collections.emptyList();
+        }
+    }
+
+    private void retryWithBackoff(final SqsException sqsException) {
+        final long delayMillis = standardBackoff.nextDelayMillis(++failedAttemptCount);
+        if (delayMillis < 0) {
+            Thread.currentThread().interrupt();
+            throw new SqsRetriesExhaustedException("SQS retries exhausted. Make sure that SQS configuration is valid and queue exists.");
+        }
+        LOG.error("Error reading from SQS: {}. Retrying with exponential backoff.", sqsException.getMessage());
+        try {
+            Thread.sleep(delayMillis);
+        } catch (final InterruptedException e){
+            LOG.error("Thread is interrupted while polling SQS with retry.", e);
         }
     }
 

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/exception/SqsRetriesExhaustedException.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/exception/SqsRetriesExhaustedException.java
@@ -1,0 +1,13 @@
+package org.opensearch.dataprepper.plugins.source.exception;
+
+/**
+ * This exception is thrown when SQS retries are exhausted
+ *
+ * @since 2.1
+ */
+public class SqsRetriesExhaustedException extends RuntimeException {
+
+    public SqsRetriesExhaustedException(final String errorMessage) {
+        super(errorMessage);
+    }
+}


### PR DESCRIPTION
### Description
- Adds backoff at client level when there is `SqsException`
- Throws `SqsRetriesExhaustedException` if retries exhaust

> This PR doesn't add backoff to SDK client as S3 source continues to poll, adding backoff to the client will not be fix the issue in #1708 and backoff will be reset after every request.
 
### Issues Resolved
resolves #1708 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
