### PR TITLE
Add grok pattern validatior to data-prepper-api

### DIFF
--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -4,6 +4,7 @@
  */
 
 dependencies {
+    implementation "io.krakens:java-grok:0.1.9"
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/validations/GrokPatternValidator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/validations/GrokPatternValidator.java
@@ -1,0 +1,46 @@
+package org.opensearch.dataprepper.validations;
+
+import io.krakens.grok.api.GrokCompiler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public final class GrokPatternValidator {
+
+    private static final GrokCompiler grokCompiler = GrokCompiler.newInstance();
+
+    static {
+        grokCompiler.registerDefaultPatterns();
+    }
+
+    private GrokPatternValidator() {
+
+    }
+
+    public static List<String> validatePatterns(final Map<String, String> additionalPatternsToRegister, final List<String> matchPatterns) {
+        final List<String> incompatiblePatternErrors = new ArrayList<>();
+        additionalPatternsToRegister.forEach((patternName, pattern) -> {
+            try {
+                grokCompiler.register(patternName, pattern);
+            } catch (final NullPointerException | IllegalArgumentException e) {
+                final String errorMessage = String.format("The grok pattern with name \"%s\" and pattern \"%s\" is invalid with the following error: %s", patternName, pattern, e.getMessage());
+                incompatiblePatternErrors.add(errorMessage);
+            }
+        });
+
+        if (incompatiblePatternErrors.isEmpty()) {
+            matchPatterns.forEach(pattern -> {
+                try {
+                    grokCompiler.compile(pattern);
+                } catch (final IllegalArgumentException e) {
+                    final String errorMessage = String.format("The grok match pattern \"%s\" is invalid with the following error: %s", pattern, e.getMessage());
+                    incompatiblePatternErrors.add(errorMessage);
+                }
+            });
+        }
+
+        return incompatiblePatternErrors;
+    }
+
+}

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/validations/GrokPatternValidatorTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/validations/GrokPatternValidatorTest.java
@@ -1,0 +1,57 @@
+package org.opensearch.dataprepper.validations;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+public class GrokPatternValidatorTest {
+
+    @Test
+    void validatePatterns_with_invalid_match_patterns_returns_expected_messages() {
+        final Map<String, String> additionalPatterns = Map.of(
+                "PATTERN1", "one_%{WORD}"
+        );
+
+        final List<String> matchPatterns = List.of("some_pattern", "%{PATTERN1}", "%{WORD} %{PATTERN10}", "%{ANOTHER_PATTERN}");
+        final List<String> validationErrors = GrokPatternValidator.validatePatterns(additionalPatterns, matchPatterns);
+
+        assertThat(validationErrors, notNullValue());
+        assertThat(validationErrors.size(), equalTo(2));
+        assertThat(validationErrors.get(0), startsWith("The grok match pattern \"%{WORD} %{PATTERN10}\" is invalid"));
+        assertThat(validationErrors.get(1), startsWith("The grok match pattern \"%{ANOTHER_PATTERN}\" is invalid"));
+    }
+
+    @Test
+    void validatePatterns_with_no_invalid_patterns_returns_empty_list() {
+        final Map<String, String> additionalPatterns = Map.of(
+                "PATTERN1", "one_%{WORD}",
+                "PATTERN2", "test_%{NUMBER}"
+        );
+
+        final List<String> matchPatterns = List.of("some_pattern", "%{PATTERN1}", "%{WORD} %{PATTERN2}");
+
+        final List<String> errorMessages = GrokPatternValidator.validatePatterns(additionalPatterns, matchPatterns);
+        assertThat(errorMessages, notNullValue());
+        assertThat(errorMessages.size(), equalTo(0));
+    }
+
+    @Test
+    void validatePatterns_with_invalid_additional_patterns_returns_expected_messages() {
+        final Map<String, String> additionalPatterns = new HashMap<>();
+        additionalPatterns.put("test", null);
+
+        final List<String> matchPatterns = List.of("some_pattern", "%{PATTERN1}", "%{WORD} %{PATTERN2}");
+
+        final List<String> errorMessages = GrokPatternValidator.validatePatterns(additionalPatterns, matchPatterns);
+        assertThat(errorMessages, notNullValue());
+        assertThat(errorMessages.size(), equalTo(1));
+        assertThat(errorMessages.get(0), startsWith("The grok pattern with name \"test\" and pattern \"null\""));
+    }
+}


### PR DESCRIPTION
### Description
Adds support for validating grok patterns through data-prepper-api
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
