### PR TITLE
Replace the java.util.* in the ObjectInputFilter with tighter access

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/codec/PeerForwarderCodecAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/codec/PeerForwarderCodecAppConfig.java
@@ -44,7 +44,15 @@ public class PeerForwarderCodecAppConfig {
 
         final String pattern =
                 "java.lang.Object;" +
-                        "java.util.*;" +
+                        "java.util.Collections*;" +
+                        "java.util.ArrayList*;" +
+                        "java.util.LinkedList*;" +
+                        "java.util.Map*;" +
+                        "java.util.HashMap*;" +
+                        "java.util.LinkedHashMap*;" +
+                        "java.util.HashSet*;" +
+                        "java.util.LinkedHashSet*;" +
+                        "java.util.Date*;" +
                         "java.time.*;" +
                         "com.fasterxml.jackson.databind.node.*;" +
                         "org.opensearch.dataprepper.peerforwarder.model.*;" +

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/codec/PeerForwarderCodecAppConfig_SerializationFilterIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/codec/PeerForwarderCodecAppConfig_SerializationFilterIT.java
@@ -40,7 +40,15 @@ import java.io.ObjectOutputStream;
 import java.lang.reflect.Modifier;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -241,7 +249,8 @@ class PeerForwarderCodecAppConfig_SerializationFilterIT {
             return Stream.of(
                     arguments(new LinkedBlockingQueue<>()),
                     arguments(new ArrayBlockingQueue<>(1)),
-                    arguments(Pattern.compile("[1-9]"))
+                    arguments(Pattern.compile("[1-9]")),
+                    arguments(Calendar.getInstance())
             );
         }
     }
@@ -252,7 +261,18 @@ class PeerForwarderCodecAppConfig_SerializationFilterIT {
             return Stream.of(
                     arguments(UUID.randomUUID().toString()),
                     arguments(Collections.singletonList(UUID.randomUUID().toString())),
+                    arguments(Collections.singleton(UUID.randomUUID().toString())),
                     arguments(Collections.singletonMap(UUID.randomUUID().toString(), UUID.randomUUID().toString())),
+                    arguments(new ArrayList<>()),
+                    arguments(new LinkedList<>()),
+                    arguments(new HashMap<>()),
+                    arguments(new LinkedHashMap<>()),
+                    arguments(new HashSet<>()),
+                    arguments(new LinkedHashSet<>()),
+                    arguments(Collections.unmodifiableList(new ArrayList<>())),
+                    arguments(Collections.unmodifiableMap(new HashMap<>())),
+                    arguments(Collections.unmodifiableSet(new HashSet<>())),
+                    arguments(new Date()),
                     arguments(Instant.now()),
                     arguments(Duration.ofMinutes(5)),
                     arguments(DefaultEventMetadata.builder().withEventType(UUID.randomUUID().toString()).build())


### PR DESCRIPTION
### Description

This PR replaces the `java.util.*` with known collections classes used commonly in Data Prepper.
 
### Issues Resolved

None. This is a follow-on to #2311.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
