### PR TITLE
FIX: traceState not required in Link

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/DefaultLink.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/DefaultLink.java
@@ -37,8 +37,6 @@ public class DefaultLink implements Link {
         checkArgument(!builder.spanId.isEmpty(), "spanId cannot be an empty String");
         this.spanId = builder.spanId;
 
-        checkNotNull(builder.traceState, "traceState cannot be null");
-        checkArgument(!builder.traceState.isEmpty(), "traceState cannot be an empty String");
         this.traceState = builder.traceState;
 
         this.attributes = builder.attributes == null ? new HashMap<>() : builder.attributes;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/DefaultLinkTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/DefaultLinkTest.java
@@ -170,14 +170,6 @@ public class DefaultLinkTest {
     }
 
     @Test
-    public void testBuilder_withMissingTraceState_throwsNullPointerException() {
-
-        builder.withTraceState(null);
-
-        assertThrows(NullPointerException.class, builder::build);
-    }
-
-    @Test
     public void testBuilder_withEmptySpanId_throwsIllegalArgumentException() {
 
         builder.withSpanId("");
@@ -189,14 +181,6 @@ public class DefaultLinkTest {
     public void testBuilder_withEmptyTraceId_throwsIllegalArgumentException() {
 
         builder.withTraceId("");
-
-        assertThrows(IllegalArgumentException.class, builder::build);
-    }
-
-    @Test
-    public void testBuilder_withEmptyTraceState_throwsIllegalArgumentException() {
-
-        builder.withTraceState("");
 
         assertThrows(IllegalArgumentException.class, builder::build);
     }


### PR DESCRIPTION
### Description
If we run https://opentelemetry.io/docs/demo/docker-deployment/ as upstream service, there will be the following error log in data-prepper:

```
2023-03-03T19:52:36,429 [entry-pipeline-otel_trace-4-122] WARN  org.opensearch.dataprepper.plugins.source.oteltrace.OTelTraceGrpcService - Failed to parse request with error 'traceState cannot be an empty String'.
```

This is due to `traceState` is required in Link. This PR makes it not required
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
