### PR TITLE
Developer Guide links Data Prepper documentation

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -157,7 +157,7 @@ issue to request that a previous change be backported.
 Documentation is very important for users of Data Prepper and contributors. We are using the
 following conventions for documentation.
 
-1. Document features in markdown. Plugins should have detailed documentation in a `README.md` file in the plugin project directory. Documentation for all of Data Prepper should be in the [docs](../docs) directory.
+1. Document features in markdown. Plugins should have detailed documentation in a `README.md` file in the plugin project directory. Documentation for all of Data Prepper should be included in the [Data Prepper documentation](https://opensearch.org/docs/latest/data-prepper/index/).
 2. Provide Javadocs for all public classes, methods, and fields. Plugins need not follow this guidance since their classes are generally not exposed.
 3. Avoid commenting within code, unless it is required to understand that code.
 


### PR DESCRIPTION
### Description

Updated part of the developer guide to show users that Data Prepper documentation should be part of the main opensearch.org documentation.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
