### PR TITLE
Updated the Java serialization allowlist to have specific classes for JsonNode

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/codec/PeerForwarderCodecAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/codec/PeerForwarderCodecAppConfig.java
@@ -54,7 +54,9 @@ public class PeerForwarderCodecAppConfig {
                         "java.util.LinkedHashSet*;" +
                         "java.util.Date*;" +
                         "java.time.*;" +
-                        "com.fasterxml.jackson.databind.node.*;" +
+                        "com.fasterxml.jackson.databind.node.NodeSerialization;" +
+                        "com.fasterxml.jackson.databind.node.ObjectNode;" +
+                        "com.fasterxml.jackson.databind.node.ArrayNode;" +
                         "org.opensearch.dataprepper.peerforwarder.model.*;" +
                         baseModelPackage + ".event.*;" +
                         baseModelPackage + ".trace.*;" +


### PR DESCRIPTION
### Description

The wildcard on the Jackson `com.fasterxml.jackson.databind.node` package was overly broad. There are really only two classes that are likely to be used: `NodeSerialization` and `ObjectNode`. I also added support for `ArrayNode` in case some Event objects have an array as the top-level.

This PR removes those wildcards to use only the specific known classes. Additionally, this adds testing with different Event data structures to ensure that different sub-nodes work.

Part of the reason this works is that `JsonNode` (including `ObjectNode` and `ArrayNode`) actually serialize to JSON internally. So double, int, boolean, string are all in JSON.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
