### PR TITLE
Add Event Factory and generic event builder infrastructure

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/BaseEventBuilder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/BaseEventBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+import java.util.Map;
+import java.time.Instant;
+
+public interface BaseEventBuilder<T extends Event> {
+    /**
+     * Sets the event type for the metadata if a {@link #withEventMetadata} is not used.
+     *
+     * @param eventType the event type
+     * @since 2.2
+     */
+    BaseEventBuilder<T> withEventType(final String eventType);
+
+    /**
+     * Sets the attributes for the metadata if a {@link #withEventMetadata} is not used.
+     *
+     * @param eventMetadataAttributes the attributes
+     * @since 2.2
+     */
+    BaseEventBuilder<T> withEventMetadataAttributes(final Map<String, Object> eventMetadataAttributes);
+
+    /**
+     * Sets the time received for the metadata if a {@link #withEventMetadata} is not used.
+     *
+     * @param timeReceived the time an event was received
+     * @since 2.2
+     */
+    BaseEventBuilder<T> withTimeReceived(final Instant timeReceived);
+
+    /**
+     * Sets the metadata.
+     *
+     * @param eventMetadata the metadata
+     * @since 2.2
+     */
+    BaseEventBuilder<T> withEventMetadata(final EventMetadata eventMetadata);
+
+    /**
+     * Sets the data of the event.
+     *
+     * @param data the data
+     * @since 2.2
+     */
+    BaseEventBuilder<T> withData(final Object data);
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
@@ -102,4 +102,12 @@ public interface Event extends Serializable {
      * @since 2.1
      */
     String formatString(final String format);
+
+    /**
+     * Returns event handle
+     *
+     * @return returns the event handle associated with the event
+     * @since 2.2
+     */
+    EventHandle getEventHandle();
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventBuilder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventBuilder.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+public interface EventBuilder extends BaseEventBuilder<Event> {
+    /**
+     * Returns a newly created {@link JacksonEvent}.
+     *
+     * @return an event
+     * @since 2.2
+     */
+    Event build();
+}
+

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventFactory.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventFactory.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+public interface EventFactory {
+    /**
+     * Builds events of a given class
+     *
+     * @param eventBuilderClass class of the event builder object
+     * @since 2.2
+     */
+    <T extends Event, B extends BaseEventBuilder<T>> B eventBuilder(Class<B> eventBuilderClass);
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventHandle.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventHandle.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+public interface EventHandle {
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -63,6 +63,8 @@ public class JacksonEvent implements Event {
 
     private final EventMetadata eventMetadata;
 
+    private EventHandle eventHandle;
+
     private final JsonNode jsonNode;
 
     static final int MAX_KEY_LENGTH = 2048;
@@ -142,6 +144,15 @@ public class JacksonEvent implements Event {
                 }
             }
         }
+    }
+
+    public void setEventHandle(EventHandle handle) {
+        this.eventHandle = handle;
+    }
+
+    @Override
+    public EventHandle getEventHandle() {
+        return eventHandle;
     }
 
     private void setNode(final JsonNode parentNode, final String leafKey, final Object value) {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/LogEventBuilder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/LogEventBuilder.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+import org.opensearch.dataprepper.model.log.Log;
+import org.opensearch.dataprepper.model.log.JacksonLog;
+
+public interface LogEventBuilder extends BaseEventBuilder<Log> {
+    /**
+     * Returns a newly created {@link JacksonLog}.
+     *
+     * @return a log event
+     * @since 2.2
+     */
+    public Log build();
+}

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -34,6 +34,9 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.test.matcher.MapEquals.isEqualWithoutTimestamp;
 
 public class JacksonEventTest {
+    
+    class TestEventHandle implements EventHandle {
+    };
 
     private Event event;
 
@@ -583,6 +586,19 @@ public class JacksonEventTest {
 
         assertThat(createdEvent.getMetadata(), notNullValue());
         assertThat(createdEvent.getMetadata(), equalTo(eventMetadata));
+    }
+
+    @Test
+    void testEventHandleGetAndSet() {
+        EventHandle testEventHandle = new TestEventHandle();
+        final String jsonString = "{\"foo\": \"bar\"}";
+
+        final JacksonEvent event = JacksonEvent.builder()
+                .withEventType(eventType)
+                .withData(jsonString)
+                .build();
+        event.setEventHandle(testEventHandle);
+        assertThat(event.getEventHandle(), equalTo(testEventHandle));
     }
 
     private static Map<String, Object> createComplexDataMap() {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultBaseEventBuilder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultBaseEventBuilder.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.event;
+
+import org.opensearch.dataprepper.model.event.BaseEventBuilder;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventMetadata;
+import org.opensearch.dataprepper.model.event.DefaultEventMetadata;
+
+import java.util.Map;
+import java.time.Instant;
+import com.google.common.collect.ImmutableMap;
+
+public abstract class DefaultBaseEventBuilder<T extends Event> implements BaseEventBuilder<T>{
+    private EventMetadata eventMetadata;
+    private Object data;
+    private String eventType;
+    private Instant timeReceived;
+    private Map<String, Object> attributes;
+
+    public DefaultBaseEventBuilder() {
+        withTimeReceived(Instant.now());
+    }
+
+    public Object getData() {
+        return this.data;
+    }
+
+    public String getEventType() {
+        return this.eventType;
+    }
+
+    public EventMetadata getEventMetadata() {
+        if (this.eventMetadata == null) {
+            this.eventMetadata = new DefaultEventMetadata.Builder()
+                           .withEventType(eventType)
+                           .withTimeReceived(timeReceived)
+                           .withAttributes(attributes)
+                           .build();
+        }
+        return this.eventMetadata;
+    }
+
+    public Instant getTimeReceived() {
+        return this.timeReceived;
+    }
+
+    public Map<String, Object> getEventMetadataAttributes() {
+        return this.attributes;
+    }
+
+    public BaseEventBuilder<T> withEventType(final String eventType) {
+        this.eventType = eventType;
+        return this;
+    }
+
+    public BaseEventBuilder<T> withEventMetadataAttributes(final Map<String, Object> eventMetadataAttributes) {
+        this.attributes = eventMetadataAttributes;
+        return this;
+    }
+
+    public BaseEventBuilder<T> withTimeReceived(final Instant timeReceived) {
+        this.timeReceived = timeReceived;
+        return this;
+    }
+
+    public BaseEventBuilder<T> withEventMetadata(final EventMetadata eventMetadata) {
+        this.eventType = eventMetadata.getEventType();
+        this.timeReceived = eventMetadata.getTimeReceived();
+        this.attributes = ImmutableMap.copyOf(eventMetadata.getAttributes());
+        return this;
+    }
+
+    public BaseEventBuilder<T> withData(final Object data) {
+        this.data = data;
+        return this;
+    }
+}
+

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultBaseEventBuilder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultBaseEventBuilder.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.time.Instant;
 import com.google.common.collect.ImmutableMap;
 
-public abstract class DefaultBaseEventBuilder<T extends Event> implements BaseEventBuilder<T>{
+abstract class DefaultBaseEventBuilder<T extends Event> implements BaseEventBuilder<T>{
     private EventMetadata eventMetadata;
     private Object data;
     private String eventType;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventBuilder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventBuilder.java
@@ -9,9 +9,9 @@ import org.opensearch.dataprepper.model.event.EventBuilder;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 
-public class DefaultEventBuilder extends DefaultBaseEventBuilder<Event> implements EventBuilder {
+class DefaultEventBuilder extends DefaultBaseEventBuilder<Event> implements EventBuilder {
 
-    static final String EVENT_TYPE = "Event";
+    static final String EVENT_TYPE = "EVENT";
 
     public Event build() {
         return (Event) JacksonEvent.builder()

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventBuilder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventBuilder.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.event;
+
+import org.opensearch.dataprepper.model.event.EventBuilder;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.event.DefaultBaseEventBuilder;
+
+public class DefaultEventBuilder extends DefaultBaseEventBuilder<Event> implements EventBuilder {
+
+    static final String EVENT_TYPE = "Event";
+
+    public Event build() {
+        return (Event) JacksonEvent.builder()
+          .withData(getData())
+          .withEventType(EVENT_TYPE)
+          .build();
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventBuilder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventBuilder.java
@@ -8,7 +8,6 @@ package org.opensearch.dataprepper.event;
 import org.opensearch.dataprepper.model.event.EventBuilder;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
-import org.opensearch.dataprepper.event.DefaultBaseEventBuilder;
 
 public class DefaultEventBuilder extends DefaultBaseEventBuilder<Event> implements EventBuilder {
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.event;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.LogEventBuilder;
+import org.opensearch.dataprepper.model.event.BaseEventBuilder;
+import org.opensearch.dataprepper.event.DefaultLogEventBuilder;
+
+public class DefaultEventFactory implements EventFactory {
+    @Override
+    public <T extends Event, B extends BaseEventBuilder<T>> B eventBuilder(Class<B> eventBuilderClass) {
+        if (eventBuilderClass.equals(LogEventBuilder.class)) {
+            return (B) new DefaultLogEventBuilder();
+        }
+        if (eventBuilderClass.equals(DefaultEventBuilder.class)) {
+            return (B) new DefaultEventBuilder();
+        }
+        return null;
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventFactory.java
@@ -9,7 +9,6 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.event.LogEventBuilder;
 import org.opensearch.dataprepper.model.event.BaseEventBuilder;
-import org.opensearch.dataprepper.event.DefaultLogEventBuilder;
 
 public class DefaultEventFactory implements EventFactory {
     @Override

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventHandle.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventHandle.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.event;
+
+import org.opensearch.dataprepper.model.event.EventHandle;
+
+public class DefaultEventHandle implements EventHandle {
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventHandle.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventHandle.java
@@ -7,5 +7,5 @@ package org.opensearch.dataprepper.event;
 
 import org.opensearch.dataprepper.model.event.EventHandle;
 
-public class DefaultEventHandle implements EventHandle {
+class DefaultEventHandle implements EventHandle {
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultLogEventBuilder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultLogEventBuilder.java
@@ -9,14 +9,18 @@ import org.opensearch.dataprepper.model.event.LogEventBuilder;
 import org.opensearch.dataprepper.model.log.Log;
 import org.opensearch.dataprepper.model.log.JacksonLog;
 
-public class DefaultLogEventBuilder extends DefaultBaseEventBuilder<Log> implements LogEventBuilder {
+class DefaultLogEventBuilder extends DefaultBaseEventBuilder<Log> implements LogEventBuilder {
 
     static final String LOG_EVENT_TYPE = "LOG";
+
+    public String getEventType() {
+        return LOG_EVENT_TYPE;
+    }
 
     public Log build() {
         return (Log) JacksonLog.builder()
           .withData(getData())
-          .withEventType(LOG_EVENT_TYPE)
+          .withEventType(getEventType())
           .build();
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultLogEventBuilder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultLogEventBuilder.java
@@ -8,7 +8,6 @@ package org.opensearch.dataprepper.event;
 import org.opensearch.dataprepper.model.event.LogEventBuilder;
 import org.opensearch.dataprepper.model.log.Log;
 import org.opensearch.dataprepper.model.log.JacksonLog;
-import org.opensearch.dataprepper.event.DefaultBaseEventBuilder;
 
 public class DefaultLogEventBuilder extends DefaultBaseEventBuilder<Log> implements LogEventBuilder {
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultLogEventBuilder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultLogEventBuilder.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.event;
+
+import org.opensearch.dataprepper.model.event.LogEventBuilder;
+import org.opensearch.dataprepper.model.log.Log;
+import org.opensearch.dataprepper.model.log.JacksonLog;
+import org.opensearch.dataprepper.event.DefaultBaseEventBuilder;
+
+public class DefaultLogEventBuilder extends DefaultBaseEventBuilder<Log> implements LogEventBuilder {
+
+    static final String LOG_EVENT_TYPE = "LOG";
+
+    public Log build() {
+        return (Log) JacksonLog.builder()
+          .withData(getData())
+          .withEventType(LOG_EVENT_TYPE)
+          .build();
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultBaseEventBuilderTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultBaseEventBuilderTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.event;
+
+import org.opensearch.dataprepper.model.event.DefaultEventMetadata;
+import org.opensearch.dataprepper.model.event.EventMetadata;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.util.Collections;
+import java.util.Map;
+import java.time.Instant;
+
+class DefaultBaseEventBuilderTests {
+    private DefaultBaseEventBuilder defaultBaseEventBuilder;
+    class TestDefaultBaseEventBuilder extends DefaultBaseEventBuilder {
+    }
+
+    @BeforeEach
+    void setup() {
+        defaultBaseEventBuilder = new TestDefaultBaseEventBuilder();
+    }
+
+    @Test
+    void testDefaultBaseEventBuilder() {
+        assertThat(defaultBaseEventBuilder.getTimeReceived(), not(equalTo(null)));
+    }
+
+    @Test
+    void testDefaultBaseEventBuilderWithTypeDataAndAttributes() {
+        String testKey = RandomStringUtils.randomAlphabetic(5);
+        String testValue = RandomStringUtils.randomAlphabetic(10);
+        Map<String, Object> data = Map.of(testKey, testValue);
+        defaultBaseEventBuilder.withData(data);
+        String testEventType = RandomStringUtils.randomAlphabetic(10);
+        defaultBaseEventBuilder.withEventType(testEventType);
+        Map<String, Object> metadataAttributes = Collections.emptyMap();
+        defaultBaseEventBuilder.withEventMetadataAttributes(metadataAttributes);
+        
+        assertThat(defaultBaseEventBuilder.getTimeReceived(), not(equalTo(null)));
+        assertThat(defaultBaseEventBuilder.getData(), equalTo(data));
+        assertThat(defaultBaseEventBuilder.getEventType(), equalTo(testEventType));
+        assertThat(defaultBaseEventBuilder.getEventMetadataAttributes(), equalTo(metadataAttributes));
+        assertThat(defaultBaseEventBuilder.getEventMetadata().getEventType(), equalTo(testEventType));
+        Instant timeReceived = defaultBaseEventBuilder.getTimeReceived();
+        assertThat(defaultBaseEventBuilder.getEventMetadata().getTimeReceived(), equalTo(timeReceived));
+        assertThat(defaultBaseEventBuilder.getData(), equalTo(data));
+    }
+
+    @Test
+    void testDefaultBaseEventBuilderWithEventMetadata() {
+        String testKey = RandomStringUtils.randomAlphabetic(5);
+        String testValue = RandomStringUtils.randomAlphabetic(10);
+        Map<String, Object> data = Map.of(testKey, testValue);
+        String testEventType = RandomStringUtils.randomAlphabetic(10);
+        Instant timeReceived = Instant.now();
+        Map<String, Object> attributes = Collections.emptyMap();
+        EventMetadata eventMetadata = new DefaultEventMetadata.Builder()
+                       .withEventType(testEventType)
+                       .withTimeReceived(timeReceived)
+                       .withAttributes(attributes)
+                       .build();
+
+        defaultBaseEventBuilder.withEventMetadata(eventMetadata);
+        defaultBaseEventBuilder.withData(data);
+        
+        assertThat(defaultBaseEventBuilder.getTimeReceived(),equalTo(timeReceived));
+        assertThat(defaultBaseEventBuilder.getData(), equalTo(data));
+        assertThat(defaultBaseEventBuilder.getEventType(), equalTo(testEventType));
+        assertThat(defaultBaseEventBuilder.getEventMetadataAttributes(), equalTo(attributes));
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultBaseEventBuilderTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultBaseEventBuilderTests.java
@@ -10,7 +10,6 @@ import org.opensearch.dataprepper.model.event.EventMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.apache.commons.lang3.RandomStringUtils;
 
@@ -19,22 +18,22 @@ import java.util.Map;
 import java.time.Instant;
 
 class DefaultBaseEventBuilderTests {
-    private DefaultBaseEventBuilder defaultBaseEventBuilder;
     class TestDefaultBaseEventBuilder extends DefaultBaseEventBuilder {
     }
 
-    @BeforeEach
-    void setup() {
-        defaultBaseEventBuilder = new TestDefaultBaseEventBuilder();
+    private DefaultBaseEventBuilder createObjectUnderTest() {
+        return new TestDefaultBaseEventBuilder();
     }
 
     @Test
     void testDefaultBaseEventBuilder() {
+        DefaultBaseEventBuilder defaultBaseEventBuilder = createObjectUnderTest();
         assertThat(defaultBaseEventBuilder.getTimeReceived(), not(equalTo(null)));
     }
 
     @Test
     void testDefaultBaseEventBuilderWithTypeDataAndAttributes() {
+        DefaultBaseEventBuilder defaultBaseEventBuilder = createObjectUnderTest();
         String testKey = RandomStringUtils.randomAlphabetic(5);
         String testValue = RandomStringUtils.randomAlphabetic(10);
         Map<String, Object> data = Map.of(testKey, testValue);
@@ -56,6 +55,7 @@ class DefaultBaseEventBuilderTests {
 
     @Test
     void testDefaultBaseEventBuilderWithEventMetadata() {
+        DefaultBaseEventBuilder defaultBaseEventBuilder = createObjectUnderTest();
         String testKey = RandomStringUtils.randomAlphabetic(5);
         String testValue = RandomStringUtils.randomAlphabetic(10);
         Map<String, Object> data = Map.of(testKey, testValue);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultEventBuilderTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultEventBuilderTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.event;
+
+import org.opensearch.dataprepper.model.event.EventMetadata;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.util.Collections;
+import java.util.Map;
+
+class DefaultEventBuilderTests {
+    private DefaultEventBuilder defaultEventBuilder;
+
+    @BeforeEach
+    void setup() {
+        defaultEventBuilder = new DefaultEventBuilder();
+    }
+
+    @Test
+    void testDefaultEventBuilder() {
+        assertThat(defaultEventBuilder.getTimeReceived(), not(equalTo(null)));
+    }
+
+    @Test
+    void testDefaultBaseEventBuilderWithTypeDataAndAttributes() {
+        String testKey = RandomStringUtils.randomAlphabetic(5);
+        String testValue = RandomStringUtils.randomAlphabetic(10);
+        Map<String, Object> data = Map.of(testKey, testValue);
+        defaultEventBuilder.withData(data);
+        Map<String, Object> metadataAttributes = Collections.emptyMap();
+        defaultEventBuilder.withEventMetadataAttributes(metadataAttributes);
+        JacksonEvent event = (JacksonEvent)defaultEventBuilder.build();
+        EventMetadata eventMetadata = event.getMetadata();
+        
+        assertThat(eventMetadata.getTimeReceived(), not(equalTo(null)));
+        assertThat(eventMetadata.getEventType(), equalTo(DefaultEventBuilder.EVENT_TYPE));
+        assertThat(eventMetadata.getAttributes(), equalTo(metadataAttributes));
+        assertThat(event.toMap(), equalTo(data));
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultEventFactoryTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultEventFactoryTests.java
@@ -9,7 +9,6 @@ import org.opensearch.dataprepper.model.event.EventMetadata;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.event.LogEventBuilder;
 import org.opensearch.dataprepper.model.log.JacksonLog;
-import org.opensearch.dataprepper.event.DefaultLogEventBuilder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultEventFactoryTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultEventFactoryTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.event;
+
+import org.opensearch.dataprepper.model.event.EventMetadata;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.event.LogEventBuilder;
+import org.opensearch.dataprepper.model.log.JacksonLog;
+import org.opensearch.dataprepper.event.DefaultLogEventBuilder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import org.junit.jupiter.api.Test;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.util.Map;
+import java.util.Collections;
+
+class DefaultEventFactoryTests {
+    private DefaultEventBuilder eventBuilder;
+    private DefaultLogEventBuilder logEventBuilder;
+    private DefaultEventFactory eventFactory;
+    
+    @Test
+    void testDefaultEventFactory() {
+        eventFactory = new DefaultEventFactory();
+        String testKey = RandomStringUtils.randomAlphabetic(5);
+        String testValue = RandomStringUtils.randomAlphabetic(10);
+        Map<String, Object> data = Map.of(testKey, testValue);
+        Map<String, Object> attributes = Collections.emptyMap();
+        final DefaultEventBuilder eventBuilder = (DefaultEventBuilder) eventFactory.eventBuilder(DefaultEventBuilder.class).withEventMetadataAttributes(attributes).withData(data);
+        JacksonEvent event = (JacksonEvent) eventBuilder.build();
+        EventMetadata eventMetadata = event.getMetadata();
+        
+        assertThat(eventMetadata.getTimeReceived(), not(equalTo(null)));
+        assertThat(eventMetadata.getEventType(), equalTo(DefaultEventBuilder.EVENT_TYPE));
+        assertThat(eventMetadata.getAttributes(), equalTo(attributes));
+        assertThat(event.toMap(), equalTo(data));
+    }
+
+    @Test
+    void testDefaultEventFactoryWithLogEvent() {
+        eventFactory = new DefaultEventFactory();
+        String testKey = RandomStringUtils.randomAlphabetic(5);
+        String testValue = RandomStringUtils.randomAlphabetic(10);
+        Map<String, Object> data = Map.of(testKey, testValue);
+        Map<String, Object> attributes = Collections.emptyMap();
+        final DefaultLogEventBuilder logEventBuilder = (DefaultLogEventBuilder) eventFactory.eventBuilder(LogEventBuilder.class).withEventMetadataAttributes(attributes).withData(data);
+        JacksonLog log = (JacksonLog) logEventBuilder.build();
+        EventMetadata eventMetadata = log.getMetadata();
+        
+        assertThat(eventMetadata.getTimeReceived(), not(equalTo(null)));
+        assertThat(eventMetadata.getEventType(), equalTo(DefaultLogEventBuilder.LOG_EVENT_TYPE));
+        assertThat(eventMetadata.getAttributes(), equalTo(attributes));
+        assertThat(log.toMap(), equalTo(data));
+    }
+
+}
+

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultLogEventBuilderTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultLogEventBuilderTests.java
@@ -17,7 +17,12 @@ import java.util.Collections;
 import java.util.Map;
 
 class DefaultLogEventBuilderTests {
-    DefaultLogEventBuilder defaultLogEventBuilder;
+
+    private DefaultLogEventBuilder createObjectUnderTest(Map<String, Object> attributes, Map<String, Object> data) {
+        return (DefaultLogEventBuilder) new DefaultLogEventBuilder()
+                                        .withEventMetadataAttributes(attributes)
+                                        .withData(data);
+    }
 
     @Test
     void testDefaultLogEventBuilder() {
@@ -25,7 +30,7 @@ class DefaultLogEventBuilderTests {
         String testValue = RandomStringUtils.randomAlphabetic(10);
         Map<String, Object> metadataAttributes = Collections.emptyMap();
         Map<String, Object> data = Map.of(testKey, testValue);
-        defaultLogEventBuilder = (DefaultLogEventBuilder) new DefaultLogEventBuilder().withEventMetadataAttributes(metadataAttributes).withData(data);
+        DefaultLogEventBuilder defaultLogEventBuilder = createObjectUnderTest(metadataAttributes, data);
         JacksonLog log = (JacksonLog)defaultLogEventBuilder.build();
         EventMetadata eventMetadata = log.getMetadata();
         
@@ -33,7 +38,5 @@ class DefaultLogEventBuilderTests {
         assertThat(eventMetadata.getEventType(), equalTo(DefaultLogEventBuilder.LOG_EVENT_TYPE));
         assertThat(eventMetadata.getAttributes(), equalTo(metadataAttributes));
         assertThat(log.toMap(), equalTo(data));
-        
     }
-
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultLogEventBuilderTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultLogEventBuilderTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.event;
+
+import org.opensearch.dataprepper.model.event.EventMetadata;
+import org.opensearch.dataprepper.model.log.JacksonLog;
+import org.junit.jupiter.api.Test;
+import org.apache.commons.lang3.RandomStringUtils;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+
+import java.util.Collections;
+import java.util.Map;
+
+class DefaultLogEventBuilderTests {
+    DefaultLogEventBuilder defaultLogEventBuilder;
+
+    @Test
+    void testDefaultLogEventBuilder() {
+        String testKey = RandomStringUtils.randomAlphabetic(5);
+        String testValue = RandomStringUtils.randomAlphabetic(10);
+        Map<String, Object> metadataAttributes = Collections.emptyMap();
+        Map<String, Object> data = Map.of(testKey, testValue);
+        defaultLogEventBuilder = (DefaultLogEventBuilder) new DefaultLogEventBuilder().withEventMetadataAttributes(metadataAttributes).withData(data);
+        JacksonLog log = (JacksonLog)defaultLogEventBuilder.build();
+        EventMetadata eventMetadata = log.getMetadata();
+        
+        assertThat(eventMetadata.getTimeReceived(), not(equalTo(null)));
+        assertThat(eventMetadata.getEventType(), equalTo(DefaultLogEventBuilder.LOG_EVENT_TYPE));
+        assertThat(eventMetadata.getAttributes(), equalTo(metadataAttributes));
+        assertThat(log.toMap(), equalTo(data));
+        
+    }
+
+}


### PR DESCRIPTION
### Description
This change adds new mechanism to create events from event factory and the necessary framework.
The framework components
1. Event Handle - This will be used for end-to-end acknowledgement of each individual events
2. BaseEventBuilder - Base Event Builder interface that allows setting event metadata and data that can be used to create different types of event
The framework components are implemented as interfaces in the `data-prepper-api` and the corresponding implementations in the `data-prepper-core`
 
### Issues Resolved

 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
