### PR TITLE
Use Gradle version catalogs for more projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,11 +84,11 @@ subprojects {
         implementation platform('com.fasterxml.jackson:jackson-bom:2.14.1')
         implementation platform('io.micrometer:micrometer-bom:1.9.4')
         implementation libs.guava.core
-        implementation 'org.slf4j:slf4j-api:2.0.5'
+        implementation libs.slf4j.api
         testImplementation testLibs.bundles.junit
         testImplementation testLibs.bundles.mockito
-        testImplementation 'org.hamcrest:hamcrest:2.2'
-        testImplementation 'org.awaitility:awaitility:4.2.0'
+        testImplementation testLibs.hamcrest
+        testImplementation testLibs.awaitility
         constraints {
             implementation('org.apache.httpcomponents:httpclient') {
                 version {

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -31,15 +31,15 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-slf4j2-impl'
     implementation 'javax.inject:javax.inject:1'
-    implementation('org.springframework:spring-core:5.3.25') {
+    implementation(libs.spring.core) {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
-    implementation('org.springframework:spring-context:5.3.25') {
+    implementation(libs.spring.context) {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation 'software.amazon.cloudwatchlogs:aws-embedded-metrics:2.0.0-beta-1'
     testImplementation 'org.apache.logging.log4j:log4j-jpl:2.17.0'
-    testImplementation 'org.springframework:spring-test:5.3.25'
+    testImplementation testLibs.spring.test
     implementation libs.armeria.core
     implementation libs.armeria.grpc
     implementation 'org.apache.commons:commons-lang3:3.12.0'

--- a/data-prepper-expression/build.gradle
+++ b/data-prepper-expression/build.gradle
@@ -18,16 +18,16 @@ dependencies {
     }
     implementation project(':data-prepper-api')
     implementation 'javax.inject:javax.inject:1'
-    implementation('org.springframework:spring-core:5.3.25') {
+    implementation(libs.spring.core) {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
-    implementation('org.springframework:spring-context:5.3.25') {
+    implementation(libs.spring.context) {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation platform('org.apache.logging.log4j:log4j-bom:2.19.0')
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-slf4j2-impl'
-    testImplementation 'org.springframework:spring-test:5.3.25'
+    testImplementation testLibs.spring.test
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 

--- a/data-prepper-logstash-configuration/build.gradle
+++ b/data-prepper-logstash-configuration/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation "org.apache.commons:commons-lang3:3.12.0"
-    testImplementation 'org.slf4j:slf4j-simple:2.0.6'
+    testImplementation testLibs.slf4j.simple
     testImplementation testLibs.mockito.inline
 }
 

--- a/data-prepper-main/build.gradle
+++ b/data-prepper-main/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation project(':data-prepper-core')
     implementation project(':data-prepper-plugins')
     implementation project(':data-prepper-logstash-configuration')
-    implementation('org.springframework:spring-context:5.3.22') {
+    implementation(libs.spring.context) {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
 }

--- a/data-prepper-plugins/log-generator-source/build.gradle
+++ b/data-prepper-plugins/log-generator-source/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:blocking-buffer')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
 }
 

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     testImplementation 'commons-io:commons-io:2.11.0'
     testImplementation 'net.bytebuddy:byte-buddy:1.12.22'
     testImplementation 'net.bytebuddy:byte-buddy-agent:1.12.22'
-    testImplementation 'org.slf4j:slf4j-simple:2.0.6'
+    testImplementation testLibs.slf4j.simple
 }
 
 sourceSets {

--- a/data-prepper-plugins/otel-logs-source/build.gradle
+++ b/data-prepper-plugins/otel-logs-source/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "org.bouncycastle:bcpkix-jdk15on:1.69"
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation testLibs.mockito.inline
-    testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation("commons-io:commons-io:2.10.0")
 }
 

--- a/data-prepper-plugins/otel-proto-common/build.gradle
+++ b/data-prepper-plugins/otel-proto-common/build.gradle
@@ -15,6 +15,5 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation "org.apache.commons:commons-lang3:3.12.0"
     implementation 'commons-codec:commons-codec:1.15'
-    testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation "org.bouncycastle:bcpkix-jdk15on:1.70"
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation testLibs.mockito.inline
-    testImplementation 'org.slf4j:slf4j-simple:2.0.6'
+    testImplementation testLibs.slf4j.simple
     testImplementation("commons-io:commons-io:2.10.0")
 }
 

--- a/data-prepper-test-common/build.gradle
+++ b/data-prepper-test-common/build.gradle
@@ -12,9 +12,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.hamcrest:hamcrest:2.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+    implementation testLibs.hamcrest
+    testRuntimeOnly testLibs.junit.engine
 }
 
 test {

--- a/e2e-test/log/build.gradle
+++ b/e2e-test/log/build.gradle
@@ -191,6 +191,6 @@ dependencies {
     integrationTestImplementation project(':data-prepper-plugins:log-generator-source')
     integrationTestImplementation project(':data-prepper-plugins:opensearch')
     integrationTestImplementation libs.armeria.core
-    integrationTestImplementation "org.awaitility:awaitility:4.1.1"
+    integrationTestImplementation testLibs.awaitility
     integrationTestImplementation libs.opensearch.rhlc
 }

--- a/e2e-test/trace/build.gradle
+++ b/e2e-test/trace/build.gradle
@@ -232,7 +232,7 @@ dependencies {
     integrationTestImplementation project(':data-prepper-plugins:common')
     integrationTestImplementation project(':data-prepper-plugins:opensearch')
     integrationTestImplementation project(':data-prepper-plugins:otel-trace-group-processor')
-    integrationTestImplementation 'org.awaitility:awaitility:4.2.0'
+    integrationTestImplementation testLibs.awaitility
     integrationTestImplementation "io.opentelemetry.proto:opentelemetry-proto:${targetOpenTelemetryVersion}"
     integrationTestImplementation libs.protobuf.util
     integrationTestImplementation libs.armeria.core

--- a/performance-test/build.gradle
+++ b/performance-test/build.gradle
@@ -20,8 +20,7 @@ repositories {
 
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+    testRuntimeOnly testLibs.junit.engine
 }
 
 test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,8 @@ rootProject.name = 'opensearch-data-prepper'
 dependencyResolutionManagement {
     versionCatalogs {
         libs {
+            version('slf4j', '2.0.6')
+            library('slf4j-api', 'org.slf4j', 'slf4j-api').versionRef('slf4j')
             version('armeria', '1.22.1')
             library('armeria-core', 'com.linecorp.armeria', 'armeria').versionRef('armeria')
             library('armeria-grpc', 'com.linecorp.armeria', 'armeria-grpc').versionRef('armeria')
@@ -26,20 +28,32 @@ dependencyResolutionManagement {
             library('opentelemetry-proto', 'io.opentelemetry.proto', 'opentelemetry-proto').versionRef('opentelemetry')
             version('opensearch', '1.3.8')
             library('opensearch-rhlc', 'org.opensearch.client', 'opensearch-rest-high-level-client').versionRef('opensearch')
+            version('spring', '5.3.25')
+            library('spring-core', 'org.springframework', 'spring-core').versionRef('spring')
+            library('spring-context', 'org.springframework', 'spring-context').versionRef('spring')
             version('guava', '31.1-jre')
             library('guava-core', 'com.google.guava', 'guava').versionRef('guava')
         }
         testLibs {
             version('junit', '5.8.2')
             version('mockito', '3.11.2')
+            version('hamcrest', '2.2')
+            version('awaitility', '4.2.0')
+            version('spring', '5.3.25')
+            version('slf4j', '2.0.6')
             library('junit-core', 'org.junit.jupiter', 'junit-jupiter').versionRef('junit')
             library('junit-params', 'org.junit.jupiter', 'junit-jupiter-params').versionRef('junit')
+            library('junit-engine', 'org.junit.jupiter', 'junit-jupiter-engine').versionRef('junit')
             library('junit-vintage', 'org.junit.vintage', 'junit-vintage-engine').versionRef('junit')
             bundle('junit', ['junit-core', 'junit-params', 'junit-vintage'])
             library('mockito-core', 'org.mockito', 'mockito-core').versionRef('mockito')
             library('mockito-junit', 'org.mockito', 'mockito-junit-jupiter').versionRef('mockito')
             library('mockito-inline', 'org.mockito', 'mockito-inline').versionRef('mockito')
             bundle('mockito', ['mockito-core', 'mockito-junit'])
+            library('hamcrest', 'org.hamcrest', 'hamcrest').versionRef('hamcrest')
+            library('awaitility', 'org.awaitility', 'awaitility').versionRef('awaitility')
+            library('spring-test', 'org.springframework', 'spring-test').versionRef('spring')
+            library('slf4j-simple', 'org.slf4j', 'slf4j-simple').versionRef('slf4j')
         }
     }
 }


### PR DESCRIPTION
### Description

Use Gradle version catalogs for:
* Slf4j
* Spring
* Hamcrest
* Awaitility
* JUnit (was missing in some locations)

Also, cleaned out some of the Hamcrest and Awaitility dependencies which come from the root project.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
