### PR TITLE
Add acknowledgementSet and acknowledgementSetManager - End-to-End Ack Support

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSet.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSet.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.acknowledgements;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventHandle;
+
+/**
+ * AcknowledgmentSet keeps track of set of events that
+ * belong to the batch of events that a source creates.
+ * Each event gets an event handle assigned when it is first
+ * added to the acknowledgement set, which can later be used
+ * to acquire more references to the event or release reference
+ * to the event when the event is completed (pushed to sink,
+ * dropped, etc)
+ */
+public interface AcknowledgementSet {
+
+    /**
+     * Adds an event to the acknowledgement set. Assigns initial reference
+     * count of 1.
+     *
+     * @param event event to be added
+     * @since 2.2
+     */
+    public void add(Event event);
+
+    /**
+     * Aquires a reference to the event by incrementing the reference
+     * count. 
+     *
+     * @param eventHandle event handle
+     * @since 2.2
+     */
+    public void acquire(final EventHandle eventHandle);
+
+    /**
+     * Releases a reference to the event by decrementing the reference
+     * count. This is used to indicate the completion of a reference of
+     * an event after successful or unsuccessful use of an event. Negative
+     * acknowledgement of an event reference can be done by using `false`
+     *  as the result
+     *
+     * @param eventHandle event handle
+     * @param result flag indicating if the event has successfully completed or not
+     * @return indicates if the release is the last release for the event
+     * @since 2.2
+     */
+    public boolean release(final EventHandle eventHandle, final boolean result);
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSetManager.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSetManager.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.acknowledgements;
+
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.model.event.Event;
+import java.util.function.Consumer;
+import java.time.Duration;
+
+/**
+ * AcknowledgementSetManager manages acknowledgement sets created by
+ * source(s). It facilitates creation of acknowledgement set and
+ * allows references for events in the acknowledgement sets to be
+ * acquired or released and when the final event in an acknowledgement
+ * set is released, the registered callback is invoked.
+ */
+public interface AcknowledgementSetManager {
+    /**
+     * Creates an acknowledgement set
+     *
+     * @param callback callback function to be invoked
+     * @param timeout expiry timeout
+     *
+     * @return AcknowledgementSet returns a new acknowledgement set
+     * @since 2.2
+     */
+    AcknowledgementSet create(final Consumer<Boolean> callback, final Duration timeout);
+
+    /**
+     * Releases an event's reference
+     *
+     * @param eventHandle event handle
+     * @param success indicates negative or positive acknowledgement
+     *
+     * @since 2.2
+     */
+    void releaseEventReference(final EventHandle eventHandle, boolean success);
+
+    /**
+     * Acquires an event's reference
+     *
+     * @param eventHandle event handle
+     *
+     * @since 2.2
+     */
+    void acquireEventReference(final EventHandle eventHandle);
+
+    /**
+     * Acquires an event's reference
+     *
+     * @param event event
+     *
+     * @since 2.2
+     */
+    void acquireEventReference(final Event event);
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/AcknowledgementSetMonitor.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/AcknowledgementSetMonitor.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.event.DefaultEventHandle;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Set;
+import java.util.HashSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+/**
+ * AcknowledgementSetMonitor - monitors the acknowledgement sets for completion/expiration
+ *
+ * Every acknowledgement set must complete (ie get acknowledgements from all the events in it)
+ * by a specified time. If it is not completed, then it is considered 'expired' and it is
+ * cleaned up. The 'run' method is invoked periodically to cleanup the acknowledgement sets
+ * that are either completed or expired.
+ */
+public class AcknowledgementSetMonitor implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(AcknowledgementSetMonitor.class);
+    private final Set<AcknowledgementSet> acknowledgementSets;
+    private final ReentrantLock lock;
+    private AtomicInteger numInvalidAcquires;
+    private AtomicInteger numInvalidReleases;
+
+    private DefaultAcknowledgementSet getAcknowledgementSet(final EventHandle eventHandle) {
+        return (DefaultAcknowledgementSet)((DefaultEventHandle)eventHandle).getAcknowledgementSet();
+    }
+
+    public AcknowledgementSetMonitor() {
+        this.acknowledgementSets = new HashSet<>();
+        this.lock = new ReentrantLock(true);
+        this.numInvalidAcquires = new AtomicInteger(0);
+        this.numInvalidReleases = new AtomicInteger(0);
+    }
+
+    public int getNumInvalidAcquires() {
+        return numInvalidAcquires.get();
+    }
+
+    public int getNumInvalidReleases() {
+        return numInvalidReleases.get();
+    }
+
+    public void add(final AcknowledgementSet acknowledgementSet) {
+        lock.lock();
+        try {
+            acknowledgementSets.add(acknowledgementSet);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void acquire(final EventHandle eventHandle) {
+        DefaultAcknowledgementSet acknowledgementSet = getAcknowledgementSet(eventHandle);
+        lock.lock();
+        boolean exists = false;
+        try {
+            exists = acknowledgementSets.contains(acknowledgementSet);
+        } finally {
+            lock.unlock();
+        }
+        // if acknowledgementSet doesn't exist then it means that the
+        // event still active even after the acknowledgement set is
+        // cleaned up.
+        if (exists) {
+            acknowledgementSet.acquire(eventHandle);
+        } else {
+            LOG.warn("Trying acquire an event in an AcknowledgementSet that does not exist");
+            numInvalidAcquires.incrementAndGet();
+        }
+    }
+
+    public void release(final EventHandle eventHandle, final boolean success) {
+        DefaultAcknowledgementSet acknowledgementSet = getAcknowledgementSet(eventHandle);
+        lock.lock();
+        boolean exists = false;
+        try {
+            exists = acknowledgementSets.contains(acknowledgementSet);
+        } finally {
+            lock.unlock();
+        }
+        // if acknowledgementSet doesn't exist then it means some late
+        // arrival of event handle release after the acknowledgement set
+        // is cleaned up.
+        if (exists) {
+            boolean b = acknowledgementSet.release(eventHandle, success);
+        } else {
+            LOG.warn("Trying to release from an AcknowledgementSet that does not exist");
+            numInvalidReleases.incrementAndGet();
+        }
+    }
+
+    // For testing
+    int getSize() {
+        return acknowledgementSets.size();
+    }
+
+    @Override
+    public void run() {
+        lock.lock();
+        try {
+            if (acknowledgementSets.size() > 0) {
+                acknowledgementSets.removeIf((ackSet) -> ((DefaultAcknowledgementSet)ackSet).isDone());
+            } 
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSet.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSet.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.event.DefaultEventHandle;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.time.Instant;
+import java.time.Duration;
+
+public class DefaultAcknowledgementSet implements AcknowledgementSet {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultAcknowledgementSet.class);
+    private final Consumer<Boolean> callback;
+    private final Instant expiryTime;
+    private final ScheduledExecutorService executor;
+    // This lock protects all the non-final members
+    private final ReentrantLock lock;
+    private boolean result;
+    private Map<EventHandle, AtomicInteger> pendingAcknowledgments;
+    private ScheduledFuture callbackFuture;
+
+    private AtomicInteger numInvalidAcquires;
+    private AtomicInteger numInvalidReleases;
+
+    public DefaultAcknowledgementSet(final ScheduledExecutorService executor, final Consumer<Boolean> callback, final Duration expiryTime) {
+        this.callback = callback;
+        this.result = true;
+        this.executor = executor;
+        this.expiryTime = Instant.now().plusMillis(expiryTime.toMillis());
+        this.callbackFuture = null;
+        pendingAcknowledgments = new HashMap<>();
+        lock = new ReentrantLock(true);
+        this.numInvalidAcquires = new AtomicInteger(0);
+        this.numInvalidReleases = new AtomicInteger(0);
+    }
+
+    public int getNumInvalidAcquires() {
+        return numInvalidAcquires.get();
+    }
+
+    public int getNumInvalidReleases() {
+        return numInvalidReleases.get();
+    }
+
+    @Override
+    public void add(Event event) {
+        lock.lock();
+        try {
+            if (event instanceof JacksonEvent) {
+                EventHandle eventHandle = new DefaultEventHandle(this);
+                ((JacksonEvent) event).setEventHandle(eventHandle);
+                pendingAcknowledgments.put(eventHandle, new AtomicInteger(1));
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void acquire(final EventHandle eventHandle) {
+        lock.lock();
+        try {
+            if (!pendingAcknowledgments.containsKey(eventHandle)) {
+                LOG.warn("Unexpected event handle acquire");
+                numInvalidAcquires.incrementAndGet();
+                return;
+            }
+            pendingAcknowledgments.get(eventHandle).incrementAndGet();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public boolean isDone() {
+        lock.lock();
+        try {
+            if (callbackFuture != null && callbackFuture.isDone()) {
+                return true;
+            }
+            if (Instant.now().isAfter(expiryTime)) {
+                if (callbackFuture != null) {
+                    callbackFuture.cancel(true);
+                }
+                return true;
+            }
+        } finally {
+            lock.unlock();
+        }
+        return false;
+    }
+
+    public Instant getExpiryTime() {
+        return expiryTime;
+    }
+
+    @Override
+    public boolean release(final EventHandle eventHandle, final boolean result) {
+        lock.lock();
+        // Result indicates negative or positive acknowledgement. Even if one of the
+        // events in the set report negative acknowledgement, then the end result
+        // is negative acknowledgement
+        this.result = this.result && result;
+        try {
+            if (!pendingAcknowledgments.containsKey(eventHandle) ||
+                pendingAcknowledgments.get(eventHandle).get() == 0) {
+                LOG.warn("Unexpected event handle release");
+                numInvalidReleases.incrementAndGet();
+                return false;
+            }
+            if (pendingAcknowledgments.get(eventHandle).decrementAndGet() == 0) {
+                pendingAcknowledgments.remove(eventHandle);
+                if (pendingAcknowledgments.size() == 0) {
+                    callbackFuture = executor.schedule(() -> {callback.accept(this.result);}, 0, TimeUnit.SECONDS);
+                    return true;
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+        return false;
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetManager.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetManager.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+
+import java.util.function.Consumer;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.time.Duration;
+
+public class DefaultAcknowledgementSetManager implements AcknowledgementSetManager {
+    private static final int MAX_THREADS = 100;
+    private static final int DEFAULT_WAIT_TIME_MS = 15 * 1000;
+    private final AcknowledgementSetMonitor acknowledgementSetMonitor;
+    private final ScheduledExecutorService executor;
+
+    public DefaultAcknowledgementSetManager() {
+        this(Duration.ofMillis(DEFAULT_WAIT_TIME_MS));
+    }
+
+    public DefaultAcknowledgementSetManager(final Duration waitTime) {
+        this.executor = Executors.newScheduledThreadPool(MAX_THREADS);
+        this.acknowledgementSetMonitor = new AcknowledgementSetMonitor();
+        this.executor.scheduleAtFixedRate(this.acknowledgementSetMonitor, waitTime.toMillis(), waitTime.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    public AcknowledgementSet create(final Consumer<Boolean> callback, final Duration timeout) {
+        AcknowledgementSet acknowledgementSet = new DefaultAcknowledgementSet(executor, callback, timeout);
+        acknowledgementSetMonitor.add(acknowledgementSet);
+        return acknowledgementSet;
+    }
+
+    public void acquireEventReference(final Event event) {
+        acquireEventReference(((JacksonEvent)event).getEventHandle());
+    }
+
+    public void acquireEventReference(final EventHandle eventHandle) {
+        acknowledgementSetMonitor.acquire(eventHandle);
+    }
+
+    public void releaseEventReference(final EventHandle eventHandle, final boolean success) {
+        acknowledgementSetMonitor.release(eventHandle, success);
+    }
+
+    public void shutdown() {
+        this.executor.shutdownNow();
+    }
+
+    // for testing
+    public AcknowledgementSetMonitor getAcknowledgementSetMonitor() {
+        return acknowledgementSetMonitor;
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventBuilder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventBuilder.java
@@ -9,7 +9,7 @@ import org.opensearch.dataprepper.model.event.EventBuilder;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 
-class DefaultEventBuilder extends DefaultBaseEventBuilder<Event> implements EventBuilder {
+public class DefaultEventBuilder extends DefaultBaseEventBuilder<Event> implements EventBuilder {
 
     static final String EVENT_TYPE = "EVENT";
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventHandle.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventHandle.java
@@ -6,6 +6,16 @@
 package org.opensearch.dataprepper.event;
 
 import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import java.lang.ref.WeakReference;
 
-class DefaultEventHandle implements EventHandle {
+public class DefaultEventHandle implements EventHandle {
+    private final WeakReference<AcknowledgementSet> acknowledgementSetRef;
+    public DefaultEventHandle(AcknowledgementSet acknowledgementSet) {
+        this.acknowledgementSetRef = new WeakReference<>(acknowledgementSet);
+    }
+
+    public AcknowledgementSet getAcknowledgementSet() {
+        return acknowledgementSetRef.get();
+    }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/AcknowledgementSetMonitorTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/AcknowledgementSetMonitorTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.opensearch.dataprepper.event.DefaultEventHandle;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doAnswer;
+import static org.hamcrest.Matchers.equalTo;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class AcknowledgementSetMonitorTests {
+    private static final int DEFAULT_WAIT_TIME_MS = 2000;
+    @Mock
+    DefaultAcknowledgementSet acknowledgementSet1;
+    @Mock
+    DefaultAcknowledgementSet acknowledgementSet2;
+    @Mock
+    DefaultEventHandle eventHandle1;
+
+    private AcknowledgementSetMonitor acknowledgementSetMonitor;
+
+    AcknowledgementSetMonitor createObjectUnderTest() {
+        return new AcknowledgementSetMonitor();
+    }
+
+    @BeforeEach
+    void setup() {
+        acknowledgementSet1 = mock(DefaultAcknowledgementSet.class);
+        eventHandle1 = mock(DefaultEventHandle.class);
+        when(acknowledgementSet1.isDone()).thenReturn(true);
+        acknowledgementSetMonitor = createObjectUnderTest();
+    }
+
+    @Test
+    public void testBasic() {
+        acknowledgementSetMonitor.add(acknowledgementSet1);
+        Thread shutdownThread = new Thread(() -> {
+            try {
+                Thread.sleep(DEFAULT_WAIT_TIME_MS);
+            } catch (Exception e){}
+        });
+        shutdownThread.start();
+        acknowledgementSetMonitor.run();
+        assertThat(acknowledgementSetMonitor.getSize(), equalTo(0));
+    }
+
+    @Test
+    public void testMultipleAcknowledgementSets() {
+        acknowledgementSet2 = mock(DefaultAcknowledgementSet.class);
+        when(acknowledgementSet2.isDone()).thenReturn(false);
+
+        acknowledgementSetMonitor.add(acknowledgementSet1);
+        acknowledgementSetMonitor.add(acknowledgementSet2);
+        Thread shutdownThread = new Thread(() -> {
+            try {
+                Thread.sleep(DEFAULT_WAIT_TIME_MS);
+            } catch (Exception e){}
+        });
+        shutdownThread.start();
+        acknowledgementSetMonitor.run();
+        assertThat(acknowledgementSetMonitor.getSize(), equalTo(1));
+    }
+
+    @Test
+    public void testAcknowledgementSetAcquireRelease() {
+        when(eventHandle1.getAcknowledgementSet()).thenReturn(acknowledgementSet1);
+        try {
+            doAnswer((i) -> {return null; }).when(acknowledgementSet1).acquire(eventHandle1);
+        } catch (Exception e){}
+        acknowledgementSetMonitor.add(acknowledgementSet1);
+        acknowledgementSetMonitor.acquire(eventHandle1);
+        acknowledgementSetMonitor.release(eventHandle1, true);
+        Thread shutdownThread = new Thread(() -> {
+            try {
+                Thread.sleep(DEFAULT_WAIT_TIME_MS);
+            } catch (Exception e){}
+        });
+        shutdownThread.start();
+        acknowledgementSetMonitor.run();
+        assertThat(acknowledgementSetMonitor.getSize(), equalTo(0));
+    }
+
+    @Test
+    public void testAcknowledgementSetInvalidAcquire() {
+        acknowledgementSet2 = mock(DefaultAcknowledgementSet.class);
+        when(eventHandle1.getAcknowledgementSet()).thenReturn(acknowledgementSet2);
+        acknowledgementSetMonitor.add(acknowledgementSet1);
+        acknowledgementSetMonitor.acquire(eventHandle1);
+        Thread shutdownThread = new Thread(() -> {
+            try {
+                Thread.sleep(DEFAULT_WAIT_TIME_MS);
+            } catch (Exception e){}
+        });
+        shutdownThread.start();
+        acknowledgementSetMonitor.run();
+        assertThat(acknowledgementSetMonitor.getSize(), equalTo(0));
+        assertThat(acknowledgementSetMonitor.getNumInvalidAcquires(), equalTo(1));
+    }
+
+    @Test
+    public void testAcknowledgementSetInvalidRelease() {
+        acknowledgementSet2 = mock(DefaultAcknowledgementSet.class);
+        when(eventHandle1.getAcknowledgementSet()).thenReturn(acknowledgementSet2);
+        acknowledgementSetMonitor.add(acknowledgementSet1);
+        acknowledgementSetMonitor.release(eventHandle1, true);
+        Thread shutdownThread = new Thread(() -> {
+            try {
+                Thread.sleep(DEFAULT_WAIT_TIME_MS);
+            } catch (Exception e){}
+        });
+        shutdownThread.start();
+        acknowledgementSetMonitor.run();
+        assertThat(acknowledgementSetMonitor.getSize(), equalTo(0));
+        assertThat(acknowledgementSetMonitor.getNumInvalidReleases(), equalTo(1));
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetManagerTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetManagerTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.event.DefaultEventBuilder;
+import org.opensearch.dataprepper.event.DefaultEventFactory;
+
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import java.util.Map;
+import java.util.Collections;
+import java.time.Duration;
+import org.apache.commons.lang3.RandomStringUtils;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultAcknowledgementSetManagerTests {
+    private static final Duration TEST_TIMEOUT_MS = Duration.ofMillis(1000);
+    DefaultAcknowledgementSetManager acknowledgementSetManager;
+
+    JacksonEvent event1;
+    JacksonEvent event2;
+    JacksonEvent event3;
+    EventHandle eventHandle1;
+    EventHandle eventHandle2;
+    EventHandle eventHandle3;
+    Boolean result;
+
+    @BeforeEach
+    void setup() {
+        DefaultEventFactory eventFactory = new DefaultEventFactory();
+        String testKey = RandomStringUtils.randomAlphabetic(5);
+        String testValue = RandomStringUtils.randomAlphabetic(10);
+        Map<String, Object> data = Map.of(testKey, testValue);
+        Map<String, Object> attributes = Collections.emptyMap();
+        final DefaultEventBuilder eventBuilder = (DefaultEventBuilder) eventFactory.eventBuilder(DefaultEventBuilder.class).withEventMetadataAttributes(attributes).withData(data);
+        event1 = (JacksonEvent) eventBuilder.build();
+        event2 = (JacksonEvent) eventBuilder.build();
+        event3 = (JacksonEvent) eventBuilder.build();
+        acknowledgementSetManager = createObjectUnderTest();
+        AcknowledgementSet acknowledgementSet1 = acknowledgementSetManager.create((flag) -> { result = flag; }, TEST_TIMEOUT_MS);
+        acknowledgementSet1.add(event1);
+        acknowledgementSet1.add(event2);
+        eventHandle1 = event1.getEventHandle();
+        eventHandle2 = event2.getEventHandle();
+    }
+
+    DefaultAcknowledgementSetManager createObjectUnderTest() {
+        return new DefaultAcknowledgementSetManager(Duration.ofMillis(TEST_TIMEOUT_MS.toMillis() * 2));
+    }
+
+    @Test
+    void testBasic() {
+        acknowledgementSetManager.releaseEventReference(eventHandle2, true);
+        acknowledgementSetManager.releaseEventReference(eventHandle1, true);
+        try {
+            Thread.sleep(TEST_TIMEOUT_MS.toMillis() * 5);
+        } catch (Exception e){}
+        assertThat(acknowledgementSetManager.getAcknowledgementSetMonitor().getSize(), equalTo(0));
+        assertThat(result, equalTo(true));
+    }
+
+    @Test
+    void testExpirations() {
+        acknowledgementSetManager.releaseEventReference(eventHandle2, true);
+        try {
+            Thread.sleep(TEST_TIMEOUT_MS.toMillis() * 5);
+        } catch (Exception e){}
+        assertThat(acknowledgementSetManager.getAcknowledgementSetMonitor().getSize(), equalTo(0));
+        assertThat(result, equalTo(null));
+    }
+
+    @Test
+    void testMultipleAcknowledgementSets() {
+        AcknowledgementSet acknowledgementSet2 = acknowledgementSetManager.create((flag) -> { result = flag; }, TEST_TIMEOUT_MS);
+        acknowledgementSet2.add(event3);
+        eventHandle3 = event3.getEventHandle();
+
+        acknowledgementSetManager.releaseEventReference(eventHandle2, true);
+        acknowledgementSetManager.releaseEventReference(eventHandle3, true);
+        try {
+            Thread.sleep(TEST_TIMEOUT_MS.toMillis() * 5);
+        } catch (Exception e){}
+        assertThat(acknowledgementSetManager.getAcknowledgementSetMonitor().getSize(), equalTo(0));
+        assertThat(result, equalTo(true));
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetTests.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.event.DefaultEventBuilder;
+import org.opensearch.dataprepper.event.DefaultEventFactory;
+import org.opensearch.dataprepper.event.DefaultEventHandle;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.apache.commons.lang3.RandomStringUtils;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+
+import java.util.Map;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.time.Duration;
+
+class DefaultAcknowledgementSetTests {
+    private static final int MAX_THREADS = 3;
+    private DefaultAcknowledgementSet defaultAcknowledgementSet;
+    private JacksonEvent event;
+    private ScheduledExecutorService executor;
+    private Boolean acknowledgementSetResult;
+    private final Duration TEST_TIMEOUT = Duration.ofMillis(5000);
+    private AtomicBoolean callbackInterrupted;
+    
+    private DefaultAcknowledgementSet createObjectUnderTest() {
+        return new DefaultAcknowledgementSet(executor, (flag) ->
+                {}, TEST_TIMEOUT);
+    }
+
+    private DefaultAcknowledgementSet createObjectUnderTestWithCallback(Consumer<Boolean> callback) {
+        return new DefaultAcknowledgementSet(executor, callback, TEST_TIMEOUT);
+    }
+
+    @BeforeEach
+    void setupEvent() {
+        executor = Executors.newScheduledThreadPool(MAX_THREADS);
+        DefaultEventFactory eventFactory = new DefaultEventFactory();
+        String testKey = RandomStringUtils.randomAlphabetic(5);
+        String testValue = RandomStringUtils.randomAlphabetic(10);
+        Map<String, Object> data = Map.of(testKey, testValue);
+        Map<String, Object> attributes = Collections.emptyMap();
+        final DefaultEventBuilder eventBuilder = (DefaultEventBuilder) eventFactory.eventBuilder(DefaultEventBuilder.class).withEventMetadataAttributes(attributes).withData(data);
+        event = (JacksonEvent) eventBuilder.build();
+        acknowledgementSetResult = null;
+        defaultAcknowledgementSet = createObjectUnderTest();
+        callbackInterrupted = new AtomicBoolean(false);
+    }
+
+    @Test
+    void testDefaultAcknowledgementSetBasic() throws Exception {
+        defaultAcknowledgementSet.add(event);
+        DefaultEventHandle handle = (DefaultEventHandle) event.getEventHandle();
+        assertThat(handle, not(equalTo(null)));
+        assertThat(handle.getAcknowledgementSet(), equalTo(defaultAcknowledgementSet));
+        assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(true));
+    }
+
+    @Test
+    void testDefaultAcknowledgementSetMultipleAcquireAndRelease() throws Exception {
+        defaultAcknowledgementSet.add(event);
+        DefaultEventHandle handle = (DefaultEventHandle) event.getEventHandle();
+        assertThat(handle, not(equalTo(null)));
+        assertThat(handle.getAcknowledgementSet(), equalTo(defaultAcknowledgementSet));
+        defaultAcknowledgementSet.acquire(handle);
+        assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(false));
+        defaultAcknowledgementSet.acquire(handle);
+        defaultAcknowledgementSet.acquire(handle);
+        assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(false));
+        assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(false));
+        assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(true));
+    }
+
+    @Test
+    void testDefaultAcknowledgementInvalidAcquire() {
+        defaultAcknowledgementSet.add(event);
+        DefaultAcknowledgementSet secondAcknowledgementSet = createObjectUnderTest();
+        DefaultEventHandle handle = new DefaultEventHandle(secondAcknowledgementSet);
+        defaultAcknowledgementSet.acquire(handle);
+        assertThat(defaultAcknowledgementSet.getNumInvalidAcquires(), equalTo(1));
+    }
+
+    @Test
+    void testDefaultAcknowledgementInvalidRelease() {
+        defaultAcknowledgementSet.add(event);
+        DefaultAcknowledgementSet secondAcknowledgementSet = createObjectUnderTest();
+        DefaultEventHandle handle = new DefaultEventHandle(secondAcknowledgementSet);
+        assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(false));
+        assertThat(defaultAcknowledgementSet.getNumInvalidReleases(), equalTo(1));
+    }
+
+    @Test
+    void testDefaultAcknowledgementDuplicateReleaseError() throws Exception {
+        defaultAcknowledgementSet.add(event);
+        DefaultEventHandle handle = (DefaultEventHandle) event.getEventHandle();
+        assertThat(handle, not(equalTo(null)));
+        assertThat(handle.getAcknowledgementSet(), equalTo(defaultAcknowledgementSet));
+        assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(true));
+        assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(false));
+        assertThat(defaultAcknowledgementSet.getNumInvalidReleases(), equalTo(1));
+    }
+
+    @Test
+    void testDefaultAcknowledgementSetWithCustomCallback() throws Exception {
+        defaultAcknowledgementSet = createObjectUnderTestWithCallback(
+            (flag) -> {
+                acknowledgementSetResult = flag;
+            }        
+        );
+        defaultAcknowledgementSet.add(event);
+        DefaultEventHandle handle = (DefaultEventHandle) event.getEventHandle();
+        assertThat(handle, not(equalTo(null)));
+        assertThat(handle.getAcknowledgementSet(), equalTo(defaultAcknowledgementSet));
+        assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(true));
+
+        while (!defaultAcknowledgementSet.isDone()) {
+            Thread.sleep(1000);
+        }
+        assertThat(acknowledgementSetResult, equalTo(true));
+    }
+
+    @Test
+    void testDefaultAcknowledgementSetNegativeAcknowledgements() throws Exception {
+        defaultAcknowledgementSet = createObjectUnderTestWithCallback(
+            (flag) -> {
+                acknowledgementSetResult = flag;
+            }        
+        );
+        defaultAcknowledgementSet.add(event);
+        DefaultEventHandle handle = (DefaultEventHandle) event.getEventHandle();
+        assertThat(handle, not(equalTo(null)));
+        assertThat(handle.getAcknowledgementSet(), equalTo(defaultAcknowledgementSet));
+        defaultAcknowledgementSet.acquire(handle);
+        assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(false));
+        defaultAcknowledgementSet.acquire(handle);
+        defaultAcknowledgementSet.acquire(handle);
+        assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(false));
+        assertThat(defaultAcknowledgementSet.release(handle, false), equalTo(false));
+        assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(true));
+        while (!defaultAcknowledgementSet.isDone()) {
+            Thread.sleep(1000);
+        }
+        assertThat(acknowledgementSetResult, equalTo(false));
+    }
+
+    @Test
+    void testDefaultAcknowledgementSetExpirations() throws Exception {
+        defaultAcknowledgementSet = createObjectUnderTestWithCallback(
+            (flag) -> {
+                try {
+                    Thread.sleep(3 * TEST_TIMEOUT.toMillis());
+                    acknowledgementSetResult = flag;
+                } catch (Exception e) {
+                    callbackInterrupted.set(true);
+                }
+            }        
+        );
+        defaultAcknowledgementSet.add(event);
+        DefaultEventHandle handle = (DefaultEventHandle) event.getEventHandle();
+        assertThat(handle, not(equalTo(null)));
+        assertThat(handle.getAcknowledgementSet(), equalTo(defaultAcknowledgementSet));
+        assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(true));
+        while (!defaultAcknowledgementSet.isDone()) {
+            Thread.sleep(1000);
+        }
+        assertThat(acknowledgementSetResult, equalTo(null));
+        final int MAX_TRIES = 10;
+        int numTries = 0;
+        // Try few times
+        while (numTries++ < MAX_TRIES && !callbackInterrupted.get()) {
+            try {
+                Thread.sleep(1000);
+            } catch (Exception e){}
+        }
+        assertThat(callbackInterrupted.get(), equalTo(true));
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultEventHandleTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultEventHandleTests.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.event;
+
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import org.junit.jupiter.api.Test;
+
+class DefaultEventHandleTests {
+    AcknowledgementSet acknowledgementSet;
+
+    @Test
+    void testBasic() {
+        DefaultEventHandle eventHandle = new DefaultEventHandle(acknowledgementSet);
+        assertThat(eventHandle.getAcknowledgementSet(), equalTo(acknowledgementSet));
+    }
+}


### PR DESCRIPTION
### Description
Add acknowledgment framework.
This change includes -
    1. AcknowledgementSetManager, an instance of which is created to be used by all components of DataPrepper
    2. It is used to create an acknowledgement set by a source plugin
    3. The source then adds a batch of events to the acknowledgement set and expects the callback provided to be invoked when all the events in the batch are acknowledged
    4. The AcknowledgementSetManager creates a AcknowledgementSetMonitor thread which monitors all acknowledgement sets for completion (happens when all events in an acknowledgement set acknowledge their completion) or expiration (when at least one of the events in an acknowledgement set does not acknowledge their completion before the expected expiration time or if the callback has not completed by the expected expiration time)
    5. Acknowledgement set allows events to be added, acquired (reference count increase) or released (reference count decrease and eventual removal when the reference count becomes 0)
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
