### PR TITLE
updating opensearch sink constructor to support loading dlq plugins

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -5,11 +5,13 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;
 
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.AbstractSink;
 import org.opensearch.dataprepper.model.sink.Sink;
@@ -82,7 +84,8 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
   private ObjectMapper objectMapper;
   private volatile boolean initialized;
 
-  public OpenSearchSink(final PluginSetting pluginSetting) {
+  @DataPrepperPluginConstructor
+  public OpenSearchSink(final PluginSetting pluginSetting, final PluginFactory pluginFactory) {
     super(pluginSetting);
     bulkRequestTimer = pluginMetrics.timer(BULKREQUEST_LATENCY);
     bulkRequestErrorsCounter = pluginMetrics.counter(BULKREQUEST_ERRORS);
@@ -98,6 +101,11 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     this.indexManagerFactory = new IndexManagerFactory(new ClusterSettingsParser());
     this.initialized = false;
     this.lock = new ReentrantLock(true);
+    // todo: enable dlq loading.
+//    final Optional<PluginModel> dlqConfig = openSearchSinkConfig.getRetryConfiguration().getDlq();
+//    if (dlqConfig.isPresent()) {
+//      // load dlq with pluginFactory
+//    }
   }
 
   @Override

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfiguration.java
@@ -11,9 +11,7 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfigurati
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class OpenSearchSinkConfiguration {
-  /**
-   * TODO: add retryConfiguration
-   */
+
   private final ConnectionConfiguration connectionConfiguration;
   private final IndexConfiguration indexConfiguration;
   private final RetryConfiguration retryConfiguration;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/RetryConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/RetryConfiguration.java
@@ -5,19 +5,28 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;
 
+import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
+
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class RetryConfiguration {
   public static final String DLQ_FILE = "dlq_file";
   public static final String MAX_RETRIES = "max_retries";
+  public static final String DLQ = "dlq";
 
   private final String dlqFile;
   private final int maxRetries;
+  private final PluginModel dlq;
 
   public String getDlqFile() {
     return dlqFile;
+  }
+
+  public Optional<PluginModel> getDlq() {
+    return Optional.ofNullable(dlq);
   }
 
   public int getMaxRetries() {
@@ -31,6 +40,8 @@ public class RetryConfiguration {
     private String dlqFile;
     private int maxRetries = Integer.MAX_VALUE;
 
+    private PluginModel dlq;
+
     public Builder withDlqFile(final String dlqFile) {
       checkNotNull(dlqFile, "dlqFile cannot be null.");
       this.dlqFile = dlqFile;
@@ -42,6 +53,12 @@ public class RetryConfiguration {
       this.maxRetries = maxRetries;
       return this;
     }
+
+    public Builder withDlq(final PluginModel dlq) {
+      checkNotNull(dlq, "dlq cannot be null");
+      this.dlq = dlq;
+      return this;
+    }
     public RetryConfiguration build() {
       return new RetryConfiguration(this);
     }
@@ -50,6 +67,7 @@ public class RetryConfiguration {
   private RetryConfiguration(final Builder builder) {
     this.dlqFile = builder.dlqFile;
     this.maxRetries = builder.maxRetries;
+    this.dlq = builder.dlq;
   }
 
   public static RetryConfiguration readRetryConfig(final PluginSetting pluginSetting) {
@@ -61,6 +79,14 @@ public class RetryConfiguration {
     final Integer maxRetries = (Integer) pluginSetting.getAttributeFromSettings(MAX_RETRIES);
     if (maxRetries != null) {
       builder = builder.withMaxRetries(maxRetries);
+    }
+    final PluginModel dlq = (PluginModel) pluginSetting.getAttributeFromSettings(DLQ);
+    if (dlq != null) {
+      if (dlqFile != null) {
+        final String dlqOptionConflictMessage = String.format("%s option cannot be used along with %s option", DLQ_FILE, DLQ);
+        throw new RuntimeException(dlqOptionConflictMessage);
+      }
+      builder = builder.withDlq(dlq);
     }
     return builder.build();
   }


### PR DESCRIPTION
### Description
Adds support for providing a plugin loader to OpenSearch sink. This will be used once #2392 is merged.
 
### Issues Resolved
part of #2298
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
