### PR TITLE
Count SQS message delete failures in the S3 source

### DIFF
--- a/data-prepper-plugins/s3-source/README.md
+++ b/data-prepper-plugins/s3-source/README.md
@@ -123,6 +123,7 @@ The AWS configuration is the same for both SQS and S3.
 * `sqsMessagesReceived` - The number of SQS messages received from the queue by the S3 Source.
 * `sqsMessagesDeleted` - The number of SQS messages deleted from the queue by the S3 Source.
 * `sqsMessagesFailed` - The number of SQS messages that the S3 Source failed to parse.
+* `sqsMessagesDeleteFailed` - The number of SQS messages that the S3 Source failed to delete from the SQS queue.
 
 
 ### Timers

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorker.java
@@ -51,7 +51,7 @@ class S3ObjectWorker implements S3ObjectHandler {
         this.bufferTimeout = s3ObjectRequest.getBufferTimeout();
         this.numberOfRecordsToAccumulate = s3ObjectRequest.getNumberOfRecordsToAccumulate();
         this.eventConsumer = s3ObjectRequest.getEventConsumer();
-        this.s3Client=s3ObjectRequest.getS3Client();
+        this.s3Client = s3ObjectRequest.getS3Client();
         this.s3ObjectPluginMetrics = s3ObjectRequest.getS3ObjectPluginMetrics();
     }
 
@@ -64,24 +64,26 @@ class S3ObjectWorker implements S3ObjectHandler {
                 .build();
 
         final BufferAccumulator<Record<Event>> bufferAccumulator = BufferAccumulator.create(buffer, numberOfRecordsToAccumulate, bufferTimeout);
-            try {
+        try {
             s3ObjectPluginMetrics.getS3ObjectReadTimer().recordCallable((Callable<Void>) () -> {
-                        doParseObject(s3ObjectReference, getObjectRequest, bufferAccumulator);
-                        return null;
-                    });
-                } catch (final IOException | RuntimeException e) {
-                    throw e;
-                } catch (final Exception e) {
-                    // doParseObject does not throw Exception, only IOException or RuntimeException. But, Callable has Exception as a checked
-                    // exception on the interface. This catch block thus should not be reached, but, in case it is, wrap it.
-                    throw new RuntimeException(e);
-                }
+                doParseObject(s3ObjectReference, getObjectRequest, bufferAccumulator);
+                return null;
+            });
+        } catch (final IOException | RuntimeException e) {
+            throw e;
+        } catch (final Exception e) {
+            // doParseObject does not throw Exception, only IOException or RuntimeException. But, Callable has Exception as a checked
+            // exception on the interface. This catch block thus should not be reached, but, in case it is, wrap it.
+            throw new RuntimeException(e);
+        }
         s3ObjectPluginMetrics.getS3ObjectsSucceededCounter().increment();
     }
 
     private void doParseObject(final S3ObjectReference s3ObjectReference, final GetObjectRequest getObjectRequest, final BufferAccumulator<Record<Event>> bufferAccumulator) throws IOException {
         final long s3ObjectSize;
         final long totalBytesRead;
+
+        LOG.info("Read S3 object: {}", s3ObjectReference);
 
         try (final ResponseInputStream<GetObjectResponse> responseInputStream = s3Client.getObject(getObjectRequest);
              final CountingInputStream inputStream = new CountingInputStream(compressionEngine.createInputStream(getObjectRequest.key(), responseInputStream))) {
@@ -98,7 +100,7 @@ class S3ObjectWorker implements S3ObjectHandler {
         } catch (final Exception ex) {
             LOG.error("Error reading from S3 object: s3ObjectReference={}.", s3ObjectReference, ex);
             s3ObjectPluginMetrics.getS3ObjectsFailedCounter().increment();
-            if(ex instanceof S3Exception) {
+            if (ex instanceof S3Exception) {
                 recordS3Exception((S3Exception) ex);
             }
             throw ex;
@@ -116,10 +118,9 @@ class S3ObjectWorker implements S3ObjectHandler {
     }
 
     private void recordS3Exception(final S3Exception ex) {
-        if(ex.statusCode() == HttpStatusCode.NOT_FOUND) {
+        if (ex.statusCode() == HttpStatusCode.NOT_FOUND) {
             s3ObjectPluginMetrics.getS3ObjectsFailedNotFoundCounter().increment();
-        }
-        else if(ex.statusCode() == HttpStatusCode.FORBIDDEN) {
+        } else if (ex.statusCode() == HttpStatusCode.FORBIDDEN) {
             s3ObjectPluginMetrics.getS3ObjectsFailedAccessDeniedCounter().increment();
         }
     }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/SqsWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/SqsWorkerTest.java
@@ -6,6 +6,15 @@
 package org.opensearch.dataprepper.plugins.source;
 
 import com.linecorp.armeria.client.retry.Backoff;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.plugins.source.configuration.AwsAuthenticationOptions;
 import org.opensearch.dataprepper.plugins.source.configuration.OnErrorOption;
@@ -13,16 +22,9 @@ import org.opensearch.dataprepper.plugins.source.configuration.SqsOptions;
 import org.opensearch.dataprepper.plugins.source.exception.SqsRetriesExhaustedException;
 import org.opensearch.dataprepper.plugins.source.filter.ObjectCreatedFilter;
 import org.opensearch.dataprepper.plugins.source.filter.S3EventFilter;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Timer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.BatchResultErrorEntry;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResponse;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResultEntry;
@@ -37,20 +39,19 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.opensearch.dataprepper.plugins.source.SqsWorker.SQS_MESSAGES_DELETED_METRIC_NAME;
-import static org.opensearch.dataprepper.plugins.source.SqsWorker.SQS_MESSAGES_FAILED_METRIC_NAME;
-import static org.opensearch.dataprepper.plugins.source.SqsWorker.SQS_MESSAGES_RECEIVED_METRIC_NAME;
-import static org.opensearch.dataprepper.plugins.source.SqsWorker.SQS_MESSAGE_DELAY_METRIC_NAME;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -58,6 +59,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.SqsWorker.SQS_MESSAGES_DELETED_METRIC_NAME;
+import static org.opensearch.dataprepper.plugins.source.SqsWorker.SQS_MESSAGES_DELETE_FAILED_METRIC_NAME;
+import static org.opensearch.dataprepper.plugins.source.SqsWorker.SQS_MESSAGES_FAILED_METRIC_NAME;
+import static org.opensearch.dataprepper.plugins.source.SqsWorker.SQS_MESSAGES_RECEIVED_METRIC_NAME;
+import static org.opensearch.dataprepper.plugins.source.SqsWorker.SQS_MESSAGE_DELAY_METRIC_NAME;
 
 class SqsWorkerTest {
     private SqsWorker sqsWorker;
@@ -70,6 +76,7 @@ class SqsWorkerTest {
     private Counter sqsMessagesReceivedCounter;
     private Counter sqsMessagesDeletedCounter;
     private Counter sqsMessagesFailedCounter;
+    private Counter sqsMessagesDeleteFailedCounter;
     private Timer sqsMessageDelayTimer;
 
     @BeforeEach
@@ -90,19 +97,16 @@ class SqsWorkerTest {
         when(s3SourceConfig.getSqsOptions()).thenReturn(sqsOptions);
         when(s3SourceConfig.getOnErrorOption()).thenReturn(OnErrorOption.RETAIN_MESSAGES);
 
-        final DeleteMessageBatchResponse deleteMessageBatchResponse = mock(DeleteMessageBatchResponse.class);
-        when(deleteMessageBatchResponse.hasSuccessful()).thenReturn(true);
-        when(deleteMessageBatchResponse.successful()).thenReturn(Collections.singletonList(mock(DeleteMessageBatchResultEntry.class)));
-        when(sqsClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenReturn(deleteMessageBatchResponse);
-
         pluginMetrics = mock(PluginMetrics.class);
         sqsMessagesReceivedCounter = mock(Counter.class);
         sqsMessagesDeletedCounter = mock(Counter.class);
         sqsMessagesFailedCounter = mock(Counter.class);
+        sqsMessagesDeleteFailedCounter = mock(Counter.class);
         sqsMessageDelayTimer = mock(Timer.class);
         when(pluginMetrics.counter(SQS_MESSAGES_RECEIVED_METRIC_NAME)).thenReturn(sqsMessagesReceivedCounter);
         when(pluginMetrics.counter(SQS_MESSAGES_DELETED_METRIC_NAME)).thenReturn(sqsMessagesDeletedCounter);
         when(pluginMetrics.counter(SQS_MESSAGES_FAILED_METRIC_NAME)).thenReturn(sqsMessagesFailedCounter);
+        when(pluginMetrics.counter(SQS_MESSAGES_DELETE_FAILED_METRIC_NAME)).thenReturn(sqsMessagesDeleteFailedCounter);
         when(pluginMetrics.timer(SQS_MESSAGE_DELAY_METRIC_NAME)).thenReturn(sqsMessageDelayTimer);
 
         sqsWorker = new SqsWorker(sqsClient, s3Service, s3SourceConfig, pluginMetrics, backoff);
@@ -116,68 +120,244 @@ class SqsWorkerTest {
         verifyNoMoreInteractions(sqsMessageDelayTimer);
     }
 
+    @Nested
+    class WithSuccessfulDeletion {
+        @BeforeEach
+        void setUp() {
+            final DeleteMessageBatchResponse deleteMessageBatchResponse = mock(DeleteMessageBatchResponse.class);
+            when(deleteMessageBatchResponse.hasSuccessful()).thenReturn(true);
+            when(deleteMessageBatchResponse.successful()).thenReturn(Collections.singletonList(mock(DeleteMessageBatchResultEntry.class)));
+            when(sqsClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenReturn(deleteMessageBatchResponse);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"ObjectCreated:Put", "ObjectCreated:Post", "ObjectCreated:Copy", "ObjectCreated:CompleteMultipartUpload"})
+        void processSqsMessages_should_return_number_of_messages_processed(final String eventName) {
+            Instant startTime = Instant.now().minus(1, ChronoUnit.HOURS);
+            final Message message = mock(Message.class);
+            when(message.body()).thenReturn(createEventNotification(eventName, startTime));
+            final String testReceiptHandle = UUID.randomUUID().toString();
+            when(message.messageId()).thenReturn(testReceiptHandle);
+            when(message.receiptHandle()).thenReturn(testReceiptHandle);
+
+            final ReceiveMessageResponse receiveMessageResponse = mock(ReceiveMessageResponse.class);
+            when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResponse);
+            when(receiveMessageResponse.messages()).thenReturn(Collections.singletonList(message));
+
+            final int messagesProcessed = sqsWorker.processSqsMessages();
+            final ArgumentCaptor<DeleteMessageBatchRequest> deleteMessageBatchRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteMessageBatchRequest.class);
+            verify(sqsClient).deleteMessageBatch(deleteMessageBatchRequestArgumentCaptor.capture());
+            final DeleteMessageBatchRequest actualDeleteMessageBatchRequest = deleteMessageBatchRequestArgumentCaptor.getValue();
+
+            final ArgumentCaptor<Duration> durationArgumentCaptor = ArgumentCaptor.forClass(Duration.class);
+            verify(sqsMessageDelayTimer).record(durationArgumentCaptor.capture());
+            Duration actualDelay = durationArgumentCaptor.getValue();
+
+            assertThat(actualDeleteMessageBatchRequest, notNullValue());
+            assertThat(actualDeleteMessageBatchRequest.entries().size(), equalTo(1));
+            assertThat(actualDeleteMessageBatchRequest.queueUrl(), equalTo(s3SourceConfig.getSqsOptions().getSqsUrl()));
+            assertThat(actualDeleteMessageBatchRequest.entries().get(0).id(), equalTo(message.messageId()));
+            assertThat(actualDeleteMessageBatchRequest.entries().get(0).receiptHandle(), equalTo(message.receiptHandle()));
+            assertThat(messagesProcessed, equalTo(1));
+            verify(s3Service).addS3Object(any(S3ObjectReference.class));
+            verify(sqsClient).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
+            verify(sqsMessagesReceivedCounter).increment(1);
+            verify(sqsMessagesDeletedCounter).increment(1);
+            assertThat(actualDelay, lessThanOrEqualTo(Duration.ofHours(1).plus(Duration.ofSeconds(5))));
+            assertThat(actualDelay, greaterThanOrEqualTo(Duration.ofHours(1).minus(Duration.ofSeconds(5))));
+        }
+
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "{\"foo\": \"bar\""})
+        void processSqsMessages_should_not_interact_with_S3Service_if_input_is_not_valid_JSON(String inputString) {
+            final Message message = mock(Message.class);
+            when(message.body()).thenReturn(inputString);
+
+            final ReceiveMessageResponse receiveMessageResponse = mock(ReceiveMessageResponse.class);
+            when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResponse);
+            when(receiveMessageResponse.messages()).thenReturn(Collections.singletonList(message));
+
+            final int messagesProcessed = sqsWorker.processSqsMessages();
+            assertThat(messagesProcessed, equalTo(1));
+            verifyNoInteractions(s3Service);
+            verify(sqsClient, never()).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
+            verify(sqsMessagesReceivedCounter).increment(1);
+            verify(sqsMessagesFailedCounter).increment();
+        }
+
+        @Test
+        void processSqsMessages_should_not_interact_with_S3Service_and_delete_message_if_TestEvent() {
+            final String messageId = UUID.randomUUID().toString();
+            final String receiptHandle = UUID.randomUUID().toString();
+            final Message message = mock(Message.class);
+            when(message.body()).thenReturn("{\"Service\":\"Amazon S3\",\"Event\":\"s3:TestEvent\",\"Time\":\"2022-10-15T16:36:25.510Z\"," +
+                    "\"Bucket\":\"bucketname\",\"RequestId\":\"abcdefg\",\"HostId\":\"hijklm\"}");
+            when(message.messageId()).thenReturn(messageId);
+            when(message.receiptHandle()).thenReturn(receiptHandle);
+
+            final ReceiveMessageResponse receiveMessageResponse = mock(ReceiveMessageResponse.class);
+            when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResponse);
+            when(receiveMessageResponse.messages()).thenReturn(Collections.singletonList(message));
+
+            final int messagesProcessed = sqsWorker.processSqsMessages();
+            assertThat(messagesProcessed, equalTo(1));
+            verifyNoInteractions(s3Service);
+
+            final ArgumentCaptor<DeleteMessageBatchRequest> deleteMessageBatchRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteMessageBatchRequest.class);
+            verify(sqsClient).deleteMessageBatch(deleteMessageBatchRequestArgumentCaptor.capture());
+            final DeleteMessageBatchRequest actualDeleteMessageBatchRequest = deleteMessageBatchRequestArgumentCaptor.getValue();
+
+            assertThat(actualDeleteMessageBatchRequest, notNullValue());
+            assertThat(actualDeleteMessageBatchRequest.entries().size(), equalTo(1));
+            assertThat(actualDeleteMessageBatchRequest.queueUrl(), equalTo(s3SourceConfig.getSqsOptions().getSqsUrl()));
+            assertThat(actualDeleteMessageBatchRequest.entries().get(0).id(), equalTo(messageId));
+            assertThat(actualDeleteMessageBatchRequest.entries().get(0).receiptHandle(), equalTo(receiptHandle));
+            assertThat(messagesProcessed, equalTo(1));
+
+            verify(sqsMessagesReceivedCounter).increment(1);
+            verify(sqsMessagesDeletedCounter).increment(1);
+        }
+
+
+        @ParameterizedTest
+        @ValueSource(strings = {"ObjectRemoved:Delete", "ObjectRemoved:DeleteMarkerCreated"})
+        void processSqsMessages_with_irrelevant_eventName_should_return_number_of_messages_processed_without_s3service_interactions(String eventName) {
+            final Message message = mock(Message.class);
+            when(message.body()).thenReturn(createEventNotification(eventName, Instant.now()));
+
+            final ReceiveMessageResponse receiveMessageResponse = mock(ReceiveMessageResponse.class);
+            when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResponse);
+            when(receiveMessageResponse.messages()).thenReturn(Collections.singletonList(message));
+
+            final int messagesProcessed = sqsWorker.processSqsMessages();
+
+            assertThat(messagesProcessed, equalTo(1));
+            verifyNoInteractions(s3Service);
+            verify(sqsMessagesReceivedCounter).increment(1);
+            verify(sqsMessagesDeletedCounter).increment(1);
+        }
+
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "{\"foo\": \"bar\""})
+        void processSqsMessages_should_invoke_delete_if_input_is_not_valid_JSON_and_delete_on_error(String inputString) {
+            when(s3SourceConfig.getOnErrorOption()).thenReturn(OnErrorOption.DELETE_MESSAGES);
+            final Message message = mock(Message.class);
+            when(message.body()).thenReturn(inputString);
+
+            final String testReceiptHandle = UUID.randomUUID().toString();
+            when(message.messageId()).thenReturn(testReceiptHandle);
+            when(message.receiptHandle()).thenReturn(testReceiptHandle);
+
+            final ReceiveMessageResponse receiveMessageResponse = mock(ReceiveMessageResponse.class);
+            when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResponse);
+            when(receiveMessageResponse.messages()).thenReturn(Collections.singletonList(message));
+
+            final int messagesProcessed = sqsWorker.processSqsMessages();
+            final ArgumentCaptor<DeleteMessageBatchRequest> deleteMessageBatchRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteMessageBatchRequest.class);
+            verify(sqsClient).deleteMessageBatch(deleteMessageBatchRequestArgumentCaptor.capture());
+            final DeleteMessageBatchRequest actualDeleteMessageBatchRequest = deleteMessageBatchRequestArgumentCaptor.getValue();
+
+            assertThat(actualDeleteMessageBatchRequest, notNullValue());
+            assertThat(actualDeleteMessageBatchRequest.entries().size(), equalTo(1));
+            assertThat(actualDeleteMessageBatchRequest.queueUrl(), equalTo(s3SourceConfig.getSqsOptions().getSqsUrl()));
+            assertThat(actualDeleteMessageBatchRequest.entries().get(0).id(), equalTo(message.messageId()));
+            assertThat(actualDeleteMessageBatchRequest.entries().get(0).receiptHandle(), equalTo(message.receiptHandle()));
+            assertThat(messagesProcessed, equalTo(1));
+            verifyNoInteractions(s3Service);
+            verify(sqsClient, times(1)).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
+            verify(sqsMessagesReceivedCounter).increment(1);
+            verify(sqsMessagesDeletedCounter).increment(1);
+            verify(sqsMessagesFailedCounter).increment();
+        }
+    }
+
     @Test
-    void processSqsMessages_should_return_number_of_messages_processed() {
+    void processSqsMessages_should_report_correct_metrics_for_DeleteMessages_when_some_succeed_and_some_fail() {
         Instant startTime = Instant.now().minus(1, ChronoUnit.HOURS);
-        final Message message = mock(Message.class);
-        when(message.body()).thenReturn("{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-east-1\"," +
-                "\"eventTime\":\"" + startTime + "\",\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:AROAX:xxxxxx\"}," +
-                "\"requestParameters\":{\"sourceIPAddress\":\"99.99.999.99\"},\"responseElements\":{\"x-amz-request-id\":\"ABCD\"," +
-                "\"x-amz-id-2\":\"abcd\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"s3SourceEventNotification\"," +
-                "\"bucket\":{\"name\":\"bucketName\",\"ownerIdentity\":{\"principalId\":\"ID\"},\"arn\":\"arn:aws:s3:::bucketName\"}," +
-                "\"object\":{\"key\":\"File.gz\",\"size\":72,\"eTag\":\"abcd\",\"sequencer\":\"ABCD\"}}}]}");
-        final String testReceiptHandle = UUID.randomUUID().toString();
-        when(message.messageId()).thenReturn(testReceiptHandle);
-        when(message.receiptHandle()).thenReturn(testReceiptHandle);
+        final List<Message> messages = IntStream.range(0, 6).mapToObj(i -> {
+                    final Message message = mock(Message.class);
+                    when(message.body()).thenReturn(createPutNotification(startTime));
+                    final String testReceiptHandle = UUID.randomUUID().toString();
+                    when(message.messageId()).thenReturn(testReceiptHandle);
+                    when(message.receiptHandle()).thenReturn(testReceiptHandle);
+                    return message;
+                })
+                .collect(Collectors.toList());
 
         final ReceiveMessageResponse receiveMessageResponse = mock(ReceiveMessageResponse.class);
         when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResponse);
-        when(receiveMessageResponse.messages()).thenReturn(Collections.singletonList(message));
+        when(receiveMessageResponse.messages()).thenReturn(messages);
+
+        final List<DeleteMessageBatchResultEntry> successfulDeletes = IntStream.range(0, 3)
+                .mapToObj(i -> mock(DeleteMessageBatchResultEntry.class))
+                .collect(Collectors.toList());
+        final List<BatchResultErrorEntry> failedDeletes = IntStream.range(0, 3)
+                .mapToObj(i -> mock(BatchResultErrorEntry.class))
+                .collect(Collectors.toList());
+        final DeleteMessageBatchResponse deleteMessageBatchResponse = mock(DeleteMessageBatchResponse.class);
+        when(deleteMessageBatchResponse.hasSuccessful()).thenReturn(true);
+        when(deleteMessageBatchResponse.successful()).thenReturn(successfulDeletes);
+        when(deleteMessageBatchResponse.hasFailed()).thenReturn(true);
+        when(deleteMessageBatchResponse.failed()).thenReturn(failedDeletes);
+        when(sqsClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenReturn(deleteMessageBatchResponse);
 
         final int messagesProcessed = sqsWorker.processSqsMessages();
+
         final ArgumentCaptor<DeleteMessageBatchRequest> deleteMessageBatchRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteMessageBatchRequest.class);
         verify(sqsClient).deleteMessageBatch(deleteMessageBatchRequestArgumentCaptor.capture());
         final DeleteMessageBatchRequest actualDeleteMessageBatchRequest = deleteMessageBatchRequestArgumentCaptor.getValue();
 
-        final ArgumentCaptor<Duration> durationArgumentCaptor = ArgumentCaptor.forClass(Duration.class);
-        verify(sqsMessageDelayTimer).record(durationArgumentCaptor.capture());
-        Duration actualDelay = durationArgumentCaptor.getValue();
-
+        assertThat(messagesProcessed, equalTo(6));
         assertThat(actualDeleteMessageBatchRequest, notNullValue());
-        assertThat(actualDeleteMessageBatchRequest.entries().size(), equalTo(1));
+        assertThat(actualDeleteMessageBatchRequest.entries().size(), equalTo(6));
         assertThat(actualDeleteMessageBatchRequest.queueUrl(), equalTo(s3SourceConfig.getSqsOptions().getSqsUrl()));
-        assertThat(actualDeleteMessageBatchRequest.entries().get(0).id(), equalTo(message.messageId()));
-        assertThat(actualDeleteMessageBatchRequest.entries().get(0).receiptHandle(), equalTo(message.receiptHandle()));
-        assertThat(messagesProcessed, equalTo(1));
-        verify(s3Service).addS3Object(any(S3ObjectReference.class));
+        verify(s3Service, times(6)).addS3Object(any(S3ObjectReference.class));
         verify(sqsClient).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
-        verify(sqsMessagesReceivedCounter).increment(1);
-        verify(sqsMessagesDeletedCounter).increment(1);
-        assertThat(actualDelay, lessThanOrEqualTo(Duration.ofHours(1).plus(Duration.ofSeconds(5))));
-        assertThat(actualDelay, greaterThanOrEqualTo(Duration.ofHours(1).minus(Duration.ofSeconds(5))));
+        verify(sqsMessagesReceivedCounter).increment(6);
+        verify(sqsMessagesDeletedCounter).increment(3);
+        verify(sqsMessagesDeleteFailedCounter).increment(3);
+
+        verify(sqsMessageDelayTimer, times(6)).record(any(Duration.class));
     }
 
-
     @Test
-    void processSqsMessages_with_object_deleted_should_return_number_of_messages_processed_without_s3service_interactions() {
-        final Message message = mock(Message.class);
-        when(message.body()).thenReturn("{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-east-1\"," +
-                "\"eventTime\":\"2022-06-06T18:02:33.495Z\",\"eventName\":\"ObjectRemoved:Delete\",\"userIdentity\":{\"principalId\":\"AWS:AROAX:xxxxxx\"}," +
-                "\"requestParameters\":{\"sourceIPAddress\":\"99.99.999.99\"},\"responseElements\":{\"x-amz-request-id\":\"ABCD\"," +
-                "\"x-amz-id-2\":\"abcd\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"s3SourceEventNotification\"," +
-                "\"bucket\":{\"name\":\"bucketName\",\"ownerIdentity\":{\"principalId\":\"ID\"},\"arn\":\"arn:aws:s3:::bucketName\"}," +
-                "\"object\":{\"key\":\"File.gz\",\"size\":72,\"eTag\":\"abcd\",\"sequencer\":\"ABCD\"}}}]}");
+    void processSqsMessages_should_report_correct_metrics_for_DeleteMessages_when_request_fails() {
+        Instant startTime = Instant.now().minus(1, ChronoUnit.HOURS);
+        final List<Message> messages = IntStream.range(0, 6).mapToObj(i -> {
+                    final Message message = mock(Message.class);
+                    when(message.body()).thenReturn(createPutNotification(startTime));
+                    final String testReceiptHandle = UUID.randomUUID().toString();
+                    when(message.messageId()).thenReturn(testReceiptHandle);
+                    when(message.receiptHandle()).thenReturn(testReceiptHandle);
+                    return message;
+                })
+                .collect(Collectors.toList());
 
         final ReceiveMessageResponse receiveMessageResponse = mock(ReceiveMessageResponse.class);
         when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResponse);
-        when(receiveMessageResponse.messages()).thenReturn(Collections.singletonList(message));
+        when(receiveMessageResponse.messages()).thenReturn(messages);
+
+        when(sqsClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenThrow(SqsException.class);
 
         final int messagesProcessed = sqsWorker.processSqsMessages();
 
-        assertThat(messagesProcessed, equalTo(1));
-        verifyNoInteractions(s3Service);
-        verify(sqsMessagesReceivedCounter).increment(1);
-        verify(sqsMessagesDeletedCounter).increment(1);
+        final ArgumentCaptor<DeleteMessageBatchRequest> deleteMessageBatchRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteMessageBatchRequest.class);
+        verify(sqsClient).deleteMessageBatch(deleteMessageBatchRequestArgumentCaptor.capture());
+        final DeleteMessageBatchRequest actualDeleteMessageBatchRequest = deleteMessageBatchRequestArgumentCaptor.getValue();
+
+        assertThat(messagesProcessed, equalTo(6));
+        assertThat(actualDeleteMessageBatchRequest, notNullValue());
+        assertThat(actualDeleteMessageBatchRequest.entries().size(), equalTo(6));
+        assertThat(actualDeleteMessageBatchRequest.queueUrl(), equalTo(s3SourceConfig.getSqsOptions().getSqsUrl()));
+        verify(s3Service, times(6)).addS3Object(any(S3ObjectReference.class));
+        verify(sqsClient).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
+        verify(sqsMessagesReceivedCounter).increment(6);
+        verifyNoInteractions(sqsMessagesDeletedCounter);
+        verify(sqsMessagesDeleteFailedCounter).increment(6);
+
+        verify(sqsMessageDelayTimer, times(6)).record(any(Duration.class));
     }
 
     @Test
@@ -204,57 +384,6 @@ class SqsWorkerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"", "{\"foo\": \"bar\""})
-    void processSqsMessages_should_not_interact_with_S3Service_if_input_is_not_valid_JSON(String inputString) {
-        final Message message = mock(Message.class);
-        when(message.body()).thenReturn(inputString);
-
-        final ReceiveMessageResponse receiveMessageResponse = mock(ReceiveMessageResponse.class);
-        when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResponse);
-        when(receiveMessageResponse.messages()).thenReturn(Collections.singletonList(message));
-
-        final int messagesProcessed = sqsWorker.processSqsMessages();
-        assertThat(messagesProcessed, equalTo(1));
-        verifyNoInteractions(s3Service);
-        verify(sqsClient, never()).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
-        verify(sqsMessagesReceivedCounter).increment(1);
-        verify(sqsMessagesFailedCounter).increment();
-    }
-
-    @Test
-    void processSqsMessages_should_not_interact_with_S3Service_and_delete_message_if_TestEvent() {
-        final String messageId = UUID.randomUUID().toString();
-        final String receiptHandle = UUID.randomUUID().toString();
-        final Message message = mock(Message.class);
-        when(message.body()).thenReturn("{\"Service\":\"Amazon S3\",\"Event\":\"s3:TestEvent\",\"Time\":\"2022-10-15T16:36:25.510Z\"," +
-                "\"Bucket\":\"bucketname\",\"RequestId\":\"abcdefg\",\"HostId\":\"hijklm\"}");
-        when(message.messageId()).thenReturn(messageId);
-        when(message.receiptHandle()).thenReturn(receiptHandle);
-
-        final ReceiveMessageResponse receiveMessageResponse = mock(ReceiveMessageResponse.class);
-        when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResponse);
-        when(receiveMessageResponse.messages()).thenReturn(Collections.singletonList(message));
-
-        final int messagesProcessed = sqsWorker.processSqsMessages();
-        assertThat(messagesProcessed, equalTo(1));
-        verifyNoInteractions(s3Service);
-
-        final ArgumentCaptor<DeleteMessageBatchRequest> deleteMessageBatchRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteMessageBatchRequest.class);
-        verify(sqsClient).deleteMessageBatch(deleteMessageBatchRequestArgumentCaptor.capture());
-        final DeleteMessageBatchRequest actualDeleteMessageBatchRequest = deleteMessageBatchRequestArgumentCaptor.getValue();
-
-        assertThat(actualDeleteMessageBatchRequest, notNullValue());
-        assertThat(actualDeleteMessageBatchRequest.entries().size(), equalTo(1));
-        assertThat(actualDeleteMessageBatchRequest.queueUrl(), equalTo(s3SourceConfig.getSqsOptions().getSqsUrl()));
-        assertThat(actualDeleteMessageBatchRequest.entries().get(0).id(), equalTo(messageId));
-        assertThat(actualDeleteMessageBatchRequest.entries().get(0).receiptHandle(), equalTo(receiptHandle));
-        assertThat(messagesProcessed, equalTo(1));
-
-        verify(sqsMessagesReceivedCounter).increment(1);
-        verify(sqsMessagesDeletedCounter).increment(1);
-    }
-
-    @ParameterizedTest
     @ValueSource(strings = {"{\"foo\": \"bar\"}", "{}"})
     void processSqsMessages_should_return_zero_messages_when_messages_are_not_S3EventsNotificationRecords(String inputString) {
         final Message message = mock(Message.class);
@@ -269,39 +398,6 @@ class SqsWorkerTest {
         verifyNoInteractions(s3Service);
         verify(sqsClient, never()).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
         verify(sqsMessagesReceivedCounter).increment(1);
-        verify(sqsMessagesFailedCounter).increment();
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"", "{\"foo\": \"bar\""})
-    void processSqsMessages_should_invoke_delete_if_input_is_not_valid_JSON_and_delete_on_error(String inputString) {
-        when(s3SourceConfig.getOnErrorOption()).thenReturn(OnErrorOption.DELETE_MESSAGES);
-        final Message message = mock(Message.class);
-        when(message.body()).thenReturn(inputString);
-
-        final String testReceiptHandle = UUID.randomUUID().toString();
-        when(message.messageId()).thenReturn(testReceiptHandle);
-        when(message.receiptHandle()).thenReturn(testReceiptHandle);
-
-        final ReceiveMessageResponse receiveMessageResponse = mock(ReceiveMessageResponse.class);
-        when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResponse);
-        when(receiveMessageResponse.messages()).thenReturn(Collections.singletonList(message));
-
-        final int messagesProcessed = sqsWorker.processSqsMessages();
-        final ArgumentCaptor<DeleteMessageBatchRequest> deleteMessageBatchRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteMessageBatchRequest.class);
-        verify(sqsClient).deleteMessageBatch(deleteMessageBatchRequestArgumentCaptor.capture());
-        final DeleteMessageBatchRequest actualDeleteMessageBatchRequest = deleteMessageBatchRequestArgumentCaptor.getValue();
-
-        assertThat(actualDeleteMessageBatchRequest, notNullValue());
-        assertThat(actualDeleteMessageBatchRequest.entries().size(), equalTo(1));
-        assertThat(actualDeleteMessageBatchRequest.queueUrl(), equalTo(s3SourceConfig.getSqsOptions().getSqsUrl()));
-        assertThat(actualDeleteMessageBatchRequest.entries().get(0).id(), equalTo(message.messageId()));
-        assertThat(actualDeleteMessageBatchRequest.entries().get(0).receiptHandle(), equalTo(message.receiptHandle()));
-        assertThat(messagesProcessed, equalTo(1));
-        verifyNoInteractions(s3Service);
-        verify(sqsClient, times(1)).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
-        verify(sqsMessagesReceivedCounter).increment(1);
-        verify(sqsMessagesDeletedCounter).increment(1);
         verify(sqsMessagesFailedCounter).increment();
     }
 
@@ -329,5 +425,18 @@ class SqsWorkerTest {
         assertThat(s3ObjectReference.getKey(), equalTo("test-key"));
         verify(s3ObjectEntity).getUrlDecodedKey();
         verifyNoMoreInteractions(s3ObjectEntity);
+    }
+
+    private static String createPutNotification(final Instant startTime) {
+        return createEventNotification("ObjectCreated:Put", startTime);
+    }
+
+    private static String createEventNotification(final String eventName, final Instant startTime) {
+        return "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-east-1\"," +
+                "\"eventTime\":\"" + startTime + "\",\"eventName\":\"" + eventName + "\",\"userIdentity\":{\"principalId\":\"AWS:AROAX:xxxxxx\"}," +
+                "\"requestParameters\":{\"sourceIPAddress\":\"99.99.999.99\"},\"responseElements\":{\"x-amz-request-id\":\"ABCD\"," +
+                "\"x-amz-id-2\":\"abcd\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"s3SourceEventNotification\"," +
+                "\"bucket\":{\"name\":\"bucketName\",\"ownerIdentity\":{\"principalId\":\"ID\"},\"arn\":\"arn:aws:s3:::bucketName\"}," +
+                "\"object\":{\"key\":\"File.gz\",\"size\":72,\"eTag\":\"abcd\",\"sequencer\":\"ABCD\"}}}]}";
     }
 }


### PR DESCRIPTION
### Description

This adds a new metric for when SQS messages fail to delete - `sqsMessagesDeleteFailed`. Additionally, it also detects failed message deletes from successful API calls.

Also adds an `INFO` log when reading from S3 so that users can better observe and debug their pipeline.
 
### Issues Resolved

Resolves #2449
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
