### PR TITLE
adding data-time patterns to key-path-prefix and creating readme for S3 DLQ

### DIFF
--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/README.md
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/README.md
@@ -1,0 +1,71 @@
+# Dead Letter Queues (DLQ)
+
+DLQ Plugins which can be used to offload failed events.
+
+### Available Plugins
+
+* [S3](#S3) 
+
+## S3
+
+An S3 DLQ writer. Failed events will be stored in an S3 bucket.
+
+```
+pipeline:
+  ...
+  sink:
+    opensearch:
+      dlq:
+        s3:
+          bucket: "my-dlq-bucket"
+          key_path_prefix: "dlq-files/"
+          region: "us-west-2"
+          sts_role_arn: "arn:aws:iam::123456789012:role/dlq-role"
+```
+
+Files written to the S3 DLQ will have the following name pattern. `version` will be the version of Data Prepper. 
+`pipelineName` is associated with the pipeline name in the pipeline configuration file. `pluginId` would be the id of the
+plugin associated with the DLQ event.
+
+```
+dlq-v${version}-${pipelineName}-${pluginId}-${timestampIso8601}-${uniqueId}
+```
+Example:
+
+```
+dlq-v2-apache-log-pipeline-opensearch-2023-04-05T15:26:19.152938Z-e7eb675a-f558-4048-8566-dac15a4f8343
+```
+
+The DLQ file will JSON file with an array of failed [DLQ Objects](#DLQ-Objects).
+
+### Configurations
+
+* `bucket`: The bucket name for the DLQ failed output records.
+* `key_path_prefix` (Optional) : The key_prefix to use in the S3 bucket.  Defaults to “” . This field supports time value patterns variables like: `/%{yyyy}/%{MM}/%{dd}`. The pattern supports all the symbols that represent one hour or above and are listed in [Java DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html). For example, with a pattern like `/%{yyyy}/%{MM}/%{dd}`, the following key prefix will be used: `/2023/01/24`.
+* `region` (Optional) : The AWS region to use for credentials. Defaults to standard SDK behavior to determine the region.
+* `sts_role_arn` (Optional) : The STS role to assume for requests to AWS. Defaults to null, which will use the standard SDK behavior for credentials.
+
+### Metrics
+
+#### Counter
+
+- `dlqS3RecordsSuccess`: measures number of successful records sent to S3.
+- `dlqS3RecordsFailed`: measures number of failed records failed to be sent to S3.
+- `dlqS3RequestSuccess`: measures number of successful S3 requests.
+- `dlqS3RequestFailed`: measures number of failed S3 requests.
+
+#### Distribution Summary
+
+- `dlqS3RequestSizeBytes`: measures the distribution of the S3 request's payload size in bytes.
+
+#### Timer
+
+- `dlqS3RequestLatency`: measures latency of sending each S3 request including retries.
+
+## DLQ Objects
+
+* `pluginId` : the id of the plugin which resulted in the event being DLQ’ed.
+* `pluginName` : the name of the plugin.
+* `failedData` : an object with the plugin’s failure options and the failed object. This object is unique to each plugin.
+* `pipelineName` : the name of the Data Prepper pipeline where the event failed.
+* `timestamp` : the timestamp of the failures is ISO8601

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/KeyPathGenerator.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/KeyPathGenerator.java
@@ -1,0 +1,86 @@
+package org.opensearch.dataprepper.plugins.dlq.s3;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class KeyPathGenerator {
+
+    private static final String TIME_PATTERN_INTERNAL_EXTRACTOR_REGULAR_EXPRESSION  = "%\\{(.*?)\\}";
+    private static final String TIME_PATTERN_STARTING_SYMBOLS = "%{";
+    private static final String TIME_PATTERN_REGULAR_EXPRESSION  = "%\\{.*?\\}";
+    static final ZoneId UTC_ZONE_ID = ZoneId.of(TimeZone.getTimeZone("UTC").getID());
+    private static final Set<Character> INVALID_CHARS = ImmutableSet.of('#', '\\', '/', '*', '?', '"', '<', '>', '|', ',', ':');
+    private static final Set<Character> UNSUPPORTED_TIME_GRANULARITY_CHARS = ImmutableSet.of('m', 's', 'S', 'A', 'n', 'N');
+
+    private final String keyPathPrefix;
+    private List<DateTimeFormatter> dateFormatters;
+    public KeyPathGenerator(final String keyPathPrefix) {
+        this.keyPathPrefix = keyPathPrefix;
+        this.dateFormatters = keyPathPrefix == null ? Collections.emptyList() : getDatePatternFormatter(keyPathPrefix);
+    }
+
+    public String generate() {
+        if (!dateFormatters.isEmpty()) {
+            final ZonedDateTime time = getCurrentUtcTime();
+            final AtomicReference<String> kpp = new AtomicReference<>(keyPathPrefix);
+            dateFormatters.forEach(dateFormatter -> {
+                final String replacement = dateFormatter.format(time);
+                final String temp = kpp.get().replaceFirst(TIME_PATTERN_REGULAR_EXPRESSION, replacement);
+                kpp.set(temp);
+            });
+            return kpp.get();
+        } else {
+            return keyPathPrefix;
+        }
+    }
+
+    private static ZonedDateTime getCurrentUtcTime() {
+        return LocalDateTime.now().atZone(ZoneId.systemDefault()).withZoneSameInstant(UTC_ZONE_ID);
+    }
+
+    private List<DateTimeFormatter> getDatePatternFormatter(final String keyPathPrefix) {
+        final Pattern pattern = Pattern.compile(TIME_PATTERN_INTERNAL_EXTRACTOR_REGULAR_EXPRESSION);
+        final Matcher timePatternMatcher = pattern.matcher(keyPathPrefix);
+        final ImmutableList.Builder<DateTimeFormatter> patterns = new ImmutableList.Builder();
+        while (timePatternMatcher.find()) {
+            final String timePattern = timePatternMatcher.group(1);
+            if (timePattern.contains(TIME_PATTERN_STARTING_SYMBOLS)) { //check if it is a nested pattern such as "%{%{yyyy}}"
+                throw new IllegalArgumentException("key_path_prefix doesn't allow nested date-time patterns.");
+            }
+            validateNoSpecialCharsInTimePattern(timePattern);
+            validateTimePatternGranularity(timePattern);
+            patterns.add(DateTimeFormatter.ofPattern(timePattern));
+        }
+        return patterns.build();
+    }
+
+    private void validateNoSpecialCharsInTimePattern(final String timePattern) {
+        final boolean containsInvalidCharacter = timePattern.chars()
+            .mapToObj(c -> (char) c)
+            .anyMatch(INVALID_CHARS::contains);
+        if (containsInvalidCharacter) {
+            throw new IllegalArgumentException("key_path_prefix date-time pattern contains one or multiple special characters: " + INVALID_CHARS);
+        }
+    }
+
+    private static void validateTimePatternGranularity(final String timePattern) {
+        final boolean containsUnsupportedTimeSymbol = timePattern.chars()
+            .mapToObj(c -> (char) c)
+            .anyMatch(UNSUPPORTED_TIME_GRANULARITY_CHARS::contains);
+        if (containsUnsupportedTimeSymbol) {
+            throw new IllegalArgumentException("key_path_prefix pattern contains date-time patterns that are less than one day: " + UNSUPPORTED_TIME_GRANULARITY_CHARS);
+        }
+    }
+}

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriter.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriter.java
@@ -60,6 +60,7 @@ public class S3DlqWriter implements DlqWriter {
     private final Counter dlqS3RequestFailedCounter;
     private final Timer dlqS3RequestTimer;
     private final DistributionSummary dlqS3RequestSizeBytesSummary;
+    private final KeyPathGenerator keyPathGenerator;
 
     S3DlqWriter(final S3DlqWriterConfig s3DlqWriterConfig, final ObjectMapper objectMapper, final PluginMetrics pluginMetrics) {
         dlqS3RecordsSuccessCounter = pluginMetrics.counter(S3_DLQ_RECORDS_SUCCESS);
@@ -74,6 +75,7 @@ public class S3DlqWriter implements DlqWriter {
         this.bucket = s3DlqWriterConfig.getBucket();
         this.keyPathPrefix = s3DlqWriterConfig.getKeyPathPrefix();
         this.objectMapper = objectMapper;
+        this.keyPathGenerator = new KeyPathGenerator(keyPathPrefix);
     }
 
     @Override
@@ -146,7 +148,7 @@ public class S3DlqWriter implements DlqWriter {
     private String buildKey(final String pipelineName, final String pluginId) {
         final String key = String.format(KEY_NAME_FORMAT, DataPrepperVersion.getCurrentVersion().getMajorVersion(),
             pipelineName, pluginId, Instant.now(), UUID.randomUUID());
-        return keyPathPrefix == null ? key : String.format(FULL_KEY_FORMAT, keyPathPrefix, key);
+        return keyPathPrefix == null ? key : String.format(FULL_KEY_FORMAT, keyPathGenerator.generate(), key);
     }
 
     @Override

--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/KeyPathGeneratorTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/KeyPathGeneratorTest.java
@@ -1,0 +1,46 @@
+package org.opensearch.dataprepper.plugins.dlq.s3;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.dataprepper.plugins.dlq.s3.KeyPathGenerator.UTC_ZONE_ID;
+
+public class KeyPathGeneratorTest {
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"/hello/world", "foobar"})
+    public void testGenericKeyPath(final String keyPathPrefix) {
+        final KeyPathGenerator keyPathGenerator = new KeyPathGenerator(keyPathPrefix);
+        final String keyPath = keyPathGenerator.generate();
+        assertThat(keyPath, is(equalTo(keyPathPrefix)));
+    }
+
+    @Test
+    public void testKeyPathWithDate() {
+        final ZonedDateTime now = LocalDateTime.now().atZone(ZoneId.systemDefault()).withZoneSameInstant(UTC_ZONE_ID);
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("/YYYY/MM/dd");
+        final String expectedResult = formatter.format(now);
+        final String keyPathPrefix = "/%{YYYY}/%{MM}/%{dd}";
+        final KeyPathGenerator keyPathGenerator = new KeyPathGenerator(keyPathPrefix);
+        final String keyPath = keyPathGenerator.generate();
+        assertThat(keyPath, is((equalTo(expectedResult))));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/%{YYYY}/%{MM}/%{dd}/%{ss}", "%{%{MM}}", "%{*.?}"})
+    public void testKeyPathWithInvalidPattern(final String keyPathPrefix) {
+        assertThrows(IllegalArgumentException.class, () -> new KeyPathGenerator(keyPathPrefix));
+    }
+}

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -142,7 +142,7 @@ e.g. [otel-v1-apm-span-index-template.json](https://github.com/opensearch-projec
 - `dlq_file`(optional): A String of absolute file path for DLQ failed output records. Defaults to null.
 If not provided, failed records will be written into the default data-prepper log file (`logs/Data-Prepper.log`). If the `dlq` option is present along with this, an error is thrown.
 
-- `dlq` (optional): DLQ configurations. See [DLQ](https://github.com/opensearch-project/data-prepper/tree/main/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/dlq/README.md) for details. If the `dlq_file` option is present along with this, an error is thrown.
+- `dlq` (optional): DLQ configurations. See [DLQ](https://github.com/opensearch-project/data-prepper/tree/main/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/README.md) for details. If the `dlq_file` option is present along with this, an error is thrown.
 
 - `max_retries`(optional): A number indicating the maximum number of times OpenSearch Sink should try to push the data to the OpenSearch server before considering it as failure. Defaults to `Integer.MAX_VALUE`.
 If not provided, the sink will try to push the data to OpenSearch server indefinitely because default value is very high and exponential backoff would increase the waiting time before retry.

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -293,7 +293,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
       });
     } else if (dlqWriter != null) {
       try {
-        dlqWriter.write(dlqObjects, "pipelineName", "pluginId");
+        dlqWriter.write(dlqObjects, pluginSetting.getPipelineName(), pluginSetting.getName());
       } catch (final IOException e) {
         dlqObjects.forEach(dlqObject -> {
           LOG.error(SENSITIVE, "DLQ failure for Document[{}]", dlqObject.getFailedData(), e);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/AbstractIndexManager.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/AbstractIndexManager.java
@@ -62,7 +62,7 @@ public abstract class AbstractIndexManager implements IndexManager {
 
     //For matching a string that begins with a "%{" and ends with a "}".
     //For a string like "data-prepper-%{yyyy-MM-dd}", "%{yyyy-MM-dd}" is matched.
-    private static final String TIME_PATTERN_REGULAR_EXPRESSION  = "%\\{.*?\\}";
+    private static final String TIME_PATTERN_REGULAR_EXPRESSION = "%\\{.*?\\}";
 
     //For matching a string enclosed by "%{" and "}".
     //For a string like "data-prepper-%{yyyy-MM}", "yyyy-MM" is matched.


### PR DESCRIPTION
### Description
1. adding data-time patterns to key-path-prefix and creating readme for s3 dlq.
2. adding detailed README for S3 DLQ Plugin
 
### Issues Resolved
- resolves #2298
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
