### PR TITLE
Add list_to_map processor

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
@@ -21,7 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -49,20 +48,21 @@ public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<
             try {
                 sourceNode = getSourceNode(recordEvent);
             } catch (final Exception e) {
-                LOG.error(EVENT, "Given source path [{}] is not valid on record [{}]",
+                LOG.warn(EVENT, "Given source path [{}] is not valid on record [{}]",
                         config.getSource(), recordEvent, e);
                 continue;
             }
 
-            ObjectNode targetNode = null;
+            ObjectNode targetNode;
             try {
                 targetNode = constructTargetNode(sourceNode);
             } catch (IllegalArgumentException e) {
-                LOG.error(EVENT, "Cannot find a list at the given source path [{}} on record [{}]",
+                LOG.warn(EVENT, "Cannot find a list at the given source path [{}} on record [{}]",
                         config.getSource(), recordEvent, e);
                 continue;
             } catch (final Exception e) {
                 LOG.error(EVENT, "Error converting source list to map on record [{}]", recordEvent, e);
+                continue;
             }
 
             try {
@@ -110,14 +110,14 @@ public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<
                 }
             }
         } else {
-            throw new IllegalArgumentException("Cannot find a list at the given source path [{}}" + config.getSource());
+            throw new IllegalArgumentException("Cannot find a list at the given source path [{}]" + config.getSource());
         }
         return targetNode;
     }
 
     private void updateEvent(Event recordEvent, ObjectNode targetNode) {
-        final TypeReference<HashMap<String, Object>> hashMapTypeReference = new TypeReference<>() {};
-        final Map<String, Object> targetMap = OBJECT_MAPPER.convertValue(targetNode, hashMapTypeReference);
+        final TypeReference<Map<String, Object>> mapTypeReference = new TypeReference<>() {};
+        final Map<String, Object> targetMap = OBJECT_MAPPER.convertValue(targetNode, mapTypeReference);
 
         final boolean doWriteToRoot = Objects.isNull(config.getTarget());
         if (doWriteToRoot) {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.mutateevent;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.processor.AbstractProcessor;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
+
+@DataPrepperPlugin(name = "list_to_map", pluginType = Processor.class, pluginConfigurationType = ListToMapProcessorConfig.class)
+public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Logger LOG = LoggerFactory.getLogger(ListToMapProcessor.class);
+    private final ListToMapProcessorConfig config;
+
+    @DataPrepperPluginConstructor
+    public ListToMapProcessor(final PluginMetrics pluginMetrics, final ListToMapProcessorConfig config) {
+        super(pluginMetrics);
+        this.config = config;
+    }
+
+    @Override
+    public Collection<Record<Event>> doExecute(final Collection<Record<Event>> records) {
+        for (final Record<Event> record : records) {
+            final Event recordEvent = record.getData();
+
+            final JsonNode sourceNode;
+            try {
+                sourceNode = getSourceNode(recordEvent);
+            } catch (final Exception e) {
+                LOG.error(EVENT, "Given source path [{}] is not valid on record [{}]",
+                        config.getSource(), recordEvent, e);
+                continue;
+            }
+
+            ObjectNode targetNode = null;
+            try {
+                targetNode = constructTargetNode(sourceNode);
+            } catch (IllegalArgumentException e) {
+                LOG.error(EVENT, "Cannot find a list at the given source path [{}} on record [{}]",
+                        config.getSource(), recordEvent, e);
+                continue;
+            } catch (final Exception e) {
+                LOG.error(EVENT, "Error converting source list to map on record [{}]", recordEvent, e);
+            }
+
+            try {
+                updateEvent(recordEvent, targetNode);
+            } catch (final Exception e) {
+                LOG.error(EVENT, "Error updating record [{}] after converting source list to map", recordEvent, e);
+            }
+        }
+        return records;
+    }
+
+    private JsonNode getSourceNode(final Event recordEvent) {
+        final Object sourceObject = recordEvent.get(config.getSource(), Object.class);
+        return OBJECT_MAPPER.convertValue(sourceObject, JsonNode.class);
+    }
+
+    private ObjectNode constructTargetNode(JsonNode sourceNode) {
+        final ObjectNode targetNode = OBJECT_MAPPER.createObjectNode();
+        if (sourceNode.isArray()) {
+            for (final JsonNode itemNode : sourceNode) {
+                String itemKey = itemNode.get(config.getKey()).asText();
+
+                if (!config.getFlatten()) {
+                    final ArrayNode itemValueNode;
+                    if (!targetNode.has(itemKey)) {
+                        itemValueNode = OBJECT_MAPPER.createArrayNode();
+                        targetNode.set(itemKey, itemValueNode);
+                    } else {
+                        itemValueNode = (ArrayNode) targetNode.get(itemKey);
+                    }
+
+                    if (config.getValueKey() == null) {
+                        itemValueNode.add(itemNode);
+                    } else {
+                        itemValueNode.add(itemNode.get(config.getValueKey()));
+                    }
+                } else {
+                    if (!targetNode.has(itemKey) || config.getFlattenedElement() == ListToMapProcessorConfig.FlattenedElement.LAST) {
+                        if (config.getValueKey() == null) {
+                            targetNode.set(itemKey, itemNode);
+                        } else  {
+                            targetNode.set(itemKey, itemNode.get(config.getValueKey()));
+                        }
+                    }
+                }
+            }
+        } else {
+            throw new IllegalArgumentException("Cannot find a list at the given source path [{}}" + config.getSource());
+        }
+        return targetNode;
+    }
+
+    private void updateEvent(Event recordEvent, ObjectNode targetNode) {
+        final TypeReference<HashMap<String, Object>> hashMapTypeReference = new TypeReference<>() {};
+        final Map<String, Object> targetMap = OBJECT_MAPPER.convertValue(targetNode, hashMapTypeReference);
+
+        final boolean doWriteToRoot = Objects.isNull(config.getTarget());
+        if (doWriteToRoot) {
+            for (final Map.Entry<String, Object> entry : targetMap.entrySet()) {
+                recordEvent.put(entry.getKey(), entry.getValue());
+            }
+        } else {
+            recordEvent.put(config.getTarget(), targetMap);
+        }
+    }
+
+    @Override
+    public void prepareForShutdown() {
+    }
+
+    @Override
+    public boolean isReadyForShutdown() {
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+    }
+}

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -31,12 +31,6 @@ public class ListToMapProcessorConfig {
             this.name = name.toLowerCase();
         }
 
-        @Override
-        public String toString() {
-            String a = "{\"notmylist\":{\"name\":\"a\",\"value\":\"val-a\"}}";
-            return name;
-        }
-
         @JsonCreator
         static FlattenedElement fromOptionValue(final String option) {
             return ACTIONS_MAP.get(option);
@@ -61,7 +55,7 @@ public class ListToMapProcessorConfig {
 
     @NotNull
     @JsonProperty("flatten")
-    private boolean flatten = true;
+    private boolean flatten = false;
 
     @NotNull
     @JsonProperty("flattened_element")

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.mutateevent;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ListToMapProcessorConfig {
+    enum FlattenedElement {
+        FIRST("first"),
+        LAST("last");
+
+        private final String name;
+
+        private static final Map<String, FlattenedElement> ACTIONS_MAP = Arrays.stream(FlattenedElement.values())
+                .collect(Collectors.toMap(
+                        value -> value.name,
+                        value -> value
+                ));
+
+        FlattenedElement(String name) {
+            this.name = name.toLowerCase();
+        }
+
+        @Override
+        public String toString() {
+            String a = "{\"notmylist\":{\"name\":\"a\",\"value\":\"val-a\"}}";
+            return name;
+        }
+
+        @JsonCreator
+        static FlattenedElement fromOptionValue(final String option) {
+            return ACTIONS_MAP.get(option);
+        }
+    }
+
+    @NotEmpty
+    @NotNull
+    @JsonProperty("source")
+    private String source;
+
+    @JsonProperty("target")
+    private String target = null;
+
+    @NotEmpty
+    @NotNull
+    @JsonProperty("key")
+    private String key;
+
+    @JsonProperty("value_key")
+    private String valueKey = null;
+
+    @NotNull
+    @JsonProperty("flatten")
+    private boolean flatten = true;
+
+    @NotNull
+    @JsonProperty("flattened_element")
+    private FlattenedElement flattenedElement = FlattenedElement.FIRST;
+
+    public String getSource() {
+        return source;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValueKey() {
+        return valueKey;
+    }
+
+    public boolean getFlatten() {
+        return flatten;
+    }
+
+    public FlattenedElement getFlattenedElement() {
+        return flattenedElement;
+    }
+}

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorTest.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.mutateevent;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ListToMapProcessorTest {
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private ListToMapProcessorConfig mockConfig;
+
+    @Test
+    public void testValueExtractionWithFlattenAndWriteToRoot() {
+        configureDefaultSettings();
+        when(mockConfig.getValueKey()).thenReturn("value");
+        when(mockConfig.getSource()).thenReturn("mylist");
+        when(mockConfig.getKey()).thenReturn("name");
+        when(mockConfig.getFlattenedElement()).thenReturn(ListToMapProcessorConfig.FlattenedElement.FIRST);
+
+        final ListToMapProcessor processor = createObjectUnderTest();
+        final Record<Event> testRecord = createTestRecord();
+        final List<Record<Event>> resultRecord = (List<Record<Event>>) processor.doExecute(Collections.singletonList(testRecord));
+
+        assertThat(resultRecord.size(), is(1));
+
+        final Event resultEvent = resultRecord.get(0).getData();
+        assertThat(resultEvent.get("a", String.class), is("val-a"));
+        assertThat(resultEvent.get("b", String.class), is("val-b1"));
+        assertThat(resultEvent.get("c", String.class), is("val-c"));
+    }
+
+    @Test
+    public void testValueExtractionWithFlattenKeepLastElementAndWriteToRoot() {
+        configureDefaultSettings();
+        when(mockConfig.getValueKey()).thenReturn("value");
+        when(mockConfig.getSource()).thenReturn("mylist");
+        when(mockConfig.getKey()).thenReturn("name");
+        when(mockConfig.getFlattenedElement()).thenReturn(ListToMapProcessorConfig.FlattenedElement.LAST);
+
+        final ListToMapProcessor processor = createObjectUnderTest();
+        final Record<Event> testRecord = createTestRecord();
+        final List<Record<Event>> resultRecord = (List<Record<Event>>) processor.doExecute(Collections.singletonList(testRecord));
+
+        assertThat(resultRecord.size(), is(1));
+
+        final Event resultEvent = resultRecord.get(0).getData();
+        assertThat(resultEvent.get("a", String.class), is("val-a"));
+        assertThat(resultEvent.get("b", String.class), is("val-b2"));
+        assertThat(resultEvent.get("c", String.class), is("val-c"));
+    }
+
+    @Test
+    public void testValueExtractionWithFlattenAndWriteToTarget() {
+        configureDefaultSettings();
+        when(mockConfig.getValueKey()).thenReturn("value");
+        when(mockConfig.getSource()).thenReturn("mylist");
+        when(mockConfig.getKey()).thenReturn("name");
+        when(mockConfig.getTarget()).thenReturn("mymap");
+        when(mockConfig.getFlattenedElement()).thenReturn(ListToMapProcessorConfig.FlattenedElement.FIRST);
+
+        final ListToMapProcessor processor = createObjectUnderTest();
+        final Record<Event> testRecord = createTestRecord();
+        final List<Record<Event>> resultRecord = (List<Record<Event>>) processor.doExecute(Collections.singletonList(testRecord));
+
+        assertThat(resultRecord.size(), is(1));
+
+        final Event resultEvent = resultRecord.get(0).getData();
+        assertThat(resultEvent.get("mymap/a", String.class), is("val-a"));
+        assertThat(resultEvent.get("mymap/b", String.class), is("val-b1"));
+        assertThat(resultEvent.get("mymap/c", String.class), is("val-c"));
+    }
+
+    @Test
+    public void testNoValueExtractionWithFlattenAndWriteToRoot() {
+        configureDefaultSettings();
+        when(mockConfig.getSource()).thenReturn("mylist");
+        when(mockConfig.getKey()).thenReturn("name");
+        when(mockConfig.getFlattenedElement()).thenReturn(ListToMapProcessorConfig.FlattenedElement.FIRST);
+
+        final ListToMapProcessor processor = createObjectUnderTest();
+        final Record<Event> testRecord = createTestRecord();
+        final List<Record<Event>> resultRecord = (List<Record<Event>>) processor.doExecute(Collections.singletonList(testRecord));
+
+        assertThat(resultRecord.size(), is(1));
+
+        final Event resultEvent = resultRecord.get(0).getData();
+        assertThat(resultEvent.get("a", Object.class), is(Map.of("name", "a", "value", "val-a")));
+        assertThat(resultEvent.get("b", Object.class), is(Map.of("name", "b", "value", "val-b1")));
+        assertThat(resultEvent.get("c", Object.class), is(Map.of("name", "c", "value", "val-c")));
+    }
+
+    @Test
+    public void testValueExtractionWithNoFlattenAndWriteToRoot() {
+        configureDefaultSettings();
+        when(mockConfig.getSource()).thenReturn("mylist");
+        when(mockConfig.getKey()).thenReturn("name");
+        when(mockConfig.getValueKey()).thenReturn("value");
+        when(mockConfig.getFlatten()).thenReturn(false);
+
+        final ListToMapProcessor processor = createObjectUnderTest();
+        final Record<Event> testRecord = createTestRecord();
+        final List<Record<Event>> resultRecord = (List<Record<Event>>) processor.doExecute(Collections.singletonList(testRecord));
+
+        assertThat(resultRecord.size(), is(1));
+
+        final Event resultEvent = resultRecord.get(0).getData();
+        assertThat(resultEvent.get("a", Object.class), is(List.of("val-a")));
+        assertThat(resultEvent.get("b", Object.class), is(List.of("val-b1", "val-b2")));
+        assertThat(resultEvent.get("c", Object.class), is(List.of("val-c")));
+    }
+
+    @Test
+    public void testNoValueExtractionWithNoFlattenAndWriteToRoot() {
+        configureDefaultSettings();
+        when(mockConfig.getSource()).thenReturn("mylist");
+        when(mockConfig.getKey()).thenReturn("name");
+        when(mockConfig.getFlatten()).thenReturn(false);
+
+        final ListToMapProcessor processor = createObjectUnderTest();
+        final Record<Event> testRecord = createTestRecord();
+        final List<Record<Event>> resultRecord = (List<Record<Event>>) processor.doExecute(Collections.singletonList(testRecord));
+
+        assertThat(resultRecord.size(), is(1));
+
+        final Event resultEvent = resultRecord.get(0).getData();
+        assertThat(resultEvent.get("a", Object.class), is(List.of(Map.of("name", "a", "value", "val-a"))));
+        assertThat(resultEvent.get("b", Object.class), is(List.of(
+                Map.of("name", "b", "value", "val-b1"),
+                Map.of("name", "b", "value", "val-b2")
+        )));
+        assertThat(resultEvent.get("c", Object.class), is(List.of(Map.of("name", "c", "value", "val-c"))));
+    }
+
+    @Test
+    public void testFailureDueToInvalidSourceKey() {
+        when(mockConfig.getSource()).thenReturn("invalid_source_key");
+
+        final ListToMapProcessor processor = createObjectUnderTest();
+        final Record<Event> testRecord = createTestRecord();
+        final List<Record<Event>> resultRecord = (List<Record<Event>>) processor.doExecute(Collections.singletonList(testRecord));
+
+        assertThat(resultRecord.size(), is(1));
+
+        final Event resultEvent = resultRecord.get(0).getData();
+        assertThat(resultEvent.get("mymap", Object.class), is(nullValue()));
+    }
+
+    @Test
+    public void testFailureDueToSourceNotList() {
+        when(mockConfig.getSource()).thenReturn("nolist");
+
+        final ListToMapProcessor processor = createObjectUnderTest();
+        final Record<Event> testRecord = createTestRecord();
+        final List<Record<Event>> resultRecord = (List<Record<Event>>) processor.doExecute(Collections.singletonList(testRecord));
+
+        assertThat(resultRecord.size(), is(1));
+
+        final Event resultEvent = resultRecord.get(0).getData();
+        assertThat(resultEvent.get("mymap", Object.class), is(nullValue()));
+    }
+
+    @Test
+    public void testFailureDueToBadEventData() {
+        configureDefaultSettings();
+        when(mockConfig.getValueKey()).thenReturn("value");
+        when(mockConfig.getSource()).thenReturn("mylist");
+        when(mockConfig.getKey()).thenReturn("name");
+        when(mockConfig.getTarget()).thenReturn("mymap");
+
+        final ListToMapProcessor processor = createObjectUnderTest();
+        final Record<Event> testRecord = createBadTestRecord();
+        final List<Record<Event>> resultRecord = (List<Record<Event>>) processor.doExecute(Collections.singletonList(testRecord));
+
+        assertThat(resultRecord.size(), is(1));
+
+        final Event resultEvent = resultRecord.get(0).getData();
+        assertThat(resultEvent.get("mymap", Object.class), is(nullValue()));
+    }
+
+    private ListToMapProcessor createObjectUnderTest() {
+        return new ListToMapProcessor(pluginMetrics, mockConfig);
+    }
+
+    private Record<Event> createTestRecord() {
+        final Map<String, Object> data = Map.of("mylist", List.of(
+                Map.of("name", "a", "value", "val-a"),
+                Map.of("name", "b", "value", "val-b1"),
+                Map.of("name", "b", "value", "val-b2"),
+                Map.of("name", "c", "value", "val-c")),
+                "nolist", "single-value");
+        final Event event = JacksonEvent.builder()
+                .withData(data)
+                .withEventType("event")
+                .build();
+        return new Record<>(event);
+    }
+
+    private void configureDefaultSettings() {
+        when(mockConfig.getTarget()).thenReturn(null);
+        when(mockConfig.getValueKey()).thenReturn(null);
+        when(mockConfig.getFlatten()).thenReturn(true);
+    }
+
+    private Record<Event> createBadTestRecord() {
+        final Map<String, Object> data = Map.of("mylist", List.of(
+                        Map.of("name", "a", "value", "val-a"),
+                        Map.of("name", "b", "value", "val-b"),
+                        Map.of("badname", "c", "value", "val-c")));
+        final Event event = JacksonEvent.builder()
+                .withData(data)
+                .withEventType("event")
+                .build();
+        return new Record<>(event);
+    }
+}

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorTest.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorTest.java
@@ -33,10 +33,10 @@ class ListToMapProcessorTest {
 
     @Test
     public void testValueExtractionWithFlattenAndWriteToRoot() {
-        configureDefaultSettings();
         when(mockConfig.getValueKey()).thenReturn("value");
         when(mockConfig.getSource()).thenReturn("mylist");
         when(mockConfig.getKey()).thenReturn("name");
+        when(mockConfig.getFlatten()).thenReturn(true);
         when(mockConfig.getFlattenedElement()).thenReturn(ListToMapProcessorConfig.FlattenedElement.FIRST);
 
         final ListToMapProcessor processor = createObjectUnderTest();
@@ -53,10 +53,10 @@ class ListToMapProcessorTest {
 
     @Test
     public void testValueExtractionWithFlattenKeepLastElementAndWriteToRoot() {
-        configureDefaultSettings();
         when(mockConfig.getValueKey()).thenReturn("value");
         when(mockConfig.getSource()).thenReturn("mylist");
         when(mockConfig.getKey()).thenReturn("name");
+        when(mockConfig.getFlatten()).thenReturn(true);
         when(mockConfig.getFlattenedElement()).thenReturn(ListToMapProcessorConfig.FlattenedElement.LAST);
 
         final ListToMapProcessor processor = createObjectUnderTest();
@@ -73,11 +73,11 @@ class ListToMapProcessorTest {
 
     @Test
     public void testValueExtractionWithFlattenAndWriteToTarget() {
-        configureDefaultSettings();
         when(mockConfig.getValueKey()).thenReturn("value");
         when(mockConfig.getSource()).thenReturn("mylist");
         when(mockConfig.getKey()).thenReturn("name");
         when(mockConfig.getTarget()).thenReturn("mymap");
+        when(mockConfig.getFlatten()).thenReturn(true);
         when(mockConfig.getFlattenedElement()).thenReturn(ListToMapProcessorConfig.FlattenedElement.FIRST);
 
         final ListToMapProcessor processor = createObjectUnderTest();
@@ -94,9 +94,9 @@ class ListToMapProcessorTest {
 
     @Test
     public void testNoValueExtractionWithFlattenAndWriteToRoot() {
-        configureDefaultSettings();
         when(mockConfig.getSource()).thenReturn("mylist");
         when(mockConfig.getKey()).thenReturn("name");
+        when(mockConfig.getFlatten()).thenReturn(true);
         when(mockConfig.getFlattenedElement()).thenReturn(ListToMapProcessorConfig.FlattenedElement.FIRST);
 
         final ListToMapProcessor processor = createObjectUnderTest();
@@ -113,11 +113,9 @@ class ListToMapProcessorTest {
 
     @Test
     public void testValueExtractionWithNoFlattenAndWriteToRoot() {
-        configureDefaultSettings();
         when(mockConfig.getSource()).thenReturn("mylist");
         when(mockConfig.getKey()).thenReturn("name");
         when(mockConfig.getValueKey()).thenReturn("value");
-        when(mockConfig.getFlatten()).thenReturn(false);
 
         final ListToMapProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createTestRecord();
@@ -133,10 +131,8 @@ class ListToMapProcessorTest {
 
     @Test
     public void testNoValueExtractionWithNoFlattenAndWriteToRoot() {
-        configureDefaultSettings();
         when(mockConfig.getSource()).thenReturn("mylist");
         when(mockConfig.getKey()).thenReturn("name");
-        when(mockConfig.getFlatten()).thenReturn(false);
 
         final ListToMapProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createTestRecord();
@@ -183,11 +179,9 @@ class ListToMapProcessorTest {
 
     @Test
     public void testFailureDueToBadEventData() {
-        configureDefaultSettings();
         when(mockConfig.getValueKey()).thenReturn("value");
         when(mockConfig.getSource()).thenReturn("mylist");
         when(mockConfig.getKey()).thenReturn("name");
-        when(mockConfig.getTarget()).thenReturn("mymap");
 
         final ListToMapProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createBadTestRecord();
@@ -215,12 +209,6 @@ class ListToMapProcessorTest {
                 .withEventType("event")
                 .build();
         return new Record<>(event);
-    }
-
-    private void configureDefaultSettings() {
-        when(mockConfig.getTarget()).thenReturn(null);
-        when(mockConfig.getValueKey()).thenReturn(null);
-        when(mockConfig.getFlatten()).thenReturn(true);
     }
 
     private Record<Event> createBadTestRecord() {


### PR DESCRIPTION
### Description
This PR adds a new `list_to_map` processor that converts an array of objects in an event to a map.
 
### Issues Resolved
Resolves #2410 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
