### PR TITLE
OpenSearchSink: add support for sending end-to-end acknowledgements

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventHandle.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventHandle.java
@@ -6,4 +6,12 @@
 package org.opensearch.dataprepper.model.event;
 
 public interface EventHandle {
+    /**
+     * releases event handle
+     *
+     * @param result result to be used while releasing. This indicates if
+     *               the operation on the event handle is success or not
+     * @since 2.2
+     */
+    void release(boolean result);
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/failures/DlqObject.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/failures/DlqObject.java
@@ -83,6 +83,12 @@ public class DlqObject {
         return eventHandle;
     }
 
+    public void releaseEventHandle(boolean result) {
+        if (eventHandle != null) {
+            eventHandle.release(result);
+        }
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/failures/DlqObject.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/failures/DlqObject.java
@@ -36,8 +36,10 @@ public class DlqObject {
 
     private final String timestamp;
 
+    private final Object eventHandle;
+
     private DlqObject(final String pluginId, final String pluginName, final String pipelineName,
-                      final String timestamp, final Object failedData) {
+                      final String timestamp, final Object failedData, final Object eventHandle) {
 
         checkNotNull(pluginId, "pluginId cannot be null");
         checkArgument(!pluginId.isEmpty(), "pluginId cannot be an empty string");
@@ -51,6 +53,7 @@ public class DlqObject {
         this.pluginName = pluginName;
         this.pipelineName = pipelineName;
         this.failedData = failedData;
+        this.eventHandle = eventHandle;
 
         this.timestamp = StringUtils.isEmpty(timestamp) ? FORMATTER.format(Instant.now()) : timestamp;
     }
@@ -75,6 +78,10 @@ public class DlqObject {
         return timestamp;
     }
 
+    public Object getEventHandle() {
+        return eventHandle;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
@@ -84,6 +91,7 @@ public class DlqObject {
             && Objects.equals(pluginId, that.pluginId)
             && Objects.equals(pluginName, that.pluginName)
             && Objects.equals(pipelineName, that.pipelineName)
+            && Objects.equals(eventHandle, that.eventHandle)
             && Objects.equals(timestamp, that.getTimestamp());
     }
 
@@ -113,6 +121,7 @@ public class DlqObject {
         private String pluginName;
         private String pipelineName;
         private Object failedData;
+        private Object eventHandle;
 
         private String timestamp;
 
@@ -141,13 +150,18 @@ public class DlqObject {
             return this;
         }
 
+        public Builder withEventHandle(final Object eventHandle) {
+            this.eventHandle = eventHandle;
+            return this;
+        }
+
         public Builder withTimestamp(final Instant instant) {
             this.timestamp = FORMATTER.format(instant);
             return this;
         }
 
         public DlqObject build() {
-            return new DlqObject(this.pluginId, this.pluginName, this.pipelineName, this.timestamp, this.failedData);
+            return new DlqObject(this.pluginId, this.pluginName, this.pipelineName, this.timestamp, this.failedData, this.eventHandle);
         }
 
     }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/failures/DlqObject.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/failures/DlqObject.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.model.failures;
 
+import org.opensearch.dataprepper.model.event.EventHandle;
 import org.apache.commons.lang3.StringUtils;
 
 import java.time.Instant;
@@ -36,10 +37,10 @@ public class DlqObject {
 
     private final String timestamp;
 
-    private final Object eventHandle;
+    private final EventHandle eventHandle;
 
     private DlqObject(final String pluginId, final String pluginName, final String pipelineName,
-                      final String timestamp, final Object failedData, final Object eventHandle) {
+                      final String timestamp, final Object failedData, final EventHandle eventHandle) {
 
         checkNotNull(pluginId, "pluginId cannot be null");
         checkArgument(!pluginId.isEmpty(), "pluginId cannot be an empty string");
@@ -78,7 +79,7 @@ public class DlqObject {
         return timestamp;
     }
 
-    public Object getEventHandle() {
+    public EventHandle getEventHandle() {
         return eventHandle;
     }
 
@@ -121,7 +122,7 @@ public class DlqObject {
         private String pluginName;
         private String pipelineName;
         private Object failedData;
-        private Object eventHandle;
+        private EventHandle eventHandle;
 
         private String timestamp;
 
@@ -150,7 +151,7 @@ public class DlqObject {
             return this;
         }
 
-        public Builder withEventHandle(final Object eventHandle) {
+        public Builder withEventHandle(final EventHandle eventHandle) {
             this.eventHandle = eventHandle;
             return this;
         }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -36,6 +36,8 @@ import static org.opensearch.dataprepper.test.matcher.MapEquals.isEqualWithoutTi
 public class JacksonEventTest {
     
     class TestEventHandle implements EventHandle {
+        @Override
+        public void release(boolean result) {}
     };
 
     private Event event;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/failures/DlqObjectTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/failures/DlqObjectTest.java
@@ -29,6 +29,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.ArgumentMatchers.any;
 
 public class DlqObjectTest {
 
@@ -164,10 +167,13 @@ public class DlqObjectTest {
         }
 
         @Test
-        public void test_get_eventHandle() {
+        public void test_get_release_eventHandle() {
+            doAnswer(a -> { return null; }).when(eventHandle).release(any(Boolean.class));
             final Object actualEventHandle = testObject.getEventHandle();
             assertThat(actualEventHandle, is(notNullValue()));
             assertThat(actualEventHandle, is(eventHandle));
+            testObject.releaseEventHandle(true);
+            verify(eventHandle).release(any(Boolean.class));
         }
 
         @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/failures/DlqObjectTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/failures/DlqObjectTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.model.failures;
 
+import org.opensearch.dataprepper.model.event.EventHandle;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 public class DlqObjectTest {
 
@@ -35,7 +37,7 @@ public class DlqObjectTest {
     private String pluginName;
     private String pipelineName;
     private Object failedData;
-    private Object eventHandle;
+    private EventHandle eventHandle;
 
     @BeforeEach
     public void setUp() {
@@ -43,7 +45,7 @@ public class DlqObjectTest {
         pluginName = randomUUID().toString();
         pipelineName = randomUUID().toString();
         failedData = randomUUID();
-        eventHandle = randomUUID();
+        eventHandle = mock(EventHandle.class);
     }
 
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/failures/DlqObjectTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/failures/DlqObjectTest.java
@@ -35,6 +35,7 @@ public class DlqObjectTest {
     private String pluginName;
     private String pipelineName;
     private Object failedData;
+    private Object eventHandle;
 
     @BeforeEach
     public void setUp() {
@@ -42,6 +43,7 @@ public class DlqObjectTest {
         pluginName = randomUUID().toString();
         pipelineName = randomUUID().toString();
         failedData = randomUUID();
+        eventHandle = randomUUID();
     }
 
     @Test
@@ -52,6 +54,7 @@ public class DlqObjectTest {
                 .withPluginName(pluginName)
                 .withPipelineName(pipelineName)
                 .withFailedData(failedData)
+                .withEventHandle(eventHandle)
                 .withTimestamp(randomUUID().toString())
                 .build();
 
@@ -126,6 +129,7 @@ public class DlqObjectTest {
                 .withPluginName(pluginName)
                 .withPipelineName(pipelineName)
                 .withFailedData(failedData)
+                .withEventHandle(eventHandle)
                 .build();
         }
 
@@ -155,6 +159,13 @@ public class DlqObjectTest {
             final Object actualFailedData = testObject.getFailedData();
             assertThat(actualFailedData, is(notNullValue()));
             assertThat(actualFailedData, is(failedData));
+        }
+
+        @Test
+        public void test_get_eventHandle() {
+            final Object actualEventHandle = testObject.getEventHandle();
+            assertThat(actualEventHandle, is(notNullValue()));
+            assertThat(actualEventHandle, is(eventHandle));
         }
 
         @Test

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventHandle.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/event/DefaultEventHandle.java
@@ -18,4 +18,12 @@ public class DefaultEventHandle implements EventHandle {
     public AcknowledgementSet getAcknowledgementSet() {
         return acknowledgementSetRef.get();
     }
+
+    @Override
+    public void release(boolean result) {
+        AcknowledgementSet acknowledgementSet = getAcknowledgementSet();
+        if (acknowledgementSet != null) {
+            acknowledgementSet.release(this, result);
+        }
+    }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultEventHandleTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/event/DefaultEventHandleTests.java
@@ -5,17 +5,28 @@
 
 package org.opensearch.dataprepper.event;
 
+import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.Mock;
 
 class DefaultEventHandleTests {
-    AcknowledgementSet acknowledgementSet;
+    @Mock
+    private AcknowledgementSet acknowledgementSet;
 
     @Test
     void testBasic() {
+        acknowledgementSet = mock(AcknowledgementSet.class);
+        when(acknowledgementSet.release(any(EventHandle.class), any(Boolean.class))).thenReturn(true);
         DefaultEventHandle eventHandle = new DefaultEventHandle(acknowledgementSet);
         assertThat(eventHandle.getAcknowledgementSet(), equalTo(acknowledgementSet));
+        eventHandle.release(true);
+        verify(acknowledgementSet).release(eventHandle, true);
     }
 }

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -212,6 +212,10 @@ Besides common metrics in [AbstractSink](https://github.com/opensearch-project/d
 - `bulkRequestTimeoutErrors`: measures number of requests failed with timeout error. `RestStatus` value of `REQUEST_TIMEOUT` is mapped to this errors counter.
 - `bulkRequestServerErrors`: measures the number of requests failed with 5xx errors. `RestStatus` value of 500-599 are mapped to this errors counter.
 
+### End-to-End acknowledgements
+
+If the events received by the OpenSearch Sink have end-to-end acknowledgements enabled (which is tracked using the presence of EventHandle in the event received for processing), then upon successful posting to OpenSearch or upon successful write to DLQ, a positive acknowledgement is sent to the acknowledgementSetManager, otherwise a negative acknowledgement is sent.
+
 ### Distribution Summary
 - `bulkRequestSizeBytes`: measures the distribution of bulk request's payload sizes in bytes.
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWithHandle.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWithHandle.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch;
+
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.dataprepper.model.event.EventHandle;
+
+public class BulkOperationWithHandle {
+    private EventHandle eventHandle;
+    private BulkOperation bulkOperation;
+
+    public BulkOperationWithHandle(final BulkOperation bulkOperation) {
+        this.bulkOperation = bulkOperation;
+        this.eventHandle = null;
+    }
+
+    public BulkOperationWithHandle(final BulkOperation bulkOperation, EventHandle eventHandle) {
+        this.bulkOperation = bulkOperation;
+        this.eventHandle = eventHandle;
+    }
+
+    public BulkOperation getBulkOperation() {
+        return bulkOperation;
+    }
+
+    public EventHandle getEventHandle() {
+        return eventHandle;
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
@@ -8,16 +8,16 @@ package org.opensearch.dataprepper.plugins.sink.opensearch;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.dataprepper.model.event.EventHandle;
 
-public class BulkOperationWithHandle {
+public class BulkOperationWrapper {
     private EventHandle eventHandle;
     private BulkOperation bulkOperation;
 
-    public BulkOperationWithHandle(final BulkOperation bulkOperation) {
+    public BulkOperationWrapper(final BulkOperation bulkOperation) {
         this.bulkOperation = bulkOperation;
         this.eventHandle = null;
     }
 
-    public BulkOperationWithHandle(final BulkOperation bulkOperation, EventHandle eventHandle) {
+    public BulkOperationWrapper(final BulkOperation bulkOperation, EventHandle eventHandle) {
         this.bulkOperation = bulkOperation;
         this.eventHandle = eventHandle;
     }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
@@ -9,15 +9,15 @@ import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.dataprepper.model.event.EventHandle;
 
 public class BulkOperationWrapper {
-    private EventHandle eventHandle;
-    private BulkOperation bulkOperation;
+    private final EventHandle eventHandle;
+    private final BulkOperation bulkOperation;
 
     public BulkOperationWrapper(final BulkOperation bulkOperation) {
         this.bulkOperation = bulkOperation;
         this.eventHandle = null;
     }
 
-    public BulkOperationWrapper(final BulkOperation bulkOperation, EventHandle eventHandle) {
+    public BulkOperationWrapper(final BulkOperation bulkOperation, final EventHandle eventHandle) {
         this.bulkOperation = bulkOperation;
         this.eventHandle = eventHandle;
     }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.sink.opensearch;
 
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.dataprepper.model.event.EventHandle;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class BulkOperationWrapper {
     private final EventHandle eventHandle;
@@ -18,6 +19,7 @@ public class BulkOperationWrapper {
     }
 
     public BulkOperationWrapper(final BulkOperation bulkOperation, final EventHandle eventHandle) {
+        checkNotNull(bulkOperation);
         this.bulkOperation = bulkOperation;
         this.eventHandle = eventHandle;
     }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
@@ -31,4 +31,10 @@ public class BulkOperationWrapper {
     public EventHandle getEventHandle() {
         return eventHandle;
     }
+
+    public void releaseEventHandle(boolean result) {
+        if (eventHandle != null) {
+            eventHandle.release(result);
+        }
+    }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -292,7 +292,7 @@ public final class BulkRetryStrategy {
         final ImmutableList.Builder<FailedBulkOperation> failures = ImmutableList.builder();
         for (int i = 0; i < itemResponses.size(); i++) {
             final BulkResponseItem bulkItemResponse = itemResponses.get(i);
-            final BulkOperationWrapper bulkOperationWithHandle = (BulkOperationWrapper)accumulatingBulkRequest.getOperationAt(i);
+            final BulkOperationWrapper bulkOperationWithHandle = accumulatingBulkRequest.getOperationAt(i);
             if (bulkItemResponse.error() != null) {
                 failures.add(FailedBulkOperation.builder()
                     .withBulkOperation(bulkOperationWithHandle)

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -243,7 +243,9 @@ public final class BulkRetryStrategy {
                 sentDocumentsCounter.increment(bulkRequestForRetry.getOperationsCount());
                 for (final BulkOperationWrapper bulkOperation: bulkRequestForRetry.getOperations()) {
                     final EventHandle eventHandle = bulkOperation.getEventHandle();
-                    eventHandle.release(true);
+                    if (eventHandle != null) {
+                        eventHandle.release(true);
+                    }
                 }
                 retryCountMap.remove(bulkRequestForRetry);
             }
@@ -281,7 +283,9 @@ public final class BulkRetryStrategy {
                 } else {
                     sentDocumentsCounter.increment();
                     final EventHandle eventHandle = bulkOperationWithHandle.getEventHandle();
-                    eventHandle.release(true);
+                    if (eventHandle != null) {
+                        eventHandle.release(true);
+                    }
                 }
                 index++;
             }
@@ -305,7 +309,9 @@ public final class BulkRetryStrategy {
             } else {
                 sentDocumentsCounter.increment();
                 final EventHandle eventHandle = bulkOperationWithHandle.getEventHandle();
-                eventHandle.release(true);
+                if (eventHandle != null) {
+                    eventHandle.release(true);
+                }
             }
         }
         logFailure.accept(failures.build(), null);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -11,7 +11,6 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import io.micrometer.core.instrument.Counter;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.action.bulk.BackoffPolicy;
-import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -243,7 +243,7 @@ public final class BulkRetryStrategy {
                 }
                 sentDocumentsCounter.increment(bulkRequestForRetry.getOperationsCount());
                 for (final BulkOperationWrapper bulkOperation: bulkRequestForRetry.getOperations()) {
-                    EventHandle eventHandle = bulkOperation.getEventHandle();
+                    final EventHandle eventHandle = bulkOperation.getEventHandle();
                     acknowledgementSetManager.releaseEventReference(eventHandle, true);
                 }
                 retryCountMap.remove(bulkRequestForRetry);
@@ -281,7 +281,7 @@ public final class BulkRetryStrategy {
                     }
                 } else {
                     sentDocumentsCounter.increment();
-                    EventHandle eventHandle = bulkOperationWithHandle.getEventHandle();
+                    final EventHandle eventHandle = bulkOperationWithHandle.getEventHandle();
                     acknowledgementSetManager.releaseEventReference(eventHandle, true);
                 }
                 index++;
@@ -305,7 +305,7 @@ public final class BulkRetryStrategy {
                 documentErrorsCounter.increment();
             } else {
                 sentDocumentsCounter.increment();
-                EventHandle eventHandle = bulkOperationWithHandle.getEventHandle();
+                final EventHandle eventHandle = bulkOperationWithHandle.getEventHandle();
                 acknowledgementSetManager.releaseEventReference(eventHandle, true);
             }
         }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -199,7 +199,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
       return;
     }
 
-    AccumulatingBulkRequest<BulkOperationWithHandle, BulkRequest> bulkRequest = bulkRequestSupplier.get();
+    AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequest = bulkRequestSupplier.get();
 
     for (final Record<Event> record : records) {
       final Event event = record.getData();
@@ -246,7 +246,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
 
       }
 
-      BulkOperationWithHandle bulkOperationWithHandle = new BulkOperationWithHandle(bulkOperation, event.getEventHandle());
+      BulkOperationWrapper bulkOperationWithHandle = new BulkOperationWrapper(bulkOperation, event.getEventHandle());
       final long estimatedBytesBeforeAdd = bulkRequest.estimateSizeInBytesWithDocument(bulkOperationWithHandle);
       if (bulkSize >= 0 && estimatedBytesBeforeAdd >= bulkSize && bulkRequest.getOperationsCount() > 0) {
         flushBatch(bulkRequest);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -15,7 +15,6 @@ import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationExcepti
 
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.AbstractSink;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -291,10 +291,14 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
         try {
           dlqFileWriter.write(String.format("{\"Document\": [%s], \"failure\": %s}\n",
               BulkOperationWriter.dlqObjectToString(dlqObject), message));
-          eventHandle.release(true);
+          if (eventHandle != null) {
+            eventHandle.release(true);
+          }
         } catch (final IOException e) {
           LOG.error(SENSITIVE, "DLQ failure for Document[{}]", dlqObject.getFailedData(), e);
-          eventHandle.release(false);
+          if (eventHandle != null) {
+            eventHandle.release(false);
+          }
         }
       });
     } else if (dlqWriter != null) {
@@ -302,20 +306,26 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
         dlqWriter.write(dlqObjects, pluginSetting.getPipelineName(), pluginSetting.getName());
         dlqObjects.forEach((dlqObject) -> {
             final EventHandle eventHandle = (EventHandle)dlqObject.getEventHandle();
-            eventHandle.release(true);
+            if (eventHandle != null) {
+              eventHandle.release(true);
+            }
         });
       } catch (final IOException e) {
         dlqObjects.forEach(dlqObject -> {
           final EventHandle eventHandle = (EventHandle)dlqObject.getEventHandle();
           LOG.error(SENSITIVE, "DLQ failure for Document[{}]", dlqObject.getFailedData(), e);
-          eventHandle.release(false);
+          if (eventHandle != null) {
+            eventHandle.release(false);
+          }
         });
       }
     } else {
       dlqObjects.forEach(dlqObject -> {
         LOG.warn(SENSITIVE, "Document [{}] has failure.", dlqObject.getFailedData(), failure);
         final EventHandle eventHandle = (EventHandle)dlqObject.getEventHandle();
-        eventHandle.release(false);
+        if (eventHandle != null) {
+          eventHandle.release(false);
+        }
       });
     }
   }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingBulkRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingBulkRequest.java
@@ -5,17 +5,17 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.bulk;
 
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWithHandle;
 import org.opensearch.client.opensearch.core.BulkRequest;
-import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkRequest<BulkOperation, BulkRequest> {
+public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkRequest<BulkOperationWithHandle, BulkRequest> {
     static final int OPERATION_OVERHEAD = 50;
 
-    private final List<BulkOperation> bulkOperations;
+    private final List<BulkOperationWithHandle> bulkOperations;
     private BulkRequest.Builder bulkRequestBuilder;
     private long currentBulkSize = 0L;
     private int operationCount = 0;
@@ -27,24 +27,24 @@ public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkReques
     }
 
     @Override
-    public long estimateSizeInBytesWithDocument(BulkOperation documentOrOperation) {
+    public long estimateSizeInBytesWithDocument(BulkOperationWithHandle documentOrOperation) {
         return currentBulkSize + estimateBulkOperationSize(documentOrOperation);
     }
 
     @Override
-    public void addOperation(BulkOperation bulkOperation) {
+    public void addOperation(BulkOperationWithHandle bulkOperation) {
         final Long documentLength = estimateBulkOperationSize(bulkOperation);
 
         currentBulkSize += documentLength;
 
-        bulkRequestBuilder = bulkRequestBuilder.operations(bulkOperation);
+        bulkRequestBuilder = bulkRequestBuilder.operations(bulkOperation.getBulkOperation());
 
         operationCount++;
         bulkOperations.add(bulkOperation);
     }
 
     @Override
-    public BulkOperation getOperationAt(int index) {
+    public BulkOperationWithHandle getOperationAt(int index) {
         return bulkOperations.get(index);
     }
 
@@ -59,7 +59,7 @@ public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkReques
     }
 
     @Override
-    public List<BulkOperation> getOperations() {
+    public List<BulkOperationWithHandle> getOperations() {
         return Collections.unmodifiableList(bulkOperations);
     }
 
@@ -70,14 +70,14 @@ public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkReques
         return builtRequest;
     }
 
-    private long estimateBulkOperationSize(BulkOperation bulkOperation) {
+    private long estimateBulkOperationSize(BulkOperationWithHandle bulkOperation) {
 
         Object anyDocument;
 
-        if (bulkOperation.isIndex()) {
-            anyDocument = bulkOperation.index().document();
-        } else if (bulkOperation.isCreate()) {
-            anyDocument = bulkOperation.create().document();
+        if (bulkOperation.getBulkOperation().isIndex()) {
+            anyDocument = bulkOperation.getBulkOperation().index().document();
+        } else if (bulkOperation.getBulkOperation().isCreate()) {
+            anyDocument = bulkOperation.getBulkOperation().create().document();
         } else {
             throw new UnsupportedOperationException("Only index or create operations are supported currently. " + bulkOperation);
         }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingBulkRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingBulkRequest.java
@@ -5,17 +5,17 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.bulk;
 
-import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWithHandle;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
 import org.opensearch.client.opensearch.core.BulkRequest;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkRequest<BulkOperationWithHandle, BulkRequest> {
+public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> {
     static final int OPERATION_OVERHEAD = 50;
 
-    private final List<BulkOperationWithHandle> bulkOperations;
+    private final List<BulkOperationWrapper> bulkOperations;
     private BulkRequest.Builder bulkRequestBuilder;
     private long currentBulkSize = 0L;
     private int operationCount = 0;
@@ -27,12 +27,12 @@ public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkReques
     }
 
     @Override
-    public long estimateSizeInBytesWithDocument(BulkOperationWithHandle documentOrOperation) {
+    public long estimateSizeInBytesWithDocument(BulkOperationWrapper documentOrOperation) {
         return currentBulkSize + estimateBulkOperationSize(documentOrOperation);
     }
 
     @Override
-    public void addOperation(BulkOperationWithHandle bulkOperation) {
+    public void addOperation(BulkOperationWrapper bulkOperation) {
         final Long documentLength = estimateBulkOperationSize(bulkOperation);
 
         currentBulkSize += documentLength;
@@ -44,7 +44,7 @@ public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkReques
     }
 
     @Override
-    public BulkOperationWithHandle getOperationAt(int index) {
+    public BulkOperationWrapper getOperationAt(int index) {
         return bulkOperations.get(index);
     }
 
@@ -59,7 +59,7 @@ public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkReques
     }
 
     @Override
-    public List<BulkOperationWithHandle> getOperations() {
+    public List<BulkOperationWrapper> getOperations() {
         return Collections.unmodifiableList(bulkOperations);
     }
 
@@ -70,7 +70,7 @@ public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkReques
         return builtRequest;
     }
 
-    private long estimateBulkOperationSize(BulkOperationWithHandle bulkOperation) {
+    private long estimateBulkOperationSize(BulkOperationWrapper bulkOperation) {
 
         Object anyDocument;
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperation.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperation.java
@@ -1,17 +1,17 @@
 package org.opensearch.dataprepper.plugins.sink.opensearch.dlq;
 
-import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWithHandle;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 
 import java.util.Objects;
 
 public class FailedBulkOperation {
 
-    private final BulkOperationWithHandle bulkOperation;
+    private final BulkOperationWrapper bulkOperation;
     private final BulkResponseItem bulkResponseItem;
     private final Throwable failure;
 
-    private FailedBulkOperation(final BulkOperationWithHandle bulkOperation, final BulkResponseItem bulkResponseItem, final Throwable failure) {
+    private FailedBulkOperation(final BulkOperationWrapper bulkOperation, final BulkResponseItem bulkResponseItem, final Throwable failure) {
         Objects.requireNonNull(bulkOperation);
         this.bulkOperation = bulkOperation;
         if (bulkResponseItem == null && failure == null) {
@@ -21,7 +21,7 @@ public class FailedBulkOperation {
         this.failure = failure;
     }
 
-    public BulkOperationWithHandle getBulkOperation() {
+    public BulkOperationWrapper getBulkOperation() {
         return bulkOperation;
     }
 
@@ -67,11 +67,11 @@ public class FailedBulkOperation {
 
     public static class Builder {
 
-        private BulkOperationWithHandle bulkOperation;
+        private BulkOperationWrapper bulkOperation;
         private BulkResponseItem bulkResponseItem;
         private Throwable failure;
 
-        public Builder withBulkOperation(final BulkOperationWithHandle bulkOperation) {
+        public Builder withBulkOperation(final BulkOperationWrapper bulkOperation) {
             this.bulkOperation = bulkOperation;
             return this;
         }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperation.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperation.java
@@ -1,17 +1,17 @@
 package org.opensearch.dataprepper.plugins.sink.opensearch.dlq;
 
-import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWithHandle;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 
 import java.util.Objects;
 
 public class FailedBulkOperation {
 
-    private final BulkOperation bulkOperation;
+    private final BulkOperationWithHandle bulkOperation;
     private final BulkResponseItem bulkResponseItem;
     private final Throwable failure;
 
-    private FailedBulkOperation(final BulkOperation bulkOperation, final BulkResponseItem bulkResponseItem, final Throwable failure) {
+    private FailedBulkOperation(final BulkOperationWithHandle bulkOperation, final BulkResponseItem bulkResponseItem, final Throwable failure) {
         Objects.requireNonNull(bulkOperation);
         this.bulkOperation = bulkOperation;
         if (bulkResponseItem == null && failure == null) {
@@ -21,7 +21,7 @@ public class FailedBulkOperation {
         this.failure = failure;
     }
 
-    public BulkOperation getBulkOperation() {
+    public BulkOperationWithHandle getBulkOperation() {
         return bulkOperation;
     }
 
@@ -67,11 +67,11 @@ public class FailedBulkOperation {
 
     public static class Builder {
 
-        private BulkOperation bulkOperation;
+        private BulkOperationWithHandle bulkOperation;
         private BulkResponseItem bulkResponseItem;
         private Throwable failure;
 
-        public Builder withBulkOperation(final BulkOperation bulkOperation) {
+        public Builder withBulkOperation(final BulkOperationWithHandle bulkOperation) {
             this.bulkOperation = bulkOperation;
             return this;
         }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationConverter.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationConverter.java
@@ -6,7 +6,7 @@ import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 import org.opensearch.dataprepper.model.failures.DlqObject;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.SerializedJson;
-import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWithHandle;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -33,7 +33,7 @@ public class FailedBulkOperationConverter {
 
     public DlqObject convertToDlqObject(final FailedBulkOperation failedBulkOperation) {
 
-        final BulkOperationWithHandle bulkOperationWithHandle = failedBulkOperation.getBulkOperation();
+        final BulkOperationWrapper bulkOperationWithHandle = failedBulkOperation.getBulkOperation();
         final BulkOperation bulkOperation = bulkOperationWithHandle.getBulkOperation();
         final BulkResponseItem bulkResponseItem = failedBulkOperation.getBulkResponseItem();
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationConverter.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationConverter.java
@@ -6,6 +6,7 @@ import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 import org.opensearch.dataprepper.model.failures.DlqObject;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.SerializedJson;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWithHandle;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -32,7 +33,8 @@ public class FailedBulkOperationConverter {
 
     public DlqObject convertToDlqObject(final FailedBulkOperation failedBulkOperation) {
 
-        final BulkOperation bulkOperation = failedBulkOperation.getBulkOperation();
+        final BulkOperationWithHandle bulkOperationWithHandle = failedBulkOperation.getBulkOperation();
+        final BulkOperation bulkOperation = bulkOperationWithHandle.getBulkOperation();
         final BulkResponseItem bulkResponseItem = failedBulkOperation.getBulkResponseItem();
 
         final Object document = convertDocumentToGenericMap(bulkOperation);
@@ -55,6 +57,7 @@ public class FailedBulkOperationConverter {
             .withPluginName(pluginName)
             .withPipelineName(pipelineName)
             .withPluginId(pluginId)
+            .withEventHandle(bulkOperationWithHandle.getEventHandle())
             .build();
     }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedDlqData.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedDlqData.java
@@ -1,6 +1,7 @@
 package org.opensearch.dataprepper.plugins.sink.opensearch.dlq;
 
 import java.util.Objects;
+import org.opensearch.dataprepper.model.event.EventHandle;
 
 public class FailedDlqData {
 
@@ -9,8 +10,9 @@ public class FailedDlqData {
     private final int status;
     private final String message;
     private final Object document;
+    private final EventHandle eventHandle;
 
-    private FailedDlqData(final String index, final String indexId, final int status, final String message, final Object document) {
+    private FailedDlqData(final String index, final String indexId, final int status, final String message, final Object document, final EventHandle eventHandle) {
         Objects.requireNonNull(index);
         this.index = index;
         this.indexId = indexId;
@@ -19,6 +21,7 @@ public class FailedDlqData {
         this.message = message;
         Objects.requireNonNull(document);
         this.document = document;
+        this.eventHandle = eventHandle;
     }
 
     public String getIndex() {
@@ -39,6 +42,10 @@ public class FailedDlqData {
 
     public Object getDocument() {
         return document;
+    }
+
+    public EventHandle getEventHandle() {
+        return eventHandle;
     }
 
     @Override
@@ -81,6 +88,7 @@ public class FailedDlqData {
 
         private String index;
         private String indexId;
+        private EventHandle eventHandle;
 
         private int status = 0;
 
@@ -113,8 +121,13 @@ public class FailedDlqData {
             return this;
         }
 
+        public Builder withEventHandle(final EventHandle eventHandle) {
+            this.eventHandle = eventHandle;
+            return this;
+        }
+
         public FailedDlqData build() {
-            return new FailedDlqData(index, indexId, status, message, document);
+            return new FailedDlqData(index, indexId, status, message, document, eventHandle);
         }
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWithHandleTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWithHandleTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch;
+
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.junit.jupiter.api.Test;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class BulkOperationWithHandleTests {
+    private BulkOperation bulkOperation;
+
+    BulkOperationWithHandle createObjectUnderTest(EventHandle eventHandle) {
+        bulkOperation = mock(BulkOperation.class);
+        if (eventHandle == null) {
+            return new BulkOperationWithHandle(bulkOperation);
+        }
+        return new BulkOperationWithHandle(bulkOperation, eventHandle);
+    }
+
+    @Test
+    public void testConstructorWithOneArgument() {
+        BulkOperationWithHandle bulkOperationWithHandle = createObjectUnderTest(null);
+        assertThat(bulkOperationWithHandle.getBulkOperation(), equalTo(bulkOperation));
+        assertThat(bulkOperationWithHandle.getEventHandle(), equalTo(null));
+    }
+
+    @Test
+    public void testConstructorWithTwoArguments() {
+        EventHandle eventHandle = mock(EventHandle.class);
+        BulkOperationWithHandle bulkOperationWithHandle = createObjectUnderTest(eventHandle);
+        assertThat(bulkOperationWithHandle.getBulkOperation(), equalTo(bulkOperation));
+        assertThat(bulkOperationWithHandle.getEventHandle(), equalTo(eventHandle));
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapperTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapperTests.java
@@ -12,20 +12,20 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class BulkOperationWithHandleTests {
+public class BulkOperationWrapperTests {
     private BulkOperation bulkOperation;
 
-    BulkOperationWithHandle createObjectUnderTest(EventHandle eventHandle) {
+    BulkOperationWrapper createObjectUnderTest(EventHandle eventHandle) {
         bulkOperation = mock(BulkOperation.class);
         if (eventHandle == null) {
-            return new BulkOperationWithHandle(bulkOperation);
+            return new BulkOperationWrapper(bulkOperation);
         }
-        return new BulkOperationWithHandle(bulkOperation, eventHandle);
+        return new BulkOperationWrapper(bulkOperation, eventHandle);
     }
 
     @Test
     public void testConstructorWithOneArgument() {
-        BulkOperationWithHandle bulkOperationWithHandle = createObjectUnderTest(null);
+        BulkOperationWrapper bulkOperationWithHandle = createObjectUnderTest(null);
         assertThat(bulkOperationWithHandle.getBulkOperation(), equalTo(bulkOperation));
         assertThat(bulkOperationWithHandle.getEventHandle(), equalTo(null));
     }
@@ -33,7 +33,7 @@ public class BulkOperationWithHandleTests {
     @Test
     public void testConstructorWithTwoArguments() {
         EventHandle eventHandle = mock(EventHandle.class);
-        BulkOperationWithHandle bulkOperationWithHandle = createObjectUnderTest(eventHandle);
+        BulkOperationWrapper bulkOperationWithHandle = createObjectUnderTest(eventHandle);
         assertThat(bulkOperationWithHandle.getBulkOperation(), equalTo(bulkOperation));
         assertThat(bulkOperationWithHandle.getEventHandle(), equalTo(eventHandle));
     }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
@@ -27,7 +27,7 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.AccumulatingBulkR
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.JavaClientAccumulatingBulkRequest;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.SerializedJson;
 import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedBulkOperation;
-import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWithHandle;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
 import org.opensearch.rest.RestStatus;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
@@ -139,10 +139,10 @@ public class BulkRetryStrategyTests {
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
         final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder());
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation1).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation2).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation3).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation4).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation4).build()));
 
         bulkRetryStrategy.execute(accumulatingBulkRequest);
 
@@ -177,10 +177,10 @@ public class BulkRetryStrategyTests {
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
         final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder());
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation1).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation2).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation3).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation4).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation4).build()));
 
         bulkRetryStrategy.execute(accumulatingBulkRequest);
 
@@ -200,7 +200,7 @@ public class BulkRetryStrategyTests {
         final List<FailedBulkOperation> failedBulkOperations = failedBulkOperationsCaptor.getValue();
         MatcherAssert.assertThat(failedBulkOperations.size(), equalTo(1));
         failedBulkOperations.forEach(failedBulkOperation -> {
-            final BulkOperationWithHandle bulkOperationWithHandle = failedBulkOperation.getBulkOperation();
+            final BulkOperationWrapper bulkOperationWithHandle = failedBulkOperation.getBulkOperation();
             final BulkOperation bulkOperation = bulkOperationWithHandle.getBulkOperation();
             MatcherAssert.assertThat(bulkOperation.index().index(), equalTo(testIndex));
             MatcherAssert.assertThat(bulkOperation.index().id(), equalTo(String.valueOf("2")));
@@ -240,10 +240,10 @@ public class BulkRetryStrategyTests {
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
         final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder());
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation1).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation2).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation3).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation4).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation4).build()));
 
         bulkRetryStrategy.execute(accumulatingBulkRequest);
 
@@ -259,7 +259,7 @@ public class BulkRetryStrategyTests {
         MatcherAssert.assertThat(failedBulkOperations.size(), equalTo(4));
         AtomicInteger expectedIndexId = new AtomicInteger(1);
         failedBulkOperations.forEach(failedBulkOperation -> {
-            final BulkOperationWithHandle bulkOperationWithHandle = failedBulkOperation.getBulkOperation();
+            final BulkOperationWrapper bulkOperationWithHandle = failedBulkOperation.getBulkOperation();
             final BulkOperation bulkOperation = bulkOperationWithHandle.getBulkOperation();
             MatcherAssert.assertThat(bulkOperation.index().index(), equalTo(testIndex));
             MatcherAssert.assertThat(bulkOperation.index().id(), equalTo(String.valueOf(expectedIndexId.get())));
@@ -305,10 +305,10 @@ public class BulkRetryStrategyTests {
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
         final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder());
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation1).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation2).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation3).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation4).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation4).build()));
         bulkRetryStrategy.execute(accumulatingBulkRequest);
         MatcherAssert.assertThat(maxRetriesLimitReached, equalTo(true));
         assertEquals(numEventsSucceeded, 0);
@@ -335,10 +335,10 @@ public class BulkRetryStrategyTests {
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
         final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder());
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation1).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation2).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation3).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation4).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation4).build()));
         bulkRetryStrategy.execute(accumulatingBulkRequest);
         MatcherAssert.assertThat(maxRetriesLimitReached, equalTo(true));
         assertEquals(numEventsSucceeded, 0);
@@ -365,10 +365,10 @@ public class BulkRetryStrategyTests {
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
         final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder());
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation1).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation2).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation3).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation4).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation4).build()));
         bulkRetryStrategy.execute(accumulatingBulkRequest);
         MatcherAssert.assertThat(maxRetriesLimitReached, equalTo(true));
         assertEquals(numEventsSucceeded, 2);
@@ -392,10 +392,10 @@ public class BulkRetryStrategyTests {
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
         final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder());
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation1).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation2).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation3).build()));
-        accumulatingBulkRequest.addOperation(new BulkOperationWithHandle(new BulkOperation.Builder().index(indexOperation4).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build()));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation4).build()));
 
         bulkRetryStrategy.execute(accumulatingBulkRequest);
 
@@ -413,7 +413,7 @@ public class BulkRetryStrategyTests {
 
         failedBulkOperations.forEach(failedBulkOperation -> {
             expectedIndexId.addAndGet(1);
-            final BulkOperationWithHandle bulkOperationWithHandle = failedBulkOperation.getBulkOperation();
+            final BulkOperationWrapper bulkOperationWithHandle = failedBulkOperation.getBulkOperation();
             final BulkOperation bulkOperation = bulkOperationWithHandle.getBulkOperation();
             MatcherAssert.assertThat(bulkOperation.index().index(), equalTo(testIndex));
             MatcherAssert.assertThat(bulkOperation.index().id(), equalTo(String.valueOf(expectedIndexId.get())));
@@ -478,7 +478,7 @@ public class BulkRetryStrategyTests {
             this.index = index;
         }
 
-        public BulkResponse bulk(final AccumulatingBulkRequest<BulkOperationWithHandle, BulkRequest> accumulatingBulkRequest) throws IOException {
+        public BulkResponse bulk(final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> accumulatingBulkRequest) throws IOException {
             final BulkRequest bulkRequest = accumulatingBulkRequest.getRequest();
             if (maxRetriesTestValue > 0) {
                 if (maxRetriesWithException) {

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
@@ -27,7 +27,6 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.AccumulatingBulkR
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.JavaClientAccumulatingBulkRequest;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.SerializedJson;
 import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedBulkOperation;
-import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
 import org.opensearch.rest.RestStatus;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingBulkRequestTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingBulkRequestTest.java
@@ -70,7 +70,7 @@ class JavaClientAccumulatingBulkRequestTest {
     void getOperationsCount_returns_the_correct_operation_count(final int operationCount) {
         final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
         for (int i = 0; i < operationCount; i++) {
-            BulkOperationWrapper bulkOperation = new BulkOperationWrapper(createBulkOperation(generateDocument()));
+            final BulkOperationWrapper bulkOperation = new BulkOperationWrapper(createBulkOperation(generateDocument()));
             objectUnderTest.addOperation(bulkOperation);
         }
 
@@ -83,7 +83,7 @@ class JavaClientAccumulatingBulkRequestTest {
         final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
         final long arbitraryDocumentSize = 175;
         for (int i = 0; i < operationCount; i++) {
-            BulkOperationWrapper bulkOperation = new BulkOperationWrapper(createBulkOperation(generateDocumentWithLength(arbitraryDocumentSize)));
+            final BulkOperationWrapper bulkOperation = new BulkOperationWrapper(createBulkOperation(generateDocumentWithLength(arbitraryDocumentSize)));
             objectUnderTest.addOperation(bulkOperation);
         }
 
@@ -146,7 +146,7 @@ class JavaClientAccumulatingBulkRequestTest {
 
     @Test
     void estimateSizeInBytesWithDocument_on_new_object_returns_operation_overhead_if_no_document() {
-        BulkOperationWrapper bulkOperation = new BulkOperationWrapper(createBulkOperation(null));
+        final BulkOperationWrapper bulkOperation = new BulkOperationWrapper(createBulkOperation(null));
 
         assertThat(createObjectUnderTest().estimateSizeInBytesWithDocument(bulkOperation),
                 equalTo((long) JavaClientAccumulatingBulkRequest.OPERATION_OVERHEAD));

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingBulkRequestTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingBulkRequestTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.IndexOperation;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWithHandle;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,9 +59,9 @@ class JavaClientAccumulatingBulkRequestTest {
 
     @Test
     void getOperations_returns_unmodifiable_list() {
-        final List<BulkOperation> operations = createObjectUnderTest().getOperations();
+        final List<BulkOperationWithHandle> operations = createObjectUnderTest().getOperations();
 
-        final BulkOperation bulkOperation = createBulkOperation(generateDocument());
+        final BulkOperationWithHandle bulkOperation = new BulkOperationWithHandle(createBulkOperation(generateDocument()));
         assertThrows(UnsupportedOperationException.class, () -> operations.add(bulkOperation));
     }
 
@@ -69,7 +70,7 @@ class JavaClientAccumulatingBulkRequestTest {
     void getOperationsCount_returns_the_correct_operation_count(final int operationCount) {
         final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
         for (int i = 0; i < operationCount; i++) {
-            BulkOperation bulkOperation = createBulkOperation(generateDocument());
+            BulkOperationWithHandle bulkOperation = new BulkOperationWithHandle(createBulkOperation(generateDocument()));
             objectUnderTest.addOperation(bulkOperation);
         }
 
@@ -82,7 +83,7 @@ class JavaClientAccumulatingBulkRequestTest {
         final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
         final long arbitraryDocumentSize = 175;
         for (int i = 0; i < operationCount; i++) {
-            BulkOperation bulkOperation = createBulkOperation(generateDocumentWithLength(arbitraryDocumentSize));
+            BulkOperationWithHandle bulkOperation = new BulkOperationWithHandle(createBulkOperation(generateDocumentWithLength(arbitraryDocumentSize)));
             objectUnderTest.addOperation(bulkOperation);
         }
 
@@ -95,7 +96,7 @@ class JavaClientAccumulatingBulkRequestTest {
     void getEstimatedSizeInBytes_returns_the_operation_overhead_if_requests_have_no_documents(final int operationCount) {
         final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
         for (int i = 0; i < operationCount; i++) {
-            objectUnderTest.addOperation(createBulkOperation(null));
+            objectUnderTest.addOperation(new BulkOperationWithHandle(createBulkOperation(null)));
         }
 
         final long expectedSize = operationCount * JavaClientAccumulatingBulkRequest.OPERATION_OVERHEAD;
@@ -106,10 +107,10 @@ class JavaClientAccumulatingBulkRequestTest {
     void getOperationAt_returns_the_correct_index() {
         final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
 
-        List<BulkOperation> knownOperations = new ArrayList<>();
+        List<BulkOperationWithHandle> knownOperations = new ArrayList<>();
 
         for (int i = 0; i < 7; i++) {
-            BulkOperation bulkOperation = createBulkOperation(generateDocument());
+            BulkOperationWithHandle bulkOperation = new BulkOperationWithHandle(createBulkOperation(generateDocument()));
             objectUnderTest.addOperation(bulkOperation);
             knownOperations.add(bulkOperation);
         }
@@ -123,7 +124,7 @@ class JavaClientAccumulatingBulkRequestTest {
     @ValueSource(longs = {0, 1, 2, 10, 50, 100})
     void estimateSizeInBytesWithDocument_on_new_object_returns_estimated_document_size_plus_operation_overhead(long inputDocumentSize) {
         final SizedDocument document = generateDocumentWithLength(inputDocumentSize);
-        final BulkOperation bulkOperation = createBulkOperation(document);
+        final BulkOperationWithHandle bulkOperation = new BulkOperationWithHandle(createBulkOperation(document));
 
         assertThat(createObjectUnderTest().estimateSizeInBytesWithDocument(bulkOperation),
                 equalTo(inputDocumentSize + JavaClientAccumulatingBulkRequest.OPERATION_OVERHEAD));
@@ -133,10 +134,10 @@ class JavaClientAccumulatingBulkRequestTest {
     @ValueSource(longs = {0, 1, 2, 10, 50, 100})
     void estimateSizeInBytesWithDocument_on_request_with_operations_returns_estimated_document_size_plus_operation_overhead(long inputDocumentSize) {
         final SizedDocument document = generateDocumentWithLength(inputDocumentSize);
-        final BulkOperation bulkOperation = createBulkOperation(document);
+        final BulkOperationWithHandle bulkOperation = new BulkOperationWithHandle(createBulkOperation(document));
 
         final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
-        objectUnderTest.addOperation(createBulkOperation(generateDocumentWithLength(inputDocumentSize)));
+        objectUnderTest.addOperation(new BulkOperationWithHandle(createBulkOperation(generateDocumentWithLength(inputDocumentSize))));
 
         final long expectedSize = 2 * (inputDocumentSize + JavaClientAccumulatingBulkRequest.OPERATION_OVERHEAD);
         assertThat(objectUnderTest.estimateSizeInBytesWithDocument(bulkOperation),
@@ -145,7 +146,7 @@ class JavaClientAccumulatingBulkRequestTest {
 
     @Test
     void estimateSizeInBytesWithDocument_on_new_object_returns_operation_overhead_if_no_document() {
-        BulkOperation bulkOperation = createBulkOperation(null);
+        BulkOperationWithHandle bulkOperation = new BulkOperationWithHandle(createBulkOperation(null));
 
         assertThat(createObjectUnderTest().estimateSizeInBytesWithDocument(bulkOperation),
                 equalTo((long) JavaClientAccumulatingBulkRequest.OPERATION_OVERHEAD));
@@ -153,16 +154,16 @@ class JavaClientAccumulatingBulkRequestTest {
 
     @Test
     void addOperation_adds_operation_to_the_BulkRequestBuilder() {
-        final BulkOperation bulkOperation = createBulkOperation(generateDocument());
+        final BulkOperationWithHandle bulkOperation = new BulkOperationWithHandle(createBulkOperation(generateDocument()));
 
         createObjectUnderTest().addOperation(bulkOperation);
 
-        verify(bulkRequestBuilder).operations(bulkOperation);
+        verify(bulkRequestBuilder).operations(bulkOperation.getBulkOperation());
     }
 
     @Test
     void addOperation_throws_when_BulkOperation_is_not_an_index_request() {
-        final BulkOperation bulkOperation = mock(BulkOperation.class);
+        final BulkOperationWithHandle bulkOperation = new BulkOperationWithHandle(mock(BulkOperation.class));
 
         final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
 
@@ -171,7 +172,7 @@ class JavaClientAccumulatingBulkRequestTest {
 
     @Test
     void addOperation_throws_when_document_is_not_JsonSize() {
-        final BulkOperation bulkOperation = createBulkOperation(UUID.randomUUID().toString());
+        final BulkOperationWithHandle bulkOperation = new BulkOperationWithHandle(createBulkOperation(UUID.randomUUID().toString()));
 
         final JavaClientAccumulatingBulkRequest objectUnderTest = createObjectUnderTest();
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationConverterTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationConverterTest.java
@@ -9,7 +9,7 @@ import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import org.opensearch.dataprepper.model.failures.DlqObject;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.SerializedJson;
-import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWithHandle;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
 import org.opensearch.rest.RestStatus;
 import java.util.Map;
 import java.util.UUID;
@@ -70,7 +70,7 @@ public class FailedBulkOperationConverterTest {
     public void testConvertToDlqObject() {
 
         final FailedBulkOperation testData = FailedBulkOperation.builder()
-            .withBulkOperation(new BulkOperationWithHandle(bulkOperation))
+            .withBulkOperation(new BulkOperationWrapper(bulkOperation))
             .withBulkResponseItem(bulkResponseItem)
             .withFailure(failure)
             .build();
@@ -83,7 +83,7 @@ public class FailedBulkOperationConverterTest {
     @Test
     public void testConvertToDlqObjectWithOnlyFailure() {
         final FailedBulkOperation testData = FailedBulkOperation.builder()
-            .withBulkOperation(new BulkOperationWithHandle(bulkOperation))
+            .withBulkOperation(new BulkOperationWrapper(bulkOperation))
             .withFailure(failure)
             .build();
 
@@ -96,7 +96,7 @@ public class FailedBulkOperationConverterTest {
     public void testConvertToDlqObjectWithOnlyBulkResponseItem() {
 
         final FailedBulkOperation testData = FailedBulkOperation.builder()
-            .withBulkOperation(new BulkOperationWithHandle(bulkOperation))
+            .withBulkOperation(new BulkOperationWrapper(bulkOperation))
             .withBulkResponseItem(bulkResponseItem)
             .build();
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationConverterTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationConverterTest.java
@@ -9,6 +9,7 @@ import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import org.opensearch.dataprepper.model.failures.DlqObject;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.SerializedJson;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWithHandle;
 import org.opensearch.rest.RestStatus;
 import java.util.Map;
 import java.util.UUID;
@@ -69,7 +70,7 @@ public class FailedBulkOperationConverterTest {
     public void testConvertToDlqObject() {
 
         final FailedBulkOperation testData = FailedBulkOperation.builder()
-            .withBulkOperation(bulkOperation)
+            .withBulkOperation(new BulkOperationWithHandle(bulkOperation))
             .withBulkResponseItem(bulkResponseItem)
             .withFailure(failure)
             .build();
@@ -82,7 +83,7 @@ public class FailedBulkOperationConverterTest {
     @Test
     public void testConvertToDlqObjectWithOnlyFailure() {
         final FailedBulkOperation testData = FailedBulkOperation.builder()
-            .withBulkOperation(bulkOperation)
+            .withBulkOperation(new BulkOperationWithHandle(bulkOperation))
             .withFailure(failure)
             .build();
 
@@ -95,7 +96,7 @@ public class FailedBulkOperationConverterTest {
     public void testConvertToDlqObjectWithOnlyBulkResponseItem() {
 
         final FailedBulkOperation testData = FailedBulkOperation.builder()
-            .withBulkOperation(bulkOperation)
+            .withBulkOperation(new BulkOperationWithHandle(bulkOperation))
             .withBulkResponseItem(bulkResponseItem)
             .build();
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationTest.java
@@ -1,11 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.sink.opensearch.dlq;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWithHandle;
+import org.opensearch.dataprepper.model.event.EventHandle;
 
 import static java.util.UUID.randomUUID;
 import static org.hamcrest.CoreMatchers.allOf;
@@ -16,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
 public class FailedBulkOperationTest {
@@ -23,16 +30,19 @@ public class FailedBulkOperationTest {
     @Nested
     class Getters {
 
-        private BulkOperation bulkOperation;
+        private BulkOperationWithHandle bulkOperation;
         private BulkResponseItem bulkResponseItem;
+        private EventHandle eventHandle;
         private Throwable failure;
 
         private FailedBulkOperation testObject;
         @BeforeEach
         public void setUp() {
-            bulkOperation = mock(BulkOperation.class);
+            bulkOperation = mock(BulkOperationWithHandle.class);
             bulkResponseItem = mock(BulkResponseItem.class);
+            eventHandle = mock(EventHandle.class);
             failure = new Exception();
+            lenient().when(bulkOperation.getEventHandle()).thenReturn(eventHandle);
 
             testObject = FailedBulkOperation.builder()
                 .withBulkOperation(bulkOperation)
@@ -44,6 +54,11 @@ public class FailedBulkOperationTest {
         @Test
         public void testGetBulkOperation() {
             assertThat(testObject.getBulkOperation(), is(equalTo(bulkOperation)));
+        }
+
+        @Test
+        public void testGetEventHandle() {
+            assertThat(testObject.getBulkOperation().getEventHandle(), is(equalTo(eventHandle)));
         }
 
         @Test
@@ -60,13 +75,13 @@ public class FailedBulkOperationTest {
 
     @Nested
     class Builder {
-        private BulkOperation bulkOperation;
+        private BulkOperationWithHandle bulkOperation;
         private BulkResponseItem bulkResponseItem;
         private Throwable failure;
 
         @BeforeEach
         public void setUp() {
-            bulkOperation = mock(BulkOperation.class);
+            bulkOperation = mock(BulkOperationWithHandle.class);
             bulkResponseItem = mock(BulkResponseItem.class);
             failure = new Exception();
         }
@@ -110,14 +125,14 @@ public class FailedBulkOperationTest {
     @Nested
     class EqualsAndHashCodeAndToString {
 
-        private BulkOperation bulkOperation;
+        private BulkOperationWithHandle bulkOperation;
         private BulkResponseItem bulkResponseItem;
         private Throwable failure;
 
         private FailedBulkOperation testObject;
         @BeforeEach
         public void setUp() {
-            bulkOperation = mock(BulkOperation.class);
+            bulkOperation = mock(BulkOperationWithHandle.class);
             bulkResponseItem = mock(BulkResponseItem.class);
             failure = new Exception();
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
-import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWithHandle;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
 import org.opensearch.dataprepper.model.event.EventHandle;
 
 import static java.util.UUID.randomUUID;
@@ -30,7 +30,7 @@ public class FailedBulkOperationTest {
     @Nested
     class Getters {
 
-        private BulkOperationWithHandle bulkOperation;
+        private BulkOperationWrapper bulkOperation;
         private BulkResponseItem bulkResponseItem;
         private EventHandle eventHandle;
         private Throwable failure;
@@ -38,7 +38,7 @@ public class FailedBulkOperationTest {
         private FailedBulkOperation testObject;
         @BeforeEach
         public void setUp() {
-            bulkOperation = mock(BulkOperationWithHandle.class);
+            bulkOperation = mock(BulkOperationWrapper.class);
             bulkResponseItem = mock(BulkResponseItem.class);
             eventHandle = mock(EventHandle.class);
             failure = new Exception();
@@ -75,13 +75,13 @@ public class FailedBulkOperationTest {
 
     @Nested
     class Builder {
-        private BulkOperationWithHandle bulkOperation;
+        private BulkOperationWrapper bulkOperation;
         private BulkResponseItem bulkResponseItem;
         private Throwable failure;
 
         @BeforeEach
         public void setUp() {
-            bulkOperation = mock(BulkOperationWithHandle.class);
+            bulkOperation = mock(BulkOperationWrapper.class);
             bulkResponseItem = mock(BulkResponseItem.class);
             failure = new Exception();
         }
@@ -125,14 +125,14 @@ public class FailedBulkOperationTest {
     @Nested
     class EqualsAndHashCodeAndToString {
 
-        private BulkOperationWithHandle bulkOperation;
+        private BulkOperationWrapper bulkOperation;
         private BulkResponseItem bulkResponseItem;
         private Throwable failure;
 
         private FailedBulkOperation testObject;
         @BeforeEach
         public void setUp() {
-            bulkOperation = mock(BulkOperationWithHandle.class);
+            bulkOperation = mock(BulkOperationWrapper.class);
             bulkResponseItem = mock(BulkResponseItem.class);
             failure = new Exception();
 


### PR DESCRIPTION
### Description
This change adds support for sending end-to-end acknowledgements in the OpenSearchSink.
Each event's event handle is captured along with the BulkOperation created for the event. When the BulkOperation is successfully sent to OpenSearchSink or Successfully written to configured DLQ, then a positive acknowledgement is sent by invoking `acknowledgementSetManager.releaseEventReference(handle, true)`. If it fails to do either of them, then negative acknowledgement is sent by invoking `acknowledgementSetManager.releaseEventReference(handle, false)`.

The `BulkOperation` used to keep track of the individual requests to OpenSearch is now wrapped in a new Object `BulkOperationWithHandle` which contains the original bulkOperation and the new event handle that keeps track of the specific event's completion. The event itself may be freed up after creating the `BulkOperationWithHandle`
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
