### PR TITLE
Address review comments from PR 2436

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/Source.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/Source.java
@@ -30,6 +30,7 @@ public interface Source<T extends Record<?>> {
      * Indicates if the source has end to end acknowledgements enabled
      *
      * @return boolean indicating if the source enabled end-to-end acknowledgements
+     * @since 2.2
      */
     default boolean areAcknowledgementsEnabled() {
         return false;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/InactiveAcknowledgementSetManager.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/InactiveAcknowledgementSetManager.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import java.util.function.Consumer;
+import java.time.Duration;
+
+public class InactiveAcknowledgementSetManager implements AcknowledgementSetManager {
+    private static InactiveAcknowledgementSetManager theInstance;
+
+    public static InactiveAcknowledgementSetManager getInstance() {
+        if (theInstance == null) {
+            theInstance = new InactiveAcknowledgementSetManager();
+        }
+        return theInstance;
+    }
+    
+    public AcknowledgementSet create(final Consumer<Boolean> callback, final Duration timeout) {
+        throw new UnsupportedOperationException("create operation not supported");
+    }
+
+    public void acquireEventReference(final Event event) {
+        throw new UnsupportedOperationException("acquire operation not supported");
+    }
+    
+    public void acquireEventReference(final EventHandle eventHandle) {
+        throw new UnsupportedOperationException("acquire operation not supported");
+    }
+    
+    public void releaseEventReference(final EventHandle eventHandle, boolean success) {
+        throw new UnsupportedOperationException("release operation not supported");
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/Pipeline.java
@@ -21,6 +21,7 @@ import org.opensearch.dataprepper.pipeline.router.RouterCopyRecordStrategy;
 import org.opensearch.dataprepper.pipeline.router.RouterGetRecordStrategy;
 import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.acknowledgements.InactiveAcknowledgementSetManager;
 import org.opensearch.dataprepper.sourcecoordination.SourceCoordinatorFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -287,7 +288,11 @@ public class Pipeline {
         final List<Future<Void>> sinkFutures = new ArrayList<>(sinksSize);
 
         final RouterGetRecordStrategy getRecordStrategy =
-                    new RouterCopyRecordStrategy(eventFactory, (source.areAcknowledgementsEnabled()) ? acknowledgementSetManager : null, sinks);
+                new RouterCopyRecordStrategy(eventFactory,
+                (source.areAcknowledgementsEnabled()) ?
+                    acknowledgementSetManager :
+                    InactiveAcknowledgementSetManager.getInstance(),
+                sinks);
         router.route(records, sinks, getRecordStrategy, (sink, events) ->
                 sinkFutures.add(sinkExecutorService.submit(() -> sink.output(events), null))
         );

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterCopyRecordStrategy.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterCopyRecordStrategy.java
@@ -58,7 +58,7 @@ public class RouterCopyRecordStrategy implements RouterGetRecordStrategy {
         return referencedRecords;
     }
 
-    private void acquireEventReference(Record record) {
+    private void acquireEventReference(final Record record) {
         if (acknowledgementSetManager == null || record.getData() == null) {
             return;
         }
@@ -72,7 +72,7 @@ public class RouterCopyRecordStrategy implements RouterGetRecordStrategy {
         }
     }
     @Override
-    public Record getRecord(Record record) {
+    public Record getRecord(final Record record) {
         if (routedRecords == null) {
             acquireEventReference(record);
             return record;
@@ -134,4 +134,10 @@ public class RouterCopyRecordStrategy implements RouterGetRecordStrategy {
         }
         return newRecords;
     }
+
+    // for testing
+    public AcknowledgementSetManager getAcknowledgementSetManager() {
+        return acknowledgementSetManager;
+    }
+
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/InactiveAcknowledgementSetManagerTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/InactiveAcknowledgementSetManagerTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.model.event.Event;
+
+import java.time.Duration;
+
+public class InactiveAcknowledgementSetManagerTests {
+    InactiveAcknowledgementSetManager acknowledgementSetManager;
+
+    @BeforeEach
+    void setup() {
+        acknowledgementSetManager = InactiveAcknowledgementSetManager.getInstance();
+    }
+
+    @Test
+    void testCreateAPI() {
+        assertThat(acknowledgementSetManager, notNullValue());
+        assertThrows(UnsupportedOperationException.class, () -> acknowledgementSetManager.create((a)->{}, Duration.ofMillis(10)));
+    }
+
+    @Test
+    void testEventAcquireAPI() {
+        assertThat(acknowledgementSetManager, notNullValue());
+        Event event = mock(Event.class);
+        assertThrows(UnsupportedOperationException.class, () -> acknowledgementSetManager.acquireEventReference(event));
+    }
+
+    @Test
+    void testEventHandleAcquireAPI() {
+        assertThat(acknowledgementSetManager, notNullValue());
+        EventHandle eventHandle = mock(EventHandle.class);
+        assertThrows(UnsupportedOperationException.class, () -> acknowledgementSetManager.acquireEventReference(eventHandle));
+    }
+
+    @Test
+    void testReleaseAPI() {
+        assertThat(acknowledgementSetManager, notNullValue());
+        EventHandle eventHandle = mock(EventHandle.class);
+        assertThrows(UnsupportedOperationException.class, () -> acknowledgementSetManager.releaseEventReference(eventHandle, true));
+    }
+
+}


### PR DESCRIPTION
### Description
This change addresses comments from PR 2436
apart from documentation and style fixes, this change introduces InactiveAcknowledgmentSetManager that is used when acknowledgement sets are not used.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
