### PR TITLE
Add format string option to add_entries processor

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -292,7 +292,7 @@ public class JacksonEvent implements Event {
         while ((position = format.indexOf("${", fromIndex)) != -1) {
             int endPosition = format.indexOf("}", position + 1);
             if (endPosition == -1) {
-                throw new RuntimeException("index name not properly formed");
+                throw new RuntimeException("Format string is not properly formed");
             }
             result += format.substring(fromIndex, position);
             String name = format.substring(position + 2, endPosition);

--- a/data-prepper-plugins/mutate-event-processors/README.md
+++ b/data-prepper-plugins/mutate-event-processors/README.md
@@ -39,10 +39,26 @@ When run, the processor will parse the message into the following output:
 
 > If `newMessage` had already existed, its existing value would have been overwritten with `3`
 
+We can also use `format` option to form the value for the new entry from existing entries. For example, if we update the above processor configuration to:
+```yaml
+  processor:
+    - add_entries:
+        entries:
+        - key: "newMessage"
+          format: "new ${message}"
+          overwrite_if_key_exists: true
+```
+then when we run with the same input, the processor will parse the message into the following output:
+
+```json
+{"message": "value", "newMessage": "new value"}
+```
+
 ### Configuration
 * `entries` - (required) - A list of entries to add to an event
   * `key` - (required) - The key of the new entry to be added
-  * `value` - (required) - The value of the new entry to be added. Strings, booleans, numbers, null, nested objects, and arrays containing the aforementioned data types are valid to use
+  * `value` - (optional) - The value of the new entry to be added. Strings, booleans, numbers, null, nested objects, and arrays containing the aforementioned data types are valid to use. Required if `format` is not specified.
+  * `format` - (optional) - A format string to use as value of the new entry to be added. For example, `${key1}-${ke2}` where `key1` and `key2` are existing keys in the event. Required if `value` is not specified.
   * `overwrite_if_key_exists` - (optional) - When set to `true`, if `key` already exists in the event, then the existing value will be overwritten. The default is `false`. 
 
 ___

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
@@ -6,10 +6,13 @@
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
+import java.util.Objects;
 
 public class AddEntryProcessorConfig {
     public static class Entry {
@@ -17,12 +20,8 @@ public class AddEntryProcessorConfig {
         @NotNull
         private String key;
 
-        @NotEmpty
-        @NotNull
         private Object value;
 
-        @NotEmpty
-        @NotNull
         private String format;
 
         @JsonProperty("overwrite_if_key_exists")
@@ -44,6 +43,11 @@ public class AddEntryProcessorConfig {
             return overwriteIfKeyExists;
         }
 
+        @AssertTrue(message = "Either value or format must be specified")
+        public boolean hasValueOrFormat() {
+            return Objects.nonNull(value) || Objects.nonNull(format);
+        }
+
         public Entry(final String key, final Object value, final String format, final boolean overwriteIfKeyExists)
         {
             this.key = key;
@@ -59,6 +63,7 @@ public class AddEntryProcessorConfig {
 
     @NotEmpty
     @NotNull
+    @Valid
     private List<Entry> entries;
 
     public List<Entry> getEntries() {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
@@ -21,6 +21,10 @@ public class AddEntryProcessorConfig {
         @NotNull
         private Object value;
 
+        @NotEmpty
+        @NotNull
+        private String format;
+
         @JsonProperty("overwrite_if_key_exists")
         private boolean overwriteIfKeyExists = false;
 
@@ -32,14 +36,19 @@ public class AddEntryProcessorConfig {
             return value;
         }
 
+        public String getFormat() {
+            return format;
+        }
+
         public boolean getOverwriteIfKeyExists() {
             return overwriteIfKeyExists;
         }
 
-        public Entry(final String key, final Object value, final boolean overwriteIfKeyExists)
+        public Entry(final String key, final Object value, final String format, final boolean overwriteIfKeyExists)
         {
             this.key = key;
             this.value = value;
+            this.format = format;
             this.overwriteIfKeyExists = overwriteIfKeyExists;
         }
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
@@ -51,6 +52,7 @@ public class CopyValueProcessorConfig {
 
     @NotEmpty
     @NotNull
+    @Valid
     private List<Entry> entries;
 
     public List<Entry> getEntries() {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
@@ -51,6 +52,7 @@ public class RenameKeyProcessorConfig {
 
     @NotEmpty
     @NotNull
+    @Valid
     private List<Entry> entries;
 
     public List<Entry> getEntries() {

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
@@ -28,6 +28,10 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class AddEntryProcessorTests {
+    private static final String TEST_FORMAT = "${date} ${time}";
+    private static final String ANOTHER_TEST_FORMAT = "${date}T${time}";
+    private static final String BAD_TEST_FORMAT = "${date} ${time";
+
     @Mock
     private PluginMetrics pluginMetrics;
 
@@ -36,7 +40,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -50,8 +54,8 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testMultiAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, false),
-                createEntry("message2", 4, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, false),
+                createEntry("message2", 4, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -67,7 +71,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleNoOverwriteAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -82,7 +86,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleOverwriteAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, true)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, true)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -97,8 +101,8 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testMultiOverwriteMixedAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, true),
-                (createEntry("message", 4, false))));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, true),
+                createEntry("message", 4, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -113,7 +117,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testIntAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -127,7 +131,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testBoolAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", true, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", true, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -141,7 +145,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testStringAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", "string", false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", "string", null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -155,7 +159,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testNullAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -181,7 +185,7 @@ public class AddEntryProcessorTests {
     public void testNestedAddProcessorTests() {
         TestObject obj = new TestObject();
         obj.a = "test";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", obj, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", obj, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -196,7 +200,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testArrayAddProcessorTests() {
         Object[] array = new Object[] { 1, 1.2, "string", true, null };
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", array, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", array, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -210,7 +214,8 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testFloatAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 1.2, false)));
+        when(mockConfig.getEntries())
+                .thenReturn(createListOfEntries(createEntry("newMessage", 1.2, null, false)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -222,12 +227,119 @@ public class AddEntryProcessorTests {
         assertThat(editedRecords.get(0).getData().get("newMessage", Object.class), equalTo(1.2));
     }
 
+    @Test
+    public void testAddSingleFormatEntry() {
+        when(mockConfig.getEntries())
+                .thenReturn(createListOfEntries(createEntry("date-time", null, TEST_FORMAT, false)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getTestEventWithMultipleFields();
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        Event event = editedRecords.get(0).getData();
+        assertThat(event.get("date", Object.class), equalTo("date-value"));
+        assertThat(event.get("time", Object.class), equalTo("time-value"));
+        assertThat(event.get("date-time", Object.class), equalTo("date-value time-value"));
+    }
+
+    @Test
+    public void testAddMultipleFormatEntries() {
+        when(mockConfig.getEntries())
+                .thenReturn(createListOfEntries(createEntry("date-time", null, TEST_FORMAT, false),
+                        createEntry("date-time2", null, ANOTHER_TEST_FORMAT, false)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getTestEventWithMultipleFields();
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        Event event = editedRecords.get(0).getData();
+        assertThat(event.get("date", Object.class), equalTo("date-value"));
+        assertThat(event.get("time", Object.class), equalTo("time-value"));
+        assertThat(event.get("date-time", Object.class), equalTo("date-value time-value"));
+        assertThat(event.get("date-time2", Object.class), equalTo("date-valueTtime-value"));
+    }
+
+    @Test
+    public void testFormatOverwritesExistingEntry() {
+        when(mockConfig.getEntries())
+                .thenReturn(
+                        createListOfEntries(createEntry("time", null, TEST_FORMAT, true)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getTestEventWithMultipleFields();
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        Event event = editedRecords.get(0).getData();
+        assertThat(event.get("date", Object.class), equalTo("date-value"));
+        assertThat(event.get("time", Object.class), equalTo("date-value time-value"));
+    }
+
+    @Test
+    public void testFormatNotOverwriteExistingEntry() {
+        when(mockConfig.getEntries())
+                .thenReturn(
+                        createListOfEntries(createEntry("time", null, TEST_FORMAT, false)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getTestEventWithMultipleFields();
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        Event event = editedRecords.get(0).getData();
+        assertThat(event.get("date", Object.class), equalTo("date-value"));
+        assertThat(event.get("time", Object.class), equalTo("time-value"));
+        assertThat(event.containsKey("date-time"), equalTo(false));
+    }
+
+    @Test
+    public void testFormatPrecedesValue() {
+        when(mockConfig.getEntries())
+                .thenReturn(
+                        createListOfEntries(createEntry("date-time", "date-time-value", TEST_FORMAT, false)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getTestEventWithMultipleFields();
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        Event event = editedRecords.get(0).getData();
+        assertThat(event.get("date", Object.class), equalTo("date-value"));
+        assertThat(event.get("time", Object.class), equalTo("time-value"));
+        assertThat(event.get("date-time", Object.class), equalTo("date-value time-value"));
+    }
+
+    @Test
+    public void testFormatVariousDataTypes() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(
+                "newField", null, "${number-key}-${boolean-key}-${string-key}", false)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getTestEventWithMultipleDataTypes();
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        Event event = editedRecords.get(0).getData();
+        assertThat(event.get("newField", Object.class), equalTo("1-true-string-value"));
+    }
+
+    @Test
+    public void testBadFormatThenEntryNotAdded() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("data-time", null, BAD_TEST_FORMAT, false)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getTestEventWithMultipleFields();
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        Event event = editedRecords.get(0).getData();
+        assertThat(event.get("date", Object.class), equalTo("date-value"));
+        assertThat(event.get("time", Object.class), equalTo("time-value"));
+        assertThat(event.containsKey("data-time"), equalTo(false));
+    }
+
     private AddEntryProcessor createObjectUnderTest() {
         return new AddEntryProcessor(pluginMetrics, mockConfig);
     }
 
-    private AddEntryProcessorConfig.Entry createEntry(final String key, final Object value, final boolean overwriteIfKeyExists) {
-        return new AddEntryProcessorConfig.Entry(key, value, overwriteIfKeyExists);
+    private AddEntryProcessorConfig.Entry createEntry(
+            final String key, final Object value, final String format, final boolean overwriteIfKeyExists) {
+        return new AddEntryProcessorConfig.Entry(key, value, format, overwriteIfKeyExists);
     }
 
     private List<AddEntryProcessorConfig.Entry> createListOfEntries(final AddEntryProcessorConfig.Entry... entries) {
@@ -235,9 +347,22 @@ public class AddEntryProcessorTests {
     }
 
     private Record<Event> getEvent(String message) {
-        final Map<String, Object> testData = new HashMap();
+        final Map<String, Object> testData = new HashMap<>();
         testData.put("message", message);
         return buildRecordWithEvent(testData);
+    }
+
+    private Record<Event> getTestEventWithMultipleFields() {
+        Map<String, Object> data = Map.of("date", "date-value", "time", "time-value");
+        return buildRecordWithEvent(data);
+    }
+
+    private Record<Event> getTestEventWithMultipleDataTypes() {
+        Map<String, Object> data = Map.of(
+                "number-key", 1,
+                "boolean-key", true,
+                "string-key", "string-value");
+        return buildRecordWithEvent(data);
     }
 
     private static Record<Event> buildRecordWithEvent(final Map<String, Object> data) {


### PR DESCRIPTION
### Description
Add an option in `add_entries` processor to add entries with format strings that can inject other event keys.

A sample config is like this
```
processor:
   - add_entries:
         entries:
            - key: "date-time"
              format: "${date} ${time}"
```
If both `format` and `value` options are provided, it takes `format` over `value`.
 
### Issues Resolved
Resolves #2424 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
