### PR TITLE
Add End to End acknowledgement support for S3 source

### DIFF
--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorkerIT.java
@@ -149,7 +149,7 @@ class S3ObjectWorkerIT {
 
     private void parseObject(final String key, final S3ObjectWorker objectUnderTest) throws IOException {
         final S3ObjectReference s3ObjectReference = S3ObjectReference.bucketAndKey(bucket, key).build();
-        objectUnderTest.parseS3Object(s3ObjectReference);
+        objectUnderTest.parseS3Object(s3ObjectReference, null);
     }
 
     static class IntegrationTestArguments implements ArgumentsProvider {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectHandler.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectHandler.java
@@ -5,11 +5,19 @@
 package org.opensearch.dataprepper.plugins.source;
 
 import java.io.IOException;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 
 /**
  * A S3ObjectHandler interface must be extended/implement for S3 Object parsing
  *
  */
 public interface S3ObjectHandler {
-    void parseS3Object(final S3ObjectReference s3ObjectReference) throws IOException;
+    /**
+     * Parse S3 object content using S3 object reference and pushing to buffer
+     * @param s3ObjectReference Contains bucket and s3 object details
+     * @param acknowledgementSet acknowledgement set for the object
+     *
+     * @throws IOException exception is thrown every time because this is not supported
+     */
+    void parseS3Object(final S3ObjectReference s3ObjectReference, final AcknowledgementSet acknowledgementSet) throws IOException;
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorker.java
@@ -9,6 +9,7 @@ import org.apache.commons.compress.utils.CountingInputStream;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.plugins.source.codec.Codec;
 import org.opensearch.dataprepper.plugins.source.compression.CompressionEngine;
 import org.opensearch.dataprepper.plugins.source.ownership.BucketOwnerProvider;
@@ -55,7 +56,7 @@ class S3ObjectWorker implements S3ObjectHandler {
         this.s3ObjectPluginMetrics = s3ObjectRequest.getS3ObjectPluginMetrics();
     }
 
-    public void parseS3Object(final S3ObjectReference s3ObjectReference) throws IOException {
+    public void parseS3Object(final S3ObjectReference s3ObjectReference, final AcknowledgementSet acknowledgementSet) throws IOException {
         final GetObjectRequest.Builder getObjectBuilder = GetObjectRequest.builder()
                 .bucket(s3ObjectReference.getBucketName())
                 .key(s3ObjectReference.getKey());
@@ -66,7 +67,7 @@ class S3ObjectWorker implements S3ObjectHandler {
         final BufferAccumulator<Record<Event>> bufferAccumulator = BufferAccumulator.create(buffer, numberOfRecordsToAccumulate, bufferTimeout);
         try {
             s3ObjectPluginMetrics.getS3ObjectReadTimer().recordCallable((Callable<Void>) () -> {
-                doParseObject(s3ObjectReference, getObjectRequest, bufferAccumulator);
+                doParseObject(acknowledgementSet, s3ObjectReference, getObjectRequest, bufferAccumulator);
                 return null;
             });
         } catch (final IOException | RuntimeException e) {
@@ -79,7 +80,7 @@ class S3ObjectWorker implements S3ObjectHandler {
         s3ObjectPluginMetrics.getS3ObjectsSucceededCounter().increment();
     }
 
-    private void doParseObject(final S3ObjectReference s3ObjectReference, final GetObjectRequest getObjectRequest, final BufferAccumulator<Record<Event>> bufferAccumulator) throws IOException {
+    private void doParseObject(final AcknowledgementSet acknowledgementSet, final S3ObjectReference s3ObjectReference, final GetObjectRequest getObjectRequest, final BufferAccumulator<Record<Event>> bufferAccumulator) throws IOException {
         final long s3ObjectSize;
         final long totalBytesRead;
 
@@ -92,6 +93,9 @@ class S3ObjectWorker implements S3ObjectHandler {
                 try {
                     eventConsumer.accept(record.getData(), s3ObjectReference);
                     bufferAccumulator.add(record);
+                    if (acknowledgementSet != null) {
+                        acknowledgementSet.add(record.getData());
+                    }
                 } catch (final Exception e) {
                     LOG.error("Failed writing S3 objects to buffer due to: {}", e.getMessage());
                 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3Service.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3Service.java
@@ -5,15 +5,17 @@
 
 package org.opensearch.dataprepper.plugins.source;
 
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import java.io.IOException;
 
 public class S3Service {
     private final S3ObjectHandler s3ObjectHandler;
     S3Service(final S3ObjectHandler s3ObjectHandler) {
-        this.s3ObjectHandler =s3ObjectHandler;
+        this.s3ObjectHandler = s3ObjectHandler;
     }
 
-    void addS3Object(final S3ObjectReference s3ObjectReference) throws IOException {
-        s3ObjectHandler.parseS3Object(s3ObjectReference);
+    void addS3Object(final S3ObjectReference s3ObjectReference, AcknowledgementSet acknowledgementSet) throws IOException {
+        s3ObjectHandler.parseS3Object(s3ObjectReference, acknowledgementSet);
     }
+
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SourceConfig.java
@@ -46,6 +46,9 @@ public class S3SourceConfig {
     @JsonProperty("on_error")
     private OnErrorOption onErrorOption = OnErrorOption.RETAIN_MESSAGES;
 
+    @JsonProperty("end_to_end_acknowledgements")
+    private boolean endToEndAcknowledgements = false;
+
     @JsonProperty("buffer_timeout")
     private Duration bufferTimeout = DEFAULT_BUFFER_TIMEOUT;
 
@@ -69,6 +72,10 @@ public class S3SourceConfig {
 
     public NotificationTypeOption getNotificationType() {
         return notificationType;
+    }
+
+    boolean getEndToEndAcknowledgements() {
+        return endToEndAcknowledgements;
     }
 
     public CompressionOption getCompression() {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
@@ -15,6 +15,8 @@ import org.opensearch.dataprepper.plugins.source.configuration.SqsOptions;
 import org.opensearch.dataprepper.plugins.source.exception.SqsRetriesExhaustedException;
 import org.opensearch.dataprepper.plugins.source.filter.ObjectCreatedFilter;
 import org.opensearch.dataprepper.plugins.source.filter.S3EventFilter;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -44,6 +46,7 @@ public class SqsWorker implements Runnable {
     static final String SQS_MESSAGES_FAILED_METRIC_NAME = "sqsMessagesFailed";
     static final String SQS_MESSAGES_DELETE_FAILED_METRIC_NAME = "sqsMessagesDeleteFailed";
     static final String SQS_MESSAGE_DELAY_METRIC_NAME = "sqsMessageDelay";
+    static final String ACKNOWLEDGEMENT_SET_CALLACK_METRIC_NAME = "acknowledgementSetCallbackCounter";
 
     private final S3SourceConfig s3SourceConfig;
     private final SqsClient sqsClient;
@@ -54,11 +57,15 @@ public class SqsWorker implements Runnable {
     private final Counter sqsMessagesDeletedCounter;
     private final Counter sqsMessagesFailedCounter;
     private final Counter sqsMessagesDeleteFailedCounter;
+    private final Counter acknowledgementSetCallbackCounter;
     private final Timer sqsMessageDelayTimer;
     private final Backoff standardBackoff;
     private int failedAttemptCount;
+    private boolean endToEndAcknowledgementsEnabled;
+    private final AcknowledgementSetManager acknowledgementSetManager;
 
-    public SqsWorker(final SqsClient sqsClient,
+    public SqsWorker(final AcknowledgementSetManager acknowledgementSetManager,
+                     final SqsClient sqsClient,
                      final S3Service s3Service,
                      final S3SourceConfig s3SourceConfig,
                      final PluginMetrics pluginMetrics,
@@ -66,7 +73,9 @@ public class SqsWorker implements Runnable {
         this.sqsClient = sqsClient;
         this.s3Service = s3Service;
         this.s3SourceConfig = s3SourceConfig;
+        this.acknowledgementSetManager = acknowledgementSetManager;
         this.standardBackoff = backoff;
+        this.endToEndAcknowledgementsEnabled = s3SourceConfig.getEndToEndAcknowledgements();
         sqsOptions = s3SourceConfig.getSqsOptions();
         objectCreatedFilter = new ObjectCreatedFilter();
         failedAttemptCount = 0;
@@ -76,6 +85,7 @@ public class SqsWorker implements Runnable {
         sqsMessagesFailedCounter = pluginMetrics.counter(SQS_MESSAGES_FAILED_METRIC_NAME);
         sqsMessagesDeleteFailedCounter = pluginMetrics.counter(SQS_MESSAGES_DELETE_FAILED_METRIC_NAME);
         sqsMessageDelayTimer = pluginMetrics.timer(SQS_MESSAGE_DELAY_METRIC_NAME);
+        acknowledgementSetCallbackCounter = pluginMetrics.counter(ACKNOWLEDGEMENT_SET_CALLACK_METRIC_NAME);
     }
 
     @Override
@@ -204,11 +214,25 @@ public class SqsWorker implements Runnable {
 
         LOG.info("Received {} messages from SQS. Processing {} messages.", s3EventNotificationRecords.size(), parsedMessagesToRead.size());
 
+        List<DeleteMessageBatchRequestEntry> waitingForAcknowledgements = new ArrayList<>();
+        AcknowledgementSet acknowledgementSet = null;
+        if (endToEndAcknowledgementsEnabled) {
+            // Acknowledgement Set timeout is slightly smaller than the visibility timeout;
+            int timeout = (int) sqsOptions.getVisibilityTimeout().getSeconds() - 2;
+            acknowledgementSet = acknowledgementSetManager.create((result) -> {
+                acknowledgementSetCallbackCounter.increment();
+                deleteSqsMessages(waitingForAcknowledgements);
+            }, Duration.ofSeconds(timeout));
+        }
         for (ParsedMessage parsedMessage : parsedMessagesToRead) {
             final List<S3EventNotification.S3EventNotificationRecord> notificationRecords = parsedMessage.notificationRecords;
             final S3ObjectReference s3ObjectReference = populateS3Reference(notificationRecords.get(0));
-            final Optional<DeleteMessageBatchRequestEntry> deleteMessageBatchRequestEntry = processS3Object(parsedMessage, s3ObjectReference);
-            deleteMessageBatchRequestEntry.ifPresent(deleteMessageBatchRequestEntryCollection::add);
+            final Optional<DeleteMessageBatchRequestEntry> deleteMessageBatchRequestEntry = processS3Object(parsedMessage, s3ObjectReference, acknowledgementSet);
+            if (endToEndAcknowledgementsEnabled) {
+                deleteMessageBatchRequestEntry.ifPresent(waitingForAcknowledgements::add);
+            } else {
+                deleteMessageBatchRequestEntry.ifPresent(deleteMessageBatchRequestEntryCollection::add);
+            }
         }
 
         return deleteMessageBatchRequestEntryCollection;
@@ -216,10 +240,11 @@ public class SqsWorker implements Runnable {
 
     private Optional<DeleteMessageBatchRequestEntry> processS3Object(
             final ParsedMessage parsedMessage,
-            final S3ObjectReference s3ObjectReference) {
+            final S3ObjectReference s3ObjectReference,
+            final AcknowledgementSet acknowledgementSet) {
         // SQS messages won't be deleted if we are unable to process S3Objects because of S3Exception: Access Denied
         try {
-            s3Service.addS3Object(s3ObjectReference);
+            s3Service.addS3Object(s3ObjectReference, acknowledgementSet);
             sqsMessageDelayTimer.record(Duration.between(
                     Instant.ofEpochMilli(parsedMessage.notificationRecords.get(0).getEventTime().toInstant().getMillis()),
                     Instant.now()

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SourceConfigTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SourceConfigTest.java
@@ -39,6 +39,18 @@ class S3SourceConfigTest {
     }
 
     @Test
+    void default_end_to_end_acknowledgements_test() {
+        assertThat(new S3SourceConfig().getEndToEndAcknowledgements(), equalTo(false));
+    }
+
+    @Test
+    void end_to_end_acknowledgements_set_to_true_test() throws Exception {
+        final S3SourceConfig s3SourceConfig = new S3SourceConfig();
+        ReflectivelySetField.setField(S3SourceConfig.class,s3SourceConfig,"endToEndAcknowledgements", true);
+        assertTrue(s3SourceConfig.getEndToEndAcknowledgements());
+    }
+
+    @Test
     void default_records_to_accumulate_test() {
         assertThat(new S3SourceConfig().getNumberOfRecordsToAccumulate(), equalTo(DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE));
     }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SourceTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SourceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -23,6 +24,7 @@ class S3SourceTest {
     private PluginMetrics pluginMetrics;
     private S3SourceConfig s3SourceConfig;
     private PluginFactory pluginFactory;
+    private AcknowledgementSetManager acknowledgementSetManager;
 
 
     @BeforeEach
@@ -30,10 +32,11 @@ class S3SourceTest {
         pluginMetrics = PluginMetrics.fromNames(PLUGIN_NAME, TEST_PIPELINE_NAME);
         s3SourceConfig = mock(S3SourceConfig.class);
         pluginFactory = mock(PluginFactory.class);
+        acknowledgementSetManager = mock(AcknowledgementSetManager.class);
 
         when(s3SourceConfig.getCodec()).thenReturn(mock(PluginModel.class));
 
-        s3Source = new S3Source(pluginMetrics, s3SourceConfig, pluginFactory);
+        s3Source = new S3Source(pluginMetrics, s3SourceConfig, pluginFactory, acknowledgementSetManager);
     }
 
     @Test


### PR DESCRIPTION
### Description
Add End to End acknowledgement support for S3 source.
This change includes - 
1. Adding an optional configuration parameter `end_to_end_acknowledgements: true` for s3 source to enable end to end acknowledgements
2. Creates an acknowledgement set and adds the created records to the set so that when all the records are pushed to the sinks, the callback can be invoked.
3. Modifies S3 codecs to use EventFactory to creates events.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
