### PR TITLE
ENH: batching metrics with same tags in EMFLoggingMeterRegistry

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/meter/EMFLoggingMeterRegistry.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/meter/EMFLoggingMeterRegistry.java
@@ -33,9 +33,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 
@@ -86,7 +89,7 @@ public class EMFLoggingMeterRegistry extends StepMeterRegistry {
     @Override
     protected void publish() {
         if (config.enabled()) {
-            metricsLoggers().forEach(MetricsLogger::flush);
+            metricsLoggers2().forEach(MetricsLogger::flush);
         }
     }
 
@@ -106,9 +109,60 @@ public class EMFLoggingMeterRegistry extends StepMeterRegistry {
         ).collect(toList());
     }
 
+    List<MetricsLogger> metricsLoggers2() {
+        final Snapshot snapshot = new Snapshot();
+        final Map<List<Tag>, List<Meter>> tagsToMeters = getMeters().stream().collect(
+                groupingBy(meter -> meter.getId().getConventionTags(config().namingConvention())));
+        return tagsToMeters.entrySet().stream()
+                .map(entry -> {
+                    final List<Tag> tags = entry.getKey();
+                    final MetricsLogger metricsLogger = prepareMetricsLogger(tags, snapshot.timestamp);
+                    final List<Meter> meters = entry.getValue();
+                    meters.stream().flatMap(m -> m.match(
+                            snapshot::gaugeData,
+                            snapshot::counterData,
+                            snapshot::timerData,
+                            snapshot::summaryData,
+                            snapshot::longTaskTimerData,
+                            snapshot::timeGaugeData,
+                            snapshot::functionCounterData,
+                            snapshot::functionTimerData,
+                            snapshot::metricData
+                    )).forEach(metricDataPoint -> 
+                            metricsLogger.putMetric(metricDataPoint.key, metricDataPoint.value, metricDataPoint.unit));
+                    return metricsLogger;
+                }).collect(toList());
+    }
+
+    private MetricsLogger prepareMetricsLogger(final List<Tag> tags, final Instant timestamp) {
+        final MetricsLogger metricsLogger = new MetricsLogger(environment)
+                .setNamespace(NAMESPACE)
+                .setTimestamp(timestamp);
+        addDimensionSet(tags, metricsLogger);
+        return metricsLogger;
+    }
+
+    private void addDimensionSet(final List<Tag> tags, final MetricsLogger metricsLogger) {
+        metricsLogger.setDimensions(toDimensionSet(tags));
+    }
+
+    private DimensionSet toDimensionSet(final List<Tag> tags) {
+        final DimensionSet dimensionSet = new DimensionSet();
+        tags.stream().filter(this::isAcceptableTag).forEach(tag -> dimensionSet.addDimension(tag.getKey(), tag.getValue()));
+        return dimensionSet;
+    }
+
+    private boolean isAcceptableTag(final Tag tag) {
+        if (StringUtils.isBlank(tag.getValue())) {
+            warnThenDebugLogger.log("Dropping a tag with key '" + tag.getKey() + "' because its value is blank.");
+            return false;
+        }
+        return true;
+    }
+
     // VisibleForTesting
     class Snapshot {
-        private final Instant timestamp = Instant.ofEpochMilli(clock.wallTime());
+        final Instant timestamp = Instant.ofEpochMilli(clock.wallTime());
 
         MetricsLogger gaugeDataMetricsLogger(final Gauge gauge) {
             final MetricsLogger metricsLogger = prepareMetricsLogger(gauge.getId());
@@ -116,10 +170,22 @@ public class EMFLoggingMeterRegistry extends StepMeterRegistry {
             return metricsLogger;
         }
 
+        Stream<MetricDataPoint> gaugeData(final Gauge gauge) {
+            return Stream.ofNullable(
+                    metricDataPoint(gauge.getId(), "value", gauge.value())
+            );
+        }
+
         MetricsLogger counterDataMetricsLogger(final Counter counter) {
             final MetricsLogger metricsLogger = prepareMetricsLogger(counter.getId());
             addMetricDatum(counter.getId(), "count", Unit.COUNT, counter.count(), metricsLogger);
             return metricsLogger;
+        }
+
+        Stream<MetricDataPoint> counterData(final Counter counter) {
+            return Stream.ofNullable(
+                    metricDataPoint(counter.getId(), "count", Unit.COUNT, counter.count())
+            );
         }
 
         MetricsLogger timerDataMetricsLogger(final Timer timer) {
@@ -134,6 +200,26 @@ public class EMFLoggingMeterRegistry extends StepMeterRegistry {
             return metricsLogger;
         }
 
+        Stream<MetricDataPoint> timerData(final Timer timer) {
+            final Stream.Builder<MetricDataPoint> metrics = Stream.builder();
+            metrics.add(
+                    metricDataPoint(timer.getId(), "sum", getBaseTimeUnit().name(), timer.totalTime(getBaseTimeUnit()))
+            );
+            final long count = timer.count();
+            metrics.add(
+                    metricDataPoint(timer.getId(), "count", Unit.COUNT, count)
+            );
+            if (count > 0) {
+                metrics.add(
+                        metricDataPoint(timer.getId(), "avg", getBaseTimeUnit().name(), timer.mean(getBaseTimeUnit()))
+                );
+                metrics.add(
+                        metricDataPoint(timer.getId(), "max", getBaseTimeUnit().name(), timer.max(getBaseTimeUnit()))
+                );
+            }
+            return metrics.build();
+        }
+
         MetricsLogger summaryDataMetricsLogger(final DistributionSummary summary) {
             final MetricsLogger metricsLogger = prepareMetricsLogger(summary.getId());
             addMetricDatum(summary.getId(), "sum", summary.totalAmount(), metricsLogger);
@@ -146,11 +232,30 @@ public class EMFLoggingMeterRegistry extends StepMeterRegistry {
             return metricsLogger;
         }
 
+        Stream<MetricDataPoint> summaryData(final DistributionSummary summary) {
+            final Stream.Builder<MetricDataPoint> metrics = Stream.builder();
+            metrics.add(metricDataPoint(summary.getId(), "sum", summary.totalAmount()));
+            final long count = summary.count();
+            metrics.add(metricDataPoint(summary.getId(), "count", Unit.COUNT, count));
+            if (count > 0) {
+                metrics.add(metricDataPoint(summary.getId(), "avg", summary.mean()));
+                metrics.add(metricDataPoint(summary.getId(), "max", summary.max()));
+            }
+            return metrics.build();
+        }
+
         MetricsLogger longTaskTimerDataMetricsLogger(final LongTaskTimer longTaskTimer) {
             final MetricsLogger metricsLogger = prepareMetricsLogger(longTaskTimer.getId());
             addMetricDatum(longTaskTimer.getId(), "activeTasks", longTaskTimer.activeTasks(), metricsLogger);
             addMetricDatum(longTaskTimer.getId(), "duration", longTaskTimer.duration(getBaseTimeUnit()), metricsLogger);
             return metricsLogger;
+        }
+
+        Stream<MetricDataPoint> longTaskTimerData(final LongTaskTimer longTaskTimer) {
+            final Stream.Builder<MetricDataPoint> metrics = Stream.builder();
+            metrics.add(metricDataPoint(longTaskTimer.getId(), "activeTasks", longTaskTimer.activeTasks()));
+            metrics.add(metricDataPoint(longTaskTimer.getId(), "duration", longTaskTimer.duration(getBaseTimeUnit())));
+            return metrics.build();
         }
 
         MetricsLogger timeGaugeDataMetricsLogger(final TimeGauge gauge) {
@@ -159,10 +264,22 @@ public class EMFLoggingMeterRegistry extends StepMeterRegistry {
             return metricsLogger;
         }
 
+        Stream<MetricDataPoint> timeGaugeData(final TimeGauge gauge) {
+            final Stream.Builder<MetricDataPoint> metrics = Stream.builder();
+            metrics.add(metricDataPoint(gauge.getId(), "value", gauge.value(getBaseTimeUnit())));
+            return metrics.build();
+        }
+
         MetricsLogger functionCounterDataMetricsLogger(final FunctionCounter counter) {
             final MetricsLogger metricsLogger = prepareMetricsLogger(counter.getId());
             addMetricDatum(counter.getId(), "count", Unit.COUNT, counter.count(), metricsLogger);
             return metricsLogger;
+        }
+
+        Stream<MetricDataPoint> functionCounterData(final FunctionCounter counter) {
+            final Stream.Builder<MetricDataPoint> metrics = Stream.builder();
+            metrics.add(metricDataPoint(counter.getId(), "count", Unit.COUNT, counter.count()));
+            return metrics.build();
         }
 
         MetricsLogger functionTimerDataMetricsLogger(final FunctionTimer timer) {
@@ -181,6 +298,22 @@ public class EMFLoggingMeterRegistry extends StepMeterRegistry {
             return metricsLogger;
         }
 
+        Stream<MetricDataPoint> functionTimerData(final FunctionTimer timer) {
+            final Stream.Builder<MetricDataPoint> metrics = Stream.builder();
+            // we can't know anything about max and percentiles originating from a function timer
+            final double sum = timer.totalTime(getBaseTimeUnit());
+            if (!Double.isFinite(sum)) {
+                return Stream.empty();
+            }
+            final double count = timer.count();
+            metrics.add(metricDataPoint(timer.getId(), "count", Unit.COUNT, count));
+            metrics.add(metricDataPoint(timer.getId(), "sum", sum));
+            if (count > 0) {
+                metrics.add(metricDataPoint(timer.getId(), "avg", timer.mean(getBaseTimeUnit())));
+            }
+            return metrics.build();
+        }
+
         MetricsLogger metricDataMetricsLogger(final Meter m) {
             final MetricsLogger metricsLogger = prepareMetricsLogger(m.getId());
             stream(m.measure().spliterator(), false)
@@ -188,22 +321,47 @@ public class EMFLoggingMeterRegistry extends StepMeterRegistry {
             return metricsLogger;
         }
 
+        Stream<MetricDataPoint> metricData(final Meter m) {
+            return stream(m.measure().spliterator(), false)
+                    .map(ms -> metricDataPoint(m.getId().withTag(ms.getStatistic()), ms.getValue()))
+                    .filter(Objects::nonNull);
+        }
+
         private void addMetricDatum(final Meter.Id id, final double value, final MetricsLogger metricsLogger) {
             addMetricDatum(id, null, id.getBaseUnit(), value, metricsLogger);
+        }
+
+        private MetricDataPoint metricDataPoint(final Meter.Id id, final double value) {
+            return metricDataPoint(id, null, id.getBaseUnit(), value);
         }
 
         private void addMetricDatum(final Meter.Id id, @Nullable final String suffix, final double value, final MetricsLogger metricsLogger) {
             addMetricDatum(id, suffix, id.getBaseUnit(), value, metricsLogger);
         }
 
+        private MetricDataPoint metricDataPoint(final Meter.Id id, @Nullable final String suffix, final double value) {
+            return metricDataPoint(id, suffix, id.getBaseUnit(), value);
+        }
+
         private void addMetricDatum(final Meter.Id id, @Nullable final String suffix, @Nullable final String unit, final double value, final MetricsLogger metricsLogger) {
             addMetricDatum(id, suffix, toUnit(unit), value, metricsLogger);
+        }
+
+        private MetricDataPoint metricDataPoint(final Meter.Id id, @Nullable final String suffix, @Nullable final String unit, final double value) {
+            return metricDataPoint(id, suffix, toUnit(unit), value);
         }
 
         private void addMetricDatum(final Meter.Id id, @Nullable final String suffix, final Unit unit, final double value, final MetricsLogger metricsLogger) {
             if (!Double.isNaN(value)) {
                 metricsLogger.putMetric(getMetricName(id, suffix), EMFMetricUtils.clampMetricValue(value), unit);
             }
+        }
+
+        private MetricDataPoint metricDataPoint(final Meter.Id id, @Nullable final String suffix, final Unit unit, final double value) {
+            if (Double.isNaN(value)) {
+                return null;
+            }
+            return new MetricDataPoint(getMetricName(id, suffix), EMFMetricUtils.clampMetricValue(value), unit);
         }
 
         private void addDimensionSet(final Meter.Id id, final MetricsLogger metricsLogger) {
@@ -244,6 +402,18 @@ public class EMFLoggingMeterRegistry extends StepMeterRegistry {
                 return false;
             }
             return true;
+        }
+    }
+
+    class MetricDataPoint {
+        String key;
+        double value;
+        Unit unit;
+
+        MetricDataPoint(String key, double value, Unit unit) {
+            this.key = key;
+            this.value = value;
+            this.unit = unit;
         }
     }
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/meter/EMFLoggingMeterRegistryTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/meter/EMFLoggingMeterRegistryTest.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.meter;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.Counter;
@@ -36,7 +35,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static io.micrometer.core.instrument.Meter.Id;
 import static io.micrometer.core.instrument.Meter.Type;
@@ -79,17 +77,6 @@ class EMFLoggingMeterRegistryTest {
     }
 
     @Test
-    void snapshotGaugeMetricsLoggerValid() throws JsonProcessingException {
-        final Gauge gauge = Gauge.builder("gauge", 1d, Number::doubleValue)
-                .tags(TEST_TAG_KEY, TEST_TAG_VALUE).register(registry);
-        final MetricsLogger metricsLogger = registrySnapshot.gaugeDataMetricsLogger(gauge);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, gauge.getId(), "value"), is(true));
-    }
-
-    @Test
     void snapshotGaugeDataValid() {
         final Gauge gauge = Gauge.builder("gauge", 1d, Number::doubleValue)
                 .tags(TEST_TAG_KEY, TEST_TAG_VALUE).register(registry);
@@ -103,17 +90,6 @@ class EMFLoggingMeterRegistryTest {
     }
 
     @Test
-    void snapshotGaugeMetricsLoggerWhenNaNShouldNotAdd() throws JsonProcessingException {
-        final Gauge gauge = Gauge.builder("gauge", Double.NaN, Number::doubleValue)
-                .tags(TEST_TAG_KEY, TEST_TAG_VALUE).register(registry);
-        final MetricsLogger metricsLogger = registrySnapshot.gaugeDataMetricsLogger(gauge);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, gauge.getId(), "value"), is(false));
-    }
-
-    @Test
     void snapshotGaugeDataWhenNaNShouldNotAdd() {
         final Gauge gauge = Gauge.builder("gauge", Double.NaN, Number::doubleValue)
                 .tags(TEST_TAG_KEY, TEST_TAG_VALUE).register(registry);
@@ -123,17 +99,7 @@ class EMFLoggingMeterRegistryTest {
     }
 
     @Test
-    void snapshotCounterMetricsLoggerValid() throws JsonProcessingException {
-        final Counter counter = Counter.builder("counter").tag(TEST_TAG_KEY, TEST_TAG_VALUE).register(registry);
-        final MetricsLogger metricsLogger = registrySnapshot.counterDataMetricsLogger(counter);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, counter.getId(), "count"), is(true));
-    }
-
-    @Test
-    void snapshotCounterMetricDataValid() throws JsonProcessingException {
+    void snapshotCounterMetricDataValid() {
         final Counter counter = Counter.builder("counter").tag(TEST_TAG_KEY, TEST_TAG_VALUE).register(registry);
         final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints = registrySnapshot.counterData(counter)
                 .collect(Collectors.toList());
@@ -145,207 +111,196 @@ class EMFLoggingMeterRegistryTest {
     }
 
     @Test
-    void snapshotShouldAddTimerAggregateMetricWhenAtLeastOneEventHappened() throws JsonProcessingException {
+    void snapshotShouldAddTimerAggregateDataWhenAtLeastOneEventHappened() {
         final Timer timer = mock(Timer.class);
         final Id meterId = new Id(METER_NAME, Tags.of(TEST_TAG_KEY, TEST_TAG_VALUE), null, null, TIMER);
         when(timer.getId()).thenReturn(meterId);
         when(timer.count()).thenReturn(2L);
 
-        final MetricsLogger metricsLogger = registrySnapshot.timerDataMetricsLogger(timer);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, meterId, "count"), is(true));
-        assertThat(hasMetric(context, meterId, "sum"), is(true));
-        assertThat(hasMetric(context, meterId, "avg"), is(true));
-        assertThat(hasMetric(context, meterId, "max"), is(true));
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints = registrySnapshot.timerData(timer)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints.size(), equalTo(4));
+        assertThat(metricDataPoints.stream().map(metricDataPoint -> metricDataPoint.key).collect(Collectors.toList())
+                .containsAll(List.of("test.count", "test.sum", "test.avg", "test.max")), is(true));
     }
 
     @Test
-    void snapshotShouldNotAddTimerAggregateMetricWhenNoEventHappened() throws JsonProcessingException {
+    void snapshotShouldNotAddTimerAggregateDataWhenNoEventHappened() {
         Timer timer = mock(Timer.class);
         Id meterId = new Id(METER_NAME, Tags.of(TEST_TAG_KEY, TEST_TAG_VALUE), null, null, TIMER);
         when(timer.getId()).thenReturn(meterId);
         when(timer.count()).thenReturn(0L);
 
-        final MetricsLogger metricsLogger = registrySnapshot.timerDataMetricsLogger(timer);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, meterId, "count"), is(true));
-        assertThat(hasMetric(context, meterId, "sum"), is(true));
-        assertThat(hasMetric(context, meterId, "avg"), is(false));
-        assertThat(hasMetric(context, meterId, "max"), is(false));
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints = registrySnapshot.timerData(timer)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints.size(), equalTo(2));
+        assertThat(metricDataPoints.stream().map(metricDataPoint -> metricDataPoint.key).collect(Collectors.toList())
+                .containsAll(List.of("test.count", "test.sum")), is(true));
     }
 
     @Test
-    void snapshotShouldAddSummaryAggregateMetricWhenAtLeastOneEventHappened() throws JsonProcessingException {
+    void snapshotShouldAddSummaryAggregateDataWhenAtLeastOneEventHappened() {
         final DistributionSummary summary = mock(DistributionSummary.class);
         final Id meterId = new Id(METER_NAME, Tags.of(TEST_TAG_KEY, TEST_TAG_VALUE), null, null, DISTRIBUTION_SUMMARY);
         when(summary.getId()).thenReturn(meterId);
         when(summary.count()).thenReturn(2L);
 
-        final MetricsLogger metricsLogger = registrySnapshot.summaryDataMetricsLogger(summary);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, meterId, "count"), is(true));
-        assertThat(hasMetric(context, meterId, "sum"), is(true));
-        assertThat(hasMetric(context, meterId, "avg"), is(true));
-        assertThat(hasMetric(context, meterId, "max"), is(true));
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints = registrySnapshot.summaryData(summary)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints.size(), equalTo(4));
+        assertThat(metricDataPoints.stream().map(metricDataPoint -> metricDataPoint.key).collect(Collectors.toList())
+                .containsAll(List.of("test.count", "test.sum", "test.avg", "test.max")), is(true));
     }
 
     @Test
-    void shouldNotAddDistributionSumAggregateMetricWhenNoEventHappened() throws JsonProcessingException {
+    void shouldNotAddDistributionSumAggregateDataWhenNoEventHappened() {
         final DistributionSummary summary = mock(DistributionSummary.class);
         final Id meterId = new Id(METER_NAME, Tags.of(TEST_TAG_KEY, TEST_TAG_VALUE), null, null, DISTRIBUTION_SUMMARY);
         when(summary.getId()).thenReturn(meterId);
         when(summary.count()).thenReturn(0L);
 
-        final MetricsLogger metricsLogger = registrySnapshot.summaryDataMetricsLogger(summary);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, meterId, "count"), is(true));
-        assertThat(hasMetric(context, meterId, "sum"), is(true));
-        assertThat(hasMetric(context, meterId, "avg"), is(false));
-        assertThat(hasMetric(context, meterId, "max"), is(false));
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints = registrySnapshot.summaryData(summary)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints.size(), equalTo(2));
+        assertThat(metricDataPoints.stream().map(metricDataPoint -> metricDataPoint.key).collect(Collectors.toList())
+                .containsAll(List.of("test.count", "test.sum")), is(true));
     }
 
     @Test
-    void snapshotLongTaskTimerMetricsLoggerValid() throws JsonProcessingException {
+    void snapshotLongTaskTimerDataValid() {
         final LongTaskTimer longTaskTimer = LongTaskTimer.builder("longTaskTimer")
                 .tag(TEST_TAG_KEY, TEST_TAG_VALUE).register(registry);
-        final MetricsLogger metricsLogger = registrySnapshot.longTaskTimerDataMetricsLogger(longTaskTimer);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, longTaskTimer.getId(), "activeTasks"), is(true));
-        assertThat(hasMetric(context, longTaskTimer.getId(), "duration"), is(true));
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints = registrySnapshot
+                .longTaskTimerData(longTaskTimer)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints.size(), equalTo(2));
+        assertThat(metricDataPoints.stream().map(metricDataPoint -> metricDataPoint.key).collect(Collectors.toList())
+                .containsAll(List.of("longTaskTimer.activeTasks", "longTaskTimer.duration")), is(true));
     }
 
     @Test
-    void snapshotTimeGaugeDataMetricsLoggerValid() throws JsonProcessingException {
+    void snapshotTimeGaugeDataValid() {
         final AtomicReference<Double> testValue = new AtomicReference<>(0.0);
         final TimeGauge timeGauge = TimeGauge.builder("timeGaugeData", testValue, TimeUnit.MILLISECONDS, AtomicReference::get)
                 .tag(TEST_TAG_KEY, TEST_TAG_VALUE).register(registry);
-        final MetricsLogger metricsLogger = registrySnapshot.timeGaugeDataMetricsLogger(timeGauge);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, timeGauge.getId(), "value"), is(true));
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints = registrySnapshot
+                .timeGaugeData(timeGauge)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints.size(), equalTo(1));
+        assertThat(metricDataPoints.stream().map(metricDataPoint -> metricDataPoint.key).collect(Collectors.toList())
+                .contains("timeGaugeData.value"), is(true));
     }
 
     @Test
-    void snapshotTimeGaugeDataMetricsLoggerWhenNaNShouldNotAdd() throws JsonProcessingException {
+    void snapshotTimeGaugeDataWhenNaNShouldNotAdd() {
         final AtomicReference<Double> testValue = new AtomicReference<>(Double.NaN);
         final TimeGauge timeGauge = TimeGauge.builder("timeGaugeData", testValue, TimeUnit.MILLISECONDS, AtomicReference::get)
                 .tag(TEST_TAG_KEY, TEST_TAG_VALUE).register(registry);
-        final MetricsLogger metricsLogger = registrySnapshot.timeGaugeDataMetricsLogger(timeGauge);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, timeGauge.getId(), "value"), is(false));
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints = registrySnapshot
+                .timeGaugeData(timeGauge)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints.size(), equalTo(0));
     }
 
     @Test
-    void snapshotFunctionCounterDataMetricsLoggerValid() throws JsonProcessingException {
+    void snapshotFunctionCounterDataValid() {
         final FunctionCounter functionCounter = FunctionCounter.builder("functionCounterData", 1d, Number::doubleValue)
                 .tag(TEST_TAG_KEY, TEST_TAG_VALUE).register(registry);
-        final MetricsLogger metricsLogger = registrySnapshot.functionCounterDataMetricsLogger(functionCounter);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, functionCounter.getId(), "count"), is(true));
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints = registrySnapshot
+                .functionCounterData(functionCounter)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints.size(), equalTo(1));
+        assertThat(metricDataPoints.stream().map(metricDataPoint -> metricDataPoint.key).collect(Collectors.toList())
+                .contains("functionCounterData.count"), is(true));
     }
 
     @Test
-    void snapshotFunctionCounterDataShouldClampInfiniteValues() throws JsonProcessingException {
+    void snapshotFunctionCounterDataShouldClampInfiniteValues() {
         FunctionCounter functionCounter = FunctionCounter
                 .builder("my.positive.infinity", Double.POSITIVE_INFINITY, Number::doubleValue).register(registry);
         clock.add(EMFLoggingRegistryConfig.DEFAULT.step());
-        MetricsLogger metricsLogger = registrySnapshot.functionCounterDataMetricsLogger(functionCounter);
-        MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertMetricEqual(context, functionCounter.getId(), "count", 1.174271e+108);
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints1 = registrySnapshot
+                .functionCounterData(functionCounter)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints1.size(), equalTo(1));
+        assertThat(metricDataPoints1.get(0).value, equalTo(1.174271e+108));
 
         functionCounter = FunctionCounter
                 .builder("my.negative.infinity", Double.NEGATIVE_INFINITY, Number::doubleValue).register(registry);
         clock.add(EMFLoggingRegistryConfig.DEFAULT.step());
-        metricsLogger = registrySnapshot.functionCounterDataMetricsLogger(functionCounter);
-        context = reflectivelyGetMetricsContext(metricsLogger);
-        assertMetricEqual(context, functionCounter.getId(), "count", -1.174271e+108);
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints2 = registrySnapshot
+                .functionCounterData(functionCounter)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints2.size(), equalTo(1));
+        assertThat(metricDataPoints2.get(0).value, equalTo(-1.174271e+108));
     }
 
     @Test
-    void snapshotShouldAddFunctionTimerAggregateMetricWhenAtLeastOneEventHappened() throws JsonProcessingException {
+    void snapshotShouldAddFunctionTimerAggregateDataWhenAtLeastOneEventHappened() {
         final FunctionTimer timer = mock(FunctionTimer.class);
         final Id meterId = new Id(METER_NAME, Tags.of(TEST_TAG_KEY, TEST_TAG_VALUE), null, null, TIMER);
         when(timer.getId()).thenReturn(meterId);
         when(timer.count()).thenReturn(2.0);
 
-        final MetricsLogger metricsLogger = registrySnapshot.functionTimerDataMetricsLogger(timer);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, meterId, "count"), is(true));
-        assertThat(hasMetric(context, meterId, "sum"), is(true));
-        assertThat(hasMetric(context, meterId, "avg"), is(true));
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints = registrySnapshot
+                .functionTimerData(timer)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints.size(), equalTo(3));
+        assertThat(metricDataPoints.stream().map(metricDataPoint -> metricDataPoint.key).collect(Collectors.toList())
+                .containsAll(List.of("test.count", "test.sum", "test.avg")), is(true));
     }
 
     @Test
-    void snapshotShouldNotAddFunctionTimerAggregateMetricWhenAtLeastOneEventHappened() throws JsonProcessingException {
+    void snapshotShouldNotAddFunctionTimerAggregateDataWhenNoEventHappened() {
         final FunctionTimer timer = mock(FunctionTimer.class);
         final Id meterId = new Id(METER_NAME, Tags.of(TEST_TAG_KEY, TEST_TAG_VALUE), null, null, TIMER);
         when(timer.getId()).thenReturn(meterId);
         when(timer.count()).thenReturn(0.0);
 
-        final MetricsLogger metricsLogger = registrySnapshot.functionTimerDataMetricsLogger(timer);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, meterId, "count"), is(true));
-        assertThat(hasMetric(context, meterId, "sum"), is(true));
-        assertThat(hasMetric(context, meterId, "avg"), is(false));
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints = registrySnapshot
+                .functionTimerData(timer)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints.size(), equalTo(2));
+        assertThat(metricDataPoints.stream().map(metricDataPoint -> metricDataPoint.key).collect(Collectors.toList())
+                .containsAll(List.of("test.count", "test.sum")), is(true));
     }
 
     @Test
-    void snapshotShouldNotAddFunctionTimerMetricWhenSumIsNaN() throws JsonProcessingException {
+    void snapshotShouldNotAddFunctionTimerDataWhenSumIsNaN() {
         final FunctionTimer functionTimer = FunctionTimer
                 .builder("my.function.timer", Double.NaN, Number::longValue, Number::doubleValue, TimeUnit.MILLISECONDS)
                 .register(registry);
         clock.add(EMFLoggingRegistryConfig.DEFAULT.step());
-        final MetricsLogger metricsLogger = registrySnapshot.functionTimerDataMetricsLogger(functionTimer);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertThat(hasMetric(context, functionTimer.getId(), "count"), is(false));
-        assertThat(hasMetric(context, functionTimer.getId(), "sum"), is(false));
-        assertThat(hasMetric(context, functionTimer.getId(), "avg"), is(false));
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints = registrySnapshot
+                .functionTimerData(functionTimer)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints.size(), equalTo(0));
     }
 
     @Test
-    void snapshotCustomMeterDataMetricsLoggerValid() throws JsonProcessingException {
+    void snapshotCustomMeterDataValid() {
         final Measurement measurement = new Measurement(() -> 2d, Statistic.VALUE);
         final List<Measurement> measurements = Collections.singletonList(measurement);
         final Meter meter = Meter.builder(METER_NAME, Meter.Type.GAUGE, measurements)
                 .tag(TEST_TAG_KEY, TEST_TAG_VALUE).register(registry);
-        final MetricsLogger metricsLogger = registrySnapshot.metricDataMetricsLogger(meter);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, meter.getId(), null), is(true));
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints = registrySnapshot
+                .metricData(meter)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints.size(), equalTo(1));
+        assertThat(metricDataPoints.stream().map(metricDataPoint -> metricDataPoint.key).collect(Collectors.toList())
+                .contains("test"), is(true));
     }
 
     @Test
-    void snapshotCustomMeterDataMetricsLoggerWhenNaNShouldNotAdd() throws JsonProcessingException {
+    void snapshotCustomMeterDataWhenNaNShouldNotAdd() {
         final Measurement measurement = new Measurement(() -> Double.NaN, Statistic.VALUE);
         final List<Measurement> measurements = Collections.singletonList(measurement);
         final Meter meter = Meter.builder(METER_NAME, Meter.Type.GAUGE, measurements)
                 .tag(TEST_TAG_KEY, TEST_TAG_VALUE).register(registry);
-        final MetricsLogger metricsLogger = registrySnapshot.metricDataMetricsLogger(meter);
-        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
-        assertThat(context.getNamespace(), equalTo(SERVICE_NAME));
-        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
-        assertThat(hasMetric(context, meter.getId(), null), is(false));
+        final List<EMFLoggingMeterRegistry.MetricDataPoint> metricDataPoints = registrySnapshot
+                .metricData(meter)
+                .collect(Collectors.toList());
+        assertThat(metricDataPoints.size(), equalTo(0));
     }
 
     @Test
@@ -361,11 +316,15 @@ class EMFLoggingMeterRegistryTest {
         final List<Measurement> measurement = Collections.singletonList(new Measurement(() -> 2d, Statistic.VALUE));
         Meter.builder(METER_NAME, Type.OTHER, measurement).tag(TEST_TAG_KEY, TEST_TAG_VALUE).register(registry);
         final List<MetricsLogger> metricsLoggerList = registry.metricsLoggers();
-        assertThat(metricsLoggerList.size(), equalTo(9));
+        assertThat(metricsLoggerList.size(), equalTo(2));
+        final MetricsLogger metricsLogger = metricsLoggerList.get(1);
+        final MetricsContext context = reflectivelyGetMetricsContext(metricsLogger);
+        assertThat(hasDimension(context, TEST_TAG_KEY), is(true));
+        assertDimensionEqual(context, TEST_TAG_KEY, TEST_TAG_VALUE);
     }
 
     @Test
-    void registryMetricsLoggerDropEmptyTag() {
+    void registryMetricsLoggersDropEmptyTag() {
         registry.gauge("gauge", Tags.of("empty", ""), 1d);
         final List<MetricsLogger> metricsLoggerList = registry.metricsLoggers();
         assertThat(metricsLoggerList.size(), equalTo(1));
@@ -413,28 +372,5 @@ class EMFLoggingMeterRegistryTest {
         final DimensionSet dimensionSet = dimensionSetList.get(0);
         assertThat(dimensionSet.getDimensionKeys().size(), equalTo(1));
         assertThat(dimensionSet.getDimensionValue(key), equalTo(value));
-    }
-
-    private boolean hasMetric(final MetricsContext context, final Id meterId, final String suffix) throws JsonProcessingException {
-        final List<String> emfJsonList = context.serialize();
-        assertThat(emfJsonList.size(), equalTo(1));
-        final Map<String, Object> emfMap = objectMapper.readValue(emfJsonList.get(0), MAP_TYPE_REFERENCE);
-        String metricName = meterId.getName();
-        if (suffix != null) {
-            metricName = metricName.concat(".").concat(suffix);
-        }
-        return emfMap.get(metricName) instanceof Double;
-    }
-
-    private void assertMetricEqual(final MetricsContext context, final Id meterId, final String suffix, final Double value)
-            throws JsonProcessingException {
-        final List<String> emfJsonList = context.serialize();
-        assertThat(emfJsonList.size(), equalTo(1));
-        final Map<String, Object> emfMap = objectMapper.readValue(emfJsonList.get(0), MAP_TYPE_REFERENCE);
-        String metricName = meterId.getName();
-        if (suffix != null) {
-            metricName = metricName.concat(".").concat(suffix);
-        }
-        assertThat(emfMap.get(metricName), equalTo(value));
     }
 }


### PR DESCRIPTION
### Description
The current implementation of EMFLoggingMeterRegistry leads to occasional missing data points in metrics when using fluent-bit as sidecar to receive metrics through TCP and output to cloudwatch. See pic:

![Screenshot 2023-04-10 at 11 34 15 AM](https://user-images.githubusercontent.com/19492223/230950971-eaca90e9-f9a4-4bb0-92e2-d41bdbdba521.png)

This PR mitigates the issue by batching metrics in the snapshot that shares the same dimensions (tags).

with the change in-place the missing data issue is at-least mitigated:

![Screenshot 2023-04-10 at 12 37 07 PM](https://user-images.githubusercontent.com/19492223/230958743-b8f46c22-dcb3-4749-a403-4a2f009bc8c8.png)

 
### Issues Resolved
#2469 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
