### PR TITLE
Retry flushing of buffer on buffer TimeoutException

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -202,6 +202,9 @@ public final class BulkRetryStrategy {
     private void handleRetry(final AccumulatingBulkRequest request, final BulkResponse response,
                              final BackOffUtils backOffUtils) throws InterruptedException {
         final AccumulatingBulkRequest<BulkOperation, BulkRequest> bulkRequestForRetry = createBulkRequestForRetry(request, response);
+        if (!retryCountMap.containsKey(bulkRequestForRetry)) {
+            retryCountMap.put(bulkRequestForRetry, 1);
+        }
         int retryCount = retryCountMap.get(bulkRequestForRetry);
         if (backOffUtils.hasNext()) {
             // Wait for backOff duration

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ClientBuilderFactory.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ClientBuilderFactory.java
@@ -49,12 +49,9 @@ public class S3ClientBuilderFactory {
         LOG.info("Creating S3 Async client");
         return S3AsyncClient.builder()
                 .region(s3SourceConfig.getAwsAuthenticationOptions().getAwsRegion())
-                .httpClient(NettyNioAsyncHttpClient.builder().
-                        connectionMaxIdleTime(Duration.ofSeconds(60))
-                        .connectionAcquisitionTimeout(Duration.ofSeconds(30))
+                .httpClient(NettyNioAsyncHttpClient.builder()
                         .maxConcurrency(200)
-                        .readTimeout(Duration.ofSeconds(30))
-                        .connectionTimeout(Duration.ofSeconds(30)).build())
+                        .connectionTimeout(Duration.ofMinutes(1)).build())
                 .credentialsProvider(s3SourceConfig.getAwsAuthenticationOptions().authenticateAwsConfiguration())
                 .overrideConfiguration(ClientOverrideConfiguration.builder()
                         .retryPolicy(retryPolicy -> retryPolicy.numRetries(5).build())

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectRequest.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectRequest.java
@@ -27,7 +27,7 @@ public class S3ObjectRequest {
     private final String expression;
     private final S3SelectSerializationFormatOption serializationFormatOption;
     private final S3AsyncClient s3AsyncClient;
-    private final S3SelectResponseHandler s3SelectResponseHandler;
+    private final S3SelectResponseHandlerFactory s3SelectResponseHandlerFactory;
     private final CompressionEngine compressionEngine;
     private final BucketOwnerProvider bucketOwnerProvider;
     private final Codec codec;
@@ -46,7 +46,7 @@ public class S3ObjectRequest {
         this.expression = builder.expression;
         this.serializationFormatOption = builder.serializationFormatOption;
         this.s3AsyncClient =builder.s3AsyncClient;
-        this.s3SelectResponseHandler = builder.s3SelectResponseHandler;
+        this.s3SelectResponseHandlerFactory = builder.s3SelectResponseHandlerFactory;
         this.compressionEngine = builder.compressionEngine;
         this.bucketOwnerProvider = builder.bucketOwnerProvider;
         this.codec = builder.codec;
@@ -86,8 +86,8 @@ public class S3ObjectRequest {
         return s3AsyncClient;
     }
 
-    public S3SelectResponseHandler getS3SelectResponseHandler() {
-        return s3SelectResponseHandler;
+    public S3SelectResponseHandlerFactory getS3SelectResponseHandlerFactory() {
+        return s3SelectResponseHandlerFactory;
     }
 
     public CompressionEngine getCompressionEngine() {
@@ -135,7 +135,7 @@ public class S3ObjectRequest {
         private String expression;
         private S3SelectSerializationFormatOption serializationFormatOption;
         private S3AsyncClient s3AsyncClient;
-        private S3SelectResponseHandler s3SelectResponseHandler;
+        private S3SelectResponseHandlerFactory s3SelectResponseHandlerFactory;
         private CompressionEngine compressionEngine;
         private Codec codec;
         private BiConsumer<Event, S3ObjectReference> eventConsumer;
@@ -175,8 +175,8 @@ public class S3ObjectRequest {
             return this;
         }
 
-        public Builder s3SelectResponseHandler(S3SelectResponseHandler s3SelectResponseHandler) {
-            this.s3SelectResponseHandler = s3SelectResponseHandler;
+        public Builder s3SelectResponseHandlerFactory(S3SelectResponseHandlerFactory s3SelectResponseHandlerFactory) {
+            this.s3SelectResponseHandlerFactory = s3SelectResponseHandlerFactory;
             return this;
         }
 

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorker.java
@@ -4,22 +4,12 @@
  */
 package org.opensearch.dataprepper.plugins.source;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.SequenceInputStream;
-import java.io.IOException;
-import java.time.Duration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.io.input.CountingInputStream;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
@@ -30,18 +20,36 @@ import org.opensearch.dataprepper.plugins.source.configuration.S3SelectJsonOptio
 import org.opensearch.dataprepper.plugins.source.configuration.S3SelectSerializationFormatOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CompressionType;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.InputSerialization;
 import software.amazon.awssdk.services.s3.model.RecordsEvent;
+import software.amazon.awssdk.services.s3.model.ScanRange;
 import software.amazon.awssdk.services.s3.model.SelectObjectContentEventStream;
 import software.amazon.awssdk.services.s3.model.SelectObjectContentRequest;
 import software.amazon.awssdk.utils.builder.SdkBuilder;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.SequenceInputStream;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 /**
  * Class responsible for taking an {@link S3SelectResponseHandler} and creating
@@ -49,6 +57,10 @@ import software.amazon.awssdk.utils.builder.SdkBuilder;
  */
 public class S3SelectObjectWorker implements S3ObjectHandler {
     private static final Logger LOG = LoggerFactory.getLogger(S3SelectObjectWorker.class);
+
+    static final long MAX_S3_OBJECT_CHUNK_SIZE = 64 * 1024 * 1024;
+    private static final int MAX_FLUSH_RETRIES_ON_IO_EXCEPTION = 5;
+    private static final Duration INITIAL_FLUSH_RETRY_DELAY_ON_IO_EXCEPTION = Duration.ofSeconds(5);
     static final String S3_BUCKET_NAME = "bucket";
     static final String S3_OBJECT_KEY = "key";
     static final String S3_BUCKET_REFERENCE_NAME = "s3";
@@ -94,38 +106,65 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
      */
     public void parseS3Object(final S3ObjectReference s3ObjectReference) throws IOException {
         try{
-            selectObjectContent(s3ObjectReference);
-        }catch(Exception e){
+            selectObjectInBatches(s3ObjectReference);
+        } catch (Exception e){
+            LOG.error("Unable to process object reference: {}", s3ObjectReference, e);
             s3ObjectPluginMetrics.getS3ObjectsFailedCounter().increment();
             throw new IOException(e);
         }
     }
 
-    private void selectObjectContent(S3ObjectReference s3ObjectReference) throws IOException {
-        final InputStream inputStreamList;
-        final BufferAccumulator<Record<Event>> bufferAccumulator = BufferAccumulator.create(buffer, numberOfRecordsToAccumulate, bufferTimeout);
+    private void selectObjectInBatches(final S3ObjectReference s3ObjectReference) throws IOException {
         final InputSerialization inputSerialization = getInputSerializationFormat(serializationFormatOption);
-        final SelectObjectContentRequest selectObjectContentRequest = getS3SelectObjRequest(s3ObjectReference, inputSerialization);
-        s3AsyncClient.selectObjectContent(selectObjectContentRequest, s3SelectResponseHandler).join();
-        if(s3SelectResponseHandler.getException()!=null)
-            throw new IOException(s3SelectResponseHandler.getException());
-        final List<SelectObjectContentEventStream> receivedEvents = s3SelectResponseHandler.getS3SelectContentEvents();
-        if (!receivedEvents.isEmpty()) {
-            inputStreamList = getInputStreamFromResponseHeader(s3SelectResponseHandler);
-            parseCompleteStreamFromResponseHeader(s3ObjectReference, bufferAccumulator, inputStreamList);
-            s3ObjectPluginMetrics.getS3ObjectEventsSummary().record(bufferAccumulator.getTotalWritten());
-            s3ObjectPluginMetrics.getS3ObjectsSucceededCounter().increment();
-            receivedEvents.clear();
-        }else{
-            LOG.info("S3 Select returned no events for S3 object {}", s3ObjectReference);
+        InputStream inputStreamList;
+        final BufferAccumulator<Record<Event>> bufferAccumulator = BufferAccumulator.create(buffer, numberOfRecordsToAccumulate, bufferTimeout);
+
+        final long objectSize = getObjectSize(s3ObjectReference);
+
+        long startRange = 0;
+        long endRange = Math.min(MAX_S3_OBJECT_CHUNK_SIZE, objectSize);
+        while (startRange < objectSize) {
+            final ScanRange scanRange = ScanRange.builder()
+                    .start(startRange)
+                    .end(endRange)
+                    .build();
+            final SelectObjectContentRequest selectObjectContentRequest = getS3SelectObjRequest(s3ObjectReference, inputSerialization, scanRange);
+
+            s3AsyncClient.selectObjectContent(selectObjectContentRequest, s3SelectResponseHandler).join();
+            if (s3SelectResponseHandler.getException() != null)
+                throw new IOException(s3SelectResponseHandler.getException());
+
+            final List<SelectObjectContentEventStream> receivedEvents = s3SelectResponseHandler.getS3SelectContentEvents();
+            if (!receivedEvents.isEmpty()) {
+                inputStreamList = getInputStreamFromResponseHeader(s3SelectResponseHandler);
+                parseCompleteStreamFromResponseHeader(s3ObjectReference, bufferAccumulator, inputStreamList);
+                s3ObjectPluginMetrics.getS3ObjectEventsSummary().record(bufferAccumulator.getTotalWritten());
+                s3ObjectPluginMetrics.getS3ObjectsSucceededCounter().increment();
+                receivedEvents.clear();
+            } else {
+                LOG.info("S3 Select returned no events for S3 object {}", s3ObjectReference);
+            }
+
+            startRange = endRange;
+            endRange += Math.min(MAX_S3_OBJECT_CHUNK_SIZE, objectSize - endRange);
         }
+    }
+
+    private Long getObjectSize(final S3ObjectReference s3ObjectReference) {
+        final HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+                .bucket(s3ObjectReference.getBucketName())
+                .key(s3ObjectReference.getKey())
+                .build();
+        final HeadObjectResponse headObjectResponse = s3AsyncClient.headObject(headObjectRequest).join();
+
+        return headObjectResponse.contentLength();
     }
 
     private InputSerialization getInputSerializationFormat(final S3SelectSerializationFormatOption serializationFormatOption) {
         InputSerialization inputSerialization = null;
         switch (serializationFormatOption) {
-        case CSV:
-            inputSerialization = InputSerialization.builder()
+            case CSV:
+                inputSerialization = InputSerialization.builder()
                         .csv( csv -> csv.fileHeaderInfo(s3SelectCSVOption.getFileHeaderInfo())
                                 .quoteEscapeCharacter(s3SelectCSVOption.getQuiteEscape())
                                 .comments(s3SelectCSVOption.getComments())
@@ -133,38 +172,40 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
                                         (s3SelectCSVOption.getQuiteEscape() != null ||
                                                 s3SelectCSVOption.getComments() != null) ? true : false).build())
                         .compressionType(compressionType).build();
-            break;
-        case JSON:
-            inputSerialization = InputSerialization.builder().json(json -> json.type(s3SelectJsonOption.getType()).build())
-                    .compressionType(compressionType).build();
-            break;
-        case PARQUET:
-            inputSerialization = InputSerialization.builder().parquet(p -> p.build())
-                    .compressionType(CompressionType.NONE).build();
-            break;
+                break;
+            case JSON:
+                inputSerialization = InputSerialization.builder().json(json -> json.type(s3SelectJsonOption.getType()).build())
+                        .compressionType(compressionType).build();
+                break;
+            case PARQUET:
+                inputSerialization = InputSerialization.builder().parquet(p -> p.build())
+                        .compressionType(CompressionType.NONE).build();
+                break;
         }
         return inputSerialization;
     }
 
     private InputStream getInputStreamFromResponseHeader(final S3SelectResponseHandler responseHand) {
-        return responseHand.getS3SelectContentEvents().stream()
+        final List<InputStream> inputStreams = responseHand.getS3SelectContentEvents().stream()
                 .filter(e -> e.sdkEventType() == SelectObjectContentEventStream.EventType.RECORDS)
-                .map(e -> ((RecordsEvent) e).payload().asInputStream()).collect(Collectors.toList()).stream()
-                .reduce(SequenceInputStream::new).orElse(null);
+                .map(e -> ((RecordsEvent) e).payload().asInputStream()).collect(Collectors.toList());
+
+        return new SequenceInputStream(Collections.enumeration(inputStreams));
     }
 
     private SelectObjectContentRequest getS3SelectObjRequest(final S3ObjectReference s3ObjectReference,
-            final InputSerialization inputSerialization) {
+                                                             final InputSerialization inputSerialization, final ScanRange scanRange) {
         return SelectObjectContentRequest.builder().bucket(s3ObjectReference.getBucketName())
                 .key(s3ObjectReference.getKey()).expressionType(expressionType)
                 .expression(expression)
                 .inputSerialization(inputSerialization)
                 .outputSerialization(outputSerialization -> outputSerialization.json(SdkBuilder::build))
+                .scanRange(scanRange)
                 .build();
     }
 
     private void parseCompleteStreamFromResponseHeader(final S3ObjectReference s3ObjectReference,
-            final BufferAccumulator<Record<Event>> bufferAccumulator,final InputStream stream) throws IOException {
+                                                       final BufferAccumulator<Record<Event>> bufferAccumulator, final InputStream stream) throws IOException {
         try (final CountingInputStream countingInputStream = new CountingInputStream(stream);
              final InputStreamReader inputStreamReader = new InputStreamReader(countingInputStream);
              final BufferedReader reader = new BufferedReader(inputStreamReader)) {
@@ -172,13 +213,15 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
             while ((selectObjectOptionalString = Optional.ofNullable(reader.readLine())).isPresent()) {
                 final Optional<JsonNode> optionalNode = addingS3Reference(s3ObjectReference,
                         getJsonNode(selectObjectOptionalString.get()));
-                if (optionalNode.isPresent()){
+                if (optionalNode.isPresent()) {
                     Record<Event> eventRecord = new Record<>(JacksonLog.builder().withData(optionalNode.get()).build());
-                    try{
-                        eventConsumer.accept(eventRecord.getData(),s3ObjectReference);
+                    try {
+                        eventConsumer.accept(eventRecord.getData(), s3ObjectReference);
                         bufferAccumulator.add(eventRecord);
-                    }catch(final Exception ex){
-                        throw new IOException(ex);
+                    } catch (final TimeoutException ex) {
+                        flushWithBackoff(bufferAccumulator, MAX_FLUSH_RETRIES_ON_IO_EXCEPTION, INITIAL_FLUSH_RETRY_DELAY_ON_IO_EXCEPTION);
+                    } catch (final Exception ex) {
+                        LOG.error("Failed writing S3 objects to buffer due to: {}", ex.getMessage());
                     }
 
                 }
@@ -189,6 +232,44 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
         } catch (Exception e) {
             throw new IOException(e);
         }
+    }
+
+    private boolean flushWithBackoff(final BufferAccumulator<Record<Event>> bufferAccumulator, final int maxRetries, final Duration initialDelay) {
+
+        final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        long nextDelay = initialDelay.toMillis();
+        int backoffRate = 2;
+        boolean flushedSuccessfully;
+
+        for (int retryCount = 0; retryCount < maxRetries; retryCount++) {
+            final ScheduledFuture<Boolean> flushBufferFuture = scheduledExecutorService.schedule(() -> {
+                try {
+                    bufferAccumulator.flush();
+                    return true;
+                } catch (final Exception e) {
+                    return false;
+                }
+            }, nextDelay, TimeUnit.MILLISECONDS);
+
+            try {
+                flushedSuccessfully = flushBufferFuture.get();
+                if (!flushedSuccessfully) {
+                    nextDelay *= backoffRate;
+                } else {
+                    scheduledExecutorService.shutdownNow();
+                    return true;
+                }
+            } catch (ExecutionException e) {
+                LOG.warn("Retrying of flushing the buffer accumulator hit an exception: {}", e.getMessage());
+            } catch (InterruptedException e) {
+                LOG.warn("Retrying of flushing the buffer accumulator was interrupted: {}", e.getMessage());
+            }
+        }
+
+
+        LOG.warn("Flushing the bufferAccumulator failed after {} attempts", maxRetries);
+        scheduledExecutorService.shutdownNow();
+        return false;
     }
 
     private JsonNode getJsonNode(String selectObjectOptionalString) throws JsonProcessingException {
@@ -202,7 +283,7 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
     }
 
     private static ObjectNode getS3BucketObjectReference(final S3ObjectReference s3ObjectReference,
-            final ObjectMapper mapper) {
+                                                         final ObjectMapper mapper) {
         ObjectNode objNode = mapper.createObjectNode();
         objNode.put(S3_BUCKET_NAME, s3ObjectReference.getBucketName());
         objNode.put(S3_OBJECT_KEY, s3ObjectReference.getKey());

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SelectResponseHandlerFactory.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SelectResponseHandlerFactory.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source;
+
+public class S3SelectResponseHandlerFactory {
+
+    public S3SelectResponseHandler provideS3SelectResponseHandler() {
+        return new S3SelectResponseHandler();
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3Source.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3Source.java
@@ -70,7 +70,7 @@ public class S3Source implements Source<Record<Event>> {
                     s3SelectCSVOption(csvOption).s3SelectJsonOption(jsonOption)
                     .expressionType(s3SelectOptional.get().getExpressionType())
                     .compressionType(CompressionType.valueOf(s3SelectOptional.get().getCompressionType().toUpperCase()))
-                    .s3SelectResponseHandler(new S3SelectResponseHandler()).build();
+                    .s3SelectResponseHandlerFactory(new S3SelectResponseHandlerFactory()).build();
             s3Handler = new S3SelectObjectWorker(s3ObjectRequest);
         } else {
             final PluginModel codecConfiguration = s3SourceConfig.getCodec();

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ObjectRequestTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ObjectRequestTest.java
@@ -56,8 +56,10 @@ public class S3ObjectRequestTest {
     private CompressionEngine compressionEngine;
     @Mock
     private BucketOwnerProvider bucketOwnerProvider;
+
     @Mock
-    private S3SelectResponseHandler s3SelectResponseHandler;
+    private S3SelectResponseHandlerFactory s3SelectResponseHandlerFactory;
+
     private final S3SelectCSVOption s3SelectCSVOption = new S3SelectCSVOption();
     @Mock
     private S3SelectJsonOption s3SelectJsonOption;
@@ -75,7 +77,7 @@ public class S3ObjectRequestTest {
                 s3SelectJsonOption(s3SelectJsonOption).
                 compressionEngine(compressionEngine).
                 bucketOwnerProvider(bucketOwnerProvider).
-                s3SelectResponseHandler(s3SelectResponseHandler).
+                s3SelectResponseHandlerFactory(s3SelectResponseHandlerFactory).
                 expression(expression).build();
         assertThat(request.getBuffer(),sameInstance(buffer));
         assertThat(request.getBufferTimeout(),sameInstance(bufferTimeout));

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorkerTest.java
@@ -4,29 +4,9 @@
  */
 package org.opensearch.dataprepper.plugins.source;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
-
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -39,112 +19,163 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.configuration.S3SelectCSVOption;
 import org.opensearch.dataprepper.plugins.source.configuration.S3SelectJsonOption;
-import org.opensearch.dataprepper.plugins.source.configuration.S3SelectOptions;
 import org.opensearch.dataprepper.plugins.source.configuration.S3SelectSerializationFormatOption;
-
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.DistributionSummary;
-import org.opensearch.dataprepper.test.helper.ReflectivelySetField;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CompressionType;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.Progress;
 import software.amazon.awssdk.services.s3.model.SelectObjectContentEventStream;
 import software.amazon.awssdk.services.s3.model.SelectObjectContentRequest;
-import software.amazon.awssdk.services.s3.model.SelectObjectContentResponseHandler;
 import software.amazon.awssdk.services.s3.model.Stats;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.opensearch.dataprepper.plugins.source.S3SelectObjectWorker.CSV_FILE_HEADER_INFO_NONE;
+import static org.opensearch.dataprepper.plugins.source.S3SelectObjectWorker.MAX_S3_OBJECT_CHUNK_SIZE;
 
 @ExtendWith(MockitoExtension.class)
 class S3SelectObjectWorkerTest {
+
     @Mock
     private Buffer<Record<Event>> buffer;
+
     @Mock
     private S3AsyncClient s3AsyncClient;
-    @Mock
-    private S3SourceConfig s3SourceConfig;
-    @Mock
-    private DistributionSummary distributionSummary;
-    @Mock
-    S3ObjectReference s3ObjectReference;
-    @Mock
-    private S3SelectOptions s3SelectOptions;
-    private String key;
-    private String bucketName;
-    @Mock
-    private Duration bufferTimeout;
-    @Mock
-    private Counter s3ObjectsFailedCounter;
-    @Mock
-    private Counter s3ObjectsSucceededCounter;
+
     @Mock
     private S3SelectResponseHandler selectResponseHandler;
-    @Mock
-    private List<SelectObjectContentEventStream> selectObjectContentEventStreamList;
 
     @Mock
     private S3ObjectPluginMetrics s3ObjectPluginMetrics;
+
+    @Mock
+    private Counter s3ObjectsFailedCounter;
+
+    @Mock
+    private DistributionSummary s3ObjectEventsSummary;
+
+    @Mock
+    private Counter s3ObjectsSucceededCounter;
+
+    @Mock
+    private S3ObjectRequest s3ObjectRequest;
+
+    @Mock
+    private S3ObjectReference s3ObjectReference;
+
     @Mock
     private BiConsumer<Event, S3ObjectReference> eventConsumer;
 
-    public void selectObjectContentResponse(final String responseFormat){
-        selectObjectContentEventStreamList = new ArrayList<>();
-        CompletableFuture<Void> feature = mock(CompletableFuture.class);
-        selectObjectContentEventStreamList.addAll(Arrays.asList(
-                SelectObjectContentEventStream.recordsBuilder().payload(SdkBytes.fromUtf8String(responseFormat)).build(),
-                SelectObjectContentEventStream.contBuilder().build(),
-                SelectObjectContentEventStream.statsBuilder()
-                        .details(Stats.builder().bytesProcessed(10L).bytesScanned(20L).bytesReturned(30L).build()).build(),
-                SelectObjectContentEventStream.progressBuilder()
-                        .details(Progress.builder().bytesProcessed(10L).bytesScanned(20L).bytesReturned(30L).build()).build(),
-                SelectObjectContentEventStream.endBuilder().build()));
-        lenient().when(s3AsyncClient.selectObjectContent(any(SelectObjectContentRequest.class),any(SelectObjectContentResponseHandler.class))).thenReturn(feature);
-        lenient().when(selectResponseHandler.getS3SelectContentEvents()).thenReturn(selectObjectContentEventStreamList);
+    private ArgumentCaptor<HeadObjectRequest> argumentCaptorForHeadObjectRequest;
+
+    private int numberOfObjectScans;
+
+    @BeforeEach
+    void setup() {
+
+        final Random random = new Random();
+
+        numberOfObjectScans = random.nextInt(5) + 1;
+
+        final String bucketName = UUID.randomUUID().toString();
+        final String objectKey = UUID.randomUUID().toString();
+
+        given(s3ObjectReference.getBucketName()).willReturn(bucketName);
+        given(s3ObjectReference.getKey()).willReturn(objectKey);
+
+        given(s3ObjectRequest.getBuffer()).willReturn(buffer);
+        given(s3ObjectRequest.getNumberOfRecordsToAccumulate()).willReturn(1);
+        given(s3ObjectRequest.getS3AsyncClient()).willReturn(s3AsyncClient);
+        given(s3ObjectRequest.getBufferTimeout()).willReturn(Duration.ofMillis(random.nextInt(100) + 100));
+        given(s3ObjectRequest.getS3SelectResponseHandler()).willReturn(selectResponseHandler);
+        given(s3ObjectRequest.getEventConsumer()).willReturn(eventConsumer);
+        given(s3ObjectRequest.getExpressionType()).willReturn(UUID.randomUUID().toString());
+
+        final S3SelectCSVOption selectCSVOption = mock(S3SelectCSVOption.class);
+        given(s3ObjectRequest.getS3SelectCSVOption()).willReturn(selectCSVOption);
+
+        final S3SelectJsonOption selectJsonOption = mock(S3SelectJsonOption.class);
+        given(s3ObjectRequest.getS3SelectJsonOption()).willReturn(selectJsonOption);
+
+        given(s3ObjectRequest.getS3ObjectPluginMetrics()).willReturn(s3ObjectPluginMetrics);
+
+        final CompletableFuture<HeadObjectResponse> headObjectResponseCompletableFuture = mock(CompletableFuture.class);
+        final HeadObjectResponse headObjectResponse = mock(HeadObjectResponse.class);
+        given(headObjectResponse.contentLength()).willReturn(MAX_S3_OBJECT_CHUNK_SIZE * numberOfObjectScans);
+        given(headObjectResponseCompletableFuture.join()).willReturn(headObjectResponse);
+
+
+        argumentCaptorForHeadObjectRequest = ArgumentCaptor.forClass(HeadObjectRequest.class);
+        given(s3AsyncClient.headObject(argumentCaptorForHeadObjectRequest.capture())).willReturn(headObjectResponseCompletableFuture);
     }
 
-    private S3SelectObjectWorker createSelectObjectUnderTest(final String responseFormat, final String expression,
-                                            final S3SelectSerializationFormatOption format,
-                                            final S3SelectResponseHandler selectResponseHandlerTest,
-                                            final S3ObjectPluginMetrics s3ObjectPluginMetrics,
-                                            final CompressionType compressionType) throws Exception {
-        if(selectResponseHandlerTest == null)
-            selectObjectContentResponse(responseFormat);
-        Random random = new Random();
-        int numberOfRecordsToAccumulate = random.nextInt(10) + 2;
-        bucketName = UUID.randomUUID().toString();
-        key = UUID.randomUUID().toString();
-        when(s3ObjectReference.getBucketName()).thenReturn(bucketName);
-        when(s3ObjectReference.getKey()).thenReturn(key);
-        when(s3SourceConfig.getS3SelectOptions()).thenReturn(s3SelectOptions);
-        when(s3SourceConfig.getS3SelectOptions().getExpression()).thenReturn(expression);
-        final S3SelectCSVOption csvOption = new S3SelectCSVOption();
-        ReflectivelySetField.setField(S3SelectCSVOption.class,csvOption,"fileHeaderInfo","none");
-        S3ObjectRequest request = new S3ObjectRequest.Builder(buffer,numberOfRecordsToAccumulate,
-                bufferTimeout,s3ObjectPluginMetrics)
-                .expression(expression).eventConsumer(eventConsumer)
-                .serializationFormatOption(format).s3SelectCSVOption(csvOption)
-                .s3SelectJsonOption(new S3SelectJsonOption())
-                .s3AsyncClient(s3AsyncClient).compressionType(compressionType)
-                .s3SelectResponseHandler(selectResponseHandler).build();
-        return new S3SelectObjectWorker(request);
+    private S3SelectObjectWorker createObjectUnderTest() {
+        return new S3SelectObjectWorker(s3ObjectRequest);
     }
+
     @Test
-    void selectObjectFromS3CsvTestWithEmptyResponse() throws Exception{
-        when(s3ObjectPluginMetrics.getS3ObjectsFailedCounter()).thenReturn(s3ObjectsFailedCounter);
-        S3SelectResponseHandler selectResponseHandler =new S3SelectResponseHandler();
-        final S3SelectObjectWorker selectObjectUnderTest = createSelectObjectUnderTest(null, "select * from s3Object", S3SelectSerializationFormatOption.CSV,
-                selectResponseHandler, s3ObjectPluginMetrics, CompressionType.NONE);
-        final ArgumentCaptor<SelectObjectContentRequest> request = ArgumentCaptor
-                .forClass(SelectObjectContentRequest.class);
-        final IOException exception = assertThrows(IOException.class, () -> selectObjectUnderTest.parseS3Object(s3ObjectReference));
-        assertNotNull(exception);
-        verify(s3AsyncClient).selectObjectContent(request.capture(), any(S3SelectResponseHandler.class));
-        assertThat(request.getValue().key(), equalTo(key));
-        assertThat(request.getValue().bucket(), equalTo(bucketName));
-        assertThat(request.getValue().expectedBucketOwner(), nullValue());
-        assertThat(request.getValue().expression(), equalTo(s3SourceConfig.getS3SelectOptions().getExpression()));
+    void parseS3Object_where_s3SelectResponseHandler_returns_exception_throws_IO_exception() {
+        given(s3ObjectRequest.getSerializationFormatOption()).willReturn(S3SelectSerializationFormatOption.CSV);
+        given(s3ObjectRequest.getCompressionType()).willReturn(CompressionType.NONE);
+        given(selectResponseHandler.getException()).willReturn(mock(Throwable.class));
+        given(s3ObjectPluginMetrics.getS3ObjectsFailedCounter()).willReturn(s3ObjectsFailedCounter);
+
+        final CompletableFuture<Void> selectObjectResponseFuture = mock(CompletableFuture.class);
+        given(selectObjectResponseFuture.join()).willReturn(mock(Void.class));
+        given(s3AsyncClient.selectObjectContent(any(SelectObjectContentRequest.class), eq(selectResponseHandler))).willReturn(selectObjectResponseFuture);
+
+
+        assertThrows(IOException.class, () -> createObjectUnderTest().parseS3Object(s3ObjectReference));
+
+        assertHeadObjectRequestIsCorrect();
+
         verify(s3ObjectsFailedCounter).increment();
-        assertTrue(selectResponseHandler.getS3SelectContentEvents().isEmpty());
+
     }
+
+    @Test
+    void parseS3Object_with_no_events_in_SelectObjectContentStream_does_not_throw_exception_and_searches_full_scanRange() throws IOException {
+        given(s3ObjectRequest.getSerializationFormatOption()).willReturn(S3SelectSerializationFormatOption.CSV);
+        given(s3ObjectRequest.getCompressionType()).willReturn(CompressionType.NONE);
+        given(selectResponseHandler.getException()).willReturn(null);
+        given(selectResponseHandler.getS3SelectContentEvents()).willReturn(Collections.emptyList());
+
+        final CompletableFuture<Void> selectObjectResponseFuture = mock(CompletableFuture.class);
+        given(selectObjectResponseFuture.join()).willReturn(mock(Void.class));
+        given(s3AsyncClient.selectObjectContent(any(SelectObjectContentRequest.class), eq(selectResponseHandler))).willReturn(selectObjectResponseFuture);
+
+        createObjectUnderTest().parseS3Object(s3ObjectReference);
+
+        assertHeadObjectRequestIsCorrect();
+
+        verify(selectResponseHandler, times(numberOfObjectScans)).getS3SelectContentEvents();
+    }
+
     @ParameterizedTest
     @CsvSource({
             "'{\"S.No\":\"1\",\"name\":\"data-prep\",\"country\":\"USA\"}',select * from s3Object,CSV,NONE",
@@ -153,20 +184,90 @@ class S3SelectObjectWorkerTest {
             "'{\"S.No\":\"4\",\"name\":\"data-prep\",\"empId\",\"123456\"}',select * from s3Object,CSV,GZIP",
             "'{\"S.No\":\"5\",\"log\":\"data-prep-log\",\"documentType\":\"test doc\"}',select * from s3Object,JSON,GZIP",
             "'{\"S.No\":\"6\",\"name\":\"data-prep-test\",\"type\":\"json\"}',select * from s3Object,PARQUET,GZIP"})
-    void selectObjectFromS3TestWithCorrectRequest(final String responseFormat,final String query,final String format,final String compression) throws Exception {
-        when(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).thenReturn(distributionSummary);
-        when(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).thenReturn(s3ObjectsSucceededCounter);
-        final S3SelectObjectWorker selectObjectUnderTest = createSelectObjectUnderTest(responseFormat, query, S3SelectSerializationFormatOption.valueOf(format),
-                null, s3ObjectPluginMetrics, CompressionType.valueOf(compression));
-        final ArgumentCaptor<SelectObjectContentRequest> request = ArgumentCaptor.forClass(SelectObjectContentRequest.class);
-        selectObjectUnderTest.parseS3Object(s3ObjectReference);
-        verify(s3AsyncClient).selectObjectContent(request.capture(), any(S3SelectResponseHandler.class));
-        assertThat(request.getValue().key(), equalTo(key));
-        assertThat(request.getValue().bucket(), equalTo(bucketName));
-        assertThat(request.getValue().expectedBucketOwner(), nullValue());
-        assertThat(request.getValue().expression(), equalTo(s3SourceConfig.getS3SelectOptions().getExpression()));
-        assertTrue(selectResponseHandler.getS3SelectContentEvents().isEmpty());
+    void parseS3Object_with_different_formats_and_events_in_the_inputstream_works_as_expected(final String responseFormat,
+                                                                                              final String query,
+                                                                                              final String format,
+                                                                                              final String compression) throws IOException {
+        if (format.equals("CSV")) {
+            given(s3ObjectRequest.getS3SelectCSVOption().getFileHeaderInfo()).willReturn(CSV_FILE_HEADER_INFO_NONE);
+            given(s3ObjectRequest.getS3SelectCSVOption().getComments()).willReturn(UUID.randomUUID().toString());
+            given(s3ObjectRequest.getS3SelectCSVOption().getQuiteEscape()).willReturn(UUID.randomUUID().toString());
+        } else if (format.equals("JSON")) {
+            given(s3ObjectRequest.getS3SelectJsonOption().getType()).willReturn(UUID.randomUUID().toString());
+        }
+
+        given(s3ObjectRequest.getCompressionType()).willReturn(CompressionType.valueOf(compression));
+        given(s3ObjectRequest.getExpression()).willReturn(query);
+        given(s3ObjectRequest.getSerializationFormatOption()).willReturn(S3SelectSerializationFormatOption.valueOf(format));
+        given(selectResponseHandler.getException()).willReturn(null);
+        given(selectResponseHandler.getS3SelectContentEvents()).willReturn(constructObjectEventStreamForResponseFormat(responseFormat));
+        given(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).willReturn(s3ObjectEventsSummary);
+        given(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).willReturn(s3ObjectsSucceededCounter);
+
+        final CompletableFuture<Void> selectObjectResponseFuture = mock(CompletableFuture.class);
+        given(selectObjectResponseFuture.join()).willReturn(mock(Void.class));
+        given(s3AsyncClient.selectObjectContent(any(SelectObjectContentRequest.class), eq(selectResponseHandler))).willReturn(selectObjectResponseFuture);
+        doAnswer(invocation -> null).when(eventConsumer).accept(any(Event.class), eq(s3ObjectReference));
+
+        createObjectUnderTest().parseS3Object(s3ObjectReference);
+
+        assertHeadObjectRequestIsCorrect();
+
+        verify(eventConsumer).accept(any(Event.class), eq(s3ObjectReference));
+        verify(s3ObjectEventsSummary).record(1);
         verify(s3ObjectsSucceededCounter).increment();
-        assertThat(distributionSummary,notNullValue());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "'{\"S.No\":\"1\",\"name\":\"data-prep\",\"country\":\"USA\"}',select * from s3Object,CSV,NONE"})
+    void parseS3Object_retries_bufferAccumulatorFlush_when_bufferWriteAll_throwsTimeoutException(final String responseFormat,
+                                                                                                 final String query,
+                                                                                                 final String format,
+                                                                                                 final String compression) throws Exception {
+        given(s3ObjectRequest.getCompressionType()).willReturn(CompressionType.valueOf(compression));
+        given(s3ObjectRequest.getExpression()).willReturn(query);
+        given(s3ObjectRequest.getSerializationFormatOption()).willReturn(S3SelectSerializationFormatOption.valueOf(format));
+        given(selectResponseHandler.getException()).willReturn(null);
+        given(selectResponseHandler.getS3SelectContentEvents()).willReturn(constructObjectEventStreamForResponseFormat(responseFormat));
+        given(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).willReturn(s3ObjectEventsSummary);
+        given(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).willReturn(s3ObjectsSucceededCounter);
+        given(s3ObjectRequest.getS3SelectCSVOption().getFileHeaderInfo()).willReturn(CSV_FILE_HEADER_INFO_NONE);
+        given(s3ObjectRequest.getS3SelectCSVOption().getComments()).willReturn(UUID.randomUUID().toString());
+        given(s3ObjectRequest.getS3SelectCSVOption().getQuiteEscape()).willReturn(UUID.randomUUID().toString());
+
+        final CompletableFuture<Void> selectObjectResponseFuture = mock(CompletableFuture.class);
+        given(selectObjectResponseFuture.join()).willReturn(mock(Void.class));
+        given(s3AsyncClient.selectObjectContent(any(SelectObjectContentRequest.class), eq(selectResponseHandler))).willReturn(selectObjectResponseFuture);
+        doAnswer(invocation -> null).when(eventConsumer).accept(any(Event.class), eq(s3ObjectReference));
+
+        doThrow(TimeoutException.class).doNothing().when(buffer).writeAll(any(Collection.class), anyInt());
+
+        System.out.println(responseFormat);
+        createObjectUnderTest().parseS3Object(s3ObjectReference);
+
+        assertHeadObjectRequestIsCorrect();
+
+        verify(eventConsumer).accept(any(Event.class), eq(s3ObjectReference));
+        verify(s3ObjectEventsSummary).record(1);
+        verify(s3ObjectsSucceededCounter).increment();
+    }
+
+    private void assertHeadObjectRequestIsCorrect() {
+        final HeadObjectRequest capturedRequest = argumentCaptorForHeadObjectRequest.getValue();
+
+        assertThat(capturedRequest.key(), equalTo(s3ObjectReference.getKey()));
+        assertThat(capturedRequest.bucket(), equalTo(s3ObjectReference.getBucketName()));
+    }
+
+    private List<SelectObjectContentEventStream> constructObjectEventStreamForResponseFormat(final String responseFormat) {
+        return new ArrayList<>(Arrays.asList(
+                SelectObjectContentEventStream.recordsBuilder().payload(SdkBytes.fromUtf8String(responseFormat)).build(),
+                SelectObjectContentEventStream.contBuilder().build(),
+                SelectObjectContentEventStream.statsBuilder()
+                        .details(Stats.builder().bytesProcessed(10L).bytesScanned(20L).bytesReturned(30L).build()).build(),
+                SelectObjectContentEventStream.progressBuilder()
+                        .details(Progress.builder().bytesProcessed(10L).bytesScanned(20L).bytesReturned(30L).build()).build(),
+                SelectObjectContentEventStream.endBuilder().build()));
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorkerTest.java
@@ -68,6 +68,9 @@ class S3SelectObjectWorkerTest {
     private S3AsyncClient s3AsyncClient;
 
     @Mock
+    private S3SelectResponseHandlerFactory responseHandlerFactory;
+
+    @Mock
     private S3SelectResponseHandler selectResponseHandler;
 
     @Mock
@@ -112,7 +115,8 @@ class S3SelectObjectWorkerTest {
         given(s3ObjectRequest.getNumberOfRecordsToAccumulate()).willReturn(1);
         given(s3ObjectRequest.getS3AsyncClient()).willReturn(s3AsyncClient);
         given(s3ObjectRequest.getBufferTimeout()).willReturn(Duration.ofMillis(random.nextInt(100) + 100));
-        given(s3ObjectRequest.getS3SelectResponseHandler()).willReturn(selectResponseHandler);
+        given(s3ObjectRequest.getS3SelectResponseHandlerFactory()).willReturn(responseHandlerFactory);
+        given(responseHandlerFactory.provideS3SelectResponseHandler()).willReturn(selectResponseHandler);
         given(s3ObjectRequest.getEventConsumer()).willReturn(eventConsumer);
         given(s3ObjectRequest.getExpressionType()).willReturn(UUID.randomUUID().toString());
 
@@ -243,7 +247,6 @@ class S3SelectObjectWorkerTest {
 
         doThrow(TimeoutException.class).doNothing().when(buffer).writeAll(any(Collection.class), anyInt());
 
-        System.out.println(responseFormat);
         createObjectUnderTest().parseS3Object(s3ObjectReference);
 
         assertHeadObjectRequestIsCorrect();


### PR DESCRIPTION
### Description
* This change retries the flushing of the buffer for the S3Source when it receives a TimeoutException from the buffer
* Refactors the `S3SelectWorkerObjectTest` 
 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
