### PR TITLE
FileSink updates: Remove call to initialize(), adds FileSinkConfig, test updates

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/FileSink.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/FileSink.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.sink;
 
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
@@ -23,7 +24,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import static java.lang.String.format;
 
-@DataPrepperPlugin(name = "file", pluginType = Sink.class)
+@DataPrepperPlugin(name = "file", pluginType = Sink.class, pluginConfigurationType = FileSinkConfig.class)
 public class FileSink implements Sink<Record<Object>> {
     private static final Logger LOG = LoggerFactory.getLogger(FileSink.class);
     private static final String SAMPLE_FILE_PATH = "src/resources/file-test-sample-output.txt";
@@ -42,30 +43,21 @@ public class FileSink implements Sink<Record<Object>> {
      * has access to pluginSetting metadata from pipeline
      * pluginSetting file.
      *
-     * @param pluginSetting instance with metadata information from pipeline pluginSetting file.
+     * @param fileSinkConfig The file sink configuration
      */
-    public FileSink(final PluginSetting pluginSetting) {
-        this((String) pluginSetting.getAttributeFromSettings(FILE_PATH));
-    }
-
-    public FileSink() {
-        this(SAMPLE_FILE_PATH);
-    }
-
-    public FileSink(final String outputFile) {
-        this.outputFilePath = outputFile == null ? SAMPLE_FILE_PATH : outputFile;
+    @DataPrepperPluginConstructor
+    public FileSink(final FileSinkConfig fileSinkConfig) {
+        this.outputFilePath = fileSinkConfig.getPath();
         isStopRequested = false;
         initialized = false;
         lock = new ReentrantLock(true);
-        initialize();
     }
 
     @Override
     public void output(final Collection<Record<Object>> records) {
-
         lock.lock();
         try {
-            if(isStopRequested)
+            if (isStopRequested)
                 return;
 
             for (final Record<Object> record : records) {

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/FileSinkConfig.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/FileSinkConfig.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+
+public class FileSinkConfig {
+    @JsonProperty("path")
+    @NotEmpty
+    private String path = "src/resources/file-test-sample-output.txt";
+
+    public String getPath() {
+        return path;
+    }
+}

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/sink/FileSinkTests.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/sink/FileSinkTests.java
@@ -5,15 +5,14 @@
 
 package org.opensearch.dataprepper.plugins.sink;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.record.Record;
-import org.apache.commons.io.FileUtils;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -23,7 +22,6 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/sink/FileSinkTests.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/sink/FileSinkTests.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.plugins.sink;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
@@ -30,10 +31,10 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class FileSinkTests {
-    private static String PLUGIN_NAME = "file";
-
     private File TEST_OUTPUT_FILE;
     private final String TEST_DATA_1 = "data_prepper";
     private final String TEST_DATA_2 = "file_sink";
@@ -43,9 +44,11 @@ class FileSinkTests {
     // TODO: remove with the completion of: https://github.com/opensearch-project/data-prepper/issues/546
     private final List<Record<Object>> TEST_STRING_RECORDS = Arrays.asList(TEST_STRING_RECORD_1, TEST_STRING_RECORD_2);
     private List<Record<Object>> TEST_RECORDS;
+    private FileSinkConfig fileSinkConfig;
 
     @BeforeEach
     void setUp() throws IOException {
+        fileSinkConfig = mock(FileSinkConfig.class);
         TEST_OUTPUT_FILE = Files.createTempFile("", "output.txt").toFile();
         TEST_RECORDS = new ArrayList<>();
 
@@ -61,6 +64,10 @@ class FileSinkTests {
                 .build()));
     }
 
+    private FileSink createObjectUnderTest() {
+        return new FileSink(fileSinkConfig);
+    }
+
     @AfterEach
     void tearDown() {
         FileUtils.deleteQuietly(TEST_OUTPUT_FILE);
@@ -68,82 +75,93 @@ class FileSinkTests {
 
     @Test
     void testInvalidFilePath() {
-        assertThrows(RuntimeException.class, () -> new FileSink(completePluginSettingForFileSink("")));
+        when(fileSinkConfig.getPath()).thenReturn("");
+        final FileSink objectUnderTest = createObjectUnderTest();
+        assertThrows(RuntimeException.class, objectUnderTest::initialize);
     }
 
-    // TODO: remove with the completion of: https://github.com/opensearch-project/data-prepper/issues/546
+    @Nested
+    class WithValidOutputFile {
+        @BeforeEach
+        void setUp() {
+            when(fileSinkConfig.getPath()).thenReturn(TEST_OUTPUT_FILE.getPath());
+        }
+
+        // TODO: remove with the completion of: https://github.com/opensearch-project/data-prepper/issues/546
+        @Test
+        void testValidFilePathStringRecord() throws IOException {
+            final FileSink fileSink = createObjectUnderTest();
+            fileSink.initialize();
+
+            Assertions.assertTrue(fileSink.isReady());
+            fileSink.output(TEST_STRING_RECORDS);
+            fileSink.shutdown();
+
+            final String outputData = readDocFromFile(TEST_OUTPUT_FILE);
+            Assertions.assertTrue(outputData.contains(TEST_DATA_1));
+            Assertions.assertTrue(outputData.contains(TEST_DATA_2));
+        }
+
+        // TODO: remove with the completion of: https://github.com/opensearch-project/data-prepper/issues/546
+        @Test
+        void testValidFilePathCustomTypeRecord() throws IOException {
+            final FileSink fileSink = createObjectUnderTest();
+            fileSink.initialize();
+            Assertions.assertTrue(fileSink.isReady());
+            final TestObject testObject = new TestObject();
+            fileSink.output(Collections.singleton(new Record<>(testObject)));
+            fileSink.shutdown();
+
+            final String outputData = readDocFromFile(TEST_OUTPUT_FILE);
+            Assertions.assertTrue(outputData.contains(testObject.toString()));
+        }
+        @Test
+        void testValidFilePath() throws IOException {
+            final FileSink fileSink = createObjectUnderTest();
+            fileSink.initialize();
+            Assertions.assertTrue(fileSink.isReady());
+            fileSink.output(TEST_RECORDS);
+            fileSink.shutdown();
+
+            final String outputData = readDocFromFile(TEST_OUTPUT_FILE);
+            Assertions.assertTrue(outputData.contains(TEST_DATA_1));
+            Assertions.assertTrue(outputData.contains(TEST_DATA_2));
+        }
+
+        @Test
+        void testMultipleCallsToOutput() throws IOException {
+            final FileSink fileSink = createObjectUnderTest();
+            fileSink.initialize();
+            Assertions.assertTrue(fileSink.isReady());
+            fileSink.output(Collections.singletonList(TEST_RECORDS.get(0)));
+            fileSink.output(Collections.singletonList(TEST_RECORDS.get(1)));
+            fileSink.shutdown();
+
+            final String outputData = readDocFromFile(TEST_OUTPUT_FILE);
+            assertThat(outputData, containsString(TEST_DATA_1));
+            assertThat(outputData, containsString(TEST_DATA_2));
+        }
+
+        @Test
+        void testCallingOutputAfterShutdownDoesNotWrite() throws IOException {
+            final FileSink fileSink = createObjectUnderTest();
+            fileSink.initialize();
+            Assertions.assertTrue(fileSink.isReady());
+            fileSink.output(Collections.singletonList(TEST_RECORDS.get(0)));
+            fileSink.shutdown();
+            fileSink.output(Collections.singletonList(TEST_RECORDS.get(1)));
+
+            final String outputData = readDocFromFile(TEST_OUTPUT_FILE);
+            assertThat(outputData, containsString(TEST_DATA_1));
+            assertThat(outputData, not(containsString(TEST_DATA_2)));
+        }
+    }
+
     @Test
-    void testValidFilePathStringRecord() throws IOException {
-        final FileSink fileSink = new FileSink(completePluginSettingForFileSink(TEST_OUTPUT_FILE.getPath()));
-        Assertions.assertTrue(fileSink.isReady());
-        fileSink.output(TEST_STRING_RECORDS);
-        fileSink.shutdown();
-
-        final String outputData = readDocFromFile(TEST_OUTPUT_FILE);
-        Assertions.assertTrue(outputData.contains(TEST_DATA_1));
-        Assertions.assertTrue(outputData.contains(TEST_DATA_2));
-    }
-
-    // TODO: remove with the completion of: https://github.com/opensearch-project/data-prepper/issues/546
-    @Test
-    void testValidFilePathCustomTypeRecord() throws IOException {
-        final FileSink fileSink = new FileSink(completePluginSettingForFileSink(TEST_OUTPUT_FILE.getPath()));
-        Assertions.assertTrue(fileSink.isReady());
-        final TestObject testObject = new TestObject();
-        fileSink.output(Collections.singleton(new Record<>(testObject)));
-        fileSink.shutdown();
-
-        final String outputData = readDocFromFile(TEST_OUTPUT_FILE);
-        Assertions.assertTrue(outputData.contains(testObject.toString()));
-    }
-
-    @Test
-    void testValidFilePath() throws IOException {
-        final FileSink fileSink = new FileSink(completePluginSettingForFileSink(TEST_OUTPUT_FILE.getPath()));
-        Assertions.assertTrue(fileSink.isReady());
-        fileSink.output(TEST_RECORDS);
-        fileSink.shutdown();
-
-        final String outputData = readDocFromFile(TEST_OUTPUT_FILE);
-        Assertions.assertTrue(outputData.contains(TEST_DATA_1));
-        Assertions.assertTrue(outputData.contains(TEST_DATA_2));
-    }
-
-    @Test
-    void testMultipleCallsToOutput() throws IOException {
-        final FileSink fileSink = new FileSink(completePluginSettingForFileSink(TEST_OUTPUT_FILE.getPath()));
-        Assertions.assertTrue(fileSink.isReady());
-        fileSink.output(Collections.singletonList(TEST_RECORDS.get(0)));
-        fileSink.output(Collections.singletonList(TEST_RECORDS.get(1)));
-        fileSink.shutdown();
-
-        final String outputData = readDocFromFile(TEST_OUTPUT_FILE);
-        assertThat(outputData, containsString(TEST_DATA_1));
-        assertThat(outputData, containsString(TEST_DATA_2));
-    }
-
-    @Test
-    void testCallingOutputAfterShutdownDoesNotWrite() throws IOException {
-        final FileSink fileSink = new FileSink(completePluginSettingForFileSink(TEST_OUTPUT_FILE.getPath()));
-        Assertions.assertTrue(fileSink.isReady());
-        fileSink.output(Collections.singletonList(TEST_RECORDS.get(0)));
-        fileSink.shutdown();
-        fileSink.output(Collections.singletonList(TEST_RECORDS.get(1)));
-
-        final String outputData = readDocFromFile(TEST_OUTPUT_FILE);
-        assertThat(outputData, containsString(TEST_DATA_1));
-        assertThat(outputData, not(containsString(TEST_DATA_2)));
-    }
-
-    @Test
-    void testWithDefaultFile() throws IOException {
-        assertThrows(RuntimeException.class, () -> new FileSink((String)null));
-    }
-
-    private PluginSetting completePluginSettingForFileSink(final String filepath) {
-        final Map<String, Object> settings = new HashMap<>();
-        settings.put(FileSink.FILE_PATH, filepath);
-        return new PluginSetting(PLUGIN_NAME, settings);
+    void testWithDefaultFile() {
+        when(fileSinkConfig.getPath()).thenReturn(null);
+        final FileSink objectUnderTest = createObjectUnderTest();
+        assertThrows(RuntimeException.class, objectUnderTest::initialize);
     }
 
     private String readDocFromFile(final File file) throws IOException {


### PR DESCRIPTION
### Description

Removes an unnecessary call to initialize() in the FileSink constructor. Updates FileSink to use a FileSinkConfig. Updates FileSink tests.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
