### PR TITLE
Fix cannot start databaseService.py with Trace Analytics Sample App (#2477)

### DIFF
--- a/examples/trace-analytics-sample-app/sample-app/requirements.txt
+++ b/examples/trace-analytics-sample-app/sample-app/requirements.txt
@@ -5,4 +5,4 @@ opentelemetry-instrumentation-flask==0.33b0
 opentelemetry-instrumentation-mysql==0.33b0
 opentelemetry-instrumentation-requests==0.33b0
 opentelemetry-sdk==1.12.0
-protobuf==3.18.3
+protobuf==3.19.6


### PR DESCRIPTION
### Description
The python protobuf library of Trace Analytics Sample App with a bug. So that the sample app can not be started.

Bump the version of it to fix this issue.
 
### Issues Resolved
#2477
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
