### PR TITLE
Move backoff strategy to BufferAccumulator

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/BufferAccumulator.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/BufferAccumulator.java
@@ -7,11 +7,19 @@ package org.opensearch.dataprepper.plugins.source;
 
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.record.Record;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Accumulates {@link Record} objects before placing them into a Data Prepper
@@ -21,6 +29,11 @@ import java.util.Objects;
  * @param <T> Type of record to accumulate
  */
 class BufferAccumulator<T extends Record<?>> {
+    private static final Logger LOG = LoggerFactory.getLogger(BufferAccumulator.class);
+
+    private static final int MAX_FLUSH_RETRIES_ON_IO_EXCEPTION = Integer.MAX_VALUE;
+    private static final Duration INITIAL_FLUSH_RETRY_DELAY_ON_IO_EXCEPTION = Duration.ofSeconds(5);
+
     private final Buffer<T> buffer;
     private final int numberOfRecordsToAccumulate;
     private final int bufferTimeoutMillis;
@@ -52,7 +65,49 @@ class BufferAccumulator<T extends Record<?>> {
     }
 
     void flush() throws Exception {
-        flushAccumulatedToBuffer();
+        try {
+            flushAccumulatedToBuffer();
+        } catch (final TimeoutException timeoutException) {
+            flushWithBackoff();
+        }
+    }
+
+    private boolean flushWithBackoff() throws Exception{
+        final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        long nextDelay = INITIAL_FLUSH_RETRY_DELAY_ON_IO_EXCEPTION.toMillis();
+        boolean flushedSuccessfully;
+
+        for (int retryCount = 0; retryCount < MAX_FLUSH_RETRIES_ON_IO_EXCEPTION; retryCount++) {
+            final ScheduledFuture<Boolean> flushBufferFuture = scheduledExecutorService.schedule(() -> {
+                try {
+                    flushAccumulatedToBuffer();
+                    return true;
+                } catch (final TimeoutException e) {
+                    return false;
+                }
+            }, nextDelay, TimeUnit.MILLISECONDS);
+
+            try {
+                flushedSuccessfully = flushBufferFuture.get();
+                if (flushedSuccessfully) {
+                    LOG.info("Successfully flushed the buffer accumulator on retry attempt {}", retryCount + 1);
+                    scheduledExecutorService.shutdownNow();
+                    return true;
+                }
+            } catch (final ExecutionException e) {
+                LOG.warn("Retrying of flushing the buffer accumulator hit an exception: {}", e.getMessage());
+                scheduledExecutorService.shutdownNow();
+                throw e;
+            } catch (final InterruptedException e) {
+                LOG.warn("Retrying of flushing the buffer accumulator was interrupted: {}", e.getMessage());
+                scheduledExecutorService.shutdownNow();
+                throw e;
+            }
+        }
+
+        LOG.warn("Flushing the bufferAccumulator failed after {} attempts", MAX_FLUSH_RETRIES_ON_IO_EXCEPTION);
+        scheduledExecutorService.shutdownNow();
+        return false;
     }
 
     private void flushAccumulatedToBuffer() throws Exception {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorker.java
@@ -43,12 +43,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -60,8 +54,6 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
     private static final Logger LOG = LoggerFactory.getLogger(S3SelectObjectWorker.class);
 
     static final long MAX_S3_OBJECT_CHUNK_SIZE = 64 * 1024 * 1024;
-    private static final int MAX_FLUSH_RETRIES_ON_IO_EXCEPTION = Integer.MAX_VALUE;
-    private static final Duration INITIAL_FLUSH_RETRY_DELAY_ON_IO_EXCEPTION = Duration.ofSeconds(5);
     static final String S3_BUCKET_NAME = "bucket";
     static final String S3_OBJECT_KEY = "key";
     static final String S3_BUCKET_REFERENCE_NAME = "s3";
@@ -220,8 +212,6 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
                         if (acknowledgementSet != null) {
                             acknowledgementSet.add(eventRecord.getData());
                         }
-                    } catch (final TimeoutException ex) {
-                        flushWithBackoff(bufferAccumulator);
                     } catch (final Exception ex) {
                         LOG.error("Failed writing S3 objects to buffer due to: {}", ex.getMessage());
                     }
@@ -234,42 +224,6 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
         } catch (Exception e) {
             throw new IOException(e);
         }
-    }
-
-    private boolean flushWithBackoff(final BufferAccumulator<Record<Event>> bufferAccumulator) {
-
-        final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-        long nextDelay = INITIAL_FLUSH_RETRY_DELAY_ON_IO_EXCEPTION.toMillis();
-        boolean flushedSuccessfully;
-
-        for (int retryCount = 0; retryCount < MAX_FLUSH_RETRIES_ON_IO_EXCEPTION; retryCount++) {
-            final ScheduledFuture<Boolean> flushBufferFuture = scheduledExecutorService.schedule(() -> {
-                try {
-                    bufferAccumulator.flush();
-                    return true;
-                } catch (final Exception e) {
-                    return false;
-                }
-            }, nextDelay, TimeUnit.MILLISECONDS);
-
-            try {
-                flushedSuccessfully = flushBufferFuture.get();
-                if (flushedSuccessfully) {
-                    LOG.info("Successfully flushed the buffer accumulator on retry attempt {}", retryCount + 1);
-                    scheduledExecutorService.shutdownNow();
-                    return true;
-                }
-            } catch (ExecutionException e) {
-                LOG.warn("Retrying of flushing the buffer accumulator hit an exception: {}", e.getMessage());
-            } catch (InterruptedException e) {
-                LOG.warn("Retrying of flushing the buffer accumulator was interrupted: {}", e.getMessage());
-            }
-        }
-
-
-        LOG.warn("Flushing the bufferAccumulator failed after {} attempts", S3SelectObjectWorker.MAX_FLUSH_RETRIES_ON_IO_EXCEPTION);
-        scheduledExecutorService.shutdownNow();
-        return false;
     }
 
     private JsonNode getJsonNode(String selectObjectOptionalString) throws JsonProcessingException {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorker.java
@@ -128,7 +128,6 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
                 inputStreamList = getInputStreamFromResponseHeader(s3SelectResponseHandler);
                 parseCompleteStreamFromResponseHeader(acknowledgementSet, s3ObjectReference, bufferAccumulator, inputStreamList);
                 s3ObjectPluginMetrics.getS3ObjectEventsSummary().record(bufferAccumulator.getTotalWritten());
-                s3ObjectPluginMetrics.getS3ObjectsSucceededCounter().increment();
                 receivedEvents.clear();
             } else {
                 LOG.info("S3 Select returned no events for S3 object {}", s3ObjectReference);
@@ -137,6 +136,8 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
             startRange = endRange;
             endRange += Math.min(MAX_S3_OBJECT_CHUNK_SIZE, objectSize - endRange);
         }
+
+        s3ObjectPluginMetrics.getS3ObjectsSucceededCounter().increment();
     }
 
     private Long getObjectSize(final S3ObjectReference s3ObjectReference) {

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorkerTest.java
@@ -178,6 +178,7 @@ class S3SelectObjectWorkerTest {
         given(s3ObjectRequest.getCompressionType()).willReturn(CompressionType.NONE);
         given(selectResponseHandler.getException()).willReturn(null);
         given(selectResponseHandler.getS3SelectContentEvents()).willReturn(Collections.emptyList());
+        given(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).willReturn(s3ObjectsSucceededCounter);
 
         final CompletableFuture<Void> selectObjectResponseFuture = mock(CompletableFuture.class);
         given(selectObjectResponseFuture.join()).willReturn(mock(Void.class));
@@ -188,6 +189,7 @@ class S3SelectObjectWorkerTest {
         assertHeadObjectRequestIsCorrect();
 
         verify(selectResponseHandler, times(numberOfObjectScans)).getS3SelectContentEvents();
+        verify(s3ObjectsSucceededCounter).increment();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Description
Moves the backoff and retry logic to the BufferAccumulator so both of the S3 sources can take advantage of it.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
