### PR TITLE
Fixes an issue where end-to-end acknowledgements prevent shutdown

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/AcknowledgementAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/AcknowledgementAppConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+@Configuration
+class AcknowledgementAppConfig {
+    private static final int MAX_THREADS = 12;
+
+    @Bean
+    CallbackTheadFactory callbackTheadFactory() {
+        final ThreadFactory defaultThreadFactory = Executors.defaultThreadFactory();
+        return new CallbackTheadFactory(defaultThreadFactory);
+    }
+
+    @Bean(name = "acknowledgementCallbackExecutor")
+    ExecutorService acknowledgementCallbackExecutor(final CallbackTheadFactory callbackTheadFactory) {
+        return Executors.newFixedThreadPool(MAX_THREADS, callbackTheadFactory);
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/AcknowledgementSetMonitor.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/AcknowledgementSetMonitor.java
@@ -18,19 +18,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 /**
  * AcknowledgementSetMonitor - monitors the acknowledgement sets for completion/expiration
- *
+ * <p>
  * Every acknowledgement set must complete (ie get acknowledgements from all the events in it)
  * by a specified time. If it is not completed, then it is considered 'expired' and it is
  * cleaned up. The 'run' method is invoked periodically to cleanup the acknowledgement sets
  * that are either completed or expired.
  */
-public class AcknowledgementSetMonitor implements Runnable {
+class AcknowledgementSetMonitor implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(AcknowledgementSetMonitor.class);
     private final Set<AcknowledgementSet> acknowledgementSets;
     private final ReentrantLock lock;
-    private AtomicInteger numInvalidAcquires;
-    private AtomicInteger numInvalidReleases;
-    private AtomicInteger numNullHandles;
+    private final AtomicInteger numInvalidAcquires;
+    private final AtomicInteger numInvalidReleases;
+    private final AtomicInteger numNullHandles;
 
     private DefaultAcknowledgementSet getAcknowledgementSet(final EventHandle eventHandle) {
         return (DefaultAcknowledgementSet)((DefaultEventHandle)eventHandle).getAcknowledgementSet();
@@ -110,7 +110,10 @@ public class AcknowledgementSetMonitor implements Runnable {
         }
     }
 
-    // For testing
+    /**
+     * for testing
+     * @return the size
+     */
     int getSize() {
         return acknowledgementSets.size();
     }
@@ -120,7 +123,7 @@ public class AcknowledgementSetMonitor implements Runnable {
         lock.lock();
         try {
             if (acknowledgementSets.size() > 0) {
-                acknowledgementSets.removeIf((ackSet) -> ((DefaultAcknowledgementSet)ackSet).isDone());
+                acknowledgementSets.removeIf((ackSet) -> ((DefaultAcknowledgementSet) ackSet).isDone());
             }
         } finally {
             lock.unlock();

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/AcknowledgementSetMonitorThread.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/AcknowledgementSetMonitorThread.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import java.time.Duration;
+
+class AcknowledgementSetMonitorThread {
+    private final Thread monitorThread;
+    private final AcknowledgementSetMonitor acknowledgementSetMonitor;
+    private final Duration delayTime;
+    private volatile boolean isStopped = false;
+
+    public AcknowledgementSetMonitorThread(
+            final AcknowledgementSetMonitor acknowledgementSetMonitor,
+            final Duration delayTime) {
+        this.acknowledgementSetMonitor = acknowledgementSetMonitor;
+        this.delayTime = delayTime;
+        monitorThread = new Thread(new Monitor());
+        monitorThread.setDaemon(true);
+        monitorThread.setName("acknowledgement-monitor");
+    }
+
+    public void start() {
+        monitorThread.start();
+    }
+
+    public void stop() {
+        isStopped = true;
+    }
+
+    private class Monitor implements Runnable {
+        @Override
+        public void run() {
+            while (!isStopped) {
+                acknowledgementSetMonitor.run();
+                try {
+                    Thread.sleep(delayTime.toMillis());
+                } catch (final InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/CallbackTheadFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/CallbackTheadFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import java.util.Objects;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class CallbackTheadFactory implements ThreadFactory {
+    private final ThreadFactory delegateFactory;
+    private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+    public CallbackTheadFactory(final ThreadFactory delegateFactory) {
+        this.delegateFactory = Objects.requireNonNull(delegateFactory);
+    }
+
+    @Override
+    public Thread newThread(final Runnable runnable) {
+        final Thread thread = delegateFactory.newThread(runnable);
+        thread.setName("acknowledgement-callback-" + threadNumber.getAndIncrement());
+        return thread;
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/AcknowledgementSetMonitorThreadTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/AcknowledgementSetMonitorThreadTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AcknowledgementSetMonitorThreadTest {
+    @Mock
+    private AcknowledgementSetMonitor acknowledgementSetMonitor;
+    private Duration delayTime;
+
+    @BeforeEach
+    void setUp() {
+        delayTime = Duration.ofMillis(10);
+    }
+
+    private AcknowledgementSetMonitorThread createObjectUnderTest() {
+        return new AcknowledgementSetMonitorThread(acknowledgementSetMonitor, delayTime);
+    }
+
+    @Test
+    void run_will_call_monitor_run() {
+        final AcknowledgementSetMonitorThread objectUnderTest = createObjectUnderTest();
+
+        objectUnderTest.start();
+        await().atMost(delayTime.plusMillis(500))
+                .untilAsserted(() -> {
+                    verify(acknowledgementSetMonitor, atLeastOnce()).run();
+                });
+
+        verify(acknowledgementSetMonitor, atLeastOnce()).run();
+
+        objectUnderTest.stop();
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/CallbackTheadFactoryTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/CallbackTheadFactoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.ThreadFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CallbackTheadFactoryTest {
+    @Mock
+    private ThreadFactory delegateThreadFactory;
+
+    @Mock
+    private Runnable runnable;
+
+    private CallbackTheadFactory createObjectUnderTest() {
+        return new CallbackTheadFactory(delegateThreadFactory);
+    }
+
+    @Test
+    void constructor_throws_with_null_delegate() {
+        delegateThreadFactory = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Nested
+    class WithNewThread {
+
+        @Mock
+        private Thread threadFromDelegate;
+
+        @BeforeEach
+        void setUp() {
+            when(delegateThreadFactory.newThread(runnable))
+                    .thenReturn(threadFromDelegate);
+        }
+
+        @Test
+        void newThread_returns_thread_from_inner() {
+            assertThat(createObjectUnderTest().newThread(runnable),
+                    equalTo(threadFromDelegate));
+        }
+
+        @Test
+        void newThread_assigns_name() {
+            createObjectUnderTest().newThread(runnable);
+            verify(threadFromDelegate).setName("acknowledgement-callback-1");
+        }
+    }
+
+    @Test
+    void newThread_called_multiple_times_uses_new_thread_name() {
+        when(delegateThreadFactory.newThread(runnable))
+                .thenAnswer(a -> mock(Thread.class));
+
+        final CallbackTheadFactory objectUnderTest = createObjectUnderTest();
+
+        final Thread thread1 = objectUnderTest.newThread(runnable);
+        final Thread thread2 = objectUnderTest.newThread(runnable);
+        final Thread thread3 = objectUnderTest.newThread(runnable);
+
+        verify(thread1).setName("acknowledgement-callback-1");
+        verify(thread2).setName("acknowledgement-callback-2");
+        verify(thread3).setName("acknowledgement-callback-3");
+    }
+}


### PR DESCRIPTION
### Description

In recent testing I found that Data Prepper was not shutting down properly on errors. It turns out that the end-to-end acknowledgements were preventing this. The scheduled thread pool was creating a new thread regularly and increasing the overall thread count. Additionally, these are user threads so they are not allowing Data Prepper to close.

This PR includes a few changes:

* Split the threads for end-to-end acknowledgement callbacks from the thread for monitoring.
* Name the threads to help with debugging.
* Make the monitoring thread a daemon. (I did not do the same with the callback threads as these are processing data).
* Create the `ExecutorService` as a Spring Bean in the application context. Spring should call `shutdown()` on this automatically.
* Use Awaitility when waiting in unit tests.
* Removed exception handling in unit tests - let the exceptions throw to the test framework.
* Various code changes
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
