### PR TITLE
end_to_end_acknowledgements option name change

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemoryConfig.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemoryConfig.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAlias;
 
 /**
  * Configuration for an in_memory plugin.
@@ -14,8 +15,9 @@ class InMemoryConfig {
     @JsonProperty("testing_key")
     private String testingKey;
 
-    @JsonProperty("end_to_end_acknowledgements")
-    private Boolean endToEndAcknowledgements = false;
+    @JsonProperty("acknowledgements")
+    @JsonAlias("acknowledgments")
+    private Boolean acknowledgements = false;
 
     public String getTestingKey() {
         return testingKey;
@@ -25,8 +27,8 @@ class InMemoryConfig {
         this.testingKey = testingKey;
     }
 
-    public Boolean getEndToEndAcknowledgements() {
-        return endToEndAcknowledgements;
+    public Boolean getAcknowledgements() {
+        return acknowledgements;
     }
 
 }

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySource.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySource.java
@@ -46,7 +46,7 @@ public class InMemorySource implements Source<Record<Event>> {
         this.inMemorySourceAccessor = inMemorySourceAccessor;
         this.inMemorySourceAccessor.setEventFactory(eventFactory);
         this.acknowledgementSetManager = acknowledgementSetManager;
-        this.enabledAcks = inMemoryConfig.getEndToEndAcknowledgements();
+        this.enabledAcks = inMemoryConfig.getAcknowledgements();
     }
 
     @Override

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/one-pipeline-ack-expiry-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/one-pipeline-ack-expiry-test.yaml
@@ -3,7 +3,7 @@ pipeline1:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      end_to_end_acknowledgements: true
+      acknowledgements: true
   sink:
     - stdout:
     - in_memory:

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/one-pipeline-three-sinks.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/one-pipeline-three-sinks.yaml
@@ -3,7 +3,7 @@ pipeline1:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      end_to_end_acknowledgements: true
+      acknowledgements: true
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/simple-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/simple-test.yaml
@@ -3,7 +3,7 @@ simple-pipeline:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      end_to_end_acknowledgements: true
+      acknowledgments: true
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipeline-route-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipeline-route-test.yaml
@@ -3,7 +3,7 @@ pipeline1:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      end_to_end_acknowledgements: true
+      acknowledgements: true
   route:
     - 2xx_route: '/status >= 200 and /status < 300'
     - other_route: '/status >= 300 or /status < 200'

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipelines-test-multi-sink.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipelines-test-multi-sink.yaml
@@ -3,7 +3,7 @@ pipeline1:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      end_to_end_acknowledgements: true
+      acknowledgements: true
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipelines-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipelines-test.yaml
@@ -3,7 +3,7 @@ pipeline1:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      end_to_end_acknowledgements: true
+      acknowledgements: true
   sink:
     - pipeline:
         name: "pipeline2"

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/two-parallel-pipelines-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/two-parallel-pipelines-test.yaml
@@ -3,7 +3,7 @@ pipeline1:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      end_to_end_acknowledgements: true
+      acknowledgements: true
   sink:
     - pipeline:
         name: "pipeline2"

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/two-pipelines-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/two-pipelines-test.yaml
@@ -3,7 +3,7 @@ pipeline1:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      end_to_end_acknowledgements: true
+      acknowledgements: true
   sink:
     - pipeline:
         name: "pipeline2"

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -134,7 +134,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     try {
         doInitializeInternal();
     } catch (IOException e) {
-        LOG.warn("Failed to initialize OpenSearch sink, retrying. Error {}", (Objects.isNull(e.getCause()) ? e : e.getCause()));
+        LOG.warn("Failed to initialize OpenSearch sink, retrying. Error {}", (Objects.isNull(e.getCause()) ? e : e.getCause()), e);
         closeFiles();
     } catch (InvalidPluginConfigurationException e) {
         LOG.error("Failed to initialize OpenSearch sink.");
@@ -146,7 +146,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
             this.shutdown();
             throw e;
         }
-        LOG.warn("Failed to initialize OpenSearch sink, retrying. Error {}", (Objects.isNull(e.getCause()) ? e : e.getCause()));
+        LOG.warn("Failed to initialize OpenSearch sink, retrying. Error {}", (Objects.isNull(e.getCause()) ? e : e.getCause()), e);
         closeFiles();
     }
   }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3Source.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3Source.java
@@ -35,20 +35,20 @@ public class S3Source implements Source<Record<Event>> {
     private SqsService sqsService;
     private final PluginFactory pluginFactory;
     private final AcknowledgementSetManager acknowledgementSetManager;
-    private final boolean endToEndAcknowledgementsEnabled;
+    private final boolean acknowledgementsEnabled;
 
     @DataPrepperPluginConstructor
     public S3Source(PluginMetrics pluginMetrics, final S3SourceConfig s3SourceConfig, final PluginFactory pluginFactory, final AcknowledgementSetManager acknowledgementSetManager) {
         this.pluginMetrics = pluginMetrics;
         this.s3SourceConfig = s3SourceConfig;
         this.pluginFactory = pluginFactory;
-        this.endToEndAcknowledgementsEnabled = s3SourceConfig.getEndToEndAcknowledgements();
+        this.acknowledgementsEnabled = s3SourceConfig.getAcknowledgements();
         this.acknowledgementSetManager = acknowledgementSetManager;
     }
 
     @Override
     public boolean areAcknowledgementsEnabled() {
-        return endToEndAcknowledgementsEnabled;
+        return acknowledgementsEnabled;
     }
 
     @Override

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SourceConfig.java
@@ -14,6 +14,7 @@ import org.opensearch.dataprepper.plugins.source.configuration.AwsAuthentication
 import org.opensearch.dataprepper.plugins.source.configuration.OnErrorOption;
 import org.opensearch.dataprepper.plugins.source.configuration.S3SelectOptions;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
@@ -46,8 +47,9 @@ public class S3SourceConfig {
     @JsonProperty("on_error")
     private OnErrorOption onErrorOption = OnErrorOption.RETAIN_MESSAGES;
 
-    @JsonProperty("end_to_end_acknowledgements")
-    private boolean endToEndAcknowledgements = false;
+    @JsonProperty("acknowledgements")
+    @JsonAlias("acknowledgments")
+    private boolean acknowledgements = false;
 
     @JsonProperty("buffer_timeout")
     private Duration bufferTimeout = DEFAULT_BUFFER_TIMEOUT;
@@ -74,8 +76,8 @@ public class S3SourceConfig {
         return notificationType;
     }
 
-    boolean getEndToEndAcknowledgements() {
-        return endToEndAcknowledgements;
+    boolean getAcknowledgements() {
+        return acknowledgements;
     }
 
     public CompressionOption getCompression() {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
@@ -75,7 +75,7 @@ public class SqsWorker implements Runnable {
         this.s3SourceConfig = s3SourceConfig;
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.standardBackoff = backoff;
-        this.endToEndAcknowledgementsEnabled = s3SourceConfig.getEndToEndAcknowledgements();
+        this.endToEndAcknowledgementsEnabled = s3SourceConfig.getAcknowledgements();
         sqsOptions = s3SourceConfig.getSqsOptions();
         objectCreatedFilter = new ObjectCreatedFilter();
         failedAttemptCount = 0;

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SourceConfigTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SourceConfigTest.java
@@ -40,14 +40,14 @@ class S3SourceConfigTest {
 
     @Test
     void default_end_to_end_acknowledgements_test() {
-        assertThat(new S3SourceConfig().getEndToEndAcknowledgements(), equalTo(false));
+        assertThat(new S3SourceConfig().getAcknowledgements(), equalTo(false));
     }
 
     @Test
     void end_to_end_acknowledgements_set_to_true_test() throws Exception {
         final S3SourceConfig s3SourceConfig = new S3SourceConfig();
-        ReflectivelySetField.setField(S3SourceConfig.class,s3SourceConfig,"endToEndAcknowledgements", true);
-        assertTrue(s3SourceConfig.getEndToEndAcknowledgements());
+        ReflectivelySetField.setField(S3SourceConfig.class,s3SourceConfig,"acknowledgements", true);
+        assertTrue(s3SourceConfig.getAcknowledgements());
     }
 
     @Test

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/SqsWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/SqsWorkerTest.java
@@ -103,7 +103,7 @@ class SqsWorkerTest {
         when(s3SourceConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
         when(s3SourceConfig.getSqsOptions()).thenReturn(sqsOptions);
         when(s3SourceConfig.getOnErrorOption()).thenReturn(OnErrorOption.RETAIN_MESSAGES);
-        when(s3SourceConfig.getEndToEndAcknowledgements()).thenReturn(false);
+        when(s3SourceConfig.getAcknowledgements()).thenReturn(false);
 
         pluginMetrics = mock(PluginMetrics.class);
         sqsMessagesReceivedCounter = mock(Counter.class);
@@ -180,7 +180,7 @@ class SqsWorkerTest {
         @ValueSource(strings = {"ObjectCreated:Put", "ObjectCreated:Post", "ObjectCreated:Copy", "ObjectCreated:CompleteMultipartUpload"})
         void processSqsMessages_should_return_number_of_messages_processed_with_acknowledgements(final String eventName) throws IOException {
             when(acknowledgementSetManager.create(any(), any(Duration.class))).thenReturn(acknowledgementSet);
-            when(s3SourceConfig.getEndToEndAcknowledgements()).thenReturn(true);
+            when(s3SourceConfig.getAcknowledgements()).thenReturn(true);
             sqsWorker = new SqsWorker(acknowledgementSetManager, sqsClient, s3Service, s3SourceConfig, pluginMetrics, backoff);
             Instant startTime = Instant.now().minus(1, ChronoUnit.HOURS);
             final Message message = mock(Message.class);


### PR DESCRIPTION
### Description
Change `end_to_end_acknowledgements` option in sources to `acknowledgements` and also support alias `acknowledgments`
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
