### PR TITLE
Properly shutdown the log_generator plugin

### DIFF
--- a/data-prepper-plugins/log-generator-source/src/main/java/org/opensearch/dataprepper/plugins/source/loggenerator/LogGeneratorSource.java
+++ b/data-prepper-plugins/log-generator-source/src/main/java/org/opensearch/dataprepper/plugins/source/loggenerator/LogGeneratorSource.java
@@ -63,6 +63,15 @@ public class LogGeneratorSource implements Source<Record<Event>> {
     @Override
     public void stop() {
         stopGenerating.set(true);
+
+        scheduledExecutorService.shutdown();
+        try {
+            if (!scheduledExecutorService.awaitTermination(500, TimeUnit.MILLISECONDS)) {
+                scheduledExecutorService.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            scheduledExecutorService.shutdownNow();
+        }
     }
 
     private boolean hasNotReachedLogCount() {


### PR DESCRIPTION
### Description

The `log_generator` was not shutting down its threads. This prevented Data Prepper from shutting down. This PR includes an ExecutorService shutdown.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
