### PR TITLE
Shut down Data Prepper after all pipelines have shutdown.

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/AbstractContextManager.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/AbstractContextManager.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * Base class for managing context. It provides hooks for inheritors to control the context to some degree.
+ * <p>Creates Spring {@link org.springframework.context.ApplicationContext} hierarchy for Dependency Injection with limited visibility.</p>
+ * <p>
+ *     Application Context Hierarchy
+ *         Public Application Context<br>
+ *         ├─ Core Application Context<br>
+ *         ├─ Shared Plugin Application Context<br>
+ *             ├─ Plugin Isolated Application Context<br>
+ * </p>
+ * @since 2.2
+ */
+public abstract class AbstractContextManager {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractContextManager.class);
+    private static final String BASE_DATA_PREPPER_PACKAGE = "org.opensearch.dataprepper";
+    private static final String EXPRESSION_PACKAGE = BASE_DATA_PREPPER_PACKAGE + ".expression";
+
+    private final AnnotationConfigApplicationContext publicApplicationContext;
+    private final AnnotationConfigApplicationContext coreApplicationContext;
+    private DataPrepper dataPrepper;
+
+    protected AbstractContextManager() {
+        publicApplicationContext = new AnnotationConfigApplicationContext();
+        coreApplicationContext = new AnnotationConfigApplicationContext();
+    }
+
+    /**
+     * @since 1.3
+     * Retrieves the instance of {@link DataPrepper} singleton
+     * @return {@link DataPrepper} instance
+     */
+    public DataPrepper getDataPrepperBean() {
+        if(dataPrepper == null) {
+            start();
+        }
+        return dataPrepper;
+    }
+
+    private void start() {
+        publicApplicationContext.scan(EXPRESSION_PACKAGE);
+        preRefreshPublicApplicationContext(publicApplicationContext);
+
+        publicApplicationContext.refresh();
+        coreApplicationContext.setParent(publicApplicationContext);
+        coreApplicationContext.scan(BASE_DATA_PREPPER_PACKAGE);
+        preRefreshCoreApplicationContext(coreApplicationContext);
+
+        coreApplicationContext.refresh();
+
+        dataPrepper = coreApplicationContext.getBean(DataPrepper.class);
+        dataPrepper.registerShutdownHandler(new ContextShutdownListener());
+
+        LOG.trace("Data Prepper context is fully refreshed.");
+    }
+
+    /**
+     * Override this method to modify the public {@link AnnotationConfigApplicationContext} before
+     * the {@link AbstractContextManager} calls {@link AnnotationConfigApplicationContext#refresh()}
+     *
+     * @param publicApplicationContext The public application context
+     */
+    protected void preRefreshPublicApplicationContext(final AnnotationConfigApplicationContext publicApplicationContext) {
+
+    }
+
+    /**
+     * Override this method to modify the core {@link AnnotationConfigApplicationContext} before
+     * the {@link AbstractContextManager} calls {@link AnnotationConfigApplicationContext#refresh()}
+     *
+     * @param coreApplicationContext The core application context
+     */
+    protected void preRefreshCoreApplicationContext(final AnnotationConfigApplicationContext coreApplicationContext) {
+
+    }
+
+    public void shutdown() {
+        coreApplicationContext.close();
+        publicApplicationContext.close();
+    }
+
+    private class ContextShutdownListener implements DataPrepperShutdownListener {
+        @Override
+        public void handleShutdown() {
+            shutdown();
+        }
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/DataPrepperShutdownListener.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/DataPrepperShutdownListener.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper;
+
+interface DataPrepperShutdownListener {
+    void handleShutdown();
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/PipelineObserver.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/PipelineObserver.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline;
+
+/**
+ * Allows an observer to observe major changes in pipelines.
+ */
+public interface PipelineObserver {
+    void shutdown(Pipeline pipeline);
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/PipelinesProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/PipelinesProvider.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline;
+
+import java.util.Map;
+
+/**
+ * Interface for a provider of available Data Prepper Pipelines.
+ */
+public interface PipelinesProvider {
+    Map<String, Pipeline> getTransformationPipelines();
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ListPipelinesHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ListPipelinesHandler.java
@@ -5,10 +5,10 @@
 
 package org.opensearch.dataprepper.pipeline.server;
 
-import org.opensearch.dataprepper.DataPrepper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
+import org.opensearch.dataprepper.pipeline.PipelinesProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,12 +24,12 @@ import java.util.stream.Collectors;
  */
 public class ListPipelinesHandler implements HttpHandler {
 
-    private final DataPrepper dataPrepper;
+    private final PipelinesProvider pipelinesProvider;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final Logger LOG = LoggerFactory.getLogger(ListPipelinesHandler.class);
 
-    public ListPipelinesHandler(final DataPrepper dataPrepper) {
-        this.dataPrepper = dataPrepper;
+    public ListPipelinesHandler(final PipelinesProvider pipelinesProvider) {
+        this.pipelinesProvider = pipelinesProvider;
     }
 
     private static class PipelineListing {
@@ -50,7 +50,7 @@ public class ListPipelinesHandler implements HttpHandler {
         }
 
         try {
-            final List<PipelineListing> pipelines = dataPrepper.getTransformationPipelines()
+            final List<PipelineListing> pipelines = pipelinesProvider.getTransformationPipelines()
                     .keySet()
                     .stream()
                     .map(PipelineListing::new)

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandler.java
@@ -36,7 +36,7 @@ public class ShutdownHandler implements HttpHandler {
         }
 
         try {
-            dataPrepper.shutdown();
+            dataPrepper.shutdownPipelines();
             exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0);
         } catch (Exception e) {
             LOG.error("Caught exception shutting down data prepper", e);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/config/DataPrepperServerConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/config/DataPrepperServerConfiguration.java
@@ -9,6 +9,7 @@ import org.opensearch.dataprepper.DataPrepper;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.pipeline.PipelinesProvider;
 import org.opensearch.dataprepper.pipeline.server.DataPrepperCoreAuthenticationProvider;
 import org.opensearch.dataprepper.pipeline.server.ListPipelinesHandler;
 import org.opensearch.dataprepper.pipeline.server.ShutdownHandler;
@@ -65,8 +66,8 @@ public class DataPrepperServerConfiguration {
     }
 
     @Bean
-    public ListPipelinesHandler listPipelinesHandler(final DataPrepper dataPrepper) {
-        return new ListPipelinesHandler(dataPrepper);
+    public ListPipelinesHandler listPipelinesHandler(final PipelinesProvider pipelinesProvider) {
+        return new ListPipelinesHandler(pipelinesProvider);
     }
 
     @Bean

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/AbstractContextManagerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/AbstractContextManagerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.MockedConstruction;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AbstractContextManagerTest {
+    private List<AnnotationConfigApplicationContext> applicationContexts;
+    private DataPrepper dataPrepper;
+
+    @BeforeEach
+    void setUp() {
+        applicationContexts = new ArrayList<>();
+
+        dataPrepper = mock(DataPrepper.class);
+    }
+
+    private AbstractContextManager createObjectUnderTest() {
+        try(final MockedConstruction<AnnotationConfigApplicationContext> mockConstruction = mockConstruction(AnnotationConfigApplicationContext.class)) {
+            final AbstractContextManager objectUnderTest = spy(AbstractContextManager.class);
+            applicationContexts.addAll(mockConstruction.constructed());
+            return objectUnderTest;
+        }
+    }
+
+    @Test
+    void getDataPrepperBean_calls_pre_refresh_hooks() {
+        final AbstractContextManager objectUnderTest = createObjectUnderTest();
+
+        assertThat(applicationContexts, notNullValue());
+
+        final AnnotationConfigApplicationContext coreContext = applicationContexts.get(1);
+        when(coreContext.getBean(DataPrepper.class)).thenReturn(dataPrepper);
+
+        verify(objectUnderTest, never()).preRefreshPublicApplicationContext(any());
+        verify(objectUnderTest, never()).preRefreshCoreApplicationContext(any());
+
+        objectUnderTest.getDataPrepperBean();
+
+        verify(objectUnderTest).preRefreshPublicApplicationContext(applicationContexts.get(0));
+        verify(objectUnderTest).preRefreshCoreApplicationContext(applicationContexts.get(1));
+    }
+
+    @Test
+    void getDataPrepperBean_calls_refresh_once_across_multiple_calls() {
+        final AbstractContextManager objectUnderTest = createObjectUnderTest();
+
+        assertThat(applicationContexts, notNullValue());
+
+        final AnnotationConfigApplicationContext coreContext = applicationContexts.get(1);
+        when(coreContext.getBean(DataPrepper.class)).thenReturn(dataPrepper);
+
+        for (int i = 0; i < 3; i++) {
+            objectUnderTest.getDataPrepperBean();
+        }
+
+        verify(applicationContexts.get(0)).refresh();
+        verify(applicationContexts.get(1)).refresh();
+    }
+
+    @Test
+    void getDataPrepperBean_closes_application_contexts_when_DataPrepper_shutsdown() {
+        final AbstractContextManager objectUnderTest = createObjectUnderTest();
+
+        assertThat(applicationContexts, notNullValue());
+
+        final AnnotationConfigApplicationContext coreContext = applicationContexts.get(1);
+        when(coreContext.getBean(DataPrepper.class)).thenReturn(dataPrepper);
+
+        objectUnderTest.getDataPrepperBean();
+
+        ArgumentCaptor<DataPrepperShutdownListener> dataPrepperShutdownListenerArgumentCaptor = ArgumentCaptor.forClass(DataPrepperShutdownListener.class);
+        verify(dataPrepper).registerShutdownHandler(dataPrepperShutdownListenerArgumentCaptor.capture());
+
+        final DataPrepperShutdownListener shutdownListener = dataPrepperShutdownListenerArgumentCaptor.getValue();
+
+        shutdownListener.handleShutdown();
+
+        final InOrder inOrder = inOrder(applicationContexts.toArray());
+        final List<AnnotationConfigApplicationContext> reversedContexts = Lists.reverse(applicationContexts);
+        for (AnnotationConfigApplicationContext applicationContext : reversedContexts) {
+            inOrder.verify(applicationContext).close();
+        }
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/DataPrepperTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/DataPrepperTests.java
@@ -5,70 +5,72 @@
 
 package org.opensearch.dataprepper;
 
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.parser.PipelineParser;
 import org.opensearch.dataprepper.peerforwarder.server.PeerForwarderServer;
 import org.opensearch.dataprepper.pipeline.Pipeline;
+import org.opensearch.dataprepper.pipeline.PipelineObserver;
 import org.opensearch.dataprepper.pipeline.server.DataPrepperServer;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import static org.mockito.Mockito.lenient;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class DataPrepperTests {
-    private static final PipelineParser pipelineParser = mock(PipelineParser.class);
-    private static final Pipeline pipeline = mock(Pipeline.class);
-    private static Map<String, Pipeline> parseConfigurationFixture;
-
+    private Map<String, Pipeline> parseConfigurationFixture;
+    @Mock
+    private PipelineParser pipelineParser;
+    @Mock
+    private Pipeline pipeline;
     @Mock
     private PluginFactory pluginFactory;
     @Mock
     private DataPrepperServer dataPrepperServer;
     @Mock
     private PeerForwarderServer peerForwarderServer;
-    @InjectMocks
-    private DataPrepper dataPrepper;
 
-    @BeforeAll
-    public static void beforeAll() {
+    @BeforeEach
+    public void before() {
         parseConfigurationFixture = new HashMap<>();
         parseConfigurationFixture.put("testKey", pipeline);
-        when(pipeline.isReady()).thenReturn(true);
+        lenient().when(pipeline.getName()).thenReturn("testKey");
+        lenient().when(pipeline.isReady()).thenReturn(true);
 
-        when(pipelineParser.parseConfiguration())
+        lenient().when(pipelineParser.parseConfiguration())
                 .thenReturn(parseConfigurationFixture);
     }
 
-    @BeforeEach
-    public void before() throws NoSuchFieldException, IllegalAccessException {
-        // Use reflection to set dataPrepper.dataPrepperServer because @InjectMock will not use field injection.
+    private DataPrepper createObjectUnderTest() throws NoSuchFieldException, IllegalAccessException {
+        final DataPrepper dataPrepper = new DataPrepper(pipelineParser, pluginFactory, peerForwarderServer);
         final Field dataPrepperServerField = dataPrepper.getClass().getDeclaredField("dataPrepperServer");
         dataPrepperServerField.setAccessible(true);
         dataPrepperServerField.set(dataPrepper, dataPrepperServer);
         dataPrepperServerField.setAccessible(false);
+
+        return dataPrepper;
     }
 
     @Test
-    public void testGivenValidInputThenInstanceCreation() {
+    public void testGivenValidInputThenInstanceCreation() throws NoSuchFieldException, IllegalAccessException {
         assertThat(
                 "Given injected with valid beans a DataPrepper bean should be available",
-                dataPrepper,
+                createObjectUnderTest(),
                 Matchers.is(Matchers.notNullValue()));
     }
 
@@ -83,18 +85,18 @@ public class DataPrepperTests {
     }
 
     @Test
-    public void testGivenInstantiatedWithPluginFactoryWhenGetPluginFactoryCalledThenReturnSamePluginFactory() {
-        assertThat(dataPrepper.getPluginFactory(), Matchers.is(pluginFactory));
+    public void testGivenInstantiatedWithPluginFactoryWhenGetPluginFactoryCalledThenReturnSamePluginFactory() throws NoSuchFieldException, IllegalAccessException {
+        assertThat(createObjectUnderTest().getPluginFactory(), Matchers.is(pluginFactory));
     }
 
     @Test
-    public void testGivenValidPipelineParserThenReturnResultOfParseConfiguration() {
-        assertThat(dataPrepper.getTransformationPipelines(), Matchers.is(parseConfigurationFixture));
+    public void testGivenValidPipelineParserThenReturnResultOfParseConfiguration() throws NoSuchFieldException, IllegalAccessException {
+        assertThat(createObjectUnderTest().getTransformationPipelines(), Matchers.is(parseConfigurationFixture));
     }
 
     @Test
-    public void testGivenValidPipelineParserWhenExecuteThenAllPipelinesExecuteAndServerStartAndReturnTrue() {
-        assertThat(dataPrepper.execute(), Matchers.is(true));
+    public void testGivenValidPipelineParserWhenExecuteThenAllPipelinesExecuteAndServerStartAndReturnTrue() throws NoSuchFieldException, IllegalAccessException {
+        assertThat(createObjectUnderTest().execute(), Matchers.is(true));
 
         verify(pipeline).execute();
         verify(dataPrepperServer).start();
@@ -102,29 +104,29 @@ public class DataPrepperTests {
     }
 
     @Test
-    public void testDataPrepperShutdown() {
-        dataPrepper.shutdown();
+    public void testDataPrepperShutdown() throws NoSuchFieldException, IllegalAccessException {
+        createObjectUnderTest().shutdownPipelines();
         verify(pipeline).shutdown();
     }
 
     @Test
-    public void testDataPrepperShutdownPipeline() {
+    public void testDataPrepperShutdownPipeline() throws NoSuchFieldException, IllegalAccessException {
         final Pipeline randomPipeline = mock(Pipeline.class);
         lenient().when(randomPipeline.isReady()).thenReturn(true);
         parseConfigurationFixture.put("Random Pipeline", randomPipeline);
-        dataPrepper.shutdown("Random Pipeline");
+        createObjectUnderTest().shutdownPipelines("Random Pipeline");
 
         verify(randomPipeline).shutdown();
     }
 
     @Test
-    public void testDataPrepperShutdownNonExistentPipelineWithoutException() {
-        dataPrepper.shutdown("Missing Pipeline");
+    public void testDataPrepperShutdownNonExistentPipelineWithoutException() throws NoSuchFieldException, IllegalAccessException {
+        createObjectUnderTest().shutdownPipelines("Missing Pipeline");
     }
 
     @Test
-    public void testShutdownServers() {
-        dataPrepper.shutdownServers();
+    public void testShutdownServers() throws NoSuchFieldException, IllegalAccessException {
+        createObjectUnderTest().shutdownServers();
 
         verify(dataPrepperServer).stop();
         verify(peerForwarderServer).stop();
@@ -135,5 +137,23 @@ public class DataPrepperTests {
         final String actual = DataPrepper.getServiceNameForMetrics();
 
         assertThat(actual, Matchers.is("dataprepper"));
+    }
+
+    @Test
+    void dataPrepper_shuts_down_when_last_pipeline_is_shutdown() throws NoSuchFieldException, IllegalAccessException {
+        final DataPrepper objectUnderTest = createObjectUnderTest();
+        objectUnderTest.execute();
+        final ArgumentCaptor<PipelineObserver> pipelineObserverArgumentCaptor = ArgumentCaptor.forClass(PipelineObserver.class);
+        verify(pipeline).addShutdownObserver(pipelineObserverArgumentCaptor.capture());
+
+        final PipelineObserver pipelineObserver = pipelineObserverArgumentCaptor.getValue();
+        pipelineObserver.shutdown(pipeline);
+
+        verify(dataPrepperServer).stop();
+        verify(peerForwarderServer).stop();
+
+        final Map<String, Pipeline> transformationPipelines = objectUnderTest.getTransformationPipelines();
+        assertThat(transformationPipelines, notNullValue());
+        assertThat(transformationPipelines.size(), equalTo(0));
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandlerTest.java
@@ -55,7 +55,7 @@ public class ShutdownHandlerTest {
         shutdownHandler.handle(exchange);
 
         verify(dataPrepper, times(1))
-                .shutdown();
+                .shutdownPipelines();
         verify(exchange, times(1))
                 .sendResponseHeaders(eq(HttpURLConnection.HTTP_OK), eq(0L));
         verify(responseBody, times(1))
@@ -82,7 +82,7 @@ public class ShutdownHandlerTest {
     public void testHandleException() throws IOException {
         when(exchange.getRequestMethod())
                 .thenReturn(HttpMethod.POST);
-        doThrow(RuntimeException.class).when(dataPrepper).shutdown();
+        doThrow(RuntimeException.class).when(dataPrepper).shutdownPipelines();
 
         shutdownHandler.handle(exchange);
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/config/DataPrepperServerConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/config/DataPrepperServerConfigurationTest.java
@@ -9,6 +9,7 @@ import org.opensearch.dataprepper.DataPrepper;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.pipeline.PipelinesProvider;
 import org.opensearch.dataprepper.pipeline.server.DataPrepperCoreAuthenticationProvider;
 import org.opensearch.dataprepper.pipeline.server.ListPipelinesHandler;
 import org.opensearch.dataprepper.pipeline.server.ShutdownHandler;
@@ -100,18 +101,18 @@ class DataPrepperServerConfigurationTest {
 
     @Test
     public void testGivenValidInputWithNoAuthenticatorThenServerListContextCreated() {
-        final DataPrepper dataPrepper = mock(DataPrepper.class);
+        final PipelinesProvider pipelinesProvider = mock(PipelinesProvider.class);
 
-        final ListPipelinesHandler handler = serverConfiguration.listPipelinesHandler(dataPrepper);
+        final ListPipelinesHandler handler = serverConfiguration.listPipelinesHandler(pipelinesProvider);
 
         assertThat(handler, isA(ListPipelinesHandler.class));
     }
 
     @Test
     public void testGivenValidInputWithAuthenticatorThenServerListContextCreated() {
-        final DataPrepper dataPrepper = mock(DataPrepper.class);
+        final PipelinesProvider pipelinesProvider = mock(PipelinesProvider.class);
 
-        final ListPipelinesHandler handler = serverConfiguration.listPipelinesHandler(dataPrepper);
+        final ListPipelinesHandler handler = serverConfiguration.listPipelinesHandler(pipelinesProvider);
 
         assertThat(handler, isA(ListPipelinesHandler.class));
     }

--- a/data-prepper-main/src/main/java/org/opensearch/dataprepper/ContextManager.java
+++ b/data-prepper-main/src/main/java/org/opensearch/dataprepper/ContextManager.java
@@ -12,19 +12,10 @@ import org.springframework.core.env.SimpleCommandLinePropertySource;
 
 /**
  * @since 1.3
- * <p>Creates Spring {@link org.springframework.context.ApplicationContext} hierarchy for Dependency Injection with limited visibility.</p>
- * <p>
- *     Application Context Hierarchy
- *         Public Application Context<br>
- *         ├─ Core Application Context<br>
- *         ├─ Shared Plugin Application Context<br>
- *             ├─ Plugin Isolated Application Context<br>
- * </p>
  */
-public class ContextManager {
+public class ContextManager extends AbstractContextManager {
     private static final Logger LOG = LoggerFactory.getLogger(ContextManager.class);
-
-    private final AnnotationConfigApplicationContext coreApplicationContext;
+    private final SimpleCommandLinePropertySource commandLinePropertySource;
 
     /**
      * @since 1.3
@@ -34,26 +25,11 @@ public class ContextManager {
      */
     public ContextManager(final String ... args) {
         LOG.trace("Reading args");
-        final SimpleCommandLinePropertySource commandLinePropertySource = new SimpleCommandLinePropertySource(args);
-
-        final AnnotationConfigApplicationContext publicApplicationContext = new AnnotationConfigApplicationContext();
-        publicApplicationContext.scan("org.opensearch.dataprepper.expression");
-        publicApplicationContext.refresh();
-
-        coreApplicationContext = new AnnotationConfigApplicationContext();
-        coreApplicationContext.setParent(publicApplicationContext);
-        coreApplicationContext.getEnvironment().getPropertySources().addFirst(commandLinePropertySource);
-        coreApplicationContext.register(DataPrepperExecute.class);
-
-        coreApplicationContext.refresh();
+        commandLinePropertySource = new SimpleCommandLinePropertySource(args);
     }
 
-    /**
-     * @since 1.3
-     * Retrieves the instance of {@link DataPrepper} singleton
-     * @return {@link DataPrepper} instance
-     */
-    public DataPrepper getDataPrepperBean() {
-        return coreApplicationContext.getBean(DataPrepper.class);
+    @Override
+    protected void preRefreshCoreApplicationContext(final AnnotationConfigApplicationContext coreApplicationContext) {
+        coreApplicationContext.getEnvironment().getPropertySources().addFirst(commandLinePropertySource);
     }
 }


### PR DESCRIPTION
### Description

When a Data Prepper pipeline shuts down, Data Prepper continues to run. If this is the last pipeline, Data Prepper will remain running.

This PR shuts down Data Prepper when the last pipeline fails.

I plan to follow this on with a configuration to allow Data Prepper to fail if any pipeline has shutdown.
 
### Issues Resolved

Resolves #2441
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
