### PR TITLE
Add Metrics to end-to-end acknowledgement core framework

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSet.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSet.java
@@ -35,7 +35,7 @@ public class DefaultAcknowledgementSet implements AcknowledgementSet {
     private Future<?> callbackFuture;
     private final DefaultAcknowledgementSetMetrics metrics;
 
-    public DefaultAcknowledgementSet(final ExecutorService executor, final Consumer<Boolean> callback, final Duration expiryTime, DefaultAcknowledgementSetMetrics metrics) {
+    public DefaultAcknowledgementSet(final ExecutorService executor, final Consumer<Boolean> callback, final Duration expiryTime, final DefaultAcknowledgementSetMetrics metrics) {
         this.callback = callback;
         this.result = true;
         this.executor = executor;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSet.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSet.java
@@ -33,28 +33,17 @@ public class DefaultAcknowledgementSet implements AcknowledgementSet {
     private boolean result;
     private final Map<EventHandle, AtomicInteger> pendingAcknowledgments;
     private Future<?> callbackFuture;
+    private final DefaultAcknowledgementSetMetrics metrics;
 
-    private final AtomicInteger numInvalidAcquires;
-    private final AtomicInteger numInvalidReleases;
-
-    public DefaultAcknowledgementSet(final ExecutorService executor, final Consumer<Boolean> callback, final Duration expiryTime) {
+    public DefaultAcknowledgementSet(final ExecutorService executor, final Consumer<Boolean> callback, final Duration expiryTime, DefaultAcknowledgementSetMetrics metrics) {
         this.callback = callback;
         this.result = true;
         this.executor = executor;
         this.expiryTime = Instant.now().plusMillis(expiryTime.toMillis());
         this.callbackFuture = null;
+        this.metrics = metrics;
         pendingAcknowledgments = new HashMap<>();
         lock = new ReentrantLock(true);
-        this.numInvalidAcquires = new AtomicInteger(0);
-        this.numInvalidReleases = new AtomicInteger(0);
-    }
-
-    public int getNumInvalidAcquires() {
-        return numInvalidAcquires.get();
-    }
-
-    public int getNumInvalidReleases() {
-        return numInvalidReleases.get();
     }
 
     @Override
@@ -76,7 +65,7 @@ public class DefaultAcknowledgementSet implements AcknowledgementSet {
         try {
             if (!pendingAcknowledgments.containsKey(eventHandle)) {
                 LOG.warn("Unexpected event handle acquire");
-                numInvalidAcquires.incrementAndGet();
+                metrics.increment(DefaultAcknowledgementSetMetrics.INVALID_ACQUIRES_METRIC_NAME);
                 return;
             }
             pendingAcknowledgments.get(eventHandle).incrementAndGet();
@@ -89,12 +78,14 @@ public class DefaultAcknowledgementSet implements AcknowledgementSet {
         lock.lock();
         try {
             if (callbackFuture != null && callbackFuture.isDone()) {
+                metrics.increment(DefaultAcknowledgementSetMetrics.COMPLETED_METRIC_NAME);
                 return true;
             }
             if (Instant.now().isAfter(expiryTime)) {
                 if (callbackFuture != null) {
                     callbackFuture.cancel(true);
                 }
+                metrics.increment(DefaultAcknowledgementSetMetrics.EXPIRED_METRIC_NAME);
                 return true;
             }
         } finally {
@@ -118,7 +109,7 @@ public class DefaultAcknowledgementSet implements AcknowledgementSet {
             if (!pendingAcknowledgments.containsKey(eventHandle) ||
                 pendingAcknowledgments.get(eventHandle).get() == 0) {
                 LOG.warn("Unexpected event handle release");
-                numInvalidReleases.incrementAndGet();
+                metrics.increment(DefaultAcknowledgementSetMetrics.INVALID_RELEASES_METRIC_NAME);
                 return false;
             }
             if (pendingAcknowledgments.get(eventHandle).decrementAndGet() == 0) {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetMetrics.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetMetrics.java
@@ -50,23 +50,5 @@ public class DefaultAcknowledgementSetMetrics {
         }
     }
 
-    public double get(String metricName) throws IllegalArgumentException {
-        switch (metricName) {
-            case CREATED_METRIC_NAME:
-                return numberOfAcknowledgementSetsCreated.count();
-            case COMPLETED_METRIC_NAME:
-                return numberOfAcknowledgementSetsCompleted.count();
-            case EXPIRED_METRIC_NAME:
-                return numberOfAcknowledgementSetsExpired.count();
-            case INVALID_ACQUIRES_METRIC_NAME:
-                return numberOfInvalidAcknowledgementAcquires.count();
-            case INVALID_RELEASES_METRIC_NAME:
-                return numberOfInvalidAcknowledgementReleases.count();
-            default:
-                throw new IllegalArgumentException("Invalid metric name");
-        }
-    }
-
 }
-
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetMetrics.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetMetrics.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import io.micrometer.core.instrument.Counter;
+
+public class DefaultAcknowledgementSetMetrics {
+    static final String CREATED_METRIC_NAME = "numberOfAcknowledgementSetsCreated";
+    static final String COMPLETED_METRIC_NAME = "numberOfAcknowledgementSetsCompleted";
+    static final String EXPIRED_METRIC_NAME = "numberOfAcknowledgementSetsExpired";
+    static final String INVALID_ACQUIRES_METRIC_NAME = "numberOfInvalidAcknowledgementAcquires";
+    static final String INVALID_RELEASES_METRIC_NAME = "numberOfInvalidAcknowledgementReleases";
+    private final Counter numberOfAcknowledgementSetsCreated;
+    private final Counter numberOfAcknowledgementSetsCompleted;
+    private final Counter numberOfAcknowledgementSetsExpired;
+    private final Counter numberOfInvalidAcknowledgementAcquires;
+    private final Counter numberOfInvalidAcknowledgementReleases;
+
+    public DefaultAcknowledgementSetMetrics(PluginMetrics pluginMetrics) {
+        numberOfAcknowledgementSetsCreated = pluginMetrics.counter(CREATED_METRIC_NAME);
+        numberOfAcknowledgementSetsCompleted = pluginMetrics.counter(COMPLETED_METRIC_NAME);
+        numberOfAcknowledgementSetsExpired = pluginMetrics.counter(EXPIRED_METRIC_NAME);
+        numberOfInvalidAcknowledgementAcquires = pluginMetrics.counter(INVALID_ACQUIRES_METRIC_NAME);
+        numberOfInvalidAcknowledgementReleases = pluginMetrics.counter(INVALID_RELEASES_METRIC_NAME);
+    }
+    
+    public void increment(String metricName) throws IllegalArgumentException {
+        switch (metricName) {
+            case CREATED_METRIC_NAME:
+                numberOfAcknowledgementSetsCreated.increment();
+                break;
+            case COMPLETED_METRIC_NAME:
+                numberOfAcknowledgementSetsCompleted.increment();
+                break;
+            case EXPIRED_METRIC_NAME:
+                numberOfAcknowledgementSetsExpired.increment();
+                break;
+            case INVALID_ACQUIRES_METRIC_NAME:
+                numberOfInvalidAcknowledgementAcquires.increment();
+                break;
+            case INVALID_RELEASES_METRIC_NAME:
+                numberOfInvalidAcknowledgementReleases.increment();
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid metric name");
+        }
+    }
+
+    public double get(String metricName) throws IllegalArgumentException {
+        switch (metricName) {
+            case CREATED_METRIC_NAME:
+                return numberOfAcknowledgementSetsCreated.count();
+            case COMPLETED_METRIC_NAME:
+                return numberOfAcknowledgementSetsCompleted.count();
+            case EXPIRED_METRIC_NAME:
+                return numberOfAcknowledgementSetsExpired.count();
+            case INVALID_ACQUIRES_METRIC_NAME:
+                return numberOfInvalidAcknowledgementAcquires.count();
+            case INVALID_RELEASES_METRIC_NAME:
+                return numberOfInvalidAcknowledgementReleases.count();
+            default:
+                throw new IllegalArgumentException("Invalid metric name");
+        }
+    }
+
+}
+
+

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetMetricsTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetMetricsTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import io.micrometer.core.instrument.Counter;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MockitoExtension.class)
+public class DefaultAcknowledgementSetMetricsTests {
+    @Mock
+    private Counter createdCounter;
+    @Mock
+    private Counter completedCounter;
+    @Mock
+    private Counter expiredCounter;
+    @Mock
+    private Counter invalidAcquiresCounter;
+    @Mock
+    private Counter invalidReleasesCounter;
+    private DefaultAcknowledgementSetMetrics metrics;
+
+    @Mock
+    PluginMetrics pluginMetrics;
+    
+    @BeforeEach
+    public void setup() {
+        pluginMetrics = mock(PluginMetrics.class);
+        when(pluginMetrics.counter(DefaultAcknowledgementSetMetrics.CREATED_METRIC_NAME)).thenReturn(createdCounter);
+        when(pluginMetrics.counter(DefaultAcknowledgementSetMetrics.COMPLETED_METRIC_NAME)).thenReturn(completedCounter);
+        when(pluginMetrics.counter(DefaultAcknowledgementSetMetrics.EXPIRED_METRIC_NAME)).thenReturn(expiredCounter);
+        when(pluginMetrics.counter(DefaultAcknowledgementSetMetrics.INVALID_ACQUIRES_METRIC_NAME)).thenReturn(invalidAcquiresCounter);
+        when(pluginMetrics.counter(DefaultAcknowledgementSetMetrics.INVALID_RELEASES_METRIC_NAME)).thenReturn(invalidReleasesCounter);
+    }
+
+    public DefaultAcknowledgementSetMetrics createObjectUnderTest() {
+        return new DefaultAcknowledgementSetMetrics(pluginMetrics);
+    }
+
+    @Test
+    public void testCounters() {
+        metrics = createObjectUnderTest();
+        metrics.increment(DefaultAcknowledgementSetMetrics.CREATED_METRIC_NAME);
+        verify(createdCounter, times(1)).increment();
+        metrics.increment(DefaultAcknowledgementSetMetrics.COMPLETED_METRIC_NAME);
+        verify(completedCounter, times(1)).increment();
+        metrics.increment(DefaultAcknowledgementSetMetrics.EXPIRED_METRIC_NAME);
+        verify(expiredCounter, times(1)).increment();
+        metrics.increment(DefaultAcknowledgementSetMetrics.INVALID_ACQUIRES_METRIC_NAME);
+        verify(invalidAcquiresCounter, times(1)).increment();
+        metrics.increment(DefaultAcknowledgementSetMetrics.INVALID_RELEASES_METRIC_NAME);
+        verify(invalidReleasesCounter, times(1)).increment();
+    }
+}
+


### PR DESCRIPTION
### Description
Adds Metrics to end-to-end acknowledgement core framework
The following metrics are added
1. Number of acknowledgement sets created
2. Number of acknowledgement sets completed successfully
3. Number of acknowledgement sets expired
4. Number of invalid acquires done
5. Number of invalid releases done
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
