### PR TITLE
Update RCF  maven repository to latest

### DIFF
--- a/data-prepper-plugins/anomaly-detector-processor/build.gradle
+++ b/data-prepper-plugins/anomaly-detector-processor/build.gradle
@@ -12,10 +12,10 @@ dependencies {
     implementation project(':data-prepper-test-common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'
-    implementation 'software.amazon.randomcutforest:randomcutforest-testutils:3.0.0'
-    implementation 'software.amazon.randomcutforest:randomcutforest-core:3.0.0'
-    implementation 'software.amazon.randomcutforest:randomcutforest-examples:3.0.0'
-    implementation 'software.amazon.randomcutforest:randomcutforest-parkservices:3.0.0'
+    implementation 'software.amazon.randomcutforest:randomcutforest-testutils:3.6.0'
+    implementation 'software.amazon.randomcutforest:randomcutforest-core:3.6.0'
+    implementation 'software.amazon.randomcutforest:randomcutforest-examples:3.6.0'
+    implementation 'software.amazon.randomcutforest:randomcutforest-parkservices:3.6.0'
     implementation 'software.amazon.randomcutforest:randomcutforest-serialization-json:1.0'
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
 }


### PR DESCRIPTION
### Description
Updated maven repository version for RCF. It has couple of fixes that are needed for proper functioning of anomaly detector processor.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
