### PR TITLE
adding wrapper dlq object, dlq file extensions and improving dlq README

### DIFF
--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/README.md
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/README.md
@@ -42,8 +42,8 @@ The DLQ file will JSON file with an array of failed [DLQ Objects](#DLQ-Objects).
 
 * `bucket`: The bucket name for the DLQ failed output records.
 * `key_path_prefix` (Optional) : The key_prefix to use in the S3 bucket.  Defaults to “” . This field supports time value patterns variables like: `/%{yyyy}/%{MM}/%{dd}`. The pattern supports all the symbols that represent one hour or above and are listed in [Java DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html). For example, with a pattern like `/%{yyyy}/%{MM}/%{dd}`, the following key prefix will be used: `/2023/01/24`.
-* `region` (Optional) : The AWS region to use for credentials. Defaults to standard SDK behavior to determine the region.
-* `sts_role_arn` (Optional) : The STS role to assume for requests to AWS. Defaults to null, which will use the standard SDK behavior for credentials.
+* `region` (Optional) : The AWS region of the S3 Bucket. Defaults to us-east-1.
+* `sts_role_arn` (Optional) : The STS role to assume to write to the AWS S3 bucket. Defaults to null, which will use the standard SDK behavior for credentials. The role or credentials used must have S3:PutObject permissions on the configured S3 Bucket.
 
 ### Metrics
 

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriter.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriter.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -44,7 +45,8 @@ public class S3DlqWriter implements DlqWriter {
     static final String S3_DLQ_REQUEST_FAILED = "dlqS3RequestFailed";
     static final String S3_DLQ_REQUEST_LATENCY = "dlqS3RequestLatency";
     static final String S3_DLQ_REQUEST_SIZE_BYTES = "dlqS3RequestSizeBytes";
-    private static final String KEY_NAME_FORMAT = "dlq-v%s-%s-%s-%s-%s";
+    static final String DLQ_OBJECTS = "dlqObjects";
+    private static final String KEY_NAME_FORMAT = "dlq-v%s-%s-%s-%s-%s.json";
     private static final String FULL_KEY_FORMAT = "%s/%s";
 
     private static final Logger LOG = LoggerFactory.getLogger(S3DlqWriter.class);
@@ -133,7 +135,9 @@ public class S3DlqWriter implements DlqWriter {
 
     private String deserialize(final List<DlqObject> dlqObjects) throws IOException {
         try {
-            final String content = objectMapper.writeValueAsString(dlqObjects);
+            final Map<String, Object> output = Map.of(DLQ_OBJECTS, dlqObjects);
+
+            final String content = objectMapper.writeValueAsString(output);
 
             dlqS3RequestSizeBytesSummary.record(content.getBytes(StandardCharsets.UTF_8).length);
 

--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterTest.java
@@ -43,6 +43,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.endsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -157,6 +158,7 @@ public class S3DlqWriterTest {
 
         assertThat(putObjectRequest.bucket(), is(equalTo(bucket)));
         assertThat(putObjectRequest.key(), startsWith(String.format("%s-%s-%s", expectedKeyPrefix, pipelineName, pluginId)));
+        assertThat(putObjectRequest.key(), endsWith(".json"));
         verify(dlqS3RequestSuccessCounter).increment();
         verify(dlqS3RecordsSuccessCounter).increment(dlqObjects.size());
     }
@@ -232,7 +234,7 @@ public class S3DlqWriterTest {
 
         @Test
         public void testDeserializeThrowsException() throws JsonProcessingException {
-            when(objectMapper.writeValueAsString(dlqObjects)).thenThrow(JsonProcessingException.class);
+            when(objectMapper.writeValueAsString(any())).thenThrow(JsonProcessingException.class);
 
             assertThrows(IOException.class, () -> s3DlqWriter.write(dlqObjects, pipelineName, pluginId));
         }


### PR DESCRIPTION
### Description
The following PR addresses a few issues with the DLQ. 1) it provides a json file extension for the data stored in S3. 2) it creates a higher level object to wrap all failed events. This will give us flexibility to add other metadata in the future. 3) Improves readme configuration details and corrects an error in the documentation.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
