### PR TITLE
removing event handle from dlq object

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/failures/DlqObject.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/failures/DlqObject.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.model.failures;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.apache.commons.lang3.StringUtils;
 
@@ -37,6 +38,7 @@ public class DlqObject {
 
     private final String timestamp;
 
+    @JsonIgnore
     private final EventHandle eventHandle;
 
     private DlqObject(final String pluginId, final String pluginName, final String pipelineName,

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedDlqData.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedDlqData.java
@@ -1,6 +1,8 @@
 package org.opensearch.dataprepper.plugins.sink.opensearch.dlq;
 
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.opensearch.dataprepper.model.event.EventHandle;
 
 public class FailedDlqData {
@@ -10,6 +12,8 @@ public class FailedDlqData {
     private final int status;
     private final String message;
     private final Object document;
+
+    @JsonIgnore
     private final EventHandle eventHandle;
 
     private FailedDlqData(final String index, final String indexId, final int status, final String message, final Object document, final EventHandle eventHandle) {


### PR DESCRIPTION
### Description
After the addition of e2e acks, the DLQ object ended up with some eventHandle null references. This PR removes those references being mapped and provided as part of the failed DLQ data.
 
### Issues Resolved
None
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
