### PR TITLE
Change the behavior of the CSV codec in the S3 source to fail fast

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/codec/CsvCodec.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/codec/CsvCodec.java
@@ -61,12 +61,22 @@ public class CsvCodec implements Codec {
         }
 
         MappingIterator<Map<String, String>> parsingIterator = mapper.readerFor(Map.class).with(schema).readValues(reader);
+        boolean hasNextValue;
         try {
-            while (parsingIterator.hasNextValue()) {
-                readCsvLine(parsingIterator, eventConsumer);
+            hasNextValue = parsingIterator.hasNextValue();
+        } catch (Exception ex) {
+            LOG.error("An Exception occurred while determining if file has next line ", ex);
+            throw ex;
+        }
+
+        while (hasNextValue) {
+            readCsvLine(parsingIterator, eventConsumer);
+            try {
+                hasNextValue = parsingIterator.hasNextValue();
+            } catch (Exception ex) {
+                LOG.error("An Exception occurred while determining if file has next line ", ex);
+                throw ex;
             }
-        } catch (Exception jsonExceptionOnHasNextLine) {
-            LOG.error("An Exception occurred while determining if file has next line ", jsonExceptionOnHasNextLine);
         }
     }
 
@@ -78,7 +88,7 @@ public class CsvCodec implements Codec {
         return firstLineNumberColumns;
     }
 
-    private void readCsvLine(final MappingIterator<Map<String, String>> parsingIterator, final Consumer<Record<Event>> eventConsumer) {
+    private void readCsvLine(final MappingIterator<Map<String, String>> parsingIterator, final Consumer<Record<Event>> eventConsumer) throws IOException {
         try {
             final Map<String, String> parsedLine = parsingIterator.nextValue();
 
@@ -90,11 +100,14 @@ public class CsvCodec implements Codec {
             LOG.error("Invalid CSV row, skipping this line. This typically means the row has too many columns. Consider using the CSV " +
                     "Processor if there might be inconsistencies in the number of columns because it is more flexible. Error: {}. Line Number: {} " +
                     "Character Number: {}", csvException.getMessage(), parsingIterator.getCurrentLocation().getLineNr(), parsingIterator.getCurrentLocation().getColumnNr());
+            throw csvException;
         } catch (JsonParseException jsonException) {
             LOG.error("A JsonParseException occurred on a row of the CSV file, skipping line. This typically means a quote character was " +
                     "not properly closed. Error: {}", jsonException.getMessage());
+            throw jsonException;
         } catch (final Exception e) {
             LOG.error("An Exception occurred while reading a row of the CSV file. Error ", e);
+            throw e;
         }
     }
 

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/codec/CsvCodecTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/codec/CsvCodecTest.java
@@ -5,12 +5,11 @@
 
 package org.opensearch.dataprepper.plugins.source.codec;
 
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.EventType;
-import org.opensearch.dataprepper.model.record.Record;
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvParser;
+import com.fasterxml.jackson.dataformat.csv.CsvReadException;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +19,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventType;
+import org.opensearch.dataprepper.model.record.Record;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -280,7 +282,7 @@ public class CsvCodecTest {
 
     @ParameterizedTest
     @ValueSource(ints = {2, 10, 100})
-    void test_when_autoDetectHeaderWrongNumberColumnsAndJaggedRows_then_skipsJaggedRows(final int numberOfRows) throws IOException {
+    void test_when_autoDetectHeaderWrongNumberColumnsAndJaggedRows_then_skipsRemainingRows(final int numberOfRows) throws IOException {
         // row that's longer than header should be skipped
         when(config.isDetectHeader()).thenReturn(Boolean.TRUE);
 
@@ -290,13 +292,14 @@ public class CsvCodecTest {
         final List<String> csvRowsExcludingHeader = new ArrayList<>(csvRowsExcludingHeaderImmutable);
 
         csvRowsExcludingHeader.add(generateCsvLine(numberOfColumns+1, config.getDelimiter(), config.getQuoteCharacter()));
+        csvRowsExcludingHeader.addAll(generateCsvLinesAsList(numberOfProperlyFormattedRows, numberOfColumns));
 
 
         final String header = generateHeader(numberOfColumns);
 
         final InputStream inputStream = createInputStreamAndAppendHeader(csvRowsExcludingHeader, header);
 
-        csvCodec.parse(inputStream, eventConsumer);
+        assertThrows(CsvReadException.class, () -> csvCodec.parse(inputStream, eventConsumer));
 
         final ArgumentCaptor<Record<Event>> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
 
@@ -322,7 +325,7 @@ public class CsvCodecTest {
 
     @ParameterizedTest
     @ValueSource(ints = {2, 10, 100})
-    void test_when_manualHeaderWrongNumberColumnsAndJaggedRows_then_skipsJaggedRows(final int numberOfRows) throws IOException {
+    void test_when_manualHeaderWrongNumberColumnsAndJaggedRows_then_skipsRemainingRows(final int numberOfRows) throws IOException {
         // row that's longer than header should be skipped
         when(config.isDetectHeader()).thenReturn(Boolean.FALSE);
 
@@ -336,10 +339,11 @@ public class CsvCodecTest {
         final List<String> csvRowsExcludingHeader = new ArrayList<>(csvRowsExcludingHeaderImmutable);
 
         csvRowsExcludingHeader.add(generateCsvLine(numberOfColumns+1, config.getDelimiter(), config.getQuoteCharacter()));
+        csvRowsExcludingHeader.addAll(generateCsvLinesAsList(numberOfProperlyFormattedRows, numberOfColumns));
 
         final InputStream inputStream = createInputStream(csvRowsExcludingHeader);
 
-        csvCodec.parse(inputStream, eventConsumer);
+        assertThrows(CsvReadException.class, () -> csvCodec.parse(inputStream, eventConsumer));
 
         final ArgumentCaptor<Record<Event>> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
 
@@ -388,7 +392,7 @@ public class CsvCodecTest {
 
     @ParameterizedTest
     @ValueSource(ints = {2, 10, 100})
-    void test_when_unrecoverableRow_then_logsExceptionAndSkipsOffendingRow(final int numberOfRows) throws IOException {
+    void test_when_unrecoverableRow_then_logsExceptionAndSkipsRemainingRows(final int numberOfRows) throws IOException {
         // If there's an unclosed quote then expected behavior is to skip that row
         when(config.isDetectHeader()).thenReturn(Boolean.TRUE);
         when(config.getQuoteCharacter()).thenReturn(";"); // ";" is also the array character
@@ -399,11 +403,13 @@ public class CsvCodecTest {
         final List<String> csvRowsExcludingHeader = new ArrayList<>(csvRowsExcludingHeaderImmutable);
         csvRowsExcludingHeader.add(generateIllegalString(numberOfColumns, config.getDelimiter(), config.getQuoteCharacter()));
         csvRowsExcludingHeader.add(generateCsvLine(numberOfColumns, config.getDelimiter(), config.getQuoteCharacter()));
+        csvRowsExcludingHeader.addAll(generateCsvLinesAsList(numberOfProperlyFormattedRows, numberOfColumns,
+                config.getDelimiter(), config.getQuoteCharacter()));
         final String header = generateHeader(numberOfColumns, config.getDelimiter().charAt(0), config.getQuoteCharacter().charAt(0));
 
         final InputStream inputStream = createInputStreamAndAppendHeader(csvRowsExcludingHeader, header);
 
-        csvCodec.parse(inputStream, eventConsumer);
+        assertThrows(JsonParseException.class, () -> csvCodec.parse(inputStream, eventConsumer));
 
         final ArgumentCaptor<Record<Event>> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
         verify(eventConsumer, times(numberOfProperlyFormattedRows)).accept(recordArgumentCaptor.capture());


### PR DESCRIPTION
### Description

This propagates exceptions from the CSV codec to provide clearer issues to users when CSV fails to process.
 
### Issues Resolved

Resolves #2512
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
