### PR TITLE
[2511] adding support for document_root_key

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
@@ -68,6 +68,14 @@ public interface Event extends Serializable {
     String toJsonString();
 
     /**
+     * Gets a serialized Json string of the specific key in the Event
+     * @param key the field to be returned
+     * @return Json string of the field
+     * @since 2.2
+     */
+    String getToJsonString(String key);
+
+    /**
      * Retrieves the EventMetadata
      * @return EventMetadata for the event
      * @since 1.2

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
@@ -73,7 +73,7 @@ public interface Event extends Serializable {
      * @return Json string of the field
      * @since 2.2
      */
-    String getToJsonString(String key);
+    String getAsJsonString(String key);
 
     /**
      * Retrieves the EventMetadata

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -277,7 +277,7 @@ public class JacksonEvent implements Event {
     }
 
     @Override
-    public String getToJsonString(final String key) {
+    public String getAsJsonString(final String key) {
         final String trimmedKey = checkAndTrimKey(key);
 
         final JsonNode node = getNode(trimmedKey);

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -276,6 +276,17 @@ public class JacksonEvent implements Event {
         return jsonNode.toString();
     }
 
+    @Override
+    public String getToJsonString(final String key) {
+        final String trimmedKey = checkAndTrimKey(key);
+
+        final JsonNode node = getNode(trimmedKey);
+        if (node.isMissingNode()) {
+            return null;
+        }
+        return node.toString();
+    }
+
     /**
      * returns a string with formatted parts replaced by their values. The input
      * string may contain parts with format "${.../.../...}" which are replaced

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -92,7 +92,7 @@ public class JacksonEventTest {
     }
 
     @Test
-    public void testPutAndGet_withMultLevelKeyTwice() {
+    public void testPutAndGet_withMultiLevelKeyTwice() {
         final String key = "foo/bar";
         final UUID value = UUID.randomUUID();
 
@@ -113,7 +113,7 @@ public class JacksonEventTest {
     }
 
     @Test
-    public void testPutAndGet_withMultLevelKeyWithADash() {
+    public void testPutAndGet_withMultiLevelKeyWithADash() {
         final String key = "foo/bar-bar";
         final UUID value = UUID.randomUUID();
 
@@ -196,6 +196,41 @@ public class JacksonEventTest {
         final String key = "foo/bar";
 
         UUID result = event.get(key, UUID.class);
+
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    public void testGetToJsonString_nestedObject() {
+        final String key = "foo/bar";
+        final String nestedValue = UUID.randomUUID().toString();
+        final TestObject value = new TestObject(nestedValue);
+
+        event.put(key, value);
+        final String actualNestedValue = event.getToJsonString(key);
+
+        assertThat(actualNestedValue, is(equalTo(String.format("{\"field1\":\"%s\"}", nestedValue))));
+    }
+
+    @Test
+    public void testGetToJsonString_randomKeys() {
+        final String key = "aRandomKey" + UUID.randomUUID();
+        final UUID value = UUID.randomUUID();
+
+        event.put(key, value);
+        final String result = event.getToJsonString(key);
+
+        assertThat(result, is(notNullValue()));
+        assertThat(result, is(equalTo(String.format("\"%s\"", value))));
+    }
+
+    @Test
+    public void testGetToJsonString_keysThatDoNotExist() {
+        final String key = "aRandomKey" + UUID.randomUUID();
+        final UUID value = UUID.randomUUID();
+
+        event.put("staticKey", value);
+        final String result = event.getToJsonString(key);
 
         assertThat(result, is(nullValue()));
     }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -207,7 +207,7 @@ public class JacksonEventTest {
         final TestObject value = new TestObject(nestedValue);
 
         event.put(key, value);
-        final String actualNestedValue = event.getToJsonString(key);
+        final String actualNestedValue = event.getAsJsonString(key);
 
         assertThat(actualNestedValue, is(equalTo(String.format("{\"field1\":\"%s\"}", nestedValue))));
     }
@@ -218,7 +218,7 @@ public class JacksonEventTest {
         final UUID value = UUID.randomUUID();
 
         event.put(key, value);
-        final String result = event.getToJsonString(key);
+        final String result = event.getAsJsonString(key);
 
         assertThat(result, is(notNullValue()));
         assertThat(result, is(equalTo(String.format("\"%s\"", value))));
@@ -230,7 +230,7 @@ public class JacksonEventTest {
         final UUID value = UUID.randomUUID();
 
         event.put("staticKey", value);
-        final String result = event.getToJsonString(key);
+        final String result = event.getAsJsonString(key);
 
         assertThat(result, is(nullValue()));
     }

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -165,6 +165,31 @@ If a single record turns out to be larger than the set bulk size, it will be sen
 
 - `trace_analytics_service_map`: No longer supported starting Data Prepper 2.0. Use `index_type` instead.
 
+- `document_root_key`: The key in the event that will be used as the root in the document. The default is the root of the event. If the key does not exist the entire event is written as the document. If the value at the `document_root_key` is a basic type (ie String, int, etc), the document will have a structure of `{"document_root_key": <value of the document_root_key>}`. For example, If we have the following sample event: 
+
+```
+{
+    status: 200,
+    message: null,
+    metadata: {
+        sourceIp: "123.212.49.58",
+        destinationIp: "79.54.67.231",
+        bytes: 3545,
+        duration: "15 ms"
+    }
+}
+```
+With the `document_root_key` set to `status`. The document structure would be `{"status": 200}`. Alternatively if, the `document_root_key` was provided as `metadata`. The document written to OpenSearch would be:
+
+```
+{
+    sourceIp: "123.212.49.58"
+    destinationIp: "79.54.67.231"
+    bytes: 3545,
+    duration: "15 ms"
+}
+```
+
 ### <a name="aws_configuration">AWS Configuration</a>
 
 * `region` (Optional) : The AWS region to use for credentials. Defaults to [standard SDK behavior to determine the region](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html).

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -165,7 +165,7 @@ If a single record turns out to be larger than the set bulk size, it will be sen
 
 - `trace_analytics_service_map`: No longer supported starting Data Prepper 2.0. Use `index_type` instead.
 
-- `document_root_key`: The key in the event that will be used as the root in the document. The default is the root of the event. If the key does not exist the entire event is written as the document. If the value at the `document_root_key` is a basic type (ie String, int, etc), the document will have a structure of `{"document_root_key": <value of the document_root_key>}`. For example, If we have the following sample event: 
+- `document_root_key`: The key in the event that will be used as the root in the document. The default is the root of the event. If the key does not exist the entire event is written as the document. If the value at the `document_root_key` is a basic type (ie String, int, etc), the document will have a structure of `{"data": <value of the document_root_key>}`. For example, If we have the following sample event: 
 
 ```
 {
@@ -179,7 +179,7 @@ If a single record turns out to be larger than the set bulk size, it will be sen
     }
 }
 ```
-With the `document_root_key` set to `status`. The document structure would be `{"status": 200}`. Alternatively if, the `document_root_key` was provided as `metadata`. The document written to OpenSearch would be:
+With the `document_root_key` set to `status`. The document structure would be `{"data": 200}`. Alternatively if, the `document_root_key` was provided as `metadata`. The document written to OpenSearch would be:
 
 ```
 {

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -72,6 +72,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.closeTo;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -40,6 +40,7 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedBulkOperatio
 import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedBulkOperationConverter;
 import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedDlqData;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.ClusterSettingsParser;
+import org.opensearch.dataprepper.plugins.sink.opensearch.index.DocumentBuilder;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexManager;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexManagerFactory;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexType;
@@ -261,20 +262,9 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     String docId = (documentIdField != null) ? event.get(documentIdField, String.class) : null;
     String routing = (routingField != null) ? event.get(routingField, String.class) : null;
 
-    final String document = buildRawDocument(event);
+    final String document = DocumentBuilder.build(event, documentRootKey);
 
     return SerializedJson.fromStringAndOptionals(document, docId, routing);
-  }
-
-  private String buildRawDocument(final Event event) {
-    if (documentRootKey != null && event.containsKey(documentRootKey)) {
-      final String document = event.getToJsonString(documentRootKey);
-      if (document == null || !document.startsWith("{")) {
-        return String.format("{\"%s\": %s}", documentRootKey, document);
-      }
-      return document;
-    }
-    return event.toJsonString();
   }
 
   private void flushBatch(AccumulatingBulkRequest accumulatingBulkRequest) {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DocumentBuilder.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DocumentBuilder.java
@@ -1,0 +1,17 @@
+package org.opensearch.dataprepper.plugins.sink.opensearch.index;
+
+import org.opensearch.dataprepper.model.event.Event;
+
+public final class DocumentBuilder {
+
+    public static String build(final Event event, final String documentRootKey) {
+        if (documentRootKey != null && event.containsKey(documentRootKey)) {
+            final String document = event.getAsJsonString(documentRootKey);
+            if (document == null || !document.startsWith("{")) {
+                return String.format("{\"data\": %s}", document);
+            }
+            return document;
+        }
+        return event.toJsonString();
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -376,6 +376,9 @@ public class IndexConfiguration {
         }
 
         public Builder withDocumentRootKey(final String documentRootKey) {
+            if (documentRootKey != null) {
+                checkArgument(!documentRootKey.isEmpty(), "documentRootKey cannot be empty string");
+            }
             this.documentRootKey = documentRootKey;
             return this;
         }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -44,6 +44,7 @@ public class IndexConfiguration {
     public static final String S3_AWS_STS_ROLE_ARN = "s3_aws_sts_role_arn";
     public static final String AWS_SERVERLESS = "aws_serverless";
     public static final String AWS_OPTION = "aws";
+    public static final String DOCUMENT_ROOT_KEY = "document_root_key";
 
     private IndexType indexType;
     private final String indexAlias;
@@ -57,6 +58,7 @@ public class IndexConfiguration {
     private final String s3AwsStsRoleArn;
     private final S3Client s3Client;
     private final boolean awsServerless;
+    private final String documentRootKey;
 
     private static final String S3_PREFIX = "s3://";
     private static final String DEFAULT_AWS_REGION = "us-east-1";
@@ -103,6 +105,7 @@ public class IndexConfiguration {
         this.documentIdField = documentIdField;
         this.ismPolicyFile = builder.ismPolicyFile;
         this.action = builder.action;
+        this.documentRootKey = builder.documentRootKey;
     }
 
     private void determineIndexType(Builder builder) {
@@ -173,6 +176,9 @@ public class IndexConfiguration {
             builder.withAwsServerless(awsServerless);
         }
 
+        final String documentRootKey = pluginSetting.getStringOrDefault(DOCUMENT_ROOT_KEY, null);
+        builder.withDocumentRootKey(documentRootKey);
+
         return builder.build();
     }
 
@@ -218,6 +224,10 @@ public class IndexConfiguration {
 
     public boolean getAwsServerless() {
         return awsServerless;
+    }
+
+    public String getDocumentRootKey() {
+        return documentRootKey;
     }
 
     /**
@@ -276,6 +286,7 @@ public class IndexConfiguration {
         private String s3AwsStsRoleArn;
         private S3Client s3Client;
         private boolean awsServerless;
+        private String documentRootKey;
 
         public Builder withIndexAlias(final String indexAlias) {
             checkArgument(indexAlias != null, "indexAlias cannot be null.");
@@ -361,6 +372,11 @@ public class IndexConfiguration {
 
         public Builder withAwsServerless(final boolean awsServerless) {
             this.awsServerless = awsServerless;
+            return this;
+        }
+
+        public Builder withDocumentRootKey(final String documentRootKey) {
+            this.documentRootKey = documentRootKey;
             return this;
         }
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DocumentBuilderTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DocumentBuilderTest.java
@@ -1,0 +1,69 @@
+package org.opensearch.dataprepper.plugins.sink.opensearch.index;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class DocumentBuilderTest {
+
+    private String random;
+    private Event event;
+    private String expectedOutput;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setup() throws JsonProcessingException {
+        final String random = UUID.randomUUID().toString();
+        Map<String, Object> nestedData = Map.of("random", random, "triangle", "equilateral");
+        Map<String, Object> data = Map.of("foo", 42, "nested", nestedData, "boolean", false);
+
+        event = JacksonEvent.builder()
+            .withData(data)
+            .withEventType("TestEvent")
+            .build();
+        expectedOutput = objectMapper.writeValueAsString(data);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"missingObject", "/"})
+    public void buildWillReturnFullObject(final String documentRootKey) {
+
+        final String doc = DocumentBuilder.build(event, documentRootKey);
+
+        assertThat(doc, is(equalTo(expectedOutput)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSingleItemKeys")
+    public void buildWillReturnSingleObject(final String documentRootKey, final Object expectedResult) {
+
+        final String doc = DocumentBuilder.build(event, documentRootKey);
+
+        assertThat(doc, is(equalTo(String.format("{\"data\": %s}", expectedResult))));
+    }
+
+    private static Stream<Arguments> provideSingleItemKeys() {
+        return Stream.of(
+            Arguments.of("foo", 42),
+            Arguments.of("boolean", false),
+            Arguments.of("nested/triangle", "\"equilateral\"")
+        );
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -331,6 +331,16 @@ public class IndexConfigurationTests {
         assertEquals(expectedRootKey, indexConfiguration.getDocumentRootKey());
     }
 
+    @Test
+    public void testReadIndexConfig_emptyDocumentRootKey() {
+        final Map<String, Object> metadata = initializeConfigMetaData(
+            IndexType.CUSTOM.getValue(), "foo", null, null, null);
+        metadata.put(DOCUMENT_ROOT_KEY, "");
+        final PluginSetting pluginSetting = getPluginSetting(metadata);
+        assertThrows(IllegalArgumentException.class, () -> IndexConfiguration.readIndexConfig(pluginSetting));
+    }
+
+
     private PluginSetting generatePluginSetting(
             final String indexType, final String indexAlias, final String templateFilePath,
             final Long bulkSize, final String documentIdField) {

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfiguration.AWS_OPTION;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfiguration.AWS_SERVERLESS;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfiguration.DOCUMENT_ROOT_KEY;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConstants.RAW_DEFAULT_TEMPLATE_FILE;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConstants.SERVICE_MAP_DEFAULT_TEMPLATE_FILE;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConstants.TYPE_TO_DEFAULT_ALIAS;
@@ -139,7 +140,7 @@ public class IndexConfigurationTests {
     }
 
     @Test
-    public void testValidCustomWithNoTemplateFileButWithShardsAndReplicas() throws MalformedURLException {
+    public void testValidCustomWithNoTemplateFileButWithShardsAndReplicas() {
         final String testIndexAlias = "foo";
         IndexConfiguration indexConfiguration = new IndexConfiguration.Builder()
                 .withIndexAlias(testIndexAlias)
@@ -164,7 +165,7 @@ public class IndexConfigurationTests {
     }
 
     @Test
-    public void testValidCustomWithTemplateFileAndShards() throws MalformedURLException {
+    public void testValidCustomWithTemplateFileAndShards() {
         final String defaultTemplateFilePath = Objects.requireNonNull(
                 getClass().getClassLoader().getResource(DEFAULT_TEMPLATE_FILE)).getFile();
         final String testIndexAlias = "foo";
@@ -236,7 +237,7 @@ public class IndexConfigurationTests {
     }
 
     @Test
-    public void testReadIndexConfigCustom() throws MalformedURLException {
+    public void testReadIndexConfigCustom() {
         final String defaultTemplateFilePath = Objects.requireNonNull(
                 getClass().getClassLoader().getResource(DEFAULT_TEMPLATE_FILE)).getFile();
         final String testIndexAlias = "foo";
@@ -253,7 +254,7 @@ public class IndexConfigurationTests {
     }
 
     @Test
-    public void testReadIndexConfig_ExplicitCustomIndexType() throws MalformedURLException {
+    public void testReadIndexConfig_ExplicitCustomIndexType() {
         final String defaultTemplateFilePath = Objects.requireNonNull(
                 getClass().getClassLoader().getResource(DEFAULT_TEMPLATE_FILE)).getFile();
         final String testIndexType = IndexType.CUSTOM.getValue();
@@ -316,6 +317,18 @@ public class IndexConfigurationTests {
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         assertEquals(IndexType.CUSTOM, indexConfiguration.getIndexType());
         assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
+        assertEquals(true, indexConfiguration.getAwsServerless());
+    }
+
+    @Test
+    public void testReadIndexConfig_documentRootKey() {
+        final Map<String, Object> metadata = initializeConfigMetaData(
+            IndexType.CUSTOM.getValue(), "foo", null, null, null);
+        final String expectedRootKey = UUID.randomUUID().toString();
+        metadata.put(DOCUMENT_ROOT_KEY, expectedRootKey);
+        final PluginSetting pluginSetting = getPluginSetting(metadata);
+        final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
+        assertEquals(expectedRootKey, indexConfiguration.getDocumentRootKey());
     }
 
     private PluginSetting generatePluginSetting(


### PR DESCRIPTION
### Description
Adding support for a `document_root_key`. This would allow users to specify the object written to the document in the opensearch sink
 
### Issues Resolved
#2511
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
