### PR TITLE
Add support for dynamically managing the visibility timeout for each sqs message

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectHandler.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectHandler.java
@@ -4,8 +4,9 @@
  */
 package org.opensearch.dataprepper.plugins.source;
 
-import java.io.IOException;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+
+import java.io.IOException;
 
 /**
  * A S3ObjectHandler interface must be extended/implement for S3 Object parsing
@@ -20,4 +21,10 @@ public interface S3ObjectHandler {
      * @throws IOException exception is thrown every time because this is not supported
      */
     void parseS3Object(final S3ObjectReference s3ObjectReference, final AcknowledgementSet acknowledgementSet) throws IOException;
+
+    /**
+     * @param s3ObjectReference the identifier for the s3 object size
+     * @return The size of the S3ObjectReference in bytes
+     */
+    Long getS3ObjectSize(final S3ObjectReference s3ObjectReference);
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorker.java
@@ -20,6 +20,8 @@ import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import java.io.IOException;
@@ -78,6 +80,17 @@ class S3ObjectWorker implements S3ObjectHandler {
             throw new RuntimeException(e);
         }
         s3ObjectPluginMetrics.getS3ObjectsSucceededCounter().increment();
+    }
+
+    @Override
+    public Long getS3ObjectSize(final S3ObjectReference s3ObjectReference) {
+        final HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+                .bucket(s3ObjectReference.getBucketName())
+                .key(s3ObjectReference.getKey())
+                .build();
+        final HeadObjectResponse headObjectResponse = s3Client.headObject(headObjectRequest);
+
+        return headObjectResponse.contentLength();
     }
 
     private void doParseObject(final AcknowledgementSet acknowledgementSet, final S3ObjectReference s3ObjectReference, final GetObjectRequest getObjectRequest, final BufferAccumulator<Record<Event>> bufferAccumulator) throws IOException {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3Service.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3Service.java
@@ -18,4 +18,7 @@ public class S3Service {
         s3ObjectHandler.parseS3Object(s3ObjectReference, acknowledgementSet);
     }
 
+    Long getObjectSize(final S3ObjectReference s3ObjectReference) {
+        return s3ObjectHandler.getS3ObjectSize(s3ObjectReference);
+    }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsDynamicVisibilityTimeoutManager.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsDynamicVisibilityTimeoutManager.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source;
+
+import org.opensearch.dataprepper.plugins.source.configuration.SqsOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public class SqsDynamicVisibilityTimeoutManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SqsDynamicVisibilityTimeoutManager.class);
+    static final int VISIBILITY_TIMEOUT_SECONDS_PER_QUARTER_GB = 30;
+    static final int QUARTER_GB_BYTES = 250_000_000;
+    static final int MAX_VISIBILITY_TIMEOUT_SECONDS = 43_200;
+    static final int MINIMUM_WAIT_BEFORE_CHANGE_VISIBILITY_TIMEOUT_SECONDS = 2;
+    static final int TIME_BETWEEN_CHANGE_MESSAGE_CALL_AND_VISIBILITY_TIMEOUT_SECONDS = 10;
+
+    private final SqsClient sqsClient;
+    private final ScheduledExecutorService scheduledExecutorService;
+    private final String queueUrl;
+    private final int initialMessageVisibilityTimeout;
+    private final int initialWaitBeforeIncrease;
+
+    private final Map<String, ScheduledFuture<?>> messageToScheduledFuture;
+
+    public SqsDynamicVisibilityTimeoutManager(final SqsClient sqsClient,
+                                              final SqsOptions sqsOptions) {
+        this.sqsClient = sqsClient;
+        this.scheduledExecutorService = Executors.newScheduledThreadPool(sqsOptions.getMaximumMessages());
+        this.queueUrl = sqsOptions.getSqsUrl();
+        this.messageToScheduledFuture = new HashMap<>();
+        this.initialMessageVisibilityTimeout = (int) sqsOptions.getVisibilityTimeout().getSeconds();
+        this.initialWaitBeforeIncrease = Math.max(MINIMUM_WAIT_BEFORE_CHANGE_VISIBILITY_TIMEOUT_SECONDS,
+                initialMessageVisibilityTimeout - TIME_BETWEEN_CHANGE_MESSAGE_CALL_AND_VISIBILITY_TIMEOUT_SECONDS);
+    }
+
+
+
+    public void startDynamicVisibilityForMessage(final Message message, final long objectSizeBytes) {
+        final int visibilityTimeoutIncrease = calculateVisibilityTimeoutFromObjectSize(objectSizeBytes);
+        final int waitBeforeIncreasingAgain = Math.min(MINIMUM_WAIT_BEFORE_CHANGE_VISIBILITY_TIMEOUT_SECONDS,
+                visibilityTimeoutIncrease - TIME_BETWEEN_CHANGE_MESSAGE_CALL_AND_VISIBILITY_TIMEOUT_SECONDS);
+
+        final ScheduledFuture<?> scheduledFuture = scheduledExecutorService.scheduleAtFixedRate(
+                () -> increaseVisibilityTimeout(visibilityTimeoutIncrease, message),
+                initialWaitBeforeIncrease,
+                waitBeforeIncreasingAgain, TimeUnit.SECONDS);
+
+        messageToScheduledFuture.put(message.messageId(), scheduledFuture);
+    }
+
+    public void stopDynamicVisibilityForMessage(final String messageId) {
+        final ScheduledFuture<?> scheduledFutureToCancel = messageToScheduledFuture.get(messageId);
+        if (Objects.nonNull(scheduledFutureToCancel)) {
+            boolean cancelled = scheduledFutureToCancel.cancel(true);
+
+            if (!cancelled) {
+                LOG.error("Unable to cancel dynamic visibility execution for message {}", messageId);
+            } else {
+                messageToScheduledFuture.remove(messageId);
+            }
+        }
+    }
+
+    public int getRemainingTimeBeforeNextChangeMessageIncrease(final String messageId) {
+        final ScheduledFuture<?> scheduledFutureToCancel = messageToScheduledFuture.get(messageId);
+        if (Objects.nonNull(scheduledFutureToCancel)) {
+            return (int) scheduledFutureToCancel.getDelay(TimeUnit.SECONDS);
+        }
+
+        return initialMessageVisibilityTimeout;
+    }
+
+    public void shutdownDynamicMessaging() {
+        try {
+            scheduledExecutorService.shutdown();
+            scheduledExecutorService.awaitTermination(3, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            LOG.error("Dynamic SQS messaging was interrupted during shutdown");
+        } finally {
+            if (!scheduledExecutorService.isTerminated()) {
+                scheduledExecutorService.shutdown();
+            }
+        }
+    }
+
+    private void increaseVisibilityTimeout(final int visibilityTimeoutIncrease,
+                                           final Message message) {
+
+        final ChangeMessageVisibilityRequest changeMessageVisibilityRequest = ChangeMessageVisibilityRequest.builder()
+                .receiptHandle(message.receiptHandle())
+                .visibilityTimeout(visibilityTimeoutIncrease)
+                .queueUrl(queueUrl)
+                .build();
+
+        try {
+            sqsClient.changeMessageVisibility(changeMessageVisibilityRequest);
+        } catch (final Exception e) {
+            LOG.error("An exception occurred while changing the visibility timeout for message {}", message.messageId(), e);
+        }
+    }
+
+    private int calculateVisibilityTimeoutFromObjectSize(final long objectSizeBytes) {
+        // simple implementation to allocate 30 seconds per 0.25 GB of object, which means a minimum of 30 seconds added
+        final int visibilityTimeoutSeconds = (int) Math.ceil((double) objectSizeBytes / QUARTER_GB_BYTES) * VISIBILITY_TIMEOUT_SECONDS_PER_QUARTER_GB;
+
+        return Math.min(visibilityTimeoutSeconds, MAX_VISIBILITY_TIMEOUT_SECONDS);
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/SqsOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/SqsOptions.java
@@ -34,6 +34,9 @@ public class SqsOptions {
     @DurationMax(seconds = 43200)
     private Duration visibilityTimeout = DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
 
+    @JsonProperty("enable_dynamic_visibility_timeout")
+    private Boolean enableDynamicVisibilityTimeout = false;
+
     @JsonProperty("wait_time")
     @DurationMin(seconds = 0)
     @DurationMax(seconds = 20)
@@ -61,5 +64,9 @@ public class SqsOptions {
 
     public Duration getPollDelay() {
         return pollDelay;
+    }
+
+    public Boolean getEnableDynamicVisibilityTimeout() {
+        return enableDynamicVisibilityTimeout;
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/SqsDynamicVisibilityTimeoutManagerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/SqsDynamicVisibilityTimeoutManagerTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.source.configuration.SqsOptions;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import java.time.Duration;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.opensearch.dataprepper.plugins.source.SqsDynamicVisibilityTimeoutManager.MAX_VISIBILITY_TIMEOUT_SECONDS;
+import static org.opensearch.dataprepper.plugins.source.SqsDynamicVisibilityTimeoutManager.MINIMUM_WAIT_BEFORE_CHANGE_VISIBILITY_TIMEOUT_SECONDS;
+import static org.opensearch.dataprepper.plugins.source.SqsDynamicVisibilityTimeoutManager.QUARTER_GB_BYTES;
+import static org.opensearch.dataprepper.plugins.source.SqsDynamicVisibilityTimeoutManager.TIME_BETWEEN_CHANGE_MESSAGE_CALL_AND_VISIBILITY_TIMEOUT_SECONDS;
+import static org.opensearch.dataprepper.plugins.source.SqsDynamicVisibilityTimeoutManager.VISIBILITY_TIMEOUT_SECONDS_PER_QUARTER_GB;
+
+@ExtendWith(MockitoExtension.class)
+public class SqsDynamicVisibilityTimeoutManagerTest {
+
+    @Mock
+    private SqsClient sqsClient;
+
+    @Mock
+    private SqsOptions sqsOptions;
+
+    @Mock
+    private ScheduledExecutorService scheduledExecutorService;
+
+    @BeforeEach
+    void setup() {
+        final Random random = new Random();
+
+        final int maxMessages = random.nextInt(10) + 1;
+
+        given(sqsOptions.getMaximumMessages()).willReturn(maxMessages);
+        given(sqsOptions.getVisibilityTimeout()).willReturn(Duration.ofSeconds(random.nextInt(MAX_VISIBILITY_TIMEOUT_SECONDS) + 1));
+        given(sqsOptions.getSqsUrl()).willReturn(UUID.randomUUID().toString());
+    }
+
+    private SqsDynamicVisibilityTimeoutManager createObjectUnderTest() {
+
+        try (MockedStatic<Executors> mockedStatic = mockStatic(Executors.class)) {
+            mockedStatic.when(() -> Executors.newScheduledThreadPool(sqsOptions.getMaximumMessages())).thenReturn(scheduledExecutorService);
+            return new SqsDynamicVisibilityTimeoutManager(sqsClient, sqsOptions);
+        }
+    }
+
+    @Test
+    void startAndStopDynamicVisibilityForMessageSchedulesCorrectlyAndCancelsExecutionOnStopForAllMessages() {
+
+        final SqsDynamicVisibilityTimeoutManager objectUnderTest = createObjectUnderTest();
+
+        final Random random = new Random();
+
+        final InOrder inOrder = Mockito.inOrder(scheduledExecutorService);
+        final InOrder inOrderSqsClient = Mockito.inOrder(sqsClient);
+
+        for (int i = 0; i < sqsOptions.getMaximumMessages(); i++) {
+            final Message mockMessage = mock(Message.class);
+            given(mockMessage.receiptHandle()).willReturn(UUID.randomUUID().toString());
+
+            final ArgumentCaptor<Runnable> argumentCaptorForChangeMessageIncreaseFunction = ArgumentCaptor.forClass(Runnable.class);
+            final ArgumentCaptor<Long> argumentCaptorForInitialWait = ArgumentCaptor.forClass(Long.class);
+            final ArgumentCaptor<Long> argumentCaptorForVisibilityIncrease = ArgumentCaptor.forClass(Long.class);
+
+            final int objectSizeBytes = random.nextInt(1_000_000_000);
+
+            final ScheduledFuture mockFuture = mock(ScheduledFuture.class);
+
+            given(scheduledExecutorService.scheduleAtFixedRate(any(), anyLong(), anyLong(), eq(TimeUnit.SECONDS)))
+                    .willReturn(mockFuture);
+
+            given(mockFuture.cancel(true)).willReturn(true);
+
+            objectUnderTest.startDynamicVisibilityForMessage(mockMessage, objectSizeBytes);
+            inOrder.verify(scheduledExecutorService).scheduleAtFixedRate(argumentCaptorForChangeMessageIncreaseFunction.capture(),
+                    argumentCaptorForInitialWait.capture(),
+                    argumentCaptorForVisibilityIncrease.capture(),
+                    eq(TimeUnit.SECONDS));
+
+            final Runnable changeMessageRunnable = argumentCaptorForChangeMessageIncreaseFunction.getValue();
+            final Long initialWait = argumentCaptorForInitialWait.getValue();
+            final Long visibilityTimeoutIncreaseRate = argumentCaptorForVisibilityIncrease.getValue();
+
+            assertThat(visibilityTimeoutIncreaseRate, equalTo(getExpectedVisibilityChangeWaitTime(objectSizeBytes)));
+            assertThat(initialWait, equalTo(getExpectedInitialWaitTime()));
+
+            final ArgumentCaptor<ChangeMessageVisibilityRequest> requestArgumentCaptor = ArgumentCaptor.forClass(ChangeMessageVisibilityRequest.class);
+
+            changeMessageRunnable.run();
+
+            inOrderSqsClient.verify(sqsClient).changeMessageVisibility(requestArgumentCaptor.capture());
+
+            final ChangeMessageVisibilityRequest changeMessageVisibilityRequest = requestArgumentCaptor.getValue();
+            assertThat(changeMessageVisibilityRequest.visibilityTimeout(), equalTo(getExpectedChangeMessageVisibilityTimeout(objectSizeBytes)));
+            assertThat(changeMessageVisibilityRequest.queueUrl(), equalTo(sqsOptions.getSqsUrl()));
+            assertThat(changeMessageVisibilityRequest.receiptHandle(), equalTo(mockMessage.receiptHandle()));
+
+            objectUnderTest.stopDynamicVisibilityForMessage(mockMessage.messageId());
+
+        }
+    }
+
+    private Long getExpectedVisibilityChangeWaitTime(final long objectSizeBytes) {
+        final int visibilityTimeoutSeconds = (int) Math.ceil((double) objectSizeBytes / QUARTER_GB_BYTES) * VISIBILITY_TIMEOUT_SECONDS_PER_QUARTER_GB;
+
+        final int visibilityTimeoutChange = Math.min(visibilityTimeoutSeconds, MAX_VISIBILITY_TIMEOUT_SECONDS);
+
+        return (long) Math.min(MINIMUM_WAIT_BEFORE_CHANGE_VISIBILITY_TIMEOUT_SECONDS,
+                visibilityTimeoutChange - TIME_BETWEEN_CHANGE_MESSAGE_CALL_AND_VISIBILITY_TIMEOUT_SECONDS);
+    }
+
+    private int getExpectedChangeMessageVisibilityTimeout(final long objectSizeBytes) {
+        final int visibilityTimeoutSeconds = (int) Math.ceil((double) objectSizeBytes / QUARTER_GB_BYTES) * VISIBILITY_TIMEOUT_SECONDS_PER_QUARTER_GB;
+
+        return Math.min(visibilityTimeoutSeconds, MAX_VISIBILITY_TIMEOUT_SECONDS);
+    }
+
+    private Long getExpectedInitialWaitTime() {
+        return Math.max(MINIMUM_WAIT_BEFORE_CHANGE_VISIBILITY_TIMEOUT_SECONDS,
+                sqsOptions.getVisibilityTimeout().getSeconds() - TIME_BETWEEN_CHANGE_MESSAGE_CALL_AND_VISIBILITY_TIMEOUT_SECONDS);
+    }
+
+}

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/SqsWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/SqsWorkerTest.java
@@ -83,6 +83,7 @@ class SqsWorkerTest {
     private Timer sqsMessageDelayTimer;
     private AcknowledgementSetManager acknowledgementSetManager;
     private AcknowledgementSet acknowledgementSet;
+    private SqsDynamicVisibilityTimeoutManager sqsDynamicVisibilityTimeoutManager;
 
     @BeforeEach
     void setUp() {
@@ -93,6 +94,7 @@ class SqsWorkerTest {
         s3SourceConfig = mock(S3SourceConfig.class);
         objectCreatedFilter = new ObjectCreatedFilter();
         backoff = mock(Backoff.class);
+        sqsDynamicVisibilityTimeoutManager = mock(SqsDynamicVisibilityTimeoutManager.class);
 
         AwsAuthenticationOptions awsAuthenticationOptions = mock(AwsAuthenticationOptions.class);
         when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_EAST_1);
@@ -117,7 +119,7 @@ class SqsWorkerTest {
         when(pluginMetrics.counter(SQS_MESSAGES_DELETE_FAILED_METRIC_NAME)).thenReturn(sqsMessagesDeleteFailedCounter);
         when(pluginMetrics.timer(SQS_MESSAGE_DELAY_METRIC_NAME)).thenReturn(sqsMessageDelayTimer);
 
-        sqsWorker = new SqsWorker(acknowledgementSetManager, sqsClient, s3Service, s3SourceConfig, pluginMetrics, backoff);
+        sqsWorker = new SqsWorker(acknowledgementSetManager, null, sqsClient, s3Service, s3SourceConfig, pluginMetrics, backoff);
     }
 
     @AfterEach
@@ -181,7 +183,7 @@ class SqsWorkerTest {
         void processSqsMessages_should_return_number_of_messages_processed_with_acknowledgements(final String eventName) throws IOException {
             when(acknowledgementSetManager.create(any(), any(Duration.class))).thenReturn(acknowledgementSet);
             when(s3SourceConfig.getEndToEndAcknowledgements()).thenReturn(true);
-            sqsWorker = new SqsWorker(acknowledgementSetManager, sqsClient, s3Service, s3SourceConfig, pluginMetrics, backoff);
+            sqsWorker = new SqsWorker(acknowledgementSetManager, null, sqsClient, s3Service, s3SourceConfig, pluginMetrics, backoff);
             Instant startTime = Instant.now().minus(1, ChronoUnit.HOURS);
             final Message message = mock(Message.class);
             when(message.body()).thenReturn(createEventNotification(eventName, startTime));


### PR DESCRIPTION
### Description
Still writing and running tests for this.

Adds config parameter to the sqsOptions in the s3 source to enable dynamic visibility timeouts for messages

```
source:
   s3:
      sqs:
          enable_dynamic_visibility_timeout: true
```

The strategy is to call the SQS API for `ChangeMessageVisibility` on a schedule based on the size of the s3 object that will be processed from the SQS message. The simple implementation is to allocate 30 seconds of visibility timeout for every 0.25 GB in the s3 object. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
