### PR TITLE
addressing metrics publishing bug for DLQ

### DIFF
--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/DlqProvider.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/DlqProvider.java
@@ -19,9 +19,11 @@ public interface DlqProvider {
 
     /**
      * Allows implementors to provide a {@link DlqWriter}. This may be optional, in which case it is not used.
+     * @param pluginMetricsScope the {@link org.opensearch.dataprepper.metrics.PluginMetrics} component scope.
+     *                           This is used to place the DLQ metrics under the correct parent plugin.
      * @since 2.2
      */
-    default Optional<DlqWriter> getDlqWriter() {
+    default Optional<DlqWriter> getDlqWriter(final String pluginMetricsScope) {
         return Optional.empty();
     }
 }

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqProvider.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqProvider.java
@@ -16,6 +16,8 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * S3 DLQ Provider for loading the S3 Writer.
  *
@@ -26,18 +28,20 @@ import java.util.Optional;
     pluginConfigurationType = S3DlqWriterConfig.class)
 public class S3DlqProvider implements DlqProvider {
 
+    private static final String S3_DLQ_PLUGIN_NAME = "s3";
+
     private final S3DlqWriterConfig s3DlqWriterConfig;
-    private final PluginMetrics pluginMetrics;
 
     @DataPrepperPluginConstructor
-    public S3DlqProvider(final S3DlqWriterConfig s3DlqWriterConfig, final PluginMetrics pluginMetrics) {
+    public S3DlqProvider(final S3DlqWriterConfig s3DlqWriterConfig) {
         Objects.requireNonNull(s3DlqWriterConfig);
         this.s3DlqWriterConfig = s3DlqWriterConfig;
-        this.pluginMetrics = pluginMetrics;
     }
 
     @Override
-    public Optional<DlqWriter> getDlqWriter() {
+    public Optional<DlqWriter> getDlqWriter(final String pluginMetricsScope) {
+        checkArgument(pluginMetricsScope == null || !pluginMetricsScope.isEmpty(), "missing pluginMetricsScope for DLQ Writer");
+        final PluginMetrics pluginMetrics = PluginMetrics.fromNames(S3_DLQ_PLUGIN_NAME, pluginMetricsScope);
         final ObjectMapper objectMapper = new ObjectMapper();
         return Optional.of(new S3DlqWriter(s3DlqWriterConfig, objectMapper, pluginMetrics));
     }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;
 
+import org.opensearch.dataprepper.metrics.MetricNames;
 import org.opensearch.dataprepper.plugins.dlq.DlqProvider;
 import org.opensearch.dataprepper.plugins.dlq.DlqWriter;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -54,6 +55,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.Supplier;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -161,7 +163,9 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     if (dlqFile != null) {
       dlqFileWriter = Files.newBufferedWriter(Paths.get(dlqFile), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
     } else if (dlqProvider != null) {
-      Optional<DlqWriter> potentialDlq = dlqProvider.getDlqWriter();
+      Optional<DlqWriter> potentialDlq = dlqProvider.getDlqWriter(new StringJoiner(MetricNames.DELIMITER)
+          .add(pluginSetting.getPipelineName())
+          .add(pluginSetting.getName()).toString());
       dlqWriter = potentialDlq.isPresent() ? potentialDlq.get() : null;
     }
     indexManager.setupIndex();


### PR DESCRIPTION
### Description
S3 DLQ metrics were appearing in the wrong scope. This follow change requires the scope be passed in as part of fetching the dlq writer. I added some unit tests and verified the format is correct by checking the metrics on `/metrics/sys`. For example:
```
apache_log_pipeline_opensearch_s3_dlqS3RequestFailed_total{serviceName="dataprepper",} 0.0
```
### Issues Resolved
- none
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
