### PR TITLE
Configurable pipeline shutdown behavior

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/DataPrepperConfiguration.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.parser.config.MetricTagFilter;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
+import org.opensearch.dataprepper.pipeline.PipelineShutdownOption;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -27,6 +28,7 @@ public class DataPrepperConfiguration {
 
     static final int MAX_TAGS_NUMBER = 3;
     private static final List<MetricRegistryType> DEFAULT_METRIC_REGISTRY_TYPE = Collections.singletonList(MetricRegistryType.Prometheus);
+    private static final PipelineShutdownOption DEFAULT_PIPELINE_SHUTDOWN = PipelineShutdownOption.ON_ANY_PIPELINE_FAILURE;
     private int serverPort = 4900;
     private boolean ssl = true;
     private String keyStoreFilePath = "";
@@ -36,6 +38,7 @@ public class DataPrepperConfiguration {
     private PluginModel authentication;
     private CircuitBreakerConfig circuitBreakerConfig;
     private SourceCoordinationConfig sourceCoordinationConfig;
+    private PipelineShutdownOption pipelineShutdown;
     private Map<String, String> metricTags = new HashMap<>();
     private List<MetricTagFilter> metricTagFilters = new LinkedList<>();
     private PeerForwarderConfiguration peerForwarderConfiguration;
@@ -78,11 +81,12 @@ public class DataPrepperConfiguration {
             @JsonAlias("sinkShutdownTimeout")
             final Duration sinkShutdownTimeout,
             @JsonProperty("circuit_breakers") final CircuitBreakerConfig circuitBreakerConfig,
-            @JsonProperty("source_coordination") final SourceCoordinationConfig sourceCoordinationConfig
-            ) {
+            @JsonProperty("source_coordination") final SourceCoordinationConfig sourceCoordinationConfig,
+            @JsonProperty("pipeline_shutdown") final PipelineShutdownOption pipelineShutdown) {
         this.authentication = authentication;
         this.circuitBreakerConfig = circuitBreakerConfig;
         this.sourceCoordinationConfig = sourceCoordinationConfig;
+        this.pipelineShutdown = pipelineShutdown != null ? pipelineShutdown : DEFAULT_PIPELINE_SHUTDOWN;
         setSsl(ssl);
         this.keyStoreFilePath = keyStoreFilePath != null ? keyStoreFilePath : "";
         this.keyStorePassword = keyStorePassword != null ? keyStorePassword : "";
@@ -201,4 +205,8 @@ public class DataPrepperConfiguration {
     }
 
     public SourceCoordinationConfig getSourceCoordinationConfig() { return sourceCoordinationConfig; }
+
+    public PipelineShutdownOption getPipelineShutdown() {
+        return pipelineShutdown;
+    }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/PipelineShutdownAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/PipelineShutdownAppConfig.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline;
+
+import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+@Configuration
+public class PipelineShutdownAppConfig {
+    @Bean("shouldShutdownOnPipelineFailurePredicate")
+    Predicate<Map<String, Pipeline>> shouldShutdownOnPipelineFailurePredicate(final DataPrepperConfiguration dataPrepperConfiguration) {
+        return dataPrepperConfiguration.getPipelineShutdown().getShouldShutdownOnPipelineFailurePredicate();
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/PipelineShutdownOption.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/PipelineShutdownOption.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public enum PipelineShutdownOption {
+    ON_ANY_PIPELINE_FAILURE("on-any-pipeline-failure", pipelines -> true),
+    ON_ALL_PIPELINE_FAILURES("on-all-pipeline-failures", pipelines -> pipelines.size() == 0);
+
+    private static final Map<String, PipelineShutdownOption> OPTION_NAMES_MAP = Arrays.stream(PipelineShutdownOption.values())
+            .collect(Collectors.toMap(
+                    value -> value.optionName,
+                    value -> value
+            ));
+    private final String optionName;
+    private final Predicate<Map<String, Pipeline>> shouldShutdownOnPipelineFailurePredicate;
+
+    PipelineShutdownOption(
+            final String optionName,
+            final Predicate<Map<String, Pipeline>> shouldShutdownOnPipelineFailurePredicate) {
+        this.optionName = optionName;
+        this.shouldShutdownOnPipelineFailurePredicate = shouldShutdownOnPipelineFailurePredicate;
+    }
+
+    public Predicate<Map<String, Pipeline>> getShouldShutdownOnPipelineFailurePredicate() {
+        return shouldShutdownOnPipelineFailurePredicate;
+    }
+
+    public String getOptionName() {
+        return optionName;
+    }
+
+    @JsonCreator
+    static PipelineShutdownOption fromOptionName(final String optionName) {
+        return OPTION_NAMES_MAP.get(optionName);
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/DataPrepperConfigurationTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/DataPrepperConfigurationTests.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.pipeline.PipelineShutdownOption;
 
 import java.io.File;
 import java.io.IOException;
@@ -244,5 +245,19 @@ public class DataPrepperConfigurationTests {
         assertThat(config.getCircuitBreakerConfig().getHeapConfig(), notNullValue());
         assertThat(config.getCircuitBreakerConfig().getHeapConfig().getUsage(), notNullValue());
         assertThat(config.getCircuitBreakerConfig().getHeapConfig().getUsage().getBytes(), Matchers.equalTo(2_684_354_560L));
+    }
+
+    @Test
+    void testConfigHasDefaultShutdown() throws IOException {
+        final DataPrepperConfiguration config = makeConfig("src/test/resources/valid_data_prepper_config.yml");
+        assertThat(config, notNullValue());
+        assertThat(config.getPipelineShutdown(), equalTo(PipelineShutdownOption.ON_ANY_PIPELINE_FAILURE));
+    }
+
+    @Test
+    void testConfigWithPipelineShutdown() throws IOException {
+        final DataPrepperConfiguration config = makeConfig("src/test/resources/valid_data_prepper_config_with_pipeline_shutdown.yml");
+        assertThat(config, notNullValue());
+        assertThat(config.getPipelineShutdown(), equalTo(PipelineShutdownOption.ON_ALL_PIPELINE_FAILURES));
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineShutdownAppConfigTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineShutdownAppConfigTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PipelineShutdownAppConfigTest {
+    @Mock
+    private DataPrepperConfiguration dataPrepperConfiguration;
+
+    @Mock
+    private PipelineShutdownOption pipelineShutdownOption;
+
+    private PipelineShutdownAppConfig createObjectUnderTest() {
+        return new PipelineShutdownAppConfig();
+    }
+
+    @Test
+    void shouldShutdownOnPipelineFailurePredicate_should_return_pipelineShutdown_predicate() {
+        final Predicate<Map<String, Pipeline>> predicate = mock(Predicate.class);
+        when(pipelineShutdownOption.getShouldShutdownOnPipelineFailurePredicate()).thenReturn(predicate);
+        when(dataPrepperConfiguration.getPipelineShutdown()).thenReturn(pipelineShutdownOption);
+
+        assertThat(createObjectUnderTest().shouldShutdownOnPipelineFailurePredicate(dataPrepperConfiguration),
+                equalTo(predicate));
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineShutdownOptionTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineShutdownOptionTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.pipeline;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PipelineShutdownOptionTest {
+    @ParameterizedTest
+    @EnumSource(PipelineShutdownOption.class)
+    void fromOptionName_returns_same_option(final PipelineShutdownOption option) {
+        assertThat(PipelineShutdownOption.fromOptionName(option.getOptionName()), equalTo(option));
+        assertThat(option.getShouldShutdownOnPipelineFailurePredicate(), notNullValue());
+    }
+
+    @ParameterizedTest
+    @EnumSource(PipelineShutdownOption.class)
+    void getShouldShutdownOnPipelineFailurePredicate_is_not_null(final PipelineShutdownOption option) {
+        assertThat(option.getShouldShutdownOnPipelineFailurePredicate(),
+                notNullValue());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 10})
+    void getShouldShutdownOnPipelineFailurePredicate_for_ON_ANY_PIPELINE_FAILURE_returns_true(final int numberOfPipelines) {
+        final Map<String, Pipeline> pipelinesMap = createPipelinesMap(numberOfPipelines);
+
+        assertThat(
+                PipelineShutdownOption.ON_ANY_PIPELINE_FAILURE.getShouldShutdownOnPipelineFailurePredicate().test(pipelinesMap),
+                equalTo(true));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10})
+    void getShouldShutdownOnPipelineFailurePredicate_for_ON_ALL_PIPELINE_FAILURES_returns_false_for_values_greater_than_0(final int numberOfPipelines) {
+        final Map<String, Pipeline> pipelinesMap = createPipelinesMap(numberOfPipelines);
+
+        assertThat(
+                PipelineShutdownOption.ON_ALL_PIPELINE_FAILURES.getShouldShutdownOnPipelineFailurePredicate().test(pipelinesMap),
+                equalTo(false));
+    }
+
+    @Test
+    void getShouldShutdownOnPipelineFailurePredicate_for_ON_ALL_PIPELINE_FAILURES_returns_true_for_empty_map() {
+        final Map<String, Pipeline> pipelinesMap = Collections.emptyMap();
+
+        assertThat(
+                PipelineShutdownOption.ON_ALL_PIPELINE_FAILURES.getShouldShutdownOnPipelineFailurePredicate().test(pipelinesMap),
+                equalTo(true));
+    }
+
+    private Map<String, Pipeline> createPipelinesMap(final int numberOfPipelines) {
+        return IntStream.range(0, numberOfPipelines)
+                .mapToObj(i -> mock(Pipeline.class))
+                .peek(pipeline -> when(pipeline.getName()).thenReturn(UUID.randomUUID().toString()))
+                .collect(Collectors.toMap(Pipeline::getName, Function.identity()));
+    }
+}

--- a/data-prepper-core/src/test/resources/valid_data_prepper_config_with_pipeline_shutdown.yml
+++ b/data-prepper-core/src/test/resources/valid_data_prepper_config_with_pipeline_shutdown.yml
@@ -1,0 +1,3 @@
+server_port: 5678
+ssl: false
+pipeline_shutdown: on-all-pipeline-failures


### PR DESCRIPTION
### Description

This PR makes two changes to Data Prepper:

1. By default, if any pipeline fails, Data Prepper shuts down.
2. Adds a new configuration in `data-prepper-config.yaml` to allow Data Prepper to run until the last pipeline fails.
 
### Issues Resolved

Resolves #2441
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
