### PR TITLE
Document acknowledgements option to s3 source

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemoryConfig.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemoryConfig.java
@@ -6,7 +6,6 @@
 package org.opensearch.dataprepper.plugins;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonAlias;
 
 /**
  * Configuration for an in_memory plugin.
@@ -15,9 +14,8 @@ class InMemoryConfig {
     @JsonProperty("testing_key")
     private String testingKey;
 
-    @JsonProperty("acknowledgements")
-    @JsonAlias("acknowledgments")
-    private Boolean acknowledgements = false;
+    @JsonProperty("acknowledgments")
+    private Boolean acknowledgments = false;
 
     public String getTestingKey() {
         return testingKey;
@@ -28,7 +26,7 @@ class InMemoryConfig {
     }
 
     public Boolean getAcknowledgements() {
-        return acknowledgements;
+        return acknowledgments;
     }
 
 }

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/one-pipeline-ack-expiry-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/one-pipeline-ack-expiry-test.yaml
@@ -3,7 +3,7 @@ pipeline1:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      acknowledgements: true
+      acknowledgments: true
   sink:
     - stdout:
     - in_memory:

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/one-pipeline-three-sinks.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/one-pipeline-three-sinks.yaml
@@ -3,7 +3,7 @@ pipeline1:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      acknowledgements: true
+      acknowledgments: true
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipeline-route-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipeline-route-test.yaml
@@ -3,7 +3,7 @@ pipeline1:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      acknowledgements: true
+      acknowledgments: true
   route:
     - 2xx_route: '/status >= 200 and /status < 300'
     - other_route: '/status >= 300 or /status < 200'

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipelines-test-multi-sink.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipelines-test-multi-sink.yaml
@@ -3,7 +3,7 @@ pipeline1:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      acknowledgements: true
+      acknowledgments: true
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipelines-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipelines-test.yaml
@@ -3,7 +3,7 @@ pipeline1:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      acknowledgements: true
+      acknowledgments: true
   sink:
     - pipeline:
         name: "pipeline2"

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/two-parallel-pipelines-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/two-parallel-pipelines-test.yaml
@@ -3,7 +3,7 @@ pipeline1:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      acknowledgements: true
+      acknowledgments: true
   sink:
     - pipeline:
         name: "pipeline2"

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/two-pipelines-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/two-pipelines-test.yaml
@@ -3,7 +3,7 @@ pipeline1:
   source:
     in_memory:
       testing_key: PipelinesWithAcksIT
-      acknowledgements: true
+      acknowledgments: true
   sink:
     - pipeline:
         name: "pipeline2"

--- a/data-prepper-plugins/s3-source/README.md
+++ b/data-prepper-plugins/s3-source/README.md
@@ -106,6 +106,8 @@ All Duration values are a string that represents a duration. They support ISO_86
 
 * `aws` (Optional) : AWS configurations. See [AWS Configuration](#aws_configuration) for details.
 
+* `acknowledgments` (Optional) : Enables End-to-end acknowledgments. If set to `true`, sqs message is deleted only after all events from the sqs message are successfully acknowledged by all sinks. Default value `false`.
+
 * `on_error` (Optional) : Determines how to handle errors in SQS. Can be either `retain_messages` or `delete_messages`. If `retain_messages`, then Data Prepper will leave the message in the SQS queue and try again. This is recommended for dead-letter queues. If `delete_messages`, then Data Prepper will delete failed messages. Defaults to `retain_messages`.
 
 * `buffer_timeout` (Optional) : Duration - The timeout for writing events to the Data Prepper buffer. Any Events which the S3 Source cannot write to the Buffer in this time will be discarded. Defaults to 10 seconds.

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SourceConfig.java
@@ -14,7 +14,6 @@ import org.opensearch.dataprepper.plugins.source.configuration.AwsAuthentication
 import org.opensearch.dataprepper.plugins.source.configuration.OnErrorOption;
 import org.opensearch.dataprepper.plugins.source.configuration.S3SelectOptions;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
@@ -47,9 +46,8 @@ public class S3SourceConfig {
     @JsonProperty("on_error")
     private OnErrorOption onErrorOption = OnErrorOption.RETAIN_MESSAGES;
 
-    @JsonProperty("acknowledgements")
-    @JsonAlias("acknowledgments")
-    private boolean acknowledgements = false;
+    @JsonProperty("acknowledgments")
+    private boolean acknowledgments = false;
 
     @JsonProperty("buffer_timeout")
     private Duration bufferTimeout = DEFAULT_BUFFER_TIMEOUT;
@@ -77,7 +75,7 @@ public class S3SourceConfig {
     }
 
     boolean getAcknowledgements() {
-        return acknowledgements;
+        return acknowledgments;
     }
 
     public CompressionOption getCompression() {

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SourceConfigTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SourceConfigTest.java
@@ -46,7 +46,7 @@ class S3SourceConfigTest {
     @Test
     void end_to_end_acknowledgements_set_to_true_test() throws Exception {
         final S3SourceConfig s3SourceConfig = new S3SourceConfig();
-        ReflectivelySetField.setField(S3SourceConfig.class,s3SourceConfig,"acknowledgements", true);
+        ReflectivelySetField.setField(S3SourceConfig.class,s3SourceConfig,"acknowledgments", true);
         assertTrue(s3SourceConfig.getAcknowledgements());
     }
 


### PR DESCRIPTION
### Description
Document acknowledgements option to s3 source. Added `acknowledgements` option to s3 source README file.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [X ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
