### PR TITLE
Added routes as an alias to route

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PipelineModel.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PipelineModel.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.model.configuration;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,6 +38,7 @@ public class PipelineModel {
     private final PluginModel buffer;
 
     @JsonProperty("route")
+    @JsonAlias("routes")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private final List<ConditionalRoute> routes;
 
@@ -66,7 +68,7 @@ public class PipelineModel {
             @JsonProperty("source") final PluginModel source,
             @JsonProperty("buffer") final PluginModel buffer,
             @JsonProperty("processor") final List<PluginModel> processors,
-            @JsonProperty("route") final List<ConditionalRoute> routes,
+            @JsonProperty("route")@JsonAlias("routes") final List<ConditionalRoute> routes,
             @JsonProperty("sink") final List<SinkModel> sinks,
             @JsonProperty("workers") final Integer workers,
             @JsonProperty("delay") final Integer delay) {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
@@ -31,6 +31,7 @@ class PipelinesDataFlowModelTest {
 
     private static final String RESOURCE_PATH = "/pipelines_data_flow_serialized.yaml";
     private static final String RESOURCE_PATH_WITH_ROUTE = "/pipelines_data_flow_route.yaml";
+    private static final String RESOURCE_PATH_WITH_ROUTES = "/pipelines_data_flow_routes.yaml";
     private static final String RESOURCE_PATH_WITH_SHORT_HAND_VERSION = "/pipeline_with_short_hand_version.yaml";
     private static final String RESOURCE_PATH_WITH_VERSION = "/pipeline_with_version.yaml";
     private ObjectMapper objectMapper;
@@ -146,6 +147,49 @@ class PipelinesDataFlowModelTest {
     void deserialize_PipelinesDataFlowModel_with_route() throws IOException {
 
         final InputStream inputStream = this.getClass().getResourceAsStream(RESOURCE_PATH_WITH_ROUTE);
+
+        final PipelinesDataFlowModel actualModel = objectMapper.readValue(inputStream, PipelinesDataFlowModel.class);
+
+        final String pipelineName = "test-pipeline";
+
+        assertThat(actualModel, notNullValue());
+        assertThat(actualModel.getPipelines(), notNullValue());
+        assertThat(actualModel.getPipelines().size(), equalTo(1));
+        assertThat(actualModel.getPipelines(), hasKey(pipelineName));
+
+        final PipelineModel pipelineModel = actualModel.getPipelines().get(pipelineName);
+
+        assertThat(pipelineModel, notNullValue());
+
+        assertThat(pipelineModel.getSource(), notNullValue());
+        assertThat(pipelineModel.getSource().getPluginName(), equalTo("testSource"));
+
+        assertThat(pipelineModel.getProcessors(), notNullValue());
+        assertThat(pipelineModel.getProcessors().size(), equalTo(1));
+        assertThat(pipelineModel.getProcessors().get(0), notNullValue());
+        assertThat(pipelineModel.getProcessors().get(0).getPluginName(), equalTo("testPrepper"));
+
+        assertThat(pipelineModel.getSinks(), notNullValue());
+        assertThat(pipelineModel.getSinks().size(), equalTo(1));
+        assertThat(pipelineModel.getSinks().get(0), notNullValue());
+        assertThat(pipelineModel.getSinks().get(0).getPluginName(), equalTo("testSink"));
+        assertThat(pipelineModel.getSinks().get(0).getRoutes(), notNullValue());
+        assertAll(
+                () -> assertThat(pipelineModel.getSinks().get(0).getRoutes().size(), equalTo(1)),
+                () -> assertThat(pipelineModel.getSinks().get(0).getRoutes(), hasItem("my-route"))
+        );
+
+        assertThat(pipelineModel.getRoutes(), notNullValue());
+        assertThat(pipelineModel.getRoutes().size(), equalTo(1));
+        assertThat(pipelineModel.getRoutes().get(0), notNullValue());
+        assertThat(pipelineModel.getRoutes().get(0).getName(), equalTo("my-route"));
+        assertThat(pipelineModel.getRoutes().get(0).getCondition(), equalTo("/a==b"));
+    }
+
+    @Test
+    void deserialize_PipelinesDataFlowModel_with_routes() throws IOException {
+
+        final InputStream inputStream = this.getClass().getResourceAsStream(RESOURCE_PATH_WITH_ROUTES);
 
         final PipelinesDataFlowModel actualModel = objectMapper.readValue(inputStream, PipelinesDataFlowModel.class);
 

--- a/data-prepper-api/src/test/resources/pipelines_data_flow_routes.yaml
+++ b/data-prepper-api/src/test/resources/pipelines_data_flow_routes.yaml
@@ -1,0 +1,13 @@
+test-pipeline:
+  source:
+    testSource: null
+  processor:
+  - testPrepper: null
+  routes:
+  - my-route: "/a==b"
+  sink:
+  - testSink:
+      routes:
+      - "my-route"
+  workers: 8
+  delay: 50

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -114,7 +114,7 @@ The above configuration uses the Pipeline Connectors. `input-pipeline` is config
 ## Conditional Routing
 
 In many situations, pipeline authors want to route some events to certain sinks. They can configure their pipeline to do this by using Data Prepper's route feature. The pipeline author
-first configures routes in `route:` part of the pipeline configuration.
+first configures routes in `route:` or `routes:` part of the pipeline configuration. 
 
 The following shows how this is configured. In the example below, `info_level` and `warn_and_above` are the names of two different routes. As a pipeline author, you can define these
 names to match your use-case. After the names of the routes, you can define the conditions that must apply to any route to make it applicable for any given event. For more information
@@ -122,6 +122,12 @@ on how to define conditions see the [Data Prepper Expression Syntax](expression_
 
 ```
 route:
+  - info_level: '/loglevel == "INFO"'
+  - warn_and_above: '/loglevel == "WARN" or /loglevel == "ERROR"'
+```
+or alternatively, you can use `routes`
+```
+routes:
   - info_level: '/loglevel == "INFO"'
   - warn_and_above: '/loglevel == "WARN" or /loglevel == "ERROR"'
 ```


### PR DESCRIPTION
### Description
- Add `routes` as an alias to `route` 
 
### Issues Resolved
resolves https://github.com/opensearch-project/data-prepper/issues/2520
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
