### PR TITLE
Adds branching on supported configurations for ScanRange

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorker.java
@@ -215,7 +215,7 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
     }
 
     private boolean isQuotedRecordDelimiterAllowed() {
-        return (s3SelectCSVOption.getQuiteEscape() != null || s3SelectCSVOption.getComments() != null);
+        return s3SelectCSVOption.getQuiteEscape() != null || s3SelectCSVOption.getComments() != null;
     }
 
     private InputStream getInputStreamFromResponseHeader(final S3SelectResponseHandler responseHand) {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SelectObjectWorker.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -59,6 +60,7 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
     static final String S3_BUCKET_REFERENCE_NAME = "s3";
 
     static final String CSV_FILE_HEADER_INFO_NONE = "none";
+    static final String JSON_LINES_TYPE = "LINES";
 
     private final S3AsyncClient s3AsyncClient;
     private final Duration bufferTimeout;
@@ -94,7 +96,7 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
 
     public void parseS3Object(final S3ObjectReference s3ObjectReference, final AcknowledgementSet acknowledgementSet) throws IOException {
         try{
-            selectObjectInBatches(s3ObjectReference, acknowledgementSet);
+            selectObject(s3ObjectReference, acknowledgementSet);
         } catch (Exception e){
             LOG.error("Unable to process object reference: {}", s3ObjectReference, e);
             s3ObjectPluginMetrics.getS3ObjectsFailedCounter().increment();
@@ -102,11 +104,47 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
         }
     }
 
-    private void selectObjectInBatches(final S3ObjectReference s3ObjectReference, final AcknowledgementSet acknowledgementSet) throws IOException {
+    private void selectObject(final S3ObjectReference s3ObjectReference, final AcknowledgementSet acknowledgementSet) throws IOException {
         final InputSerialization inputSerialization = getInputSerializationFormat(serializationFormatOption);
-        InputStream inputStreamList;
         final BufferAccumulator<Record<Event>> bufferAccumulator = BufferAccumulator.create(buffer, numberOfRecordsToAccumulate, bufferTimeout);
 
+        if (isScanRangeSupported()) {
+            selectObjectInBatches(s3ObjectReference, acknowledgementSet, inputSerialization, bufferAccumulator);
+        } else {
+            final SelectObjectContentRequest selectObjectContentRequest = getS3SelectObjRequest(s3ObjectReference, inputSerialization, null);
+            processSelectObjectRequest(selectObjectContentRequest, s3ObjectReference, acknowledgementSet, bufferAccumulator);
+        }
+
+        s3ObjectPluginMetrics.getS3ObjectsSucceededCounter().increment();
+    }
+
+    private boolean isScanRangeSupported() {
+        // Supported configurations:
+        // https://docs.aws.amazon.com/AmazonS3/latest/userguide/selecting-content-from-objects.html#selecting-content-from-objects-contructing-request
+        return isScanRangeSupportedForParquetConfiguration() || isScanRangeSupportedForJsonConfiguration() || isScanRangeSupportedForCsvConfiguration();
+
+    }
+
+    private boolean isScanRangeSupportedForParquetConfiguration() {
+        return S3SelectSerializationFormatOption.PARQUET.equals(serializationFormatOption);
+    }
+
+    private boolean isScanRangeSupportedForJsonConfiguration() {
+        return S3SelectSerializationFormatOption.JSON.equals(serializationFormatOption) &&
+                Objects.nonNull(s3SelectJsonOption) &&
+                s3SelectJsonOption.getType().equalsIgnoreCase(JSON_LINES_TYPE) &&
+                CompressionType.NONE.equals(compressionType);
+    }
+
+    private boolean isScanRangeSupportedForCsvConfiguration() {
+        return S3SelectSerializationFormatOption.CSV.equals(serializationFormatOption) &&
+                Objects.nonNull(s3SelectCSVOption) &&
+                !isQuotedRecordDelimiterAllowed() &&
+                CompressionType.NONE.equals(compressionType);
+    }
+
+    private void selectObjectInBatches(final S3ObjectReference s3ObjectReference, final AcknowledgementSet acknowledgementSet,
+                                       final InputSerialization inputSerialization, final BufferAccumulator<Record<Event>> bufferAccumulator) throws IOException {
         final long objectSize = getObjectSize(s3ObjectReference);
 
         long startRange = 0;
@@ -116,28 +154,13 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
                     .start(startRange)
                     .end(endRange)
                     .build();
+
             final SelectObjectContentRequest selectObjectContentRequest = getS3SelectObjRequest(s3ObjectReference, inputSerialization, scanRange);
-
-            final S3SelectResponseHandler s3SelectResponseHandler = s3SelectResponseHandlerFactory.provideS3SelectResponseHandler();
-            s3AsyncClient.selectObjectContent(selectObjectContentRequest, s3SelectResponseHandler).join();
-            if (s3SelectResponseHandler.getException() != null)
-                throw new IOException(s3SelectResponseHandler.getException());
-
-            final List<SelectObjectContentEventStream> receivedEvents = s3SelectResponseHandler.getS3SelectContentEvents();
-            if (!receivedEvents.isEmpty()) {
-                inputStreamList = getInputStreamFromResponseHeader(s3SelectResponseHandler);
-                parseCompleteStreamFromResponseHeader(acknowledgementSet, s3ObjectReference, bufferAccumulator, inputStreamList);
-                s3ObjectPluginMetrics.getS3ObjectEventsSummary().record(bufferAccumulator.getTotalWritten());
-                receivedEvents.clear();
-            } else {
-                LOG.info("S3 Select returned no events for S3 object {}", s3ObjectReference);
-            }
+            processSelectObjectRequest(selectObjectContentRequest, s3ObjectReference, acknowledgementSet, bufferAccumulator);
 
             startRange = endRange;
             endRange += Math.min(MAX_S3_OBJECT_CHUNK_SIZE, objectSize - endRange);
         }
-
-        s3ObjectPluginMetrics.getS3ObjectsSucceededCounter().increment();
     }
 
     private Long getObjectSize(final S3ObjectReference s3ObjectReference) {
@@ -150,6 +173,24 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
         return headObjectResponse.contentLength();
     }
 
+    private void processSelectObjectRequest(final SelectObjectContentRequest selectObjectContentRequest, final S3ObjectReference s3ObjectReference,
+                                            final AcknowledgementSet acknowledgementSet, final BufferAccumulator<Record<Event>> bufferAccumulator) throws IOException {
+        final S3SelectResponseHandler s3SelectResponseHandler = s3SelectResponseHandlerFactory.provideS3SelectResponseHandler();
+        s3AsyncClient.selectObjectContent(selectObjectContentRequest, s3SelectResponseHandler).join();
+        if (s3SelectResponseHandler.getException() != null)
+            throw new IOException(s3SelectResponseHandler.getException());
+
+        final List<SelectObjectContentEventStream> receivedEvents = s3SelectResponseHandler.getS3SelectContentEvents();
+        if (!receivedEvents.isEmpty()) {
+            final InputStream inputStreamList = getInputStreamFromResponseHeader(s3SelectResponseHandler);
+            parseCompleteStreamFromResponseHeader(acknowledgementSet, s3ObjectReference, bufferAccumulator, inputStreamList);
+            s3ObjectPluginMetrics.getS3ObjectEventsSummary().record(bufferAccumulator.getTotalWritten());
+            receivedEvents.clear();
+        } else {
+            LOG.info("S3 Select returned no events for S3 object {}", s3ObjectReference);
+        }
+    }
+
     private InputSerialization getInputSerializationFormat(final S3SelectSerializationFormatOption serializationFormatOption) {
         InputSerialization inputSerialization = null;
         switch (serializationFormatOption) {
@@ -158,9 +199,7 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
                         .csv( csv -> csv.fileHeaderInfo(s3SelectCSVOption.getFileHeaderInfo())
                                 .quoteEscapeCharacter(s3SelectCSVOption.getQuiteEscape())
                                 .comments(s3SelectCSVOption.getComments())
-                                .allowQuotedRecordDelimiter(
-                                        (s3SelectCSVOption.getQuiteEscape() != null ||
-                                                s3SelectCSVOption.getComments() != null) ? true : false).build())
+                                .allowQuotedRecordDelimiter(isQuotedRecordDelimiterAllowed()).build())
                         .compressionType(compressionType).build();
                 break;
             case JSON:
@@ -175,6 +214,10 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
         return inputSerialization;
     }
 
+    private boolean isQuotedRecordDelimiterAllowed() {
+        return (s3SelectCSVOption.getQuiteEscape() != null || s3SelectCSVOption.getComments() != null);
+    }
+
     private InputStream getInputStreamFromResponseHeader(final S3SelectResponseHandler responseHand) {
         final List<InputStream> inputStreams = responseHand.getS3SelectContentEvents().stream()
                 .filter(e -> e.sdkEventType() == SelectObjectContentEventStream.EventType.RECORDS)
@@ -185,8 +228,10 @@ public class S3SelectObjectWorker implements S3ObjectHandler {
 
     private SelectObjectContentRequest getS3SelectObjRequest(final S3ObjectReference s3ObjectReference,
                                                              final InputSerialization inputSerialization, final ScanRange scanRange) {
-        return SelectObjectContentRequest.builder().bucket(s3ObjectReference.getBucketName())
-                .key(s3ObjectReference.getKey()).expressionType(expressionType)
+        return SelectObjectContentRequest.builder()
+                .bucket(s3ObjectReference.getBucketName())
+                .key(s3ObjectReference.getKey())
+                .expressionType(expressionType)
                 .expression(expression)
                 .inputSerialization(inputSerialization)
                 .outputSerialization(outputSerialization -> outputSerialization.json(SdkBuilder::build))

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3Source.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3Source.java
@@ -76,8 +76,9 @@ public class S3Source implements Source<Record<Event>> {
                     s3SelectOptional.get().getS3SelectJsonOption() : new S3SelectJsonOption();
             S3ObjectRequest s3ObjectRequest = s3ObjectRequestBuilder.expression(s3SelectOptional.get().getExpression())
                     .serializationFormatOption(s3SelectOptional.get().getS3SelectSerializationFormatOption())
-                    .s3AsyncClient(s3ClientBuilderFactory.getS3AsyncClient()).eventConsumer(eventMetadataModifier).
-                    s3SelectCSVOption(csvOption).s3SelectJsonOption(jsonOption)
+                    .s3AsyncClient(s3ClientBuilderFactory.getS3AsyncClient()).eventConsumer(eventMetadataModifier)
+                    .s3SelectCSVOption(csvOption)
+                    .s3SelectJsonOption(jsonOption)
                     .expressionType(s3SelectOptional.get().getExpressionType())
                     .compressionType(CompressionType.valueOf(s3SelectOptional.get().getCompressionType().toUpperCase()))
                     .s3SelectResponseHandlerFactory(new S3SelectResponseHandlerFactory()).build();

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3Source.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3Source.java
@@ -76,7 +76,8 @@ public class S3Source implements Source<Record<Event>> {
                     s3SelectOptional.get().getS3SelectJsonOption() : new S3SelectJsonOption();
             S3ObjectRequest s3ObjectRequest = s3ObjectRequestBuilder.expression(s3SelectOptional.get().getExpression())
                     .serializationFormatOption(s3SelectOptional.get().getS3SelectSerializationFormatOption())
-                    .s3AsyncClient(s3ClientBuilderFactory.getS3AsyncClient()).eventConsumer(eventMetadataModifier)
+                    .s3AsyncClient(s3ClientBuilderFactory.getS3AsyncClient())
+                    .eventConsumer(eventMetadataModifier)
                     .s3SelectCSVOption(csvOption)
                     .s3SelectJsonOption(jsonOption)
                     .expressionType(s3SelectOptional.get().getExpressionType())


### PR DESCRIPTION
### Description
ScanRange is only supported for some S3 select queries. This PR branches based on supported vs not supported.

Functionally tested the following configurations:
JSON document -> no batching
JSON lines -> yes batching
JSON document GZIP -> no batching
JSON lines GZIP -> no batching
JSON document BZIP2 -> no batching
JSON lines BZIP2 -> no batching
CSV no quote escape no comment -> yes batching
CSV quote, no comment -> no batching
CSV no quote, comment -> no batching
CSV quote, comment -> no batching
CSV no quote escape no comment GZIP -> no batching
CSV no quote escape no comment BZIP2 -> no batching 
Parquet -> yes batching

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
