### PR TITLE
Opensearch serverless change

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -69,8 +69,6 @@ pipeline:
 - `cert`(optional): CA certificate that is pem encoded. Accepts both .pem or .crt. This enables the client to trust the CA that has signed the certificate that the OpenSearch cluster is using.
 Default is null.
 
-- `aws_serverless`: A boolean flag to indicate the OpenSearch backend is Amazon OpenSearch Serverless. Default to `false`.
-
 - `aws_sigv4`: A boolean flag to sign the HTTP request with AWS credentials. Only applies to Amazon OpenSearch Service. See [security](security.md) for details. Default to `false`.
 
 - `aws_region`: A String represents the region of Amazon OpenSearch Service domain, e.g. us-west-2. Only applies to Amazon OpenSearch Service. Defaults to `us-east-1`.
@@ -81,7 +79,7 @@ Default is null.
 
 - `insecure`: A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Default to `false`.
 
-- `aws` (Optional) : AWS configurations. See [AWS Configuration](#aws_configuration) for details. If this option is present, `aws_` options are not expected to be present. If any of `aws_` options are present along with this, error is thrown.
+- `aws` (Optional) : AWS configurations. See [AWS Configuration](#aws_configuration) for details. SigV4 is enabled by default when this option is used. If this option is present, `aws_` options are not expected to be present. If any of `aws_` options are present along with this, error is thrown.
 
 - `socket_timeout`(optional): An integer value indicates the timeout in milliseconds for waiting for data (or, put differently, a maximum period inactivity between two consecutive data packets). A timeout value of zero is interpreted as an infinite timeout. If this timeout value is either negative or not set, the underlying Apache HttpClient would rely on operating system settings for managing socket timeouts.
 
@@ -93,7 +91,7 @@ Default is null.
 
 - `proxy`(optional): A String of the address of a forward HTTP proxy. The format is like "<host-name-or-ip>:\<port\>". Examples: "example.com:8100", "http://example.com:8100", "112.112.112.112:8100". Note: port number cannot be omitted.
 
-- `index_type` (optional): a String from the list [`custom`, `trace-analytics-raw`, `trace-analytics-service-map`, `management_disabled`], which represents an index type. Defaults to `custom` if `aws_serverless` is `false`, otherwise defaults to `management_disabled`. This index_type instructs Sink plugin what type of data it is handling. 
+- `index_type` (optional): a String from the list [`custom`, `trace-analytics-raw`, `trace-analytics-service-map`, `management_disabled`], which represents an index type. Defaults to `custom` if `serverless` is `false` in [AWS Configuration](#aws_configuration), otherwise defaults to `management_disabled`. This index_type instructs Sink plugin what type of data it is handling. 
 
 ```
     APM trace analytics raw span data type example:

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
@@ -91,7 +91,7 @@ public class ConnectionConfiguration {
   public static final String AWS_STS_ROLE_ARN = "aws_sts_role_arn";
   public static final String AWS_STS_HEADER_OVERRIDES = "aws_sts_header_overrides";
   public static final String PROXY = "proxy";
-  public static final String AWS_SERVERLESS = "aws_serverless";
+  public static final String SERVERLESS = "serverless";
 
   /**
    * The valid port range per https://tools.ietf.org/html/rfc6335.
@@ -112,7 +112,7 @@ public class ConnectionConfiguration {
   private final Map<String, String> awsStsHeaderOverrides;
   private final Optional<String> proxy;
   private final String pipelineName;
-  private final boolean awsServerless;
+  private final boolean serverless;
 
   List<String> getHosts() {
     return hosts;
@@ -154,8 +154,8 @@ public class ConnectionConfiguration {
     return connectTimeout;
   }
 
-  boolean isAwsServerless() {
-    return awsServerless;
+  boolean isServerless() {
+    return serverless;
   }
 
   private ConnectionConfiguration(final Builder builder) {
@@ -171,7 +171,7 @@ public class ConnectionConfiguration {
     this.awsStsRoleArn = builder.awsStsRoleArn;
     this.awsStsHeaderOverrides = builder.awsStsHeaderOverrides;
     this.proxy = builder.proxy;
-    this.awsServerless = builder.awsServerless;
+    this.serverless = builder.serverless;
     this.pipelineName = builder.pipelineName;
   }
 
@@ -206,7 +206,9 @@ public class ConnectionConfiguration {
         builder.withAwsRegion((String)(awsOption.getOrDefault(AWS_REGION.substring(4), DEFAULT_AWS_REGION)));
         builder.withAWSStsRoleArn((String)(awsOption.getOrDefault(AWS_STS_ROLE_ARN.substring(4), null)));
         builder.withAwsStsHeaderOverrides((Map<String, String>)awsOption.get(AWS_STS_HEADER_OVERRIDES.substring(4)));
-        builder.withAwsServerless((Boolean)awsOption.getOrDefault(AWS_SERVERLESS.substring(4), false));
+        builder.withServerless((Boolean)awsOption.getOrDefault(SERVERLESS, false));
+    } else {
+      builder.withServerless(false);
     }
     boolean awsSigv4 = pluginSetting.getBooleanOrDefault(AWS_SIGV4, false);
     final String awsOptionConflictMessage = String.format("%s option cannot be used along with %s option", AWS_SIGV4, AWS_OPTION);
@@ -218,7 +220,6 @@ public class ConnectionConfiguration {
       builder.withAwsRegion(pluginSetting.getStringOrDefault(AWS_REGION, DEFAULT_AWS_REGION));
       builder.withAWSStsRoleArn(pluginSetting.getStringOrDefault(AWS_STS_ROLE_ARN, null));
       builder.withAwsStsHeaderOverrides(pluginSetting.getTypedMap(AWS_STS_HEADER_OVERRIDES, String.class, String.class));
-      builder.withAwsServerless(pluginSetting.getBooleanOrDefault(AWS_SERVERLESS, false));
     }
 
     final String certPath = pluginSetting.getStringOrDefault(CERT_PATH, null);
@@ -416,7 +417,7 @@ public class ConnectionConfiguration {
       } else {
         credentialsProvider = DefaultCredentialsProvider.create();
       }
-      final String serviceName = awsServerless ? AOSS_SERVICE_NAME : AOS_SERVICE_NAME;
+      final String serviceName = serverless ? AOSS_SERVICE_NAME : AOS_SERVICE_NAME;
       return new AwsSdk2Transport(createSdkHttpClient(), HttpHost.create(hosts.get(0)).getHostName(),
               serviceName, Region.of(awsRegion),
               AwsSdk2TransportOptions.builder()
@@ -495,8 +496,7 @@ public class ConnectionConfiguration {
     private Map<String, String> awsStsHeaderOverrides;
     private Optional<String> proxy = Optional.empty();
     private String pipelineName;
-
-    private boolean awsServerless;
+    private boolean serverless;
 
     private void validateStsRoleArn(final String awsStsRoleArn) {
       final Arn arn = getArn(awsStsRoleArn);
@@ -595,8 +595,8 @@ public class ConnectionConfiguration {
       return this;
     }
 
-    public Builder withAwsServerless(boolean awsServerless) {
-      this.awsServerless = awsServerless;
+    public Builder withServerless(boolean serverless) {
+      this.serverless = serverless;
       return this;
     }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -42,7 +42,7 @@ public class IndexConfiguration {
     public static final String ACTION = "action";
     public static final String S3_AWS_REGION = "s3_aws_region";
     public static final String S3_AWS_STS_ROLE_ARN = "s3_aws_sts_role_arn";
-    public static final String AWS_SERVERLESS = "aws_serverless";
+    public static final String SERVERLESS = "serverless";
     public static final String AWS_OPTION = "aws";
     public static final String DOCUMENT_ROOT_KEY = "document_root_key";
 
@@ -57,7 +57,7 @@ public class IndexConfiguration {
     private final String s3AwsRegion;
     private final String s3AwsStsRoleArn;
     private final S3Client s3Client;
-    private final boolean awsServerless;
+    private final boolean serverless;
     private final String documentRootKey;
 
     private static final String S3_PREFIX = "s3://";
@@ -65,7 +65,7 @@ public class IndexConfiguration {
 
     @SuppressWarnings("unchecked")
     private IndexConfiguration(final Builder builder) {
-        this.awsServerless = builder.awsServerless;
+        this.serverless = builder.serverless;
         determineIndexType(builder);
 
         this.s3AwsRegion = builder.s3AwsRegion;
@@ -114,7 +114,7 @@ public class IndexConfiguration {
             indexType = mappedIndexType.orElseThrow(
                     () -> new IllegalArgumentException("Value of the parameter, index_type, must be from the list: "
                     + IndexType.getIndexTypeValues()));
-        } else if (builder.awsServerless) {
+        } else if (builder.serverless) {
             this.indexType = IndexType.MANAGEMENT_DISABLED;
         } else {
             this.indexType  = IndexType.CUSTOM;
@@ -163,17 +163,10 @@ public class IndexConfiguration {
         }
 
         Map<String, Object> awsOption = pluginSetting.getTypedMap(AWS_OPTION, String.class, Object.class);
-        boolean awsOptionUsed = false;
         if (awsOption != null && !awsOption.isEmpty()) {
-            awsOptionUsed = true;
-            builder.withAwsServerless((Boolean)awsOption.getOrDefault(AWS_SERVERLESS.substring(4), false));
-        }
-        final boolean awsServerless = pluginSetting.getBooleanOrDefault(AWS_SERVERLESS, false);
-        if (awsServerless) {
-            if (awsOptionUsed) {
-                throw new RuntimeException(String.format("%s option cannot be used along with %s option", AWS_SERVERLESS, AWS_OPTION));
-            }
-            builder.withAwsServerless(awsServerless);
+            builder.withServerless((Boolean)awsOption.getOrDefault(SERVERLESS, false));
+        } else {
+            builder.withServerless(false);
         }
 
         final String documentRootKey = pluginSetting.getStringOrDefault(DOCUMENT_ROOT_KEY, null);
@@ -222,12 +215,8 @@ public class IndexConfiguration {
         return s3AwsStsRoleArn;
     }
 
-    public boolean getAwsServerless() {
-        return awsServerless;
-    }
-
-    public String getDocumentRootKey() {
-        return documentRootKey;
+    public boolean getServerless() {
+        return serverless;
     }
 
     /**
@@ -285,7 +274,7 @@ public class IndexConfiguration {
         private String s3AwsRegion;
         private String s3AwsStsRoleArn;
         private S3Client s3Client;
-        private boolean awsServerless;
+        private boolean serverless;
         private String documentRootKey;
 
         public Builder withIndexAlias(final String indexAlias) {
@@ -370,8 +359,8 @@ public class IndexConfiguration {
             return this;
         }
 
-        public Builder withAwsServerless(final boolean awsServerless) {
-            this.awsServerless = awsServerless;
+        public Builder withServerless(final boolean serverless) {
+            this.serverless = serverless;
             return this;
         }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -219,6 +219,10 @@ public class IndexConfiguration {
         return serverless;
     }
 
+    public String getDocumentRootKey() {
+        return documentRootKey;
+    }
+
     /**
      * This method is used in the creation of IndexConfiguration object. It takes in the template file path
      * or index type and returns the index template read from the file or specific to index type or returns an

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfigurationTests.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration.AWS_SERVERLESS;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration.SERVERLESS;
 
 @ExtendWith(MockitoExtension.class)
 class ConnectionConfigurationTests {
@@ -88,24 +88,13 @@ class ConnectionConfigurationTests {
     }
 
     @Test
-    void testReadConnectionConfigurationAwsServerlessDefault() {
-        final Map<String, Object> configMetadata = generateConfigurationMetadata(
-                TEST_HOSTS, null, null, null, null, true, null, null, null, false);
-        configMetadata.put(AWS_SERVERLESS, true);
-        final PluginSetting pluginSetting = getPluginSettingByConfigurationMetadata(configMetadata);
-        final ConnectionConfiguration connectionConfiguration =
-                ConnectionConfiguration.readConnectionConfiguration(pluginSetting);
-        assertTrue(connectionConfiguration.isAwsServerless());
-    }
-
-    @Test
     void testReadConnectionConfigurationAwsOptionServerlessDefault() {
         final String testArn = TEST_ROLE;
         final Map<String, Object> configMetadata = generateConfigurationMetadataWithAwsOption(TEST_HOSTS, null, null, null, null, true, false, null, testArn, TEST_CERT_PATH, false, Collections.emptyMap());
         final PluginSetting pluginSetting = getPluginSettingByConfigurationMetadata(configMetadata);
         final ConnectionConfiguration connectionConfiguration =
                 ConnectionConfiguration.readConnectionConfiguration(pluginSetting);
-        assertTrue(connectionConfiguration.isAwsServerless());
+        assertTrue(connectionConfiguration.isServerless());
     }
 
     @Test
@@ -138,7 +127,7 @@ class ConnectionConfigurationTests {
     void testCreateOpenSearchClientAwsServerlessDefault() throws IOException {
         final Map<String, Object> configMetadata = generateConfigurationMetadata(
                 TEST_HOSTS, null, null, null, null, true, null, null, null, false);
-        configMetadata.put(AWS_SERVERLESS, true);
+        configMetadata.put(SERVERLESS, true);
         final PluginSetting pluginSetting = getPluginSettingByConfigurationMetadata(configMetadata);
         final ConnectionConfiguration connectionConfiguration =
                 ConnectionConfiguration.readConnectionConfiguration(pluginSetting);

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfiguration.AWS_OPTION;
-import static org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfiguration.AWS_SERVERLESS;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfiguration.SERVERLESS;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfiguration.DOCUMENT_ROOT_KEY;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConstants.RAW_DEFAULT_TEMPLATE_FILE;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConstants.SERVICE_MAP_DEFAULT_TEMPLATE_FILE;
@@ -272,39 +272,28 @@ public class IndexConfigurationTests {
         assertEquals(testIdField, indexConfiguration.getDocumentIdField());
     }
 
-    @Test
-    public void testReadIndexConfig_awsServerlessDefault() {
-        final String testIndexAlias = "foo";
-        final Map<String, Object> metadata = initializeConfigMetaData(
-                null, testIndexAlias, null, null, null);
-        metadata.put(AWS_SERVERLESS, true);
-        final PluginSetting pluginSetting = getPluginSetting(metadata);
-        final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
-        assertEquals(IndexType.MANAGEMENT_DISABLED, indexConfiguration.getIndexType());
-        assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
-    }
+//    @Test
+//    public void testReadIndexConfig_awsServerlessDefault() {
+//        final String testIndexAlias = "foo";
+//        final Map<String, Object> metadata = initializeConfigMetaData(
+//                null, testIndexAlias, null, null, null);
+//        metadata.put(SERVERLESS, true);
+//        final PluginSetting pluginSetting = getPluginSetting(metadata);
+//        final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
+//        assertEquals(IndexType.MANAGEMENT_DISABLED, indexConfiguration.getIndexType());
+//        assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
+//    }
 
     @Test
     public void testReadIndexConfig_awsOptionServerlessDefault() {
         final String testIndexAlias = "foo";
         final Map<String, Object> metadata = initializeConfigMetaData(
                 null, testIndexAlias, null, null, null);
-        metadata.put(AWS_OPTION, Map.of(AWS_SERVERLESS.substring(4), true));
+        metadata.put(AWS_OPTION, Map.of(SERVERLESS, true));
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         assertEquals(IndexType.MANAGEMENT_DISABLED, indexConfiguration.getIndexType());
         assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
-    }
-
-    @Test
-    public void testReadIndexConfig_awsOptionServerlessConflictWithAwsServerless() {
-        final String testIndexAlias = "foo";
-        final Map<String, Object> metadata = initializeConfigMetaData(
-                null, testIndexAlias, null, null, null);
-        metadata.put(AWS_OPTION, Map.of(AWS_SERVERLESS.substring(4), true));
-        metadata.put(AWS_SERVERLESS, true);
-        final PluginSetting pluginSetting = getPluginSetting(metadata);
-        assertThrows(RuntimeException.class, () -> IndexConfiguration.readIndexConfig(pluginSetting));
     }
 
     @Test
@@ -312,12 +301,12 @@ public class IndexConfigurationTests {
         final String testIndexAlias = "foo";
         final Map<String, Object> metadata = initializeConfigMetaData(
                 IndexType.CUSTOM.getValue(), testIndexAlias, null, null, null);
-        metadata.put(AWS_SERVERLESS, true);
+        metadata.put(AWS_OPTION, Map.of(SERVERLESS, true));
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         assertEquals(IndexType.CUSTOM, indexConfiguration.getIndexType());
         assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
-        assertEquals(true, indexConfiguration.getAwsServerless());
+        assertEquals(true, indexConfiguration.getServerless());
     }
 
     @Test

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -272,18 +272,6 @@ public class IndexConfigurationTests {
         assertEquals(testIdField, indexConfiguration.getDocumentIdField());
     }
 
-//    @Test
-//    public void testReadIndexConfig_awsServerlessDefault() {
-//        final String testIndexAlias = "foo";
-//        final Map<String, Object> metadata = initializeConfigMetaData(
-//                null, testIndexAlias, null, null, null);
-//        metadata.put(SERVERLESS, true);
-//        final PluginSetting pluginSetting = getPluginSetting(metadata);
-//        final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
-//        assertEquals(IndexType.MANAGEMENT_DISABLED, indexConfiguration.getIndexType());
-//        assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
-//    }
-
     @Test
     public void testReadIndexConfig_awsOptionServerlessDefault() {
         final String testIndexAlias = "foo";


### PR DESCRIPTION
### Description
- Removed `aws_serverless` option and serverless can only be enabled by `aws` option.
- Updated documentation
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
