### PR TITLE
Update dependency versions to fix CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ subprojects {
         constraints {
             implementation('org.apache.httpcomponents:httpclient') {
                 version {
-                    require '4.5.13'
+                    require '4.5.14'
                 }
                 because 'We want the newest version of httpclient.'
             }

--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'org.xerial.snappy:snappy-java:1.1.9.1'
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
-    testImplementation 'com.github.tomakehurst:wiremock:3.0.0-beta-5'
+    testImplementation 'com.github.tomakehurst:wiremock:3.0.0-beta-7'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation project(':data-prepper-test-common')
     testImplementation project(':data-prepper-plugins:csv-processor')

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,7 +28,7 @@ dependencyResolutionManagement {
             library('opentelemetry-proto', 'io.opentelemetry.proto', 'opentelemetry-proto').versionRef('opentelemetry')
             version('opensearch', '1.3.8')
             library('opensearch-rhlc', 'org.opensearch.client', 'opensearch-rest-high-level-client').versionRef('opensearch')
-            version('spring', '5.2.24.RELEASE')
+            version('spring', '5.3.27')
             library('spring-core', 'org.springframework', 'spring-core').versionRef('spring')
             library('spring-context', 'org.springframework', 'spring-context').versionRef('spring')
             version('guava', '31.1-jre')

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,7 +28,7 @@ dependencyResolutionManagement {
             library('opentelemetry-proto', 'io.opentelemetry.proto', 'opentelemetry-proto').versionRef('opentelemetry')
             version('opensearch', '1.3.8')
             library('opensearch-rhlc', 'org.opensearch.client', 'opensearch-rest-high-level-client').versionRef('opensearch')
-            version('spring', '5.3.26')
+            version('spring', '5.2.24.RELEASE')
             library('spring-core', 'org.springframework', 'spring-core').versionRef('spring')
             library('spring-context', 'org.springframework', 'spring-context').versionRef('spring')
             version('guava', '31.1-jre')


### PR DESCRIPTION
### Description
Update dependency versions to fix CVEs. See details below:
 
### Issues Resolved
- Fixes #2492 through spring version `5.3.27`
- Fixes #2418 through `wiremock:3.0.0-beta-7`, which uses `json-smart 2.4.10`
- Fixes #1428 through `httpclient:4.5.14`
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
