### PR TITLE
Use repo1.maven.org instead of mavenCentral() to fix build (#2548)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,8 @@ import com.github.jk1.license.render.TextReportRenderer
 
 buildscript {
     repositories {
-        mavenCentral() {
+        maven {
+            url 'https://repo1.maven.org/maven2/'
             metadataSources {
                 mavenPom()
                 ignoreGradleMetadataRedirection()
@@ -43,7 +44,7 @@ allprojects {
     }
     
     repositories {
-        mavenCentral()
+        maven { url 'https://repo1.maven.org/maven2/' }
         maven { url 'https://jitpack.io' }
     }
 

--- a/data-prepper-plugins/mapdb-processor-state/build.gradle
+++ b/data-prepper-plugins/mapdb-processor-state/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
+    maven { url 'https://repo1.maven.org/maven2/' }
 }
 
 dependencies {

--- a/data-prepper-plugins/newline-codecs/build.gradle
+++ b/data-prepper-plugins/newline-codecs/build.gradle
@@ -2,11 +2,6 @@ plugins {
     id 'java'
 }
 
-
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(':data-prepper-api')
     implementation 'com.fasterxml.jackson.core:jackson-core'

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     repositories {
-        mavenCentral()
+        maven { url 'https://repo1.maven.org/maven2/' }
         gradlePluginPortal()
     }
 
@@ -27,10 +27,6 @@ buildscript {
 
 plugins {
     id 'java'
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {

--- a/data-prepper-plugins/parse-json-processor/build.gradle
+++ b/data-prepper-plugins/parse-json-processor/build.gradle
@@ -7,10 +7,6 @@ plugins {
     id 'java'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')

--- a/data-prepper-plugins/rss-source/build.gradle
+++ b/data-prepper-plugins/rss-source/build.gradle
@@ -7,10 +7,6 @@ plugins {
     id 'java'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(':data-prepper-api')
     implementation 'io.micrometer:micrometer-core'

--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -7,10 +7,6 @@ plugins {
     id 'java'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(':data-prepper-api')
     implementation libs.armeria.core

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -7,10 +7,6 @@ plugins {
     id 'java'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')

--- a/data-prepper-test-common/build.gradle
+++ b/data-prepper-test-common/build.gradle
@@ -7,10 +7,6 @@ plugins {
     id 'java'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation testLibs.hamcrest
     testRuntimeOnly testLibs.junit.engine

--- a/e2e-test/build.gradle
+++ b/e2e-test/build.gradle
@@ -6,7 +6,7 @@
 subprojects {
     buildscript {
         repositories {
-            mavenCentral()
+            maven { url 'https://repo1.maven.org/maven2/' }
             gradlePluginPortal()
         }
         dependencies {

--- a/examples/trace-analytics-sample-app/sample-app/analytics-service/build.gradle
+++ b/examples/trace-analytics-sample-app/sample-app/analytics-service/build.gradle
@@ -15,7 +15,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 repositories {
-    mavenCentral()
+    maven { url 'https://repo1.maven.org/maven2/' }
 }
 
 dependencies {

--- a/performance-test/build.gradle
+++ b/performance-test/build.gradle
@@ -15,7 +15,7 @@ configurations.all {
 group 'org.opensearch.dataprepper.test.performance'
 
 repositories {
-    mavenCentral()
+    maven { url 'https://repo1.maven.org/maven2/' }
 }
 
 dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@
 
 pluginManagement {
     repositories {
-        mavenCentral()
+        maven { url 'https://repo1.maven.org/maven2/' }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
### Description

Use repo1.maven.org instead of mavenCentral(). 
 
### Issues Resolved

Fixes #2548.

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
