### PR TITLE
Baselines the MAINTAINERS.md and CODEOWNERS files per #2275

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/data-prepper
+*   @chenqi0805 @engechas @graytaylor0 @dinujoh @cmanning09 @asifsmohammed @dlvenable @oeyh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,15 +6,21 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer           | GitHub ID                                             | Affiliation |
 | -------------------- | ----------------------------------------------------- | ----------- |
-| Steven Bayer         | [sbayer55](https://github.com/sbayer55)               | Amazon      |
 | Qi Chen              | [chenqi0805](https://github.com/chenqi0805)           | Amazon      |
 | Chase Engelbrecht    | [engechas](https://github.com/engechas)               | Amazon      |
 | Taylor Gray          | [graytaylor0](https://github.com/graytaylor0)         | Amazon      |
 | Dinu John            | [dinujoh](https://github.com/dinujoh)                 | Amazon      |
 | Christopher Manning  | [cmanning09](https://github.com/cmanning09)           | Amazon      |
 | Asif Sohail Mohammed | [asifsmohammed](https://github.com/asifsmohammed)     | Amazon      |
+| David Venable        | [dlvenable](https://github.com/dlvenable)             | Amazon      |
+| Hai Yan              | [oeyh](https://github.com/oeyh)                       | Amazon      |
+
+
+## Emeritus
+
+| Maintainer           | GitHub ID                                             | Affiliation |
+| -------------------- | ----------------------------------------------------- | ----------- |
+| Steven Bayer         | [sbayer55](https://github.com/sbayer55)               | Amazon      |
 | David Powers         | [dapowers87](https://github.com/dapowers87)           | Amazon      |
 | Shivani Shukla       | [sshivanii](https://github.com/sshivanii)             | Amazon      |
 | Phill Treddenick     | [treddeni-amazon](https://github.com/treddeni-amazon) | Amazon      |
-| David Venable        | [dlvenable](https://github.com/dlvenable)             | Amazon      |
-| Hai Yan              | [oeyh](https://github.com/oeyh)                       | Amazon      |


### PR DESCRIPTION
### Description

Baselines the MAINTAINERS.md and CODEOWNERS files.

Adds the Emeritus section with previous maintainers.
 
### Issues Resolved

Resolves #2275
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
