### PR TITLE
Log full errors when the OpenSearch sink fails to start

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -138,19 +138,19 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     try {
         doInitializeInternal();
     } catch (IOException e) {
-        LOG.warn("Failed to initialize OpenSearch sink, retrying. ", e);
+        LOG.warn("Failed to initialize OpenSearch sink, retrying: {} ", e.getMessage());
         closeFiles();
     } catch (InvalidPluginConfigurationException e) {
-        LOG.error("Failed to initialize OpenSearch sink.");
+        LOG.error("Failed to initialize OpenSearch sink due to a configuration error.", e);
         this.shutdown();
         throw new RuntimeException(e.getMessage(), e);
     } catch (Exception e) {
         if (!BulkRetryStrategy.canRetry(e)) {
-            LOG.error("Failed to initialize OpenSearch sink.");
+            LOG.error("Failed to initialize OpenSearch sink with a non-retryable exception.", e);
             this.shutdown();
             throw e;
         }
-        LOG.warn("Failed to initialize OpenSearch sink, retrying. ", e);
+        LOG.warn("Failed to initialize OpenSearch sink with a retryable exception. ", e);
         closeFiles();
     }
   }


### PR DESCRIPTION
### Description
In the cases where the OpenSearch sink fails to initialize, we log that it failed to start and then throw a RuntimeException, which is not as easy to track down in the logs since it bubbles up to "No pipeline available for execution".

This change logs the full error with the "Failed to initialize OpenSearch sink" error log
 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
