### PR TITLE
Increase the backoff delays in the S3 source polling thread

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsService.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsService.java
@@ -14,10 +14,12 @@ import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 
+import java.time.Duration;
+
 public class SqsService {
     private static final Logger LOG = LoggerFactory.getLogger(SqsService.class);
-    static final int INITIAL_DELAY = 1000;
-    static final int MAXIMUM_DELAY = 5 * 60 * 1000;
+    static final long INITIAL_DELAY = Duration.ofSeconds(20).toMillis();
+    static final long MAXIMUM_DELAY = Duration.ofMinutes(5).toMillis();
     static final double JITTER_RATE = 0.20;
 
     private final S3SourceConfig s3SourceConfig;

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
@@ -150,6 +150,9 @@ public class SqsWorker implements Runnable {
             Thread.currentThread().interrupt();
             throw new SqsRetriesExhaustedException("SQS retries exhausted. Make sure that SQS configuration is valid, SQS queue exists, and IAM role has required permissions.");
         }
+        final Duration delayDuration = Duration.ofMillis(delayMillis);
+        LOG.info("Pausing SQS processing for {}.{} seconds due to an error in processing.",
+                delayDuration.getSeconds(), delayDuration.toMillisPart());
         try {
             Thread.sleep(delayMillis);
         } catch (final InterruptedException e){


### PR DESCRIPTION
### Description

When this thread throws errors, it will repeat quite a bit which results in somewhat excessive AWS calls and excess logging.
This put the retry in the range of 20 seconds to 5 minutes.

I also added an INFO log about the sleep. Since the delay can be a while I think this will help anybody monitoring the logs.
 
### Issues Resolved

Fixes #2568.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
