### PR TITLE
Maximum array length and object depth for Java deserialization

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderConfiguration.java
@@ -28,7 +28,7 @@ public class PeerForwarderConfiguration {
     public static final String DEFAULT_CERTIFICATE_FILE_PATH = "config/default_certificate.pem";
     public static final String DEFAULT_PRIVATE_KEY_FILE_PATH = "config/default_private_key.pem";
     private static final String S3_PREFIX = "s3://";
-    private static final int MAX_FORWARDING_BATCH_SIZE = 15000;
+    public static final int MAX_FORWARDING_BATCH_SIZE = 15000;
 
     private Integer serverPort = 4994;
     private Integer requestTimeout = 10_000;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/codec/PeerForwarderCodecAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/codec/PeerForwarderCodecAppConfig.java
@@ -39,11 +39,20 @@ public class PeerForwarderCodecAppConfig {
     }
 
     @Bean
-    public ObjectInputFilter objectInputFilter() {
+    public ObjectInputFilter objectInputFilter(final PeerForwarderConfiguration peerForwarderConfiguration) {
         final String baseModelPackage = "org.opensearch.dataprepper.model";
 
+        Integer maxArrayLength = peerForwarderConfiguration.getForwardingBatchSize();
+        if(maxArrayLength == null) {
+            maxArrayLength = PeerForwarderConfiguration.MAX_FORWARDING_BATCH_SIZE;
+        } else if(maxArrayLength < 10) {
+            maxArrayLength = 10;
+        }
+
         final String pattern =
-                "java.lang.Object;" +
+                "maxarray=" + maxArrayLength + ";" +
+                        "maxdepth=10;" +
+                        "java.lang.Object;" +
                         "java.util.Collections*;" +
                         "java.util.ArrayList*;" +
                         "java.util.LinkedList*;" +


### PR DESCRIPTION
### Description

This PR adds the following validations on the deserialization of events in core peer-forwarder:

* The maximum array/list length is the value of `forwarding_batch_size`.
* The maximum object depth is set to `10`. In my testing I've found that this value is normally `6`. Note that each `Event` serializes as a JSON string and any depths in here do not count toward this value.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
