### PR TITLE
Apply exponential backoff for exceptions when reading from S3

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
@@ -259,6 +260,10 @@ public class SqsWorker implements Runnable {
                     Instant.now()
             ));
             return Optional.of(buildDeleteMessageBatchRequestEntry(parsedMessage.message));
+        } catch (final S3Exception | StsException e) {
+            LOG.error("Error processing from S3: {}. Retrying with exponential backoff.", e.getMessage());
+            applyBackoff();
+            return Optional.empty();
         } catch (final Exception e) {
             return Optional.empty();
         }


### PR DESCRIPTION
### Description

Also apply exponential backoff when S3 requests result in exceptions.
 
### Issues Resolved

Resolves #2568
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
