### PR TITLE
Updates to the log-ingestion example

### DIFF
--- a/examples/log-ingestion/README.md
+++ b/examples/log-ingestion/README.md
@@ -37,7 +37,7 @@ docker-compose --project-name data-prepper up
 1. Pull down the latest Data Prepper Docker image.
 
 ```
-docker pull opensearchproject/data-prepper:latest
+docker pull opensearchproject/data-prepper:2
 ```
  
 2. Take a look at [log_pipeline.yaml](log_pipeline.yaml). This configuration will take logs sent to the [http source](../../data-prepper-plugins/http-source), 
@@ -48,14 +48,10 @@ and send the processed logs to a local [OpenSearch sink](../../data-prepper-plug
 3. Run the Data Prepper docker image with the `log_pipeline.yaml` from step 2 passed in. This command attaches the Data Prepper Docker image to the Docker network `log-ingestion_opensearch_net` so that 
 FluentBit is able to send logs to the http source of Data Prepper.
 
-For Data Prepper 2.0 or above:
-```
-docker run --name data-prepper -v /full/path/to/log_pipeline.yaml:/usr/share/data-prepper/pipelines/log_pipeline.yaml --network "data-prepper_opensearch-net" opensearchproject/data-prepper:latest
-```
+Run the following to start Data Prepper:
 
-For Data Prepper before version 2.0:
 ```
-docker run --name data-prepper -v /full/path/to/log_pipeline.yaml:/usr/share/data-prepper/pipelines.yaml --network "data-prepper_opensearch-net" opensearchproject/data-prepper:latest
+docker run --name data-prepper -v ${PWD}/log_pipeline.yaml:/usr/share/data-prepper/pipelines/log_pipeline.yaml --network "data-prepper_opensearch-net" opensearchproject/data-prepper:2
 ```
 
 If Data Prepper is running correctly, you should see something similar to the following line as the latest output in your terminal.


### PR DESCRIPTION
### Description

Updates the log-ingestion example:
* Explicit use of Data Prepper 2.x.
* Use `${PWD}` to support copy-and-paste for many users.
* Remove Data Prepper 1.x entirely.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
