### PR TITLE
Add null check for bulkRetryCountMap in opensearch sink to prevent NullPointerException

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -201,7 +201,7 @@ public final class BulkRetryStrategy {
     private void handleRetry(final AccumulatingBulkRequest request, final BulkResponse response,
                              final BackOffUtils backOffUtils) throws InterruptedException {
         final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequestForRetry = createBulkRequestForRetry(request, response);
-        if (!retryCountMap.containsKey(bulkRequestForRetry)) {
+        if (!retryCountMap.containsKey(bulkRequestForRetry) || Objects.isNull(retryCountMap.get(bulkRequestForRetry))) {
             retryCountMap.put(bulkRequestForRetry, 1);
         }
         int retryCount = retryCountMap.get(bulkRequestForRetry);


### PR DESCRIPTION
### Description
This change is meant to prevent a NullPointerException from occurring when the value pulled from the `retryCountMap` is null
 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
