### PR TITLE
Adding Krishna Kondaka (kkondaka) as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @chenqi0805 @engechas @graytaylor0 @dinujoh @cmanning09 @asifsmohammed @dlvenable @oeyh
+*   @chenqi0805 @engechas @graytaylor0 @dinujoh @kkondaka @cmanning09 @asifsmohammed @dlvenable @oeyh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,6 +10,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Chase Engelbrecht    | [engechas](https://github.com/engechas)               | Amazon      |
 | Taylor Gray          | [graytaylor0](https://github.com/graytaylor0)         | Amazon      |
 | Dinu John            | [dinujoh](https://github.com/dinujoh)                 | Amazon      |
+| Krishna Kondaka      | [kkondaka](https://github.com/kkondaka)               | Amazon      |
 | Christopher Manning  | [cmanning09](https://github.com/cmanning09)           | Amazon      |
 | Asif Sohail Mohammed | [asifsmohammed](https://github.com/asifsmohammed)     | Amazon      |
 | David Venable        | [dlvenable](https://github.com/dlvenable)             | Amazon      |


### PR DESCRIPTION
### Description

Adding @kkondaka as a maintainer as voted upon by the existing Data Prepper maintainers.

He has contributed [49 PRs](https://github.com/opensearch-project/data-prepper/pulls?q=is:pr+is:closed+author:kkondaka). Some of these include significant new features.
 
* [End-to-end acknowledgements](https://github.com/opensearch-project/data-prepper/issues/2496#issuecomment-1509169592) for the S3 source.
* [Anomaly detector](https://github.com/opensearch-project/data-prepper/pull/2058)
* [Dynamic Index Name in OpenSearch sink](https://github.com/opensearch-project/data-prepper/pull/1999)
* [Type conversion / cast processor](https://github.com/opensearch-project/data-prepper/pull/2020)
* [Fix PipelineConnector to duplicate events](https://github.com/opensearch-project/data-prepper/pull/1897)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
