### PR TITLE
Add when conditions to commonly used processors

### DIFF
--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -21,6 +21,7 @@ public class GrokProcessorConfig {
     static final String PATTERNS_FILES_GLOB = "patterns_files_glob";
     static final String TIMEOUT_MILLIS = "timeout_millis";
     static final String TARGET_KEY = "target_key";
+    static final String GROK_WHEN = "grok_when";
 
     static final boolean DEFAULT_BREAK_ON_MATCH = true;
     static final boolean DEFAULT_KEEP_EMPTY_CAPTURES = false;
@@ -39,6 +40,7 @@ public class GrokProcessorConfig {
     private final Map<String, String> patternDefinitions;
     private final int timeoutMillis;
     private final String targetKey;
+    private final String grokWhen;
 
     private GrokProcessorConfig(final boolean breakOnMatch,
                                 final boolean keepEmptyCaptures,
@@ -49,7 +51,8 @@ public class GrokProcessorConfig {
                                 final String patternsFilesGlob,
                                 final Map<String, String> patternDefinitions,
                                 final int timeoutMillis,
-                                final String targetKey) {
+                                final String targetKey,
+                                final String grokWhen) {
 
         this.breakOnMatch = breakOnMatch;
         this.keepEmptyCaptures = keepEmptyCaptures;
@@ -61,6 +64,7 @@ public class GrokProcessorConfig {
         this.patternDefinitions = patternDefinitions;
         this.timeoutMillis = timeoutMillis;
         this.targetKey = targetKey;
+        this.grokWhen = grokWhen;
     }
 
     public static GrokProcessorConfig buildConfig(final PluginSetting pluginSetting) {
@@ -73,7 +77,8 @@ public class GrokProcessorConfig {
                 pluginSetting.getStringOrDefault(PATTERNS_FILES_GLOB, DEFAULT_PATTERNS_FILES_GLOB),
                 pluginSetting.getTypedMap(PATTERN_DEFINITIONS, String.class, String.class),
                 pluginSetting.getIntegerOrDefault(TIMEOUT_MILLIS, DEFAULT_TIMEOUT_MILLIS),
-                pluginSetting.getStringOrDefault(TARGET_KEY, DEFAULT_TARGET_KEY));
+                pluginSetting.getStringOrDefault(TARGET_KEY, DEFAULT_TARGET_KEY),
+                pluginSetting.getStringOrDefault(GROK_WHEN, null));
     }
 
     public boolean isBreakOnMatch() {
@@ -115,4 +120,6 @@ public class GrokProcessorConfig {
     public String getTargetKey() {
         return targetKey;
     }
+
+    public String getGrokWhen() { return grokWhen; }
 }

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfigTests.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfigTests.java
@@ -73,6 +73,7 @@ public class GrokProcessorConfigTests {
         assertThat(grokProcessorConfig.getTargetKey(), equalTo(DEFAULT_TARGET_KEY));
         assertThat(grokProcessorConfig.isNamedCapturesOnly(), equalTo(DEFAULT_NAMED_CAPTURES_ONLY));
         assertThat(grokProcessorConfig.getTimeoutMillis(), equalTo(DEFAULT_TIMEOUT_MILLIS));
+        assertThat(grokProcessorConfig.getGrokWhen(), equalTo(null));
     }
 
     @Test

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessor.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -26,10 +27,13 @@ public class AddEntryProcessor extends AbstractProcessor<Record<Event>, Record<E
     private static final Logger LOG = LoggerFactory.getLogger(AddEntryProcessor.class);
     private final List<AddEntryProcessorConfig.Entry> entries;
 
+    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+
     @DataPrepperPluginConstructor
-    public AddEntryProcessor(final PluginMetrics pluginMetrics, final AddEntryProcessorConfig config) {
+    public AddEntryProcessor(final PluginMetrics pluginMetrics, final AddEntryProcessorConfig config, final ExpressionEvaluator<Boolean> expressionEvaluator) {
         super(pluginMetrics);
         this.entries = config.getEntries();
+        this.expressionEvaluator = expressionEvaluator;
     }
 
     @Override
@@ -38,6 +42,11 @@ public class AddEntryProcessor extends AbstractProcessor<Record<Event>, Record<E
             final Event recordEvent = record.getData();
 
             for(AddEntryProcessorConfig.Entry entry : entries) {
+
+                if (Objects.nonNull(entry.getAddWhen()) && !expressionEvaluator.evaluate(entry.getAddWhen(), recordEvent)) {
+                    continue;
+                }
+
                 try {
                     if (!recordEvent.containsKey(entry.getKey()) || entry.getOverwriteIfKeyExists()) {
                         if (!Objects.isNull(entry.getFormat())) {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorConfig.java
@@ -24,6 +24,9 @@ public class AddEntryProcessorConfig {
 
         private String format;
 
+        @JsonProperty("add_when")
+        private String addWhen;
+
         @JsonProperty("overwrite_if_key_exists")
         private boolean overwriteIfKeyExists = false;
 
@@ -43,17 +46,24 @@ public class AddEntryProcessorConfig {
             return overwriteIfKeyExists;
         }
 
+        public String getAddWhen() { return addWhen; }
+
         @AssertTrue(message = "Either value or format must be specified")
         public boolean hasValueOrFormat() {
             return Objects.nonNull(value) || Objects.nonNull(format);
         }
 
-        public Entry(final String key, final Object value, final String format, final boolean overwriteIfKeyExists)
+        public Entry(final String key,
+                     final Object value,
+                     final String format,
+                     final boolean overwriteIfKeyExists,
+                     final String addWhen)
         {
             this.key = key;
             this.value = value;
             this.format = format;
             this.overwriteIfKeyExists = overwriteIfKeyExists;
+            this.addWhen = addWhen;
         }
 
         public Entry() {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessor.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -15,23 +16,36 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.typeconverter.TypeConverter;
 
 import java.util.Collection;
+import java.util.Objects;
 
 @DataPrepperPlugin(name = "convert_entry_type", pluginType = Processor.class, pluginConfigurationType = ConvertEntryTypeProcessorConfig.class)
 public class ConvertEntryTypeProcessor  extends AbstractProcessor<Record<Event>, Record<Event>> {
     private final String key;
     private final TypeConverter converter;
+    private final String convertWhen;
+
+    private final ExpressionEvaluator<Boolean> expressionEvaluator;
 
     @DataPrepperPluginConstructor
-    public ConvertEntryTypeProcessor(final PluginMetrics pluginMetrics, final ConvertEntryTypeProcessorConfig convertEntryTypeProcessorConfig) {
+    public ConvertEntryTypeProcessor(final PluginMetrics pluginMetrics,
+                                     final ConvertEntryTypeProcessorConfig convertEntryTypeProcessorConfig,
+                                     final ExpressionEvaluator<Boolean> expressionEvaluator) {
         super(pluginMetrics);
         this.key = convertEntryTypeProcessorConfig.getKey();
         this.converter = convertEntryTypeProcessorConfig.getType().getTargetConverter();
+        this.convertWhen = convertEntryTypeProcessorConfig.getConvertWhen();
+        this.expressionEvaluator = expressionEvaluator;
     }
 
     @Override
     public Collection<Record<Event>> doExecute(final Collection<Record<Event>> records) {
         for(final Record<Event> record : records) {
             final Event recordEvent = record.getData();
+
+            if (Objects.nonNull(convertWhen) && !expressionEvaluator.evaluate(convertWhen, recordEvent)) {
+                continue;
+            }
+
             Object keyVal = recordEvent.get(key, Object.class);
             if (keyVal != null) {
                 recordEvent.delete(key);

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
@@ -16,6 +16,9 @@ public class ConvertEntryTypeProcessorConfig  {
     @JsonProperty("type")
     private TargetType type = TargetType.INTEGER;
 
+    @JsonProperty("convert_when")
+    private String convertWhen;
+
     public String getKey() {
         return key;
     }
@@ -23,4 +26,6 @@ public class ConvertEntryTypeProcessorConfig  {
     public TargetType getType() {
         return type;
     }
+
+    public String getConvertWhen() { return convertWhen; }
 }

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
@@ -24,6 +24,9 @@ public class CopyValueProcessorConfig {
         @JsonProperty("to_key")
         private String toKey;
 
+        @JsonProperty("copy_when")
+        private String copyWhen;
+
         @JsonProperty("overwrite_if_to_key_exists")
         private boolean overwriteIfToKeyExists = false;
 
@@ -39,10 +42,13 @@ public class CopyValueProcessorConfig {
             return overwriteIfToKeyExists;
         }
 
-        public Entry(final String fromKey, final String toKey, final boolean overwriteIfToKeyExists) {
+        public String getCopyWhen() { return copyWhen; }
+
+        public Entry(final String fromKey, final String toKey, final boolean overwriteIfToKeyExists, final String copyWhen) {
             this.fromKey = fromKey;
             this.toKey = toKey;
             this.overwriteIfToKeyExists = overwriteIfToKeyExists;
+            this.copyWhen = copyWhen;
         }
 
         public Entry() {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessor.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -14,21 +15,32 @@ import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.Collection;
+import java.util.Objects;
 
 @DataPrepperPlugin(name = "delete_entries", pluginType = Processor.class, pluginConfigurationType = DeleteEntryProcessorConfig.class)
 public class DeleteEntryProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
     private final String[] entries;
+    private final String deleteWhen;
+
+    private final ExpressionEvaluator<Boolean> expressionEvaluator;
 
     @DataPrepperPluginConstructor
-    public DeleteEntryProcessor(final PluginMetrics pluginMetrics, final DeleteEntryProcessorConfig config) {
+    public DeleteEntryProcessor(final PluginMetrics pluginMetrics, final DeleteEntryProcessorConfig config, final ExpressionEvaluator<Boolean> expressionEvaluator) {
         super(pluginMetrics);
         this.entries = config.getWithKeys();
+        this.deleteWhen = config.getDeleteWhen();
+        this.expressionEvaluator = expressionEvaluator;
     }
 
     @Override
     public Collection<Record<Event>> doExecute(final Collection<Record<Event>> records) {
         for(final Record<Event> record : records) {
             final Event recordEvent = record.getData();
+
+            if (Objects.nonNull(deleteWhen) && !expressionEvaluator.evaluate(deleteWhen, recordEvent)) {
+                continue;
+            }
+
 
             for(String entry : entries) {
                 recordEvent.delete(entry);

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
@@ -15,7 +15,14 @@ public class DeleteEntryProcessorConfig {
     @JsonProperty("with_keys")
     private String[] withKeys;
 
+    @JsonProperty("delete_when")
+    private String deleteWhen;
+
     public String[] getWithKeys() {
         return withKeys;
+    }
+
+    public String getDeleteWhen() {
+        return deleteWhen;
     }
 }

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -61,6 +61,9 @@ public class ListToMapProcessorConfig {
     @JsonProperty("flattened_element")
     private FlattenedElement flattenedElement = FlattenedElement.FIRST;
 
+    @JsonProperty("list_to_map_when")
+    private String listToMapWhen;
+
     public String getSource() {
         return source;
     }
@@ -80,6 +83,8 @@ public class ListToMapProcessorConfig {
     public boolean getFlatten() {
         return flatten;
     }
+
+    public String getListToMapWhen() { return listToMapWhen; }
 
     public FlattenedElement getFlattenedElement() {
         return flattenedElement;

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
@@ -27,6 +27,9 @@ public class RenameKeyProcessorConfig {
         @JsonProperty("overwrite_if_to_key_exists")
         private boolean overwriteIfToKeyExists = false;
 
+        @JsonProperty("rename_when")
+        private String renameWhen;
+
         public String getFromKey() {
             return fromKey;
         }
@@ -39,10 +42,13 @@ public class RenameKeyProcessorConfig {
             return overwriteIfToKeyExists;
         }
 
-        public Entry(final String fromKey, final String toKey, final boolean overwriteIfKeyExists) {
+        public String getRenameWhen() { return renameWhen; }
+
+        public Entry(final String fromKey, final String toKey, final boolean overwriteIfKeyExists, final String renameWhen) {
             this.fromKey = fromKey;
             this.toKey = toKey;
             this.overwriteIfToKeyExists = overwriteIfKeyExists;
+            this.renameWhen = renameWhen;
         }
 
         public Entry() {

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
@@ -5,14 +5,15 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
-import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
-import org.opensearch.dataprepper.model.record.Record;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,6 +21,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -38,9 +40,12 @@ public class AddEntryProcessorTests {
     @Mock
     private AddEntryProcessorConfig mockConfig;
 
+    @Mock
+    private ExpressionEvaluator<Boolean> expressionEvaluator;
+
     @Test
     public void testSingleAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -54,8 +59,8 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testMultiAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, false),
-                createEntry("message2", 4, null, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, false, null),
+                createEntry("message2", 4, null, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -71,7 +76,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleNoOverwriteAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -86,7 +91,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testSingleOverwriteAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, true)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -101,8 +106,8 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testMultiOverwriteMixedAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, true),
-                createEntry("message", 4, null, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, true, null),
+                createEntry("message", 4, null, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -117,7 +122,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testIntAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -131,7 +136,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testBoolAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", true, null, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", true, null, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -145,7 +150,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testStringAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", "string", null, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", "string", null, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -159,7 +164,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testNullAddProcessorTests() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, null, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", null, null, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -185,7 +190,7 @@ public class AddEntryProcessorTests {
     public void testNestedAddProcessorTests() {
         TestObject obj = new TestObject();
         obj.a = "test";
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", obj, null, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", obj, null, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -200,7 +205,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testArrayAddProcessorTests() {
         Object[] array = new Object[] { 1, 1.2, "string", true, null };
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", array, null, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", array, null, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -215,7 +220,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testFloatAddProcessorTests() {
         when(mockConfig.getEntries())
-                .thenReturn(createListOfEntries(createEntry("newMessage", 1.2, null, false)));
+                .thenReturn(createListOfEntries(createEntry("newMessage", 1.2, null, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
@@ -230,7 +235,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testAddSingleFormatEntry() {
         when(mockConfig.getEntries())
-                .thenReturn(createListOfEntries(createEntry("date-time", null, TEST_FORMAT, false)));
+                .thenReturn(createListOfEntries(createEntry("date-time", null, TEST_FORMAT, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -245,8 +250,8 @@ public class AddEntryProcessorTests {
     @Test
     public void testAddMultipleFormatEntries() {
         when(mockConfig.getEntries())
-                .thenReturn(createListOfEntries(createEntry("date-time", null, TEST_FORMAT, false),
-                        createEntry("date-time2", null, ANOTHER_TEST_FORMAT, false)));
+                .thenReturn(createListOfEntries(createEntry("date-time", null, TEST_FORMAT, false, null),
+                        createEntry("date-time2", null, ANOTHER_TEST_FORMAT, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -263,7 +268,7 @@ public class AddEntryProcessorTests {
     public void testFormatOverwritesExistingEntry() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry("time", null, TEST_FORMAT, true)));
+                        createListOfEntries(createEntry("time", null, TEST_FORMAT, true, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -278,7 +283,7 @@ public class AddEntryProcessorTests {
     public void testFormatNotOverwriteExistingEntry() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry("time", null, TEST_FORMAT, false)));
+                        createListOfEntries(createEntry("time", null, TEST_FORMAT, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -294,7 +299,7 @@ public class AddEntryProcessorTests {
     public void testFormatPrecedesValue() {
         when(mockConfig.getEntries())
                 .thenReturn(
-                        createListOfEntries(createEntry("date-time", "date-time-value", TEST_FORMAT, false)));
+                        createListOfEntries(createEntry("date-time", "date-time-value", TEST_FORMAT, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -309,7 +314,7 @@ public class AddEntryProcessorTests {
     @Test
     public void testFormatVariousDataTypes() {
         when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry(
-                "newField", null, "${number-key}-${boolean-key}-${string-key}", false)));
+                "newField", null, "${number-key}-${boolean-key}-${string-key}", false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleDataTypes();
@@ -321,7 +326,7 @@ public class AddEntryProcessorTests {
 
     @Test
     public void testBadFormatThenEntryNotAdded() {
-        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("data-time", null, BAD_TEST_FORMAT, false)));
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("data-time", null, BAD_TEST_FORMAT, false, null)));
 
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getTestEventWithMultipleFields();
@@ -333,13 +338,30 @@ public class AddEntryProcessorTests {
         assertThat(event.containsKey("data-time"), equalTo(false));
     }
 
+    @Test
+    public void testKeyIsNotAdded_when_addWhen_condition_is_false() {
+        final String addWhen = UUID.randomUUID().toString();
+
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("newMessage", 3, null, false, addWhen)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("thisisamessage");
+
+        when(expressionEvaluator.evaluate(addWhen, record.getData())).thenReturn(false);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", Object.class), equalTo("thisisamessage"));
+        assertThat(editedRecords.get(0).getData().containsKey("newMessage"), is(false));
+    }
+
     private AddEntryProcessor createObjectUnderTest() {
-        return new AddEntryProcessor(pluginMetrics, mockConfig);
+        return new AddEntryProcessor(pluginMetrics, mockConfig, expressionEvaluator);
     }
 
     private AddEntryProcessorConfig.Entry createEntry(
-            final String key, final Object value, final String format, final boolean overwriteIfKeyExists) {
-        return new AddEntryProcessorConfig.Entry(key, value, format, overwriteIfKeyExists);
+            final String key, final Object value, final String format, final boolean overwriteIfKeyExists, final String addWhen) {
+        return new AddEntryProcessorConfig.Entry(key, value, format, overwriteIfKeyExists, addWhen);
     }
 
     private List<AddEntryProcessorConfig.Entry> createListOfEntries(final AddEntryProcessorConfig.Entry... entries) {

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorTest.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
@@ -17,7 +18,9 @@ import org.opensearch.dataprepper.model.record.Record;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,6 +34,9 @@ class ListToMapProcessorTest {
     @Mock
     private ListToMapProcessorConfig mockConfig;
 
+    @Mock
+    private ExpressionEvaluator<Boolean> expressionEvaluator;
+
     @Test
     public void testValueExtractionWithFlattenAndWriteToRoot() {
         when(mockConfig.getValueKey()).thenReturn("value");
@@ -38,6 +44,7 @@ class ListToMapProcessorTest {
         when(mockConfig.getKey()).thenReturn("name");
         when(mockConfig.getFlatten()).thenReturn(true);
         when(mockConfig.getFlattenedElement()).thenReturn(ListToMapProcessorConfig.FlattenedElement.FIRST);
+        when(mockConfig.getListToMapWhen()).thenReturn(null);
 
         final ListToMapProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createTestRecord();
@@ -58,6 +65,7 @@ class ListToMapProcessorTest {
         when(mockConfig.getKey()).thenReturn("name");
         when(mockConfig.getFlatten()).thenReturn(true);
         when(mockConfig.getFlattenedElement()).thenReturn(ListToMapProcessorConfig.FlattenedElement.LAST);
+        when(mockConfig.getListToMapWhen()).thenReturn(null);
 
         final ListToMapProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createTestRecord();
@@ -79,6 +87,7 @@ class ListToMapProcessorTest {
         when(mockConfig.getTarget()).thenReturn("mymap");
         when(mockConfig.getFlatten()).thenReturn(true);
         when(mockConfig.getFlattenedElement()).thenReturn(ListToMapProcessorConfig.FlattenedElement.FIRST);
+        when(mockConfig.getListToMapWhen()).thenReturn(null);
 
         final ListToMapProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createTestRecord();
@@ -98,6 +107,7 @@ class ListToMapProcessorTest {
         when(mockConfig.getKey()).thenReturn("name");
         when(mockConfig.getFlatten()).thenReturn(true);
         when(mockConfig.getFlattenedElement()).thenReturn(ListToMapProcessorConfig.FlattenedElement.FIRST);
+        when(mockConfig.getListToMapWhen()).thenReturn(null);
 
         final ListToMapProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createTestRecord();
@@ -116,6 +126,7 @@ class ListToMapProcessorTest {
         when(mockConfig.getSource()).thenReturn("mylist");
         when(mockConfig.getKey()).thenReturn("name");
         when(mockConfig.getValueKey()).thenReturn("value");
+        when(mockConfig.getListToMapWhen()).thenReturn(null);
 
         final ListToMapProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createTestRecord();
@@ -133,6 +144,7 @@ class ListToMapProcessorTest {
     public void testNoValueExtractionWithNoFlattenAndWriteToRoot() {
         when(mockConfig.getSource()).thenReturn("mylist");
         when(mockConfig.getKey()).thenReturn("name");
+        when(mockConfig.getListToMapWhen()).thenReturn(null);
 
         final ListToMapProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createTestRecord();
@@ -152,6 +164,7 @@ class ListToMapProcessorTest {
     @Test
     public void testFailureDueToInvalidSourceKey() {
         when(mockConfig.getSource()).thenReturn("invalid_source_key");
+        when(mockConfig.getListToMapWhen()).thenReturn(null);
 
         final ListToMapProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createTestRecord();
@@ -166,6 +179,7 @@ class ListToMapProcessorTest {
     @Test
     public void testFailureDueToSourceNotList() {
         when(mockConfig.getSource()).thenReturn("nolist");
+        when(mockConfig.getListToMapWhen()).thenReturn(null);
 
         final ListToMapProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createTestRecord();
@@ -182,6 +196,7 @@ class ListToMapProcessorTest {
         when(mockConfig.getValueKey()).thenReturn("value");
         when(mockConfig.getSource()).thenReturn("mylist");
         when(mockConfig.getKey()).thenReturn("name");
+        when(mockConfig.getListToMapWhen()).thenReturn(null);
 
         final ListToMapProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createBadTestRecord();
@@ -193,8 +208,25 @@ class ListToMapProcessorTest {
         assertThat(resultEvent.get("mymap", Object.class), is(nullValue()));
     }
 
+    @Test
+    public void testNoValueExtraction_when_the_when_condition_returns_false() {
+        final String whenCondition = UUID.randomUUID().toString();
+        when(mockConfig.getListToMapWhen()).thenReturn(whenCondition);
+
+        final ListToMapProcessor processor = createObjectUnderTest();
+        final Record<Event> testRecord = createTestRecord();
+
+        when(expressionEvaluator.evaluate(whenCondition, testRecord.getData())).thenReturn(false);
+        final List<Record<Event>> resultRecord = (List<Record<Event>>) processor.doExecute(Collections.singletonList(testRecord));
+
+        assertThat(resultRecord.size(), is(1));
+
+        final Event resultEvent = resultRecord.get(0).getData();
+        assertThat(resultEvent.toMap(), equalTo(testRecord.getData().toMap()));
+    }
+
     private ListToMapProcessor createObjectUnderTest() {
-        return new ListToMapProcessor(pluginMetrics, mockConfig);
+        return new ListToMapProcessor(pluginMetrics, mockConfig, expressionEvaluator);
     }
 
     private Record<Event> createTestRecord() {

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/AbstractStringProcessor.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/AbstractStringProcessor.java
@@ -15,7 +15,7 @@ import java.util.Collection;
 import java.util.List;
 
 public abstract class AbstractStringProcessor<T> extends AbstractProcessor<Record<Event>, Record<Event>> {
-    private List<T> entries;
+    private final List<T> entries;
 
     @DataPrepperPluginConstructor
     public AbstractStringProcessor(final PluginMetrics pluginMetrics, final StringProcessorConfig<T> config) {
@@ -36,6 +36,8 @@ public abstract class AbstractStringProcessor<T> extends AbstractProcessor<Recor
     private void performStringAction(final Event recordEvent)
     {
         for(T entry : entries) {
+
+
             final String key = getKey(entry);
 
             if(recordEvent.containsKey(key)) {

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorConfig.java
@@ -27,6 +27,9 @@ public class SplitStringProcessorConfig implements StringProcessorConfig<SplitSt
         @Size(min = 1, max = 1)
         private String delimiter;
 
+        @JsonProperty("split_when")
+        private String splitWhen;
+
         public String getSource() {
             return source;
         }
@@ -39,10 +42,13 @@ public class SplitStringProcessorConfig implements StringProcessorConfig<SplitSt
             return delimiter;
         }
 
-        public Entry(final String source, final String delimiterRegex, final String delimiter) {
+        public String getSplitWhen() { return splitWhen; }
+
+        public Entry(final String source, final String delimiterRegex, final String delimiter, final String splitWhen) {
             this.source = source;
             this.delimiterRegex = delimiterRegex;
             this.delimiter = delimiter;
+            this.splitWhen = splitWhen;
         }
 
         public Entry() {}

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessor.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessor.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutatestring;
 
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -13,6 +14,7 @@ import org.opensearch.dataprepper.model.processor.Processor;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,10 +25,12 @@ import java.util.regex.Pattern;
 @DataPrepperPlugin(name = "substitute_string", pluginType = Processor.class, pluginConfigurationType = SubstituteStringProcessorConfig.class)
 public class SubstituteStringProcessor extends AbstractStringProcessor<SubstituteStringProcessorConfig.Entry> {
     private final Map<String, Pattern> patternMap = new HashMap<>();
+    private final ExpressionEvaluator<Boolean> expressionEvaluator;
 
     @DataPrepperPluginConstructor
-    public SubstituteStringProcessor(final PluginMetrics pluginMetrics, final SubstituteStringProcessorConfig config) {
+    public SubstituteStringProcessor(final PluginMetrics pluginMetrics, final SubstituteStringProcessorConfig config, final ExpressionEvaluator<Boolean> expressionEvaluator) {
         super(pluginMetrics, config);
+        this.expressionEvaluator = expressionEvaluator;
 
         for(final SubstituteStringProcessorConfig.Entry entry : config.getEntries()) {
             patternMap.put(entry.getFrom(), Pattern.compile(entry.getFrom()));
@@ -36,6 +40,10 @@ public class SubstituteStringProcessor extends AbstractStringProcessor<Substitut
     @Override
     protected void performKeyAction(final Event recordEvent, final SubstituteStringProcessorConfig.Entry entry, final String value)
     {
+        if (Objects.nonNull(entry.getSubstituteWhen()) && !expressionEvaluator.evaluate(entry.getSubstituteWhen(), recordEvent)) {
+            return;
+        }
+
         final Pattern pattern = patternMap.get(entry.getFrom());
         final Matcher matcher = pattern.matcher(value);
         final String newValue = matcher.replaceAll(entry.getTo());

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorConfig.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorConfig.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutatestring;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public class SubstituteStringProcessorConfig implements StringProcessorConfig<SubstituteStringProcessorConfig.Entry> {
@@ -12,6 +14,9 @@ public class SubstituteStringProcessorConfig implements StringProcessorConfig<Su
         private String source;
         private String from;
         private String to;
+
+        @JsonProperty("substitute_when")
+        private String substituteWhen;
 
         public String getSource() {
             return source;
@@ -25,10 +30,13 @@ public class SubstituteStringProcessorConfig implements StringProcessorConfig<Su
             return to;
         }
 
-        public Entry(final String source, final String from, final String to) {
+        public String getSubstituteWhen() { return substituteWhen; }
+
+        public Entry(final String source, final String from, final String to, final String substituteWhen) {
             this.source = source;
             this.from = from;
             this.to = to;
+            this.substituteWhen = substituteWhen;
         }
 
         public Entry() {}

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfig.java
@@ -24,6 +24,9 @@ public class ParseJsonProcessorConfig {
     @JsonProperty("pointer")
     private String pointer;
 
+    @JsonProperty("parse_when")
+    private String parseWhen;
+
     /**
      * The field of the Event that contains the JSON data.
      *
@@ -54,6 +57,8 @@ public class ParseJsonProcessorConfig {
     public String getPointer() {
         return pointer;
     }
+
+    public String getParseWhen() { return parseWhen; }
 
     @AssertTrue(message = "destination cannot be empty, whitespace, or a front slash (/)")
     boolean isValidDestination() {


### PR DESCRIPTION
### Description
This change adds "when" conditional support to the following processors
* grok (`grok_when`)
* parse_json (`parse_when`)
* add_entries (`add_when` on each entry)
* convert_entry_type (`convert_when`)
* copy_value (`copy_when` on each entry)
* delete_entries (`delete_when`)
* list_to_map (`list_to_map_when`)
* rename_keys (`rename_when` on each entry)
* split_string (`split_when` on each entry)
* substitute_string (`substitute_when` on each entry)

This PR also fixes a bug that occurred when the `parse_json` processor is used on a key that does not exist in the Event, resulting in an an exception that results in Events being dropped
 
### Issues Resolved
closes #2613 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
