### PR TITLE
Support reading S3 Event messages from SNS fan-out

### DIFF
--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/SqsWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/SqsWorkerIT.java
@@ -47,6 +47,7 @@ class SqsWorkerIT {
     private PluginMetrics pluginMetrics;
     private S3ObjectGenerator s3ObjectGenerator;
     private String bucket;
+    private S3EventMessageParser s3EventMessageParser;
     private Backoff backoff;
     private AcknowledgementSetManager acknowledgementSetManager;
 
@@ -58,6 +59,7 @@ class SqsWorkerIT {
                 .build();
         bucket = System.getProperty("tests.s3source.bucket");
         s3ObjectGenerator = new S3ObjectGenerator(s3Client, bucket);
+        s3EventMessageParser = new S3EventMessageParser();
 
         sqsClient = SqsClient.builder()
                 .region(Region.of(System.getProperty("tests.s3source.region")))
@@ -88,7 +90,7 @@ class SqsWorkerIT {
     }
 
     private SqsWorker createObjectUnderTest() {
-        return new SqsWorker(acknowledgementSetManager, sqsClient, s3Service, s3SourceConfig, pluginMetrics, backoff);
+        return new SqsWorker(acknowledgementSetManager, sqsClient, s3Service, s3SourceConfig, pluginMetrics, s3EventMessageParser, backoff);
     }
 
     @AfterEach

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3EventMessageParser.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3EventMessageParser.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Handles parsing of S3 Event messages.
+ */
+public class S3EventMessageParser {
+    private static final String SNS_MESSAGE_KEY = "Message";
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Parses a message body into an {@link S3EventNotification} class.
+     *
+     * @param messageBody Input body
+     * @return The parsed event notification
+     * @throws JsonProcessingException An exception with parsing the event notification.
+     */
+    S3EventNotification parseMessage(final String messageBody) throws JsonProcessingException {
+        final JsonNode parsedNode = objectMapper.readTree(messageBody);
+
+        final JsonNode eventNode = getS3EventNode(parsedNode);
+
+        return objectMapper.treeToValue(eventNode, S3EventNotification.class);
+    }
+
+    private JsonNode getS3EventNode(final JsonNode parsedNode) throws JsonProcessingException {
+        if(isSnsWrappedMessage(parsedNode)) {
+            final String messageString = parsedNode.get(SNS_MESSAGE_KEY).asText();
+            return objectMapper.readValue(messageString, JsonNode.class);
+        }
+
+        return parsedNode;
+    }
+
+    private boolean isSnsWrappedMessage(final JsonNode parsedNode) {
+        return parsedNode.has(SNS_MESSAGE_KEY);
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3EventNotification.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3EventNotification.java
@@ -20,7 +20,7 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
 /**
  * A helper class that represents a strongly typed S3 EventNotification item sent
  * to SQS, SNS, or Lambda.
- *
+ * <p>
  * This class is derived from <code>S3EventNotification</code> in the AWS SDKv1 for Java.
  */
 public class S3EventNotification {
@@ -32,30 +32,6 @@ public class S3EventNotification {
       @JsonProperty(value = "Records") List<S3EventNotificationRecord> records)
   {
     this.records = records;
-  }
-
-  /**
-   * <p>
-   * Parse the JSON string into a S3EventNotification object.
-   * </p>
-   * <p>
-   * The function will try its best to parse input JSON string as best as it can.
-   * It will not fail even if the JSON string contains unknown properties.
-   * The function will throw SdkClientException if the input JSON string is
-   * not valid JSON.
-   * </p>
-   * @param json
-   *         JSON string to parse. Typically this is the body of your SQS
-   *         notification message body.
-   *
-   * @return The resulting S3EventNotification object.
-   */
-  public static S3EventNotification parseJson(String json) throws JsonProcessingException {
-    if (json == null) {
-      return null;
-    }
-    final ObjectMapper objectMapper = new ObjectMapper();
-    return objectMapper.readValue(json, S3EventNotification.class);
   }
 
   /**

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3EventNotification.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3EventNotification.java
@@ -5,17 +5,14 @@
 
 package org.opensearch.dataprepper.plugins.source;
 
-import java.util.List;
-
-import org.joda.time.DateTime;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.joda.time.DateTime;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
+
+import java.util.List;
 
 /**
  * A helper class that represents a strongly typed S3 EventNotification item sent

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsService.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsService.java
@@ -27,6 +27,7 @@ public class SqsService {
     private final SqsClient sqsClient;
     private final PluginMetrics pluginMetrics;
     private final AcknowledgementSetManager acknowledgementSetManager;
+    private final S3EventMessageParser s3EventMessageParser;
 
     private Thread sqsWorkerThread;
 
@@ -39,12 +40,13 @@ public class SqsService {
         this.pluginMetrics = pluginMetrics;
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.sqsClient = createSqsClient();
+        s3EventMessageParser = new S3EventMessageParser();
     }
 
     public void start() {
         final Backoff backoff = Backoff.exponential(INITIAL_DELAY, MAXIMUM_DELAY).withJitter(JITTER_RATE)
                 .withMaxAttempts(Integer.MAX_VALUE);
-        sqsWorkerThread = new Thread(new SqsWorker(acknowledgementSetManager, sqsClient, s3Accessor, s3SourceConfig, pluginMetrics, backoff));
+        sqsWorkerThread = new Thread(new SqsWorker(acknowledgementSetManager, sqsClient, s3Accessor, s3SourceConfig, pluginMetrics, s3EventMessageParser, backoff));
         sqsWorkerThread.start();
     }
 

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3EventMessageParserTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3EventMessageParserTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class S3EventMessageParserTest {
+    private static final String DIRECT_SQS_MESSAGE =
+            "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-east-1\",\"eventTime\":\"2023-04-28T16:00:11.324Z\"," +
+                    "\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:xyz\"},\"requestParameters\":{\"sourceIPAddress\":\"127.0.0.1\"}," +
+                    "\"responseElements\":{\"x-amz-request-id\":\"xyz\",\"x-amz-id-2\":\"xyz\"},\"s3\":{\"s3SchemaVersion\":\"1.0\"," +
+                    "\"configurationId\":\"xyz\",\"bucket\":{\"name\":\"my-bucket\",\"ownerIdentity\":{\"principalId\":\"ABC\"}," +
+                    "\"arn\":\"arn:aws:s3:::my-bucket\"},\"object\":{\"key\":\"path/to/myfile.log.gz\",\"size\":3159112,\"eTag\":\"abcd123\"," +
+                    "\"sequencer\":\"000\"}}}]}";
+
+    private static final String SNS_BASED_MESSAGE = "{\n" +
+            "  \"Type\" : \"Notification\",\n" +
+            "  \"MessageId\" : \"4e01e115-5b91-5096-8a74-bee95ed1e123\",\n" +
+            "  \"TopicArn\" : \"arn:aws:sns:us-east-1:123456789012:notifications\",\n" +
+            "  \"Subject\" : \"Amazon S3 Notification\",\n" +
+            "  \"Message\" : \"{\\\"Records\\\":[{\\\"eventVersion\\\":\\\"2.1\\\",\\\"eventSource\\\":\\\"aws:s3\\\",\\\"awsRegion\\\":\\\"us-east-1\\\",\\\"eventTime\\\":\\\"2023-05-02T13:37:03.502Z\\\",\\\"eventName\\\":\\\"ObjectCreated:Put\\\",\\\"userIdentity\\\":{\\\"principalId\\\":\\\"AWS:ABC\\\"},\\\"requestParameters\\\":{\\\"sourceIPAddress\\\":\\\"127.0.0.1\\\"},\\\"responseElements\\\":{\\\"x-amz-request-id\\\":\\\"ABC\\\",\\\"x-amz-id-2\\\":\\\"ABC\\\"},\\\"s3\\\":{\\\"s3SchemaVersion\\\":\\\"1.0\\\",\\\"configurationId\\\":\\\"S3ToSnsTest\\\",\\\"bucket\\\":{\\\"name\\\":\\\"my-sns-bucket\\\",\\\"ownerIdentity\\\":{\\\"principalId\\\":\\\"ABC\\\"},\\\"arn\\\":\\\"arn:aws:s3:::my-sns-bucket\\\"},\\\"object\\\":{\\\"key\\\":\\\"path/to/testlogs.log.gz\\\",\\\"size\\\":25,\\\"eTag\\\":\\\"abc\\\",\\\"sequencer\\\":\\\"ABC\\\"}}}]}\",\n" +
+            "  \"Timestamp\" : \"2023-05-02T13:37:04.554Z\",\n" +
+            "  \"SignatureVersion\" : \"1\",\n" +
+            "  \"Signature\" : \"x//abcde==\",\n" +
+            "  \"SigningCertURL\" : \"https://sns.us-east-1.amazonaws.com/SimpleNotificationService.pem\",\n" +
+            "  \"UnsubscribeURL\" : \"https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:notifications:abc\"\n" +
+            "}";
+
+    private S3EventMessageParser createObjectUnderTest() {
+        return new S3EventMessageParser();
+    }
+
+    @Test
+    void parseMessage_returns_expected_S3EventNotification_from_SQS_message() throws JsonProcessingException {
+        final S3EventNotification s3EventNotification = createObjectUnderTest().parseMessage(DIRECT_SQS_MESSAGE);
+
+        assertThat(s3EventNotification, notNullValue());
+        assertThat(s3EventNotification.getRecords(), notNullValue());
+        assertThat(s3EventNotification.getRecords(), hasSize(1));
+        final S3EventNotification.S3EventNotificationRecord s3EventNotificationRecord = s3EventNotification.getRecords().get(0);
+        assertThat(s3EventNotificationRecord, notNullValue());
+        assertThat(s3EventNotificationRecord.getEventName(), equalTo("ObjectCreated:Put"));
+        assertThat(s3EventNotificationRecord.getS3(), notNullValue());
+        assertThat(s3EventNotificationRecord.getS3().getBucket(), notNullValue());
+        assertThat(s3EventNotificationRecord.getS3().getBucket().getName(), equalTo("my-bucket"));
+        assertThat(s3EventNotificationRecord.getS3().getObject(), notNullValue());
+        assertThat(s3EventNotificationRecord.getS3().getObject().getKey(), equalTo("path/to/myfile.log.gz"));
+    }
+
+    @Test
+    void parseMessage_returns_expected_S3EventNotification_from_SNS_to_SQS_message() throws JsonProcessingException {
+        final S3EventNotification s3EventNotification = createObjectUnderTest().parseMessage(SNS_BASED_MESSAGE);
+
+        assertThat(s3EventNotification, notNullValue());
+        assertThat(s3EventNotification.getRecords(), notNullValue());
+        assertThat(s3EventNotification.getRecords(), hasSize(1));
+        final S3EventNotification.S3EventNotificationRecord s3EventNotificationRecord = s3EventNotification.getRecords().get(0);
+        assertThat(s3EventNotificationRecord, notNullValue());
+        assertThat(s3EventNotificationRecord.getEventName(), equalTo("ObjectCreated:Put"));
+        assertThat(s3EventNotificationRecord.getS3(), notNullValue());
+        assertThat(s3EventNotificationRecord.getS3().getBucket(), notNullValue());
+        assertThat(s3EventNotificationRecord.getS3().getBucket().getName(), equalTo("my-sns-bucket"));
+        assertThat(s3EventNotificationRecord.getS3().getObject(), notNullValue());
+        assertThat(s3EventNotificationRecord.getS3().getObject().getKey(), equalTo("path/to/testlogs.log.gz"));
+    }
+
+    @Test
+    void parseMessage_throws_for_TestEvent() {
+        final String testEventMessage = "{\"Service\":\"Amazon S3\",\"Event\":\"s3:TestEvent\",\"Time\":\"2022-10-15T16:36:25.510Z\"," +
+                "\"Bucket\":\"bucketname\",\"RequestId\":\"abcdefg\",\"HostId\":\"hijklm\"}";
+
+        final S3EventMessageParser objectUnderTest = createObjectUnderTest();
+
+        assertThrows(JsonProcessingException.class, () -> objectUnderTest.parseMessage(testEventMessage));
+    }
+}


### PR DESCRIPTION
### Description

Adds a new class for parsing for S3 Event notifications. Detect if the message was wrapped by SNS to SQS by checking for the presence of a `Message` key. Then parse that as a string.
 
### Issues Resolved

Resolves #2604 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
