### PR TITLE
Tagging Events in Data Prepper. Issue #629

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventMetadata.java
@@ -78,7 +78,7 @@ public class DefaultEventMetadata implements EventMetadata {
     }
 
     @Override
-    public void setTag(final String tag) {
+    public void addTag(final String tag) {
         tags.add(tag);
     }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventMetadata.java
@@ -10,6 +10,8 @@ import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.HashSet;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -27,6 +29,8 @@ public class DefaultEventMetadata implements EventMetadata {
 
     private final ImmutableMap<String, Object> attributes;
 
+    private Set<String> tags;
+
     private DefaultEventMetadata(final Builder builder) {
 
         checkNotNull(builder.eventType, "eventType cannot be null");
@@ -37,12 +41,15 @@ public class DefaultEventMetadata implements EventMetadata {
         this.timeReceived = builder.timeReceived == null ? Instant.now() : builder.timeReceived;
 
         this.attributes = builder.attributes == null ? ImmutableMap.of() : ImmutableMap.copyOf(builder.attributes);
+
+        this.tags = builder.tags == null ? new HashSet<>() : new HashSet(builder.tags);
     }
 
     private DefaultEventMetadata(final EventMetadata eventMetadata) {
         this.eventType = eventMetadata.getEventType();
         this.timeReceived = eventMetadata.getTimeReceived();
         this.attributes = ImmutableMap.copyOf(eventMetadata.getAttributes());
+        this.tags = new HashSet<>(eventMetadata.getTags());
     }
 
     @Override
@@ -61,13 +68,29 @@ public class DefaultEventMetadata implements EventMetadata {
     }
 
     @Override
+    public Set<String> getTags() {
+        return tags;
+    }
+
+    @Override
+    public Boolean hasTag(final String tag) {
+        return tags.contains(tag);
+    }
+
+    @Override
+    public void setTag(final String tag) {
+        tags.add(tag);
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         final DefaultEventMetadata that = (DefaultEventMetadata) o;
         return Objects.equals(eventType, that.eventType)
                 && Objects.equals(timeReceived, that.timeReceived)
-                && Objects.equals(attributes, that.attributes);
+                && Objects.equals(attributes, that.attributes)
+                && Objects.equals(tags, that.tags);
     }
 
     @Override
@@ -81,6 +104,7 @@ public class DefaultEventMetadata implements EventMetadata {
                 "eventType='" + eventType + '\'' +
                 ", timeReceived=" + timeReceived +
                 ", attributes=" + attributes +
+                ", tags=" + tags +
                 '}';
     }
 
@@ -106,6 +130,7 @@ public class DefaultEventMetadata implements EventMetadata {
         private String eventType;
         private Instant timeReceived;
         private Map<String, Object> attributes;
+        private Set<String> tags;
 
         /**
          * Sets the event type. A non-null or empty event type is required, otherwise it will cause {@link #build()} to fail.
@@ -137,6 +162,17 @@ public class DefaultEventMetadata implements EventMetadata {
          */
         public Builder withAttributes(final Map<String, Object> attributes) {
             this.attributes = attributes;
+            return this;
+        }
+
+        /**
+         * Sets the tags. An empty set is the default value.
+         * @param tags a set of string tags
+         * @return returns the builder
+         * @since 2.3
+         */
+        public Builder withTags(final Set<String> tags) {
+            this.tags = tags;
             return this;
         }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
@@ -68,6 +68,14 @@ public interface Event extends Serializable {
     String toJsonString();
 
     /**
+     * Generates a serialized Json string of the entire Event
+     * @param tagsKey key name for tags
+     * @return Json string of the event with Tags under key
+     * @since 2.3
+     */
+    String toJsonStringWithTags(final String tagsKey);
+
+    /**
      * Gets a serialized Json string of the specific key in the Event
      * @param key the field to be returned
      * @return Json string of the field

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
@@ -68,14 +68,6 @@ public interface Event extends Serializable {
     String toJsonString();
 
     /**
-     * Generates a serialized Json string of the entire Event
-     * @param tagsKey key name for tags
-     * @return Json string of the event with Tags under key
-     * @since 2.3
-     */
-    String toJsonStringWithTags(final String tagsKey);
-
-    /**
      * Gets a serialized Json string of the specific key in the Event
      * @param key the field to be returned
      * @return Json string of the field

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventMetadata.java
@@ -53,8 +53,8 @@ public interface EventMetadata extends Serializable {
     Boolean hasTag(final String tag);
 
     /**
-     * Returns the attributes
-     * @param tag to be set
+     * Adds a tag to the Metadata
+     * @param tag to be added
      * @since 2.3
      */
     void addTag(final String tag);

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventMetadata.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.model.event;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The event metadata contains internal event fields. These fields are used only within Data Prepper, and are not passed down to Sinks.
@@ -35,4 +36,26 @@ public interface EventMetadata extends Serializable {
      * @since 1.2
      */
     Map<String, Object> getAttributes();
+
+    /**
+     * Returns the tags
+     * @return a set of tags
+     * @since 2.3
+     */
+    Set<String> getTags();
+
+    /**
+     * Indicates if a tag is present
+     * @param tag name of the tag to be looked up
+     * @return true if the tag is present, false otherwise
+     * @since 2.3
+     */
+    Boolean hasTag(final String tag);
+
+    /**
+     * Returns the attributes
+     * @param tag to be set
+     * @since 2.3
+     */
+    void setTag(final String tag);
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventMetadata.java
@@ -57,5 +57,5 @@ public interface EventMetadata extends Serializable {
      * @param tag to be set
      * @since 2.3
      */
-    void setTag(final String tag);
+    void addTag(final String tag);
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -277,6 +277,12 @@ public class JacksonEvent implements Event {
     }
 
     @Override
+    public String toJsonStringWithTags(final String tagsKey) {
+        String result = jsonNode.toString();
+        return result.substring(0, result.length()-1) + ",\""+tagsKey+"\":"+ getMetadata().getTags()+"}";
+    }
+
+    @Override
     public String getAsJsonString(final String key) {
         final String trimmedKey = checkAndTrimKey(key);
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -277,20 +277,6 @@ public class JacksonEvent implements Event {
     }
 
     @Override
-    public String toJsonStringWithTags(final String tagsKey) {
-        String result = jsonNode.toString();
-        String separator = "";
-
-        result = result.substring(0, result.length()-1) + ",\"tags\":[";
-        for (final String tag: getMetadata().getTags()) {
-            result += separator + "\"" + tag + "\"";
-            separator = ", ";
-        }
-        result += "]}";
-        return result;
-    }
-
-    @Override
     public String getAsJsonString(final String key) {
         final String trimmedKey = checkAndTrimKey(key);
 
@@ -430,6 +416,10 @@ public class JacksonEvent implements Event {
         };
     }
 
+    public static JsonStringBuilder jsonBuilder() {
+        return new JsonStringBuilder();
+    }
+
     public static JacksonEvent fromEvent(final Event event) {
         if (event instanceof JacksonEvent) {
             return new JacksonEvent((JacksonEvent) event);
@@ -524,6 +514,33 @@ public class JacksonEvent implements Event {
          */
         public JacksonEvent build() {
             return new JacksonEvent(this);
+        }
+    }
+
+    public static class JsonStringBuilder {
+        private String tagsKey;
+        private JacksonEvent event;
+
+        public JsonStringBuilder withEvent(final JacksonEvent event) {
+            this.event = event;
+            return this;
+        }
+
+        public JsonStringBuilder includeTags(String key) {
+            tagsKey = key;
+            return this;
+        }
+
+        public String toJsonString() {
+            if (event == null) {
+                return null;
+            }
+            final String jsonString = event.toJsonString().trim();
+            if(tagsKey != null) {
+                final JsonNode tagsNode = mapper.valueToTree(event.getMetadata().getTags());
+                return jsonString.substring(0, jsonString.length()-1) + ",\""+tagsKey+"\":" + tagsNode.toString()+"}";
+            }
+            return jsonString;
         }
     }
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -279,7 +279,15 @@ public class JacksonEvent implements Event {
     @Override
     public String toJsonStringWithTags(final String tagsKey) {
         String result = jsonNode.toString();
-        return result.substring(0, result.length()-1) + ",\""+tagsKey+"\":"+ getMetadata().getTags()+"}";
+        String separator = "";
+
+        result = result.substring(0, result.length()-1) + ",\"tags\":[";
+        for (final String tag: getMetadata().getTags()) {
+            result += separator + "\"" + tag + "\"";
+            separator = ", ";
+        }
+        result += "]}";
+        return result;
     }
 
     @Override

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.allOf;
@@ -28,6 +29,7 @@ import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -173,6 +175,25 @@ public class DefaultEventMetadataTest {
         assertThat(copiedMetadata.getTimeReceived(), equalTo(timeReceived));
         assertThat(copiedMetadata.getAttributes(), equalTo(attributes));
         assertThat(copiedMetadata.getAttributes(), not(sameInstance(attributes)));
+    }
+
+    @Test
+    public void testBuild_withTags() {
+        final String testEventType = UUID.randomUUID().toString();
+
+        final Set<String> testTags = Set.of("tag1", "tag2");
+        final EventMetadata result = DefaultEventMetadata.builder()
+                .withEventType(testEventType)
+                .withTags(testTags)
+                .build();
+
+        assertThat(result, notNullValue());
+
+        assertThat(result.getTags(), equalTo(testTags));
+        result.setTag("tag3");
+        assertTrue(result.hasTag("tag1"));
+        assertTrue(result.hasTag("tag2"));
+        assertTrue(result.hasTag("tag3"));
     }
 
     @Nested

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
@@ -190,7 +190,7 @@ public class DefaultEventMetadataTest {
         assertThat(result, notNullValue());
 
         assertThat(result.getTags(), equalTo(testTags));
-        result.setTag("tag3");
+        result.addTag("tag3");
         assertTrue(result.hasTag("tag1"));
         assertTrue(result.hasTag("tag2"));
         assertTrue(result.hasTag("tag3"));

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -638,6 +638,21 @@ public class JacksonEventTest {
         assertThat(event.getEventHandle(), equalTo(testEventHandle));
     }
 
+    @Test
+    void testEventToJsonStringWithTags() {
+        final String jsonString = "{\"foo\": \"bar\"}";
+
+        final JacksonEvent event = JacksonEvent.builder()
+                .withEventType(eventType)
+                .withData(jsonString)
+                .build();
+        final EventMetadata eventMetadata = event.getMetadata();
+        eventMetadata.setTag("tag1");
+        eventMetadata.setTag("tag2");
+        final String expectedJsonString = "{\"foo\":\"bar\",\"tags\":[tag1, tag2]}";
+        assertThat(event.toJsonStringWithTags("tags"), equalTo(expectedJsonString));
+    }
+
     private static Map<String, Object> createComplexDataMap() {
         final Map<String, Object> dataObject = new HashMap<>();
         final int fullDepth = 6;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -639,8 +639,8 @@ public class JacksonEventTest {
     }
 
     @Test
-    void testEventToJsonStringWithTags() {
-        final String jsonString = "{\"foo\": \"bar\"}";
+    void testJsonStringBuilder() {
+        final String jsonString = "{\"foo\":\"bar\"}";
 
         final JacksonEvent event = JacksonEvent.builder()
                 .withEventType(eventType)
@@ -649,8 +649,10 @@ public class JacksonEventTest {
         final EventMetadata eventMetadata = event.getMetadata();
         eventMetadata.addTag("tag1");
         eventMetadata.addTag("tag2");
-        final String expectedJsonString = "{\"foo\":\"bar\",\"tags\":[\"tag1\", \"tag2\"]}";
-        assertThat(event.toJsonStringWithTags("tags"), equalTo(expectedJsonString));
+        final String expectedJsonString = "{\"foo\":\"bar\",\"tags\":[\"tag1\",\"tag2\"]}";
+        assertThat(JacksonEvent.jsonBuilder().withEvent(event).includeTags("tags").toJsonString(), equalTo(expectedJsonString));
+        assertThat(JacksonEvent.jsonBuilder().withEvent(event).toJsonString(), equalTo(jsonString));
+        assertThat(JacksonEvent.jsonBuilder().toJsonString(), equalTo(null));
     }
 
     private static Map<String, Object> createComplexDataMap() {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -647,9 +647,9 @@ public class JacksonEventTest {
                 .withData(jsonString)
                 .build();
         final EventMetadata eventMetadata = event.getMetadata();
-        eventMetadata.setTag("tag1");
-        eventMetadata.setTag("tag2");
-        final String expectedJsonString = "{\"foo\":\"bar\",\"tags\":[tag1, tag2]}";
+        eventMetadata.addTag("tag1");
+        eventMetadata.addTag("tag2");
+        final String expectedJsonString = "{\"foo\":\"bar\",\"tags\":[\"tag1\", \"tag2\"]}";
         assertThat(event.toJsonStringWithTags("tags"), equalTo(expectedJsonString));
     }
 


### PR DESCRIPTION
### Description
Added support to add tags to events.
Tags can be added at the time of creation of a event or after creating it. The tags are added to event meta data as per the discussion in issue #629.

Resolves #629 
 
### Issues Resolved
#629 
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
