### PR TITLE
Update json-java to address CVE-2022-45688

### DIFF
--- a/data-prepper-plugins/avro-codecs/build.gradle
+++ b/data-prepper-plugins/avro-codecs/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation project(path: ':data-prepper-api')
     implementation 'org.apache.avro:avro:1.11.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    testImplementation 'org.json:json:20180130'
+    testImplementation 'org.json:json:20230227'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 }
 


### PR DESCRIPTION
### Description
Update json-java to address CVE-2022-45688
 
### Issues Resolved
Fixes #2615 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
