### PR TITLE
Updates Jackson to 2.15 and Snakeyaml to 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ subprojects {
         }
     }
     dependencies {
-        implementation platform('com.fasterxml.jackson:jackson-bom:2.14.1')
+        implementation platform('com.fasterxml.jackson:jackson-bom:2.15.0')
         implementation platform('io.micrometer:micrometer-bom:1.10.5')
         implementation libs.guava.core
         implementation libs.slf4j.api
@@ -119,6 +119,12 @@ subprojects {
                     require '3.21.11'
                 }
                 because 'Fixes CVE-2022-3509, CVE-2022-3510'
+            }
+            implementation('org.yaml:snakeyaml') {
+                version {
+                    require '2.0'
+                }
+                because 'Fixes CVE-2022-1471'
             }
         }
     }


### PR DESCRIPTION
### Description

Updates Jackson to 2.15.0 which uses Snakeyaml 2.0.

Require Snakeyaml 2.0 in any other projects which include it as a transitive dependency.

This should resolve security warnings on CVE-2022-1471. However, according to the Jackson team, Jackson was already not vulnerable to this CVE.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
