### PR TITLE
 Updates the example Spring Boot application to Spring Boot 2.7.11

### DIFF
--- a/examples/trace-analytics-sample-app/sample-app/analytics-service/build.gradle
+++ b/examples/trace-analytics-sample-app/sample-app/analytics-service/build.gradle
@@ -5,14 +5,14 @@
 
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.3'
-    id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+    id 'org.springframework.boot' version '2.7.11'
+    id 'io.spring.dependency-management' version '1.1.0'
 }
 
 
 group = 'com.example.restservice'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '1.8'
+sourceCompatibility = '11'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
### Description

This updates the example Spring Boot application.
* Spring Boot 2.7.11 from 2.7.3
* Spring Dependency plugin 1.1.0 from 1.0.9
* Java 11 from Java 8

This should resolve CVE-2023-20863, CVE-2022-45143.
 
Some dependency updates:

```
\--- org.springframework.boot:spring-boot-starter-web -> 2.7.11
     +--- org.springframework.boot:spring-boot-starter:2.7.11
     |    +--- org.springframework.boot:spring-boot:2.7.11
     |    |    +--- org.springframework:spring-core:5.3.27
```

```
     +--- org.springframework.boot:spring-boot-starter-tomcat:2.7.11
     |    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
     |    +--- org.apache.tomcat.embed:tomcat-embed-core:9.0.74
     |    +--- org.apache.tomcat.embed:tomcat-embed-el:9.0.74
     |    \--- org.apache.tomcat.embed:tomcat-embed-websocket:9.0.74
     |         \--- org.apache.tomcat.embed:tomcat-embed-core:9.0.74
```

### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
