### PR TITLE
Update to use Jetty 11.0.14 in the s3-source project to fix 

### DIFF
--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -29,13 +29,21 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.2'
     implementation 'org.xerial.snappy:snappy-java:1.1.9.1'
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
-    testImplementation 'com.github.tomakehurst:wiremock:3.0.0-beta-7'
+    testImplementation 'com.github.tomakehurst:wiremock:3.0.0-beta-8'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation project(':data-prepper-test-common')
     testImplementation project(':data-prepper-plugins:csv-processor')
     testImplementation project(':data-prepper-plugins:parse-json-processor')
     testImplementation project(':data-prepper-plugins:newline-codecs')
     testImplementation project(':data-prepper-plugins:avro-codecs')
+    constraints {
+        testImplementation('org.eclipse.jetty:jetty-bom') {
+            version {
+                require '11.0.14'
+            }
+            because 'Fixes CVE-2023-26048'
+        }
+    }
 }
 
 test {


### PR DESCRIPTION
### Description

Require using Jetty 11.0.14 in the `s3-source` plugin.

Update to use wiremock 3.0.0-beta-8 in the `s3-source` plugin.

Jetty 11.0.4 resolves CVE-2023-26048.
 
Relevant dependency output:

```
+--- com.github.tomakehurst:wiremock:3.0.0-beta-8
|    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.7
|    +--- org.eclipse.jetty:jetty-bom:11.0.12 -> 11.0.14
|    |    +--- org.eclipse.jetty:jetty-alpn-client:11.0.14 (c)
|    |    +--- org.eclipse.jetty:jetty-alpn-java-client:11.0.14 (c)
|    |    +--- org.eclipse.jetty:jetty-alpn-java-server:11.0.14 (c)
|    |    +--- org.eclipse.jetty:jetty-alpn-server:11.0.14 (c)
|    |    +--- org.eclipse.jetty.http2:http2-server:11.0.14 (c)
|    |    +--- org.eclipse.jetty:jetty-proxy:11.0.14 (c)
|    |    +--- org.eclipse.jetty:jetty-server:11.0.14 (c)
|    |    +--- org.eclipse.jetty:jetty-servlet:11.0.14 (c)
|    |    +--- org.eclipse.jetty:jetty-servlets:11.0.14 (c)
|    |    +--- org.eclipse.jetty:jetty-webapp:11.0.14 (c)
|    |    +--- org.eclipse.jetty:jetty-io:11.0.14 (c)
|    |    +--- org.eclipse.jetty.http2:http2-common:11.0.14 (c)
|    |    +--- org.eclipse.jetty:jetty-util:11.0.14 (c)
|    |    +--- org.eclipse.jetty:jetty-client:11.0.14 (c)
|    |    +--- org.eclipse.jetty:jetty-http:11.0.14 (c)
|    |    +--- org.eclipse.jetty:jetty-security:11.0.14 (c)
|    |    +--- org.eclipse.jetty:jetty-xml:11.0.14 (c)
|    |    \--- org.eclipse.jetty.http2:http2-hpack:11.0.14 (c)
|    +--- org.eclipse.jetty:jetty-server -> 11.0.14
|    |    +--- org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:5.0.2
|    |    +--- org.eclipse.jetty:jetty-http:11.0.14
|    |    |    +--- org.eclipse.jetty:jetty-util:11.0.14
|    |    |    |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    |    |    +--- org.eclipse.jetty:jetty-io:11.0.14
|    |    |    |    +--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    |    |    |    \--- org.eclipse.jetty:jetty-util:11.0.14 (*)
|    |    |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    |    +--- org.eclipse.jetty:jetty-io:11.0.14 (*)
|    |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    +--- org.eclipse.jetty:jetty-servlet -> 11.0.14
|    |    +--- org.eclipse.jetty:jetty-security:11.0.14
|    |    |    +--- org.eclipse.jetty:jetty-server:11.0.14 (*)
|    |    |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    +--- org.eclipse.jetty:jetty-servlets -> 11.0.14
|    |    +--- org.eclipse.jetty:jetty-http:11.0.14 (*)
|    |    +--- org.eclipse.jetty:jetty-util:11.0.14 (*)
|    |    +--- org.eclipse.jetty:jetty-io:11.0.14 (*)
|    |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    +--- org.eclipse.jetty:jetty-webapp -> 11.0.14
|    |    +--- org.eclipse.jetty:jetty-servlet:11.0.14 (*)
|    |    +--- org.eclipse.jetty:jetty-xml:11.0.14
|    |    |    +--- org.eclipse.jetty:jetty-util:11.0.14 (*)
|    |    |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    +--- org.eclipse.jetty:jetty-proxy -> 11.0.14
|    |    +--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    |    +--- org.eclipse.jetty:jetty-util:11.0.14 (*)
|    |    \--- org.eclipse.jetty:jetty-client:11.0.14
|    |         +--- org.eclipse.jetty:jetty-http:11.0.14 (*)
|    |         +--- org.eclipse.jetty:jetty-io:11.0.14 (*)
|    |         +--- org.eclipse.jetty:jetty-alpn-client:11.0.14
|    |         |    +--- org.eclipse.jetty:jetty-io:11.0.14 (*)
|    |         |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    |         \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    +--- org.eclipse.jetty.http2:http2-server -> 11.0.14
|    |    +--- org.eclipse.jetty.http2:http2-common:11.0.14
|    |    |    +--- org.eclipse.jetty.http2:http2-hpack:11.0.14
|    |    |    |    +--- org.eclipse.jetty:jetty-util:11.0.14 (*)
|    |    |    |    +--- org.eclipse.jetty:jetty-http:11.0.14 (*)
|    |    |    |    +--- org.eclipse.jetty:jetty-io:11.0.14 (*)
|    |    |    |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    |    |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    |    +--- org.eclipse.jetty:jetty-server:11.0.14 (*)
|    |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    +--- org.eclipse.jetty:jetty-alpn-server -> 11.0.14
|    |    +--- org.eclipse.jetty:jetty-server:11.0.14 (*)
|    |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    +--- org.eclipse.jetty:jetty-alpn-java-server -> 11.0.14
|    |    +--- org.eclipse.jetty:jetty-io:11.0.14 (*)
|    |    +--- org.eclipse.jetty:jetty-alpn-server:11.0.14 (*)
|    |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
|    +--- org.eclipse.jetty:jetty-alpn-java-client -> 11.0.14
|    |    +--- org.eclipse.jetty:jetty-alpn-client:11.0.14 (*)
|    |    \--- org.slf4j:slf4j-api:2.0.5 -> 2.0.7
```

### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
