### PR TITLE
Support functions in Data Prepper expressions #2626

### DIFF
--- a/data-prepper-expression/build.gradle
+++ b/data-prepper-expression/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-slf4j2-impl'
     testImplementation testLibs.spring.test
+    testImplementation "org.apache.commons:commons-lang3:3.12.0"
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 

--- a/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
+++ b/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
@@ -86,7 +86,6 @@ setInitializer
     : LBRACE primary (SET_DELIMITER primary)* RBRACE
     ;
 
-
 unaryOperator
     : NOT
     | SUBTRACT
@@ -94,6 +93,7 @@ unaryOperator
 
 primary
     : jsonPointer
+    | function
     | variableIdentifier
     | setInitializer
     | literal
@@ -102,6 +102,25 @@ primary
 jsonPointer
     : JsonPointer
     | EscapedJsonPointer
+    ;
+
+function
+    : Function
+    ;
+
+Function
+    : JsonPointerCharacters LPAREN FunctionArgs RPAREN
+    ;
+
+fragment
+FunctionArgs
+    : (FunctionArg SPACE* COMMA)* SPACE* FunctionArg
+    ;
+
+fragment
+FunctionArg
+    : JsonPointer
+    | String
     ;
 
 variableIdentifier
@@ -227,7 +246,10 @@ EscapeSequence
     : '\\' [btnfr"'\\$]
     ;
 
-SET_DELIMITER : ',';
+SET_DELIMITER
+    : COMMA
+    ;
+COMMA : ',';
 EQUAL : '==';
 NOT_EQUAL : '!=';
 LT : '<';

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListenerTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorListenerTest.java
@@ -12,6 +12,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -127,6 +128,22 @@ class ParseTreeEvaluatorListenerTest {
         final Event testEvent = createTestEvent(data);
         final String equalStatement = String.format("/%s == %d", testKey, testValue);
         final String notEqualStatement = String.format("/%s != %d", testKey, testValue + 1);
+        assertThat(evaluateStatementOnEvent(equalStatement, testEvent), is(true));
+        assertThat(evaluateStatementOnEvent(notEqualStatement, testEvent), is(true));
+    }
+
+    @Test
+    void testSimpleEqualityOperatorExpressionWithFunctionType() {
+        final String testKey = RandomStringUtils.randomAlphabetic(5);
+        final String testValue = RandomStringUtils.randomAlphabetic(10);
+        final Map<String, String> data = Map.of(testKey, testValue);
+        final Event testEvent = createTestEvent(data);
+        String equalStatement = String.format("length(/%s) == %d", testKey, testValue.length());
+        String notEqualStatement = String.format("length(/%s) != %d", testKey, testValue.length() + 1);
+        assertThat(evaluateStatementOnEvent(equalStatement, testEvent), is(true));
+        assertThat(evaluateStatementOnEvent(notEqualStatement, testEvent), is(true));
+        equalStatement = String.format("length(\"%s\") == %d", testValue, testValue.length());
+        notEqualStatement = String.format("length(\"%s\") != %d", testValue, testValue.length() + 1);
         assertThat(evaluateStatementOnEvent(equalStatement, testEvent), is(true));
         assertThat(evaluateStatementOnEvent(notEqualStatement, testEvent), is(true));
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeTest.java
@@ -20,6 +20,7 @@ import static org.opensearch.dataprepper.expression.util.ContextMatcher.isExpres
 import static org.opensearch.dataprepper.expression.util.ContextMatcher.isOperator;
 import static org.opensearch.dataprepper.expression.util.ContextMatcherFactory.isParseTree;
 import static org.opensearch.dataprepper.expression.util.JsonPointerMatcher.isJsonPointerUnaryTree;
+import static org.opensearch.dataprepper.expression.util.FunctionMatcher.isFunctionUnaryTree;
 import static org.opensearch.dataprepper.expression.util.LiteralMatcher.isUnaryTree;
 
 class ParseTreeTest extends GrammarTest {
@@ -96,6 +97,22 @@ class ParseTreeTest extends GrammarTest {
                         EQUALITY_OPERATOR_EXPRESSION
                 ).withChildrenMatching(
                         isJsonPointerUnaryTree(),
+                        isOperator(EQUALITY_OPERATOR),
+                        isUnaryTree()
+                )
+        ));
+        assertThat(errorListener.isErrorFound(), is(false));
+    }
+
+    @Test
+    void testFunction() {
+        final ParserRuleContext expression = parseExpression("length(\"abcd\") == 4");
+
+        assertThat(expression, isExpression(isParseTree(
+                        CONDITIONAL_EXPRESSION,
+                        EQUALITY_OPERATOR_EXPRESSION
+                ).withChildrenMatching(
+                        isFunctionUnaryTree(),
                         isOperator(EQUALITY_OPERATOR),
                         isUnaryTree()
                 )

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/FunctionMatcher.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/FunctionMatcher.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression.util;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.hamcrest.Description;
+import org.hamcrest.DiagnosingMatcher;
+import org.hamcrest.Matcher;
+import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
+
+import static org.opensearch.dataprepper.expression.util.ContextMatcher.describeContextTo;
+import static org.opensearch.dataprepper.expression.util.TerminalNodeMatcher.isTerminalNode;
+
+public class FunctionMatcher extends SimpleExpressionMatcher {
+    private static final Matcher<ParseTree> TERMINAL_NODE_MATCHER = isTerminalNode();
+
+    /**
+     * Creates a matcher to check if a nodes is a unary tree with all nodes in a valid order that ends in a json pointer
+     * @return DiagnosingMatcher
+     *
+     * @see TerminalNodeMatcher#isTerminalNode()
+     */
+    public static DiagnosingMatcher<ParseTree> isFunctionUnaryTree() {
+        return new FunctionMatcher(VALID_JSON_POINTER_RULE_ORDER);
+    }
+
+    //region valid rule order
+    private static final RuleClassOrderedList VALID_JSON_POINTER_RULE_ORDER = new RuleClassOrderedList(
+            DataPrepperExpressionParser.ExpressionContext.class,
+            DataPrepperExpressionParser.ConditionalExpressionContext.class,
+            DataPrepperExpressionParser.EqualityOperatorExpressionContext.class,
+            DataPrepperExpressionParser.RegexOperatorExpressionContext.class,
+            DataPrepperExpressionParser.RelationalOperatorExpressionContext.class,
+            DataPrepperExpressionParser.SetOperatorExpressionContext.class,
+            DataPrepperExpressionParser.UnaryOperatorExpressionContext.class,
+            DataPrepperExpressionParser.PrimaryContext.class,
+            DataPrepperExpressionParser.FunctionContext.class
+    );
+    //endregion
+
+    private FunctionMatcher(final RuleClassOrderedList validRuleOrder) {
+        super(validRuleOrder);
+    }
+
+    @Override
+    protected boolean baseCase(final ParseTree item, final Description mismatchDescription) {
+        if (!SINGLE_CHILD_MATCHER.matches(item.getChildCount())) {
+            mismatchDescription.appendText("\n\t\t expected " + item.getText() + " to have 1 child node");
+            describeContextTo(item, mismatchDescription);
+            return false;
+        }
+        else if (!TERMINAL_NODE_MATCHER.matches(item.getChild(0))) {
+            mismatchDescription.appendText("\n\t\t expected " + item.getText() + " child to be of type TerminalNode");
+            describeContextTo(item, mismatchDescription);
+            return false;
+        }
+        else {
+            return true;
+        }
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendText("Expected FunctionContext");
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/FunctionMatcherTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/util/FunctionMatcherTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression.util;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.hamcrest.DiagnosingMatcher;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.opensearch.dataprepper.expression.util.FunctionMatcher.isFunctionUnaryTree;
+
+class FunctionMatcherTest {
+
+    @Test
+    void baseCase() {
+        final DiagnosingMatcher<ParseTree> isFunctionUnaryTree = isFunctionUnaryTree();
+        final ParseTree primary = mock(DataPrepperExpressionParser.PrimaryContext.class, "PrimaryContext");
+        final ParseTree jsonPointer = mock(DataPrepperExpressionParser.FunctionContext.class, "FunctionContext");
+        final ParseTree terminal = mock(TerminalNode.class, "TerminalNode");
+
+        doReturn(1)
+                .when(primary)
+                .getChildCount();
+        doReturn(jsonPointer)
+                .when(primary)
+                .getChild(eq(0));
+        doReturn(1)
+                .when(jsonPointer)
+                .getChildCount();
+        doReturn(terminal)
+                .when(jsonPointer)
+                .getChild(eq(0));
+
+        assertTrue(isFunctionUnaryTree.matches(primary));
+    }
+}
+


### PR DESCRIPTION
### Description
Adds supports for functions in expressions.

Only length() function is supported initially.

Resolves #2626 
 
### Issues Resolved
#2626 
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
