### PR TITLE
Github-issue#1048 : s3-sink with local-file buffer implementation.

### DIFF
--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/S3Sink.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/S3Sink.java
@@ -16,7 +16,9 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.AbstractSink;
 import org.opensearch.dataprepper.model.sink.Sink;
 import org.opensearch.dataprepper.plugins.sink.accumulator.BufferFactory;
+import org.opensearch.dataprepper.plugins.sink.accumulator.BufferTypeOptions;
 import org.opensearch.dataprepper.plugins.sink.accumulator.InMemoryBufferFactory;
+import org.opensearch.dataprepper.plugins.sink.accumulator.LocalFileBufferFactory;
 import org.opensearch.dataprepper.plugins.sink.codec.Codec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +54,11 @@ public class S3Sink extends AbstractSink<Record<Event>> {
         codec = pluginFactory.loadPlugin(Codec.class, codecPluginSettings);
         sinkInitialized = Boolean.FALSE;
 
-        bufferFactory = new InMemoryBufferFactory();
+        if (s3SinkConfig.getBufferType().equals(BufferTypeOptions.LOCALFILE)) {
+            bufferFactory = new LocalFileBufferFactory();
+        } else {
+            bufferFactory = new InMemoryBufferFactory();
+        }
     }
 
     @Override

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/BufferTypeOptions.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/BufferTypeOptions.java
@@ -6,6 +6,9 @@
 package org.opensearch.dataprepper.plugins.sink.accumulator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -16,7 +19,15 @@ import java.util.stream.Collectors;
 public enum BufferTypeOptions {
 
     INMEMORY("in_memory", new InMemoryBuffer()),
-    LOCALFILE("local_file", new LocalFileBuffer());
+    LOCALFILE("local_file", new Object() {
+        LocalFileBuffer evaluate() {
+            try {
+                return new LocalFileBuffer(File.createTempFile("local", null));
+            } catch (IOException e) {
+                return null;
+            }
+        }
+    }.evaluate());
 
     private final String option;
     private final Buffer bufferType;

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/BufferTypeOptions.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/BufferTypeOptions.java
@@ -15,7 +15,8 @@ import java.util.stream.Collectors;
  */
 public enum BufferTypeOptions {
 
-    INMEMORY("in_memory", new InMemoryBuffer());
+    INMEMORY("in_memory", new InMemoryBuffer()),
+    LOCALFILE("local_file", new LocalFileBuffer());
 
     private final String option;
     private final Buffer bufferType;

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/BufferTypeOptions.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/BufferTypeOptions.java
@@ -6,9 +6,6 @@
 package org.opensearch.dataprepper.plugins.sink.accumulator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-
-import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -18,28 +15,20 @@ import java.util.stream.Collectors;
  */
 public enum BufferTypeOptions {
 
-    INMEMORY("in_memory", new InMemoryBuffer()),
-    LOCALFILE("local_file", new Object() {
-        LocalFileBuffer evaluate() {
-            try {
-                return new LocalFileBuffer(File.createTempFile("local", null));
-            } catch (IOException e) {
-                return null;
-            }
-        }
-    }.evaluate());
+    INMEMORY("in_memory", new InMemoryBufferFactory()),
+    LOCALFILE("local_file", new LocalFileBufferFactory());
 
     private final String option;
-    private final Buffer bufferType;
+    private final BufferFactory bufferType;
     private static final Map<String, BufferTypeOptions> OPTIONS_MAP = Arrays.stream(BufferTypeOptions.values())
             .collect(Collectors.toMap(value -> value.option, value -> value));
 
-    BufferTypeOptions(final String option, final Buffer bufferType) {
+    BufferTypeOptions(final String option, final BufferFactory bufferType) {
         this.option = option.toLowerCase();
         this.bufferType = bufferType;
     }
 
-    public Buffer getBufferType() {
+    public BufferFactory getBufferType() {
         return bufferType;
     }
 

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBuffer.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBuffer.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.accumulator;
+
+import org.apache.commons.lang3.time.StopWatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A buffer can hold local file data and flushing it to S3.
+ */
+public class LocalFileBuffer implements Buffer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LocalFileBuffer.class);
+    private BufferedOutputStream bufferedOutputStream;
+    private int eventCount;
+    private final StopWatch watch;
+    private File localFile;
+
+    LocalFileBuffer() {
+        try {
+            localFile = new File(String.valueOf(UUID.randomUUID()));
+            bufferedOutputStream = new BufferedOutputStream(new FileOutputStream(localFile));
+        } catch (IOException e) {
+            LOG.error("Unable to create local file ", e);
+        }
+
+        eventCount = 0;
+
+        watch = new StopWatch();
+        watch.start();
+    }
+
+    @Override
+    public long getSize() {
+        try {
+            bufferedOutputStream.flush();
+        } catch (IOException e) {
+            LOG.error("An exception occurred while flushing data to buffered output stream :", e);
+        }
+        return localFile.length();
+    }
+
+    @Override
+    public int getEventCount() {
+        return eventCount;
+    }
+
+    public long getDuration(){
+        return watch.getTime(TimeUnit.SECONDS);
+    }
+
+    /**
+     * Upload accumulated data to amazon s3
+     * @param s3Client s3 client object.
+     * @param bucket bucket name.
+     * @param key s3 object key path.
+     */
+    @Override
+    public void flushToS3(S3Client s3Client, String bucket, String key) {
+        try {
+            bufferedOutputStream.flush();
+            bufferedOutputStream.close();
+        } catch (IOException e) {
+            LOG.error("An exception occurred while flushing data to buffered output stream :", e);
+        }
+        s3Client.putObject(
+                PutObjectRequest.builder().bucket(bucket).key(key).build(),
+                RequestBody.fromFile(localFile));
+        removeTemporaryFile();
+    }
+
+    /**
+     * write byte array to output stream.
+     * @param bytes byte array.
+     * @throws IOException while writing to output stream fails.
+     */
+    @Override
+    public void writeEvent(byte[] bytes) throws IOException {
+        bufferedOutputStream.write(bytes);
+        bufferedOutputStream.write(System.lineSeparator().getBytes());
+        eventCount++;
+    }
+
+    /**
+     * Remove the local temp file after flushing data to s3.
+     */
+    private void removeTemporaryFile() {
+        if (localFile != null) {
+            try {
+                Files.deleteIfExists(Paths.get(localFile.toString()));
+            } catch (IOException e) {
+                LOG.error("Unable to delete Local file {}", localFile, e);
+            }
+        }
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBuffer.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBuffer.java
@@ -60,6 +60,7 @@ public class LocalFileBuffer implements Buffer {
         return eventCount;
     }
 
+    @Override
     public long getDuration(){
         return watch.getTime(TimeUnit.SECONDS);
     }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBuffer.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBuffer.java
@@ -66,7 +66,7 @@ public class LocalFileBuffer implements Buffer {
     }
 
     /**
-     * Upload accumulated data to amazon s3
+     * Upload accumulated data to amazon s3.
      * @param s3Client s3 client object.
      * @param bucket bucket name.
      * @param key s3 object key path.

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferFactory.java
@@ -5,9 +5,26 @@
 
 package org.opensearch.dataprepper.plugins.sink.accumulator;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+
 public class LocalFileBufferFactory implements BufferFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LocalFileBufferFactory.class);
+    public static final String PREFIX = "local";
     @Override
     public Buffer getBuffer() {
-        return new LocalFileBuffer();
+        File tempFile = null;
+        Buffer localfileBuffer = null;
+        try {
+            tempFile = File.createTempFile(PREFIX, null);
+            localfileBuffer = new LocalFileBuffer(tempFile);
+        } catch (IOException e) {
+            LOG.error("Unable to create temp file ", e);
+        }
+        return localfileBuffer;
     }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferFactory.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.accumulator;
+
+public class LocalFileBufferFactory implements BufferFactory {
+    @Override
+    public Buffer getBuffer() {
+        return new LocalFileBuffer();
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferFactory.java
@@ -7,7 +7,6 @@ package org.opensearch.dataprepper.plugins.sink.accumulator;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.IOException;
 
@@ -15,12 +14,13 @@ public class LocalFileBufferFactory implements BufferFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(LocalFileBufferFactory.class);
     public static final String PREFIX = "local";
+    public static final String SUFFIX = ".log";
     @Override
     public Buffer getBuffer() {
         File tempFile = null;
         Buffer localfileBuffer = null;
         try {
-            tempFile = File.createTempFile(PREFIX, null);
+            tempFile = File.createTempFile(PREFIX, SUFFIX);
             localfileBuffer = new LocalFileBuffer(tempFile);
         } catch (IOException e) {
             LOG.error("Unable to create temp file ", e);

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferFactoryTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferFactoryTest.java
@@ -15,12 +15,14 @@ class LocalFileBufferFactoryTest {
     void test_localFileBufferFactory_notNull() {
         LocalFileBufferFactory localFileBufferFactory = new LocalFileBufferFactory();
         Assertions.assertNotNull(localFileBufferFactory);
+        assertThat(localFileBufferFactory, instanceOf(LocalFileBufferFactory.class));
     }
 
     @Test
     void test_buffer_notNull() {
         LocalFileBufferFactory localFileBufferFactory = new LocalFileBufferFactory();
         Assertions.assertNotNull(localFileBufferFactory);
+        assertThat(localFileBufferFactory, instanceOf(LocalFileBufferFactory.class));
         Buffer buffer = localFileBufferFactory.getBuffer();
         Assertions.assertNotNull(buffer);
         assertThat(buffer, instanceOf(Buffer.class));

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferFactoryTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferFactoryTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.accumulator;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class LocalFileBufferFactoryTest {
+    @Test
+    void test_localFileBufferFactory_notNull() {
+        LocalFileBufferFactory localFileBufferFactory = new LocalFileBufferFactory();
+        Assertions.assertNotNull(localFileBufferFactory);
+    }
+
+    @Test
+    void test_buffer_notNull() {
+        LocalFileBufferFactory localFileBufferFactory = new LocalFileBufferFactory();
+        Assertions.assertNotNull(localFileBufferFactory);
+        Buffer buffer = localFileBufferFactory.getBuffer();
+        Assertions.assertNotNull(buffer);
+        assertThat(buffer, instanceOf(Buffer.class));
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferFactoryTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferFactoryTest.java
@@ -23,7 +23,6 @@ class LocalFileBufferFactoryTest {
         Assertions.assertNotNull(localFileBufferFactory);
         Buffer buffer = localFileBufferFactory.getBuffer();
         Assertions.assertNotNull(buffer);
-        assertThat(buffer, instanceOf(Buffer.class));
         assertThat(buffer, instanceOf(LocalFileBuffer.class));
     }
 }

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferFactoryTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferFactoryTest.java
@@ -15,16 +15,15 @@ class LocalFileBufferFactoryTest {
     void test_localFileBufferFactory_notNull() {
         LocalFileBufferFactory localFileBufferFactory = new LocalFileBufferFactory();
         Assertions.assertNotNull(localFileBufferFactory);
-        assertThat(localFileBufferFactory, instanceOf(LocalFileBufferFactory.class));
     }
 
     @Test
     void test_buffer_notNull() {
         LocalFileBufferFactory localFileBufferFactory = new LocalFileBufferFactory();
         Assertions.assertNotNull(localFileBufferFactory);
-        assertThat(localFileBufferFactory, instanceOf(LocalFileBufferFactory.class));
         Buffer buffer = localFileBufferFactory.getBuffer();
         Assertions.assertNotNull(buffer);
         assertThat(buffer, instanceOf(Buffer.class));
+        assertThat(buffer, instanceOf(LocalFileBuffer.class));
     }
 }

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferTest.java
@@ -1,72 +1,118 @@
 package org.opensearch.dataprepper.plugins.sink.accumulator;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
-
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class LocalFileBufferTest {
 
     public static final String BUCKET_NAME = UUID.randomUUID().toString();
+    public static final String KEY = UUID.randomUUID().toString() + ".temp";
+    public static final String PREFIX = "local";
+    public static final String SUFFIX = ".temp";
     @Mock
     private S3Client s3Client;
     private LocalFileBuffer localFileBuffer;
+    private File tempFile;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tempFile = File.createTempFile(PREFIX, SUFFIX);
+        localFileBuffer = new LocalFileBuffer(tempFile);
+    }
 
     @Test
-    void test_with_write_event_into_buffer() throws IOException {
-        localFileBuffer = new LocalFileBuffer();
-
+    void test_with_write_events_into_buffer() throws IOException {
         while (localFileBuffer.getEventCount() < 55) {
             localFileBuffer.writeEvent(generateByteArray());
         }
         assertThat(localFileBuffer.getSize(), greaterThan(1l));
         assertThat(localFileBuffer.getEventCount(), equalTo(55));
-        assertThat(localFileBuffer.getDuration(), greaterThanOrEqualTo(0L));
+        assertThat(localFileBuffer.getDuration(), equalTo(0L));
+        localFileBuffer.flushAndCloseStream();
+        localFileBuffer.removeTemporaryFile();
+        assertFalse(tempFile.exists(), "The temp file has not been deleted.");
     }
 
     @Test
-    void test_without_write_event_into_buffer() {
-        localFileBuffer = new LocalFileBuffer();
+    void test_without_write_events_into_buffer() {
         assertThat(localFileBuffer.getSize(), equalTo(0L));
         assertThat(localFileBuffer.getEventCount(), equalTo(0));
-        assertThat(localFileBuffer.getDuration(), lessThanOrEqualTo(0L));
-
+        assertThat(localFileBuffer.getDuration(), equalTo(0L));
+        localFileBuffer.flushAndCloseStream();
+        localFileBuffer.removeTemporaryFile();
+        assertFalse(tempFile.exists(), "The temp file has not been deleted.");
     }
 
     @Test
-    void test_with_write_event_into_buffer_and_flush_toS3() throws IOException {
-        localFileBuffer = new LocalFileBuffer();
-
+    void test_with_write_events_into_buffer_and_flush_toS3() throws IOException {
         while (localFileBuffer.getEventCount() < 55) {
             localFileBuffer.writeEvent(generateByteArray());
         }
         assertThat(localFileBuffer.getSize(), greaterThan(1l));
         assertThat(localFileBuffer.getEventCount(), equalTo(55));
         assertThat(localFileBuffer.getDuration(), greaterThanOrEqualTo(0L));
+
         assertDoesNotThrow(() -> {
-            localFileBuffer.flushToS3(s3Client, BUCKET_NAME, "log.txt");
+            localFileBuffer.flushToS3(s3Client, BUCKET_NAME, KEY);
         });
+
+        ArgumentCaptor<PutObjectRequest> putObjectRequestArgumentCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(s3Client).putObject(putObjectRequestArgumentCaptor.capture(), any(RequestBody.class));
+        PutObjectRequest actualRequest = putObjectRequestArgumentCaptor.getValue();
+
+        assertThat(actualRequest, notNullValue());
+        assertThat(actualRequest.bucket(), equalTo(BUCKET_NAME));
+        assertThat(actualRequest.key(), equalTo(KEY));
+        assertThat(actualRequest.expectedBucketOwner(), nullValue());
+
+        assertFalse(tempFile.exists(), "The temp file has not been deleted.");
     }
 
     @Test
     void test_uploadedToS3_success() {
-        localFileBuffer = new LocalFileBuffer();
         Assertions.assertNotNull(localFileBuffer);
         assertDoesNotThrow(() -> {
-            localFileBuffer.flushToS3(s3Client, BUCKET_NAME, "log.txt");
+            localFileBuffer.flushToS3(s3Client, BUCKET_NAME, KEY);
         });
+
+        ArgumentCaptor<PutObjectRequest> putObjectRequestArgumentCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(s3Client).putObject(putObjectRequestArgumentCaptor.capture(), any(RequestBody.class));
+        PutObjectRequest actualRequest = putObjectRequestArgumentCaptor.getValue();
+
+        assertThat(actualRequest, notNullValue());
+        assertThat(actualRequest.bucket(), equalTo(BUCKET_NAME));
+        assertThat(actualRequest.key(), equalTo(KEY));
+        assertThat(actualRequest.expectedBucketOwner(), nullValue());
+
+        assertFalse(tempFile.exists(), "The temp file has not been deleted.");
+    }
+
+    @AfterEach
+    void cleanup() {
+        tempFile.deleteOnExit();
     }
 
     private byte[] generateByteArray() {

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferTest.java
@@ -1,0 +1,79 @@
+package org.opensearch.dataprepper.plugins.sink.accumulator;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.S3Client;
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@ExtendWith(MockitoExtension.class)
+class LocalFileBufferTest {
+
+    public static final String BUCKET_NAME = UUID.randomUUID().toString();
+    @Mock
+    private S3Client s3Client;
+    private LocalFileBuffer localFileBuffer;
+
+    @Test
+    void test_with_write_event_into_buffer() throws IOException {
+        localFileBuffer = new LocalFileBuffer();
+
+        while (localFileBuffer.getEventCount() < 55) {
+            localFileBuffer.writeEvent(generateByteArray());
+        }
+        assertThat(localFileBuffer.getSize(), greaterThan(1l));
+        assertThat(localFileBuffer.getEventCount(), equalTo(55));
+        assertThat(localFileBuffer.getDuration(), greaterThanOrEqualTo(0L));
+    }
+
+    @Test
+    void test_without_write_event_into_buffer() {
+        localFileBuffer = new LocalFileBuffer();
+        assertThat(localFileBuffer.getSize(), equalTo(0L));
+        assertThat(localFileBuffer.getEventCount(), equalTo(0));
+        assertThat(localFileBuffer.getDuration(), lessThanOrEqualTo(0L));
+
+    }
+
+    @Test
+    void test_with_write_event_into_buffer_and_flush_toS3() throws IOException {
+        localFileBuffer = new LocalFileBuffer();
+
+        while (localFileBuffer.getEventCount() < 55) {
+            localFileBuffer.writeEvent(generateByteArray());
+        }
+        assertThat(localFileBuffer.getSize(), greaterThan(1l));
+        assertThat(localFileBuffer.getEventCount(), equalTo(55));
+        assertThat(localFileBuffer.getDuration(), greaterThanOrEqualTo(0L));
+        assertDoesNotThrow(() -> {
+            localFileBuffer.flushToS3(s3Client, BUCKET_NAME, "log.txt");
+        });
+    }
+
+    @Test
+    void test_uploadedToS3_success() {
+        localFileBuffer = new LocalFileBuffer();
+        Assertions.assertNotNull(localFileBuffer);
+        assertDoesNotThrow(() -> {
+            localFileBuffer.flushToS3(s3Client, BUCKET_NAME, "log.txt");
+        });
+    }
+
+    private byte[] generateByteArray() {
+        byte[] bytes = new byte[1000];
+        for (int i = 0; i < 1000; i++) {
+            bytes[i] = (byte) i;
+        }
+        return bytes;
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/accumulator/LocalFileBufferTest.java
@@ -29,9 +29,9 @@ import static org.mockito.Mockito.verify;
 class LocalFileBufferTest {
 
     public static final String BUCKET_NAME = UUID.randomUUID().toString();
-    public static final String KEY = UUID.randomUUID().toString() + ".temp";
+    public static final String KEY = UUID.randomUUID().toString() + ".log";
     public static final String PREFIX = "local";
-    public static final String SUFFIX = ".temp";
+    public static final String SUFFIX = ".log";
     @Mock
     private S3Client s3Client;
     private LocalFileBuffer localFileBuffer;


### PR DESCRIPTION
### Description

- Implementation of s3-sink local-file buffer functionality.
 
### Issues Resolved
GitHub-issue #1048 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
