### PR TITLE
Implement dynamo db source coordination store

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/SourceCoordinationStore.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/SourceCoordinationStore.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.model.source;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStatus;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
 
+import java.time.Duration;
 import java.util.Optional;
 
 /**
@@ -24,7 +25,7 @@ public interface SourceCoordinationStore {
                                    final Long closedCount,
                                    final String partitionProgressState);
 
-    Optional<SourcePartitionStoreItem> tryAcquireAvailablePartition();
+    Optional<SourcePartitionStoreItem> tryAcquireAvailablePartition(final String ownerId, final Duration ownershipTimeout);
 
     /**
      * This method attempts to update the partition item to the desired state

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/SourceCoordinationStore.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/SourceCoordinationStore.java
@@ -18,6 +18,8 @@ import java.util.Optional;
  */
 public interface SourceCoordinationStore {
 
+    void initializeStore();
+
     Optional<SourcePartitionStoreItem> getSourcePartitionItem(final String partitionKey);
 
     boolean tryCreatePartitionItem(final String partitionKey,

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/SourceCoordinationStore.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/SourceCoordinationStore.java
@@ -25,6 +25,12 @@ public interface SourceCoordinationStore {
                                    final Long closedCount,
                                    final String partitionProgressState);
 
+    /**
+     * The following scenarios should qualify a partition as available to be acquired
+     * 1. The partition status is UNASSIGNED
+     * 2. The partition status is CLOSED and the reOpenAt timestamp has passed
+     * 3. The partition status is ASSIGNED and the partitionOwnershipTimeout has passed
+     */
     Optional<SourcePartitionStoreItem> tryAcquireAvailablePartition(final String ownerId, final Duration ownershipTimeout);
 
     /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourceCoordinator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourceCoordinator.java
@@ -17,6 +17,14 @@ import java.util.function.Supplier;
  * @since 2.2
  */
 public interface SourceCoordinator<T> {
+
+    /**
+     * This method should be called by the source on startup when it is using source coordination. This method is meant to
+     * explicitly say that source coordination should be used, since a source that implements {@link UsesSourceCoordination}
+     * does not always use source coordination
+     */
+    void initialize();
+
     /**
      * This should be called by the source when it needs to get the next partition it should process on.
      * This method will attempt to acquire a partition for this instance of the source to work on, and if no partition is acquired, the partitionCreatorSupplier will be called to potentially create

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/exceptions/UninitializedSourceCoordinatorException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/exceptions/UninitializedSourceCoordinatorException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.source.coordinator.exceptions;
+
+import org.opensearch.dataprepper.model.annotations.SkipTestCoverageGenerated;
+import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
+
+/**
+ * This exception is thrown by all other {@link org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator} methods when
+ * the {@link SourceCoordinator#initialize()} has not been called yet
+ */
+@SkipTestCoverageGenerated
+public class UninitializedSourceCoordinatorException extends RuntimeException {
+    public UninitializedSourceCoordinatorException(final String message) {
+        super(message);
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinator.java
@@ -14,6 +14,7 @@ import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStatus
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
 import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionNotFoundException;
 import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionNotOwnedException;
+import org.opensearch.dataprepper.model.source.coordinator.exceptions.UninitializedSourceCoordinatorException;
 import org.opensearch.dataprepper.parser.model.SourceCoordinationConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +43,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
 
     private final Class<T> partitionProgressStateClass;
     private final String ownerId;
+    private boolean initialized = false;
 
     static {
         try {
@@ -64,7 +66,15 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     }
 
     @Override
+    public void initialize() {
+        sourceCoordinationStore.initializeStore();
+        initialized = true;
+    }
+
+    @Override
     public Optional<SourcePartition<T>> getNextPartition(final Supplier<List<PartitionIdentifier>> partitionsCreatorSupplier) {
+        validateIsInitialized();
+
         if (partitionManager.getActivePartition().isPresent()) {
             return partitionManager.getActivePartition();
         }
@@ -119,6 +129,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
 
     @Override
     public void completePartition(final String partitionKey) {
+        validateIsInitialized();
 
         final SourcePartitionStoreItem itemToUpdate = validateAndGetSourcePartitionStoreItem(partitionKey, "complete");
         validatePartitionOwnership(itemToUpdate);
@@ -136,18 +147,21 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
 
     @Override
     public void closePartition(final String partitionKey, final Duration reopenAfter, final int maxClosedCount) {
+        validateIsInitialized();
 
         final SourcePartitionStoreItem itemToUpdate = validateAndGetSourcePartitionStoreItem(partitionKey, "close");
         validatePartitionOwnership(itemToUpdate);
 
         itemToUpdate.setPartitionOwner(null);
         itemToUpdate.setPartitionOwnershipTimeout(null);
+        itemToUpdate.setPartitionProgressState(null);
+        itemToUpdate.setClosedCount(itemToUpdate.getClosedCount() + 1L);
         if (itemToUpdate.getClosedCount() >= maxClosedCount) {
             itemToUpdate.setSourcePartitionStatus(SourcePartitionStatus.COMPLETED);
+            itemToUpdate.setReOpenAt(null);
         } else {
             itemToUpdate.setSourcePartitionStatus(SourcePartitionStatus.CLOSED);
             itemToUpdate.setReOpenAt(Instant.now().plus(reopenAfter));
-            itemToUpdate.setClosedCount(itemToUpdate.getClosedCount() + 1);
         }
 
 
@@ -159,6 +173,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
 
     @Override
     public <S extends T> void saveProgressStateForPartition(final String partitionKey, final S partitionProgressState) {
+        validateIsInitialized();
 
         final SourcePartitionStoreItem itemToUpdate = validateAndGetSourcePartitionStoreItem(partitionKey, "save state");
         validatePartitionOwnership(itemToUpdate);
@@ -174,6 +189,8 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
 
     @Override
     public void giveUpPartitions() {
+        validateIsInitialized();
+
         final Optional<SourcePartition<T>> activePartition = partitionManager.getActivePartition();
         if (activePartition.isPresent()) {
             final Optional<SourcePartitionStoreItem> optionalItem = sourceCoordinationStore.getSourcePartitionItem(activePartition.get().getPartitionKey());
@@ -229,5 +246,11 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
         }
 
         return optionalPartitionItem.get();
+    }
+
+    private void validateIsInitialized() {
+        if (!initialized) {
+            throw new UninitializedSourceCoordinatorException("The initialize method has not been called on this source coordinator. initialize must be called before further interactions with the SourceCoordinator");
+        }
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinator.java
@@ -69,14 +69,14 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
             return partitionManager.getActivePartition();
         }
 
-        Optional<SourcePartitionStoreItem> ownedPartitions = sourceCoordinationStore.tryAcquireAvailablePartition();
+        Optional<SourcePartitionStoreItem> ownedPartitions = sourceCoordinationStore.tryAcquireAvailablePartition(ownerId, DEFAULT_LEASE_TIMEOUT);
 
         if (ownedPartitions.isEmpty()) {
             LOG.info("Partition owner {} did not acquire any partitions. Running partition creation supplier to create more partitions", ownerId);
 
             createPartitions(partitionsCreatorSupplier.get());
 
-            ownedPartitions = sourceCoordinationStore.tryAcquireAvailablePartition();
+            ownedPartitions = sourceCoordinationStore.tryAcquireAvailablePartition(ownerId, DEFAULT_LEASE_TIMEOUT);
         }
 
         if (ownedPartitions.isEmpty()) {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/SourceCoordinatorFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/SourceCoordinatorFactory.java
@@ -9,6 +9,8 @@ import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
 import org.opensearch.dataprepper.model.source.SourceCoordinationStore;
 import org.opensearch.dataprepper.parser.model.SourceCoordinationConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A factory class that will create the {@link SourceCoordinator} implementation based on the
@@ -16,6 +18,8 @@ import org.opensearch.dataprepper.parser.model.SourceCoordinationConfig;
  * @since 2.2
  */
 public class SourceCoordinatorFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(SourceCoordinatorFactory.class);
+
     private final SourceCoordinationConfig sourceCoordinationConfig;
     private final PluginFactory pluginFactory;
 
@@ -33,9 +37,13 @@ public class SourceCoordinatorFactory {
             return null;
         }
 
+
+
         final SourceCoordinationStore sourceCoordinationStore =
                 pluginFactory.loadPlugin(SourceCoordinationStore.class, sourceCoordinationConfig.getSourceCoordinationStoreConfig());
 
+        LOG.info("Creating LeaseBasedSourceCoordinator with coordination store {} for sub-pipeline {}",
+                sourceCoordinationConfig.getSourceCoordinationStoreConfig().getName(), ownerPrefix);
         return new LeaseBasedSourceCoordinator<T>(clazz, sourceCoordinationStore, sourceCoordinationConfig, new PartitionManager<>(), ownerPrefix);
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinatorTest.java
@@ -82,7 +82,7 @@ public class LeaseBasedSourceCoordinatorTest {
         final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
         final Supplier<List<PartitionIdentifier>> partitionCreationSupplier = () -> List.of(partitionIdentifier);
 
-        given(sourceCoordinationStore.tryAcquireAvailablePartition()).willReturn(Optional.empty()).willReturn( Optional.empty());
+        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), any())).willReturn(Optional.empty()).willReturn( Optional.empty());
         given(sourceCoordinationStore.getSourcePartitionItem(partitionIdentifier.getPartitionKey())).willReturn(Optional.empty());
         given(sourceCoordinationStore.tryCreatePartitionItem(partitionIdentifier.getPartitionKey(), SourcePartitionStatus.UNASSIGNED, 0L, null)).willReturn(true);
 
@@ -96,7 +96,7 @@ public class LeaseBasedSourceCoordinatorTest {
         final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
         final Supplier<List<PartitionIdentifier>> partitionCreationSupplier = () -> List.of(partitionIdentifier);
 
-        given(sourceCoordinationStore.tryAcquireAvailablePartition()).willReturn(Optional.empty()).willReturn( Optional.empty());
+        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), any())).willReturn(Optional.empty()).willReturn( Optional.empty());
         given(sourceCoordinationStore.getSourcePartitionItem(partitionIdentifier.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition(partitionCreationSupplier);
@@ -111,7 +111,7 @@ public class LeaseBasedSourceCoordinatorTest {
         final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
         final Supplier<List<PartitionIdentifier>> partitionCreationSupplier = () -> List.of(partitionIdentifier);
 
-        given(sourceCoordinationStore.tryAcquireAvailablePartition()).willReturn(Optional.empty()).willReturn( Optional.empty());
+        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), any())).willReturn(Optional.empty()).willReturn( Optional.empty());
         given(sourceCoordinationStore.getSourcePartitionItem(partitionIdentifier.getPartitionKey())).willReturn(Optional.empty());
         given(sourceCoordinationStore.tryCreatePartitionItem(partitionIdentifier.getPartitionKey(), SourcePartitionStatus.UNASSIGNED, 0L, null)).willReturn(false);
 
@@ -141,7 +141,7 @@ public class LeaseBasedSourceCoordinatorTest {
     @Test
     void getNextPartition_with_no_active_partition_and_unsuccessful_tryAcquireAvailablePartition_returns_empty_Optional() {
         given(partitionManager.getActivePartition()).willReturn(Optional.empty());
-        given(sourceCoordinationStore.tryAcquireAvailablePartition()).willReturn(Optional.empty()).willReturn(Optional.empty());
+        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), any())).willReturn(Optional.empty()).willReturn(Optional.empty());
 
 
         final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition(Collections::emptyList);
@@ -154,7 +154,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(partitionManager.getActivePartition()).willReturn(Optional.empty());
         given(sourcePartitionStoreItem.getSourcePartitionKey()).willReturn(UUID.randomUUID().toString());
         given(sourcePartitionStoreItem.getPartitionProgressState()).willReturn(UUID.randomUUID().toString());
-        given(sourceCoordinationStore.tryAcquireAvailablePartition()).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), any())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition(Collections::emptyList);
 

--- a/data-prepper-plugins/dynamodb-source-coordination-store/build.gradle
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/build.gradle
@@ -8,9 +8,11 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    implementation 'software.amazon.awssdk:arns'
     implementation 'software.amazon.awssdk:dynamodb'
     implementation 'software.amazon.awssdk:dynamodb-enhanced'
     implementation 'software.amazon.awssdk:sts'
+    testImplementation testLibs.mockito.inline
 }
 
 test {

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DdbClientCustomRetryCondition.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DdbClientCustomRetryCondition.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputExcee
 
 public class DdbClientCustomRetryCondition implements RetryCondition {
     private static final Logger LOG = LoggerFactory.getLogger(DdbClientCustomRetryCondition.class);
+    private static final int DEFAULT_RETRIES = 10;
 
     private final RetryCondition defaultRetryCondition;
 
@@ -27,6 +28,11 @@ public class DdbClientCustomRetryCondition implements RetryCondition {
             LOG.warn("Received throttling from DynamoDb after {} attempts, retrying: {}", context.retriesAttempted(), context.exception().getMessage());
             return true;
         }
+
+        if (context.retriesAttempted() >= DEFAULT_RETRIES) {
+            return false;
+        }
+
         return defaultRetryCondition.shouldRetry(context);
     }
 }

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DdbClientCustomRetryCondition.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DdbClientCustomRetryCondition.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputExceededException;
+
+public class DdbClientCustomRetryCondition implements RetryCondition {
+    private static final Logger LOG = LoggerFactory.getLogger(DdbClientCustomRetryCondition.class);
+
+    private final RetryCondition defaultRetryCondition;
+
+    public DdbClientCustomRetryCondition() {
+        this.defaultRetryCondition = RetryCondition.defaultRetryCondition();
+    }
+
+    @Override
+    public boolean shouldRetry(final RetryPolicyContext context) {
+
+        if (context.exception() instanceof ProvisionedThroughputExceededException) {
+            LOG.warn("Received throttling from DynamoDb after {} attempts, retrying: {}", context.retriesAttempted(), context.exception().getMessage());
+            return true;
+        }
+        return defaultRetryCondition.shouldRetry(context);
+    }
+}

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientFactory.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb;
+
+import software.amazon.awssdk.arns.Arn;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
+import software.amazon.awssdk.core.retry.backoff.EqualJitterBackoffStrategy;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+
+import java.time.Duration;
+import java.util.UUID;
+
+public class DynamoDbClientFactory {
+
+    private static final int DYNAMO_CLIENT_RETRIES = 10;
+    private static final long DYNAMO_CLIENT_BASE_BACKOFF_MILLIS = 1000L;
+    private static final long DYNAMO_CLIENT_MAX_BACKOFF_MILLIS = 60000L;
+
+    public static DynamoDbEnhancedClient provideDynamoDbEnhancedClient(final String region, final String stsRoleArn) {
+        final DynamoDbClient dynamoDbClient = DynamoDbClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(getAwsCredentials(Region.of(region), stsRoleArn))
+                .overrideConfiguration(getClientOverrideConfiguration())
+                .build();
+
+        return DynamoDbEnhancedClient.builder()
+                .dynamoDbClient(dynamoDbClient)
+                .build();
+    }
+
+    private static ClientOverrideConfiguration getClientOverrideConfiguration() {
+        final BackoffStrategy backoffStrategy = EqualJitterBackoffStrategy.builder()
+                .baseDelay(Duration.ofMillis(DYNAMO_CLIENT_BASE_BACKOFF_MILLIS))
+                .maxBackoffTime(Duration.ofMillis(DYNAMO_CLIENT_MAX_BACKOFF_MILLIS))
+                .build();
+
+        final RetryPolicy retryPolicy = RetryPolicy.builder()
+                .numRetries(DYNAMO_CLIENT_RETRIES)
+                .retryCondition(RetryCondition.defaultRetryCondition())
+                .backoffStrategy(backoffStrategy)
+                .throttlingBackoffStrategy(backoffStrategy)
+                .build();
+
+        return ClientOverrideConfiguration.builder()
+                .retryPolicy(retryPolicy)
+                .build();
+    }
+
+    private static AwsCredentialsProvider getAwsCredentials(final Region region, final String stsRoleArn) {
+
+        AwsCredentialsProvider awsCredentialsProvider;
+        if (stsRoleArn != null && !stsRoleArn.isEmpty()) {
+            try {
+                Arn.fromString(stsRoleArn);
+            } catch (final Exception e) {
+                throw new IllegalArgumentException("Invalid ARN format for dynamodb sts_role_arn");
+            }
+
+            final StsClient stsClient = StsClient.builder()
+                    .region(region)
+                    .overrideConfiguration(getClientOverrideConfiguration())
+                    .build();
+
+            AssumeRoleRequest.Builder assumeRoleRequestBuilder = AssumeRoleRequest.builder()
+                    .roleSessionName("Dynamo-Source-Coordination-" + UUID.randomUUID())
+                    .roleArn(stsRoleArn);
+
+            awsCredentialsProvider = StsAssumeRoleCredentialsProvider.builder()
+                    .stsClient(stsClient)
+                    .refreshRequest(assumeRoleRequestBuilder.build())
+                    .build();
+
+        } else {
+            // use default credential provider
+            awsCredentialsProvider = DefaultCredentialsProvider.create();
+        }
+
+        return awsCredentialsProvider;
+    }
+}

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientFactory.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientFactory.java
@@ -24,7 +24,11 @@ import java.util.UUID;
 
 public class DynamoDbClientFactory {
 
-    private static final int DYNAMO_CLIENT_RETRIES = 10;
+    /**
+     * Set to infinite retries for ProvisionedThroughputExceededException.
+     * All other retryable exceptions will retry 10 times due to {@link DdbClientCustomRetryCondition}
+     */
+    private static final int DYNAMO_CLIENT_RETRIES = Integer.MAX_VALUE;
     private static final long DYNAMO_CLIENT_BASE_BACKOFF_MILLIS = 1000L;
     private static final long DYNAMO_CLIENT_MAX_BACKOFF_MILLIS = 60000L;
 

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientFactory.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientFactory.java
@@ -12,7 +12,6 @@ import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
 import software.amazon.awssdk.core.retry.backoff.EqualJitterBackoffStrategy;
-import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -49,7 +48,7 @@ public class DynamoDbClientFactory {
 
         final RetryPolicy retryPolicy = RetryPolicy.builder()
                 .numRetries(DYNAMO_CLIENT_RETRIES)
-                .retryCondition(RetryCondition.defaultRetryCondition())
+                .retryCondition(new DdbClientCustomRetryCondition())
                 .backoffStrategy(backoffStrategy)
                 .throttlingBackoffStrategy(backoffStrategy)
                 .build();

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb;
+
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
+import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionUpdateException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.internal.waiters.ResponseOrException;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.CreateTableEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputExceededException;
+import software.amazon.awssdk.services.dynamodb.model.ResourceInUseException;
+import software.amazon.awssdk.services.dynamodb.waiters.DynamoDbWaiter;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class DynamoDbClientWrapper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DynamoDbClientWrapper.class);
+
+    static final String ITEM_DOES_NOT_EXIST_EXPRESSION = "attribute_not_exists(sourcePartitionKey)";
+    static final String ITEM_EXISTS_AND_HAS_LATEST_VERSION = "attribute_exists(sourcePartitionKey) and version = :v";
+
+    private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
+    private DynamoDbTable<DynamoDbSourcePartitionItem> table;
+
+
+    private DynamoDbClientWrapper(final String region, final String stsRoleArn) {
+        this.dynamoDbEnhancedClient = DynamoDbClientFactory.provideDynamoDbEnhancedClient(region, stsRoleArn);
+    }
+
+    public static DynamoDbClientWrapper create(final String region, final String stsRoleArn) {
+        return new DynamoDbClientWrapper(region, stsRoleArn);
+    }
+
+    public boolean tryCreateTable(final String tableName,
+                                  final ProvisionedThroughput provisionedThroughput) {
+        boolean createdTable = false;
+
+        this.table = dynamoDbEnhancedClient.table(tableName, TableSchema.fromBean(DynamoDbSourcePartitionItem.class));
+
+        try {
+            final CreateTableEnhancedRequest createTableEnhancedRequest = CreateTableEnhancedRequest.builder()
+                            .provisionedThroughput(provisionedThroughput)
+                            .build();
+            table.createTable(createTableEnhancedRequest);
+            createdTable = true;
+        } catch (final ResourceInUseException e) {
+            LOG.info("The table creation for {} was already triggered by another instance of data prepper", tableName);
+        }
+
+        try(final DynamoDbWaiter dynamoDbWaiter = DynamoDbWaiter.create()) {
+            final DescribeTableRequest describeTableRequest = DescribeTableRequest.builder().tableName(tableName).build();
+            final ResponseOrException<DescribeTableResponse> response = dynamoDbWaiter
+                    .waitUntilTableExists(describeTableRequest)
+                    .matched();
+
+            final DescribeTableResponse describeTableResponse = response.response().orElseThrow(
+                    () -> new RuntimeException(String.format("Table %s was not created successfully", tableName))
+            );
+
+            LOG.info("DynamoDB table {} was created successfully for source coordination", describeTableResponse.table().tableName());
+        }
+
+        return createdTable;
+    }
+
+    public boolean tryCreatePartitionItem(final DynamoDbSourcePartitionItem dynamoDbSourcePartitionItem) {
+        try {
+            table.putItem(PutItemEnhancedRequest.builder(DynamoDbSourcePartitionItem.class)
+                    .item(dynamoDbSourcePartitionItem)
+                    .conditionExpression(Expression.builder()
+                            .expression(ITEM_DOES_NOT_EXIST_EXPRESSION)
+                            .build())
+                    .build());
+            return true;
+        } catch (final ConditionalCheckFailedException e) {
+            return false;
+        } catch (final ProvisionedThroughputExceededException e) {
+            LOG.error("Unable to create partition item for {} in DynamoDb due to throttling even after exponential backoff and retry {}", dynamoDbSourcePartitionItem.getSourcePartitionKey(), e.getMessage());
+            return false;
+        } catch (final Exception e) {
+            LOG.error("An exception occurred while attempting to create a DynamoDb partition item {}", dynamoDbSourcePartitionItem.getSourcePartitionKey());
+            return false;
+        }
+    }
+
+    public void tryUpdatePartitionItem(final DynamoDbSourcePartitionItem dynamoDbSourcePartitionItem) {
+        try {
+            dynamoDbSourcePartitionItem.setVersion(dynamoDbSourcePartitionItem.getVersion() + 1L);
+            table.putItem(PutItemEnhancedRequest.builder(DynamoDbSourcePartitionItem.class)
+                    .item(dynamoDbSourcePartitionItem)
+                    .conditionExpression(Expression.builder()
+                            .expression(ITEM_EXISTS_AND_HAS_LATEST_VERSION)
+                            .expressionValues(Map.of(":v", AttributeValue.builder().n(String.valueOf(dynamoDbSourcePartitionItem.getVersion() - 1L)).build()))
+                            .build())
+                    .build());
+        } catch (final ConditionalCheckFailedException e) {
+            final String message = String.format(
+                    "ConditionalCheckFailed while updating partition %s. This partition item was either deleted from the dynamo table, " +
+                            "or another instance of Data Prepper has modified it.",
+                    dynamoDbSourcePartitionItem.getSourcePartitionKey());
+            LOG.warn(message, e);
+            throw new PartitionUpdateException(message, e);
+        } catch (final ProvisionedThroughputExceededException e) {
+            final String errorMessage = String.format("Unable to update partition item for %s in DynamoDb due to throttling even after exponential backoff and retry",
+                    dynamoDbSourcePartitionItem.getSourcePartitionKey());
+            LOG.error(errorMessage, e);
+            throw new PartitionUpdateException(errorMessage, e);
+        } catch (final Exception e) {
+            final String errorMessage = String.format("An exception occurred while attempting to update a DynamoDb partition item %s",
+                    dynamoDbSourcePartitionItem.getSourcePartitionKey());
+            LOG.error(errorMessage, e);
+            throw new PartitionUpdateException(errorMessage, e);
+        }
+    }
+
+    public Optional<SourcePartitionStoreItem> getSourcePartitionItem(final String sourcePartitionKey) {
+        try {
+            final Key key = Key.builder()
+                    .partitionValue(sourcePartitionKey)
+                    .build();
+
+            final SourcePartitionStoreItem result = table.getItem(GetItemEnhancedRequest.builder().key(key).build());
+
+            if (Objects.isNull(result)) {
+                return Optional.empty();
+            }
+            return Optional.of(result);
+        } catch (final ProvisionedThroughputExceededException e) {
+            LOG.error("Unable to update partition item for {} in DynamoDb due to throttling even after exponential backoff and retry {}", sourcePartitionKey, e.getMessage());
+            return Optional.empty();
+        } catch (final Exception e) {
+            LOG.error("An exception occurred while attempting to update a DynamoDb partition item {}", sourcePartitionKey, e);
+            return Optional.empty();
+        }
+    }
+
+    public Optional<PageIterable<DynamoDbSourcePartitionItem>> getSourcePartitionItems(final Expression filterExpression) {
+        final ScanEnhancedRequest scanRequest = ScanEnhancedRequest.builder()
+                .filterExpression(filterExpression)
+                .limit(20)
+                .build();
+
+        try {
+            return Optional.of(table.scan(scanRequest));
+        } catch (final ProvisionedThroughputExceededException e) {
+            LOG.error("Unable to get source partition items to acquire in DynamoDb due to throttling even after exponential backoff and retry: {}", e.getMessage());
+        } catch (final Exception e) {
+            LOG.error("An exception occurred while attempting to get source partition items to acquire in DynamoDb", e);
+        }
+
+        return Optional.empty();
+    }
+}
+

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStore.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStore.java
@@ -11,7 +11,17 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor
 import org.opensearch.dataprepper.model.source.SourceCoordinationStore;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStatus;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputExceededException;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -23,17 +33,28 @@ import java.util.Optional;
 @DataPrepperPlugin(name = "dynamodb", pluginType = SourceCoordinationStore.class, pluginConfigurationType = DynamoStoreSettings.class )
 public class DynamoDbSourceCoordinationStore implements SourceCoordinationStore {
 
+    private static final Logger LOG = LoggerFactory.getLogger(DynamoDbSourceCoordinationStore.class);
+
+    static final String AVAILABLE_PARTITIONS_FILTER_EXPRESSION = "contains(sourcePartitionStatus, :s) " +
+            "and (attribute_not_exists(reOpenAt) or reOpenAt = :null or reOpenAt <= :ro) " +
+            "and (attribute_not_exists(partitionOwnershipTimeout) or partitionOwnershipTimeout = :null or partitionOwnershipTimeout <= :t)";
+
     private final DynamoStoreSettings dynamoStoreSettings;
     private final PluginMetrics pluginMetrics;
+    private final DynamoDbClientWrapper dynamoDbClientWrapper;
 
     @DataPrepperPluginConstructor
     public DynamoDbSourceCoordinationStore(final DynamoStoreSettings dynamoStoreSettings, final PluginMetrics pluginMetrics) {
         this.dynamoStoreSettings = dynamoStoreSettings;
         this.pluginMetrics = pluginMetrics;
+        this.dynamoDbClientWrapper = DynamoDbClientWrapper.create(dynamoStoreSettings.getRegion(), dynamoStoreSettings.getStsRoleArn());
+        dynamoDbClientWrapper.tryCreateTable(dynamoStoreSettings.getTableName(), constructProvisionedThroughput(
+                dynamoStoreSettings.getProvisionedReadCapacityUnits(), dynamoStoreSettings.getProvisionedWriteCapacityUnits()));
     }
+
     @Override
     public Optional<SourcePartitionStoreItem> getSourcePartitionItem(final String partitionKey) {
-        return Optional.empty();
+        return dynamoDbClientWrapper.getSourcePartitionItem(partitionKey);
     }
 
     @Override
@@ -41,15 +62,77 @@ public class DynamoDbSourceCoordinationStore implements SourceCoordinationStore 
                                           final SourcePartitionStatus sourcePartitionStatus,
                                           final Long closedCount,
                                           final String partitionProgressState) {
+        final DynamoDbSourcePartitionItem newPartitionItem = new DynamoDbSourcePartitionItem();
+        newPartitionItem.setSourcePartitionKey(partitionKey);
+        newPartitionItem.setSourcePartitionStatus(sourcePartitionStatus);
+        newPartitionItem.setClosedCount(closedCount);
+        newPartitionItem.setPartitionProgressState(partitionProgressState);
+        newPartitionItem.setVersion(0L);
+
+        final Optional<SourcePartitionStoreItem> optionalPartitionItem = dynamoDbClientWrapper.getSourcePartitionItem(partitionKey);
+        if (optionalPartitionItem.isEmpty()) {
+             return dynamoDbClientWrapper.tryCreatePartitionItem(newPartitionItem);
+        }
+
         return false;
     }
 
     @Override
-    public Optional<SourcePartitionStoreItem> tryAcquireAvailablePartition() {
+    public Optional<SourcePartitionStoreItem> tryAcquireAvailablePartition(final String ownerId, final Duration ownershipTimeout) {
+        final Optional<PageIterable<DynamoDbSourcePartitionItem>> dynamoDbSourcePartitionItemPageIterable =
+                dynamoDbClientWrapper.getSourcePartitionItems(Expression.builder()
+                        .expressionValues(Map.of(
+                                ":s", AttributeValue.builder().s(SourcePartitionStatus.UNASSIGNED.name()).build(),
+                                ":t", AttributeValue.builder().s(Instant.now().toString()).build(),
+                                ":ro", AttributeValue.builder().s(Instant.now().toString()).build(),
+                                ":null", AttributeValue.builder().nul(true).build()))
+                        .expression(AVAILABLE_PARTITIONS_FILTER_EXPRESSION)
+                        .build());
+
+        if (dynamoDbSourcePartitionItemPageIterable.isEmpty()) {
+            return Optional.empty();
+        }
+
+        try {
+            for (final DynamoDbSourcePartitionItem item : dynamoDbSourcePartitionItemPageIterable.get().items()) {
+                item.setPartitionOwner(ownerId);
+                item.setPartitionOwnershipTimeout(Instant.now().plus(ownershipTimeout));
+                item.setSourcePartitionStatus(SourcePartitionStatus.ASSIGNED);
+                final boolean acquired = tryAcquireItem(item);
+
+                if (acquired) {
+                    return Optional.of(item);
+                }
+            }
+        } catch (final ProvisionedThroughputExceededException e) {
+            LOG.error("Throttling occurred from DynamoDb during a scan to acquire a partition item: {}", e.getMessage());
+        } catch (final Exception e) {
+            LOG.error("An exception occurred while attempting to scan partition items to acquire in DynamoDb", e);
+        }
+
         return Optional.empty();
     }
 
     @Override
     public void tryUpdateSourcePartitionItem(final SourcePartitionStoreItem updateItem) {
+        final DynamoDbSourcePartitionItem dynamoDbSourcePartitionItem = (DynamoDbSourcePartitionItem) updateItem;
+        dynamoDbClientWrapper.tryUpdatePartitionItem(dynamoDbSourcePartitionItem);
+    }
+
+    private ProvisionedThroughput constructProvisionedThroughput(final Long readCapacityUnits,
+                                                                 final Long writeCapacityUnits) {
+        return ProvisionedThroughput.builder()
+                .readCapacityUnits(readCapacityUnits)
+                .writeCapacityUnits(writeCapacityUnits)
+                .build();
+    }
+
+    private boolean tryAcquireItem(final DynamoDbSourcePartitionItem item) {
+        try {
+            dynamoDbClientWrapper.tryUpdatePartitionItem(item);
+            return true;
+        } catch (final Exception e) {
+            return false;
+        }
     }
 }

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourcePartitionItem.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourcePartitionItem.java
@@ -80,6 +80,7 @@ public class DynamoDbSourcePartitionItem implements SourcePartitionStoreItem {
         this.partitionProgressState = partitionProgressState;
     }
 
+    // TODO: Make this a global secondary index to improve performance to scan for available partitions only on unassigned or closed partitions (can be optional setting on the store)
     public void setSourcePartitionStatus(final SourcePartitionStatus sourcePartitionStatus) {
         this.sourcePartitionStatus = sourcePartitionStatus;
     }

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoStoreSettings.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoStoreSettings.java
@@ -17,15 +17,56 @@ import java.util.Objects;
  */
 public class DynamoStoreSettings {
 
+    private static final Long DEFAULT_PROVISIONED_READ_CAPACITY_UNITS = 10L;
+    private static final Long DEFAULT_PROVISIONED_WRITE_CAPACITY_UNITS = 10L;
+
     private final String tableName;
+    private final String region;
+    private final String stsRoleArn;
+
+    private Long provisionedReadCapacityUnits = DEFAULT_PROVISIONED_READ_CAPACITY_UNITS;
+    private Long provisionedWriteCapacityUnits = DEFAULT_PROVISIONED_WRITE_CAPACITY_UNITS;
 
     @JsonCreator
-    public DynamoStoreSettings(@JsonProperty("table_name") final String tableName) {
+    public DynamoStoreSettings(@JsonProperty("table_name") final String tableName,
+                               @JsonProperty("region") final String region,
+                               @JsonProperty("sts_role_arn") final String stsRoleArn,
+                               @JsonProperty("provisioned_read_capacity_units") final Long provisionedReadCapacityUnits,
+                               @JsonProperty("provisioned_write_capacity_units") final Long provisionedWriteCapacityUnits) {
         Objects.requireNonNull(tableName, "table_name is required for dynamo store settings");
+        Objects.requireNonNull(region, "region is required for dynamo store settings");
+        Objects.requireNonNull(stsRoleArn, "sts_role_arn is required for dynamo store settings");
+
         this.tableName = tableName;
+        this.region = region;
+        this.stsRoleArn = stsRoleArn;
+
+        if (Objects.nonNull(provisionedReadCapacityUnits)) {
+            this.provisionedReadCapacityUnits = provisionedReadCapacityUnits;
+        }
+
+        if (Objects.nonNull(provisionedWriteCapacityUnits)) {
+            this.provisionedWriteCapacityUnits = provisionedWriteCapacityUnits;
+        }
     }
 
     public String getTableName() {
         return tableName;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public String getStsRoleArn() {
+        return stsRoleArn;
+    }
+
+    public Long getProvisionedReadCapacityUnits() {
+        return provisionedReadCapacityUnits;
+    }
+
+    public Long getProvisionedWriteCapacityUnits() {
+        return provisionedWriteCapacityUnits;
     }
 }

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DdbClientCustomRetryConditionTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DdbClientCustomRetryConditionTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputExceededException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+@ExtendWith(MockitoExtension.class)
+public class DdbClientCustomRetryConditionTest {
+
+    @Mock
+    private RetryPolicyContext retryPolicyContext;
+
+    @Mock
+    private RetryCondition defaultRetryCondition;
+
+    private DdbClientCustomRetryCondition createObjectUnderTest() {
+        try (final MockedStatic<RetryCondition> retryConditionMockedStatic = mockStatic(RetryCondition.class)) {
+            retryConditionMockedStatic.when(RetryCondition::defaultRetryCondition).thenReturn(defaultRetryCondition);
+            return new DdbClientCustomRetryCondition();
+        }
+    }
+
+    @Test
+    void shouldRetry_with_ProvisionedThroughPutExceededException_returns_true() {
+        final ProvisionedThroughputExceededException provisionedThroughputExceededException = mock(ProvisionedThroughputExceededException.class);
+
+        given(retryPolicyContext.exception()).willReturn(provisionedThroughputExceededException);
+        given(retryPolicyContext.retriesAttempted()).willReturn(10);
+
+        final boolean result = createObjectUnderTest().shouldRetry(retryPolicyContext);
+
+        assertThat(result, equalTo(true));
+    }
+
+    @Test
+    void shouldRetry_with_other_exception_calls_defaultRetryCondition() {
+        final SdkException exception = mock(SdkException.class);
+
+        given(retryPolicyContext.exception()).willReturn(exception);
+
+        final DdbClientCustomRetryCondition objectUnderTest = createObjectUnderTest();
+        given(defaultRetryCondition.shouldRetry(retryPolicyContext)).willReturn(false);
+
+        final boolean result = objectUnderTest.shouldRetry(retryPolicyContext);
+
+        assertThat(result, equalTo(false));
+    }
+}

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientFactoryTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientFactoryTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class DynamoDbClientFactoryTest {
+
+    private String region;
+    private String stsRoleArn;
+
+    @Mock
+    private DynamoDbClient dynamoDbClient;
+
+    @Mock
+    private DynamoDbEnhancedClient dynamoDbEnhancedClient;
+
+    @BeforeEach
+    void setup() {
+        region = "us-east-1";
+        stsRoleArn = "arn:aws:iam::123456789012:role/ddb-role";
+    }
+
+    @Test
+    void provideDynamoDbEnhancedClient_with_null_stsRole_creates_client_with_default_credentials() {
+
+        try (final MockedStatic<Region> regionMockedStatic = mockStatic(Region.class);
+             final MockedStatic<DynamoDbClient> dynamoDbClientMockedStatic = mockStatic(DynamoDbClient.class);
+             final MockedStatic<DefaultCredentialsProvider> defaultCredentialsProviderMockedStatic = mockStatic(DefaultCredentialsProvider.class);
+             final MockedStatic<DynamoDbEnhancedClient> dynamoDbEnhancedClientMockedStatic = mockStatic(DynamoDbEnhancedClient.class)) {
+            regionMockedStatic.when(() -> Region.of(region)).thenReturn(Region.US_EAST_1);
+            final DynamoDbClientBuilder dynamoDbClientBuilder = mock(DynamoDbClientBuilder.class);
+            dynamoDbClientMockedStatic.when(DynamoDbClient::builder).thenReturn(dynamoDbClientBuilder);
+
+            final DefaultCredentialsProvider defaultCredentialsProvider = mock(DefaultCredentialsProvider.class);
+            defaultCredentialsProviderMockedStatic.when(DefaultCredentialsProvider::create).thenReturn(defaultCredentialsProvider);
+            when(dynamoDbClientBuilder.region(Region.US_EAST_1)).thenReturn(dynamoDbClientBuilder);
+            when(dynamoDbClientBuilder.credentialsProvider(defaultCredentialsProvider)).thenReturn(dynamoDbClientBuilder);
+            when(dynamoDbClientBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class))).thenReturn(dynamoDbClientBuilder);
+            when(dynamoDbClientBuilder.build()).thenReturn(dynamoDbClient);
+
+            final DynamoDbEnhancedClient.Builder builder = mock(DynamoDbEnhancedClient.Builder.class);
+
+            dynamoDbEnhancedClientMockedStatic.when(DynamoDbEnhancedClient::builder).thenReturn(builder);
+            when(builder.dynamoDbClient(dynamoDbClient)).thenReturn(builder);
+            when(builder.build()).thenReturn(dynamoDbEnhancedClient);
+
+            final DynamoDbEnhancedClient enhancedClient = DynamoDbClientFactory.provideDynamoDbEnhancedClient(region, null);
+
+            assertThat(enhancedClient, equalTo(dynamoDbEnhancedClient));
+        }
+    }
+
+    @Test
+    void provideDynamoDbEnhancedClient_with_stsRole_creates_client_with_sts_credentials() {
+
+        try (final MockedStatic<Region> regionMockedStatic = mockStatic(Region.class);
+             final MockedStatic<DynamoDbClient> dynamoDbClientMockedStatic = mockStatic(DynamoDbClient.class);
+             final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
+             final MockedStatic<AssumeRoleRequest> assumeRoleRequestMockedStatic = mockStatic(AssumeRoleRequest.class);
+             final MockedStatic<StsAssumeRoleCredentialsProvider> stsAssumeRoleCredentialsProviderMockedStatic = mockStatic(StsAssumeRoleCredentialsProvider.class);
+             final MockedStatic<DynamoDbEnhancedClient> dynamoDbEnhancedClientMockedStatic = mockStatic(DynamoDbEnhancedClient.class)) {
+            regionMockedStatic.when(() -> Region.of(region)).thenReturn(Region.US_EAST_1);
+            final DynamoDbClientBuilder dynamoDbClientBuilder = mock(DynamoDbClientBuilder.class);
+            dynamoDbClientMockedStatic.when(DynamoDbClient::builder).thenReturn(dynamoDbClientBuilder);
+
+            final StsClient stsClient = mock(StsClient.class);
+            final StsClientBuilder stsClientBuilder = mock(StsClientBuilder.class);
+            stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
+            when(stsClientBuilder.region(Region.US_EAST_1)).thenReturn(stsClientBuilder);
+            when(stsClientBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class))).thenReturn(stsClientBuilder);
+            when(stsClientBuilder.build()).thenReturn(stsClient);
+
+            final AssumeRoleRequest.Builder assumeRoleBuilder = mock(AssumeRoleRequest.Builder.class);
+            assumeRoleRequestMockedStatic.when(AssumeRoleRequest::builder).thenReturn(assumeRoleBuilder);
+            when(assumeRoleBuilder.roleSessionName(anyString())).thenReturn(assumeRoleBuilder);
+            when(assumeRoleBuilder.roleArn(stsRoleArn)).thenReturn(assumeRoleBuilder);
+
+            final AssumeRoleRequest assumeRoleRequest = mock(AssumeRoleRequest.class);
+            when(assumeRoleBuilder.build()).thenReturn(assumeRoleRequest);
+
+            final StsAssumeRoleCredentialsProvider awsCredentialsProvider = mock(StsAssumeRoleCredentialsProvider.class);
+
+            final StsAssumeRoleCredentialsProvider.Builder credentialsBuilder = mock(StsAssumeRoleCredentialsProvider.Builder.class);
+            stsAssumeRoleCredentialsProviderMockedStatic.when(StsAssumeRoleCredentialsProvider::builder).thenReturn(credentialsBuilder);
+            when(credentialsBuilder.stsClient(stsClient)).thenReturn(credentialsBuilder);
+            when(credentialsBuilder.refreshRequest(assumeRoleRequest)).thenReturn(credentialsBuilder);
+            when(credentialsBuilder.build()).thenReturn(awsCredentialsProvider);
+
+            when(dynamoDbClientBuilder.region(Region.US_EAST_1)).thenReturn(dynamoDbClientBuilder);
+            when(dynamoDbClientBuilder.credentialsProvider(awsCredentialsProvider)).thenReturn(dynamoDbClientBuilder);
+            when(dynamoDbClientBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class))).thenReturn(dynamoDbClientBuilder);
+            when(dynamoDbClientBuilder.build()).thenReturn(dynamoDbClient);
+
+            final DynamoDbEnhancedClient.Builder builder = mock(DynamoDbEnhancedClient.Builder.class);
+
+            dynamoDbEnhancedClientMockedStatic.when(DynamoDbEnhancedClient::builder).thenReturn(builder);
+            when(builder.dynamoDbClient(dynamoDbClient)).thenReturn(builder);
+            when(builder.build()).thenReturn(dynamoDbEnhancedClient);
+
+            final DynamoDbEnhancedClient enhancedClient = DynamoDbClientFactory.provideDynamoDbEnhancedClient(region, stsRoleArn);
+
+            assertThat(enhancedClient, equalTo(dynamoDbEnhancedClient));
+        }
+    }
+}

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
+import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionUpdateException;
+import software.amazon.awssdk.core.internal.waiters.ResponseOrException;
+import software.amazon.awssdk.core.waiters.WaiterResponse;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.CreateTableEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputExceededException;
+import software.amazon.awssdk.services.dynamodb.model.ResourceInUseException;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
+import software.amazon.awssdk.services.dynamodb.waiters.DynamoDbWaiter;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb.DynamoDbClientWrapper.ITEM_DOES_NOT_EXIST_EXPRESSION;
+import static org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb.DynamoDbClientWrapper.ITEM_EXISTS_AND_HAS_LATEST_VERSION;
+
+@ExtendWith(MockitoExtension.class)
+public class DynamoDbClientWrapperTest {
+
+    @Mock
+    private DynamoDbEnhancedClient dynamoDbEnhancedClient;
+
+    private String region;
+    private String stsRoleArn;
+
+    @BeforeEach
+    void setup() {
+        region = "us-east-1";
+        stsRoleArn = "arn:aws:iam::123456789012:role/source-coordination-ddb-role";
+    }
+
+    private DynamoDbClientWrapper createObjectUnderTest() {
+        try (final MockedStatic<DynamoDbClientFactory> dynamoDbClientFactoryMockedStatic = mockStatic(DynamoDbClientFactory.class)) {
+              dynamoDbClientFactoryMockedStatic.when(() -> DynamoDbClientFactory.provideDynamoDbEnhancedClient(region, stsRoleArn)).thenReturn(dynamoDbEnhancedClient);
+            return DynamoDbClientWrapper.create(region, stsRoleArn);
+        }
+    }
+
+    @Test
+    void tryCreateTableWithNonExistingTable_creates_table() {
+
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+
+        final String tableName = UUID.randomUUID().toString();
+        final ProvisionedThroughput provisionedThroughput = mock(ProvisionedThroughput.class);
+
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        given(dynamoDbEnhancedClient.table(eq(tableName), any(BeanTableSchema.class))).willReturn(table);
+
+        doNothing().when(table).createTable(any(CreateTableEnhancedRequest.class));
+
+        try (MockedStatic<DynamoDbWaiter> dynamoDbWaiterMockedStatic = mockStatic(DynamoDbWaiter.class)) {
+            final DynamoDbWaiter dynamoDbWaiter = mock(DynamoDbWaiter.class);
+            dynamoDbWaiterMockedStatic.when(DynamoDbWaiter::create).thenReturn(dynamoDbWaiter);
+            final WaiterResponse waiterResponse = mock(WaiterResponse.class);
+            final ResponseOrException<DescribeTableResponse> response = mock(ResponseOrException.class);
+            final DescribeTableResponse describeTableResponse = mock(DescribeTableResponse.class);
+            given(response.response()).willReturn(Optional.of(describeTableResponse));
+            given(dynamoDbWaiter.waitUntilTableExists(any(DescribeTableRequest.class))).willReturn(waiterResponse);
+
+            given(waiterResponse.matched()).willReturn(response);
+            final TableDescription tableDescription = mock(TableDescription.class);
+            given(describeTableResponse.table()).willReturn(tableDescription);
+            given(tableDescription.tableName()).willReturn(tableName);
+
+            final boolean createdTable = objectUnderTest.tryCreateTable(tableName, provisionedThroughput);
+
+            assertThat(createdTable, equalTo(true));
+        }
+    }
+
+    @Test
+    void tryCreateTable_does_not_create_table_when_createTable_throws_ResourceInUseException() {
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+
+        final String tableName = UUID.randomUUID().toString();
+        final ProvisionedThroughput provisionedThroughput = mock(ProvisionedThroughput.class);
+
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        given(dynamoDbEnhancedClient.table(eq(tableName), any(BeanTableSchema.class))).willReturn(table);
+
+        doThrow(ResourceInUseException.class).when(table).createTable(any(CreateTableEnhancedRequest.class));
+
+        try (MockedStatic<DynamoDbWaiter> dynamoDbWaiterMockedStatic = mockStatic(DynamoDbWaiter.class)) {
+            final DynamoDbWaiter dynamoDbWaiter = mock(DynamoDbWaiter.class);
+            dynamoDbWaiterMockedStatic.when(DynamoDbWaiter::create).thenReturn(dynamoDbWaiter);
+            final WaiterResponse waiterResponse = mock(WaiterResponse.class);
+            final ResponseOrException<DescribeTableResponse> response = mock(ResponseOrException.class);
+            final DescribeTableResponse describeTableResponse = mock(DescribeTableResponse.class);
+            given(response.response()).willReturn(Optional.of(describeTableResponse));
+            given(dynamoDbWaiter.waitUntilTableExists(any(DescribeTableRequest.class))).willReturn(waiterResponse);
+
+            given(waiterResponse.matched()).willReturn(response);
+            final TableDescription tableDescription = mock(TableDescription.class);
+            given(describeTableResponse.table()).willReturn(tableDescription);
+            given(tableDescription.tableName()).willReturn(tableName);
+
+            final boolean createdTable = objectUnderTest.tryCreateTable(tableName, provisionedThroughput);
+
+            assertThat(createdTable, equalTo(false));
+        }
+    }
+
+    @Test
+    void tryCreateTableThrows_runtime_exception_when_waiter_returns_empty_describe_response() {
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+
+        final String tableName = UUID.randomUUID().toString();
+        final ProvisionedThroughput provisionedThroughput = mock(ProvisionedThroughput.class);
+
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        given(dynamoDbEnhancedClient.table(eq(tableName), any(BeanTableSchema.class))).willReturn(table);
+
+        doThrow(ResourceInUseException.class).when(table).createTable(any(CreateTableEnhancedRequest.class));
+
+        try (MockedStatic<DynamoDbWaiter> dynamoDbWaiterMockedStatic = mockStatic(DynamoDbWaiter.class)) {
+            final DynamoDbWaiter dynamoDbWaiter = mock(DynamoDbWaiter.class);
+            dynamoDbWaiterMockedStatic.when(DynamoDbWaiter::create).thenReturn(dynamoDbWaiter);
+            final WaiterResponse waiterResponse = mock(WaiterResponse.class);
+            final ResponseOrException<DescribeTableResponse> response = mock(ResponseOrException.class);
+            given(response.response()).willReturn(Optional.empty());
+            given(dynamoDbWaiter.waitUntilTableExists(any(DescribeTableRequest.class))).willReturn(waiterResponse);
+
+            given(waiterResponse.matched()).willReturn(response);
+
+            assertThrows(RuntimeException.class, () -> objectUnderTest.tryCreateTable(tableName, provisionedThroughput));
+        }
+    }
+
+    @Test
+    void tryCreatePartitionItem_creates_expected_partition_item() throws NoSuchFieldException, IllegalAccessException {
+        final ArgumentCaptor<PutItemEnhancedRequest> putItemEnhancedRequestArgumentCaptor = ArgumentCaptor.forClass(PutItemEnhancedRequest.class);
+        final DynamoDbSourcePartitionItem dynamoDbSourcePartitionItem = mock(DynamoDbSourcePartitionItem.class);
+
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        doNothing().when(table).putItem(putItemEnhancedRequestArgumentCaptor.capture());
+
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+
+        reflectivelySetField(objectUnderTest, "table", table);
+
+        final boolean result = objectUnderTest.tryCreatePartitionItem(dynamoDbSourcePartitionItem);
+
+        assertThat(result, equalTo(true));
+
+        final PutItemEnhancedRequest<DynamoDbSourcePartitionItem> putItemEnhancedRequest = putItemEnhancedRequestArgumentCaptor.getValue();
+
+        assertThat(putItemEnhancedRequest.item(), equalTo(dynamoDbSourcePartitionItem));
+        assertThat(putItemEnhancedRequest.conditionExpression().expression(), equalTo(ITEM_DOES_NOT_EXIST_EXPRESSION));
+    }
+
+    @ParameterizedTest
+    @MethodSource("exceptionProvider")
+    void tryCreatePartitionItem_catches_exception_from_putItem_and_returns_false(final Class exception) throws NoSuchFieldException, IllegalAccessException {
+        final DynamoDbSourcePartitionItem dynamoDbSourcePartitionItem = mock(DynamoDbSourcePartitionItem.class);
+
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        doThrow(exception).when(table).putItem(any(PutItemEnhancedRequest.class));
+
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+
+        reflectivelySetField(objectUnderTest, "table", table);
+
+        final boolean result = objectUnderTest.tryCreatePartitionItem(dynamoDbSourcePartitionItem);
+
+        assertThat(result, equalTo(false));
+    }
+
+    @Test
+    void tryUpdatePartitionItem_updates_expected_partition_item_correctly() throws NoSuchFieldException, IllegalAccessException {
+        final ArgumentCaptor<PutItemEnhancedRequest> putItemEnhancedRequestArgumentCaptor = ArgumentCaptor.forClass(PutItemEnhancedRequest.class);
+        final DynamoDbSourcePartitionItem dynamoDbSourcePartitionItem = mock(DynamoDbSourcePartitionItem.class);
+
+        final Long version = (long) new Random().nextInt(10);
+        given(dynamoDbSourcePartitionItem.getVersion()).willReturn(version).willReturn(version + 1L);
+
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        doNothing().when(table).putItem(putItemEnhancedRequestArgumentCaptor.capture());
+
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+
+        reflectivelySetField(objectUnderTest, "table", table);
+
+        objectUnderTest.tryUpdatePartitionItem(dynamoDbSourcePartitionItem);
+        verify(dynamoDbSourcePartitionItem).setVersion(version + 1L);
+
+        final PutItemEnhancedRequest<DynamoDbSourcePartitionItem> putItemEnhancedRequest = putItemEnhancedRequestArgumentCaptor.getValue();
+
+        assertThat(putItemEnhancedRequest.item(), equalTo(dynamoDbSourcePartitionItem));
+        assertThat(putItemEnhancedRequest.conditionExpression().expression(), equalTo(ITEM_EXISTS_AND_HAS_LATEST_VERSION));
+        assertThat(putItemEnhancedRequest.conditionExpression().expressionValues(), notNullValue());
+        assertThat(putItemEnhancedRequest.conditionExpression().expressionValues().containsKey(":v"), equalTo(true));
+        assertThat(putItemEnhancedRequest.conditionExpression().expressionValues().get(":v"), notNullValue());
+        assertThat(putItemEnhancedRequest.conditionExpression().expressionValues().get(":v").n(), equalTo(version.toString()));
+
+    }
+
+    @ParameterizedTest
+    @MethodSource("exceptionProvider")
+    void tryUpdatePartitionItem_catches_exception_from_putItem_and_throws_PartitionUpdateException(final Class exception) throws NoSuchFieldException, IllegalAccessException {
+        final DynamoDbSourcePartitionItem dynamoDbSourcePartitionItem = mock(DynamoDbSourcePartitionItem.class);
+        final Long version = (long) new Random().nextInt(10);
+        given(dynamoDbSourcePartitionItem.getVersion()).willReturn(version).willReturn(version + 1L);
+
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        doThrow(exception).when(table).putItem(any(PutItemEnhancedRequest.class));
+
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+
+        reflectivelySetField(objectUnderTest, "table", table);
+
+        assertThrows(PartitionUpdateException.class, () -> objectUnderTest.tryUpdatePartitionItem(dynamoDbSourcePartitionItem));
+        verify(dynamoDbSourcePartitionItem).setVersion(version + 1L);
+    }
+
+    @Test
+    void getSourcePartitionItem_returns_expected_item_when_it_exists() throws NoSuchFieldException, IllegalAccessException {
+        final ArgumentCaptor<GetItemEnhancedRequest> getItemEnhancedRequestArgumentCaptor = ArgumentCaptor.forClass(GetItemEnhancedRequest.class);
+
+        final SourcePartitionStoreItem sourcePartitionStoreItem = mock(DynamoDbSourcePartitionItem.class);
+
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        given(table.getItem(getItemEnhancedRequestArgumentCaptor.capture())).willReturn((DynamoDbSourcePartitionItem) sourcePartitionStoreItem);
+
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+
+        reflectivelySetField(objectUnderTest, "table", table);
+
+        final String sourcePartitionKey = UUID.randomUUID().toString();
+
+        final Optional<SourcePartitionStoreItem> result = objectUnderTest.getSourcePartitionItem(sourcePartitionKey);
+
+        assertThat(result.isPresent(), equalTo(true));
+        assertThat(result.get(), equalTo(sourcePartitionStoreItem));
+
+        final GetItemEnhancedRequest getItemEnhancedRequest = getItemEnhancedRequestArgumentCaptor.getValue();
+
+        assertThat(getItemEnhancedRequest.key(), notNullValue());
+        assertThat(getItemEnhancedRequest.key().partitionKeyValue().s(), equalTo(sourcePartitionKey));
+    }
+
+    @Test
+    void getSourcePartitionItem_returns_empty_optional_when_item_does_not_exist() throws NoSuchFieldException, IllegalAccessException {
+        final ArgumentCaptor<GetItemEnhancedRequest> getItemEnhancedRequestArgumentCaptor = ArgumentCaptor.forClass(GetItemEnhancedRequest.class);
+
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        given(table.getItem(getItemEnhancedRequestArgumentCaptor.capture())).willReturn(null);
+
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+
+        reflectivelySetField(objectUnderTest, "table", table);
+
+        final String sourcePartitionKey = UUID.randomUUID().toString();
+
+        final Optional<SourcePartitionStoreItem> result = objectUnderTest.getSourcePartitionItem(sourcePartitionKey);
+
+        assertThat(result.isEmpty(), equalTo(true));
+
+        final GetItemEnhancedRequest getItemEnhancedRequest = getItemEnhancedRequestArgumentCaptor.getValue();
+
+        assertThat(getItemEnhancedRequest.key(), notNullValue());
+        assertThat(getItemEnhancedRequest.key().partitionKeyValue().s(), equalTo(sourcePartitionKey));
+    }
+
+    @ParameterizedTest
+    @MethodSource("exceptionProvider")
+    void getSourcePartitionItem_catches_exception_from_getItem_and_returns_empty_optional(final Class exception) throws NoSuchFieldException, IllegalAccessException {
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        doThrow(exception).when(table).getItem(any(GetItemEnhancedRequest.class));
+
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+
+        reflectivelySetField(objectUnderTest, "table", table);
+
+        final String sourcePartitionKey = UUID.randomUUID().toString();
+
+        final Optional<SourcePartitionStoreItem> result = objectUnderTest.getSourcePartitionItem(sourcePartitionKey);
+
+        assertThat(result.isEmpty(), equalTo(true));
+    }
+
+    @Test
+    void getSourcePartitionItems_returns_expected_PageIterable() throws NoSuchFieldException, IllegalAccessException {
+        final ArgumentCaptor<ScanEnhancedRequest> requestArgumentCaptor = ArgumentCaptor.forClass(ScanEnhancedRequest.class);
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+
+        final Expression filterExpression = mock(Expression.class);
+
+        final PageIterable<DynamoDbSourcePartitionItem> dynamoDbSourcePartitionItemPageIterable = mock(PageIterable.class);
+
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+
+        reflectivelySetField(objectUnderTest, "table", table);
+
+        given(table.scan(requestArgumentCaptor.capture())).willReturn(dynamoDbSourcePartitionItemPageIterable);
+
+        final Optional<PageIterable<DynamoDbSourcePartitionItem>> result = objectUnderTest.getSourcePartitionItems(filterExpression);
+
+        assertThat(result.isPresent(), equalTo(true));
+        assertThat(result.get(), equalTo(dynamoDbSourcePartitionItemPageIterable));
+
+        final ScanEnhancedRequest scanEnhancedRequest = requestArgumentCaptor.getValue();
+
+        assertThat(scanEnhancedRequest.filterExpression(), equalTo(filterExpression));
+        assertThat(scanEnhancedRequest.limit(), equalTo(20));
+    }
+
+    @ParameterizedTest
+    @MethodSource("exceptionProvider")
+    void getSourcePartitionItems_catches_exception_from_scan_and_returns_empty_optional(final Class exception) throws NoSuchFieldException, IllegalAccessException {
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        doThrow(exception).when(table).scan(any(ScanEnhancedRequest.class));
+
+        final Expression filterExpression = mock(Expression.class);
+
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+
+        reflectivelySetField(objectUnderTest, "table", table);
+
+        final Optional<PageIterable<DynamoDbSourcePartitionItem>> result = objectUnderTest.getSourcePartitionItems(filterExpression);
+
+        assertThat(result.isEmpty(), equalTo(true));
+    }
+
+    static Stream<Class> exceptionProvider() {
+        return Stream.of(ConditionalCheckFailedException.class, ProvisionedThroughputExceededException.class, RuntimeException.class);
+    }
+
+    private void reflectivelySetField(final DynamoDbClientWrapper dynamoDbClientWrapper, final String fieldName, final Object value) throws NoSuchFieldException, IllegalAccessException {
+        final Field field = DynamoDbClientWrapper.class.getDeclaredField(fieldName);
+        try {
+            field.setAccessible(true);
+            field.set(dynamoDbClientWrapper, value);
+        } finally {
+            field.setAccessible(false);
+        }
+    }
+}

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStatus;
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputExceededException;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb.DynamoDbSourceCoordinationStore.AVAILABLE_PARTITIONS_FILTER_EXPRESSION;
+
+@ExtendWith(MockitoExtension.class)
+public class DynamoDbSourceCoordinationStoreTest {
+
+    @Mock
+    private DynamoStoreSettings dynamoStoreSettings;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private DynamoDbClientWrapper dynamoDbClientWrapper;
+
+    @BeforeEach
+    void setup() {
+        given(dynamoStoreSettings.getRegion()).willReturn(UUID.randomUUID().toString());
+        given(dynamoStoreSettings.getTableName()).willReturn(UUID.randomUUID().toString());
+        given(dynamoStoreSettings.getProvisionedReadCapacityUnits()).willReturn((long) new Random().nextInt(10));
+        given(dynamoStoreSettings.getProvisionedWriteCapacityUnits()).willReturn((long) new Random().nextInt(10));
+    }
+
+    private DynamoDbSourceCoordinationStore createObjectUnderTest() {
+        try (final MockedStatic<DynamoDbClientWrapper> dynamoDbClientWrapperMockedStatic = mockStatic(DynamoDbClientWrapper.class)) {
+            dynamoDbClientWrapperMockedStatic.when(() -> DynamoDbClientWrapper.create(dynamoStoreSettings.getRegion(), dynamoStoreSettings.getStsRoleArn()))
+                            .thenReturn(dynamoDbClientWrapper);
+            given(dynamoDbClientWrapper.tryCreateTable(eq(dynamoStoreSettings.getTableName()), any(ProvisionedThroughput.class))).willReturn(true);
+            return new DynamoDbSourceCoordinationStore(dynamoStoreSettings, pluginMetrics);
+        }
+    }
+
+    @Test
+    void getSourcePartitionItem_calls_dynamoClientWrapper_correctly() {
+        final SourcePartitionStoreItem sourcePartitionStoreItem = mock(DynamoDbSourcePartitionItem.class);
+
+        final String partitionKey = UUID.randomUUID().toString();
+
+        given(dynamoDbClientWrapper.getSourcePartitionItem(partitionKey)).willReturn(Optional.ofNullable(sourcePartitionStoreItem));
+
+        final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().getSourcePartitionItem(partitionKey);
+
+        assertThat(result.isPresent(), equalTo(true));
+        assertThat(result.get(), equalTo(sourcePartitionStoreItem));
+    }
+
+    @Test
+    void tryCreatePartitionItem_creates_item_when_it_does_not_exist() {
+        final String partitionKey = UUID.randomUUID().toString();
+        final SourcePartitionStatus sourcePartitionStatus = SourcePartitionStatus.UNASSIGNED;
+        final Long closedCount = 0L;
+        final String partitionProgressState = UUID.randomUUID().toString();
+
+        given(dynamoDbClientWrapper.getSourcePartitionItem(partitionKey)).willReturn(Optional.empty());
+
+        final ArgumentCaptor<DynamoDbSourcePartitionItem> itemArgumentCaptor = ArgumentCaptor.forClass(DynamoDbSourcePartitionItem.class);
+
+        given(dynamoDbClientWrapper.tryCreatePartitionItem(itemArgumentCaptor.capture())).willReturn(true);
+
+        final boolean result = createObjectUnderTest().tryCreatePartitionItem(partitionKey, sourcePartitionStatus, closedCount, partitionProgressState);
+
+        assertThat(result, equalTo(true));
+
+        final DynamoDbSourcePartitionItem newItem = itemArgumentCaptor.getValue();
+        assertThat(newItem.getSourcePartitionKey(), equalTo(partitionKey));
+        assertThat(newItem.getPartitionProgressState(), equalTo(partitionProgressState));
+        assertThat(newItem.getClosedCount(), equalTo(closedCount));
+        assertThat(newItem.getSourcePartitionStatus(), equalTo(sourcePartitionStatus));
+        assertThat(newItem.getPartitionOwner(), equalTo(null));
+    }
+
+    @Test
+    void tryCreatePartitionItem_does_not_create_item_when_it_exists() {
+        final String partitionKey = UUID.randomUUID().toString();
+        final SourcePartitionStatus sourcePartitionStatus = SourcePartitionStatus.UNASSIGNED;
+        final Long closedCount = 0L;
+        final String partitionProgressState = UUID.randomUUID().toString();
+
+        given(dynamoDbClientWrapper.getSourcePartitionItem(partitionKey)).willReturn(Optional.of(mock(SourcePartitionStoreItem.class)));
+
+        final boolean result = createObjectUnderTest().tryCreatePartitionItem(partitionKey, sourcePartitionStatus, closedCount, partitionProgressState);
+
+        assertThat(result, equalTo(false));
+        verify(dynamoDbClientWrapper, never()).tryCreatePartitionItem(any(DynamoDbSourcePartitionItem.class));
+    }
+
+    @Test
+    void tryUpdateSourcePartitionItem_calls_dynamoClientWrapper_correctly() {
+        final SourcePartitionStoreItem updateItem = mock(DynamoDbSourcePartitionItem.class);
+
+        doNothing().when(dynamoDbClientWrapper).tryUpdatePartitionItem((DynamoDbSourcePartitionItem) updateItem);
+
+        createObjectUnderTest().tryUpdateSourcePartitionItem(updateItem);
+    }
+
+    @Test
+    void tryAcquireAvailablePartition_with_empty_page_iterable_returns_empty_optional() {
+        final String ownerId = UUID.randomUUID().toString();
+        final Duration ownershipTimeout = Duration.ofMinutes(2);
+
+        final ArgumentCaptor<Expression> expressionArgumentCaptor = ArgumentCaptor.forClass(Expression.class);
+
+        given(dynamoDbClientWrapper.getSourcePartitionItems(expressionArgumentCaptor.capture())).willReturn(Optional.empty());
+
+        final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().tryAcquireAvailablePartition(ownerId, ownershipTimeout);
+
+        assertThat(result.isEmpty(), equalTo(true));
+
+        final Expression expression = expressionArgumentCaptor.getValue();
+        assertThat(expression.expression(), equalTo(AVAILABLE_PARTITIONS_FILTER_EXPRESSION));
+        assertThat(expression.expressionValues().size(), equalTo(4));
+        assertThat(expression.expressionValues().containsKey(":s"), equalTo(true));
+        assertThat(expression.expressionValues().containsKey(":t"), equalTo(true));
+        assertThat(expression.expressionValues().containsKey(":ro"), equalTo(true));
+        assertThat(expression.expressionValues().containsKey(":null"), equalTo(true));
+    }
+
+    @Test
+    void tryAcquireAvailablePartition_iterates_until_it_successfully_acquires_a_partition() {
+        final String ownerId = UUID.randomUUID().toString();
+        final Duration ownershipTimeout = Duration.ofMinutes(2);
+
+        final Instant now = Instant.now();
+
+        final PageIterable<DynamoDbSourcePartitionItem> pageIterable = mock(PageIterable.class);
+
+        final List<DynamoDbSourcePartitionItem> itemList = List.of(mock(DynamoDbSourcePartitionItem.class), mock(DynamoDbSourcePartitionItem.class), mock(DynamoDbSourcePartitionItem.class));
+        given(pageIterable.items()).willReturn(itemList::iterator);
+        given(dynamoDbClientWrapper.getSourcePartitionItems(any(Expression.class))).willReturn(Optional.of(pageIterable));
+
+        doThrow(RuntimeException.class).when(dynamoDbClientWrapper).tryUpdatePartitionItem(itemList.get(0));
+        doNothing().when(dynamoDbClientWrapper).tryUpdatePartitionItem(itemList.get(1));
+
+        final ArgumentCaptor<Instant> argumentCaptor = ArgumentCaptor.forClass(Instant.class);
+        doNothing().when(itemList.get(0)).setPartitionOwnershipTimeout(argumentCaptor.capture());
+
+        final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().tryAcquireAvailablePartition(ownerId, ownershipTimeout);
+
+        assertThat(result.isPresent(), equalTo(true));
+        assertThat(result.get(), is(itemList.get(1)));
+
+        verifyNoMoreInteractions(dynamoDbClientWrapper);
+
+        verify(itemList.get(0)).setSourcePartitionStatus(SourcePartitionStatus.ASSIGNED);
+        verify(itemList.get(0)).setPartitionOwner(ownerId);
+
+        final Instant newOwnershipTimeout = argumentCaptor.getValue();
+
+        assertThat(newOwnershipTimeout, greaterThan(now.plus(ownershipTimeout)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("exceptionProvider")
+    void tryAcquireAvailablePartition_returns_empty_optional_when_an_exception_is_thrown_while_iterating(final Class exception) {
+        final String ownerId = UUID.randomUUID().toString();
+        final Duration ownershipTimeout = Duration.ofMinutes(2);
+
+        final Instant now = Instant.now();
+
+        final PageIterable<DynamoDbSourcePartitionItem> pageIterable = mock(PageIterable.class);
+
+        final List<DynamoDbSourcePartitionItem> itemList = List.of(mock(DynamoDbSourcePartitionItem.class), mock(DynamoDbSourcePartitionItem.class), mock(DynamoDbSourcePartitionItem.class));
+        given(pageIterable.items()).willReturn(itemList::iterator);
+        given(dynamoDbClientWrapper.getSourcePartitionItems(any(Expression.class))).willReturn(Optional.of(pageIterable));
+
+        doThrow(exception).when(dynamoDbClientWrapper).tryUpdatePartitionItem(itemList.get(0));
+        doThrow(exception).when(dynamoDbClientWrapper).tryUpdatePartitionItem(itemList.get(1));
+        doThrow(exception).when(dynamoDbClientWrapper).tryUpdatePartitionItem(itemList.get(2));
+
+        final ArgumentCaptor<Instant> argumentCaptor = ArgumentCaptor.forClass(Instant.class);
+        doNothing().when(itemList.get(0)).setPartitionOwnershipTimeout(argumentCaptor.capture());
+
+        final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().tryAcquireAvailablePartition(ownerId, ownershipTimeout);
+
+        assertThat(result.isEmpty(), equalTo(true));
+
+        verifyNoMoreInteractions(dynamoDbClientWrapper);
+
+        verify(itemList.get(0)).setSourcePartitionStatus(SourcePartitionStatus.ASSIGNED);
+        verify(itemList.get(0)).setPartitionOwner(ownerId);
+
+        final Instant newOwnershipTimeout = argumentCaptor.getValue();
+
+        assertThat(newOwnershipTimeout, greaterThan(now.plus(ownershipTimeout)));
+    }
+
+    static Stream<Class> exceptionProvider() {
+        return Stream.of(ProvisionedThroughputExceededException.class, RuntimeException.class);
+    }
+}

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
@@ -154,7 +154,9 @@ public class DynamoDbSourceCoordinationStoreTest {
         final Expression expression = expressionArgumentCaptor.getValue();
         assertThat(expression.expression(), equalTo(AVAILABLE_PARTITIONS_FILTER_EXPRESSION));
         assertThat(expression.expressionValues().size(), equalTo(4));
-        assertThat(expression.expressionValues().containsKey(":s"), equalTo(true));
+        assertThat(expression.expressionValues().containsKey(":unassigned"), equalTo(true));
+        assertThat(expression.expressionValues().containsKey(":closed"), equalTo(true));
+        assertThat(expression.expressionValues().containsKey(":assigned"), equalTo(true));
         assertThat(expression.expressionValues().containsKey(":t"), equalTo(true));
         assertThat(expression.expressionValues().containsKey(":ro"), equalTo(true));
         assertThat(expression.expressionValues().containsKey(":null"), equalTo(true));


### PR DESCRIPTION
### Description
This change implements the dynamo db source coordination store, which can be configured in the data-prepper-config.yaml with the following config

```
source_coordination:
  store:
    dynamodb:
        table_name: "TestSourceCoordinationDemo"
        region: "us-east-1"
        sts_role_arn: "arn:aws:iam::123456789012:role/source-coordination-ddb-role"
```
 
### Issues Resolved
Related to #2412 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
