### PR TITLE
Change JsonStringBuilder in JacksonEvent to be non static for ease-of-use

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
@@ -120,4 +120,34 @@ public interface Event extends Serializable {
      * @since 2.2
      */
     EventHandle getEventHandle();
+
+    JsonStringBuilder jsonBuilder();
+
+    public abstract class JsonStringBuilder {
+        private String tagsKey;
+
+        /**
+         * @param key key to be used for tags
+         * @return JsonStringString with tags included
+         * @since 2.3
+         */
+        public JsonStringBuilder includeTags(String key) {
+            this.tagsKey = key;
+            return this;
+        }
+
+        /**
+         * @return key used for tags
+         * @since 2.3
+         */
+        public String getTagsKey() {
+            return tagsKey;
+        }
+
+        /**
+         * @return json string
+         * @since 2.3
+         */
+        public abstract String toJsonString();
+    }
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -416,8 +416,8 @@ public class JacksonEvent implements Event {
         };
     }
 
-    public static JsonStringBuilder jsonBuilder() {
-        return new JsonStringBuilder();
+    public JsonStringBuilder jsonBuilder() {
+        return new JsonStringBuilder(this);
     }
 
     public static JacksonEvent fromEvent(final Event event) {
@@ -517,18 +517,11 @@ public class JacksonEvent implements Event {
         }
     }
 
-    public static class JsonStringBuilder {
-        private String tagsKey;
-        private JacksonEvent event;
+    public class JsonStringBuilder extends Event.JsonStringBuilder {
+        private Event event;
 
-        public JsonStringBuilder withEvent(final JacksonEvent event) {
+        public JsonStringBuilder(final Event event) {
             this.event = event;
-            return this;
-        }
-
-        public JsonStringBuilder includeTags(String key) {
-            tagsKey = key;
-            return this;
         }
 
         public String toJsonString() {
@@ -536,6 +529,7 @@ public class JacksonEvent implements Event {
                 return null;
             }
             final String jsonString = event.toJsonString().trim();
+            final String tagsKey = getTagsKey();
             if(tagsKey != null) {
                 final JsonNode tagsNode = mapper.valueToTree(event.getMetadata().getTags());
                 return jsonString.substring(0, jsonString.length()-1) + ",\""+tagsKey+"\":" + tagsNode.toString()+"}";

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -520,7 +520,7 @@ public class JacksonEvent implements Event {
     public class JsonStringBuilder extends Event.JsonStringBuilder {
         private Event event;
 
-        public JsonStringBuilder(final Event event) {
+        private JsonStringBuilder(final Event event) {
             checkNotNull(event, "event cannot be null");
             this.event = event;
         }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -521,13 +521,11 @@ public class JacksonEvent implements Event {
         private Event event;
 
         public JsonStringBuilder(final Event event) {
+            checkNotNull(event, "event cannot be null");
             this.event = event;
         }
 
         public String toJsonString() {
-            if (event == null) {
-                return null;
-            }
             final String jsonString = event.toJsonString().trim();
             final String tagsKey = getTagsKey();
             if(tagsKey != null) {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -650,9 +650,8 @@ public class JacksonEventTest {
         eventMetadata.addTag("tag1");
         eventMetadata.addTag("tag2");
         final String expectedJsonString = "{\"foo\":\"bar\",\"tags\":[\"tag1\",\"tag2\"]}";
-        assertThat(JacksonEvent.jsonBuilder().withEvent(event).includeTags("tags").toJsonString(), equalTo(expectedJsonString));
-        assertThat(JacksonEvent.jsonBuilder().withEvent(event).toJsonString(), equalTo(jsonString));
-        assertThat(JacksonEvent.jsonBuilder().toJsonString(), equalTo(null));
+        assertThat(event.jsonBuilder().includeTags("tags").toJsonString(), equalTo(expectedJsonString));
+        assertThat(event.jsonBuilder().toJsonString(), equalTo(jsonString));
     }
 
     private static Map<String, Object> createComplexDataMap() {


### PR DESCRIPTION
Change JsonStringBuilder in JacksonEvent to be non static for ease-of-use.
Changes 
`JacksonEvent.jsonBuilder().withEvent(event).includeTags("tags").toJsonString()`
to
`event.jsonBuilder().includeTags("tags").toJsonString()`

Resolves #2665 

### Description
Resolves #2665 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
