### PR TITLE
updating documentation and providing tests which demonstrate json poi…

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorTests.java
@@ -98,6 +98,21 @@ public class DeleteEntryProcessorTests {
         assertThat(editedRecords.get(0).getData().containsKey("newMessage"), is(true));
     }
 
+    public void testNestedDeleteProcessorTest() {
+        when(mockConfig.getWithKeys()).thenReturn(new String[]{"nested/foo"});
+
+        Map<String, Object> nested = Map.of("foo", "bar", "fizz", 42);
+
+        final DeleteEntryProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("thisisamessage");
+        record.getData().put("nested", nested);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("nested/foo"), is(false));
+        assertThat(editedRecords.get(0).getData().containsKey("nested/fizz"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+    }
+
     private DeleteEntryProcessor createObjectUnderTest() {
         return new DeleteEntryProcessor(pluginMetrics, mockConfig, expressionEvaluator);
     }

--- a/docs/expression_syntax.md
+++ b/docs/expression_syntax.md
@@ -180,3 +180,8 @@ White space is **required** surrounding Set Initializers, Priority Expressions, 
 | `==`, `!=`           | Equality Operators       | No                   | `/status == 200`<br>`/status_code==200`                        |                                       |
 | `and`, `or`, `not`   | Conditional Operators    | Yes                  | `/a<300 and /b>200`                                            | `/b<300and/b>200`                     |
 | `,`                  | Set Value Delimiter      | No                   | `/a in {200, 202}`<br>`/a in {200,202}`<br>`/a in {200 , 202}` | `/a in {200,}`                        |
+
+## JsonPointers
+
+The event data structure can be nested and have multiple levels of data. JsonPointers can be leveraged within expressions
+to reference elements throughout an event.


### PR DESCRIPTION
…nters can be used to reference nested elements

### Description
- Adding a unit test which demonstrate deleting nested elements.
- Adding documentation in expression syntax doc which highlights Json pointers can be used to reference nested elements. I will follow up with the documentation project on including this. 
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
