### PR TITLE
eliminates in built slash in s3 dlq key and resolves 2581

### DIFF
--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/README.md
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/README.md
@@ -36,6 +36,11 @@ Example:
 dlq-v2-apache-log-pipeline-opensearch-2023-04-05T15:26:19.152938Z-e7eb675a-f558-4048-8566-dac15a4f8343
 ```
 
+The full key path for a file written to the S3 DLQ will have the following pattern using the `key_path_prefix` from the 
+configuration and the file name specified above: `${key_path_prefix}${file name}`. If the `key_prefix` is non-null and is
+not suffixed with a `/`, one will be added by default. This will enforce a `/` is always between the `key_path_prefix`
+and `file name` when a `key_path_prefix` is provided. 
+
 The DLQ file will JSON file with an array of failed [DLQ Objects](#DLQ-Objects).
 
 ### Configurations

--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterTest.java
@@ -108,7 +108,7 @@ public class S3DlqWriterTest {
         bucket = UUID.randomUUID().toString();
         keyPathPrefix = UUID.randomUUID().toString();
 
-        expectedKeyPrefix = String.format("%s/dlq-v%s-%s-%s", keyPathPrefix, DataPrepperVersion.getCurrentVersion(), pipelineName, pluginId);
+        expectedKeyPrefix = String.format("%sdlq-v%s-%s-%s", keyPathPrefix, DataPrepperVersion.getCurrentVersion(), pipelineName, pluginId);
 
         putObjectResponse = (PutObjectResponse) PutObjectResponse.builder()
             .sdkHttpResponse(mockHttpResponse)
@@ -168,7 +168,9 @@ public class S3DlqWriterTest {
 
         return Stream.of(
             Arguments.of(randomKeyPathPrefix, String.format("%s/dlq-v%s", randomKeyPathPrefix, DataPrepperVersion.getCurrentVersion().getMajorVersion())),
-            Arguments.of(null, String.format("dlq-v%s", DataPrepperVersion.getCurrentVersion().getMajorVersion()))
+            Arguments.of(randomKeyPathPrefix + "/", String.format("%s/dlq-v%s", randomKeyPathPrefix, DataPrepperVersion.getCurrentVersion().getMajorVersion())),
+            Arguments.of(null, String.format("dlq-v%s", DataPrepperVersion.getCurrentVersion().getMajorVersion())),
+            Arguments.of("", String.format("dlq-v%s", DataPrepperVersion.getCurrentVersion().getMajorVersion()))
         );
     }
 


### PR DESCRIPTION
### Description
Eliminating extra slash in determining s3 key for DLQ. Updated documentation as well.
 
### Issues Resolved
- resolves #2581
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
