### PR TITLE
addressing copy and paste error

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -202,7 +202,7 @@ public final class BulkRetryStrategy {
                 try {
                     Thread.sleep(delayMillis);
                 } catch (final InterruptedException e){
-                    LOG.error("Thread is interrupted while polling SQS with retry.", e);
+                    LOG.error("Thread is interrupted while attempting to bulk write to OpenSearch with retry.", e);
                 }
             }
         } while (operationResponse != null);


### PR DESCRIPTION
### Description
There is a log line in the opensearch sink that was introduced from #2643 that used a log line from the S3 Source [SQS Worker](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java#L163)
 
### Issues Resolved
None
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
