### PR TITLE
Add hasTags() function to dataprepper expressions

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventMetadata.java
@@ -8,10 +8,11 @@ package org.opensearch.dataprepper.model.event;
 import com.google.common.collect.ImmutableMap;
 
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.HashSet;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -73,8 +74,13 @@ public class DefaultEventMetadata implements EventMetadata {
     }
 
     @Override
-    public Boolean hasTag(final String tag) {
-        return tags.contains(tag);
+    public Boolean hasTags(final List<String> tagsList) {
+        for (final String tag: tagsList) {
+            if (!tags.contains(tag)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventMetadata.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.model.event;
 
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -46,11 +47,11 @@ public interface EventMetadata extends Serializable {
 
     /**
      * Indicates if a tag is present
-     * @param tag name of the tag to be looked up
-     * @return true if the tag is present, false otherwise
+     * @param tags list of the tags to be looked up
+     * @return true if all tags are present, false otherwise
      * @since 2.3
      */
-    Boolean hasTag(final String tag);
+    Boolean hasTags(final List<String> tags);
 
     /**
      * Adds a tag to the Metadata

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -191,9 +192,9 @@ public class DefaultEventMetadataTest {
 
         assertThat(result.getTags(), equalTo(testTags));
         result.addTag("tag3");
-        assertTrue(result.hasTag("tag1"));
-        assertTrue(result.hasTag("tag2"));
-        assertTrue(result.hasTag("tag3"));
+        assertTrue(result.hasTags(List.of("tag1")));
+        assertTrue(result.hasTags(List.of("tag1", "tag2")));
+        assertTrue(result.hasTags(List.of("tag1", "tag2", "tag3")));
     }
 
     @Nested

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -191,10 +192,16 @@ public class DefaultEventMetadataTest {
         assertThat(result, notNullValue());
 
         assertThat(result.getTags(), equalTo(testTags));
+        assertFalse(result.hasTags(List.of("tag3")));
+        assertFalse(result.hasTags(List.of("tag3", "tag1")));
         result.addTag("tag3");
         assertTrue(result.hasTags(List.of("tag1")));
         assertTrue(result.hasTags(List.of("tag1", "tag2")));
         assertTrue(result.hasTags(List.of("tag1", "tag2", "tag3")));
+        assertFalse(result.hasTags(List.of("notPresentTag")));
+        assertFalse(result.hasTags(List.of("notPresentTag1", "notPresentTag2")));
+        assertFalse(result.hasTags(List.of("tag1", "notPresentTag")));
+        assertFalse(result.hasTags(List.of("tag1", "tag2", "notPresentTag")));
     }
 
     @Nested

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.opensearch.dataprepper.model.event.Event;
+import java.util.List;
+import java.util.Set;
+import javax.inject.Named;
+import java.util.function.Function;
+
+@Named
+public class HasTagsExpressionFunction implements ExpressionFunction {
+    public String getFunctionName() {
+        return "hasTags";
+    }
+
+    public Object evaluate(final List<Object> args, Event event, Function<Object, Object> convertLiteralType) {
+        if (args.size() == 0) {
+            throw new RuntimeException("hasTags() takes at least one argument");
+        }
+        Set<String> tags = event.getMetadata().getTags();
+        for (final Object arg: args) {
+            if (!(arg instanceof String)) {
+                throw new RuntimeException("hasTags() takes only String type arguments");
+            }
+            if (!tags.contains((String)arg)) {
+                return Boolean.FALSE;
+            }
+        }
+        return Boolean.TRUE;
+    }
+}
+
+

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunction.java
@@ -21,11 +21,14 @@ public class HasTagsExpressionFunction implements ExpressionFunction {
         if (args.size() == 0) {
             throw new RuntimeException("hasTags() takes at least one argument");
         }
-        if(!args.stream().allMatch(a -> a instanceof String)) {
-            throw new RuntimeException("hasTags() takes only String type arguments");
+        if(!args.stream().allMatch(a -> ((a instanceof String) && (((String)a).length() > 0) && (((String)a).charAt(0) == '"')))) {
+            throw new RuntimeException("hasTags() takes only non-empty string literal type arguments");
         }
         final List<String> tags = args.stream()
-                                    .map(a -> (String) a)
+                                    .map(a -> {
+                                        String str = (String) a;
+                                        return str.substring(1, str.length()-1);
+                                     })
                                     .collect(Collectors.toList());
         return event.getMetadata().hasTags(tags);
     }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunction.java
@@ -6,8 +6,8 @@
 package org.opensearch.dataprepper.expression;
 
 import org.opensearch.dataprepper.model.event.Event;
+import java.util.stream.Collectors;
 import java.util.List;
-import java.util.Set;
 import javax.inject.Named;
 import java.util.function.Function;
 
@@ -21,16 +21,13 @@ public class HasTagsExpressionFunction implements ExpressionFunction {
         if (args.size() == 0) {
             throw new RuntimeException("hasTags() takes at least one argument");
         }
-        Set<String> tags = event.getMetadata().getTags();
-        for (final Object arg: args) {
-            if (!(arg instanceof String)) {
-                throw new RuntimeException("hasTags() takes only String type arguments");
-            }
-            if (!tags.contains((String)arg)) {
-                return Boolean.FALSE;
-            }
+        if(!args.stream().allMatch(a -> a instanceof String)) {
+            throw new RuntimeException("hasTags() takes only String type arguments");
         }
-        return Boolean.TRUE;
+        final List<String> tags = args.stream()
+                                    .map(a -> (String) a)
+                                    .collect(Collectors.toList());
+        return event.getMetadata().hasTags(tags);
     }
 }
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ConditionalExpressionEvaluatorIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ConditionalExpressionEvaluatorIT.java
@@ -129,6 +129,13 @@ class ConditionalExpressionEvaluatorIT {
                 .withData(eventMap)
                 .build();
 
+        String testTag1 = RandomStringUtils.randomAlphabetic(6);
+        String testTag2 = RandomStringUtils.randomAlphabetic(7);
+        String testTag3 = RandomStringUtils.randomAlphabetic(6);
+        String testTag4 = RandomStringUtils.randomAlphabetic(7);
+        longEvent.getMetadata().addTag(testTag1);
+        longEvent.getMetadata().addTag(testTag2);
+
         Random random = new Random();
         int testStringLength = random.nextInt(10);
         String testString = RandomStringUtils.randomAlphabetic(testStringLength);
@@ -166,12 +173,29 @@ class ConditionalExpressionEvaluatorIT {
                         true),
                 Arguments.of("/durationInNanos > 5000000000", event("{\"durationInNanos\": 6000000000}"), true),
                 Arguments.of("/response == \"OK\"", event("{\"response\": \"OK\"}"), true),
-                Arguments.of("length(/response) == "+testStringLength, event("{\"response\": \""+testString+"\"}"), true)
+                Arguments.of("length(/response) == "+testStringLength, event("{\"response\": \""+testString+"\"}"), true),
+                Arguments.of("hasTags(\""+ testTag1+"\")", longEvent, true),
+                Arguments.of("hasTags(\""+ testTag1+"\",\""+testTag2+"\")", longEvent, true),
+                Arguments.of("hasTags(\""+ testTag3+"\")", longEvent, false),
+                Arguments.of("hasTags(\""+ testTag3+"\",\""+testTag4+"\")", longEvent, false)
         );
     }
 
     private static Stream<Arguments> invalidExpressionArguments() {
         Random random = new Random();
+
+        final String key = RandomStringUtils.randomAlphabetic(5);
+        final String value = RandomStringUtils.randomAlphabetic(10);
+        Map<Object, Object> eventMap = Collections.singletonMap(key, value);
+        Event tagEvent = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(eventMap)
+                .build();
+        String testTag1 = RandomStringUtils.randomAlphabetic(6);
+        String testTag2 = RandomStringUtils.randomAlphabetic(7);
+        tagEvent.getMetadata().addTag(testTag1);
+        tagEvent.getMetadata().addTag(testTag2);
+
         int testStringLength = random.nextInt(10);
         String testString = RandomStringUtils.randomAlphabetic(testStringLength);
         return Stream.of(
@@ -194,7 +218,13 @@ class ConditionalExpressionEvaluatorIT {
                 Arguments.of("trueand/status_code", event("{\"status_code\": 200}")),
                 Arguments.of("trueor/status_code", event("{\"status_code\": 200}")),
                 Arguments.of("length(\""+testString+") == "+testStringLength, event("{\"response\": \""+testString+"\"}")),
-                Arguments.of("length(\""+testString+"\") == "+testStringLength, event("{\"response\": \""+testString+"\"}"))
+                Arguments.of("length(\""+testString+"\") == "+testStringLength, event("{\"response\": \""+testString+"\"}")),
+                Arguments.of("hasTags(10)", tagEvent),
+                Arguments.of("hasTags("+ testTag1+")", tagEvent),
+                Arguments.of("hasTags(\""+ testTag1+")", tagEvent),
+                Arguments.of("hasTags(\""+ testTag1+"\","+testTag2+"\")", tagEvent),
+                Arguments.of("hasTags(,\""+testTag2+"\")", tagEvent),
+                Arguments.of("hasTags(\""+testTag2+"\",)", tagEvent)
         );
     }
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunctionTest.java
@@ -45,7 +45,7 @@ class HasTagsExpressionFunctionTest {
         for (int i = 0; i < numTags; i++) {
             String tag = RandomStringUtils.randomAlphabetic(5);
             testEvent.getMetadata().addTag(tag);
-            tags.add(tag);
+            tags.add("\""+tag+"\"");
         }
     }
 
@@ -69,7 +69,7 @@ class HasTagsExpressionFunctionTest {
         generateTags(testEvent, numTags);
         hasTagsExpressionFunction = createObjectUnderTest();
         for (int i = 0; i < numTags; i++) {
-            String unknownTag = RandomStringUtils.randomAlphabetic(5);
+            String unknownTag = "\""+RandomStringUtils.randomAlphabetic(5)+"\"";
             List<Object> tagsList = tags.subList(0, i);
             tagsList.add((Object)unknownTag);
             assertThat(hasTagsExpressionFunction.evaluate(tagsList, testEvent, testFunction), equalTo(false));
@@ -83,15 +83,27 @@ class HasTagsExpressionFunctionTest {
     }
 
     @Test
+    void testHasTagsWithMissingTag() {
+        hasTagsExpressionFunction = createObjectUnderTest();
+        assertThrows(RuntimeException.class, () -> hasTagsExpressionFunction.evaluate(List.of(""), testEvent, testFunction));
+    }
+
+    @Test
     void testHasTagsWithEmptyTag() {
         hasTagsExpressionFunction = createObjectUnderTest();
-        assertThat(hasTagsExpressionFunction.evaluate(List.of(""), testEvent, testFunction), equalTo(false));
+        assertThat(hasTagsExpressionFunction.evaluate(List.of("\"\""), testEvent, testFunction), equalTo(false));
     }
 
     @Test
     void testHasTagsWithNonStringTags() {
         hasTagsExpressionFunction = createObjectUnderTest();
         assertThrows(RuntimeException.class, () -> hasTagsExpressionFunction.evaluate(List.of(30), testEvent, testFunction));
+    }
+
+    @Test
+    void testHasTagsWithStringTagsWithOutQuotes() {
+        hasTagsExpressionFunction = createObjectUnderTest();
+        assertThrows(RuntimeException.class, () -> hasTagsExpressionFunction.evaluate(List.of("tag"), testEvent, testFunction));
     }
 
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunctionTest.java
@@ -78,6 +78,7 @@ class HasTagsExpressionFunctionTest {
 
     @Test
     void testHasTagsWithZeroTags() {
+        hasTagsExpressionFunction = createObjectUnderTest();
         assertThrows(RuntimeException.class, () -> hasTagsExpressionFunction.evaluate(List.of(), testEvent, testFunction));
     }
 
@@ -89,6 +90,7 @@ class HasTagsExpressionFunctionTest {
 
     @Test
     void testHasTagsWithNonStringTags() {
+        hasTagsExpressionFunction = createObjectUnderTest();
         assertThrows(RuntimeException.class, () -> hasTagsExpressionFunction.evaluate(List.of(30), testEvent, testFunction));
     }
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/HasTagsExpressionFunctionTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.apache.commons.lang3.RandomStringUtils;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Random;
+import java.util.function.Function;
+
+class HasTagsExpressionFunctionTest {
+    private HasTagsExpressionFunction hasTagsExpressionFunction;
+    private Event testEvent;
+    private Function<Object, Object> testFunction;
+    private List<Object> tags;
+    private int numTags;
+
+    private Event createTestEvent(final Object data) {
+        return JacksonEvent.builder().withEventType("event").withData(data).build();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        String key = RandomStringUtils.randomAlphabetic(5);
+        String value = RandomStringUtils.randomAlphabetic(10);
+        testEvent = createTestEvent(Map.of(key, value));
+        tags = new ArrayList<>();
+        Random random = new Random();
+        numTags = random.nextInt(9) + 1;
+        for (int i = 0; i < numTags; i++) {
+            String tag = RandomStringUtils.randomAlphabetic(5);
+            testEvent.getMetadata().addTag(tag);
+            tags.add(tag);
+        }
+        testFunction = mock(Function.class);
+    }
+
+    public HasTagsExpressionFunction createObjectUnderTest() {
+        return new HasTagsExpressionFunction();
+    }
+
+    @Test
+    void testHasTagsBasic() {
+        hasTagsExpressionFunction = createObjectUnderTest();
+        for (int i = 1; i <= numTags; i++) {
+            assertThat(hasTagsExpressionFunction.evaluate(tags.subList(0, i), testEvent, testFunction), equalTo(true));
+        }
+    }
+
+    @Test
+    void testHasTagsWithOneUnknownTag() {
+        hasTagsExpressionFunction = createObjectUnderTest();
+        for (int i = 0; i < numTags; i++) {
+            String unknownTag = RandomStringUtils.randomAlphabetic(5);
+            List<Object> tagsList = tags.subList(0, i);
+            tagsList.add((Object)unknownTag);
+            assertThat(hasTagsExpressionFunction.evaluate(tagsList, testEvent, testFunction), equalTo(false));
+        }
+    }
+
+    @Test
+    void testHasTagsWithZeroTags() {
+        assertThrows(RuntimeException.class, () -> hasTagsExpressionFunction.evaluate(List.of(), testEvent, testFunction));
+    }
+
+    @Test
+    void testHasTagsWithEmptyTag() {
+        hasTagsExpressionFunction = createObjectUnderTest();
+        assertThat(hasTagsExpressionFunction.evaluate(List.of(""), testEvent, testFunction), equalTo(false));
+    }
+
+    @Test
+    void testHasTagsWithNonStringTags() {
+        assertThrows(RuntimeException.class, () -> hasTagsExpressionFunction.evaluate(List.of(30), testEvent, testFunction));
+    }
+
+}

--- a/docs/expression_syntax.md
+++ b/docs/expression_syntax.md
@@ -170,7 +170,13 @@ will extract `message` field from the event and compares it's length with 20. Th
 Currently the following functions are supported
  * `length()`
    - takes one argument of JsonPointer type
-   - returns the length of the value of the argument passed if it's type is string. For example, `length("/message")` returns 10 if the key `message` exists in the event and has the value of `"1234567890"`.
+   - returns the length of the value of the argument passed if it's type is string.
+   For example, `length("/message")` returns 10 if the key `message` exists in the event and has the value of `"1234567890"`.
+ * `hasTags()`
+   - takes at least one argument
+   - all arguments must be of String type
+   - returns true if all arguments are present in the event's tags, returns false otherwise
+   For example, if event has tags "tag1", "tag2", and "tag3", `hasTags("tag1")` or `hasTags("tag1", "tag2")` would return true and `hasTags("tag4")` would return false.
 
 
 ## White Space

--- a/docs/expression_syntax.md
+++ b/docs/expression_syntax.md
@@ -176,7 +176,7 @@ Currently the following functions are supported
    - takes at least one argument
    - all arguments must be of String type
    - returns true if all arguments are present in the event's tags, returns false otherwise
-   For example, if event has tags "tag1", "tag2", and "tag3", `hasTags("tag1")` or `hasTags("tag1", "tag2")` would return true and `hasTags("tag4")` would return false.
+   For example, if event has tags "tag1", "tag2", and "tag3", `hasTags("tag1")` or `hasTags("tag1", "tag2")` would return true and `hasTags("tag4")` and `hadTags("tag1", "tag4")` would return false.
 
 
 ## White Space


### PR DESCRIPTION
### Description
Add hasTags() function to dataprepper expressions.
Data Prepper expressions can now check about presence of tags in the event.
For example an expression may look like 
`hasTag("tag1") and /status_code == 200` 
which returns true if the event has a tag with name "tag1" and status_code value is 200.

Resolves #629 
 
### Issues Resolved
#629 
 
### Check List
- [ X] New functionality includes testing.
- [ X] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
