### PR TITLE
Add isIpInCidr function

### DIFF
--- a/data-prepper-expression/build.gradle
+++ b/data-prepper-expression/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation platform('org.apache.logging.log4j:log4j-bom:2.20.0')
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-slf4j2-impl'
+    implementation 'com.github.seancfoley:ipaddress:5.4.0'
     testImplementation testLibs.spring.test
     testImplementation "org.apache.commons:commons-lang3:3.12.0"
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/CidrExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/CidrExpressionFunction.java
@@ -47,7 +47,10 @@ public class CidrExpressionFunction implements ExpressionFunction {
     }
 
     private boolean isIpInCidr(final String ipAddressStr, final List<String> cidrBlockStrs) {
-        Objects.requireNonNull(ipAddressStr, "The IP address field to check with isIpInCidr() is null or cannot be found in the event.");
+        if (Objects.isNull(ipAddressStr)) {
+            // The IP address field is null or cannot be found in the event
+            return false;
+        }
 
         IPAddress address = new IPAddressString(ipAddressStr).getAddress();
         List<IPAddress> cidrBlocks = cidrBlockStrs.stream()

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/CidrExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/CidrExpressionFunction.java
@@ -20,7 +20,7 @@ public class CidrExpressionFunction implements ExpressionFunction {
 
     @Override
     public String getFunctionName() {
-        return "isIpInCidr";
+        return "isIPinCIDR";
     }
 
     @Override

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/CidrExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/CidrExpressionFunction.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
+import org.opensearch.dataprepper.model.event.Event;
+
+import javax.inject.Named;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Named
+public class CidrExpressionFunction implements ExpressionFunction {
+
+    @Override
+    public String getFunctionName() {
+        return "isIpInCidr";
+    }
+
+    @Override
+    public Object evaluate(final List<Object> args, Event event, Function<Object, Object> convertLiteralType) {
+        if (args.size() <= 1) {
+            throw new IllegalArgumentException("isIpInCidr() takes at least two arguments");
+        }
+
+        final List<String> argStrings;
+        try {
+            argStrings = args.stream()
+                    .map(arg -> ((String)arg).trim())
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Arguments in isIpInCidr() function should be of Json Pointer type or String type");
+        }
+
+        final String ipAddressInEvent = event.get(argStrings.get(0), String.class);
+        final List<String> cidrBlockStrs = argStrings.subList(1, argStrings.size()).stream()
+                .map(str -> str.substring(1, str.length() - 1))
+                .collect(Collectors.toList());
+
+        return isIpInCidr(ipAddressInEvent, cidrBlockStrs);
+    }
+
+    private boolean isIpInCidr(final String ipAddressStr, final List<String> cidrBlockStrs) {
+        Objects.requireNonNull(ipAddressStr, "The IP address field to check with isIpInCidr() is null or cannot be found in the event.");
+
+        IPAddress address = new IPAddressString(ipAddressStr).getAddress();
+        List<IPAddress> cidrBlocks = cidrBlockStrs.stream()
+                .map(blockStr -> new IPAddressString(blockStr).getAddress())
+                .collect(Collectors.toList());
+
+        boolean result = false;
+        for (IPAddress cidrBlock : cidrBlocks) {
+            if (cidrBlock.contains(address)) {
+                result = true;
+            }
+        }
+        return result;
+    }
+}

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/CidrExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/CidrExpressionFunction.java
@@ -57,12 +57,11 @@ public class CidrExpressionFunction implements ExpressionFunction {
                 .map(blockStr -> new IPAddressString(blockStr).getAddress())
                 .collect(Collectors.toList());
 
-        boolean result = false;
         for (IPAddress cidrBlock : cidrBlocks) {
             if (cidrBlock.contains(address)) {
-                result = true;
+                return true;
             }
         }
-        return result;
+        return false;
     }
 }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/CidrExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/CidrExpressionFunction.java
@@ -18,15 +18,16 @@ import java.util.stream.Collectors;
 @Named
 public class CidrExpressionFunction implements ExpressionFunction {
 
+    private static final String FUNCTION_NAME = "cidrContains";
     @Override
     public String getFunctionName() {
-        return "isIPinCIDR";
+        return FUNCTION_NAME;
     }
 
     @Override
     public Object evaluate(final List<Object> args, Event event, Function<Object, Object> convertLiteralType) {
         if (args.size() <= 1) {
-            throw new IllegalArgumentException("isIpInCidr() takes at least two arguments");
+            throw new IllegalArgumentException(FUNCTION_NAME + "() takes at least two arguments");
         }
 
         final List<String> argStrings;
@@ -35,7 +36,8 @@ public class CidrExpressionFunction implements ExpressionFunction {
                     .map(arg -> ((String)arg).trim())
                     .collect(Collectors.toList());
         } catch (Exception e) {
-            throw new IllegalArgumentException("Arguments in isIpInCidr() function should be of Json Pointer type or String type");
+            throw new IllegalArgumentException(
+                    "Arguments in " + FUNCTION_NAME + "() function should be of Json Pointer type or String type");
         }
 
         final String ipAddressInEvent = event.get(argStrings.get(0), String.class);

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/CidrExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/CidrExpressionFunctionTest.java
@@ -8,6 +8,9 @@ package org.opensearch.dataprepper.expression;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.event.Event;
@@ -16,6 +19,8 @@ import org.opensearch.dataprepper.model.event.JacksonEvent;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -42,20 +47,22 @@ class CidrExpressionFunctionTest {
         cidrExpressionFunction = createObjectUnderTest();
     }
 
-    @Test
-    void testIpv4MatchWithSingleCidrBlock() {
-        String network = "\"192.0.2.0/24\"";
-        testEvent = createTestEvent(Map.of("sourceIp", "192.0.2.3"));
+    @ParameterizedTest
+    @MethodSource("ipv4AddressesInRange")
+    void testIpv4MatchWithSingleCidrBlock(String testIp) {
+        String network = "\"192.0.2.0/26\"";
+        testEvent = createTestEvent(Map.of("sourceIp", testIp));
         Object expressionResult = cidrExpressionFunction.evaluate(List.of("/sourceIp", network), testEvent, testFunction);
         assertThat((boolean)expressionResult, equalTo(true));
     }
 
-    @Test
-    void testIpv4MatchWithMultipleCidrBlocks() {
-        String network1 = "\"192.0.2.0/24\"";
+    @ParameterizedTest
+    @MethodSource("ipv4AddressesInRange")
+    void testIpv4MatchWithMultipleCidrBlocks(String testIp) {
+        String network1 = "\"192.0.2.0/26\"";
         String network2 = "\"192.168.1.0/24\"";
         String network3 = "\"10.0.1.0/24\"";
-        testEvent = createTestEvent(Map.of("sourceIp", "192.0.2.3"));
+        testEvent = createTestEvent(Map.of("sourceIp", testIp));
         Object expressionResult = cidrExpressionFunction.evaluate(
                 List.of("/sourceIp", network1, network2, network3), testEvent, testFunction);
         assertThat((boolean)expressionResult, equalTo(true));
@@ -72,20 +79,22 @@ class CidrExpressionFunctionTest {
         assertThat((boolean)expressionResult, equalTo(false));
     }
 
-    @Test
-    void testIpv6MatchWithSingleCidrBlock() {
+    @ParameterizedTest
+    @MethodSource("ipv6AddressesInRange")
+    void testIpv6MatchWithSingleCidrBlock(String testIp) {
         String network = "\"2001:0db8::/32\"";
-        testEvent = createTestEvent(Map.of("sourceIp", "2001:0db8:aaaa:bbbb::"));
+        testEvent = createTestEvent(Map.of("sourceIp", testIp));
         Object expressionResult = cidrExpressionFunction.evaluate(List.of("/sourceIp", network), testEvent, testFunction);
         assertThat((boolean)expressionResult, equalTo(true));
     }
 
-    @Test
-    void testIpv6MatchWithMultipleCidrBlocks() {
+    @ParameterizedTest
+    @MethodSource("ipv6AddressesInRange")
+    void testIpv6MatchWithMultipleCidrBlocks(String testIp) {
         String network1 = "\"2001:0db8::/32\"";
         String network2 = "\"2001:aaaa::/32\"";
         String network3 = "\"2001:bbbb:cccc::/48\"";
-        testEvent = createTestEvent(Map.of("sourceIp", "2001:0db8:aaaa:bbbb::"));
+        testEvent = createTestEvent(Map.of("sourceIp", testIp));
         Object expressionResult = cidrExpressionFunction.evaluate(List.of("/sourceIp", network1, network2, network3), testEvent, testFunction);
         assertThat((boolean)expressionResult, equalTo(true));
     }
@@ -120,5 +129,20 @@ class CidrExpressionFunctionTest {
         testEvent = createTestEvent(Map.of("sourceIp", "192.0.2.3"));
         assertThrows(NullPointerException.class,
                 () -> cidrExpressionFunction.evaluate(List.of("/destinationIp", network), testEvent, testFunction));
+    }
+
+    private static Stream<Arguments> ipv4AddressesInRange() {
+        final String prefix = "192.0.2.";
+        return IntStream.range(0, 64)
+                .boxed()
+                .map(num -> Arguments.of(prefix + num));
+    }
+
+    private static Stream<Arguments> ipv6AddressesInRange() {
+        return Stream.of(
+                Arguments.of("2001:0db8::"),
+                Arguments.of("2001:0db8:aaaa:bbbb::"),
+                Arguments.of("2001:0db8:ffff:ffff:ffff:ffff:ffff:ffff")
+        );
     }
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/CidrExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/CidrExpressionFunctionTest.java
@@ -124,11 +124,11 @@ class CidrExpressionFunctionTest {
     }
 
     @Test
-    void testIpAddressNotExistInEventThrowsException() {
+    void testIpAddressNotExistInEventReturnsFalse() {
         String network = "\"192.0.2.0/24\"";
         testEvent = createTestEvent(Map.of("sourceIp", "192.0.2.3"));
-        assertThrows(NullPointerException.class,
-                () -> cidrExpressionFunction.evaluate(List.of("/destinationIp", network), testEvent, testFunction));
+        Object expressionResult = cidrExpressionFunction.evaluate(List.of("/destinationIp", network), testEvent, testFunction);
+        assertThat((boolean)expressionResult, equalTo(false));
     }
 
     private static Stream<Arguments> ipv4AddressesInRange() {

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/CidrExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/CidrExpressionFunctionTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class CidrExpressionFunctionTest {
+    private CidrExpressionFunction cidrExpressionFunction;
+    private Event testEvent;
+
+    @Mock
+    private Function<Object, Object> testFunction;
+
+    private Event createTestEvent(final Object data) {
+        return JacksonEvent.builder().withEventType("event").withData(data).build();
+    }
+
+    private CidrExpressionFunction createObjectUnderTest() {
+        return new CidrExpressionFunction();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        cidrExpressionFunction = createObjectUnderTest();
+    }
+
+    @Test
+    void testIpv4MatchWithSingleCidrBlock() {
+        String network = "\"192.0.2.0/24\"";
+        testEvent = createTestEvent(Map.of("sourceIp", "192.0.2.3"));
+        Object expressionResult = cidrExpressionFunction.evaluate(List.of("/sourceIp", network), testEvent, testFunction);
+        assertThat((boolean)expressionResult, equalTo(true));
+    }
+
+    @Test
+    void testIpv4MatchWithMultipleCidrBlocks() {
+        String network1 = "\"192.0.2.0/24\"";
+        String network2 = "\"192.168.1.0/24\"";
+        String network3 = "\"10.0.1.0/24\"";
+        testEvent = createTestEvent(Map.of("sourceIp", "192.0.2.3"));
+        Object expressionResult = cidrExpressionFunction.evaluate(
+                List.of("/sourceIp", network1, network2, network3), testEvent, testFunction);
+        assertThat((boolean)expressionResult, equalTo(true));
+    }
+
+    @Test
+    void testIpv4NonMatchWithMultipleCidrBlocks() {
+        String network1 = "\"192.0.2.0/24\"";
+        String network2 = "\"192.168.1.0/24\"";
+        String network3 = "\"10.0.1.0/24\"";
+        testEvent = createTestEvent(Map.of("sourceIp", "192.0.5.3"));
+        Object expressionResult = cidrExpressionFunction.evaluate(
+                List.of("/sourceIp", network1, network2, network3), testEvent, testFunction);
+        assertThat((boolean)expressionResult, equalTo(false));
+    }
+
+    @Test
+    void testIpv6MatchWithSingleCidrBlock() {
+        String network = "\"2001:0db8::/32\"";
+        testEvent = createTestEvent(Map.of("sourceIp", "2001:0db8:aaaa:bbbb::"));
+        Object expressionResult = cidrExpressionFunction.evaluate(List.of("/sourceIp", network), testEvent, testFunction);
+        assertThat((boolean)expressionResult, equalTo(true));
+    }
+
+    @Test
+    void testIpv6MatchWithMultipleCidrBlocks() {
+        String network1 = "\"2001:0db8::/32\"";
+        String network2 = "\"2001:aaaa::/32\"";
+        String network3 = "\"2001:bbbb:cccc::/48\"";
+        testEvent = createTestEvent(Map.of("sourceIp", "2001:0db8:aaaa:bbbb::"));
+        Object expressionResult = cidrExpressionFunction.evaluate(List.of("/sourceIp", network1, network2, network3), testEvent, testFunction);
+        assertThat((boolean)expressionResult, equalTo(true));
+    }
+
+    @Test
+    void testIpv6NonMatchWithMultipleCidrBlocks() {
+        String network1 = "\"2001:0db8::/32\"";
+        String network2 = "\"2001:aaaa::/32\"";
+        String network3 = "\"2001:bbbb:cccc::/48\"";
+        testEvent = createTestEvent(Map.of("sourceIp", "2001:dddd:aaaa:bbbb::"));
+        Object expressionResult = cidrExpressionFunction.evaluate(List.of("/sourceIp", network1, network2, network3), testEvent, testFunction);
+        assertThat((boolean)expressionResult, equalTo(false));
+    }
+
+    @Test
+    void testTooFewArgumentsThrowsException() {
+        testEvent = createTestEvent(Map.of("sourceIp", "192.0.2.3"));
+        assertThrows(IllegalArgumentException.class,
+                () -> cidrExpressionFunction.evaluate(List.of("/sourceIp"), testEvent, testFunction));
+    }
+
+    @Test
+    void testArgumentTypeNotSupportedThrowsException() {
+        testEvent = createTestEvent(Map.of("sourceIp", "192.0.2.3"));
+        assertThrows(IllegalArgumentException.class,
+                () -> cidrExpressionFunction.evaluate(List.of("/sourceIp", 123), testEvent, testFunction));
+    }
+
+    @Test
+    void testIpAddressNotExistInEventThrowsException() {
+        String network = "\"192.0.2.0/24\"";
+        testEvent = createTestEvent(Map.of("sourceIp", "192.0.2.3"));
+        assertThrows(NullPointerException.class,
+                () -> cidrExpressionFunction.evaluate(List.of("/destinationIp", network), testEvent, testFunction));
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
@@ -197,12 +197,12 @@ class GenericExpressionEvaluator_ConditionalIT {
                 Arguments.of("getMetadata(\"key3\") == "+value5, longEvent, true),
                 Arguments.of("getMetadata(\"/key6\") == \""+value5+"\"", longEvent, false),
                 Arguments.of("getMetadata(\"key6\") == "+value5, longEvent, false),
-                Arguments.of("isIpInCidr(/sourceIp,\"192.0.2.0/24\")", event("{\"sourceIp\": \"192.0.2.3\"}"), true),
-                Arguments.of("isIpInCidr(/sourceIp,\"192.0.2.0/24\",\"192.1.1.0/24\")", event("{\"sourceIp\": \"192.0.2.3\"}"), true),
-                Arguments.of("isIpInCidr(/sourceIp,\"192.0.2.0/24\",\"192.1.1.0/24\")", event("{\"sourceIp\": \"192.2.2.3\"}"), false),
-                Arguments.of("isIpInCidr(/sourceIp,\"2001:0db8::/32\")", event("{\"sourceIp\": \"2001:0db8:aaaa:bbbb::\"}"), true),
-                Arguments.of("isIpInCidr(/sourceIp,\"2001:0db8::/32\",\"2001:aaaa::/32\")", event("{\"sourceIp\": \"2001:0db8:aaaa:bbbb::\"}"), true),
-                Arguments.of("isIpInCidr(/sourceIp,\"2001:0db8::/32\",\"2001:aaaa::/32\")", event("{\"sourceIp\": \"2001:abcd:aaaa:bbbb::\"}"), false)
+                Arguments.of("isIPinCIDR(/sourceIp,\"192.0.2.0/24\")", event("{\"sourceIp\": \"192.0.2.3\"}"), true),
+                Arguments.of("isIPinCIDR(/sourceIp,\"192.0.2.0/24\",\"192.1.1.0/24\")", event("{\"sourceIp\": \"192.0.2.3\"}"), true),
+                Arguments.of("isIPinCIDR(/sourceIp,\"192.0.2.0/24\",\"192.1.1.0/24\")", event("{\"sourceIp\": \"192.2.2.3\"}"), false),
+                Arguments.of("isIPinCIDR(/sourceIp,\"2001:0db8::/32\")", event("{\"sourceIp\": \"2001:0db8:aaaa:bbbb::\"}"), true),
+                Arguments.of("isIPinCIDR(/sourceIp,\"2001:0db8::/32\",\"2001:aaaa::/32\")", event("{\"sourceIp\": \"2001:0db8:aaaa:bbbb::\"}"), true),
+                Arguments.of("isIPinCIDR(/sourceIp,\"2001:0db8::/32\",\"2001:aaaa::/32\")", event("{\"sourceIp\": \"2001:abcd:aaaa:bbbb::\"}"), false)
         );
     }
 
@@ -253,8 +253,8 @@ class GenericExpressionEvaluator_ConditionalIT {
                 Arguments.of("getMetadata(10)", tagEvent),
                 Arguments.of("getMetadata("+ testMetadataKey+ ")", tagEvent),
                 Arguments.of("getMetadata(\""+ testMetadataKey+")", tagEvent),
-                Arguments.of("isIpInCidr(/sourceIp)", event("{\"sourceIp\": \"192.0.2.3\"}")),
-                Arguments.of("isIpInCidr(/sourceIp,123)", event("{\"sourceIp\": \"192.0.2.3\"}"))
+                Arguments.of("isIPinCIDR(/sourceIp)", event("{\"sourceIp\": \"192.0.2.3\"}")),
+                Arguments.of("isIPinCIDR(/sourceIp,123)", event("{\"sourceIp\": \"192.0.2.3\"}"))
         );
     }
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
@@ -197,12 +197,12 @@ class GenericExpressionEvaluator_ConditionalIT {
                 Arguments.of("getMetadata(\"key3\") == "+value5, longEvent, true),
                 Arguments.of("getMetadata(\"/key6\") == \""+value5+"\"", longEvent, false),
                 Arguments.of("getMetadata(\"key6\") == "+value5, longEvent, false),
-                Arguments.of("isIPinCIDR(/sourceIp,\"192.0.2.0/24\")", event("{\"sourceIp\": \"192.0.2.3\"}"), true),
-                Arguments.of("isIPinCIDR(/sourceIp,\"192.0.2.0/24\",\"192.1.1.0/24\")", event("{\"sourceIp\": \"192.0.2.3\"}"), true),
-                Arguments.of("isIPinCIDR(/sourceIp,\"192.0.2.0/24\",\"192.1.1.0/24\")", event("{\"sourceIp\": \"192.2.2.3\"}"), false),
-                Arguments.of("isIPinCIDR(/sourceIp,\"2001:0db8::/32\")", event("{\"sourceIp\": \"2001:0db8:aaaa:bbbb::\"}"), true),
-                Arguments.of("isIPinCIDR(/sourceIp,\"2001:0db8::/32\",\"2001:aaaa::/32\")", event("{\"sourceIp\": \"2001:0db8:aaaa:bbbb::\"}"), true),
-                Arguments.of("isIPinCIDR(/sourceIp,\"2001:0db8::/32\",\"2001:aaaa::/32\")", event("{\"sourceIp\": \"2001:abcd:aaaa:bbbb::\"}"), false)
+                Arguments.of("cidrContains(/sourceIp,\"192.0.2.0/24\")", event("{\"sourceIp\": \"192.0.2.3\"}"), true),
+                Arguments.of("cidrContains(/sourceIp,\"192.0.2.0/24\",\"192.1.1.0/24\")", event("{\"sourceIp\": \"192.0.2.3\"}"), true),
+                Arguments.of("cidrContains(/sourceIp,\"192.0.2.0/24\",\"192.1.1.0/24\")", event("{\"sourceIp\": \"192.2.2.3\"}"), false),
+                Arguments.of("cidrContains(/sourceIp,\"2001:0db8::/32\")", event("{\"sourceIp\": \"2001:0db8:aaaa:bbbb::\"}"), true),
+                Arguments.of("cidrContains(/sourceIp,\"2001:0db8::/32\",\"2001:aaaa::/32\")", event("{\"sourceIp\": \"2001:0db8:aaaa:bbbb::\"}"), true),
+                Arguments.of("cidrContains(/sourceIp,\"2001:0db8::/32\",\"2001:aaaa::/32\")", event("{\"sourceIp\": \"2001:abcd:aaaa:bbbb::\"}"), false)
         );
     }
 
@@ -253,8 +253,8 @@ class GenericExpressionEvaluator_ConditionalIT {
                 Arguments.of("getMetadata(10)", tagEvent),
                 Arguments.of("getMetadata("+ testMetadataKey+ ")", tagEvent),
                 Arguments.of("getMetadata(\""+ testMetadataKey+")", tagEvent),
-                Arguments.of("isIPinCIDR(/sourceIp)", event("{\"sourceIp\": \"192.0.2.3\"}")),
-                Arguments.of("isIPinCIDR(/sourceIp,123)", event("{\"sourceIp\": \"192.0.2.3\"}"))
+                Arguments.of("cidrContains(/sourceIp)", event("{\"sourceIp\": \"192.0.2.3\"}")),
+                Arguments.of("cidrContains(/sourceIp,123)", event("{\"sourceIp\": \"192.0.2.3\"}"))
         );
     }
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
@@ -196,7 +196,13 @@ class GenericExpressionEvaluator_ConditionalIT {
                 Arguments.of("getMetadata(\"/key2\") == "+value4, longEvent, true),
                 Arguments.of("getMetadata(\"key3\") == "+value5, longEvent, true),
                 Arguments.of("getMetadata(\"/key6\") == \""+value5+"\"", longEvent, false),
-                Arguments.of("getMetadata(\"key6\") == "+value5, longEvent, false)
+                Arguments.of("getMetadata(\"key6\") == "+value5, longEvent, false),
+                Arguments.of("isIpInCidr(/sourceIp,\"192.0.2.0/24\")", event("{\"sourceIp\": \"192.0.2.3\"}"), true),
+                Arguments.of("isIpInCidr(/sourceIp,\"192.0.2.0/24\",\"192.1.1.0/24\")", event("{\"sourceIp\": \"192.0.2.3\"}"), true),
+                Arguments.of("isIpInCidr(/sourceIp,\"192.0.2.0/24\",\"192.1.1.0/24\")", event("{\"sourceIp\": \"192.2.2.3\"}"), false),
+                Arguments.of("isIpInCidr(/sourceIp,\"2001:0db8::/32\")", event("{\"sourceIp\": \"2001:0db8:aaaa:bbbb::\"}"), true),
+                Arguments.of("isIpInCidr(/sourceIp,\"2001:0db8::/32\",\"2001:aaaa::/32\")", event("{\"sourceIp\": \"2001:0db8:aaaa:bbbb::\"}"), true),
+                Arguments.of("isIpInCidr(/sourceIp,\"2001:0db8::/32\",\"2001:aaaa::/32\")", event("{\"sourceIp\": \"2001:abcd:aaaa:bbbb::\"}"), false)
         );
     }
 
@@ -246,7 +252,9 @@ class GenericExpressionEvaluator_ConditionalIT {
                 Arguments.of("hasTags(\""+testTag2+"\",)", tagEvent),
                 Arguments.of("getMetadata(10)", tagEvent),
                 Arguments.of("getMetadata("+ testMetadataKey+ ")", tagEvent),
-                Arguments.of("getMetadata(\""+ testMetadataKey+")", tagEvent)
+                Arguments.of("getMetadata(\""+ testMetadataKey+")", tagEvent),
+                Arguments.of("isIpInCidr(/sourceIp)", event("{\"sourceIp\": \"192.0.2.3\"}")),
+                Arguments.of("isIpInCidr(/sourceIp,123)", event("{\"sourceIp\": \"192.0.2.3\"}"))
         );
     }
 

--- a/docs/expression_syntax.md
+++ b/docs/expression_syntax.md
@@ -167,11 +167,11 @@ Escaped Example
 DataPrepper has some in-built functions that can be used as operand in an expression. For example
 `length(/message) > 20`
 will extract `message` field from the event and compares it's length with 20. The value of `message` field is expected to be of String type. If the field is not present in the event, null is returned and the function is not applied on it. If the field's value is not String then error is thrown.
-Currently the following functions are supported
+Currently, the following functions are supported
  * `length()`
    - takes one argument of JsonPointer type
    - returns the length of the value of the argument passed if it's type is string.
-   For example, `length("/message")` returns 10 if the key `message` exists in the event and has the value of `"1234567890"`.
+   For example, `length(/message)` returns 10 if the key `message` exists in the event and has the value of `"1234567890"`.
  * `hasTags()`
    - takes at least one argument
    - all arguments must be of String type
@@ -181,6 +181,11 @@ Currently the following functions are supported
    - takes one String literal as argument. This is the key to lookup in the event's metadata. If the key contains "/", then recursive lookup into the metadata attributes is done.
    - returns the value corresponding to the argument (key) passed. Value can be of any type.
    For example, if metadata contains {"key1": "value2", "key2": 10}, then `getMetadata("key1")` returns "value2", and `getMetadata("key2")` return 10.
+* `isIpInCidr()`
+   - The function takes two or more arguments. The first argument is of Json Pointer type representing the key to the IP address to check; the argument(s) that follows is of String type representing CIDR block(s) to check against.
+   - If the IP address is in the range of any given CIDR blocks, the function evaluates to true; otherwise, the function evaluates to false.
+   - The function supports both IPv4 and IPv6 addresses.
+   For example, `isIpInCidr(/sourceIp,"192.0.2.0/24","10.0.1.0/16")` evaluates to true if the event has `sourceIp` field with value "192.0.2.5".
 
 
 ## White Space

--- a/docs/expression_syntax.md
+++ b/docs/expression_syntax.md
@@ -181,11 +181,11 @@ Currently, the following functions are supported
    - takes one String literal as argument. This is the key to lookup in the event's metadata. If the key contains "/", then recursive lookup into the metadata attributes is done.
    - returns the value corresponding to the argument (key) passed. Value can be of any type.
    For example, if metadata contains {"key1": "value2", "key2": 10}, then `getMetadata("key1")` returns "value2", and `getMetadata("key2")` return 10.
-* `isIpInCidr()`
+* `isIPinCIDR()`
    - The function takes two or more arguments. The first argument is of Json Pointer type representing the key to the IP address to check; the argument(s) that follows is of String type representing CIDR block(s) to check against.
    - If the IP address is in the range of any given CIDR blocks, the function evaluates to true; otherwise, the function evaluates to false.
    - The function supports both IPv4 and IPv6 addresses.
-   For example, `isIpInCidr(/sourceIp,"192.0.2.0/24","10.0.1.0/16")` evaluates to true if the event has `sourceIp` field with value "192.0.2.5".
+   For example, `isIPinCIDR(/sourceIp,"192.0.2.0/24","10.0.1.0/16")` evaluates to true if the event has `sourceIp` field with value "192.0.2.5".
 
 
 ## White Space

--- a/docs/expression_syntax.md
+++ b/docs/expression_syntax.md
@@ -181,11 +181,11 @@ Currently, the following functions are supported
    - takes one String literal as argument. This is the key to lookup in the event's metadata. If the key contains "/", then recursive lookup into the metadata attributes is done.
    - returns the value corresponding to the argument (key) passed. Value can be of any type.
    For example, if metadata contains {"key1": "value2", "key2": 10}, then `getMetadata("key1")` returns "value2", and `getMetadata("key2")` return 10.
-* `isIPinCIDR()`
+* `cidrContains()`
    - The function takes two or more arguments. The first argument is of Json Pointer type representing the key to the IP address to check; the argument(s) that follows is of String type representing CIDR block(s) to check against.
    - If the IP address is in the range of any given CIDR blocks, the function evaluates to true; otherwise, the function evaluates to false.
    - The function supports both IPv4 and IPv6 addresses.
-   For example, `isIPinCIDR(/sourceIp,"192.0.2.0/24","10.0.1.0/16")` evaluates to true if the event has `sourceIp` field with value "192.0.2.5".
+   For example, `cidrContains(/sourceIp,"192.0.2.0/24","10.0.1.0/16")` evaluates to true if the event has `sourceIp` field with value "192.0.2.5".
 
 
 ## White Space


### PR DESCRIPTION
### Description
Adds a function to check if an IP address is in the range of given CIDR blocks. For example: `isIpInCidr(/sourceIp,"192.0.2.0/24","10.0.1.0/16")` evaluates to true if the event has `sourceIp` field with value "192.0.2.5"
 
### Issues Resolved
Resolves #2625 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
