### PR TITLE
Fix spaces between function args

### DIFF
--- a/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
+++ b/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
@@ -114,7 +114,7 @@ Function
 
 fragment
 FunctionArgs
-    : (FunctionArg SPACE* COMMA)* SPACE* FunctionArg
+    : (FunctionArg SPACE* COMMA SPACE*)* SPACE* FunctionArg
     ;
 
 fragment

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ConditionalExpressionEvaluatorIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ConditionalExpressionEvaluatorIT.java
@@ -135,6 +135,7 @@ class ConditionalExpressionEvaluatorIT {
         String testTag4 = RandomStringUtils.randomAlphabetic(7);
         longEvent.getMetadata().addTag(testTag1);
         longEvent.getMetadata().addTag(testTag2);
+        longEvent.getMetadata().addTag(testTag3);
 
         Random random = new Random();
         int testStringLength = random.nextInt(10);
@@ -176,7 +177,8 @@ class ConditionalExpressionEvaluatorIT {
                 Arguments.of("length(/response) == "+testStringLength, event("{\"response\": \""+testString+"\"}"), true),
                 Arguments.of("hasTags(\""+ testTag1+"\")", longEvent, true),
                 Arguments.of("hasTags(\""+ testTag1+"\",\""+testTag2+"\")", longEvent, true),
-                Arguments.of("hasTags(\""+ testTag3+"\")", longEvent, false),
+                Arguments.of("hasTags(\""+ testTag1+"\", \""+testTag2+"\", \""+testTag3+"\")", longEvent, true),
+                Arguments.of("hasTags(\""+ testTag4+"\")", longEvent, false),
                 Arguments.of("hasTags(\""+ testTag3+"\",\""+testTag4+"\")", longEvent, false)
         );
     }


### PR DESCRIPTION
### Description
Currently, the function expression allows spaces between 1st and 2nd arguments but not between 2nd and 3rd arguments or beyond. For example, `hasTags("tag1", "tag2")` would be OK, but `hasTags("tag1", "tag2", "tag3")` would result in the follow error:
```
line 1:0 token recognition error at: 'hasTags("tag1", "tag2",'
line 1:30 extraneous input ')' expecting <EOF>
2023-05-12T16:38:41,571 [...] ERROR org.opensearch.dataprepper.pipeline.ProcessWorker - Encountered exception during pipeline simple-pipeline processing
org.opensearch.dataprepper.expression.ExpressionEvaluationException: Unable to evaluate statement "hasTags("tag1", "tag2", "tag3")"
...
```

This CR tries to fix the issue by adding spaces in `FunctionArgs` rule.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
