### PR TITLE
Add support for basic arithmetic and string returning expressions to DataPrepper Expression

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/expression/ExpressionEvaluator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/expression/ExpressionEvaluator.java
@@ -11,7 +11,7 @@ import org.opensearch.dataprepper.model.event.Event;
  * @since 1.3
  * ExpressionEvaluator interface to abstract the parse and evaluate implementations.
  */
-public interface ExpressionEvaluator<T> {
+public interface ExpressionEvaluator {
 
     /**
      * @since 1.3
@@ -20,9 +20,16 @@ public interface ExpressionEvaluator<T> {
      *
      * @param statement string to be parsed and evaluated
      * @param context event used to resolve external references in the statement
-     * @return coerced result of statement evaluation
-     *
-     * @throws ExpressionEvaluationException if unable to evaluate or coerce the statement result to type T
+     * @return result of statement evaluation
      */
-    T evaluate(final String statement, final Event context);
+    Object evaluate(final String statement, final Event context);
+
+    default Boolean evaluateConditional(final String statement, final Event context) {
+        final Object result = evaluate(statement, context);
+        if (result instanceof Boolean) {
+            return (Boolean) result;
+        } else {
+            throw new ClassCastException("Unexpected expression return type of " + result.getClass());
+        }
+    }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/expression/ExpressionEvaluatorTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/expression/ExpressionEvaluatorTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.junit.jupiter.api.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class ExpressionEvaluatorTest {
+    private ExpressionEvaluator expressionEvaluator;
+    class TestExpressionEvaluator implements ExpressionEvaluator {
+        public Object evaluate(final String statement, final Event event) {
+            return event.get(statement, Object.class);
+        }
+    }
+
+    @Test
+    public void testDefaultEvaluateConditional() {
+        expressionEvaluator = new TestExpressionEvaluator();
+        assertThat(expressionEvaluator.evaluateConditional("/status", event("{\"status\":true}")), equalTo(true));
+        
+    }
+
+    @Test
+    public void testDefaultEvaluateConditionalThrows() {
+        expressionEvaluator = new TestExpressionEvaluator();
+        assertThrows(ClassCastException.class, () -> expressionEvaluator.evaluateConditional("/status", event("{\"status\":200}")));
+    }
+
+    private static Event event(final String data) {
+        return JacksonEvent.builder().withEventType("event").withData(data).build();
+    }
+}
+
+

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouteEventEvaluator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouteEventEvaluator.java
@@ -23,10 +23,10 @@ class RouteEventEvaluator {
 
     private static final Logger LOG = LoggerFactory.getLogger(RouteEventEvaluator.class);
 
-    private final ExpressionEvaluator<Boolean> evaluator;
+    private final ExpressionEvaluator evaluator;
     private final Collection<ConditionalRoute> routes;
 
-    RouteEventEvaluator(final ExpressionEvaluator<Boolean> evaluator, final Collection<ConditionalRoute> routes) {
+    RouteEventEvaluator(final ExpressionEvaluator evaluator, final Collection<ConditionalRoute> routes) {
         this.evaluator = evaluator;
         this.routes = routes;
     }
@@ -61,7 +61,7 @@ class RouteEventEvaluator {
         final Set<String> matchRoutes = new HashSet<>();
         for (ConditionalRoute route : routes) {
             try {
-                if (evaluator.evaluate(route.getCondition(), event)) {
+                if (evaluator.evaluateConditional(route.getCondition(), event)) {
                     matchRoutes.add(route.getName());
                 }
             } catch (final Exception ex) {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterAppConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 class RouterAppConfig {
     @Bean
-    public RouterFactory routeEvaluatorFactory(final ExpressionEvaluator<Boolean> expressionEvaluator) {
+    public RouterFactory routeEvaluatorFactory(final ExpressionEvaluator expressionEvaluator) {
         return new RouterFactory(expressionEvaluator);
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterFactory.java
@@ -12,10 +12,10 @@ import java.util.Objects;
 import java.util.Set;
 
 public class RouterFactory {
-    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final ExpressionEvaluator expressionEvaluator;
     private final DataFlowComponentRouter dataFlowComponentRouter;
 
-    RouterFactory(final ExpressionEvaluator<Boolean> expressionEvaluator) {
+    RouterFactory(final ExpressionEvaluator expressionEvaluator) {
         this.expressionEvaluator = Objects.requireNonNull(expressionEvaluator);
         dataFlowComponentRouter = new DataFlowComponentRouter();
     }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/RouteEventEvaluatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/RouteEventEvaluatorTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
 class RouteEventEvaluatorTest {
 
     @Mock
-    private ExpressionEvaluator<Boolean> evaluator;
+    private ExpressionEvaluator evaluator;
     private List<ConditionalRoute> routes;
 
     private RouteEventEvaluator createObjectUnderTest() {
@@ -162,7 +162,7 @@ class RouteEventEvaluatorTest {
             final Record recordMatchingAllRoutes = records.get(1);
             final Event eventMatchingAllRoutes = (Event) records.get(1).getData();
             for (ConditionalRoute route : routes) {
-                when(evaluator.evaluate(route.getCondition(), eventMatchingAllRoutes))
+                when(evaluator.evaluateConditional(route.getCondition(), eventMatchingAllRoutes))
                         .thenReturn(true);
 
                 for (Record record : records) {
@@ -202,14 +202,14 @@ class RouteEventEvaluatorTest {
             final Record recordMatchingAllRoutes = records.get(1);
             final Event eventMatchingAllRoutes = (Event) records.get(1).getData();
             for (ConditionalRoute route : routes) {
-                when(evaluator.evaluate(route.getCondition(), eventMatchingAllRoutes))
+                when(evaluator.evaluateConditional(route.getCondition(), eventMatchingAllRoutes))
                         .thenReturn(true);
 
                 for (Record record : records) {
                     if(recordMatchingAllRoutes == record)
                         continue;
 
-                    when(evaluator.evaluate(route.getCondition(), (Event) record.getData()))
+                    when(evaluator.evaluateConditional(route.getCondition(), (Event) record.getData()))
                             .thenThrow(RuntimeException.class);
                 }
             }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/RouterFactoryTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/RouterFactoryTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.mock;
 class RouterFactoryTest {
 
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
     private Set<ConditionalRoute> routes;
 
     @BeforeEach

--- a/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
+++ b/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
@@ -11,7 +11,22 @@ grammar DataPrepperExpression;
 
 expression
     : conditionalExpression EOF
+    | arithmeticExpression EOF
+    | stringExpression EOF
     | OTHER {System.err.println("unknown char: " + $OTHER.text);}
+    ;
+
+stringExpression
+    : function
+    | jsonPointer
+    | String
+    ;
+
+arithmeticExpression
+    : function
+    | jsonPointer
+    | Integer
+    | Float
     ;
 
 conditionalExpression

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator.java
@@ -16,12 +16,12 @@ import javax.inject.Named;
  * {@link org.opensearch.dataprepper.model.sink.Sink} and data-prepper-core objects can use to evaluate statements.
  */
 @Named
-class ConditionalExpressionEvaluator implements ExpressionEvaluator<Boolean> {
+class GenericExpressionEvaluator implements ExpressionEvaluator {
     private final Parser<ParseTree> parser;
     private final Evaluator<ParseTree, Event> evaluator;
 
     @Inject
-    public ConditionalExpressionEvaluator(final Parser<ParseTree> parser, final Evaluator<ParseTree, Event> evaluator) {
+    public GenericExpressionEvaluator(final Parser<ParseTree> parser, final Evaluator<ParseTree, Event> evaluator) {
         this.parser = parser;
         this.evaluator = evaluator;
     }
@@ -32,17 +32,10 @@ class ConditionalExpressionEvaluator implements ExpressionEvaluator<Boolean> {
      * @throws ExpressionEvaluationException if unable to evaluate or coerce the statement result to type T
      */
     @Override
-    public Boolean evaluate(final String statement, final Event context) {
+    public Object evaluate(final String statement, final Event context) {
         try {
             final ParseTree parseTree = parser.parse(statement);
-            final Object result = evaluator.evaluate(parseTree, context);
-
-            if (result instanceof Boolean) {
-                return (Boolean) result;
-            }
-            else {
-                throw new ClassCastException("Unexpected expression return type of " + result.getClass());
-            }
+            return evaluator.evaluate(parseTree, context);
         }
         catch (final Exception exception) {
             throw new ExpressionEvaluationException("Unable to evaluate statement \"" + statement + "\"", exception);

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeEvaluator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeEvaluator.java
@@ -31,11 +31,11 @@ class ParseTreeEvaluator implements Evaluator<ParseTree, Event> {
     }
 
     @Override
-    public Boolean evaluate(ParseTree parseTree, Event event) {
+    public Object evaluate(ParseTree parseTree, Event event) {
         try {
             final ParseTreeEvaluatorListener listener = new ParseTreeEvaluatorListener(operatorProvider, coercionService, event);
             walker.walk(listener, parseTree);
-            return coercionService.coerce(listener.getResult(), Boolean.class);
+            return listener.getResult();
         } catch (final Exception e) {
             LOG.error("Unable to evaluate event", e);
             throw new ExpressionEvaluationException(e.getMessage(), e);

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ArithmeticExpressionEvaluatorIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ArithmeticExpressionEvaluatorIT.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import java.util.Random;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.not;
+import org.apache.commons.lang3.RandomStringUtils;
+
+class ArithmeticExpressionEvaluatorIT {
+
+    private AnnotationConfigApplicationContext applicationContext;
+
+    @BeforeEach
+    void beforeEach() {
+        applicationContext = new AnnotationConfigApplicationContext();
+        applicationContext.scan("org.opensearch.dataprepper.expression");
+        applicationContext.refresh();
+    }
+
+    @Test
+    void testArithmeticExpressionEvaluatorBeanAvailable() {
+        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
+        assertThat(evaluator, isA(GenericExpressionEvaluator.class));
+    }
+
+    @Test
+    void testArithmeticExpressionEvaluatorBeanSingleton() {
+        final GenericExpressionEvaluator instanceA = applicationContext.getBean(GenericExpressionEvaluator.class);
+        final GenericExpressionEvaluator instanceB = applicationContext.getBean(GenericExpressionEvaluator.class);
+        assertThat(instanceA, sameInstance(instanceB));
+    }
+
+    @Test
+    void testParserBeanInstanceOfMultiThreadParser() {
+        final Parser instance = applicationContext.getBean(Parser.class);
+        assertThat(instance, instanceOf(MultiThreadParser.class));
+    }
+
+    @Test
+    void testSingleThreadParserBeanNotSingleton() {
+        final Parser instanceA = applicationContext.getBean(ParseTreeParser.SINGLE_THREAD_PARSER_NAME, Parser.class);
+        final Parser instanceB = applicationContext.getBean(ParseTreeParser.SINGLE_THREAD_PARSER_NAME, Parser.class);
+        assertThat(instanceA, not(sameInstance(instanceB)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validExpressionArguments")
+    void testArithmeticExpressionEvaluator(final String expression, final Event event, final Number expected, final Class expectedClass) {
+        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
+
+        final Number actual = (Number)evaluator.evaluate(expression, event);
+
+        assertThat(actual, is(expected));
+        assertThat(actual, instanceOf(expectedClass));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validExpressionArguments")
+    void testArithmeticExpressionEvaluatorWithMultipleThreads(final String expression, final Event event, final Number expected, final Class expectedClass) {
+        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
+
+        final int numberOfThreads = 50;
+        final ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        List<Number> evaluationResults = Collections.synchronizedList(new ArrayList<>());
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.execute(() -> evaluationResults.add((Number)evaluator.evaluate(expression, event)));
+        }
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> evaluationResults.size() == numberOfThreads);
+
+        assertThat(evaluationResults.size(), equalTo(numberOfThreads));
+        for (Number evaluationResult : evaluationResults) {
+            assertThat(evaluationResult, equalTo(expected));
+            assertThat(evaluationResult, instanceOf(expectedClass));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidExpressionArguments")
+    void testArithmeticExpressionEvaluatorInvalidInput(final String expression, final Event event, final Class expectedClass) {
+        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
+        Object result = evaluator.evaluate(expression, event);
+        assertThat(result, not(instanceOf(expectedClass)));
+    }
+
+    private static Stream<Arguments> validExpressionArguments() {
+        Random random = new Random();
+        int randomInt = random.nextInt(10000);
+        float randomFloat = random.nextFloat();
+        int testStringLength = random.nextInt(30);
+        String testString = RandomStringUtils.randomAlphabetic(testStringLength);
+        return Stream.of(
+                Arguments.of(""+randomInt, event("{}"), randomInt, Integer.class),
+                Arguments.of("/status_code", event("{\"status_code\": "+randomInt+"}"), randomInt, Integer.class),
+                Arguments.of("/status_code", event("{\"status_code\": "+randomFloat+"}"), randomFloat, Float.class),
+                Arguments.of("length(/message)", event("{\"message\": \""+testString+"\"}"), testString.length(), Integer.class)
+        );
+    }
+
+    private static Stream<Arguments> invalidExpressionArguments() {
+        Random random = new Random();
+        int testStringLength = random.nextInt(10);
+        String testString = RandomStringUtils.randomAlphabetic(testStringLength);
+        return Stream.of(
+                Arguments.of("/missing", event("{}"), Integer.class),
+                Arguments.of("/message", event("{\"message\": \""+testString+"\"}"), Integer.class),
+                Arguments.of("/status", event("{\"status\": true}"), Integer.class),
+                Arguments.of("/status", event("{\"status\": 5.55}"), Integer.class),
+                Arguments.of("/status", event("{\"status\": 200}"), Float.class)
+        );
+    }
+
+    private static Event event(final String data) {
+        return JacksonEvent.builder().withEventType("event").withData(data).build();
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ConditionalExpressionEvaluatorIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ConditionalExpressionEvaluatorIT.java
@@ -54,15 +54,15 @@ class ConditionalExpressionEvaluatorIT {
     }
 
     @Test
-    void testConditionalExpressionEvaluatorBeanAvailable() {
-        final ConditionalExpressionEvaluator evaluator = applicationContext.getBean(ConditionalExpressionEvaluator.class);
-        assertThat(evaluator, isA(ConditionalExpressionEvaluator.class));
+    void testGenericExpressionEvaluatorBeanAvailable() {
+        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
+        assertThat(evaluator, isA(GenericExpressionEvaluator.class));
     }
 
     @Test
-    void testConditionalExpressionEvaluatorBeanSingleton() {
-        final ConditionalExpressionEvaluator instanceA = applicationContext.getBean(ConditionalExpressionEvaluator.class);
-        final ConditionalExpressionEvaluator instanceB = applicationContext.getBean(ConditionalExpressionEvaluator.class);
+    void testGenericExpressionEvaluatorBeanSingleton() {
+        final GenericExpressionEvaluator instanceA = applicationContext.getBean(GenericExpressionEvaluator.class);
+        final GenericExpressionEvaluator instanceB = applicationContext.getBean(GenericExpressionEvaluator.class);
         assertThat(instanceA, sameInstance(instanceB));
     }
 
@@ -82,17 +82,17 @@ class ConditionalExpressionEvaluatorIT {
     @ParameterizedTest
     @MethodSource("validExpressionArguments")
     void testConditionalExpressionEvaluator(final String expression, final Event event, final Boolean expected) {
-        final ConditionalExpressionEvaluator evaluator = applicationContext.getBean(ConditionalExpressionEvaluator.class);
+        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
 
-        final Boolean actual = evaluator.evaluate(expression, event);
+        final Boolean actual = evaluator.evaluateConditional(expression, event);
 
         assertThat(actual, is(expected));
     }
 
     @ParameterizedTest
     @MethodSource("validExpressionArguments")
-    void testConditionalExpressionEvaluatorWithMultipleThreads(final String expression, final Event event, final Boolean expected) {
-        final ConditionalExpressionEvaluator evaluator = applicationContext.getBean(ConditionalExpressionEvaluator.class);
+    void testGenericExpressionEvaluatorWithMultipleThreads(final String expression, final Event event, final Boolean expected) {
+        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
 
         final int numberOfThreads = 50;
         final ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
@@ -100,7 +100,7 @@ class ConditionalExpressionEvaluatorIT {
         List<Boolean> evaluationResults = Collections.synchronizedList(new ArrayList<>());
 
         for (int i = 0; i < numberOfThreads; i++) {
-            executorService.execute(() -> evaluationResults.add(evaluator.evaluate(expression, event)));
+            executorService.execute(() -> evaluationResults.add(evaluator.evaluateConditional(expression, event)));
         }
 
         await().atMost(5, TimeUnit.SECONDS)
@@ -114,10 +114,10 @@ class ConditionalExpressionEvaluatorIT {
 
     @ParameterizedTest
     @MethodSource("invalidExpressionArguments")
-    void testConditionalExpressionEvaluatorThrows(final String expression, final Event event) {
-        final ConditionalExpressionEvaluator evaluator = applicationContext.getBean(ConditionalExpressionEvaluator.class);
+    void testGenericExpressionEvaluatorThrows(final String expression, final Event event) {
+        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
 
-        assertThrows(RuntimeException.class, () -> evaluator.evaluate(expression, event));
+        assertThrows(RuntimeException.class, () -> evaluator.evaluateConditional(expression, event));
     }
 
     private static Stream<Arguments> validExpressionArguments() {

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluatorTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.UUID;
+import java.util.Random;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,7 +28,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class ConditionalExpressionEvaluatorTest {
+class GenericExpressionEvaluatorTest {
 
     @Mock
     private Parser<ParseTree> parser;
@@ -41,32 +42,28 @@ class ConditionalExpressionEvaluatorTest {
         final String statement = UUID.randomUUID().toString();
         final ParseTree parseTree = mock(ParseTree.class);
         final Event event = mock(Event.class);
-        final Boolean expected = true;
+        final String expectedStr = UUID.randomUUID().toString();
 
         doReturn(parseTree).when(parser).parse(eq(statement));
-        doReturn(expected).when(evaluator).evaluate(eq(parseTree), eq(event));
+        doReturn(expectedStr).when(evaluator).evaluate(eq(parseTree), eq(event));
 
-        final Boolean actual = statementEvaluator.evaluateConditional(statement, event);
+        final Object actualStr = statementEvaluator.evaluate(statement, event);
 
-        assertThat(actual, is(expected));
+        assertThat((String)actualStr, is(expectedStr));
         verify(parser).parse(eq(statement));
         verify(evaluator).evaluate(eq(parseTree), eq(event));
-    }
 
-    @Test
-    void testGivenUnexpectedEvaluatorResultTypeThenExceptionThrown() {
-        final String statement = UUID.randomUUID().toString();
-        final ParseTree parseTree = mock(ParseTree.class);
-        final Event event = mock(Event.class);
-        final Object result = mock(Object.class);
+        final Random random = new Random();
+        final Integer expectedInt = random.nextInt(1000);
 
         doReturn(parseTree).when(parser).parse(eq(statement));
-        doReturn(result).when(evaluator).evaluate(eq(parseTree), eq(event));
+        doReturn(expectedInt).when(evaluator).evaluate(eq(parseTree), eq(event));
 
-        assertThrows(ClassCastException.class, () -> statementEvaluator.evaluateConditional(statement, event));
+        final Object actualInt = statementEvaluator.evaluate(statement, event);
 
-        verify(parser).parse(eq(statement));
-        verify(evaluator).evaluate(eq(parseTree), eq(event));
+        assertThat((Integer)actualInt, is(expectedInt));
+        verify(parser, times(2)).parse(eq(statement));
+        verify(evaluator, times(2)).evaluate(eq(parseTree), eq(event));
     }
 
     @Test
@@ -75,7 +72,7 @@ class ConditionalExpressionEvaluatorTest {
 
         doThrow(new RuntimeException()).when(parser).parse(eq(statement));
 
-        assertThrows(ExpressionEvaluationException.class, () -> statementEvaluator.evaluateConditional(statement, null));
+        assertThrows(ExpressionEvaluationException.class, () -> statementEvaluator.evaluate(statement, null));
 
         verify(parser).parse(eq(statement));
         verify(evaluator, times(0)).evaluate(any(), any());
@@ -95,4 +92,6 @@ class ConditionalExpressionEvaluatorTest {
         verify(parser).parse(eq(statement));
         verify(evaluator).evaluate(eq(parseTree), eq(event));
     }
+
 }
+

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
@@ -36,7 +36,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.apache.commons.lang3.RandomStringUtils;
 
-class ConditionalExpressionEvaluatorIT {
+class GenericExpressionEvaluator_ConditionalIT {
     /**
      * {@link JacksonEvent#get(String, Class)} supports a String matching the following regex expression:
      * ^[A-Za-z0-9]+([A-Za-z0-9.-_][A-Za-z0-9])*$

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class ConditionalExpressionEvaluatorTest {
+class GenericExpressionEvaluator_ConditionalTest {
 
     @Mock
     private Parser<ParseTree> parser;

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_StringIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_StringIT.java
@@ -31,10 +31,9 @@ import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.not;
 import org.apache.commons.lang3.RandomStringUtils;
 
-class ArithmeticExpressionEvaluatorIT {
+class GenericExpressionEvaluator_StringIT {
 
     private AnnotationConfigApplicationContext applicationContext;
 
@@ -46,13 +45,13 @@ class ArithmeticExpressionEvaluatorIT {
     }
 
     @Test
-    void testArithmeticExpressionEvaluatorBeanAvailable() {
+    void testStringExpressionEvaluatorBeanAvailable() {
         final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
         assertThat(evaluator, isA(GenericExpressionEvaluator.class));
     }
 
     @Test
-    void testArithmeticExpressionEvaluatorBeanSingleton() {
+    void testStringExpressionEvaluatorBeanSingleton() {
         final GenericExpressionEvaluator instanceA = applicationContext.getBean(GenericExpressionEvaluator.class);
         final GenericExpressionEvaluator instanceB = applicationContext.getBean(GenericExpressionEvaluator.class);
         assertThat(instanceA, sameInstance(instanceB));
@@ -73,10 +72,10 @@ class ArithmeticExpressionEvaluatorIT {
 
     @ParameterizedTest
     @MethodSource("validExpressionArguments")
-    void testArithmeticExpressionEvaluator(final String expression, final Event event, final Number expected, final Class expectedClass) {
+    void testStringExpressionEvaluator(final String expression, final Event event, final String expected, final Class expectedClass) {
         final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
 
-        final Number actual = (Number)evaluator.evaluate(expression, event);
+        final String actual = (String)evaluator.evaluate(expression, event);
 
         assertThat(actual, is(expected));
         assertThat(actual, instanceOf(expectedClass));
@@ -84,23 +83,23 @@ class ArithmeticExpressionEvaluatorIT {
 
     @ParameterizedTest
     @MethodSource("validExpressionArguments")
-    void testArithmeticExpressionEvaluatorWithMultipleThreads(final String expression, final Event event, final Number expected, final Class expectedClass) {
+    void testStringExpressionEvaluatorWithMultipleThreads(final String expression, final Event event, final String expected, final Class expectedClass) {
         final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
 
         final int numberOfThreads = 50;
         final ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
 
-        List<Number> evaluationResults = Collections.synchronizedList(new ArrayList<>());
+        List<String> evaluationResults = Collections.synchronizedList(new ArrayList<>());
 
         for (int i = 0; i < numberOfThreads; i++) {
-            executorService.execute(() -> evaluationResults.add((Number)evaluator.evaluate(expression, event)));
+            executorService.execute(() -> evaluationResults.add((String)evaluator.evaluate(expression, event)));
         }
 
         await().atMost(5, TimeUnit.SECONDS)
                 .until(() -> evaluationResults.size() == numberOfThreads);
 
         assertThat(evaluationResults.size(), equalTo(numberOfThreads));
-        for (Number evaluationResult : evaluationResults) {
+        for (String evaluationResult : evaluationResults) {
             assertThat(evaluationResult, equalTo(expected));
             assertThat(evaluationResult, instanceOf(expectedClass));
         }
@@ -108,23 +107,20 @@ class ArithmeticExpressionEvaluatorIT {
 
     @ParameterizedTest
     @MethodSource("invalidExpressionArguments")
-    void testArithmeticExpressionEvaluatorInvalidInput(final String expression, final Event event, final Class expectedClass) {
+    void testStringExpressionEvaluatorInvalidInput(final String expression, final Event event, final Class expectedClass) {
         final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
-        Object result = evaluator.evaluate(expression, event);
+
+        final Object result = evaluator.evaluate(expression, event);
         assertThat(result, not(instanceOf(expectedClass)));
     }
 
     private static Stream<Arguments> validExpressionArguments() {
         Random random = new Random();
-        int randomInt = random.nextInt(10000);
-        float randomFloat = random.nextFloat();
         int testStringLength = random.nextInt(30);
         String testString = RandomStringUtils.randomAlphabetic(testStringLength);
         return Stream.of(
-                Arguments.of(""+randomInt, event("{}"), randomInt, Integer.class),
-                Arguments.of("/status_code", event("{\"status_code\": "+randomInt+"}"), randomInt, Integer.class),
-                Arguments.of("/status_code", event("{\"status_code\": "+randomFloat+"}"), randomFloat, Float.class),
-                Arguments.of("length(/message)", event("{\"message\": \""+testString+"\"}"), testString.length(), Integer.class)
+                Arguments.of("\""+testString+"\"", event("{}"), testString, String.class),
+                Arguments.of("/status_message", event("{\"status_message\": \""+testString+"\"}"), testString, String.class)
         );
     }
 
@@ -132,12 +128,11 @@ class ArithmeticExpressionEvaluatorIT {
         Random random = new Random();
         int testStringLength = random.nextInt(10);
         String testString = RandomStringUtils.randomAlphabetic(testStringLength);
+        int randomInt = random.nextInt(10000);
         return Stream.of(
-                Arguments.of("/missing", event("{}"), Integer.class),
-                Arguments.of("/message", event("{\"message\": \""+testString+"\"}"), Integer.class),
-                Arguments.of("/status", event("{\"status\": true}"), Integer.class),
-                Arguments.of("/status", event("{\"status\": 5.55}"), Integer.class),
-                Arguments.of("/status", event("{\"status\": 200}"), Float.class)
+                Arguments.of("/missing", event("{}"), String.class),
+                Arguments.of("/value", event("{\"value\": "+randomInt+"}"), String.class),
+                Arguments.of("length(/message)", event("{\"message\": \""+testString+"\"}"), String.class)
         );
     }
 
@@ -145,3 +140,4 @@ class ArithmeticExpressionEvaluatorIT {
         return JacksonEvent.builder().withEventType("event").withData(data).build();
     }
 }
+

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeEvaluatorTest.java
@@ -50,11 +50,6 @@ class ParseTreeEvaluatorTest {
 
     @Test
     void testEvaluateSuccess() throws ExpressionCoercionException {
-        when(coercionService.coerce(any(), any())).thenAnswer(invocation -> {
-            final Object res = invocation.getArgument(0);
-            final Class<Boolean> clazz = invocation.getArgument(1);
-            return clazz.cast(res);
-        });
         try (final MockedConstruction<ParseTreeEvaluatorListener> ignored =
                      mockConstruction(ParseTreeEvaluatorListener.class, (mock, context) -> when(mock.getResult()).thenReturn(true))) {
             assertThat(objectUnderTest.evaluate(parseTree, event), is(true));
@@ -80,12 +75,4 @@ class ParseTreeEvaluatorTest {
         }
     }
 
-    @Test
-    void testEvaluateFailureInCoerce() throws ExpressionCoercionException {
-        when(coercionService.coerce(any(), any())).thenThrow(new ExpressionCoercionException("test message"));
-        try (final MockedConstruction<ParseTreeEvaluatorListener> ignored =
-                     mockConstruction(ParseTreeEvaluatorListener.class, (mock, context) -> when(mock.getResult()).thenReturn(true))) {
-            assertThrows(ExpressionEvaluationException.class, () -> objectUnderTest.evaluate(parseTree, event));
-        }
-    }
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/StringExpressionEvaluatorIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/StringExpressionEvaluatorIT.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import java.util.Random;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import org.apache.commons.lang3.RandomStringUtils;
+
+class StringExpressionEvaluatorIT {
+
+    private AnnotationConfigApplicationContext applicationContext;
+
+    @BeforeEach
+    void beforeEach() {
+        applicationContext = new AnnotationConfigApplicationContext();
+        applicationContext.scan("org.opensearch.dataprepper.expression");
+        applicationContext.refresh();
+    }
+
+    @Test
+    void testStringExpressionEvaluatorBeanAvailable() {
+        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
+        assertThat(evaluator, isA(GenericExpressionEvaluator.class));
+    }
+
+    @Test
+    void testStringExpressionEvaluatorBeanSingleton() {
+        final GenericExpressionEvaluator instanceA = applicationContext.getBean(GenericExpressionEvaluator.class);
+        final GenericExpressionEvaluator instanceB = applicationContext.getBean(GenericExpressionEvaluator.class);
+        assertThat(instanceA, sameInstance(instanceB));
+    }
+
+    @Test
+    void testParserBeanInstanceOfMultiThreadParser() {
+        final Parser instance = applicationContext.getBean(Parser.class);
+        assertThat(instance, instanceOf(MultiThreadParser.class));
+    }
+
+    @Test
+    void testSingleThreadParserBeanNotSingleton() {
+        final Parser instanceA = applicationContext.getBean(ParseTreeParser.SINGLE_THREAD_PARSER_NAME, Parser.class);
+        final Parser instanceB = applicationContext.getBean(ParseTreeParser.SINGLE_THREAD_PARSER_NAME, Parser.class);
+        assertThat(instanceA, not(sameInstance(instanceB)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validExpressionArguments")
+    void testStringExpressionEvaluator(final String expression, final Event event, final String expected, final Class expectedClass) {
+        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
+
+        final String actual = (String)evaluator.evaluate(expression, event);
+
+        assertThat(actual, is(expected));
+        assertThat(actual, instanceOf(expectedClass));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validExpressionArguments")
+    void testStringExpressionEvaluatorWithMultipleThreads(final String expression, final Event event, final String expected, final Class expectedClass) {
+        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
+
+        final int numberOfThreads = 50;
+        final ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        List<String> evaluationResults = Collections.synchronizedList(new ArrayList<>());
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.execute(() -> evaluationResults.add((String)evaluator.evaluate(expression, event)));
+        }
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> evaluationResults.size() == numberOfThreads);
+
+        assertThat(evaluationResults.size(), equalTo(numberOfThreads));
+        for (String evaluationResult : evaluationResults) {
+            assertThat(evaluationResult, equalTo(expected));
+            assertThat(evaluationResult, instanceOf(expectedClass));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidExpressionArguments")
+    void testStringExpressionEvaluatorInvalidInput(final String expression, final Event event, final Class expectedClass) {
+        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
+
+        final Object result = evaluator.evaluate(expression, event);
+        assertThat(result, not(instanceOf(expectedClass)));
+    }
+
+    private static Stream<Arguments> validExpressionArguments() {
+        Random random = new Random();
+        int testStringLength = random.nextInt(30);
+        String testString = RandomStringUtils.randomAlphabetic(testStringLength);
+        return Stream.of(
+                Arguments.of("\""+testString+"\"", event("{}"), testString, String.class),
+                Arguments.of("/status_message", event("{\"status_message\": \""+testString+"\"}"), testString, String.class)
+        );
+    }
+
+    private static Stream<Arguments> invalidExpressionArguments() {
+        Random random = new Random();
+        int testStringLength = random.nextInt(10);
+        String testString = RandomStringUtils.randomAlphabetic(testStringLength);
+        int randomInt = random.nextInt(10000);
+        return Stream.of(
+                Arguments.of("/missing", event("{}"), String.class),
+                Arguments.of("/value", event("{\"value\": "+randomInt+"}"), String.class),
+                Arguments.of("length(/message)", event("{\"message\": \""+testString+"\"}"), String.class)
+        );
+    }
+
+    private static Event event(final String data) {
+        return JacksonEvent.builder().withEventType("event").withData(data).build();
+    }
+}
+

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -46,15 +46,15 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
 
     private boolean forceConclude = false;
     private final String whenCondition;
-    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final ExpressionEvaluator expressionEvaluator;
 
     @DataPrepperPluginConstructor
-    public AggregateProcessor(final AggregateProcessorConfig aggregateProcessorConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory, final ExpressionEvaluator<Boolean> expressionEvaluator) {
+    public AggregateProcessor(final AggregateProcessorConfig aggregateProcessorConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory, final ExpressionEvaluator expressionEvaluator) {
         this(aggregateProcessorConfig, pluginMetrics, pluginFactory, new AggregateGroupManager(aggregateProcessorConfig.getGroupDuration()),
                 new AggregateIdentificationKeysHasher(aggregateProcessorConfig.getIdentificationKeys()), new AggregateActionSynchronizer.AggregateActionSynchronizerProvider(), expressionEvaluator);
     }
     public AggregateProcessor(final AggregateProcessorConfig aggregateProcessorConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory, final AggregateGroupManager aggregateGroupManager,
-                              final AggregateIdentificationKeysHasher aggregateIdentificationKeysHasher, final AggregateActionSynchronizer.AggregateActionSynchronizerProvider aggregateActionSynchronizerProvider, final ExpressionEvaluator<Boolean> expressionEvaluator) {
+                              final AggregateIdentificationKeysHasher aggregateIdentificationKeysHasher, final AggregateActionSynchronizer.AggregateActionSynchronizerProvider aggregateActionSynchronizerProvider, final ExpressionEvaluator expressionEvaluator) {
         super(pluginMetrics);
         this.aggregateProcessorConfig = aggregateProcessorConfig;
         this.aggregateGroupManager = aggregateGroupManager;
@@ -101,7 +101,7 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
         int handleEventsDropped = 0;
         for (final Record<Event> record : records) {
             final Event event = record.getData();
-            if (whenCondition != null && !expressionEvaluator.evaluate(whenCondition, event)) {
+            if (whenCondition != null && !expressionEvaluator.evaluateConditional(whenCondition, event)) {
                 handleEventsDropped++;
                 continue;
             }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/TailSamplerAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/TailSamplerAggregateAction.java
@@ -33,12 +33,12 @@ public class TailSamplerAggregateAction implements AggregateAction {
     static final String ERROR_STATUS_KEY = "error_status";
     private final double percent;
     private final Duration waitPeriod;
-    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final ExpressionEvaluator expressionEvaluator;
     private final String errorCondition;
     private boolean shouldCarryGroupState;
 
     @DataPrepperPluginConstructor
-    public TailSamplerAggregateAction(final TailSamplerAggregateActionConfig tailSamplerAggregateActionConfig, final ExpressionEvaluator<Boolean> expressionEvaluator) {
+    public TailSamplerAggregateAction(final TailSamplerAggregateActionConfig tailSamplerAggregateActionConfig, final ExpressionEvaluator expressionEvaluator) {
         percent = tailSamplerAggregateActionConfig.getPercent();
         waitPeriod = tailSamplerAggregateActionConfig.getWaitPeriod();
         errorCondition = tailSamplerAggregateActionConfig.getErrorCondition();
@@ -60,7 +60,7 @@ public class TailSamplerAggregateAction implements AggregateAction {
         List<Event> events = (List)groupState.getOrDefault(EVENTS_KEY, new ArrayList<>());
         events.add(event);
         groupState.put(EVENTS_KEY, events);
-        if (errorCondition != null && !errorCondition.isEmpty() && expressionEvaluator.evaluate(errorCondition, event)) {
+        if (errorCondition != null && !errorCondition.isEmpty() && expressionEvaluator.evaluateConditional(errorCondition, event)) {
             groupState.put(ERROR_STATUS_KEY, true);
         }
         groupState.put(LAST_RECEIVED_TIME_KEY, Instant.now());

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
@@ -215,7 +215,7 @@ public class AggregateProcessorIT {
         for (Record<Event> record: eventBatch) {
             Event event = record.getData();
             boolean value = (count % 2 == 0) ? true : false;
-            when(expressionEvaluator.evaluate(condition, event)).thenReturn(value);
+            when(expressionEvaluator.evaluateConditional(condition, event)).thenReturn(value);
             if (!value) {
                 uniqueEventMaps.remove(event.toMap());
             }
@@ -405,7 +405,7 @@ public class AggregateProcessorIT {
         for (Record<Event> record: eventBatch) {
             Event event = record.getData();
             boolean value = (count % 2 == 0) ? true : false;
-            when(expressionEvaluator.evaluate(condition, event)).thenReturn(value);
+            when(expressionEvaluator.evaluateConditional(condition, event)).thenReturn(value);
             count++;
         }
 

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -110,7 +110,7 @@ public class AggregateProcessorTest {
     private Timer timeElapsed;
 
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
 
     private Event event;
 
@@ -212,9 +212,9 @@ public class AggregateProcessorTest {
             when(aggregateIdentificationKeysHasher.createIdentificationKeysMapFromEvent(firstEvent))
                     .thenReturn(identificationKeysMap);
             when(aggregateActionSynchronizer.handleEventForGroup(firstEvent, identificationKeysMap, aggregateGroup)).thenReturn(firstAggregateActionResponse);
-            when(expressionEvaluator.evaluate(condition, event)).thenReturn(true);
-            when(expressionEvaluator.evaluate(condition, firstEvent)).thenReturn(true);
-            when(expressionEvaluator.evaluate(condition, secondEvent)).thenReturn(false);
+            when(expressionEvaluator.evaluateConditional(condition, event)).thenReturn(true);
+            when(expressionEvaluator.evaluateConditional(condition, firstEvent)).thenReturn(true);
+            when(expressionEvaluator.evaluateConditional(condition, secondEvent)).thenReturn(false);
             when(aggregateProcessorConfig.getWhenCondition()).thenReturn(condition);
             final AggregateProcessor objectUnderTest = createObjectUnderTest();
             when(aggregateGroupManager.getGroupsToConclude(eq(false))).thenReturn(Collections.emptyList());

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/TailSamplerAggregateActionTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/TailSamplerAggregateActionTests.java
@@ -38,7 +38,7 @@ public class TailSamplerAggregateActionTests {
     AggregateActionInput aggregateActionInput;
 
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
 
     private AggregateAction tailSamplerAggregateAction;
 
@@ -96,7 +96,7 @@ public class TailSamplerAggregateActionTests {
         when(tailSamplerAggregateActionConfig.getPercent()).thenReturn(testPercent);
         when(tailSamplerAggregateActionConfig.getWaitPeriod()).thenReturn(testWaitPeriod);
         when(tailSamplerAggregateActionConfig.getErrorCondition()).thenReturn(errorCondition);
-        when(expressionEvaluator.evaluate(any(String.class), any(Event.class))).thenReturn(true);
+        when(expressionEvaluator.evaluateConditional(any(String.class), any(Event.class))).thenReturn(true);
         tailSamplerAggregateAction = createObjectUnderTest(tailSamplerAggregateActionConfig);
         final String key = UUID.randomUUID().toString();
         final String value = UUID.randomUUID().toString();

--- a/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventsProcessor.java
+++ b/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventsProcessor.java
@@ -29,7 +29,7 @@ public class DropEventsProcessor extends AbstractProcessor<Record<Event>, Record
     public DropEventsProcessor(
             final PluginMetrics pluginMetrics,
             final DropEventProcessorConfig dropEventProcessorConfig,
-            final ExpressionEvaluator<Boolean> expressionEvaluator
+            final ExpressionEvaluator expressionEvaluator
     ) {
         super(pluginMetrics);
 

--- a/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventsWhenCondition.java
+++ b/data-prepper-plugins/drop-events-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventsWhenCondition.java
@@ -24,7 +24,7 @@ class DropEventsWhenCondition {
 
     private final String dropWhen;
     private final HandleFailedEventsOption handleFailedEventsSetting;
-    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final ExpressionEvaluator expressionEvaluator;
     private final boolean notAlwaysTrue;
 
     DropEventsWhenCondition(final Builder builder) {
@@ -55,7 +55,7 @@ class DropEventsWhenCondition {
      */
     public boolean isStatementFalseWith(final Event event) {
         try {
-            return !expressionEvaluator.evaluate(dropWhen, event);
+            return !expressionEvaluator.evaluateConditional(dropWhen, event);
         } catch (final Exception e) {
             return handleFailedEventsSetting.isDropEventOption(event, e, LOG);
         }
@@ -70,7 +70,7 @@ class DropEventsWhenCondition {
         private String dropWhen;
         private HandleFailedEventsOption handleFailedEventsSetting;
 
-        private ExpressionEvaluator<Boolean> expressionEvaluator;
+        private ExpressionEvaluator expressionEvaluator;
 
         public Builder withDropEventsProcessorConfig(final DropEventProcessorConfig dropEventProcessorConfig) {
             this.dropWhen = Objects.requireNonNull(dropEventProcessorConfig.getDropWhen());
@@ -78,7 +78,7 @@ class DropEventsWhenCondition {
             return this;
         }
 
-        public Builder withExpressionEvaluator(final ExpressionEvaluator<Boolean> expressionEvaluator) {
+        public Builder withExpressionEvaluator(final ExpressionEvaluator expressionEvaluator) {
             this.expressionEvaluator = expressionEvaluator;
             return this;
         }

--- a/data-prepper-plugins/drop-events-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventsProcessorTests.java
+++ b/data-prepper-plugins/drop-events-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventsProcessorTests.java
@@ -40,7 +40,7 @@ public class DropEventsProcessorTests {
     @Mock
     private DropEventProcessorConfig dropEventProcessorConfig;
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
     private String whenSetting;
     private String messageInput;
     private DropEventsProcessor dropProcessor;
@@ -112,7 +112,7 @@ public class DropEventsProcessorTests {
                 true,
                 repeatedReturnValue
         ).when(expressionEvaluator)
-                .evaluate(eq(whenSetting), eq(event));
+                .evaluateConditional(eq(whenSetting), eq(event));
         doReturn(event)
                 .when(record)
                 .getData();

--- a/data-prepper-plugins/drop-events-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventsWhenConditionBuilderTest.java
+++ b/data-prepper-plugins/drop-events-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventsWhenConditionBuilderTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.doReturn;
 @ExtendWith(MockitoExtension.class)
 class DropEventsWhenConditionBuilderTest {
     @Mock
-    private ExpressionEvaluator<Boolean> evaluator;
+    private ExpressionEvaluator evaluator;
     @Mock
     private DropEventProcessorConfig dropEventProcessorConfig;
 

--- a/data-prepper-plugins/drop-events-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventsWhenConditionTest.java
+++ b/data-prepper-plugins/drop-events-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/drop/DropEventsWhenConditionTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class DropEventsWhenConditionTest {
     @Mock
-    private ExpressionEvaluator<Boolean> evaluator;
+    private ExpressionEvaluator evaluator;
     @Mock
     private DropEventProcessorConfig dropEventProcessorConfig;
 
@@ -87,7 +87,7 @@ class DropEventsWhenConditionTest {
                 .getDropWhen();
         doReturn(evaluatorResult)
                 .when(evaluator)
-                .evaluate(eq(whenStatement), eq(event));
+                .evaluateConditional(eq(whenStatement), eq(event));
 
         final DropEventsWhenCondition whenCondition = new DropEventsWhenCondition.Builder()
                 .withDropEventsProcessorConfig(dropEventProcessorConfig)
@@ -97,7 +97,7 @@ class DropEventsWhenConditionTest {
         final boolean result = whenCondition.isStatementFalseWith(event);
 
         assertThat(result, not(is(evaluatorResult)));
-        verify(evaluator).evaluate(eq(whenStatement), eq(event));
+        verify(evaluator).evaluateConditional(eq(whenStatement), eq(event));
     }
 
 
@@ -132,7 +132,7 @@ class DropEventsWhenConditionTest {
         final String whenStatement = UUID.randomUUID().toString();
         final DropEventProcessorConfig dropEventProcessorConfig = mock(DropEventProcessorConfig.class);
 
-        doThrow(RuntimeException.class).when(evaluator).evaluate(any(), any());
+        doThrow(RuntimeException.class).when(evaluator).evaluateConditional(any(), any());
         doReturn(whenStatement).when(dropEventProcessorConfig).getDropWhen();
         doReturn(option).when(dropEventProcessorConfig).getHandleFailedEventsOption();
 

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
@@ -83,14 +83,14 @@ public class GrokProcessor extends AbstractProcessor<Record<Event>, Record<Event
     private final ExecutorService executorService;
     private final List<String> tagsOnMatchFailure;
 
-    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final ExpressionEvaluator expressionEvaluator;
 
     @DataPrepperPluginConstructor
-    public GrokProcessor(final PluginSetting pluginSetting, final ExpressionEvaluator<Boolean> expressionEvaluator) {
+    public GrokProcessor(final PluginSetting pluginSetting, final ExpressionEvaluator expressionEvaluator) {
         this(pluginSetting, GrokCompiler.newInstance(), Executors.newSingleThreadExecutor(), expressionEvaluator);
     }
 
-    GrokProcessor(final PluginSetting pluginSetting, final GrokCompiler grokCompiler, final ExecutorService executorService, final ExpressionEvaluator<Boolean> expressionEvaluator) {
+    GrokProcessor(final PluginSetting pluginSetting, final GrokCompiler grokCompiler, final ExecutorService executorService, final ExpressionEvaluator expressionEvaluator) {
         super(pluginSetting);
         this.grokProcessorConfig = GrokProcessorConfig.buildConfig(pluginSetting);
         this.keysToOverwrite = new HashSet<>(grokProcessorConfig.getkeysToOverwrite());
@@ -121,7 +121,7 @@ public class GrokProcessor extends AbstractProcessor<Record<Event>, Record<Event
         for (final Record<Event> record : records) {
             final Event event = record.getData();
             try {
-                if (Objects.nonNull(grokProcessorConfig.getGrokWhen()) && !expressionEvaluator.evaluate(grokProcessorConfig.getGrokWhen(), event)) {
+                if (Objects.nonNull(grokProcessorConfig.getGrokWhen()) && !expressionEvaluator.evaluateConditional(grokProcessorConfig.getGrokWhen(), event)) {
                     continue;
                 }
 

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorIT.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorIT.java
@@ -45,7 +45,7 @@ public class GrokProcessorIT {
     private String messageInput;
 
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
 
     @BeforeEach
     public void setup() {

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorTests.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorTests.java
@@ -101,7 +101,7 @@ public class GrokProcessorTests {
     private Timer grokProcessingTime;
 
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
 
     private PluginSetting pluginSetting;
     private final String PLUGIN_NAME = "grok";
@@ -637,7 +637,7 @@ public class GrokProcessorTests {
         testData.put("message", messageInput);
         final Record<Event> record = buildRecordWithEvent(testData);
 
-        when(expressionEvaluator.evaluate(grokWhen, record.getData())).thenReturn(false);
+        when(expressionEvaluator.evaluateConditional(grokWhen, record.getData())).thenReturn(false);
 
         final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessor.java
@@ -27,10 +27,10 @@ public class AddEntryProcessor extends AbstractProcessor<Record<Event>, Record<E
     private static final Logger LOG = LoggerFactory.getLogger(AddEntryProcessor.class);
     private final List<AddEntryProcessorConfig.Entry> entries;
 
-    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final ExpressionEvaluator expressionEvaluator;
 
     @DataPrepperPluginConstructor
-    public AddEntryProcessor(final PluginMetrics pluginMetrics, final AddEntryProcessorConfig config, final ExpressionEvaluator<Boolean> expressionEvaluator) {
+    public AddEntryProcessor(final PluginMetrics pluginMetrics, final AddEntryProcessorConfig config, final ExpressionEvaluator expressionEvaluator) {
         super(pluginMetrics);
         this.entries = config.getEntries();
         this.expressionEvaluator = expressionEvaluator;
@@ -43,7 +43,7 @@ public class AddEntryProcessor extends AbstractProcessor<Record<Event>, Record<E
 
             for(AddEntryProcessorConfig.Entry entry : entries) {
 
-                if (Objects.nonNull(entry.getAddWhen()) && !expressionEvaluator.evaluate(entry.getAddWhen(), recordEvent)) {
+                if (Objects.nonNull(entry.getAddWhen()) && !expressionEvaluator.evaluateConditional(entry.getAddWhen(), recordEvent)) {
                     continue;
                 }
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessor.java
@@ -24,12 +24,12 @@ public class ConvertEntryTypeProcessor  extends AbstractProcessor<Record<Event>,
     private final TypeConverter converter;
     private final String convertWhen;
 
-    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final ExpressionEvaluator expressionEvaluator;
 
     @DataPrepperPluginConstructor
     public ConvertEntryTypeProcessor(final PluginMetrics pluginMetrics,
                                      final ConvertEntryTypeProcessorConfig convertEntryTypeProcessorConfig,
-                                     final ExpressionEvaluator<Boolean> expressionEvaluator) {
+                                     final ExpressionEvaluator expressionEvaluator) {
         super(pluginMetrics);
         this.key = convertEntryTypeProcessorConfig.getKey();
         this.converter = convertEntryTypeProcessorConfig.getType().getTargetConverter();
@@ -42,7 +42,7 @@ public class ConvertEntryTypeProcessor  extends AbstractProcessor<Record<Event>,
         for(final Record<Event> record : records) {
             final Event recordEvent = record.getData();
 
-            if (Objects.nonNull(convertWhen) && !expressionEvaluator.evaluate(convertWhen, recordEvent)) {
+            if (Objects.nonNull(convertWhen) && !expressionEvaluator.evaluateConditional(convertWhen, recordEvent)) {
                 continue;
             }
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessor.java
@@ -22,10 +22,10 @@ import java.util.Objects;
 public class CopyValueProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
     private final List<CopyValueProcessorConfig.Entry> entries;
 
-    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final ExpressionEvaluator expressionEvaluator;
 
     @DataPrepperPluginConstructor
-    public CopyValueProcessor(final PluginMetrics pluginMetrics, final CopyValueProcessorConfig config, final ExpressionEvaluator<Boolean> expressionEvaluator) {
+    public CopyValueProcessor(final PluginMetrics pluginMetrics, final CopyValueProcessorConfig config, final ExpressionEvaluator expressionEvaluator) {
         super(pluginMetrics);
         this.entries = config.getEntries();
         this.expressionEvaluator = expressionEvaluator;
@@ -36,7 +36,7 @@ public class CopyValueProcessor extends AbstractProcessor<Record<Event>, Record<
         for(final Record<Event> record : records) {
             final Event recordEvent = record.getData();
             for(CopyValueProcessorConfig.Entry entry : entries) {
-                if (Objects.nonNull(entry.getCopyWhen()) && !expressionEvaluator.evaluate(entry.getCopyWhen(), recordEvent)) {
+                if (Objects.nonNull(entry.getCopyWhen()) && !expressionEvaluator.evaluateConditional(entry.getCopyWhen(), recordEvent)) {
                     continue;
                 }
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessor.java
@@ -22,10 +22,10 @@ public class DeleteEntryProcessor extends AbstractProcessor<Record<Event>, Recor
     private final String[] entries;
     private final String deleteWhen;
 
-    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final ExpressionEvaluator expressionEvaluator;
 
     @DataPrepperPluginConstructor
-    public DeleteEntryProcessor(final PluginMetrics pluginMetrics, final DeleteEntryProcessorConfig config, final ExpressionEvaluator<Boolean> expressionEvaluator) {
+    public DeleteEntryProcessor(final PluginMetrics pluginMetrics, final DeleteEntryProcessorConfig config, final ExpressionEvaluator expressionEvaluator) {
         super(pluginMetrics);
         this.entries = config.getWithKeys();
         this.deleteWhen = config.getDeleteWhen();
@@ -37,7 +37,7 @@ public class DeleteEntryProcessor extends AbstractProcessor<Record<Event>, Recor
         for(final Record<Event> record : records) {
             final Event recordEvent = record.getData();
 
-            if (Objects.nonNull(deleteWhen) && !expressionEvaluator.evaluate(deleteWhen, recordEvent)) {
+            if (Objects.nonNull(deleteWhen) && !expressionEvaluator.evaluateConditional(deleteWhen, recordEvent)) {
                 continue;
             }
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
@@ -34,10 +34,10 @@ public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<
     private static final Logger LOG = LoggerFactory.getLogger(ListToMapProcessor.class);
     private final ListToMapProcessorConfig config;
 
-    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final ExpressionEvaluator expressionEvaluator;
 
     @DataPrepperPluginConstructor
-    public ListToMapProcessor(final PluginMetrics pluginMetrics, final ListToMapProcessorConfig config, final ExpressionEvaluator<Boolean> expressionEvaluator) {
+    public ListToMapProcessor(final PluginMetrics pluginMetrics, final ListToMapProcessorConfig config, final ExpressionEvaluator expressionEvaluator) {
         super(pluginMetrics);
         this.config = config;
         this.expressionEvaluator = expressionEvaluator;
@@ -48,7 +48,7 @@ public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<
         for (final Record<Event> record : records) {
             final Event recordEvent = record.getData();
 
-            if (Objects.nonNull(config.getListToMapWhen()) && !expressionEvaluator.evaluate(config.getListToMapWhen(), recordEvent)) {
+            if (Objects.nonNull(config.getListToMapWhen()) && !expressionEvaluator.evaluateConditional(config.getListToMapWhen(), recordEvent)) {
                 continue;
             }
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessor.java
@@ -22,10 +22,10 @@ import java.util.Objects;
 public class RenameKeyProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
     private final List<RenameKeyProcessorConfig.Entry> entries;
 
-    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final ExpressionEvaluator expressionEvaluator;
 
     @DataPrepperPluginConstructor
-    public RenameKeyProcessor(final PluginMetrics pluginMetrics, final RenameKeyProcessorConfig config, final ExpressionEvaluator<Boolean> expressionEvaluator) {
+    public RenameKeyProcessor(final PluginMetrics pluginMetrics, final RenameKeyProcessorConfig config, final ExpressionEvaluator expressionEvaluator) {
         super(pluginMetrics);
         this.entries = config.getEntries();
         this.expressionEvaluator = expressionEvaluator;
@@ -37,7 +37,7 @@ public class RenameKeyProcessor extends AbstractProcessor<Record<Event>, Record<
             final Event recordEvent = record.getData();
 
             for(RenameKeyProcessorConfig.Entry entry : entries) {
-                if (Objects.nonNull(entry.getRenameWhen()) && !expressionEvaluator.evaluate(entry.getRenameWhen(), recordEvent)) {
+                if (Objects.nonNull(entry.getRenameWhen()) && !expressionEvaluator.evaluateConditional(entry.getRenameWhen(), recordEvent)) {
                     continue;
                 }
 

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
@@ -41,7 +41,7 @@ public class AddEntryProcessorTests {
     private AddEntryProcessorConfig mockConfig;
 
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
 
     @Test
     public void testSingleAddProcessorTests() {
@@ -347,7 +347,7 @@ public class AddEntryProcessorTests {
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
 
-        when(expressionEvaluator.evaluate(addWhen, record.getData())).thenReturn(false);
+        when(expressionEvaluator.evaluateConditional(addWhen, record.getData())).thenReturn(false);
         final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
         assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
@@ -38,7 +38,7 @@ public class ConvertEntryTypeProcessorTests {
     private ConvertEntryTypeProcessorConfig mockConfig;
 
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
 
     private ConvertEntryTypeProcessor typeConversionProcessor;
 
@@ -191,7 +191,7 @@ public class ConvertEntryTypeProcessorTests {
         when(mockConfig.getConvertWhen()).thenReturn(convertWhen);
 
         final Record<Event> record = getMessage(UUID.randomUUID().toString(), TEST_KEY, testValue);
-        when(expressionEvaluator.evaluate(convertWhen, record.getData())).thenReturn(false);
+        when(expressionEvaluator.evaluateConditional(convertWhen, record.getData())).thenReturn(false);
         typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
         Event event = executeAndGetProcessedEvent(record);
         assertThat(event.get(TEST_KEY, Integer.class), equalTo(testValue));

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorTests.java
@@ -37,7 +37,7 @@ public class CopyValueProcessorTests {
     private CopyValueProcessorConfig mockConfig;
 
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
 
     @Test
     public void testSingleCopyProcessorTests() {
@@ -178,7 +178,7 @@ public class CopyValueProcessorTests {
 
         final CopyValueProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
-        when(expressionEvaluator.evaluate(copyWhen, record.getData())).thenReturn(false);
+        when(expressionEvaluator.evaluateConditional(copyWhen, record.getData())).thenReturn(false);
         final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
         assertThat(editedRecords.get(0).getData().containsKey("newMessage"), is(false));

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorTests.java
@@ -34,7 +34,7 @@ public class DeleteEntryProcessorTests {
     private DeleteEntryProcessorConfig mockConfig;
 
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
 
     @Test
     public void testSingleDeleteProcessorTest() {
@@ -91,7 +91,7 @@ public class DeleteEntryProcessorTests {
         final Record<Event> record = getEvent("thisisamessage");
         record.getData().put("newMessage", "test");
 
-        when(expressionEvaluator.evaluate(deleteWhen, record.getData())).thenReturn(false);
+        when(expressionEvaluator.evaluateConditional(deleteWhen, record.getData())).thenReturn(false);
         final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
         assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorTest.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorTest.java
@@ -35,7 +35,7 @@ class ListToMapProcessorTest {
     private ListToMapProcessorConfig mockConfig;
 
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
 
     @Test
     public void testValueExtractionWithFlattenAndWriteToRoot() {
@@ -216,7 +216,7 @@ class ListToMapProcessorTest {
         final ListToMapProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createTestRecord();
 
-        when(expressionEvaluator.evaluate(whenCondition, testRecord.getData())).thenReturn(false);
+        when(expressionEvaluator.evaluateConditional(whenCondition, testRecord.getData())).thenReturn(false);
         final List<Record<Event>> resultRecord = (List<Record<Event>>) processor.doExecute(Collections.singletonList(testRecord));
 
         assertThat(resultRecord.size(), is(1));

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorTests.java
@@ -37,7 +37,7 @@ public class RenameKeyProcessorTests {
     private RenameKeyProcessorConfig mockConfig;
 
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
 
     @Test
     public void testSingleOverwriteRenameProcessorTests() {
@@ -122,7 +122,7 @@ public class RenameKeyProcessorTests {
         final RenameKeyProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("thisisamessage");
 
-        when(expressionEvaluator.evaluate(renameWhen, record.getData())).thenReturn(false);
+        when(expressionEvaluator.evaluateConditional(renameWhen, record.getData())).thenReturn(false);
 
         final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessor.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessor.java
@@ -21,10 +21,10 @@ import java.util.regex.Pattern;
 public class SplitStringProcessor extends AbstractStringProcessor<SplitStringProcessorConfig.Entry> {
 
     private final Map<String, Pattern> patternMap = new HashMap<>();
-    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final ExpressionEvaluator expressionEvaluator;
 
     @DataPrepperPluginConstructor
-    public SplitStringProcessor(final PluginMetrics pluginMetrics, final SplitStringProcessorConfig config, final ExpressionEvaluator<Boolean> expressionEvaluator) {
+    public SplitStringProcessor(final PluginMetrics pluginMetrics, final SplitStringProcessorConfig config, final ExpressionEvaluator expressionEvaluator) {
         super(pluginMetrics, config);
         this.expressionEvaluator = expressionEvaluator;
 
@@ -47,7 +47,7 @@ public class SplitStringProcessor extends AbstractStringProcessor<SplitStringPro
 
     @Override
     protected void performKeyAction(final Event recordEvent, final SplitStringProcessorConfig.Entry entry, final String value) {
-        if (Objects.nonNull(entry.getSplitWhen()) && !expressionEvaluator.evaluate(entry.getSplitWhen(), recordEvent)) {
+        if (Objects.nonNull(entry.getSplitWhen()) && !expressionEvaluator.evaluateConditional(entry.getSplitWhen(), recordEvent)) {
             return;
         }
 

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessor.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessor.java
@@ -25,10 +25,10 @@ import java.util.regex.Pattern;
 @DataPrepperPlugin(name = "substitute_string", pluginType = Processor.class, pluginConfigurationType = SubstituteStringProcessorConfig.class)
 public class SubstituteStringProcessor extends AbstractStringProcessor<SubstituteStringProcessorConfig.Entry> {
     private final Map<String, Pattern> patternMap = new HashMap<>();
-    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final ExpressionEvaluator expressionEvaluator;
 
     @DataPrepperPluginConstructor
-    public SubstituteStringProcessor(final PluginMetrics pluginMetrics, final SubstituteStringProcessorConfig config, final ExpressionEvaluator<Boolean> expressionEvaluator) {
+    public SubstituteStringProcessor(final PluginMetrics pluginMetrics, final SubstituteStringProcessorConfig config, final ExpressionEvaluator expressionEvaluator) {
         super(pluginMetrics, config);
         this.expressionEvaluator = expressionEvaluator;
 
@@ -40,7 +40,7 @@ public class SubstituteStringProcessor extends AbstractStringProcessor<Substitut
     @Override
     protected void performKeyAction(final Event recordEvent, final SubstituteStringProcessorConfig.Entry entry, final String value)
     {
-        if (Objects.nonNull(entry.getSubstituteWhen()) && !expressionEvaluator.evaluate(entry.getSubstituteWhen(), recordEvent)) {
+        if (Objects.nonNull(entry.getSubstituteWhen()) && !expressionEvaluator.evaluateConditional(entry.getSubstituteWhen(), recordEvent)) {
             return;
         }
 

--- a/data-prepper-plugins/mutate-string-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorTests.java
+++ b/data-prepper-plugins/mutate-string-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SplitStringProcessorTests.java
@@ -44,7 +44,7 @@ class SplitStringProcessorTests {
     private SplitStringProcessorConfig config;
 
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
 
     private SplitStringProcessor createObjectUnderTest() {
         return new SplitStringProcessor(pluginMetrics, config, expressionEvaluator);
@@ -107,7 +107,7 @@ class SplitStringProcessorTests {
 
         final SplitStringProcessor splitStringProcessor = createObjectUnderTest();
         final Record<Event> record = createEvent(message);
-        when(expressionEvaluator.evaluate(splitWhen, record.getData())).thenReturn(false);
+        when(expressionEvaluator.evaluateConditional(splitWhen, record.getData())).thenReturn(false);
         final List<Record<Event>> splitRecords = (List<Record<Event>>) splitStringProcessor.doExecute(Collections.singletonList(record));
 
         assertThat(splitRecords.get(0).getData().toMap(), equalTo(record.getData().toMap()));

--- a/data-prepper-plugins/mutate-string-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorTests.java
+++ b/data-prepper-plugins/mutate-string-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutatestring/SubstituteStringProcessorTests.java
@@ -40,7 +40,7 @@ public class SubstituteStringProcessorTests {
     private SubstituteStringProcessorConfig config;
 
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
 
     @BeforeEach
     public void setup() {
@@ -147,7 +147,7 @@ public class SubstituteStringProcessorTests {
         final SubstituteStringProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("abcd");
 
-        when(expressionEvaluator.evaluate(substituteWhen, record.getData())).thenReturn(false);
+        when(expressionEvaluator.evaluateConditional(substituteWhen, record.getData())).thenReturn(false);
         final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
         assertThat(editedRecords.get(0).getData().toMap(), equalTo(record.getData().toMap()));

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessor.java
@@ -39,12 +39,12 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
     private final String pointer;
     private final String parseWhen;
 
-    private final ExpressionEvaluator<Boolean> expressionEvaluator;
+    private final ExpressionEvaluator expressionEvaluator;
 
     @DataPrepperPluginConstructor
     public ParseJsonProcessor(final PluginMetrics pluginMetrics,
                               final ParseJsonProcessorConfig parseJsonProcessorConfig,
-                              final ExpressionEvaluator<Boolean> expressionEvaluator) {
+                              final ExpressionEvaluator expressionEvaluator) {
         super(pluginMetrics);
 
         source = parseJsonProcessorConfig.getSource();
@@ -63,7 +63,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
         for (final Record<Event> record : records) {
             final Event event = record.getData();
 
-            if (Objects.nonNull(parseWhen) && !expressionEvaluator.evaluate(parseWhen, event)) {
+            if (Objects.nonNull(parseWhen) && !expressionEvaluator.evaluateConditional(parseWhen, event)) {
                 continue;
             }
 

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorTest.java
@@ -40,7 +40,7 @@ class ParseJsonProcessorTest {
     private PluginMetrics pluginMetrics;
 
     @Mock
-    private ExpressionEvaluator<Boolean> expressionEvaluator;
+    private ExpressionEvaluator expressionEvaluator;
 
     private ParseJsonProcessor parseJsonProcessor;
 
@@ -278,7 +278,7 @@ class ParseJsonProcessorTest {
         final Map<String, Object> data = Collections.singletonMap("key", "value");
         final String serializedMessage = convertMapToJSONString(data);
         final Record<Event> testEvent = createMessageEvent(serializedMessage);
-        when(expressionEvaluator.evaluate(whenCondition, testEvent.getData())).thenReturn(false);
+        when(expressionEvaluator.evaluateConditional(whenCondition, testEvent.getData())).thenReturn(false);
         parseJsonProcessor = createObjectUnderTest(); // need to recreate so that new config options are used
 
         final Event parsedEvent = createAndParseMessageEvent(testEvent);


### PR DESCRIPTION
### Description
Add support for basic arithmetic and string returning expressions to DataPrepper Expression.

Adds support for expressions returning arithmetic (integer/float) values from function/JsonPointers/literals

Also, adds support for expressions returning string values from function/JsonPointers/literals

Partially addresses the issues #2686 and #2685 
Resolves #2703 
 
### Issues Resolved
#2703 
 
### Check List
- [X ] New functionality includes testing.
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
