### PR TITLE
ENH: support gzip compression for armeria sources

### DIFF
--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/compression/CompressionOption.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/compression/CompressionOption.java
@@ -1,0 +1,29 @@
+package org.opensearch.dataprepper.compression;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public enum CompressionOption {
+    NONE("none"),
+    GZIP("gzip");
+
+    private final String option;
+
+    private static final Map<String, CompressionOption> OPTIONS_MAP = Arrays.stream(CompressionOption.values())
+            .collect(Collectors.toMap(
+                    value -> value.option,
+                    value -> value
+            ));
+
+    CompressionOption(final String option) {
+        this.option = option.toLowerCase();
+    }
+
+    @JsonCreator
+    static CompressionOption fromOptionValue(final String option) {
+        return OPTIONS_MAP.get(option.toLowerCase());
+    }
+}

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/compression/CompressionOption.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/compression/CompressionOption.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public enum CompressionOption {
@@ -24,6 +25,7 @@ public enum CompressionOption {
 
     @JsonCreator
     static CompressionOption fromOptionValue(final String option) {
-        return OPTIONS_MAP.get(option.toLowerCase());
+        return Optional.ofNullable(OPTIONS_MAP.get(option.toLowerCase())).orElseThrow(
+                () -> new IllegalArgumentException("Unrecognized compression: " + option));
     }
 }

--- a/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/compression/CompressionOptionTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/compression/CompressionOptionTest.java
@@ -1,15 +1,22 @@
 package org.opensearch.dataprepper.compression;
 
+import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CompressionOptionTest {
     @ParameterizedTest
     @EnumSource(CompressionOption.class)
-    void fromOptionValue(final CompressionOption option) {
+    void fromOptionValueValid(final CompressionOption option) {
         assertThat(CompressionOption.fromOptionValue(option.name()), is(option));
+    }
+
+    @Test
+    void fromOptionValueInValid() {
+        assertThrows(IllegalArgumentException.class, () -> CompressionOption.fromOptionValue("unknown"));
     }
 }

--- a/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/compression/CompressionOptionTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/compression/CompressionOptionTest.java
@@ -1,0 +1,15 @@
+package org.opensearch.dataprepper.compression;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class CompressionOptionTest {
+    @ParameterizedTest
+    @EnumSource(CompressionOption.class)
+    void fromOptionValue(final CompressionOption option) {
+        assertThat(CompressionOption.fromOptionValue(option.name()), is(option));
+    }
+}

--- a/data-prepper-plugins/http-source/README.md
+++ b/data-prepper-plugins/http-source/README.md
@@ -30,6 +30,9 @@ source:
 * max_connection_count (Optional) => An `int` larger than 0 represents the maximum allowed number of open connections. Default is `500`.
 * max_pending_requests (Optional) => An `int` larger than 0 represents the maximum allowed number of tasks in the ScheduledThreadPool work queue. Default is `1024`.
 * authentication (Optional) => An authentication configuration. By default, this runs an unauthenticated server. See below for more information.
+* compression (Optional) : The compression type applied on the client request payload. Defaults to `none`. Supported values are: 
+  * `none`: no compression 
+  * `gzip`: apply GZip de-compression on the incoming request.
 
 ### Authentication Configurations
 

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.loghttp;
 
 import jakarta.validation.constraints.Size;
+import org.opensearch.dataprepper.compression.CompressionOption;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micrometer.core.instrument.util.StringUtils;
@@ -18,6 +19,7 @@ public class HTTPSourceConfig {
     static final String SSL = "ssl";
     static final String SSL_CERTIFICATE_FILE = "ssl_certificate_file";
     static final String SSL_KEY_FILE = "ssl_key_file";
+    static final String COMPRESSION = "compression";
     static final boolean DEFAULT_USE_ACM_CERTIFICATE_FOR_SSL = false;
     static final int DEFAULT_ACM_CERTIFICATE_TIMEOUT_MILLIS = 120000;
     static final int DEFAULT_PORT = 2021;
@@ -86,6 +88,9 @@ public class HTTPSourceConfig {
 
     @JsonProperty(UNAUTHENTICATED_HEALTH_CHECK)
     private boolean unauthenticatedHealthCheck = false;
+
+    @JsonProperty(COMPRESSION)
+    private CompressionOption compression = CompressionOption.NONE;
 
     private PluginModel authentication;
 
@@ -207,5 +212,9 @@ public class HTTPSourceConfig {
 
     public boolean isUnauthenticatedHealthCheck() {
         return unauthenticatedHealthCheck;
+    }
+
+    public CompressionOption getCompression() {
+        return compression;
     }
 }

--- a/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.loghttp;
 
+import org.opensearch.dataprepper.compression.CompressionOption;
 import org.opensearch.dataprepper.metrics.MetricNames;
 import org.opensearch.dataprepper.metrics.MetricsTestUtil;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -176,6 +177,7 @@ class HTTPSourceTest {
         lenient().when(sourceConfig.getMaxConnectionCount()).thenReturn(500);
         lenient().when(sourceConfig.getMaxPendingRequests()).thenReturn(1024);
         lenient().when(sourceConfig.hasHealthCheckService()).thenReturn(true);
+        lenient().when(sourceConfig.getCompression()).thenReturn(CompressionOption.NONE);
 
         MetricsTestUtil.initMetrics();
         pluginMetrics = PluginMetrics.fromNames(PLUGIN_NAME, TEST_PIPELINE_NAME);

--- a/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.loghttp;
 
+import com.linecorp.armeria.common.HttpHeaderNames;
 import org.opensearch.dataprepper.compression.CompressionOption;
 import org.opensearch.dataprepper.metrics.MetricNames;
 import org.opensearch.dataprepper.metrics.MetricsTestUtil;
@@ -47,6 +48,7 @@ import org.opensearch.dataprepper.armeria.authentication.HttpBasicAuthentication
 import org.opensearch.dataprepper.plugins.HttpBasicArmeriaHttpAuthenticationProvider;
 import org.opensearch.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -64,6 +66,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+import java.util.zip.GZIPOutputStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -161,6 +164,15 @@ class HTTPSourceTest {
                         .add(LogHTTPService.PAYLOAD_SIZE).toString());
     }
 
+    private byte[] createGZipCompressedPayload(final String payload) throws IOException {
+        // Create a GZip compressed request body
+        final ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        try (final GZIPOutputStream gzipStream = new GZIPOutputStream(byteStream)) {
+            gzipStream.write(payload.getBytes(StandardCharsets.UTF_8));
+        }
+        return byteStream.toByteArray();
+    }
+
     @BeforeEach
     public void setUp() {
         lenient().when(serverBuilder.annotatedService(any())).thenReturn(serverBuilder);
@@ -255,6 +267,50 @@ class HTTPSourceTest {
         final Measurement payloadSizeMax = MetricsTestUtil.getMeasurementFromList(
                 payloadSizeSummaryMeasurements, Statistic.MAX);
         Assertions.assertEquals(testPayloadSize, payloadSizeMax.getValue());
+    }
+
+    @Test
+    public void testHttpCompressionResponse200() throws IOException {
+        // Prepare
+        final String testData = "[{\"log\": \"somelog\"}]";
+        when(sourceConfig.getCompression()).thenReturn(CompressionOption.GZIP);
+        HTTPSourceUnderTest = new HTTPSource(sourceConfig, pluginMetrics, pluginFactory, pipelineDescription);
+        HTTPSourceUnderTest.start(testBuffer);
+        refreshMeasurements();
+
+        // When
+        WebClient.of().execute(RequestHeaders.builder()
+                                .scheme(SessionProtocol.HTTP)
+                                .authority("127.0.0.1:2021")
+                                .method(HttpMethod.POST)
+                                .path("/log/ingest")
+                                .add(HttpHeaderNames.CONTENT_ENCODING, "gzip")
+                                .build(),
+                        createGZipCompressedPayload(testData))
+                .aggregate()
+                .whenComplete((i, ex) -> assertSecureResponseWithStatusCode(i, HttpStatus.OK)).join();
+
+        // Then
+        Assertions.assertFalse(testBuffer.isEmpty());
+
+        final Map.Entry<Collection<Record<Log>>, CheckpointState> result = testBuffer.read(100);
+        List<Record<Log>> records = new ArrayList<>(result.getKey());
+        Assertions.assertEquals(1, records.size());
+        final Record<Log> record = records.get(0);
+        Assertions.assertEquals("somelog", record.getData().get("log", String.class));
+        // Verify metrics
+        final Measurement requestReceivedCount = MetricsTestUtil.getMeasurementFromList(
+                requestsReceivedMeasurements, Statistic.COUNT);
+        Assertions.assertEquals(1.0, requestReceivedCount.getValue());
+        final Measurement successRequestsCount = MetricsTestUtil.getMeasurementFromList(
+                successRequestsMeasurements, Statistic.COUNT);
+        Assertions.assertEquals(1.0, successRequestsCount.getValue());
+        final Measurement requestProcessDurationCount = MetricsTestUtil.getMeasurementFromList(
+                requestProcessDurationMeasurements, Statistic.COUNT);
+        Assertions.assertEquals(1.0, requestProcessDurationCount.getValue());
+        final Measurement requestProcessDurationMax = MetricsTestUtil.getMeasurementFromList(
+                requestProcessDurationMeasurements, Statistic.MAX);
+        Assertions.assertTrue(requestProcessDurationMax.getValue() > 0);
     }
 
     @Test

--- a/data-prepper-plugins/otel-logs-source/README.md
+++ b/data-prepper-plugins/otel-logs-source/README.md
@@ -22,6 +22,9 @@ source:
 * unframed_requests(Optional) => A boolean to enable requests not framed using the gRPC wire protocol. 
 * thread_count(Optional) => the number of threads to keep in the ScheduledThreadPool. Default is `200`.
 * max_connection_count(Optional) => the maximum allowed number of open connections. Default is `500`.
+* compression (Optional) : The compression type applied on the client request payload. Defaults to `none`. Supported values are:
+    * `none`: no compression
+    * `gzip`: apply GZip de-compression on the incoming request.
 
 ### SSL
 

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSource.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSource.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper.plugins.source.otellogs;
 
+import com.linecorp.armeria.server.encoding.DecodingService;
+import org.opensearch.dataprepper.compression.CompressionOption;
 import org.opensearch.dataprepper.plugins.health.HealthGrpcService;
 import org.opensearch.dataprepper.plugins.source.otellogs.certificate.CertificateProviderFactory;
 import com.linecorp.armeria.server.Server;
@@ -120,7 +122,11 @@ public class OTelLogsSource implements Source<Record<Object>> {
 
             final ServerBuilder sb = Server.builder();
             sb.disableServerHeader();
-            sb.service(grpcServiceBuilder.build());
+            if (CompressionOption.NONE.equals(oTelLogsSourceConfig.getCompression())) {
+                sb.service(grpcServiceBuilder.build());
+            } else {
+                sb.service(grpcServiceBuilder.build(), DecodingService.newDecorator());
+            }
             sb.requestTimeoutMillis(oTelLogsSourceConfig.getRequestTimeoutInMillis());
 
             // ACM Cert for SSL takes preference

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceConfig.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceConfig.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
 import org.apache.commons.lang3.StringUtils;
+import org.opensearch.dataprepper.compression.CompressionOption;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 
 public class OTelLogsSourceConfig {
@@ -29,6 +30,7 @@ public class OTelLogsSourceConfig {
     static final String THREAD_COUNT = "thread_count";
     static final String MAX_CONNECTION_COUNT = "max_connection_count";
     static final String ENABLE_UNFRAMED_REQUESTS = "unframed_requests";
+    static final String COMPRESSION = "compression";
     static final int DEFAULT_REQUEST_TIMEOUT_MS = 10000;
     static final int DEFAULT_PORT = 21892;
     static final int DEFAULT_THREAD_COUNT = 200;
@@ -94,6 +96,9 @@ public class OTelLogsSourceConfig {
 
     @JsonProperty("authentication")
     private PluginModel authentication;
+
+    @JsonProperty(COMPRESSION)
+    private CompressionOption compression = CompressionOption.NONE;
 
     @AssertTrue(message = "path should start with /")
     boolean isPathValid() {
@@ -200,5 +205,9 @@ public class OTelLogsSourceConfig {
     }
 
     public PluginModel getAuthentication() { return authentication; }
+
+    public CompressionOption getCompression() {
+        return compression;
+    }
 }
 

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.otellogs;
 
+import com.linecorp.armeria.common.HttpHeaderNames;
 import org.opensearch.dataprepper.compression.CompressionOption;
 import org.opensearch.dataprepper.plugins.health.HealthGrpcService;
 import org.opensearch.dataprepper.plugins.source.otellogs.certificate.CertificateProviderFactory;
@@ -69,6 +70,7 @@ import org.opensearch.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
 import org.opensearch.dataprepper.plugins.certificate.CertificateProvider;
 import org.opensearch.dataprepper.plugins.certificate.model.Certificate;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -85,6 +87,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.GZIPOutputStream;
 
 import static org.opensearch.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.DEFAULT_PORT;
 import static org.opensearch.dataprepper.plugins.source.otellogs.OTelLogsSourceConfig.DEFAULT_REQUEST_TIMEOUT_MS;
@@ -283,6 +286,26 @@ class OTelLogsSourceTest {
                                 .contentType(MediaType.JSON_UTF_8)
                                 .build(),
                         HttpData.copyOf(JsonFormat.printer().print(LOGS_REQUEST).getBytes()))
+                .aggregate()
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.OK, throwable))
+                .join();
+    }
+
+    @Test
+    void testHttpCompressionWithUnframedRequests() throws IOException {
+        when(oTelLogsSourceConfig.enableUnframedRequests()).thenReturn(true);
+        when(oTelLogsSourceConfig.getCompression()).thenReturn(CompressionOption.GZIP);
+        SOURCE.start(buffer);
+
+        WebClient.of().execute(RequestHeaders.builder()
+                                .scheme(SessionProtocol.HTTP)
+                                .authority("127.0.0.1:21892")
+                                .method(HttpMethod.POST)
+                                .path("/opentelemetry.proto.collector.logs.v1.LogsService/Export")
+                                .contentType(MediaType.JSON_UTF_8)
+                                .add(HttpHeaderNames.CONTENT_ENCODING, "gzip")
+                                .build(),
+                        createGZipCompressedPayload(JsonFormat.printer().print(LOGS_REQUEST)))
                 .aggregate()
                 .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.OK, throwable))
                 .join();
@@ -777,6 +800,15 @@ class OTelLogsSourceTest {
                 .map(AsciiString::toString)
                 .collect(Collectors.toList());
         assertThat("Response Header Keys", headerKeys, not(contains("server")));
+    }
+
+    private byte[] createGZipCompressedPayload(final String payload) throws IOException {
+        // Create a GZip compressed request body
+        final ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        try (final GZIPOutputStream gzipStream = new GZIPOutputStream(byteStream)) {
+            gzipStream.write(payload.getBytes(StandardCharsets.UTF_8));
+        }
+        return byteStream.toByteArray();
     }
 
 }

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.otellogs;
 
+import org.opensearch.dataprepper.compression.CompressionOption;
 import org.opensearch.dataprepper.plugins.health.HealthGrpcService;
 import org.opensearch.dataprepper.plugins.source.otellogs.certificate.CertificateProviderFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -188,6 +189,7 @@ class OTelLogsSourceTest {
         when(oTelLogsSourceConfig.getRequestTimeoutInMillis()).thenReturn(DEFAULT_REQUEST_TIMEOUT_MS);
         when(oTelLogsSourceConfig.getMaxConnectionCount()).thenReturn(10);
         when(oTelLogsSourceConfig.getThreadCount()).thenReturn(5);
+        when(oTelLogsSourceConfig.getCompression()).thenReturn(CompressionOption.NONE);
         pluginMetrics = PluginMetrics.fromNames("otel_logs", "pipeline");
 
         when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))

--- a/data-prepper-plugins/otel-metrics-source/README.md
+++ b/data-prepper-plugins/otel-metrics-source/README.md
@@ -22,6 +22,9 @@ source:
 * unframed_requests(Optional) => A boolean to enable requests not framed using the gRPC wire protocol. When ```health_check_service``` is true and ```unframed_requests``` is true, enables HTTP health check service under ```/health```.
 * thread_count(Optional) => the number of threads to keep in the ScheduledThreadPool. Default is `200`.
 * max_connection_count(Optional) => the maximum allowed number of open connections. Default is `500`.
+* compression (Optional) : The compression type applied on the client request payload. Defaults to `none`. Supported values are:
+    * `none`: no compression
+    * `gzip`: apply GZip de-compression on the incoming request.
 
 ### SSL
 

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceConfig.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceConfig.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
 import org.apache.commons.lang3.StringUtils;
+import org.opensearch.dataprepper.compression.CompressionOption;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 
 public class OTelMetricsSourceConfig {
@@ -28,6 +29,7 @@ public class OTelMetricsSourceConfig {
     static final String THREAD_COUNT = "thread_count";
     static final String MAX_CONNECTION_COUNT = "max_connection_count";
     static final String ENABLE_UNFRAMED_REQUESTS = "unframed_requests";
+    static final String COMPRESSION = "compression";
     static final int DEFAULT_REQUEST_TIMEOUT_MS = 10000;
     static final int DEFAULT_PORT = 21891;
     static final int DEFAULT_THREAD_COUNT = 200;
@@ -97,6 +99,9 @@ public class OTelMetricsSourceConfig {
 
     @JsonProperty(UNAUTHENTICATED_HEALTH_CHECK)
     private boolean unauthenticatedHealthCheck = false;
+
+    @JsonProperty(COMPRESSION)
+    private CompressionOption compression = CompressionOption.NONE;
 
     @AssertTrue(message = "path should start with /")
     boolean isPathValid() {
@@ -210,6 +215,10 @@ public class OTelMetricsSourceConfig {
 
     public boolean isUnauthenticatedHealthCheck() {
         return unauthenticatedHealthCheck;
+    }
+
+    public CompressionOption getCompression() {
+        return compression;
     }
 }
 

--- a/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceTest.java
+++ b/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceTest.java
@@ -55,6 +55,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
 import org.opensearch.dataprepper.armeria.authentication.HttpBasicAuthenticationConfig;
+import org.opensearch.dataprepper.compression.CompressionOption;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
@@ -187,6 +188,7 @@ class OTelMetricsSourceTest {
         when(oTelMetricsSourceConfig.getRequestTimeoutInMillis()).thenReturn(DEFAULT_REQUEST_TIMEOUT_MS);
         when(oTelMetricsSourceConfig.getMaxConnectionCount()).thenReturn(10);
         when(oTelMetricsSourceConfig.getThreadCount()).thenReturn(5);
+        when(oTelMetricsSourceConfig.getCompression()).thenReturn(CompressionOption.NONE);
 
         when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))
                 .thenReturn(authenticationProvider);

--- a/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceTest.java
+++ b/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceTest.java
@@ -14,6 +14,7 @@ import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
@@ -69,6 +70,7 @@ import org.opensearch.dataprepper.plugins.certificate.model.Certificate;
 import org.opensearch.dataprepper.plugins.health.HealthGrpcService;
 import org.opensearch.dataprepper.plugins.source.otelmetrics.certificate.CertificateProviderFactory;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -85,6 +87,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.GZIPOutputStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -280,6 +283,26 @@ class OTelMetricsSourceTest {
                                 .contentType(MediaType.JSON_UTF_8)
                                 .build(),
                         HttpData.copyOf(JsonFormat.printer().print(METRICS_REQUEST).getBytes()))
+                .aggregate()
+                .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.OK, throwable))
+                .join();
+    }
+
+    @Test
+    void testHttpCompressionWithUnframedRequests() throws IOException {
+        when(oTelMetricsSourceConfig.enableUnframedRequests()).thenReturn(true);
+        when(oTelMetricsSourceConfig.getCompression()).thenReturn(CompressionOption.GZIP);
+        SOURCE.start(buffer);
+
+        WebClient.of().execute(RequestHeaders.builder()
+                                .scheme(SessionProtocol.HTTP)
+                                .authority("127.0.0.1:21891")
+                                .method(HttpMethod.POST)
+                                .path("/opentelemetry.proto.collector.metrics.v1.MetricsService/Export")
+                                .contentType(MediaType.JSON_UTF_8)
+                                .add(HttpHeaderNames.CONTENT_ENCODING, "gzip")
+                                .build(),
+                        createGZipCompressedPayload(JsonFormat.printer().print(METRICS_REQUEST)))
                 .aggregate()
                 .whenComplete((response, throwable) -> assertSecureResponseWithStatusCode(response, HttpStatus.OK, throwable))
                 .join();
@@ -987,5 +1010,14 @@ class OTelMetricsSourceTest {
                 .map(AsciiString::toString)
                 .collect(Collectors.toList());
         assertThat("Response Header Keys", headerKeys, not(contains("server")));
+    }
+
+    private byte[] createGZipCompressedPayload(final String payload) throws IOException {
+        // Create a GZip compressed request body
+        final ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        try (final GZIPOutputStream gzipStream = new GZIPOutputStream(byteStream)) {
+            gzipStream.write(payload.getBytes(StandardCharsets.UTF_8));
+        }
+        return byteStream.toByteArray();
     }
 }

--- a/data-prepper-plugins/otel-trace-source/README.md
+++ b/data-prepper-plugins/otel-trace-source/README.md
@@ -38,6 +38,9 @@ For more information on migrating from Data Prepper 1.x to Data Prepper 2.x, see
 * max_connection_count(Optional) => the maximum allowed number of open connections. Default is `500`. 
 * authentication(Optional) => An authentication configuration. By default, this runs an unauthenticated server. See below for more information.
 * record_type(Optional) => A string represents the supported record data type that is written into the buffer plugin. Value options are `otlp` or `event`. Default is `otlp`.
+* compression (Optional) : The compression type applied on the client request payload. Defaults to `none`. Supported values are:
+    * `none`: no compression
+    * `gzip`: apply GZip de-compression on the incoming request.
 
 ### Authentication Configurations
 

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.source.oteltrace;
 
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
+import org.opensearch.dataprepper.compression.CompressionOption;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.StringUtils;
@@ -29,6 +30,7 @@ public class OTelTraceSourceConfig {
     static final String MAX_CONNECTION_COUNT = "max_connection_count";
     static final String ENABLE_UNFRAMED_REQUESTS = "unframed_requests";
     static final String UNAUTHENTICATED_HEALTH_CHECK = "unauthenticated_health_check";
+    static final String COMPRESSION = "compression";
     static final int DEFAULT_REQUEST_TIMEOUT_MS = 10000;
     static final int DEFAULT_PORT = 21890;
     static final int DEFAULT_THREAD_COUNT = 200;
@@ -97,6 +99,9 @@ public class OTelTraceSourceConfig {
 
     @JsonProperty(UNAUTHENTICATED_HEALTH_CHECK)
     private boolean unauthenticatedHealthCheck = false;
+
+    @JsonProperty(COMPRESSION)
+    private CompressionOption compression = CompressionOption.NONE;
 
     @AssertTrue(message = "path should start with /")
     boolean isPathValid() {
@@ -210,5 +215,9 @@ public class OTelTraceSourceConfig {
 
     public boolean isUnauthenticatedHealthCheck() {
         return unauthenticatedHealthCheck;
+    }
+
+    public CompressionOption getCompression() {
+        return compression;
     }
 }

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -54,6 +54,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
 import org.opensearch.dataprepper.armeria.authentication.HttpBasicAuthenticationConfig;
+import org.opensearch.dataprepper.compression.CompressionOption;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
@@ -201,6 +202,7 @@ class OTelTraceSourceTest {
         when(oTelTraceSourceConfig.getRequestTimeoutInMillis()).thenReturn(DEFAULT_REQUEST_TIMEOUT_MS);
         when(oTelTraceSourceConfig.getMaxConnectionCount()).thenReturn(10);
         when(oTelTraceSourceConfig.getThreadCount()).thenReturn(5);
+        when(oTelTraceSourceConfig.getCompression()).thenReturn(CompressionOption.NONE);
 
         when(pluginFactory.loadPlugin(eq(GrpcAuthenticationProvider.class), any(PluginSetting.class)))
                 .thenReturn(authenticationProvider);

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
@@ -5,12 +5,20 @@
 
 package org.opensearch.dataprepper.plugins.source.oteltrace;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.compression.CompressionOption;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -37,6 +45,10 @@ class OtelTraceSourceConfigTests {
     private static final int TEST_THREAD_COUNT = 888;
     private static final int TEST_MAX_CONNECTION_COUNT = 999;
 
+    private static Stream<Arguments> provideCompressionOption() {
+        return Stream.of(Arguments.of(CompressionOption.GZIP));
+    }
+
     @Test
     void testDefault() {
 
@@ -49,6 +61,7 @@ class OtelTraceSourceConfigTests {
         assertEquals(OTelTraceSourceConfig.DEFAULT_PORT, otelTraceSourceConfig.getPort());
         assertEquals(OTelTraceSourceConfig.DEFAULT_THREAD_COUNT, otelTraceSourceConfig.getThreadCount());
         assertEquals(OTelTraceSourceConfig.DEFAULT_MAX_CONNECTION_COUNT, otelTraceSourceConfig.getMaxConnectionCount());
+        assertEquals(CompressionOption.NONE, otelTraceSourceConfig.getCompression());
         assertFalse(otelTraceSourceConfig.hasHealthCheck());
         assertFalse(otelTraceSourceConfig.hasProtoReflectionService());
         assertFalse(otelTraceSourceConfig.enableHttpHealthCheck());
@@ -92,6 +105,20 @@ class OtelTraceSourceConfigTests {
         assertFalse(otelTraceSourceConfig.enableUnframedRequests());
         assertTrue(otelTraceSourceConfig.hasProtoReflectionService());
         assertFalse(otelTraceSourceConfig.enableHttpHealthCheck());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideCompressionOption")
+    void testValidCompression(final CompressionOption compressionOption) {
+        // Prepare
+        final Map<String, Object> settings = new HashMap<>();
+        settings.put(OTelTraceSourceConfig.COMPRESSION, compressionOption.name());
+
+        final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, settings);
+        final OTelTraceSourceConfig otelTraceSourceConfig = OBJECT_MAPPER.convertValue(pluginSetting.getSettings(), OTelTraceSourceConfig.class);
+
+        // When/Then
+        assertEquals(compressionOption, otelTraceSourceConfig.getCompression());
     }
 
     @Test

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
@@ -5,11 +5,9 @@
 
 package org.opensearch.dataprepper.plugins.source.oteltrace;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.dataprepper.compression.CompressionOption;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
### Description
This PR supports gzip as compression type in push based sources
* http
* otel-trace
* otel-logs
* otel-metrics
 
### Issues Resolved
Resolves #1399 
Resolves #1176 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
