### PR TITLE
Rework ddb source coordination store to support multi-source, remove scan for queries on global secondary index

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/SourceCoordinationStore.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/SourceCoordinationStore.java
@@ -20,9 +20,10 @@ public interface SourceCoordinationStore {
 
     void initializeStore();
 
-    Optional<SourcePartitionStoreItem> getSourcePartitionItem(final String partitionKey);
+    Optional<SourcePartitionStoreItem> getSourcePartitionItem(final String sourceIdentifier, final String sourcePartitionKey);
 
-    boolean tryCreatePartitionItem(final String partitionKey,
+    boolean tryCreatePartitionItem(final String sourceIdentifier,
+                                   final String partitionKey,
                                    final SourcePartitionStatus sourcePartitionStatus,
                                    final Long closedCount,
                                    final String partitionProgressState);
@@ -33,7 +34,7 @@ public interface SourceCoordinationStore {
      * 2. The partition status is CLOSED and the reOpenAt timestamp has passed
      * 3. The partition status is ASSIGNED and the partitionOwnershipTimeout has passed
      */
-    Optional<SourcePartitionStoreItem> tryAcquireAvailablePartition(final String ownerId, final Duration ownershipTimeout);
+    Optional<SourcePartitionStoreItem> tryAcquireAvailablePartition(final String sourceIdentifier, final String ownerId, final Duration ownershipTimeout);
 
     /**
      * This method attempts to update the partition item to the desired state

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartitionStoreItem.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartitionStoreItem.java
@@ -13,6 +13,8 @@ import java.time.Instant;
  * @since 2.2
  */
 public interface SourcePartitionStoreItem {
+
+    String getSourceIdentifier();
     String getSourcePartitionKey();
     String getPartitionOwner();
     String getPartitionProgressState();

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/SourceCoordinationConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/SourceCoordinationConfig.java
@@ -22,16 +22,24 @@ public class SourceCoordinationConfig {
 
     private static final String SOURCE_COORDINATOR_METRIC_PREFIX = "source-coordinator";
     private final PluginSetting sourceCoordinationStoreConfig;
+    private final String partitionPrefix;
 
     @JsonCreator
-    public SourceCoordinationConfig(@JsonProperty("store") final PluginModel sourceCoordinationStoreConfig) {
+    public SourceCoordinationConfig(@JsonProperty("store") final PluginModel sourceCoordinationStoreConfig,
+                                    @JsonProperty("partition_prefix") final String partitionPrefix) {
         Objects.requireNonNull(sourceCoordinationStoreConfig, "source_coordination store must not be null");
 
         this.sourceCoordinationStoreConfig = new PluginSetting(sourceCoordinationStoreConfig.getPluginName(), sourceCoordinationStoreConfig.getPluginSettings());
         this.sourceCoordinationStoreConfig.setPipelineName(SOURCE_COORDINATOR_METRIC_PREFIX);
+
+        this.partitionPrefix = Objects.nonNull(partitionPrefix) ? partitionPrefix : null;
     }
 
     public PluginSetting getSourceCoordinationStoreConfig() {
         return sourceCoordinationStoreConfig;
+    }
+
+    public String getPartitionPrefix() {
+        return partitionPrefix;
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/SourceCoordinatorFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/SourceCoordinatorFactory.java
@@ -37,6 +37,8 @@ public class SourceCoordinatorFactory {
             return null;
         }
 
+        sourceCoordinationConfig.getSourceCoordinationStoreConfig().getPipelineName();
+
 
 
         final SourceCoordinationStore sourceCoordinationStore =

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinatorTest.java
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.DEFAULT_LEASE_TIMEOUT;
+import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.PARTITION_TYPE;
 
 @ExtendWith(MockitoExtension.class)
 public class LeaseBasedSourceCoordinatorTest {
@@ -67,15 +68,20 @@ public class LeaseBasedSourceCoordinatorTest {
     @Mock
     private SourcePartitionStoreItem sourcePartitionStoreItem;
 
-    private String ownerPrefix;
+    private String sourceIdentifier;
+    private String partitionPrefix;
+    private String fullSourceIdentifier;
 
     @BeforeEach
     void setup() {
-        ownerPrefix = UUID.randomUUID().toString();
+        sourceIdentifier = UUID.randomUUID().toString();
+        partitionPrefix = UUID.randomUUID().toString();
+        fullSourceIdentifier = partitionPrefix + "|" + sourceIdentifier + "|" + PARTITION_TYPE;
+        given(sourceCoordinationConfig.getPartitionPrefix()).willReturn(partitionPrefix);
     }
 
     private SourceCoordinator<String> createObjectUnderTest() {
-        final SourceCoordinator<String> objectUnderTest = new LeaseBasedSourceCoordinator<>(String.class, sourceCoordinationStore, sourceCoordinationConfig, partitionManager, ownerPrefix);
+        final SourceCoordinator<String> objectUnderTest = new LeaseBasedSourceCoordinator<>(String.class, sourceCoordinationStore, sourceCoordinationConfig, partitionManager, sourceIdentifier);
         doNothing().when(sourceCoordinationStore).initializeStore();
         objectUnderTest.initialize();
         return objectUnderTest;
@@ -83,7 +89,7 @@ public class LeaseBasedSourceCoordinatorTest {
 
     @Test
     void initialize_calls_initializeStore() {
-        final SourceCoordinator<String> objectUnderTest = new LeaseBasedSourceCoordinator<>(String.class, sourceCoordinationStore, sourceCoordinationConfig, partitionManager, ownerPrefix);
+        final SourceCoordinator<String> objectUnderTest = new LeaseBasedSourceCoordinator<>(String.class, sourceCoordinationStore, sourceCoordinationConfig, partitionManager, sourceIdentifier);
         objectUnderTest.initialize();
 
         verify(sourceCoordinationStore).initializeStore();
@@ -94,7 +100,7 @@ public class LeaseBasedSourceCoordinatorTest {
         final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
         final Supplier<List<PartitionIdentifier>> partitionCreationSupplier = () -> List.of(partitionIdentifier);
 
-        final SourceCoordinator<String> objectUnderTest = new LeaseBasedSourceCoordinator<>(String.class, sourceCoordinationStore, sourceCoordinationConfig, partitionManager, ownerPrefix);
+        final SourceCoordinator<String> objectUnderTest = new LeaseBasedSourceCoordinator<>(String.class, sourceCoordinationStore, sourceCoordinationConfig, partitionManager, sourceIdentifier);
         assertThrows(UninitializedSourceCoordinatorException.class, () -> objectUnderTest.getNextPartition(partitionCreationSupplier));
     }
 
@@ -103,9 +109,9 @@ public class LeaseBasedSourceCoordinatorTest {
         final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
         final Supplier<List<PartitionIdentifier>> partitionCreationSupplier = () -> List.of(partitionIdentifier);
 
-        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), any())).willReturn(Optional.empty()).willReturn( Optional.empty());
-        given(sourceCoordinationStore.getSourcePartitionItem(partitionIdentifier.getPartitionKey())).willReturn(Optional.empty());
-        given(sourceCoordinationStore.tryCreatePartitionItem(partitionIdentifier.getPartitionKey(), SourcePartitionStatus.UNASSIGNED, 0L, null)).willReturn(true);
+        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), anyString(), any())).willReturn(Optional.empty()).willReturn( Optional.empty());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, partitionIdentifier.getPartitionKey())).willReturn(Optional.empty());
+        given(sourceCoordinationStore.tryCreatePartitionItem(fullSourceIdentifier, partitionIdentifier.getPartitionKey(), SourcePartitionStatus.UNASSIGNED, 0L, null)).willReturn(true);
 
         final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition(partitionCreationSupplier);
 
@@ -117,14 +123,14 @@ public class LeaseBasedSourceCoordinatorTest {
         final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
         final Supplier<List<PartitionIdentifier>> partitionCreationSupplier = () -> List.of(partitionIdentifier);
 
-        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), any())).willReturn(Optional.empty()).willReturn( Optional.empty());
-        given(sourceCoordinationStore.getSourcePartitionItem(partitionIdentifier.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), anyString(), any())).willReturn(Optional.empty()).willReturn( Optional.empty());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, partitionIdentifier.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition(partitionCreationSupplier);
 
         assertThat(result.isEmpty(), equalTo(true));
 
-        verify(sourceCoordinationStore, never()).tryCreatePartitionItem(anyString(), any(), anyLong(), anyString());
+        verify(sourceCoordinationStore, never()).tryCreatePartitionItem(anyString(), anyString(), any(), anyLong(), anyString());
     }
 
     @Test
@@ -132,9 +138,9 @@ public class LeaseBasedSourceCoordinatorTest {
         final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
         final Supplier<List<PartitionIdentifier>> partitionCreationSupplier = () -> List.of(partitionIdentifier);
 
-        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), any())).willReturn(Optional.empty()).willReturn( Optional.empty());
-        given(sourceCoordinationStore.getSourcePartitionItem(partitionIdentifier.getPartitionKey())).willReturn(Optional.empty());
-        given(sourceCoordinationStore.tryCreatePartitionItem(partitionIdentifier.getPartitionKey(), SourcePartitionStatus.UNASSIGNED, 0L, null)).willReturn(false);
+        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), anyString(), any())).willReturn(Optional.empty()).willReturn( Optional.empty());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, partitionIdentifier.getPartitionKey())).willReturn(Optional.empty());
+        given(sourceCoordinationStore.tryCreatePartitionItem(fullSourceIdentifier, partitionIdentifier.getPartitionKey(), SourcePartitionStatus.UNASSIGNED, 0L, null)).willReturn(false);
 
         final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition(partitionCreationSupplier);
 
@@ -162,7 +168,7 @@ public class LeaseBasedSourceCoordinatorTest {
     @Test
     void getNextPartition_with_no_active_partition_and_unsuccessful_tryAcquireAvailablePartition_returns_empty_Optional() {
         given(partitionManager.getActivePartition()).willReturn(Optional.empty());
-        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), any())).willReturn(Optional.empty()).willReturn(Optional.empty());
+        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), anyString(), any())).willReturn(Optional.empty()).willReturn(Optional.empty());
 
 
         final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition(Collections::emptyList);
@@ -175,7 +181,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(partitionManager.getActivePartition()).willReturn(Optional.empty());
         given(sourcePartitionStoreItem.getSourcePartitionKey()).willReturn(UUID.randomUUID().toString());
         given(sourcePartitionStoreItem.getPartitionProgressState()).willReturn(UUID.randomUUID().toString());
-        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), any())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), anyString(), any())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition(Collections::emptyList);
 
@@ -185,8 +191,8 @@ public class LeaseBasedSourceCoordinatorTest {
         assertThat(result.get().getPartitionState(), equalTo(sourcePartitionStoreItem.getPartitionProgressState()));
 
         verify(partitionManager).setActivePartition(result.get());
-        verify(sourceCoordinationStore, never()).getSourcePartitionItem(anyString());
-        verify(sourceCoordinationStore, never()).tryCreatePartitionItem(anyString(), any(), anyLong(), anyString());
+        verify(sourceCoordinationStore, never()).getSourcePartitionItem(anyString(), anyString());
+        verify(sourceCoordinationStore, never()).tryCreatePartitionItem(anyString(), anyString(), any(), anyLong(), anyString());
     }
 
     @Test
@@ -209,7 +215,7 @@ public class LeaseBasedSourceCoordinatorTest {
                 .build();
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
-        given(sourceCoordinationStore.getSourcePartitionItem(sourcePartition.getPartitionKey())).willReturn(Optional.empty());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.empty());
 
         assertThrows(PartitionNotFoundException.class, () -> createObjectUnderTest().completePartition(sourcePartition.getPartitionKey()));
     }
@@ -224,7 +230,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
         given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(UUID.randomUUID().toString());
         given(sourcePartitionStoreItem.getSourcePartitionKey()).willReturn(sourcePartition.getPartitionKey());
-        given(sourceCoordinationStore.getSourcePartitionItem(sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         assertThrows(PartitionNotOwnedException.class, () -> createObjectUnderTest().completePartition(sourcePartition.getPartitionKey()));
 
@@ -240,9 +246,9 @@ public class LeaseBasedSourceCoordinatorTest {
                 .build();
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
-        given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(ownerPrefix + ":" + InetAddress.getLocalHost().getHostName());
+        given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(sourceIdentifier + ":" + InetAddress.getLocalHost().getHostName());
 
-        given(sourceCoordinationStore.getSourcePartitionItem(sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         if (updatedItemSuccessfully) {
             doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);
@@ -280,7 +286,7 @@ public class LeaseBasedSourceCoordinatorTest {
                 .build();
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
-        given(sourceCoordinationStore.getSourcePartitionItem(sourcePartition.getPartitionKey())).willReturn(Optional.empty());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.empty());
 
         assertThrows(PartitionNotFoundException.class, () -> createObjectUnderTest().closePartition(sourcePartition.getPartitionKey(), Duration.ofMinutes(2), 1));
     }
@@ -295,7 +301,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
         given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(UUID.randomUUID().toString());
         given(sourcePartitionStoreItem.getSourcePartitionKey()).willReturn(sourcePartition.getPartitionKey());
-        given(sourceCoordinationStore.getSourcePartitionItem(sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         assertThrows(PartitionNotOwnedException.class, () -> createObjectUnderTest().closePartition(sourcePartition.getPartitionKey(), Duration.ofMinutes(2), 1));
 
@@ -311,9 +317,9 @@ public class LeaseBasedSourceCoordinatorTest {
                 .build();
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
-        given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(ownerPrefix + ":" + InetAddress.getLocalHost().getHostName());
+        given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(sourceIdentifier + ":" + InetAddress.getLocalHost().getHostName());
         given(sourcePartitionStoreItem.getClosedCount()).willReturn(closedCount);
-        given(sourceCoordinationStore.getSourcePartitionItem(sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         final int maxClosedCount = 2;
         if (updatedItemSuccessfully) {
@@ -358,7 +364,7 @@ public class LeaseBasedSourceCoordinatorTest {
                 .build();
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
-        given(sourceCoordinationStore.getSourcePartitionItem(sourcePartition.getPartitionKey())).willReturn(Optional.empty());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.empty());
 
         assertThrows(PartitionNotFoundException.class, () -> createObjectUnderTest().saveProgressStateForPartition(sourcePartition.getPartitionKey(), UUID.randomUUID().toString()));
     }
@@ -373,7 +379,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
         given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(UUID.randomUUID().toString());
         given(sourcePartitionStoreItem.getSourcePartitionKey()).willReturn(sourcePartition.getPartitionKey());
-        given(sourceCoordinationStore.getSourcePartitionItem(sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         assertThrows(PartitionNotOwnedException.class, () -> createObjectUnderTest().saveProgressStateForPartition(sourcePartition.getPartitionKey(), UUID.randomUUID().toString()));
 
@@ -392,8 +398,8 @@ public class LeaseBasedSourceCoordinatorTest {
         final String newProgressState = UUID.randomUUID().toString();
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
-        given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(ownerPrefix + ":" + InetAddress.getLocalHost().getHostName());
-        given(sourceCoordinationStore.getSourcePartitionItem(sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(sourceIdentifier + ":" + InetAddress.getLocalHost().getHostName());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         if (updatedItemSuccessfully) {
             doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);
@@ -413,7 +419,7 @@ public class LeaseBasedSourceCoordinatorTest {
 
     @Test
     void giveUpPartitions_with_nonInitialized_store_does_nothing_and_returns() {
-        final SourceCoordinator<String> objectUnderTest = new LeaseBasedSourceCoordinator<>(String.class, sourceCoordinationStore, sourceCoordinationConfig, partitionManager, ownerPrefix);
+        final SourceCoordinator<String> objectUnderTest = new LeaseBasedSourceCoordinator<>(String.class, sourceCoordinationStore, sourceCoordinationConfig, partitionManager, sourceIdentifier);
 
         objectUnderTest.giveUpPartitions();
 
@@ -428,7 +434,7 @@ public class LeaseBasedSourceCoordinatorTest {
                 .build();
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
-        given(sourceCoordinationStore.getSourcePartitionItem(sourcePartition.getPartitionKey())).willReturn(Optional.empty());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.empty());
 
         createObjectUnderTest().giveUpPartitions();
 
@@ -446,8 +452,8 @@ public class LeaseBasedSourceCoordinatorTest {
                 .build();
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
-        given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(ownerPrefix + ":" + InetAddress.getLocalHost().getHostName());
-        given(sourceCoordinationStore.getSourcePartitionItem(sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(sourceIdentifier + ":" + InetAddress.getLocalHost().getHostName());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         if (updatedItemSuccessfully) {
             doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
@@ -4,29 +4,38 @@
  */
 package org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb;
 
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStatus;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
 import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionUpdateException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.internal.waiters.ResponseOrException;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.CreateTableEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedGlobalSecondaryIndex;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.Projection;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 import software.amazon.awssdk.services.dynamodb.model.ResourceInUseException;
 import software.amazon.awssdk.services.dynamodb.waiters.DynamoDbWaiter;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -34,9 +43,10 @@ import java.util.Optional;
 public class DynamoDbClientWrapper {
 
     private static final Logger LOG = LoggerFactory.getLogger(DynamoDbClientWrapper.class);
+    static final String SOURCE_STATUS_COMBINATION_KEY_GLOBAL_SECONDARY_INDEX = "source-status";
 
-    static final String ITEM_DOES_NOT_EXIST_EXPRESSION = "attribute_not_exists(sourcePartitionKey)";
-    static final String ITEM_EXISTS_AND_HAS_LATEST_VERSION = "attribute_exists(sourcePartitionKey) and version = :v";
+    static final String ITEM_DOES_NOT_EXIST_EXPRESSION = "attribute_not_exists(sourceIdentifier) or attribute_not_exists(sourcePartitionKey)";
+    static final String ITEM_EXISTS_AND_HAS_LATEST_VERSION = "attribute_exists(sourceIdentifier) and attribute_exists(sourcePartitionKey) and version = :v";
 
     private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
     private DynamoDbTable<DynamoDbSourcePartitionItem> table;
@@ -51,13 +61,18 @@ public class DynamoDbClientWrapper {
     }
 
     public void tryCreateTable(final String tableName,
-                                  final ProvisionedThroughput provisionedThroughput) {
+                               final ProvisionedThroughput provisionedThroughput) {
 
         this.table = dynamoDbEnhancedClient.table(tableName, TableSchema.fromBean(DynamoDbSourcePartitionItem.class));
 
         try {
             final CreateTableEnhancedRequest createTableEnhancedRequest = CreateTableEnhancedRequest.builder()
                             .provisionedThroughput(provisionedThroughput)
+                            .globalSecondaryIndices(EnhancedGlobalSecondaryIndex.builder()
+                                    .indexName(SOURCE_STATUS_COMBINATION_KEY_GLOBAL_SECONDARY_INDEX)
+                                    .provisionedThroughput(provisionedThroughput)
+                                    .projection(Projection.builder().projectionType(ProjectionType.ALL).build())
+                                    .build())
                             .build();
             table.createTable(createTableEnhancedRequest);
         } catch (final ResourceInUseException e) {
@@ -96,7 +111,7 @@ public class DynamoDbClientWrapper {
         }
     }
 
-    public boolean tryAcquirePartitionItem(final DynamoDbSourcePartitionItem dynamoDbSourcePartitionItem) {
+    private boolean tryAcquirePartitionItem(final DynamoDbSourcePartitionItem dynamoDbSourcePartitionItem) {
         try {
             tryUpdateItem(dynamoDbSourcePartitionItem);
             return true;
@@ -138,10 +153,11 @@ public class DynamoDbClientWrapper {
         }
     }
 
-    public Optional<SourcePartitionStoreItem> getSourcePartitionItem(final String sourcePartitionKey) {
+    public Optional<SourcePartitionStoreItem> getSourcePartitionItem(final String sourceIdentifier, final String sourcePartitionKey) {
         try {
             final Key key = Key.builder()
-                    .partitionValue(sourcePartitionKey)
+                    .partitionValue(sourceIdentifier)
+                    .sortValue(sourcePartitionKey)
                     .build();
 
             final SourcePartitionStoreItem result = table.getItem(GetItemEnhancedRequest.builder().key(key).build());
@@ -156,16 +172,53 @@ public class DynamoDbClientWrapper {
         }
     }
 
-    public Optional<PageIterable<DynamoDbSourcePartitionItem>> getSourcePartitionItems(final Expression filterExpression) {
-        final ScanEnhancedRequest scanRequest = ScanEnhancedRequest.builder()
-                .filterExpression(filterExpression)
-                .limit(20)
-                .build();
-
+    public Optional<SourcePartitionStoreItem> getAvailablePartition(final String ownerId,
+                                                                    final Duration ownershipTimeout,
+                                                                    final SourcePartitionStatus sourcePartitionStatus,
+                                                                    final String sourceStatusCombinationKey) {
         try {
-            return Optional.of(table.scan(scanRequest));
-        } catch (final Exception e) {
-            LOG.error("An exception occurred while attempting to get source partition items to acquire in DynamoDb", e);
+
+            final DynamoDbIndex<DynamoDbSourcePartitionItem> sourceStatusIndex = table.index(SOURCE_STATUS_COMBINATION_KEY_GLOBAL_SECONDARY_INDEX);
+
+            final QueryEnhancedRequest queryEnhancedRequest = QueryEnhancedRequest.builder()
+                    .limit(10)
+                    .queryConditional(QueryConditional.keyEqualTo(Key.builder().partitionValue(sourceStatusCombinationKey).build()))
+                    .build();
+
+            final SdkIterable<Page<DynamoDbSourcePartitionItem>> availableItems = sourceStatusIndex.query(queryEnhancedRequest);
+
+            for (final Page<DynamoDbSourcePartitionItem> page : availableItems) {
+                for (final DynamoDbSourcePartitionItem item : page.items()) {
+
+                    // For ASSIGNED partitions we are sorting based on partitionOwnershipTimeout, so if any item has partitionOwnershipTimeout
+                    // in the future, we can know that the remaining items will not be available.
+                    if (SourcePartitionStatus.ASSIGNED.equals(sourcePartitionStatus) && Instant.now().isBefore(item.getPartitionOwnershipTimeout())) {
+                        return Optional.empty();
+                    }
+
+                    // For CLOSED partitions we are sorting based on reOpenAt time, so if any item has reOpenAt in the future,
+                    // we can know that the remaining items will not be ready to be acquired again.
+                    if (SourcePartitionStatus.CLOSED.equals(sourcePartitionStatus) && Instant.now().isBefore(item.getReOpenAt())) {
+                        return Optional.empty();
+                    }
+
+                    final Instant partitionOwnershipTimeout = Instant.now().plus(ownershipTimeout);
+
+                    item.setPartitionOwner(ownerId);
+                    item.setPartitionOwnershipTimeout(partitionOwnershipTimeout);
+                    item.setSourcePartitionStatus(SourcePartitionStatus.ASSIGNED);
+                    item.setSourceStatusCombinationKey(item.getSourceIdentifier() + "|" + SourcePartitionStatus.ASSIGNED);
+                    item.setPartitionPriority(partitionOwnershipTimeout.toString());
+                    final boolean acquired = this.tryAcquirePartitionItem(item);
+
+                    if (acquired) {
+                        return Optional.of(item);
+                    }
+                }
+            }
+        } catch( final Exception e){
+            LOG.error("An exception occurred while attempting to acquire a DynamoDb partition item for {}", sourceStatusCombinationKey, e);
+            return Optional.empty();
         }
 
         return Optional.empty();

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStore.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStore.java
@@ -13,14 +13,10 @@ import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStatus
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.enhanced.dynamodb.Expression;
-import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -33,16 +29,6 @@ import java.util.Optional;
 public class DynamoDbSourceCoordinationStore implements SourceCoordinationStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(DynamoDbSourceCoordinationStore.class);
-
-    /**
-     * This filter expression considers partitions available in the following scenarios
-     * 1. The partition status is UNASSIGNED
-     * 2. The partition status is CLOSED and the reOpenAt timestamp has passed
-     * 3. The partition status is ASSIGNED and the partitionOwnershipTimeout has passed
-     */
-    static final String AVAILABLE_PARTITIONS_FILTER_EXPRESSION = "contains(sourcePartitionStatus, :unassigned) " +
-            "or (contains(sourcePartitionStatus, :closed) and (attribute_not_exists(reOpenAt) or reOpenAt = :null or reOpenAt <= :ro)) " +
-            "or (contains(sourcePartitionStatus, :assigned) and (attribute_not_exists(partitionOwnershipTimeout) or partitionOwnershipTimeout = :null or partitionOwnershipTimeout <= :t))";
 
     private final DynamoStoreSettings dynamoStoreSettings;
     private final PluginMetrics pluginMetrics;
@@ -62,17 +48,21 @@ public class DynamoDbSourceCoordinationStore implements SourceCoordinationStore 
     }
 
     @Override
-    public Optional<SourcePartitionStoreItem> getSourcePartitionItem(final String partitionKey) {
-        return dynamoDbClientWrapper.getSourcePartitionItem(partitionKey);
+    public Optional<SourcePartitionStoreItem> getSourcePartitionItem(final String sourceIdentifier, final String sourcePartitionKey) {
+        return dynamoDbClientWrapper.getSourcePartitionItem(sourceIdentifier, sourcePartitionKey);
     }
 
     @Override
-    public boolean tryCreatePartitionItem(final String partitionKey,
+    public boolean tryCreatePartitionItem(final String sourceIdentifier,
+                                          final String sourcePartitionKey,
                                           final SourcePartitionStatus sourcePartitionStatus,
                                           final Long closedCount,
                                           final String partitionProgressState) {
         final DynamoDbSourcePartitionItem newPartitionItem = new DynamoDbSourcePartitionItem();
-        newPartitionItem.setSourcePartitionKey(partitionKey);
+        newPartitionItem.setSourceIdentifier(sourceIdentifier);
+        newPartitionItem.setSourceStatusCombinationKey(sourceIdentifier + "|" + sourcePartitionStatus);
+        newPartitionItem.setPartitionPriority(Instant.now().toString());
+        newPartitionItem.setSourcePartitionKey(sourcePartitionKey);
         newPartitionItem.setSourcePartitionStatus(sourcePartitionStatus);
         newPartitionItem.setClosedCount(closedCount);
         newPartitionItem.setPartitionProgressState(partitionProgressState);
@@ -82,44 +72,38 @@ public class DynamoDbSourceCoordinationStore implements SourceCoordinationStore 
     }
 
     @Override
-    public Optional<SourcePartitionStoreItem> tryAcquireAvailablePartition(final String ownerId, final Duration ownershipTimeout) {
-        final Optional<PageIterable<DynamoDbSourcePartitionItem>> dynamoDbSourcePartitionItemPageIterable =
-                dynamoDbClientWrapper.getSourcePartitionItems(Expression.builder()
-                        .expressionValues(Map.of(
-                                ":unassigned", AttributeValue.builder().s(SourcePartitionStatus.UNASSIGNED.name()).build(),
-                                ":assigned", AttributeValue.builder().s(SourcePartitionStatus.ASSIGNED.name()).build(),
-                                ":closed", AttributeValue.builder().s(SourcePartitionStatus.CLOSED.name()).build(),
-                                ":t", AttributeValue.builder().s(Instant.now().toString()).build(),
-                                ":ro", AttributeValue.builder().s(Instant.now().toString()).build(),
-                                ":null", AttributeValue.builder().nul(true).build()))
-                        .expression(AVAILABLE_PARTITIONS_FILTER_EXPRESSION)
-                        .build());
+    public Optional<SourcePartitionStoreItem> tryAcquireAvailablePartition(final String sourceIdentifier, final String ownerId, final Duration ownershipTimeout) {
+        final Optional<SourcePartitionStoreItem> acquiredAssignedItem = dynamoDbClientWrapper.getAvailablePartition(
+                ownerId, ownershipTimeout, SourcePartitionStatus.ASSIGNED, sourceIdentifier + "|" + SourcePartitionStatus.ASSIGNED);
 
-        if (dynamoDbSourcePartitionItemPageIterable.isEmpty()) {
-            return Optional.empty();
+        if (acquiredAssignedItem.isPresent()) {
+            return acquiredAssignedItem;
         }
 
-        try {
-            for (final DynamoDbSourcePartitionItem item : dynamoDbSourcePartitionItemPageIterable.get().items()) {
-                item.setPartitionOwner(ownerId);
-                item.setPartitionOwnershipTimeout(Instant.now().plus(ownershipTimeout));
-                item.setSourcePartitionStatus(SourcePartitionStatus.ASSIGNED);
-                final boolean acquired = dynamoDbClientWrapper.tryAcquirePartitionItem(item);
+        final Optional<SourcePartitionStoreItem> acquiredClosedItem = dynamoDbClientWrapper.getAvailablePartition(
+                ownerId, ownershipTimeout, SourcePartitionStatus.CLOSED, sourceIdentifier + "|" + SourcePartitionStatus.CLOSED);
 
-                if (acquired) {
-                    return Optional.of(item);
-                }
-            }
-        } catch (final Exception e) {
-            LOG.error("An exception occurred while iterating on items to acquire in DynamoDb", e);
+        if (acquiredClosedItem.isPresent()) {
+            return acquiredClosedItem;
         }
 
-        return Optional.empty();
+        return dynamoDbClientWrapper.getAvailablePartition(
+                ownerId, ownershipTimeout, SourcePartitionStatus.UNASSIGNED, sourceIdentifier + "|" + SourcePartitionStatus.UNASSIGNED);
     }
 
     @Override
     public void tryUpdateSourcePartitionItem(final SourcePartitionStoreItem updateItem) {
         final DynamoDbSourcePartitionItem dynamoDbSourcePartitionItem = (DynamoDbSourcePartitionItem) updateItem;
+        dynamoDbSourcePartitionItem.setSourceStatusCombinationKey(updateItem.getSourceIdentifier() + "|" + updateItem.getSourcePartitionStatus());
+
+        if (SourcePartitionStatus.CLOSED.equals(updateItem.getSourcePartitionStatus())) {
+            dynamoDbSourcePartitionItem.setPartitionPriority(updateItem.getReOpenAt().toString());
+        }
+
+        if (SourcePartitionStatus.ASSIGNED.equals(updateItem.getSourcePartitionStatus())) {
+            dynamoDbSourcePartitionItem.setPartitionPriority(updateItem.getPartitionOwnershipTimeout().toString());
+        }
+
         dynamoDbClientWrapper.tryUpdatePartitionItem(dynamoDbSourcePartitionItem);
     }
 

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourcePartitionItem.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourcePartitionItem.java
@@ -9,12 +9,16 @@ import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStatus
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondarySortKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
 
 import java.time.Instant;
 
 @DynamoDbBean
 public class DynamoDbSourcePartitionItem implements SourcePartitionStoreItem {
 
+    private String sourceIdentifier;
     private String sourcePartitionKey;
     private String partitionOwner;
     private Long version;
@@ -23,11 +27,29 @@ public class DynamoDbSourcePartitionItem implements SourcePartitionStoreItem {
     private Instant partitionOwnershipTimeout;
     private Instant reOpenAt;
     private Long closedCount;
+    private String sourceStatusCombinationKey;
+    private String partitionPriority;
 
     @Override
     @DynamoDbPartitionKey
+    public String getSourceIdentifier() {
+        return sourceIdentifier;
+    }
+
+    @Override
+    @DynamoDbSortKey
     public String getSourcePartitionKey() {
         return sourcePartitionKey;
+    }
+
+    @DynamoDbSecondaryPartitionKey(indexNames = "source-status")
+    public String getSourceStatusCombinationKey() {
+        return sourceStatusCombinationKey;
+    }
+
+    @DynamoDbSecondarySortKey(indexNames = "source-status")
+    public String getPartitionPriority() {
+        return partitionPriority;
     }
 
     @Override
@@ -80,7 +102,6 @@ public class DynamoDbSourcePartitionItem implements SourcePartitionStoreItem {
         this.partitionProgressState = partitionProgressState;
     }
 
-    // TODO: Make this a global secondary index to improve performance to scan for available partitions only on unassigned or closed partitions (can be optional setting on the store)
     public void setSourcePartitionStatus(final SourcePartitionStatus sourcePartitionStatus) {
         this.sourcePartitionStatus = sourcePartitionStatus;
     }
@@ -97,5 +118,15 @@ public class DynamoDbSourcePartitionItem implements SourcePartitionStoreItem {
         this.closedCount = closedCount;
     }
 
+    public void setSourceIdentifier(final String sourceIdentifier) {
+        this.sourceIdentifier = sourceIdentifier;
+    }
 
+    public void setSourceStatusCombinationKey(final String sourceStatusCombinationKey) {
+        this.sourceStatusCombinationKey = sourceStatusCombinationKey;
+    }
+
+    public void setPartitionPriority(final String partitionPriority) {
+        this.partitionPriority = partitionPriority;
+    }
 }

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
@@ -10,23 +10,26 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStatus;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
 import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionUpdateException;
 import software.amazon.awssdk.core.internal.waiters.ResponseOrException;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.core.waiters.WaiterResponse;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
-import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.CreateTableEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
@@ -36,6 +39,11 @@ import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 import software.amazon.awssdk.services.dynamodb.waiters.DynamoDbWaiter;
 
 import java.lang.reflect.Field;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
@@ -53,8 +61,11 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb.DynamoDbClientWrapper.ITEM_DOES_NOT_EXIST_EXPRESSION;
 import static org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb.DynamoDbClientWrapper.ITEM_EXISTS_AND_HAS_LATEST_VERSION;
+import static org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb.DynamoDbClientWrapper.SOURCE_STATUS_COMBINATION_KEY_GLOBAL_SECONDARY_INDEX;
 
 @ExtendWith(MockitoExtension.class)
 public class DynamoDbClientWrapperTest {
@@ -64,11 +75,13 @@ public class DynamoDbClientWrapperTest {
 
     private String region;
     private String stsRoleArn;
+    private String sourceIdentifier;
 
     @BeforeEach
     void setup() {
         region = "us-east-1";
         stsRoleArn = "arn:aws:iam::123456789012:role/source-coordination-ddb-role";
+        sourceIdentifier = UUID.randomUUID().toString();
     }
 
     private DynamoDbClientWrapper createObjectUnderTest() {
@@ -233,23 +246,23 @@ public class DynamoDbClientWrapperTest {
 
     }
 
-    @ParameterizedTest
-    @MethodSource("exceptionProvider")
-    void tryAcquirePartitionItem_catches_exception_from_putItem_and_returns_false(final Class exception) throws NoSuchFieldException, IllegalAccessException {
-        final DynamoDbSourcePartitionItem dynamoDbSourcePartitionItem = mock(DynamoDbSourcePartitionItem.class);
-        final Long version = (long) new Random().nextInt(10);
-        given(dynamoDbSourcePartitionItem.getVersion()).willReturn(version).willReturn(version + 1L);
-
-        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
-        doThrow(exception).when(table).putItem(any(PutItemEnhancedRequest.class));
-
-        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
-
-        reflectivelySetField(objectUnderTest, "table", table);
-
-        final boolean result = objectUnderTest.tryAcquirePartitionItem(dynamoDbSourcePartitionItem);
-        verify(dynamoDbSourcePartitionItem).setVersion(version + 1L);
-    }
+//    @ParameterizedTest
+//    @MethodSource("exceptionProvider")
+//    void getAvailable_catches_exception_from_putItem_and_returns_false(final Class exception) throws NoSuchFieldException, IllegalAccessException {
+//        final DynamoDbSourcePartitionItem dynamoDbSourcePartitionItem = mock(DynamoDbSourcePartitionItem.class);
+//        final Long version = (long) new Random().nextInt(10);
+//        given(dynamoDbSourcePartitionItem.getVersion()).willReturn(version).willReturn(version + 1L);
+//
+//        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+//        doThrow(exception).when(table).putItem(any(PutItemEnhancedRequest.class));
+//
+//        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+//
+//        reflectivelySetField(objectUnderTest, "table", table);
+//
+//        final boolean result = objectUnderTest.tryAcquirePartitionItem(dynamoDbSourcePartitionItem);
+//        verify(dynamoDbSourcePartitionItem).setVersion(version + 1L);
+//    }
 
     @ParameterizedTest
     @MethodSource("exceptionProvider")
@@ -284,7 +297,7 @@ public class DynamoDbClientWrapperTest {
 
         final String sourcePartitionKey = UUID.randomUUID().toString();
 
-        final Optional<SourcePartitionStoreItem> result = objectUnderTest.getSourcePartitionItem(sourcePartitionKey);
+        final Optional<SourcePartitionStoreItem> result = objectUnderTest.getSourcePartitionItem(sourceIdentifier, sourcePartitionKey);
 
         assertThat(result.isPresent(), equalTo(true));
         assertThat(result.get(), equalTo(sourcePartitionStoreItem));
@@ -292,7 +305,9 @@ public class DynamoDbClientWrapperTest {
         final GetItemEnhancedRequest getItemEnhancedRequest = getItemEnhancedRequestArgumentCaptor.getValue();
 
         assertThat(getItemEnhancedRequest.key(), notNullValue());
-        assertThat(getItemEnhancedRequest.key().partitionKeyValue().s(), equalTo(sourcePartitionKey));
+        assertThat(getItemEnhancedRequest.key().partitionKeyValue().s(), equalTo(sourceIdentifier));
+        assertThat(getItemEnhancedRequest.key().sortKeyValue().isPresent(), equalTo(true));
+        assertThat(getItemEnhancedRequest.key().sortKeyValue().get().s(), equalTo(sourcePartitionKey));
     }
 
     @Test
@@ -308,14 +323,16 @@ public class DynamoDbClientWrapperTest {
 
         final String sourcePartitionKey = UUID.randomUUID().toString();
 
-        final Optional<SourcePartitionStoreItem> result = objectUnderTest.getSourcePartitionItem(sourcePartitionKey);
+        final Optional<SourcePartitionStoreItem> result = objectUnderTest.getSourcePartitionItem(sourceIdentifier, sourcePartitionKey);
 
         assertThat(result.isEmpty(), equalTo(true));
 
         final GetItemEnhancedRequest getItemEnhancedRequest = getItemEnhancedRequestArgumentCaptor.getValue();
 
         assertThat(getItemEnhancedRequest.key(), notNullValue());
-        assertThat(getItemEnhancedRequest.key().partitionKeyValue().s(), equalTo(sourcePartitionKey));
+        assertThat(getItemEnhancedRequest.key().partitionKeyValue().s(), equalTo(sourceIdentifier));
+        assertThat(getItemEnhancedRequest.key().sortKeyValue().isPresent(), equalTo(true));
+        assertThat(getItemEnhancedRequest.key().sortKeyValue().get().s(), equalTo(sourcePartitionKey));
     }
 
     @ParameterizedTest
@@ -330,52 +347,175 @@ public class DynamoDbClientWrapperTest {
 
         final String sourcePartitionKey = UUID.randomUUID().toString();
 
-        final Optional<SourcePartitionStoreItem> result = objectUnderTest.getSourcePartitionItem(sourcePartitionKey);
+        final Optional<SourcePartitionStoreItem> result = objectUnderTest.getSourcePartitionItem(sourceIdentifier, sourcePartitionKey);
 
         assertThat(result.isEmpty(), equalTo(true));
-    }
-
-    @Test
-    void getSourcePartitionItems_returns_expected_PageIterable() throws NoSuchFieldException, IllegalAccessException {
-        final ArgumentCaptor<ScanEnhancedRequest> requestArgumentCaptor = ArgumentCaptor.forClass(ScanEnhancedRequest.class);
-        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
-
-        final Expression filterExpression = mock(Expression.class);
-
-        final PageIterable<DynamoDbSourcePartitionItem> dynamoDbSourcePartitionItemPageIterable = mock(PageIterable.class);
-
-        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
-
-        reflectivelySetField(objectUnderTest, "table", table);
-
-        given(table.scan(requestArgumentCaptor.capture())).willReturn(dynamoDbSourcePartitionItemPageIterable);
-
-        final Optional<PageIterable<DynamoDbSourcePartitionItem>> result = objectUnderTest.getSourcePartitionItems(filterExpression);
-
-        assertThat(result.isPresent(), equalTo(true));
-        assertThat(result.get(), equalTo(dynamoDbSourcePartitionItemPageIterable));
-
-        final ScanEnhancedRequest scanEnhancedRequest = requestArgumentCaptor.getValue();
-
-        assertThat(scanEnhancedRequest.filterExpression(), equalTo(filterExpression));
-        assertThat(scanEnhancedRequest.limit(), equalTo(20));
     }
 
     @ParameterizedTest
-    @MethodSource("exceptionProvider")
-    void getSourcePartitionItems_catches_exception_from_scan_and_returns_empty_optional(final Class exception) throws NoSuchFieldException, IllegalAccessException {
-        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
-        doThrow(exception).when(table).scan(any(ScanEnhancedRequest.class));
+    @ValueSource(strings = {"ASSIGNED", "UNASSIGNED", "CLOSED"})
+    void getAvailablePartition_with_no_items_from_query_returns_empty_optional(final String sourcePartitionStatus) throws NoSuchFieldException, IllegalAccessException {
+        final String ownerId = UUID.randomUUID().toString();
+        final Duration ownershipTimeout = Duration.ofMinutes(1);
+        final String sourceStatusCombinationKey = sourceIdentifier + "|" + sourcePartitionStatus;
 
-        final Expression filterExpression = mock(Expression.class);
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        final DynamoDbIndex<DynamoDbSourcePartitionItem> sourceStatusIndex = mock(DynamoDbIndex.class);
+        given(table.index(SOURCE_STATUS_COMBINATION_KEY_GLOBAL_SECONDARY_INDEX)).willReturn(sourceStatusIndex);
+
+        final ArgumentCaptor<QueryEnhancedRequest> queryRequestArgumentCaptor = ArgumentCaptor.forClass(QueryEnhancedRequest.class);
+
+        final SdkIterable<Page<DynamoDbSourcePartitionItem>> pageSdkIterable = () -> {
+            final Page<DynamoDbSourcePartitionItem> emptyPage = mock(Page.class);
+            given(emptyPage.items()).willReturn(Collections.emptyList());
+
+            return List.of(emptyPage).iterator();
+        };
+
+
+        given(sourceStatusIndex.query(queryRequestArgumentCaptor.capture())).willReturn(pageSdkIterable);
 
         final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
-
         reflectivelySetField(objectUnderTest, "table", table);
 
-        final Optional<PageIterable<DynamoDbSourcePartitionItem>> result = objectUnderTest.getSourcePartitionItems(filterExpression);
+        final Optional<SourcePartitionStoreItem> result = objectUnderTest.getAvailablePartition(
+                ownerId, ownershipTimeout, SourcePartitionStatus.valueOf(sourcePartitionStatus), sourceStatusCombinationKey);
 
         assertThat(result.isEmpty(), equalTo(true));
+
+        final QueryEnhancedRequest queryEnhancedRequest = queryRequestArgumentCaptor.getValue();
+        assertThat(queryEnhancedRequest, notNullValue());
+        assertThat(queryEnhancedRequest.limit(), equalTo(10));
+        assertThat(queryEnhancedRequest.queryConditional(), notNullValue());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ASSIGNED", "UNASSIGNED", "CLOSED"})
+    void getAvailablePartition_will_continue_until_tryAcquirePartition_succeeds(final String sourcePartitionStatus) throws NoSuchFieldException, IllegalAccessException {
+        final Instant now = Instant.now();
+        final String ownerId = UUID.randomUUID().toString();
+        final Duration ownershipTimeout = Duration.ofMinutes(1);
+        final String sourceStatusCombinationKey = sourceIdentifier + "|" + sourcePartitionStatus;
+
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        final DynamoDbIndex<DynamoDbSourcePartitionItem> sourceStatusIndex = mock(DynamoDbIndex.class);
+        given(table.index(SOURCE_STATUS_COMBINATION_KEY_GLOBAL_SECONDARY_INDEX)).willReturn(sourceStatusIndex);
+
+        final DynamoDbSourcePartitionItem unacquiredItem = mock(DynamoDbSourcePartitionItem.class);
+        final DynamoDbSourcePartitionItem acquiredItem = mock(DynamoDbSourcePartitionItem.class);
+        if (sourcePartitionStatus.equals(SourcePartitionStatus.ASSIGNED.toString())) {
+            given(unacquiredItem.getPartitionOwnershipTimeout()).willReturn(Instant.now().minus(2, ChronoUnit.MINUTES));
+            given(acquiredItem.getPartitionOwnershipTimeout()).willReturn(Instant.now().minus(2, ChronoUnit.MINUTES));
+        } else if (sourcePartitionStatus.equals(SourcePartitionStatus.CLOSED.toString())) {
+            given(unacquiredItem.getReOpenAt()).willReturn(Instant.now().minus(2, ChronoUnit.MINUTES));
+            given(acquiredItem.getReOpenAt()).willReturn(Instant.now().minus(2, ChronoUnit.MINUTES));
+        }
+
+        given(acquiredItem.getSourceIdentifier()).willReturn(sourceIdentifier);
+        given(unacquiredItem.getSourceIdentifier()).willReturn(sourceIdentifier);
+
+        final SdkIterable<Page<DynamoDbSourcePartitionItem>> pageSdkIterable = () -> {
+            final Page<DynamoDbSourcePartitionItem> emptyPage = mock(Page.class);
+            given(emptyPage.items()).willReturn(List.of(unacquiredItem, acquiredItem));
+            return List.of(emptyPage).iterator();
+        };
+
+        doThrow(PartitionUpdateException.class).doNothing().when(table).putItem(any(PutItemEnhancedRequest.class));
+
+        given(sourceStatusIndex.query(any(QueryEnhancedRequest.class))).willReturn(pageSdkIterable);
+
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+        reflectivelySetField(objectUnderTest, "table", table);
+
+        final Optional<SourcePartitionStoreItem> result = objectUnderTest.getAvailablePartition(
+                ownerId, ownershipTimeout, SourcePartitionStatus.valueOf(sourcePartitionStatus), sourceStatusCombinationKey);
+
+        assertThat(result.isPresent(), equalTo(true));
+        assertThat(result.get(), equalTo(acquiredItem));
+
+        verify(acquiredItem).setPartitionOwner(ownerId);
+        verify(acquiredItem).setSourcePartitionStatus(SourcePartitionStatus.ASSIGNED);
+        verify(acquiredItem).setSourceStatusCombinationKey(sourceIdentifier + "|" + SourcePartitionStatus.ASSIGNED);
+
+        final ArgumentCaptor<Instant> partitionOwnershipArgumentCaptor = ArgumentCaptor.forClass(Instant.class);
+
+        verify(acquiredItem).setPartitionOwnershipTimeout(partitionOwnershipArgumentCaptor.capture());
+
+        final Instant newPartitionOwnershipTimeout = partitionOwnershipArgumentCaptor.getValue();
+
+        assertThat(newPartitionOwnershipTimeout.isAfter(now.plus(ownershipTimeout)), equalTo(true));
+
+        verify(acquiredItem).setPartitionPriority(newPartitionOwnershipTimeout.toString());
+    }
+
+    @Test
+    void getAvailablePartition_with_assigned_partition_with_unexpired_partitionOwnershipTimeout_returns_empty_optional() throws NoSuchFieldException, IllegalAccessException {
+        final String ownerId = UUID.randomUUID().toString();
+        final Duration ownershipTimeout = Duration.ofMinutes(1);
+        final String sourceStatusCombinationKey = sourceIdentifier + "|" + SourcePartitionStatus.ASSIGNED;
+
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        final DynamoDbIndex<DynamoDbSourcePartitionItem> sourceStatusIndex = mock(DynamoDbIndex.class);
+        given(table.index(SOURCE_STATUS_COMBINATION_KEY_GLOBAL_SECONDARY_INDEX)).willReturn(sourceStatusIndex);
+
+        final DynamoDbSourcePartitionItem firstItem = mock(DynamoDbSourcePartitionItem.class);
+        final DynamoDbSourcePartitionItem secondItem = mock(DynamoDbSourcePartitionItem.class);
+        given(firstItem.getPartitionOwnershipTimeout()).willReturn(Instant.now().plus(2, ChronoUnit.MINUTES));
+
+        final SdkIterable<Page<DynamoDbSourcePartitionItem>> pageSdkIterable = () -> {
+            final Page<DynamoDbSourcePartitionItem> emptyPage = mock(Page.class);
+            given(emptyPage.items()).willReturn(List.of(firstItem, secondItem));
+            return List.of(emptyPage).iterator();
+        };
+
+        given(sourceStatusIndex.query(any(QueryEnhancedRequest.class))).willReturn(pageSdkIterable);
+
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+        reflectivelySetField(objectUnderTest, "table", table);
+
+        final Optional<SourcePartitionStoreItem> result = objectUnderTest.getAvailablePartition(
+                ownerId, ownershipTimeout, SourcePartitionStatus.ASSIGNED, sourceStatusCombinationKey);
+
+        assertThat(result.isEmpty(), equalTo(true));
+
+        verifyNoMoreInteractions(table);
+        verifyNoInteractions(secondItem);
+
+    }
+
+    @Test
+    void getAvailablePartition_with_closed_partition_with_unreached_reOpenAt_time_returns_empty_optional() throws NoSuchFieldException, IllegalAccessException {
+        final String ownerId = UUID.randomUUID().toString();
+        final Duration ownershipTimeout = Duration.ofMinutes(1);
+        final String sourceStatusCombinationKey = sourceIdentifier + "|" + SourcePartitionStatus.CLOSED;
+
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        final DynamoDbIndex<DynamoDbSourcePartitionItem> sourceStatusIndex = mock(DynamoDbIndex.class);
+        given(table.index(SOURCE_STATUS_COMBINATION_KEY_GLOBAL_SECONDARY_INDEX)).willReturn(sourceStatusIndex);
+
+        final DynamoDbSourcePartitionItem firstItem = mock(DynamoDbSourcePartitionItem.class);
+        final DynamoDbSourcePartitionItem secondItem = mock(DynamoDbSourcePartitionItem.class);
+        given(firstItem.getReOpenAt()).willReturn(Instant.now().plus(2, ChronoUnit.MINUTES));
+
+        final SdkIterable<Page<DynamoDbSourcePartitionItem>> pageSdkIterable = () -> {
+            final Page<DynamoDbSourcePartitionItem> emptyPage = mock(Page.class);
+            given(emptyPage.items()).willReturn(List.of(firstItem, secondItem));
+            return List.of(emptyPage).iterator();
+        };
+
+        given(sourceStatusIndex.query(any(QueryEnhancedRequest.class))).willReturn(pageSdkIterable);
+
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+        reflectivelySetField(objectUnderTest, "table", table);
+
+        final Optional<SourcePartitionStoreItem> result = objectUnderTest.getAvailablePartition(
+                ownerId, ownershipTimeout, SourcePartitionStatus.CLOSED, sourceStatusCombinationKey);
+
+        assertThat(result.isEmpty(), equalTo(true));
+
+        verifyNoMoreInteractions(table);
+        verifyNoInteractions(secondItem);
+
     }
 
     static Stream<Class> exceptionProvider() {

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -17,35 +17,27 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStatus;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
-import software.amazon.awssdk.enhanced.dynamodb.Expression;
-import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
-import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputExceededException;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb.DynamoDbSourceCoordinationStore.AVAILABLE_PARTITIONS_FILTER_EXPRESSION;
 
 @ExtendWith(MockitoExtension.class)
 public class DynamoDbSourceCoordinationStoreTest {
@@ -90,11 +82,12 @@ public class DynamoDbSourceCoordinationStoreTest {
     void getSourcePartitionItem_calls_dynamoClientWrapper_correctly() {
         final SourcePartitionStoreItem sourcePartitionStoreItem = mock(DynamoDbSourcePartitionItem.class);
 
-        final String partitionKey = UUID.randomUUID().toString();
+        final String sourcePartitionKey = UUID.randomUUID().toString();
+        final String sourceIdentifier = UUID.randomUUID().toString();
 
-        given(dynamoDbClientWrapper.getSourcePartitionItem(partitionKey)).willReturn(Optional.ofNullable(sourcePartitionStoreItem));
+        given(dynamoDbClientWrapper.getSourcePartitionItem(sourceIdentifier, sourcePartitionKey)).willReturn(Optional.ofNullable(sourcePartitionStoreItem));
 
-        final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().getSourcePartitionItem(partitionKey);
+        final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().getSourcePartitionItem(sourceIdentifier, sourcePartitionKey);
 
         assertThat(result.isPresent(), equalTo(true));
         assertThat(result.get(), equalTo(sourcePartitionStoreItem));
@@ -102,7 +95,8 @@ public class DynamoDbSourceCoordinationStoreTest {
 
     @Test
     void tryCreatePartitionItem_calls_dynamoDbClientWrapper_correctly() {
-        final String partitionKey = UUID.randomUUID().toString();
+        final String sourceIdentifier = UUID.randomUUID().toString();
+        final String sourcePartitionKey = UUID.randomUUID().toString();
         final SourcePartitionStatus sourcePartitionStatus = SourcePartitionStatus.UNASSIGNED;
         final Long closedCount = 0L;
         final String partitionProgressState = UUID.randomUUID().toString();
@@ -110,119 +104,138 @@ public class DynamoDbSourceCoordinationStoreTest {
         final ArgumentCaptor<DynamoDbSourcePartitionItem> argumentCaptor = ArgumentCaptor.forClass(DynamoDbSourcePartitionItem.class);
         given(dynamoDbClientWrapper.tryCreatePartitionItem(argumentCaptor.capture())).willReturn(true);
 
-        final boolean result = createObjectUnderTest().tryCreatePartitionItem(partitionKey, sourcePartitionStatus, closedCount, partitionProgressState);
+        final boolean result = createObjectUnderTest().tryCreatePartitionItem(sourceIdentifier, sourcePartitionKey, sourcePartitionStatus, closedCount, partitionProgressState);
 
         assertThat(result, equalTo(true));
 
         final DynamoDbSourcePartitionItem createdItem = argumentCaptor.getValue();
         assertThat(createdItem, notNullValue());
-        assertThat(createdItem.getSourcePartitionKey(), equalTo(partitionKey));
+        assertThat(createdItem.getSourceIdentifier(), equalTo(sourceIdentifier));
+        assertThat(createdItem.getSourcePartitionKey(), equalTo(sourcePartitionKey));
         assertThat(createdItem.getSourcePartitionStatus(), equalTo(SourcePartitionStatus.UNASSIGNED));
         assertThat(createdItem.getClosedCount(), equalTo(closedCount));
         assertThat(createdItem.getPartitionProgressState(), equalTo(partitionProgressState));
-    }
-
-    @Test
-    void tryUpdateSourcePartitionItem_calls_dynamoClientWrapper_correctly() {
-        final SourcePartitionStoreItem updateItem = mock(DynamoDbSourcePartitionItem.class);
-
-        doNothing().when(dynamoDbClientWrapper).tryUpdatePartitionItem((DynamoDbSourcePartitionItem) updateItem);
-
-        createObjectUnderTest().tryUpdateSourcePartitionItem(updateItem);
-    }
-
-    @Test
-    void tryAcquireAvailablePartition_with_empty_page_iterable_returns_empty_optional() {
-        final String ownerId = UUID.randomUUID().toString();
-        final Duration ownershipTimeout = Duration.ofMinutes(2);
-
-        final ArgumentCaptor<Expression> expressionArgumentCaptor = ArgumentCaptor.forClass(Expression.class);
-
-        given(dynamoDbClientWrapper.getSourcePartitionItems(expressionArgumentCaptor.capture())).willReturn(Optional.empty());
-
-        final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().tryAcquireAvailablePartition(ownerId, ownershipTimeout);
-
-        assertThat(result.isEmpty(), equalTo(true));
-
-        final Expression expression = expressionArgumentCaptor.getValue();
-        assertThat(expression.expression(), equalTo(AVAILABLE_PARTITIONS_FILTER_EXPRESSION));
-        assertThat(expression.expressionValues().size(), equalTo(6));
-        assertThat(expression.expressionValues().containsKey(":unassigned"), equalTo(true));
-        assertThat(expression.expressionValues().containsKey(":closed"), equalTo(true));
-        assertThat(expression.expressionValues().containsKey(":assigned"), equalTo(true));
-        assertThat(expression.expressionValues().containsKey(":t"), equalTo(true));
-        assertThat(expression.expressionValues().containsKey(":ro"), equalTo(true));
-        assertThat(expression.expressionValues().containsKey(":null"), equalTo(true));
-    }
-
-    @Test
-    void tryAcquireAvailablePartition_iterates_until_it_successfully_acquires_a_partition() {
-        final String ownerId = UUID.randomUUID().toString();
-        final Duration ownershipTimeout = Duration.ofMinutes(2);
-
-        final Instant now = Instant.now();
-
-        final PageIterable<DynamoDbSourcePartitionItem> pageIterable = mock(PageIterable.class);
-
-        final List<DynamoDbSourcePartitionItem> itemList = List.of(mock(DynamoDbSourcePartitionItem.class), mock(DynamoDbSourcePartitionItem.class), mock(DynamoDbSourcePartitionItem.class));
-        given(pageIterable.items()).willReturn(itemList::iterator);
-        given(dynamoDbClientWrapper.getSourcePartitionItems(any(Expression.class))).willReturn(Optional.of(pageIterable));
-
-        doReturn(false).when(dynamoDbClientWrapper).tryAcquirePartitionItem(itemList.get(0));
-        doReturn(true).when(dynamoDbClientWrapper).tryAcquirePartitionItem(itemList.get(1));
-
-        final ArgumentCaptor<Instant> argumentCaptor = ArgumentCaptor.forClass(Instant.class);
-        doNothing().when(itemList.get(0)).setPartitionOwnershipTimeout(argumentCaptor.capture());
-
-        final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().tryAcquireAvailablePartition(ownerId, ownershipTimeout);
-
-        assertThat(result.isPresent(), equalTo(true));
-        assertThat(result.get(), is(itemList.get(1)));
-
-        verifyNoMoreInteractions(dynamoDbClientWrapper);
-
-        verify(itemList.get(0)).setSourcePartitionStatus(SourcePartitionStatus.ASSIGNED);
-        verify(itemList.get(0)).setPartitionOwner(ownerId);
-
-        final Instant newOwnershipTimeout = argumentCaptor.getValue();
-
-        assertThat(newOwnershipTimeout, greaterThan(now.plus(ownershipTimeout)));
+        assertThat(createdItem.getSourceStatusCombinationKey(), equalTo(sourceIdentifier + "|" + sourcePartitionStatus));
+        assertThat(createdItem.getPartitionPriority(), notNullValue());
     }
 
     @ParameterizedTest
-    @MethodSource("exceptionProvider")
-    void tryAcquireAvailablePartition_returns_empty_optional_when_an_exception_is_thrown_while_iterating(final Class exception) {
-        final String ownerId = UUID.randomUUID().toString();
-        final Duration ownershipTimeout = Duration.ofMinutes(2);
+    @ValueSource(strings = {"UNASSIGNED", "ASSIGNED" ,"CLOSED", "COMPLETED" })
+    void tryUpdateSourcePartitionItem_calls_dynamoClientWrapper_correctly_for_different_statuses(final String sourcePartitionStatus) {
+        final String sourceIdentifier = UUID.randomUUID().toString();
 
-        final Instant now = Instant.now();
+        final SourcePartitionStoreItem updateItem = mock(DynamoDbSourcePartitionItem.class);
+        given(updateItem.getSourceIdentifier()).willReturn(sourceIdentifier);
+        given(updateItem.getSourcePartitionStatus()).willReturn(SourcePartitionStatus.valueOf(sourcePartitionStatus));
 
-        final PageIterable<DynamoDbSourcePartitionItem> pageIterable = mock(PageIterable.class);
+        doNothing().when(dynamoDbClientWrapper).tryUpdatePartitionItem((DynamoDbSourcePartitionItem) updateItem);
 
-        final List<DynamoDbSourcePartitionItem> itemList = List.of(mock(DynamoDbSourcePartitionItem.class), mock(DynamoDbSourcePartitionItem.class), mock(DynamoDbSourcePartitionItem.class));
-        given(pageIterable.items()).willReturn(itemList::iterator);
-        given(dynamoDbClientWrapper.getSourcePartitionItems(any(Expression.class))).willReturn(Optional.of(pageIterable));
+        if (sourcePartitionStatus.equals(SourcePartitionStatus.ASSIGNED.toString())) {
+            final Instant partitionOwnershipTimeout = Instant.now();
+            given(updateItem.getPartitionOwnershipTimeout()).willReturn(partitionOwnershipTimeout);
+            doNothing().when((DynamoDbSourcePartitionItem)updateItem).setPartitionPriority(partitionOwnershipTimeout.toString());
+        } else if (sourcePartitionStatus.equals(SourcePartitionStatus.CLOSED.toString())) {
+            final Instant reOpenAtTime = Instant.now();
+            given(updateItem.getReOpenAt()).willReturn(reOpenAtTime);
+            doNothing().when((DynamoDbSourcePartitionItem) updateItem).setPartitionPriority(reOpenAtTime.toString());
+        }
 
-        doThrow(exception).when(dynamoDbClientWrapper).tryAcquirePartitionItem(itemList.get(0));
+        createObjectUnderTest().tryUpdateSourcePartitionItem(updateItem);
 
-        final ArgumentCaptor<Instant> argumentCaptor = ArgumentCaptor.forClass(Instant.class);
-        doNothing().when(itemList.get(0)).setPartitionOwnershipTimeout(argumentCaptor.capture());
+        verify((DynamoDbSourcePartitionItem) updateItem).setSourceStatusCombinationKey(sourceIdentifier + "|" + sourcePartitionStatus);
 
-        final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().tryAcquireAvailablePartition(ownerId, ownershipTimeout);
-
-        assertThat(result.isEmpty(), equalTo(true));
-
-        verifyNoMoreInteractions(dynamoDbClientWrapper);
-
-        verify(itemList.get(0)).setSourcePartitionStatus(SourcePartitionStatus.ASSIGNED);
-        verify(itemList.get(0)).setPartitionOwner(ownerId);
-
-        final Instant newOwnershipTimeout = argumentCaptor.getValue();
-
-        assertThat(newOwnershipTimeout, greaterThan(now.plus(ownershipTimeout)));
+        if (sourcePartitionStatus.equals(SourcePartitionStatus.UNASSIGNED) || sourcePartitionStatus.equals(SourcePartitionStatus.COMPLETED)) {
+            verify((DynamoDbSourcePartitionItem) updateItem, never()).setPartitionPriority(anyString());
+        }
     }
 
-    static Stream<Class> exceptionProvider() {
-        return Stream.of(ProvisionedThroughputExceededException.class, RuntimeException.class);
+    @Test
+    void getAvailablePartition_with_no_item_acquired_returns_empty_optional() {
+        final String ownerId = UUID.randomUUID().toString();
+        final String sourceIdentifier = UUID.randomUUID().toString();
+        final Duration ownershipTimeout = Duration.ofMinutes(2);
+
+        given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
+                SourcePartitionStatus.ASSIGNED, sourceIdentifier + "|" + SourcePartitionStatus.ASSIGNED))
+                .willReturn(Optional.empty());
+        given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
+                SourcePartitionStatus.CLOSED, sourceIdentifier + "|" + SourcePartitionStatus.CLOSED))
+                .willReturn(Optional.empty());
+        given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
+                SourcePartitionStatus.UNASSIGNED, sourceIdentifier + "|" + SourcePartitionStatus.UNASSIGNED))
+                .willReturn(Optional.empty());
+
+        final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().tryAcquireAvailablePartition(sourceIdentifier, ownerId, ownershipTimeout);
+
+        assertThat(result.isEmpty(), equalTo(true));
+    }
+
+    @Test
+    void getAvailablePartition_with_acquired_ASSIGNED_partition_returns_the_partition() {
+        final String ownerId = UUID.randomUUID().toString();
+        final String sourceIdentifier = UUID.randomUUID().toString();
+        final Duration ownershipTimeout = Duration.ofMinutes(2);
+
+        final DynamoDbSourcePartitionItem acquiredItem = mock(DynamoDbSourcePartitionItem.class);
+
+        given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
+                SourcePartitionStatus.ASSIGNED, sourceIdentifier + "|" + SourcePartitionStatus.ASSIGNED))
+                .willReturn(Optional.of(acquiredItem));
+
+        final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().tryAcquireAvailablePartition(sourceIdentifier, ownerId, ownershipTimeout);
+
+        assertThat(result.isPresent(), equalTo(true));
+        assertThat(result.get(), equalTo(acquiredItem));
+
+        verifyNoMoreInteractions(dynamoDbClientWrapper);
+    }
+
+    @Test
+    void getAvailablePartition_with_acquired_CLOSED_partition_returns_the_partition() {
+        final String ownerId = UUID.randomUUID().toString();
+        final String sourceIdentifier = UUID.randomUUID().toString();
+        final Duration ownershipTimeout = Duration.ofMinutes(2);
+
+        final DynamoDbSourcePartitionItem acquiredItem = mock(DynamoDbSourcePartitionItem.class);
+
+        given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
+                SourcePartitionStatus.ASSIGNED, sourceIdentifier + "|" + SourcePartitionStatus.ASSIGNED))
+                .willReturn(Optional.empty());
+        given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
+                SourcePartitionStatus.CLOSED, sourceIdentifier + "|" + SourcePartitionStatus.CLOSED))
+                .willReturn(Optional.of(acquiredItem));
+
+        final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().tryAcquireAvailablePartition(sourceIdentifier, ownerId, ownershipTimeout);
+
+        assertThat(result.isPresent(), equalTo(true));
+        assertThat(result.get(), equalTo(acquiredItem));
+
+        verifyNoMoreInteractions(dynamoDbClientWrapper);
+    }
+
+    @Test
+    void getAvailablePartition_with_acquired_UNASSIGNED_partition_returns_the_partition() {
+        final String ownerId = UUID.randomUUID().toString();
+        final String sourceIdentifier = UUID.randomUUID().toString();
+        final Duration ownershipTimeout = Duration.ofMinutes(2);
+
+        final DynamoDbSourcePartitionItem acquiredItem = mock(DynamoDbSourcePartitionItem.class);
+
+        given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
+                SourcePartitionStatus.ASSIGNED, sourceIdentifier + "|" + SourcePartitionStatus.ASSIGNED))
+                .willReturn(Optional.empty());
+        given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
+                SourcePartitionStatus.CLOSED, sourceIdentifier + "|" + SourcePartitionStatus.CLOSED))
+                .willReturn(Optional.empty());
+        given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
+                SourcePartitionStatus.UNASSIGNED, sourceIdentifier + "|" + SourcePartitionStatus.UNASSIGNED))
+                .willReturn(Optional.of(acquiredItem));
+
+        final Optional<SourcePartitionStoreItem> result = createObjectUnderTest().tryAcquireAvailablePartition(sourceIdentifier, ownerId, ownershipTimeout);
+
+        assertThat(result.isPresent(), equalTo(true));
+        assertThat(result.get(), equalTo(acquiredItem));
+
+        verifyNoMoreInteractions(dynamoDbClientWrapper);
     }
 }


### PR DESCRIPTION
### Description
This change reworks the `dynamodb-source-coordination-store` plugin to support multiple sub-pipelines within the same pipeline config.

This change also removes the scan of the table when looking for new partitions to acquire. The attempt to acquire partitions will now be done with up to 3 queries.

1. Query the ASSIGNED partitions for those have had the partitiion ownership expire
2. Query the CLOSED partitions for those that have just reOpened
3. Query the UNASSIGNED partitions for the remaining available partitions
 
### Issues Resolved
Related to #2412 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
