### PR TITLE
Fix build failure

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
@@ -379,7 +379,7 @@ public class AddEntryProcessorTests {
         final AddEntryProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEventWithMetadata("thisisamessage", Map.of("key", "value"));
 
-        when(expressionEvaluator.evaluate(addWhen, record.getData())).thenReturn(false);
+        when(expressionEvaluator.evaluateConditional(addWhen, record.getData())).thenReturn(false);
         final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
         Event event = editedRecords.get(0).getData();


### PR DESCRIPTION
### Description
PR to fix a recent build failure caused by:
```
AddEntryProcessorTests > testMetadataKeyIsNotAdded_when_addWhen_condition_is_false() FAILED
    org.mockito.exceptions.misusing.UnnecessaryStubbingException at MockitoExtension.java:186
```
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
