### PR TITLE
Use the same Log4j configuration for integration tests as used for unit testing

### DIFF
--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -77,6 +77,8 @@ task integrationTest(type: Test) {
 
     classpath = sourceSets.integrationTest.runtimeClasspath
 
+    systemProperty 'log4j.configurationFile', 'src/test/resources/log4j2.properties'
+
     filter {
         includeTestsMatching '*IT'
     }


### PR DESCRIPTION
### Description

Configurations the `data-prepper-core` `integrationTest` tests to use the same Log4j configuration as used by `test`. This puts the unit test and integration test logging in sync. It also enables DEBUG logging for the integration tests.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
