### PR TITLE
Log all plugin classes found when DEBUG logging is enabled.

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ClasspathPluginProvider.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ClasspathPluginProvider.java
@@ -8,11 +8,14 @@ package org.opensearch.dataprepper.plugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.reflections.Reflections;
 import org.reflections.util.ConfigurationBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.opensearch.dataprepper.model.annotations.DataPrepperPlugin.DEFAULT_DEPRECATED_NAME;
 
@@ -23,7 +26,7 @@ import static org.opensearch.dataprepper.model.annotations.DataPrepperPlugin.DEF
  * @since 1.2
  */
 public class ClasspathPluginProvider implements PluginProvider {
-
+    private static final Logger LOG = LoggerFactory.getLogger(ClasspathPluginProvider.class);
     private final Reflections reflections;
     private Map<String, Map<Class<?>, Class<?>>> nameToSupportedTypeToPluginType;
 
@@ -57,6 +60,12 @@ public class ClasspathPluginProvider implements PluginProvider {
     private Map<String, Map<Class<?>, Class<?>>> scanForPlugins() {
         final Set<Class<?>> dataPrepperPluginClasses =
                 reflections.getTypesAnnotatedWith(DataPrepperPlugin.class);
+
+        if(LOG.isDebugEnabled()) {
+            LOG.debug("Found {} plugin classes.", dataPrepperPluginClasses.size());
+            LOG.debug("Plugin classes: {}",
+                    dataPrepperPluginClasses.stream().map(Class::getName).collect(Collectors.joining(", ")));
+        }
 
         final Map<String, Map<Class<?>, Class<?>>> pluginsMap = new HashMap<>(dataPrepperPluginClasses.size());
         for (final Class<?> concretePluginClass : dataPrepperPluginClasses) {


### PR DESCRIPTION
### Description

Adds a new DEBUG log which logs detected plugin classes. This can help when debugging issues loading plugins.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
