### PR TITLE
Add support to tag events when parse_json fails to parse

### DIFF
--- a/data-prepper-plugins/parse-json-processor/README.md
+++ b/data-prepper-plugins/parse-json-processor/README.md
@@ -58,6 +58,8 @@ The processor will parse the message into the following:
     * If the JSON Pointer is invalid then the entire `source` data is parsed into the outgoing `Event`.
     * If the pointed-to key already exists in the `Event` and the `destination` is the root, then the entire path of the key will be used.
 
+* `tags_on_failure` (Optional): A `List` of `String`s that specifies the tags to be set in the event the processor fails to parse or an unknown exception occurs while parsing. This tag may be used in conditional expressions in other parts of the configuration
+
 ## Developer Guide
 This plugin is compatible with Java 8 and up. See
 - [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md)

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessor.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -38,6 +39,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
     private final String destination;
     private final String pointer;
     private final String parseWhen;
+    private final List<String> tagsOnFailure;
 
     private final ExpressionEvaluator expressionEvaluator;
 
@@ -51,6 +53,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
         destination = parseJsonProcessorConfig.getDestination();
         pointer = parseJsonProcessorConfig.getPointer();
         parseWhen = parseJsonProcessorConfig.getParseWhen();
+        tagsOnFailure = parseJsonProcessorConfig.getTagsOnFailure();
         this.expressionEvaluator = expressionEvaluator;
     }
 
@@ -86,6 +89,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
                     event.put(destination, parsedJson);
                 }
             } catch (final JsonProcessingException jsonException) {
+                event.getMetadata().addTags(tagsOnFailure);
                 LOG.error(EVENT, "An exception occurred due to invalid JSON while reading event [{}]", event, jsonException);
             }
         }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfig.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 
 import java.util.Objects;
+import java.util.List;
 
 public class ParseJsonProcessorConfig {
     static final String DEFAULT_SOURCE = "message";
@@ -26,6 +27,9 @@ public class ParseJsonProcessorConfig {
 
     @JsonProperty("parse_when")
     private String parseWhen;
+
+    @JsonProperty("tags_on_failure")
+    private List<String> tagsOnFailure;
 
     /**
      * The field of the Event that contains the JSON data.
@@ -56,6 +60,10 @@ public class ParseJsonProcessorConfig {
      */
     public String getPointer() {
         return pointer;
+    }
+
+    public List<String> getTagsOnFailure() {
+        return tagsOnFailure;
     }
 
     public String getParseWhen() { return parseWhen; }

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfigTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfigTest.java
@@ -13,6 +13,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.dataprepper.plugins.processor.parsejson.ParseJsonProcessorConfig.DEFAULT_SOURCE;
 import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
+import java.util.List;
+
 public class ParseJsonProcessorConfigTest {
 
     private ParseJsonProcessorConfig createObjectUnderTest() {
@@ -26,6 +28,7 @@ public class ParseJsonProcessorConfigTest {
         assertThat(objectUnderTest.getSource(), equalTo(DEFAULT_SOURCE));
         assertThat(objectUnderTest.getDestination(), equalTo(null));
         assertThat(objectUnderTest.getPointer(), equalTo(null));
+        assertThat(objectUnderTest.getTagsOnFailure(), equalTo(null));
     }
 
     @Nested
@@ -50,6 +53,10 @@ public class ParseJsonProcessorConfigTest {
             setField(ParseJsonProcessorConfig.class, config, "destination", "   /   ");
 
             assertThat(config.isValidDestination(), equalTo(false));
+            List<String> tagsList = List.of("tag1", "tag2");
+            setField(ParseJsonProcessorConfig.class, config, "tagsOnFailure", tagsList);
+
+            assertThat(config.getTagsOnFailure(), equalTo(tagsList));
         }
     }
 }

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorTest.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -285,6 +286,24 @@ class ParseJsonProcessorTest {
 
         assertThat(parsedEvent.toMap(), equalTo(testEvent.getData().toMap()));
 
+    }
+
+    @Test
+    void test_tags_when_json_parse_fails() {
+        final String source = "different_source";
+        final String destination = "destination_key";
+        when(processorConfig.getSource()).thenReturn(source);
+        when(processorConfig.getDestination()).thenReturn(destination);
+        final String whenCondition = UUID.randomUUID().toString();
+        when(processorConfig.getParseWhen()).thenReturn(whenCondition);
+        List<String> testTags = List.of("tag1", "tag2");
+        when(processorConfig.getTagsOnFailure()).thenReturn(testTags);
+        final Record<Event> testEvent = createMessageEvent("{key:}");
+        when(expressionEvaluator.evaluateConditional(whenCondition, testEvent.getData())).thenReturn(true);
+        parseJsonProcessor = createObjectUnderTest();
+
+        final Event parsedEvent = createAndParseMessageEvent(testEvent);
+        assertTrue(parsedEvent.getMetadata().hasTags(testTags));
     }
 
     private String constructDeeplyNestedJsonPointer(final int numberOfLayers) {


### PR DESCRIPTION
### Description
Add support to tag events when parse_json fails to parse.
Resolves #2744

Adds `tags_on_failure` new option to parse_json processor. An example, parse_json processor config would be
```
processor:                                                                                                                                              
     - parse_json:                                                                                                                                        
          source: "log"                                                                                                                                     
          tags_on_failure: ["json_parse_fail", "tag2"]   
```
 
### Issues Resolved
Resolves #2744 
 
### Check List
- [ X] New functionality includes testing.
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
