### PR TITLE
adding metric and logs in the event an S3 object does not contain records or no records were parsed from the object

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectPluginMetrics.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectPluginMetrics.java
@@ -18,6 +18,7 @@ public class S3ObjectPluginMetrics {
     static final String S3_OBJECTS_FAILED_NOT_FOUND_ACCESS_DENIED = "s3ObjectsAccessDenied";
     static final String S3_OBJECTS_TIME_ELAPSED_METRIC_NAME = "s3ObjectReadTimeElapsed";
     static final String S3_OBJECTS_SIZE = "s3ObjectSizeBytes";
+    static final String S3_OBJECTS_NO_RECORDS_FOUND = "s3ObjectNoRecordsFound";
     private final Counter s3ObjectsFailedCounter;
     private final Counter s3ObjectsFailedNotFoundCounter;
     private final Counter s3ObjectsFailedAccessDeniedCounter;
@@ -26,6 +27,7 @@ public class S3ObjectPluginMetrics {
     private final DistributionSummary s3ObjectSizeSummary;
     private final DistributionSummary s3ObjectSizeProcessedSummary;
     private final DistributionSummary s3ObjectEventsSummary;
+    private final Counter s3ObjectNoRecordsFound;
 
     public S3ObjectPluginMetrics(final PluginMetrics pluginMetrics){
         s3ObjectsFailedCounter = pluginMetrics.counter(S3_OBJECTS_FAILED_METRIC_NAME);
@@ -36,6 +38,7 @@ public class S3ObjectPluginMetrics {
         s3ObjectSizeSummary = pluginMetrics.summary(S3_OBJECTS_SIZE);
         s3ObjectSizeProcessedSummary = pluginMetrics.summary(S3_OBJECTS_SIZE_PROCESSED);
         s3ObjectEventsSummary = pluginMetrics.summary(S3_OBJECTS_EVENTS);
+        s3ObjectNoRecordsFound = pluginMetrics.counter(S3_OBJECTS_NO_RECORDS_FOUND);
     }
 
     public Counter getS3ObjectsFailedCounter() {
@@ -68,5 +71,8 @@ public class S3ObjectPluginMetrics {
 
     public DistributionSummary getS3ObjectEventsSummary() {
         return s3ObjectEventsSummary;
+    }
+    public Counter getS3ObjectNoRecordsFound() {
+        return s3ObjectNoRecordsFound;
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorker.java
@@ -25,7 +25,6 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 
 /**


### PR DESCRIPTION
### Description
This PR adds a new metric (`s3ObjectNoRecordsFound`) when the codec parse an S3 Object but does not capture any records from the object. A warning message is also logged at this time as well.
 
### Issues Resolved
resolves #2699
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
