### PR TITLE
Adds the new AWS Extension Plugin for Data Prepper

### DIFF
--- a/data-prepper-plugins/aws-plugin-api/README.md
+++ b/data-prepper-plugins/aws-plugin-api/README.md
@@ -1,0 +1,13 @@
+# AWS Plugin API
+
+This provides an API for plugins which wish to use the AWS Plugin for Data Prepper.
+
+## Using
+
+Add the following project:
+
+```
+implementation project(':data-prepper-plugins:aws-plugin-api')
+```
+
+This project does not yet deploy to Maven, so you cannot use it for external plugin development at the time.

--- a/data-prepper-plugins/aws-plugin-api/build.gradle
+++ b/data-prepper-plugins/aws-plugin-api/build.gradle
@@ -1,0 +1,21 @@
+
+dependencies {
+    implementation 'software.amazon.awssdk:auth'
+}
+
+test {
+    useJUnitPlatform()
+}
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule {
+            limit {
+                minimum = 1.0
+            }
+        }
+    }
+}
+
+check.dependsOn jacocoTestCoverageVerification

--- a/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptions.java
+++ b/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptions.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.aws.api;
+
+import software.amazon.awssdk.regions.Region;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides a standard model for requesting AWS credentials.
+ */
+public class AwsCredentialsOptions {
+    private final String stsRoleArn;
+    private final Region region;
+    private final Map<String, String> stsHeaderOverrides;
+
+    private AwsCredentialsOptions(final Builder builder) {
+        this.stsRoleArn = builder.stsRoleArn;
+        this.region = builder.region;
+        this.stsHeaderOverrides = new HashMap<>(builder.stsHeaderOverrides);
+    }
+
+    /**
+     * Constructs a new {@link Builder} to build the credentials
+     * options.
+     *
+     * @return A new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getStsRoleArn() {
+        return stsRoleArn;
+    }
+
+    public Region getRegion() {
+        return region;
+    }
+
+    public Map<String, String> getStsHeaderOverrides() {
+        return stsHeaderOverrides;
+    }
+
+    /**
+     * Builder class for {@link AwsCredentialsOptions}.
+     */
+    public static class Builder {
+        private String stsRoleArn;
+        private Region region;
+        private Map<String, String> stsHeaderOverrides = Collections.emptyMap();
+
+        /**
+         * Sets the STS role ARN to use.
+         *
+         * @param stsRoleArn The STS role ARN
+         * @return The {@link Builder} for continuing to build
+         */
+        public Builder withStsRoleArn(final String stsRoleArn) {
+            this.stsRoleArn = stsRoleArn;
+            return this;
+        }
+
+        /**
+         * Sets the AWS region using the model class from the AWS SDK.
+         *
+         * @param region The AWS region
+         * @return The {@link Builder} for continuing to build
+         */
+        public Builder withRegion(final Region region) {
+            this.region = region;
+            return this;
+        }
+
+        /**
+         * Sets the AWS region from a string.
+         *
+         * @param region The AWS region
+         * @return The {@link Builder} for continuing to build
+         */
+        public Builder withRegion(final String region) {
+            this.region = Region.of(region);
+            return this;
+        }
+
+        /**
+         * Configures header overrides for requests to STS.
+         *
+         * @param stsHeaderOverrides A map of STS header overrides
+         * @return The {@link Builder} for continuing to build
+         */
+        public Builder withStsHeaderOverrides(final Map<String, String> stsHeaderOverrides) {
+            this.stsHeaderOverrides = stsHeaderOverrides;
+            return this;
+        }
+
+        /**
+         * Builds the {@link AwsCredentialsOptions}.
+         *
+         * @return A new {@link AwsCredentialsOptions}.
+         */
+        public AwsCredentialsOptions build() {
+            return new AwsCredentialsOptions(this);
+        }
+    }
+}

--- a/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsSupplier.java
+++ b/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsSupplier.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.aws.api;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+/**
+ * An interface available to plugins via the AWS Plugin Extension which supplies
+ * AWS credentials.
+ */
+public interface AwsCredentialsSupplier {
+    /**
+     * Gets an AWS SDK {@link AwsCredentialsProvider} which consumers can use within
+     * AWS SDK clients.
+     * @param options The {@link AwsCredentialsOptions} defining the credentials.
+     * @return An {@link AwsCredentialsProvider} to use.
+     */
+    AwsCredentialsProvider getProvider(AwsCredentialsOptions options);
+}

--- a/data-prepper-plugins/aws-plugin-api/src/test/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptionsTest.java
+++ b/data-prepper-plugins/aws-plugin-api/src/test/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptionsTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.aws.api;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class AwsCredentialsOptionsTest {
+    @Test
+    void without_StsRoleArn() {
+        final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                .build();
+
+        assertThat(awsCredentialsOptions, notNullValue());
+        assertThat(awsCredentialsOptions.getStsRoleArn(), nullValue());
+    }
+
+    @Test
+    void with_StsRoleArn() {
+        final String roleArn = "arn:aws:iam::123456789012:role/" + UUID.randomUUID();
+        final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                .withStsRoleArn(roleArn)
+                .build();
+
+        assertThat(awsCredentialsOptions, notNullValue());
+        assertThat(awsCredentialsOptions.getStsRoleArn(), notNullValue());
+        assertThat(awsCredentialsOptions.getStsRoleArn(), equalTo(roleArn));
+    }
+
+    @Test
+    void without_Region() {
+        final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                .build();
+
+        assertThat(awsCredentialsOptions, notNullValue());
+        assertThat(awsCredentialsOptions.getRegion(), nullValue());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"us-east-1", "us-west-2", "eu-west-1"})
+    void with_Region_string(final String regionString) {
+        final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                .withRegion(regionString)
+                .build();
+
+        assertThat(awsCredentialsOptions, notNullValue());
+        assertThat(awsCredentialsOptions.getRegion(), notNullValue());
+        assertThat(awsCredentialsOptions.getRegion(), equalTo(Region.of(regionString)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"us-east-1", "us-west-2", "eu-west-1"})
+    void with_Region_model(final String regionString) {
+        final Region region = Region.of(regionString);
+
+        final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                .withRegion(region)
+                .build();
+
+        assertThat(awsCredentialsOptions, notNullValue());
+        assertThat(awsCredentialsOptions.getRegion(), notNullValue());
+        assertThat(awsCredentialsOptions.getRegion(), equalTo(region));
+    }
+
+    @Test
+    void without_StsHeaderOverrides() {
+        final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                .build();
+
+        assertThat(awsCredentialsOptions, notNullValue());
+        assertThat(awsCredentialsOptions.getStsHeaderOverrides(), notNullValue());
+        assertThat(awsCredentialsOptions.getStsHeaderOverrides().size(), equalTo(0));
+    }
+
+    @Test
+    void with_StsHeaderOverrides() {
+        final Map<String, String> stsHeaderOverrides = Map.of(
+                UUID.randomUUID().toString(), UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                .withStsHeaderOverrides(stsHeaderOverrides)
+                .build();
+
+        assertThat(awsCredentialsOptions, notNullValue());
+        assertThat(awsCredentialsOptions.getStsHeaderOverrides(), notNullValue());
+        assertThat(awsCredentialsOptions.getStsHeaderOverrides().size(), equalTo(stsHeaderOverrides.size()));
+        assertThat(awsCredentialsOptions.getStsHeaderOverrides(), equalTo(stsHeaderOverrides));
+    }
+}

--- a/data-prepper-plugins/aws-plugin/README.md
+++ b/data-prepper-plugins/aws-plugin/README.md
@@ -1,0 +1,5 @@
+# AWS Plugin
+
+This plugin provides an extension to Data Prepper for AWS support.
+
+Other plugins should not use this project directly. Instead, they will get it from Data Prepper.

--- a/data-prepper-plugins/aws-plugin/build.gradle
+++ b/data-prepper-plugins/aws-plugin/build.gradle
@@ -1,0 +1,25 @@
+
+dependencies {
+    implementation project(':data-prepper-api')
+    implementation project(':data-prepper-plugins:aws-plugin-api')
+    implementation 'software.amazon.awssdk:auth'
+    implementation 'software.amazon.awssdk:sts'
+    implementation 'software.amazon.awssdk:arns'
+}
+
+test {
+    useJUnitPlatform()
+}
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule {
+            limit {
+                minimum = 1.0
+            }
+        }
+    }
+}
+
+check.dependsOn jacocoTestCoverageVerification

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsExtensionProvider.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsExtensionProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.model.plugin.ExtensionProvider;
+
+import java.util.Optional;
+
+class AwsExtensionProvider implements ExtensionProvider<AwsCredentialsSupplier> {
+    private final AwsCredentialsSupplier awsCredentialsSupplier;
+
+    AwsExtensionProvider(final AwsCredentialsSupplier awsCredentialsSupplier) {
+        this.awsCredentialsSupplier = awsCredentialsSupplier;
+    }
+
+    @Override
+    public Optional<AwsCredentialsSupplier> provideInstance(final Context context) {
+        return Optional.of(awsCredentialsSupplier);
+    }
+
+    @Override
+    public Class<AwsCredentialsSupplier> supportedClass() {
+        return AwsCredentialsSupplier.class;
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsPlugin.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsPlugin.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.plugin.ExtensionPlugin;
+import org.opensearch.dataprepper.model.plugin.ExtensionPoints;
+
+/**
+ * The {@link ExtensionPlugin} class which adds the AWS Plugin to
+ * Data Prepper as an extension plugin. Everything starts from here.
+ */
+public class AwsPlugin implements ExtensionPlugin {
+    private final DefaultAwsCredentialsSupplier defaultAwsCredentialsSupplier;
+
+    @DataPrepperPluginConstructor
+    public AwsPlugin() {
+        final CredentialsProviderFactory credentialsProviderFactory = new CredentialsProviderFactory();
+        final CredentialsCache credentialsCache = new CredentialsCache();
+        defaultAwsCredentialsSupplier = new DefaultAwsCredentialsSupplier(credentialsProviderFactory, credentialsCache);
+    }
+
+    @Override
+    public void apply(final ExtensionPoints extensionPoints) {
+        extensionPoints.addExtensionProvider(new AwsExtensionProvider(defaultAwsCredentialsSupplier));
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsCache.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsCache.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+class CredentialsCache {
+    private final Map<CredentialsIdentifier, AwsCredentialsProvider> credentialsProviderMap;
+
+    CredentialsCache() {
+        credentialsProviderMap = new HashMap<>();
+    }
+
+    AwsCredentialsProvider getOrCreate(final AwsCredentialsOptions awsCredentialsOptions, final Supplier<AwsCredentialsProvider> providerSupplier) {
+        final CredentialsIdentifier identifier = CredentialsIdentifier.fromAwsCredentialsOption(awsCredentialsOptions);
+
+        return credentialsProviderMap.computeIfAbsent(identifier, i -> providerSupplier.get());
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsIdentifier.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsIdentifier.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Internal class to identify credentials. This is a distinct class from
+ * {@link AwsCredentialsOptions} in order to ensure that the internal caching
+ * is distinct from the external model.
+ */
+class CredentialsIdentifier {
+    private final String stsRoleArn;
+    private final Region region;
+    private final Map<String, String> stsHeaderOverrides;
+
+    private CredentialsIdentifier(
+            final String stsRoleArn,
+            final Region region,
+            final Map<String, String> stsHeaderOverrides) {
+
+        this.stsRoleArn = stsRoleArn;
+        this.region = region;
+        this.stsHeaderOverrides = stsHeaderOverrides;
+    }
+
+    static CredentialsIdentifier fromAwsCredentialsOption(final AwsCredentialsOptions options) {
+        return new CredentialsIdentifier(
+                options.getStsRoleArn(),
+                options.getRegion(),
+                options.getStsHeaderOverrides()
+        );
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final CredentialsIdentifier that = (CredentialsIdentifier) o;
+        return Objects.equals(stsRoleArn, that.stsRoleArn) && Objects.equals(region, that.region) && Objects.equals(stsHeaderOverrides, that.stsHeaderOverrides);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(stsRoleArn, region, stsHeaderOverrides);
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.arns.Arn;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+class CredentialsProviderFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(CredentialsProviderFactory.class);
+    private static final String AWS_IAM = "iam";
+    private static final String AWS_IAM_ROLE = "role";
+
+    AwsCredentialsProvider providerFromOptions(final AwsCredentialsOptions credentialsOptions) {
+        Objects.requireNonNull(credentialsOptions);
+
+        if(credentialsOptions.getStsRoleArn() != null) {
+            return createStsCredentials(credentialsOptions);
+        }
+
+        return DefaultCredentialsProvider.create();
+    }
+
+    private AwsCredentialsProvider createStsCredentials(final AwsCredentialsOptions credentialsOptions) {
+
+        final String stsRoleArn = credentialsOptions.getStsRoleArn();
+
+        validateStsRoleArn(stsRoleArn);
+
+        LOG.debug("Creating new AwsCredentialsProvider with role {}.", stsRoleArn);
+
+        StsClientBuilder stsClientBuilder = StsClient.builder();
+
+        stsClientBuilder = Optional.ofNullable(credentialsOptions.getRegion())
+                .map(stsClientBuilder::region)
+                .orElse(stsClientBuilder);
+
+        final StsClient stsClient = stsClientBuilder.build();
+
+        AssumeRoleRequest.Builder assumeRoleRequestBuilder = AssumeRoleRequest.builder()
+                .roleSessionName("Data-Prepper-" + UUID.randomUUID())
+                .roleArn(stsRoleArn);
+
+        final Map<String, String> awsStsHeaderOverrides = credentialsOptions.getStsHeaderOverrides();
+
+        if(awsStsHeaderOverrides != null && !awsStsHeaderOverrides.isEmpty()) {
+            assumeRoleRequestBuilder = assumeRoleRequestBuilder
+                    .overrideConfiguration(configuration -> awsStsHeaderOverrides.forEach(configuration::putHeader));
+        }
+
+        return StsAssumeRoleCredentialsProvider.builder()
+                .stsClient(stsClient)
+                .refreshRequest(assumeRoleRequestBuilder.build())
+                .build();
+    }
+
+    private void validateStsRoleArn(final String stsRoleArn) {
+        final Arn arn = getArn(stsRoleArn);
+        if (!AWS_IAM.equals(arn.service())) {
+            throw new IllegalArgumentException("sts_role_arn must be an IAM Role");
+        }
+        final Optional<String> resourceType = arn.resource().resourceType();
+        if (resourceType.isEmpty() || !resourceType.get().equals(AWS_IAM_ROLE)) {
+            throw new IllegalArgumentException("sts_role_arn must be an IAM Role");
+        }
+    }
+
+    private Arn getArn(final String stsRoleArn) {
+        try {
+            return Arn.fromString(stsRoleArn);
+        } catch (final Exception e) {
+            throw new IllegalArgumentException(String.format("Invalid ARN format for awsStsRoleArn. Check the format of %s", stsRoleArn));
+        }
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplier.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplier.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+class DefaultAwsCredentialsSupplier implements AwsCredentialsSupplier {
+    private final CredentialsProviderFactory credentialsProviderFactory;
+    private final CredentialsCache credentialsCache;
+
+    DefaultAwsCredentialsSupplier(final CredentialsProviderFactory credentialsProviderFactory, final CredentialsCache credentialsCache) {
+        this.credentialsProviderFactory = credentialsProviderFactory;
+        this.credentialsCache = credentialsCache;
+    }
+
+    @Override
+    public AwsCredentialsProvider getProvider(final AwsCredentialsOptions options) {
+        return credentialsCache.getOrCreate(options, () -> credentialsProviderFactory.providerFromOptions(options));
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsExtensionProviderTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsExtensionProviderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.model.plugin.ExtensionProvider;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class AwsExtensionProviderTest {
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
+
+    @Mock
+    private ExtensionProvider.Context context;
+
+    private AwsExtensionProvider createObjectUnderTest() {
+        return new AwsExtensionProvider(awsCredentialsSupplier);
+    }
+
+    @Test
+    void supportedClass_returns_AwsCredentialsSupplier() {
+        assertThat(createObjectUnderTest().supportedClass(), equalTo(AwsCredentialsSupplier.class));
+    }
+
+    @Test
+    void provideInstance_returns_the_AwsCredentialsSupplier_from_the_constructor() {
+        final AwsExtensionProvider objectUnderTest = createObjectUnderTest();
+
+        final Optional<AwsCredentialsSupplier> optionalCredentialsSupplier = objectUnderTest.provideInstance(context);
+        assertThat(optionalCredentialsSupplier, notNullValue());
+        assertThat(optionalCredentialsSupplier.isPresent(), equalTo(true));
+        assertThat(optionalCredentialsSupplier.get(), equalTo(awsCredentialsSupplier));
+
+        final Optional<AwsCredentialsSupplier> anotherOptionalCredentialsSupplier = objectUnderTest.provideInstance(context);
+        assertThat(anotherOptionalCredentialsSupplier, notNullValue());
+        assertThat(anotherOptionalCredentialsSupplier.isPresent(), equalTo(true));
+        assertThat(anotherOptionalCredentialsSupplier.get(), sameInstance(optionalCredentialsSupplier.get()));
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginIT.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.model.plugin.ExtensionPoints;
+import org.opensearch.dataprepper.model.plugin.ExtensionProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsPluginIT {
+    @Mock
+    private ExtensionPoints extensionPoints;
+
+    @Mock
+    private ExtensionProvider.Context context;
+
+    private AwsPlugin createObjectUnderTest() {
+        return new AwsPlugin();
+    }
+
+    @Test
+    void test_AwsPlugin_with_STS_role() {
+        createObjectUnderTest().apply(extensionPoints);
+
+        final ArgumentCaptor<ExtensionProvider<AwsCredentialsSupplier>> extensionProviderArgumentCaptor = ArgumentCaptor.forClass(ExtensionProvider.class);
+        verify(extensionPoints).addExtensionProvider(extensionProviderArgumentCaptor.capture());
+
+        final ExtensionProvider<AwsCredentialsSupplier> extensionProvider = extensionProviderArgumentCaptor.getValue();
+
+        final Optional<AwsCredentialsSupplier> optionalSupplier = extensionProvider.provideInstance(context);
+        assertThat(optionalSupplier, notNullValue());
+        assertThat(optionalSupplier.isPresent(), equalTo(true));
+
+        final AwsCredentialsSupplier awsCredentialsSupplier = optionalSupplier.get();
+
+        final String stsRole = createStsRole();
+        final AwsCredentialsOptions awsCredentialsOptions1 = AwsCredentialsOptions.builder()
+                .withStsRoleArn(stsRole)
+                .withRegion(Region.US_EAST_1)
+                .build();
+
+        final AwsCredentialsProvider awsCredentialsProvider1 = awsCredentialsSupplier.getProvider(awsCredentialsOptions1);
+
+        assertThat(awsCredentialsProvider1, instanceOf(StsAssumeRoleCredentialsProvider.class));
+
+        final AwsCredentialsOptions awsCredentialsOptions2 = AwsCredentialsOptions.builder()
+                .withStsRoleArn(stsRole)
+                .withRegion(Region.US_EAST_1)
+                .build();
+
+        final AwsCredentialsProvider awsCredentialsProvider2 = awsCredentialsSupplier.getProvider(awsCredentialsOptions2);
+
+        assertThat(awsCredentialsProvider2, sameInstance(awsCredentialsProvider1));
+    }
+
+    @Test
+    void test_AwsPlugin_without_STS_role() {
+        createObjectUnderTest().apply(extensionPoints);
+
+        final ArgumentCaptor<ExtensionProvider<AwsCredentialsSupplier>> extensionProviderArgumentCaptor = ArgumentCaptor.forClass(ExtensionProvider.class);
+        verify(extensionPoints).addExtensionProvider(extensionProviderArgumentCaptor.capture());
+
+        final ExtensionProvider<AwsCredentialsSupplier> extensionProvider = extensionProviderArgumentCaptor.getValue();
+
+        final Optional<AwsCredentialsSupplier> optionalSupplier = extensionProvider.provideInstance(context);
+        assertThat(optionalSupplier, notNullValue());
+        assertThat(optionalSupplier.isPresent(), equalTo(true));
+
+        final AwsCredentialsSupplier awsCredentialsSupplier = optionalSupplier.get();
+
+        final AwsCredentialsOptions awsCredentialsOptions1 = AwsCredentialsOptions.builder()
+                .withRegion(Region.US_EAST_1)
+                .build();
+
+        final AwsCredentialsProvider awsCredentialsProvider1 = awsCredentialsSupplier.getProvider(awsCredentialsOptions1);
+
+        assertThat(awsCredentialsProvider1, instanceOf(DefaultCredentialsProvider.class));
+
+        final AwsCredentialsOptions awsCredentialsOptions2 = AwsCredentialsOptions.builder()
+                .withRegion(Region.US_EAST_1)
+                .build();
+
+        final AwsCredentialsProvider awsCredentialsProvider2 = awsCredentialsSupplier.getProvider(awsCredentialsOptions2);
+
+        assertThat(awsCredentialsProvider2, sameInstance(awsCredentialsProvider1));
+    }
+
+    private String createStsRole() {
+        return String.format("arn:aws:iam::123456789012:role/%s", UUID.randomUUID());
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.plugin.ExtensionPoints;
+import org.opensearch.dataprepper.model.plugin.ExtensionProvider;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AwsPluginTest {
+    @Mock
+    private ExtensionPoints extensionPoints;
+
+    private AwsPlugin createObjectUnderTest() {
+        return new AwsPlugin();
+    }
+
+    @Test
+    void apply_should_addExtensionProvider() {
+        createObjectUnderTest().apply(extensionPoints);
+
+        final ArgumentCaptor<ExtensionProvider> extensionProviderArgumentCaptor =
+                ArgumentCaptor.forClass(ExtensionProvider.class);
+
+        verify(extensionPoints).addExtensionProvider(extensionProviderArgumentCaptor.capture());
+
+        final ExtensionProvider actualExtensionProvider = extensionProviderArgumentCaptor.getValue();
+
+        assertThat(actualExtensionProvider, instanceOf(AwsExtensionProvider.class));
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsCacheTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsCacheTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CredentialsCacheTest {
+    @Mock
+    private AwsCredentialsOptions credentialsOptions;
+
+    @Mock
+    private Supplier<AwsCredentialsProvider> credentialsProviderSupplier;
+
+    @Mock
+    private AwsCredentialsProvider credentialsProvider;
+
+    @BeforeEach
+    void setUp() {
+        when(credentialsOptions.getStsRoleArn()).thenReturn(UUID.randomUUID().toString());
+        when(credentialsProviderSupplier.get()).thenReturn(credentialsProvider);
+    }
+
+    private CredentialsCache createObjectUnderTest() {
+        return new CredentialsCache();
+    }
+
+    @Test
+    void getOrCreate_with_single_object_returns_expected_value() {
+        final CredentialsCache objectUnderTest = createObjectUnderTest();
+        assertThat(objectUnderTest.getOrCreate(credentialsOptions, credentialsProviderSupplier),
+                equalTo(credentialsProvider));
+
+        assertThat(objectUnderTest.getOrCreate(credentialsOptions, credentialsProviderSupplier),
+                equalTo(credentialsProvider));
+
+        verify(credentialsProviderSupplier).get();
+    }
+
+    @Test
+    void getOrCreate_returns_value_from_supplier_as_expected_with_multiple_objects() {
+        final AwsCredentialsOptions existingCredentialsOptions = mock(AwsCredentialsOptions.class);
+        when(existingCredentialsOptions.getStsRoleArn()).thenReturn(UUID.randomUUID().toString());
+        final Supplier<AwsCredentialsProvider> existingCredentialsProviderSupplier = mock(Supplier.class);
+        final AwsCredentialsProvider existingCredentialsProvider = mock(AwsCredentialsProvider.class);
+
+        when(existingCredentialsProviderSupplier.get()).thenReturn(existingCredentialsProvider);
+
+        final CredentialsCache objectUnderTest = createObjectUnderTest();
+        objectUnderTest.getOrCreate(existingCredentialsOptions, existingCredentialsProviderSupplier);
+
+        assertThat(objectUnderTest.getOrCreate(credentialsOptions, credentialsProviderSupplier),
+                equalTo(credentialsProvider));
+
+        assertThat(objectUnderTest.getOrCreate(credentialsOptions, credentialsProviderSupplier),
+                equalTo(credentialsProvider));
+
+        assertThat(objectUnderTest.getOrCreate(existingCredentialsOptions, existingCredentialsProviderSupplier),
+                equalTo(existingCredentialsProvider));
+
+        verify(existingCredentialsProviderSupplier).get();
+        verify(credentialsProviderSupplier).get();
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsIdentifierTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsIdentifierTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CredentialsIdentifierTest {
+    @Mock
+    private AwsCredentialsOptions credentialsOptions;
+
+    @Mock
+    private AwsCredentialsOptions otherCredentialsOptions;
+
+    @Test
+    void equals_on_null_other() {
+        final CredentialsIdentifier objectUnderTest = CredentialsIdentifier.fromAwsCredentialsOption(credentialsOptions);
+
+        assertThat(objectUnderTest.equals(null), equalTo(false));
+    }
+
+    @Test
+    void equals_hashCode_on_same_instance() {
+        final CredentialsIdentifier objectUnderTest = CredentialsIdentifier.fromAwsCredentialsOption(credentialsOptions);
+
+        assertThat(objectUnderTest.equals(objectUnderTest), equalTo(true));
+        assertThat(objectUnderTest.hashCode(), equalTo(objectUnderTest.hashCode()));
+    }
+
+    @Test
+    void equals_hashCode_on_empty_objects() {
+        final CredentialsIdentifier objectUnderTest = CredentialsIdentifier.fromAwsCredentialsOption(credentialsOptions);
+        final CredentialsIdentifier other = CredentialsIdentifier.fromAwsCredentialsOption(otherCredentialsOptions);
+
+        assertThat(objectUnderTest.equals(other), equalTo(true));
+        assertThat(objectUnderTest.hashCode(), equalTo(other.hashCode()));
+    }
+
+    @Test
+    void equals_hashCode_on_equal_objects() {
+        final String stsRoleArn = UUID.randomUUID().toString();
+        when(credentialsOptions.getStsRoleArn()).thenReturn(stsRoleArn);
+        when(otherCredentialsOptions.getStsRoleArn()).thenReturn(stsRoleArn);
+        when(credentialsOptions.getRegion()).thenReturn(Region.US_EAST_1);
+        when(otherCredentialsOptions.getRegion()).thenReturn(Region.US_EAST_1);
+        final String headerName = UUID.randomUUID().toString();
+        final String headerValue = UUID.randomUUID().toString();
+        when(credentialsOptions.getStsHeaderOverrides()).thenReturn(Collections.singletonMap(headerName, headerValue));
+        when(otherCredentialsOptions.getStsHeaderOverrides()).thenReturn(Collections.singletonMap(headerName, headerValue));
+
+        final CredentialsIdentifier objectUnderTest = CredentialsIdentifier.fromAwsCredentialsOption(credentialsOptions);
+        final CredentialsIdentifier other = CredentialsIdentifier.fromAwsCredentialsOption(otherCredentialsOptions);
+
+        assertThat(objectUnderTest.equals(other), equalTo(true));
+        assertThat(objectUnderTest.hashCode(), equalTo(other.hashCode()));
+    }
+
+    @Test
+    void equals_hashCode_on_non_equal_objects() {
+        when(credentialsOptions.getStsRoleArn()).thenReturn(UUID.randomUUID().toString());
+        when(otherCredentialsOptions.getStsRoleArn()).thenReturn(UUID.randomUUID().toString());
+        when(credentialsOptions.getRegion()).thenReturn(Region.US_EAST_1);
+        when(otherCredentialsOptions.getRegion()).thenReturn(Region.US_EAST_1);
+        final String headerName = UUID.randomUUID().toString();
+        final String headerValue = UUID.randomUUID().toString();
+        when(credentialsOptions.getStsHeaderOverrides()).thenReturn(Collections.singletonMap(headerName, headerValue));
+        when(otherCredentialsOptions.getStsHeaderOverrides()).thenReturn(Collections.singletonMap(headerName, headerValue));
+
+        final CredentialsIdentifier objectUnderTest = CredentialsIdentifier.fromAwsCredentialsOption(credentialsOptions);
+        final CredentialsIdentifier other = CredentialsIdentifier.fromAwsCredentialsOption(otherCredentialsOptions);
+
+        assertThat(objectUnderTest.equals(other), equalTo(false));
+        assertThat(objectUnderTest.hashCode(), not(equalTo(other.hashCode())));
+    }
+
+    @Test
+    void equals_hashCode_on_equal_StsRoleArn() {
+
+        final String stsRoleArn = UUID.randomUUID().toString();
+        when(credentialsOptions.getStsRoleArn()).thenReturn(stsRoleArn);
+        when(otherCredentialsOptions.getStsRoleArn()).thenReturn(stsRoleArn);
+
+        final CredentialsIdentifier objectUnderTest = CredentialsIdentifier.fromAwsCredentialsOption(credentialsOptions);
+        final CredentialsIdentifier other = CredentialsIdentifier.fromAwsCredentialsOption(otherCredentialsOptions);
+
+        assertThat(objectUnderTest.equals(other), equalTo(true));
+        assertThat(objectUnderTest.hashCode(), equalTo(other.hashCode()));
+    }
+
+    @Test
+    void equals_hashCode_on_non_equal_StsRoleArn() {
+
+        when(credentialsOptions.getStsRoleArn()).thenReturn(UUID.randomUUID().toString());
+        when(otherCredentialsOptions.getStsRoleArn()).thenReturn(UUID.randomUUID().toString());
+
+        final CredentialsIdentifier objectUnderTest = CredentialsIdentifier.fromAwsCredentialsOption(credentialsOptions);
+        final CredentialsIdentifier other = CredentialsIdentifier.fromAwsCredentialsOption(otherCredentialsOptions);
+
+        assertThat(objectUnderTest.equals(other), equalTo(false));
+        assertThat(objectUnderTest.hashCode(), not(equalTo(other.hashCode())));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"us-east-1", "eu-central-1"})
+    void equals_hashCode_on_equal_regions(final String regionString) {
+
+        final Region region = Region.of(regionString);
+        when(credentialsOptions.getRegion()).thenReturn(region);
+        when(otherCredentialsOptions.getRegion()).thenReturn(region);
+
+        final CredentialsIdentifier objectUnderTest = CredentialsIdentifier.fromAwsCredentialsOption(credentialsOptions);
+        final CredentialsIdentifier other = CredentialsIdentifier.fromAwsCredentialsOption(otherCredentialsOptions);
+
+        assertThat(objectUnderTest.equals(other), equalTo(true));
+        assertThat(objectUnderTest.hashCode(), equalTo(other.hashCode()));
+    }
+
+    @Test
+    void equals_hashCode_on_non_equal_regions() {
+        when(credentialsOptions.getRegion()).thenReturn(Region.US_EAST_1);
+        when(otherCredentialsOptions.getRegion()).thenReturn(Region.US_EAST_2);
+
+        final CredentialsIdentifier objectUnderTest = CredentialsIdentifier.fromAwsCredentialsOption(credentialsOptions);
+        final CredentialsIdentifier other = CredentialsIdentifier.fromAwsCredentialsOption(otherCredentialsOptions);
+
+        assertThat(objectUnderTest.equals(other), equalTo(false));
+        assertThat(objectUnderTest.hashCode(), not(equalTo(other.hashCode())));
+    }
+
+    @Test
+    void equals_hashCode_on_equal_StsHeaderOverrides() {
+        when(credentialsOptions.getStsHeaderOverrides()).thenReturn(Collections.emptyMap());
+        when(otherCredentialsOptions.getStsHeaderOverrides()).thenReturn(Collections.emptyMap());
+
+        final CredentialsIdentifier objectUnderTest = CredentialsIdentifier.fromAwsCredentialsOption(credentialsOptions);
+        final CredentialsIdentifier other = CredentialsIdentifier.fromAwsCredentialsOption(otherCredentialsOptions);
+
+        assertThat(objectUnderTest.equals(other), equalTo(true));
+        assertThat(objectUnderTest.hashCode(), equalTo(other.hashCode()));
+    }
+
+    @Test
+    void equals_hashCode_on_non_equal_StsHeaderOverrides() {
+        when(credentialsOptions.getStsHeaderOverrides()).thenReturn(Collections.singletonMap(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+        when(otherCredentialsOptions.getStsHeaderOverrides()).thenReturn(Collections.emptyMap());
+
+        final CredentialsIdentifier objectUnderTest = CredentialsIdentifier.fromAwsCredentialsOption(credentialsOptions);
+        final CredentialsIdentifier other = CredentialsIdentifier.fromAwsCredentialsOption(otherCredentialsOptions);
+
+        assertThat(objectUnderTest.equals(other), equalTo(false));
+        assertThat(objectUnderTest.hashCode(), not(equalTo(other.hashCode())));
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
@@ -86,6 +86,8 @@ class CredentialsProviderFactoryTest {
     void providerFromOptions_with_StsRoleArn() {
         when(awsCredentialsOptions.getStsRoleArn())
                 .thenReturn(createStsRole());
+        when(awsCredentialsOptions.getRegion())
+                .thenReturn(Region.US_EAST_1);
         final AwsCredentialsProvider awsCredentialsProvider = createObjectUnderTest().providerFromOptions(awsCredentialsOptions);
         assertThat(awsCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
     }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CredentialsProviderFactoryTest {
+    @Mock
+    private AwsCredentialsOptions awsCredentialsOptions;
+
+    @BeforeEach
+    void setUp() {
+
+    }
+
+    private CredentialsProviderFactory createObjectUnderTest() {
+        return new CredentialsProviderFactory();
+    }
+
+    @Test
+    void providerFromOptions_with_null_AwsCredentialsOptions_throws() {
+        final CredentialsProviderFactory objectUnderTest = createObjectUnderTest();
+        assertThrows(NullPointerException.class, () -> objectUnderTest.providerFromOptions(null));
+    }
+
+    @Test
+    void providerFromOptions_without_StsRoleArn_returns_DefaultCredentialsProvider() {
+        assertThat(createObjectUnderTest().providerFromOptions(awsCredentialsOptions),
+                instanceOf(DefaultCredentialsProvider.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "notanarn:something:else",
+            "arn:aws:notiam::123456789012:role/TestRole",
+            "arn:aws:iam::123456789012:notrole/TestRole",
+            "arn:aws:iam::123456789012:/",
+            "arn:aws:iam::123456789012:"
+    })
+    void providerFromOptions_with_invalid_StsRoleArn_throws(final String stsRoleArn) {
+        when(awsCredentialsOptions.getStsRoleArn()).thenReturn(stsRoleArn);
+        final CredentialsProviderFactory objectUnderTest = createObjectUnderTest();
+
+        assertThrows(IllegalArgumentException.class, () -> objectUnderTest.providerFromOptions(awsCredentialsOptions));
+    }
+
+    @Test
+    void providerFromOptions_with_StsRoleArn() {
+        when(awsCredentialsOptions.getStsRoleArn())
+                .thenReturn(createStsRole());
+        final AwsCredentialsProvider awsCredentialsProvider = createObjectUnderTest().providerFromOptions(awsCredentialsOptions);
+        assertThat(awsCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
+    }
+
+
+    @Nested
+    class WithSts {
+        private StsClient stsClient;
+        private StsClientBuilder stsClientBuilder;
+        private String testStsRole;
+
+        @BeforeEach
+        void setUp() {
+            stsClient = mock(StsClient.class);
+            stsClientBuilder = mock(StsClientBuilder.class);
+
+            when(stsClientBuilder.build()).thenReturn(stsClient);
+
+            testStsRole = createStsRole();
+        }
+
+        @Test
+        void authenticateAWSConfiguration_should_return_s3Client_with_sts_role_arn() {
+            when(awsCredentialsOptions.getRegion()).thenReturn(Region.US_EAST_1);
+            when(awsCredentialsOptions.getStsRoleArn()).thenReturn(testStsRole);
+
+            when(stsClientBuilder.region(Region.US_EAST_1)).thenReturn(stsClientBuilder);
+            final AssumeRoleRequest.Builder assumeRoleRequestBuilder = mock(AssumeRoleRequest.Builder.class);
+            when(assumeRoleRequestBuilder.roleSessionName(anyString()))
+                    .thenReturn(assumeRoleRequestBuilder);
+            when(assumeRoleRequestBuilder.roleArn(anyString()))
+                    .thenReturn(assumeRoleRequestBuilder);
+
+
+            final CredentialsProviderFactory objectUnderTest = createObjectUnderTest();
+            final AwsCredentialsProvider actualCredentialsProvider;
+            try (final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
+                 final MockedStatic<AssumeRoleRequest> assumeRoleRequestMockedStatic = mockStatic(AssumeRoleRequest.class)) {
+                stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
+                assumeRoleRequestMockedStatic.when(AssumeRoleRequest::builder).thenReturn(assumeRoleRequestBuilder);
+                actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
+            }
+
+            assertThat(actualCredentialsProvider, instanceOf(AwsCredentialsProvider.class));
+
+            verify(assumeRoleRequestBuilder).roleArn(testStsRole);
+            verify(assumeRoleRequestBuilder).roleSessionName(anyString());
+            verify(assumeRoleRequestBuilder).build();
+            verifyNoMoreInteractions(assumeRoleRequestBuilder);
+        }
+
+        @Test
+        void authenticateAWSConfiguration_should_return_s3Client_with_sts_role_arn_when_no_region() {
+            when(awsCredentialsOptions.getRegion()).thenReturn(null);
+            when(awsCredentialsOptions.getStsRoleArn()).thenReturn(testStsRole);
+
+            final CredentialsProviderFactory objectUnderTest = createObjectUnderTest();
+            final AwsCredentialsProvider actualCredentialsProvider;
+            try (final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class)) {
+                stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
+                actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
+            }
+
+            assertThat(actualCredentialsProvider, instanceOf(AwsCredentialsProvider.class));
+        }
+
+        @Test
+        void authenticateAWSConfiguration_should_override_STS_Headers_when_HeaderOverrides_when_set() {
+            final String headerName1 = UUID.randomUUID().toString();
+            final String headerValue1 = UUID.randomUUID().toString();
+            final String headerName2 = UUID.randomUUID().toString();
+            final String headerValue2 = UUID.randomUUID().toString();
+            final Map<String, String> overrideHeaders = Map.of(headerName1, headerValue1, headerName2, headerValue2);
+
+            when(awsCredentialsOptions.getRegion()).thenReturn(Region.US_EAST_1);
+            when(awsCredentialsOptions.getStsRoleArn()).thenReturn(testStsRole);
+            when(awsCredentialsOptions.getStsHeaderOverrides()).thenReturn(overrideHeaders);
+
+            when(stsClientBuilder.region(Region.US_EAST_1)).thenReturn(stsClientBuilder);
+
+            final AssumeRoleRequest.Builder assumeRoleRequestBuilder = mock(AssumeRoleRequest.Builder.class);
+            when(assumeRoleRequestBuilder.roleSessionName(anyString()))
+                    .thenReturn(assumeRoleRequestBuilder);
+            when(assumeRoleRequestBuilder.roleArn(anyString()))
+                    .thenReturn(assumeRoleRequestBuilder);
+            when(assumeRoleRequestBuilder.overrideConfiguration(any(Consumer.class)))
+                    .thenReturn(assumeRoleRequestBuilder);
+
+            final CredentialsProviderFactory objectUnderTest = createObjectUnderTest();
+            final AwsCredentialsProvider actualCredentialsProvider;
+            try (final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
+                 final MockedStatic<AssumeRoleRequest> assumeRoleRequestMockedStatic = mockStatic(AssumeRoleRequest.class)) {
+                stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
+                assumeRoleRequestMockedStatic.when(AssumeRoleRequest::builder).thenReturn(assumeRoleRequestBuilder);
+                actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
+            }
+
+            assertThat(actualCredentialsProvider, instanceOf(AwsCredentialsProvider.class));
+
+            final ArgumentCaptor<Consumer<AwsRequestOverrideConfiguration.Builder>> configurationCaptor = ArgumentCaptor.forClass(Consumer.class);
+
+            verify(assumeRoleRequestBuilder).roleArn(testStsRole);
+            verify(assumeRoleRequestBuilder).roleSessionName(anyString());
+            verify(assumeRoleRequestBuilder).overrideConfiguration(configurationCaptor.capture());
+            verify(assumeRoleRequestBuilder).build();
+            verifyNoMoreInteractions(assumeRoleRequestBuilder);
+
+            final Consumer<AwsRequestOverrideConfiguration.Builder> actualOverride = configurationCaptor.getValue();
+
+            final AwsRequestOverrideConfiguration.Builder configurationBuilder = mock(AwsRequestOverrideConfiguration.Builder.class);
+            actualOverride.accept(configurationBuilder);
+            verify(configurationBuilder).putHeader(headerName1, headerValue1);
+            verify(configurationBuilder).putHeader(headerName2, headerValue2);
+            verifyNoMoreInteractions(configurationBuilder);
+        }
+
+        @Test
+        void authenticateAWSConfiguration_should_not_override_STS_Headers_when_HeaderOverrides_are_empty() {
+            when(awsCredentialsOptions.getRegion()).thenReturn(Region.US_EAST_1);
+            when(awsCredentialsOptions.getStsRoleArn()).thenReturn(testStsRole);
+            when(awsCredentialsOptions.getStsHeaderOverrides()).thenReturn(Collections.emptyMap());
+
+            when(stsClientBuilder.region(Region.US_EAST_1)).thenReturn(stsClientBuilder);
+            final AssumeRoleRequest.Builder assumeRoleRequestBuilder = mock(AssumeRoleRequest.Builder.class);
+            when(assumeRoleRequestBuilder.roleSessionName(anyString()))
+                    .thenReturn(assumeRoleRequestBuilder);
+            when(assumeRoleRequestBuilder.roleArn(anyString()))
+                    .thenReturn(assumeRoleRequestBuilder);
+
+            final CredentialsProviderFactory objectUnderTest = createObjectUnderTest();
+            final AwsCredentialsProvider actualCredentialsProvider;
+            try (final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
+                 final MockedStatic<AssumeRoleRequest> assumeRoleRequestMockedStatic = mockStatic(AssumeRoleRequest.class)) {
+                stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
+                assumeRoleRequestMockedStatic.when(AssumeRoleRequest::builder).thenReturn(assumeRoleRequestBuilder);
+                actualCredentialsProvider = objectUnderTest.providerFromOptions(awsCredentialsOptions);
+            }
+
+            assertThat(actualCredentialsProvider, instanceOf(AwsCredentialsProvider.class));
+
+            verify(assumeRoleRequestBuilder).roleArn(testStsRole);
+            verify(assumeRoleRequestBuilder).roleSessionName(anyString());
+            verify(assumeRoleRequestBuilder).build();
+            verifyNoMoreInteractions(assumeRoleRequestBuilder);
+        }
+    }
+
+    private String createStsRole() {
+        return String.format("arn:aws:iam::123456789012:role/%s", UUID.randomUUID());
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplierTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplierTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+import java.util.function.Supplier;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultAwsCredentialsSupplierTest {
+    @Mock
+    private CredentialsProviderFactory credentialsProviderFactory;
+    @Mock
+    private CredentialsCache credentialsCache;
+
+    private DefaultAwsCredentialsSupplier createObjectUnderTest() {
+        return new DefaultAwsCredentialsSupplier(credentialsProviderFactory, credentialsCache);
+    }
+
+    @Test
+    void getProvider_returns_from_getOrCreate() {
+        final AwsCredentialsOptions options = mock(AwsCredentialsOptions.class);
+
+        final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
+        when(credentialsCache.getOrCreate(eq(options), any(Supplier.class)))
+                .thenReturn(awsCredentialsProvider);
+
+        assertThat(createObjectUnderTest().getProvider(options), equalTo(awsCredentialsProvider));
+    }
+
+    @Test
+    void getProvider_calls_getOrCreate_with_Supplier() {
+        final AwsCredentialsOptions options = mock(AwsCredentialsOptions.class);
+        final ArgumentCaptor<Supplier<AwsCredentialsProvider>> supplierArgumentCaptor = ArgumentCaptor.forClass(Supplier.class);
+
+        createObjectUnderTest().getProvider(options);
+
+        verify(credentialsCache).getOrCreate(eq(options), supplierArgumentCaptor.capture());
+        verifyNoInteractions(credentialsProviderFactory);
+
+        final Supplier<AwsCredentialsProvider> actualCredentialsSupplier = supplierArgumentCaptor.getValue();
+
+        final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
+        when(credentialsProviderFactory.providerFromOptions(options)).thenReturn(awsCredentialsProvider);
+        assertThat(actualCredentialsSupplier.get(), equalTo(awsCredentialsProvider));
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-plugins/aws-plugin/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,3 @@
+# To enable mocking of final classes with vanilla Mockito
+# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
+mock-maker-inline

--- a/settings.gradle
+++ b/settings.gradle
@@ -117,3 +117,6 @@ include 'data-prepper-plugins:kafka-plugins'
 include 'data-prepper-plugins:opensearch-source'
 include 'data-prepper-plugins:user-agent-processor'
 include 'data-prepper-plugins:in-memory-source-coordination-store'
+include 'data-prepper-plugins:aws-plugin-api'
+include 'data-prepper-plugins:aws-plugin'
+


### PR DESCRIPTION
### Description

This creates a new AWS Extension Plugin. With this initial PR, this plugin supports a standard approach to AWS credentials management.

To try to keep this PR from being too large, I only included the new plugin. You can see #2731 to get a sense of how this will be used in other plugins. I'll create follow-on PRs to incorporate this into the other plugins accordingly.
 
### Issues Resolved

Resolves #2751
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
