### PR TITLE
addressing build issue with s3-sink

### DIFF
--- a/data-prepper-plugins/s3-sink/README.md
+++ b/data-prepper-plugins/s3-sink/README.md
@@ -72,4 +72,3 @@ The following command runs the integration tests:
 ```
 ./gradlew :data-prepper-plugins:s3-sink:integrationTest -Dtests.s3sink.region=<your-aws-region> -Dtests.s3sink.bucket=<your-bucket>
 ```
-


### PR DESCRIPTION
### Description
Addresses build failure observed in PR: https://github.com/opensearch-project/data-prepper/pull/2726

```
* What went wrong:
Execution failed for task ':data-prepper-plugins:s3-sink:spotlessMarkdownCheck'.
> The following files had format violations:
      README.md
          @@ -72,4 +72,3 @@
           ```
           ./gradlew·:data-prepper-plugins:s3-sink:integrationTest·-Dtests.s3sink.region=<your-aws-region>·-Dtests.s3sink.bucket=<your-bucket>
           ```
          -
  Run './gradlew :data-prepper-plugins:s3-sink:spotlessApply' to fix these violations.
```

See: https://github.com/opensearch-project/data-prepper/actions/runs/5082697390/jobs/9132752111?pr=2726
 
### Issues Resolved
None, pro-active clean up
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
