### PR TITLE
Allow explicit setting of null STS header overrides in AwsCredentialsOptions

### DIFF
--- a/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptions.java
+++ b/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptions.java
@@ -22,7 +22,7 @@ public class AwsCredentialsOptions {
     private AwsCredentialsOptions(final Builder builder) {
         this.stsRoleArn = builder.stsRoleArn;
         this.region = builder.region;
-        this.stsHeaderOverrides = new HashMap<>(builder.stsHeaderOverrides);
+        this.stsHeaderOverrides = builder.stsHeaderOverrides != null ? new HashMap<>(builder.stsHeaderOverrides) : Collections.emptyMap();
     }
 
     /**

--- a/data-prepper-plugins/aws-plugin-api/src/test/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptionsTest.java
+++ b/data-prepper-plugins/aws-plugin-api/src/test/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptionsTest.java
@@ -86,6 +86,17 @@ class AwsCredentialsOptionsTest {
     }
 
     @Test
+    void with_explicit_null_StsHeaderOverrides() {
+        final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                .withStsHeaderOverrides(null)
+                .build();
+
+        assertThat(awsCredentialsOptions, notNullValue());
+        assertThat(awsCredentialsOptions.getStsHeaderOverrides(), notNullValue());
+        assertThat(awsCredentialsOptions.getStsHeaderOverrides().size(), equalTo(0));
+    }
+
+    @Test
     void with_StsHeaderOverrides() {
         final Map<String, String> stsHeaderOverrides = Map.of(
                 UUID.randomUUID().toString(), UUID.randomUUID().toString(),


### PR DESCRIPTION
### Description

The current code throws an NPE when the builder is used with null STS header overrides. Rather than make clients think about this, this code change handles it in the common plugin code.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
