### PR TITLE
Updates the S3 source to use the aws-plugin for loading AWS credentia…

### DIFF
--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:sts'
     implementation 'software.amazon.awssdk:sqs'
+    implementation project(':data-prepper-plugins:aws-plugin-api')
     implementation 'software.amazon.awssdk:netty-nio-client'
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/AwsAuthenticationAdapter.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/AwsAuthenticationAdapter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source;
+
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.plugins.source.configuration.AwsAuthenticationOptions;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+class AwsAuthenticationAdapter {
+    private final AwsCredentialsSupplier awsCredentialsSupplier;
+    private final S3SourceConfig s3SourceConfig;
+
+
+    AwsAuthenticationAdapter(
+            final AwsCredentialsSupplier awsCredentialsSupplier,
+            final S3SourceConfig s3SourceConfig) {
+        this.awsCredentialsSupplier = awsCredentialsSupplier;
+        this.s3SourceConfig = s3SourceConfig;
+    }
+
+    AwsCredentialsProvider getCredentialsProvider() {
+        final AwsAuthenticationOptions awsAuthenticationOptions = s3SourceConfig.getAwsAuthenticationOptions();
+
+        final AwsCredentialsOptions options = AwsCredentialsOptions.builder()
+                .withStsRoleArn(awsAuthenticationOptions.getAwsStsRoleArn())
+                .withRegion(awsAuthenticationOptions.getAwsRegion())
+                .withStsHeaderOverrides(awsAuthenticationOptions.getAwsStsHeaderOverrides())
+                .build();
+
+        return awsCredentialsSupplier.getProvider(options);
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ClientBuilderFactory.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ClientBuilderFactory.java
@@ -6,6 +6,7 @@ package org.opensearch.dataprepper.plugins.source;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -19,10 +20,12 @@ import java.time.Duration;
 public class S3ClientBuilderFactory {
     private static final Logger LOG = LoggerFactory.getLogger(S3ClientBuilderFactory.class);
     private final S3SourceConfig s3SourceConfig;
+    private final AwsCredentialsProvider credentialsProvider;
     private final S3Client s3Client;
     private final S3AsyncClient s3AsyncClient;
-    public S3ClientBuilderFactory(final S3SourceConfig s3SourceConfig){
+    public S3ClientBuilderFactory(final S3SourceConfig s3SourceConfig, AwsCredentialsProvider credentialsProvider){
         this.s3SourceConfig = s3SourceConfig;
+        this.credentialsProvider = credentialsProvider;
         this.s3Client = createS3Client();
         this.s3AsyncClient = createS3AsyncClient();
     }
@@ -34,7 +37,7 @@ public class S3ClientBuilderFactory {
         LOG.info("Creating S3 client");
             return S3Client.builder()
                 .region(s3SourceConfig.getAwsAuthenticationOptions().getAwsRegion())
-                .credentialsProvider(s3SourceConfig.getAwsAuthenticationOptions().authenticateAwsConfiguration())
+                .credentialsProvider(credentialsProvider)
                     .overrideConfiguration(ClientOverrideConfiguration.builder()
                             .retryPolicy(retryPolicy -> retryPolicy.numRetries(5).build())
                             .build())
@@ -52,7 +55,7 @@ public class S3ClientBuilderFactory {
                 .httpClient(NettyNioAsyncHttpClient.builder()
                         .maxConcurrency(200)
                         .connectionTimeout(Duration.ofMinutes(1)).build())
-                .credentialsProvider(s3SourceConfig.getAwsAuthenticationOptions().authenticateAwsConfiguration())
+                .credentialsProvider(credentialsProvider)
                 .overrideConfiguration(ClientOverrideConfiguration.builder()
                         .retryPolicy(retryPolicy -> retryPolicy.numRetries(5).build())
                         .build())

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3Source.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3Source.java
@@ -5,7 +5,9 @@
 
 package org.opensearch.dataprepper.plugins.source;
 
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -16,15 +18,15 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
-import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.UsesSourceCoordination;
 import org.opensearch.dataprepper.plugins.source.configuration.S3ScanScanOptions;
-import org.opensearch.dataprepper.plugins.source.ownership.BucketOwnerProvider;
-import org.opensearch.dataprepper.plugins.source.ownership.ConfigBucketOwnerProviderFactory;
-import org.opensearch.dataprepper.plugins.source.configuration.S3SelectOptions;
 import org.opensearch.dataprepper.plugins.source.configuration.S3SelectCSVOption;
 import org.opensearch.dataprepper.plugins.source.configuration.S3SelectJsonOption;
+import org.opensearch.dataprepper.plugins.source.configuration.S3SelectOptions;
+import org.opensearch.dataprepper.plugins.source.ownership.BucketOwnerProvider;
+import org.opensearch.dataprepper.plugins.source.ownership.ConfigBucketOwnerProviderFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.s3.model.CompressionType;
 
 import java.util.Objects;
@@ -41,18 +43,25 @@ public class S3Source implements Source<Record<Event>>, UsesSourceCoordination {
     private final PluginFactory pluginFactory;
     private final Optional<S3ScanScanOptions> s3ScanScanOptional;
     private final AcknowledgementSetManager acknowledgementSetManager;
+    private final AwsCredentialsSupplier awsCredentialsSupplier;
     private final boolean acknowledgementsEnabled;
     private SourceCoordinator<S3SourceProgressState> sourceCoordinator;
 
 
     @DataPrepperPluginConstructor
-    public S3Source(PluginMetrics pluginMetrics, final S3SourceConfig s3SourceConfig, final PluginFactory pluginFactory, final AcknowledgementSetManager acknowledgementSetManager) {
+    public S3Source(
+            final PluginMetrics pluginMetrics,
+            final S3SourceConfig s3SourceConfig,
+            final PluginFactory pluginFactory,
+            final AcknowledgementSetManager acknowledgementSetManager,
+            final AwsCredentialsSupplier awsCredentialsSupplier) {
         this.pluginMetrics = pluginMetrics;
         this.s3SourceConfig = s3SourceConfig;
         this.pluginFactory = pluginFactory;
         this.s3ScanScanOptional = Optional.ofNullable(s3SourceConfig.getS3ScanScanOptions());
         this.acknowledgementsEnabled = s3SourceConfig.getAcknowledgements();
-        this.acknowledgementSetManager = acknowledgementSetManager;   
+        this.acknowledgementSetManager = acknowledgementSetManager;
+        this.awsCredentialsSupplier = awsCredentialsSupplier;
     }
 
     @Override
@@ -65,12 +74,14 @@ public class S3Source implements Source<Record<Event>>, UsesSourceCoordination {
         if (buffer == null) {
             throw new IllegalStateException("Buffer provided is null");
         }
+        final AwsAuthenticationAdapter awsAuthenticationAdapter = new AwsAuthenticationAdapter(awsCredentialsSupplier, s3SourceConfig);
+        final AwsCredentialsProvider credentialsProvider = awsAuthenticationAdapter.getCredentialsProvider();
         final ConfigBucketOwnerProviderFactory configBucketOwnerProviderFactory = new ConfigBucketOwnerProviderFactory();
         final BucketOwnerProvider bucketOwnerProvider = configBucketOwnerProviderFactory.createBucketOwnerProvider(s3SourceConfig);
         Optional<S3SelectOptions> s3SelectOptional = Optional.ofNullable(s3SourceConfig.getS3SelectOptions());
         S3ObjectPluginMetrics s3ObjectPluginMetrics = new S3ObjectPluginMetrics(pluginMetrics);
 
-        S3ClientBuilderFactory s3ClientBuilderFactory = new S3ClientBuilderFactory(s3SourceConfig);
+        S3ClientBuilderFactory s3ClientBuilderFactory = new S3ClientBuilderFactory(s3SourceConfig, credentialsProvider);
         final S3ObjectHandler s3Handler;
         final S3ObjectRequest.Builder s3ObjectRequestBuilder = new S3ObjectRequest.Builder(buffer, s3SourceConfig.getNumberOfRecordsToAccumulate(),
                 s3SourceConfig.getBufferTimeout(), s3ObjectPluginMetrics);
@@ -107,7 +118,7 @@ public class S3Source implements Source<Record<Event>>, UsesSourceCoordination {
         }
         if(Objects.nonNull(s3SourceConfig.getSqsOptions())) {
             final S3Service s3Service = new S3Service(s3Handler);
-            sqsService = new SqsService(acknowledgementSetManager, s3SourceConfig, s3Service, pluginMetrics);
+            sqsService = new SqsService(acknowledgementSetManager, s3SourceConfig, s3Service, pluginMetrics, credentialsProvider);
             sqsService.start();
         }
         if(s3ScanScanOptional.isPresent()) {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/AwsAuthenticationOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/AwsAuthenticationOptions.java
@@ -8,16 +8,10 @@ package org.opensearch.dataprepper.plugins.source.configuration;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Size;
 import software.amazon.awssdk.arns.Arn;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.sts.StsClient;
-import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
-import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 public class AwsAuthenticationOptions {
     private static final String AWS_IAM_ROLE = "role";
@@ -62,36 +56,8 @@ public class AwsAuthenticationOptions {
         return awsRegion != null ? Region.of(awsRegion) : null;
     }
 
-    public AwsCredentialsProvider authenticateAwsConfiguration() {
-
-        final AwsCredentialsProvider awsCredentialsProvider;
-        if (awsStsRoleArn != null && !awsStsRoleArn.isEmpty()) {
-
-            validateStsRoleArn();
-
-            final StsClient stsClient = StsClient.builder()
-                    .region(getAwsRegion())
-                    .build();
-
-            AssumeRoleRequest.Builder assumeRoleRequestBuilder = AssumeRoleRequest.builder()
-                    .roleSessionName("S3-Source-" + UUID.randomUUID())
-                    .roleArn(awsStsRoleArn);
-            if(awsStsHeaderOverrides != null && !awsStsHeaderOverrides.isEmpty()) {
-                assumeRoleRequestBuilder = assumeRoleRequestBuilder
-                        .overrideConfiguration(configuration -> awsStsHeaderOverrides.forEach(configuration::putHeader));
-            }
-
-            awsCredentialsProvider = StsAssumeRoleCredentialsProvider.builder()
-                    .stsClient(stsClient)
-                    .refreshRequest(assumeRoleRequestBuilder.build())
-                    .build();
-
-        } else {
-            // use default credential provider
-            awsCredentialsProvider = DefaultCredentialsProvider.create();
-        }
-
-        return awsCredentialsProvider;
+    public Map<String, String> getAwsStsHeaderOverrides() {
+        return awsStsHeaderOverrides;
     }
 }
 

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/AwsAuthenticationAdapterTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/AwsAuthenticationAdapterTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.plugins.source.configuration.AwsAuthenticationOptions;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AwsAuthenticationAdapterTest {
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
+    @Mock
+    private S3SourceConfig s3SourceConfig;
+
+    @Mock
+    private AwsAuthenticationOptions awsAuthenticationOptions;
+    private String stsRoleArn;
+
+    @BeforeEach
+    void setUp() {
+        when(s3SourceConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
+
+        stsRoleArn = UUID.randomUUID().toString();
+        when(awsAuthenticationOptions.getAwsStsRoleArn()).thenReturn(stsRoleArn);
+    }
+
+    private AwsAuthenticationAdapter createObjectUnderTest() {
+        return new AwsAuthenticationAdapter(awsCredentialsSupplier, s3SourceConfig);
+    }
+
+    @Test
+    void getCredentialsProvider_returns_AwsCredentialsProvider_from_AwsCredentialsSupplier() {
+        final AwsCredentialsProvider expectedProvider = mock(AwsCredentialsProvider.class);
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class)))
+                .thenReturn(expectedProvider);
+
+        assertThat(createObjectUnderTest().getCredentialsProvider(), equalTo(expectedProvider));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"us-east-1", "eu-west-1"})
+    void getCredentialsProvider_creates_expected_AwsCredentialsOptions(final String regionString) {
+
+        final Region region = Region.of(regionString);
+
+        final Map<String, String> headerOverrides = Collections.singletonMap(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        when(awsAuthenticationOptions.getAwsRegion()).thenReturn(region);
+        when(awsAuthenticationOptions.getAwsStsHeaderOverrides()).thenReturn(headerOverrides);
+
+        createObjectUnderTest().getCredentialsProvider();
+
+        final ArgumentCaptor<AwsCredentialsOptions> credentialsOptionsArgumentCaptor = ArgumentCaptor.forClass(AwsCredentialsOptions.class);
+        verify(awsCredentialsSupplier).getProvider(credentialsOptionsArgumentCaptor.capture());
+
+        final AwsCredentialsOptions actualOptions = credentialsOptionsArgumentCaptor.getValue();
+
+        assertThat(actualOptions, notNullValue());
+        assertThat(actualOptions.getStsRoleArn(), equalTo(stsRoleArn));
+        assertThat(actualOptions.getRegion(), equalTo(region));
+        assertThat(actualOptions.getStsHeaderOverrides(), equalTo(headerOverrides));
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SourceTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3SourceTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.source;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
@@ -25,6 +26,7 @@ class S3SourceTest {
     private S3SourceConfig s3SourceConfig;
     private PluginFactory pluginFactory;
     private AcknowledgementSetManager acknowledgementSetManager;
+    private AwsCredentialsSupplier awsCredentialsSupplier;
 
 
     @BeforeEach
@@ -33,10 +35,11 @@ class S3SourceTest {
         s3SourceConfig = mock(S3SourceConfig.class);
         pluginFactory = mock(PluginFactory.class);
         acknowledgementSetManager = mock(AcknowledgementSetManager.class);
+        awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
 
         when(s3SourceConfig.getCodec()).thenReturn(mock(PluginModel.class));
 
-        s3Source = new S3Source(pluginMetrics, s3SourceConfig, pluginFactory, acknowledgementSetManager);
+        s3Source = new S3Source(pluginMetrics, s3SourceConfig, pluginFactory, acknowledgementSetManager, awsCredentialsSupplier);
     }
 
     @Test

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/configuration/AwsAuthenticationOptionsTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/configuration/AwsAuthenticationOptionsTest.java
@@ -6,42 +6,22 @@
 package org.opensearch.dataprepper.plugins.source.configuration;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.sts.StsClient;
-import software.amazon.awssdk.services.sts.StsClientBuilder;
-import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
-import java.util.Map;
 import java.util.UUID;
-import java.util.function.Consumer;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 class AwsAuthenticationOptionsTest {
 
     private AwsAuthenticationOptions awsAuthenticationOptions;
-
-    private final String TEST_ROLE = "arn:aws:iam::123456789012:role/test-role";
 
     @BeforeEach
     void setUp() {
@@ -65,159 +45,6 @@ class AwsAuthenticationOptionsTest {
     void getAwsRegion_returns_null_when_region_is_null() throws NoSuchFieldException, IllegalAccessException {
         reflectivelySetField(awsAuthenticationOptions, "awsRegion", null);
         assertThat(awsAuthenticationOptions.getAwsRegion(), nullValue());
-    }
-
-    @Test
-    void authenticateAWSConfiguration_should_return_s3Client_without_sts_role_arn() throws NoSuchFieldException, IllegalAccessException {
-        reflectivelySetField(awsAuthenticationOptions, "awsRegion", "us-east-1");
-        reflectivelySetField(awsAuthenticationOptions, "awsStsRoleArn", null);
-
-        final DefaultCredentialsProvider mockedCredentialsProvider = mock(DefaultCredentialsProvider.class);
-        final AwsCredentialsProvider actualCredentialsProvider;
-        try (final MockedStatic<DefaultCredentialsProvider> defaultCredentialsProviderMockedStatic = mockStatic(DefaultCredentialsProvider.class)) {
-            defaultCredentialsProviderMockedStatic.when(DefaultCredentialsProvider::create)
-                    .thenReturn(mockedCredentialsProvider);
-            actualCredentialsProvider = awsAuthenticationOptions.authenticateAwsConfiguration();
-        }
-
-        assertThat(actualCredentialsProvider, sameInstance(mockedCredentialsProvider));
-    }
-
-    @Nested
-    class WithSts {
-        private StsClient stsClient;
-        private StsClientBuilder stsClientBuilder;
-
-        @BeforeEach
-        void setUp() {
-            stsClient = mock(StsClient.class);
-            stsClientBuilder = mock(StsClientBuilder.class);
-
-            when(stsClientBuilder.build()).thenReturn(stsClient);
-        }
-
-        @Test
-        void authenticateAWSConfiguration_should_return_s3Client_with_sts_role_arn() throws NoSuchFieldException, IllegalAccessException {
-            reflectivelySetField(awsAuthenticationOptions, "awsRegion", "us-east-1");
-            reflectivelySetField(awsAuthenticationOptions, "awsStsRoleArn", TEST_ROLE);
-
-            when(stsClientBuilder.region(Region.US_EAST_1)).thenReturn(stsClientBuilder);
-            final AssumeRoleRequest.Builder assumeRoleRequestBuilder = mock(AssumeRoleRequest.Builder.class);
-            when(assumeRoleRequestBuilder.roleSessionName(anyString()))
-                    .thenReturn(assumeRoleRequestBuilder);
-            when(assumeRoleRequestBuilder.roleArn(anyString()))
-                    .thenReturn(assumeRoleRequestBuilder);
-
-            final AwsCredentialsProvider actualCredentialsProvider;
-            try (final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
-                 final MockedStatic<AssumeRoleRequest> assumeRoleRequestMockedStatic = mockStatic(AssumeRoleRequest.class)) {
-                stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
-                assumeRoleRequestMockedStatic.when(AssumeRoleRequest::builder).thenReturn(assumeRoleRequestBuilder);
-                actualCredentialsProvider = awsAuthenticationOptions.authenticateAwsConfiguration();
-            }
-
-            assertThat(actualCredentialsProvider, instanceOf(AwsCredentialsProvider.class));
-
-            verify(assumeRoleRequestBuilder).roleArn(TEST_ROLE);
-            verify(assumeRoleRequestBuilder).roleSessionName(anyString());
-            verify(assumeRoleRequestBuilder).build();
-            verifyNoMoreInteractions(assumeRoleRequestBuilder);
-        }
-
-        @Test
-        void authenticateAWSConfiguration_should_return_s3Client_with_sts_role_arn_when_no_region() throws NoSuchFieldException, IllegalAccessException {
-            reflectivelySetField(awsAuthenticationOptions, "awsRegion", null);
-            reflectivelySetField(awsAuthenticationOptions, "awsStsRoleArn", TEST_ROLE);
-            assertThat(awsAuthenticationOptions.getAwsRegion(), equalTo(null));
-
-            when(stsClientBuilder.region(null)).thenReturn(stsClientBuilder);
-
-            final AwsCredentialsProvider actualCredentialsProvider;
-            try (final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class)) {
-                stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
-                actualCredentialsProvider = awsAuthenticationOptions.authenticateAwsConfiguration();
-            }
-
-            assertThat(actualCredentialsProvider, instanceOf(AwsCredentialsProvider.class));
-        }
-
-        @Test
-        void authenticateAWSConfiguration_should_override_STS_Headers_when_HeaderOverrides_when_set() throws NoSuchFieldException, IllegalAccessException {
-            final String headerName1 = UUID.randomUUID().toString();
-            final String headerValue1 = UUID.randomUUID().toString();
-            final String headerName2 = UUID.randomUUID().toString();
-            final String headerValue2 = UUID.randomUUID().toString();
-            final Map<String, String> overrideHeaders = Map.of(headerName1, headerValue1, headerName2, headerValue2);
-
-            reflectivelySetField(awsAuthenticationOptions, "awsRegion", "us-east-1");
-            reflectivelySetField(awsAuthenticationOptions, "awsStsRoleArn", TEST_ROLE);
-            reflectivelySetField(awsAuthenticationOptions, "awsStsHeaderOverrides", overrideHeaders);
-
-            when(stsClientBuilder.region(Region.US_EAST_1)).thenReturn(stsClientBuilder);
-
-            final AssumeRoleRequest.Builder assumeRoleRequestBuilder = mock(AssumeRoleRequest.Builder.class);
-            when(assumeRoleRequestBuilder.roleSessionName(anyString()))
-                    .thenReturn(assumeRoleRequestBuilder);
-            when(assumeRoleRequestBuilder.roleArn(anyString()))
-                    .thenReturn(assumeRoleRequestBuilder);
-            when(assumeRoleRequestBuilder.overrideConfiguration(any(Consumer.class)))
-                    .thenReturn(assumeRoleRequestBuilder);
-
-            final AwsCredentialsProvider actualCredentialsProvider;
-            try (final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
-                 final MockedStatic<AssumeRoleRequest> assumeRoleRequestMockedStatic = mockStatic(AssumeRoleRequest.class)) {
-                stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
-                assumeRoleRequestMockedStatic.when(AssumeRoleRequest::builder).thenReturn(assumeRoleRequestBuilder);
-                actualCredentialsProvider = awsAuthenticationOptions.authenticateAwsConfiguration();
-            }
-
-            assertThat(actualCredentialsProvider, instanceOf(AwsCredentialsProvider.class));
-
-            final ArgumentCaptor<Consumer<AwsRequestOverrideConfiguration.Builder>> configurationCaptor = ArgumentCaptor.forClass(Consumer.class);
-
-            verify(assumeRoleRequestBuilder).roleArn(TEST_ROLE);
-            verify(assumeRoleRequestBuilder).roleSessionName(anyString());
-            verify(assumeRoleRequestBuilder).overrideConfiguration(configurationCaptor.capture());
-            verify(assumeRoleRequestBuilder).build();
-            verifyNoMoreInteractions(assumeRoleRequestBuilder);
-
-            final Consumer<AwsRequestOverrideConfiguration.Builder> actualOverride = configurationCaptor.getValue();
-
-            final AwsRequestOverrideConfiguration.Builder configurationBuilder = mock(AwsRequestOverrideConfiguration.Builder.class);
-            actualOverride.accept(configurationBuilder);
-            verify(configurationBuilder).putHeader(headerName1, headerValue1);
-            verify(configurationBuilder).putHeader(headerName2, headerValue2);
-            verifyNoMoreInteractions(configurationBuilder);
-        }
-
-        @Test
-        void authenticateAWSConfiguration_should_not_override_STS_Headers_when_HeaderOverrides_are_empty() throws NoSuchFieldException, IllegalAccessException {
-            reflectivelySetField(awsAuthenticationOptions, "awsRegion", "us-east-1");
-            reflectivelySetField(awsAuthenticationOptions, "awsStsRoleArn", TEST_ROLE);
-            reflectivelySetField(awsAuthenticationOptions, "awsStsHeaderOverrides", Collections.emptyMap());
-
-            when(stsClientBuilder.region(Region.US_EAST_1)).thenReturn(stsClientBuilder);
-            final AssumeRoleRequest.Builder assumeRoleRequestBuilder = mock(AssumeRoleRequest.Builder.class);
-            when(assumeRoleRequestBuilder.roleSessionName(anyString()))
-                    .thenReturn(assumeRoleRequestBuilder);
-            when(assumeRoleRequestBuilder.roleArn(anyString()))
-                    .thenReturn(assumeRoleRequestBuilder);
-
-            final AwsCredentialsProvider actualCredentialsProvider;
-            try (final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
-                 final MockedStatic<AssumeRoleRequest> assumeRoleRequestMockedStatic = mockStatic(AssumeRoleRequest.class)) {
-                stsClientMockedStatic.when(StsClient::builder).thenReturn(stsClientBuilder);
-                assumeRoleRequestMockedStatic.when(AssumeRoleRequest::builder).thenReturn(assumeRoleRequestBuilder);
-                actualCredentialsProvider = awsAuthenticationOptions.authenticateAwsConfiguration();
-            }
-
-            assertThat(actualCredentialsProvider, instanceOf(AwsCredentialsProvider.class));
-
-            verify(assumeRoleRequestBuilder).roleArn(TEST_ROLE);
-            verify(assumeRoleRequestBuilder).roleSessionName(anyString());
-            verify(assumeRoleRequestBuilder).build();
-            verifyNoMoreInteractions(assumeRoleRequestBuilder);
-        }
     }
 
     private void reflectivelySetField(final AwsAuthenticationOptions awsAuthenticationOptions, final String fieldName, final Object value) throws NoSuchFieldException, IllegalAccessException {


### PR DESCRIPTION
### Description

Updates the `s3` source to use the aws-plugin for loading AWS credentials.
 
### Issues Resolved

Resolves #2766.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
