### PR TITLE
Fix failing S3ScanObjectWorkerIT tests by creating a source coordinator for these tests to use

### DIFF
--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     testImplementation project(':data-prepper-plugins:parse-json-processor')
     testImplementation project(':data-prepper-plugins:newline-codecs')
     testImplementation project(':data-prepper-plugins:avro-codecs')
+    testImplementation project(':data-prepper-plugins:in-memory-source-coordination-store')
+    testImplementation project(':data-prepper-core')
     constraints {
         testImplementation('org.eclipse.jetty:jetty-bom') {
             version {


### PR DESCRIPTION
### Description
Create a source coordinator and in memory store for use in the s3 scan integration tests

Ran all tests for `S3ScanObjectWorker` locally. All passed but the parquet tests, which were already not working.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
