### PR TITLE
Enable TTL for the ddb source coordination store, add option to skip store creation to source coordination config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ subprojects {
     jacocoTestReport {
         dependsOn test // tests are required to run before generating the report
         reports {
-            xml.enabled true
+            xml.required
         }
     }
 
@@ -204,8 +204,8 @@ configure(coreProjects) {
     jacocoTestReport {
         dependsOn test // tests are required to run before generating the report
         reports {
-            xml.enabled true
-            csv.enabled false
+            xml.required
+            csv.required
             html.destination file("${buildDir}/reports/jacocoHtml")
         }
     }

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientFactory.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientFactory.java
@@ -12,7 +12,6 @@ import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
 import software.amazon.awssdk.core.retry.backoff.EqualJitterBackoffStrategy;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -32,15 +31,11 @@ public class DynamoDbClientFactory {
     private static final long DYNAMO_CLIENT_BASE_BACKOFF_MILLIS = 1000L;
     private static final long DYNAMO_CLIENT_MAX_BACKOFF_MILLIS = 60000L;
 
-    public static DynamoDbEnhancedClient provideDynamoDbEnhancedClient(final String region, final String stsRoleArn) {
-        final DynamoDbClient dynamoDbClient = DynamoDbClient.builder()
+    public static DynamoDbClient provideDynamoDbClient(final String region, final String stsRoleArn) {
+        return DynamoDbClient.builder()
                 .region(Region.of(region))
                 .credentialsProvider(getAwsCredentials(Region.of(region), stsRoleArn))
                 .overrideConfiguration(getClientOverrideConfiguration())
-                .build();
-
-        return DynamoDbEnhancedClient.builder()
-                .dynamoDbClient(dynamoDbClient)
                 .build();
     }
 

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
@@ -24,14 +24,20 @@ import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTimeToLiveRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTimeToLiveResponse;
 import software.amazon.awssdk.services.dynamodb.model.Projection;
 import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 import software.amazon.awssdk.services.dynamodb.model.ResourceInUseException;
+import software.amazon.awssdk.services.dynamodb.model.TimeToLiveSpecification;
+import software.amazon.awssdk.services.dynamodb.model.TimeToLiveStatus;
+import software.amazon.awssdk.services.dynamodb.model.UpdateTimeToLiveRequest;
 import software.amazon.awssdk.services.dynamodb.waiters.DynamoDbWaiter;
 
 import java.time.Duration;
@@ -46,52 +52,79 @@ public class DynamoDbClientWrapper {
 
     private static final Logger LOG = LoggerFactory.getLogger(DynamoDbClientWrapper.class);
     static final String SOURCE_STATUS_COMBINATION_KEY_GLOBAL_SECONDARY_INDEX = "source-status";
+    static final String TTL_ATTRIBUTE_NAME = "expirationTime";
 
     static final String ITEM_DOES_NOT_EXIST_EXPRESSION = "attribute_not_exists(sourceIdentifier) or attribute_not_exists(sourcePartitionKey)";
     static final String ITEM_EXISTS_AND_HAS_LATEST_VERSION = "attribute_exists(sourceIdentifier) and attribute_exists(sourcePartitionKey) and version = :v";
 
     private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
+    private final DynamoDbClient dynamoDbClient;
     private DynamoDbTable<DynamoDbSourcePartitionItem> table;
 
 
     private DynamoDbClientWrapper(final String region, final String stsRoleArn) {
-        this.dynamoDbEnhancedClient = DynamoDbClientFactory.provideDynamoDbEnhancedClient(region, stsRoleArn);
+        this.dynamoDbClient = DynamoDbClientFactory.provideDynamoDbClient(region, stsRoleArn);
+        this.dynamoDbEnhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build();
     }
 
     public static DynamoDbClientWrapper create(final String region, final String stsRoleArn) {
         return new DynamoDbClientWrapper(region, stsRoleArn);
     }
 
-    public void tryCreateTable(final String tableName,
-                               final ProvisionedThroughput provisionedThroughput) {
-
-        this.table = dynamoDbEnhancedClient.table(tableName, TableSchema.fromBean(DynamoDbSourcePartitionItem.class));
-
-        try {
-            final CreateTableEnhancedRequest createTableEnhancedRequest = CreateTableEnhancedRequest.builder()
-                            .provisionedThroughput(provisionedThroughput)
-                            .globalSecondaryIndices(EnhancedGlobalSecondaryIndex.builder()
-                                    .indexName(SOURCE_STATUS_COMBINATION_KEY_GLOBAL_SECONDARY_INDEX)
-                                    .provisionedThroughput(provisionedThroughput)
-                                    .projection(Projection.builder().projectionType(ProjectionType.ALL).build())
-                                    .build())
-                            .build();
-            table.createTable(createTableEnhancedRequest);
-        } catch (final ResourceInUseException e) {
-            LOG.info("The table creation for {} was already triggered by another instance of data prepper", tableName);
+    public void initializeTable(final DynamoStoreSettings dynamoStoreSettings,
+                                final ProvisionedThroughput provisionedThroughput) {
+        this.table = dynamoDbEnhancedClient.table(dynamoStoreSettings.getTableName(), TableSchema.fromBean(DynamoDbSourcePartitionItem.class));
+        if (!dynamoStoreSettings.skipTableCreation()) {
+            try {
+                final CreateTableEnhancedRequest createTableEnhancedRequest = CreateTableEnhancedRequest.builder()
+                        .provisionedThroughput(provisionedThroughput)
+                        .globalSecondaryIndices(EnhancedGlobalSecondaryIndex.builder()
+                                .indexName(SOURCE_STATUS_COMBINATION_KEY_GLOBAL_SECONDARY_INDEX)
+                                .provisionedThroughput(provisionedThroughput)
+                                .projection(Projection.builder().projectionType(ProjectionType.ALL).build())
+                                .build())
+                        .build();
+                table.createTable(createTableEnhancedRequest);
+            } catch (final ResourceInUseException e) {
+                LOG.info("The table creation for {} was already triggered by another instance of data prepper", dynamoStoreSettings.getTableName());
+            }
         }
 
         try(final DynamoDbWaiter dynamoDbWaiter = DynamoDbWaiter.create()) {
-            final DescribeTableRequest describeTableRequest = DescribeTableRequest.builder().tableName(tableName).build();
+            final DescribeTableRequest describeTableRequest = DescribeTableRequest.builder().tableName(dynamoStoreSettings.getTableName()).build();
             final ResponseOrException<DescribeTableResponse> response = dynamoDbWaiter
                     .waitUntilTableExists(describeTableRequest)
                     .matched();
 
             final DescribeTableResponse describeTableResponse = response.response().orElseThrow(
-                    () -> new RuntimeException(String.format("Table %s was not created successfully", tableName))
+                    () -> new RuntimeException(String.format("DynamoDb Table %s could not be found.", dynamoStoreSettings.getTableName()))
             );
 
-            LOG.info("DynamoDB table {} was created successfully for source coordination", describeTableResponse.table().tableName());
+            LOG.debug("DynamoDB table {} was created successfully for source coordination", describeTableResponse.table().tableName());
+
+            if (Objects.nonNull(dynamoStoreSettings.getTtl())) {
+                if (!dynamoStoreSettings.skipTableCreation()) {
+                    dynamoDbClient.updateTimeToLive(UpdateTimeToLiveRequest.builder()
+                            .tableName(table.tableName())
+                            .timeToLiveSpecification(TimeToLiveSpecification.builder()
+                                    .attributeName(TTL_ATTRIBUTE_NAME)
+                                    .enabled(Objects.nonNull(dynamoStoreSettings.getTtl()))
+                                    .build())
+                            .build());
+                }
+
+                final DescribeTimeToLiveResponse describeTimeToLiveResponse = dynamoDbClient.describeTimeToLive(DescribeTimeToLiveRequest.builder()
+                        .tableName(table.tableName())
+                        .build());
+
+                if (Objects.isNull(describeTimeToLiveResponse.timeToLiveDescription()) ||
+                    !TTL_ATTRIBUTE_NAME.equals(describeTimeToLiveResponse.timeToLiveDescription().attributeName()) ||
+                    !TimeToLiveStatus.ENABLED.equals(describeTimeToLiveResponse.timeToLiveDescription().timeToLiveStatus())) {
+                    throw new RuntimeException(String.format("TTL is set for the DynamoDb source coordination store, " +
+                            "but the necessary TTL is not enabled on the table. To use TTL with source coordination to clean up COMPLETED partitions, " +
+                            "the table must have TTL enabled on the %s attribute.", TTL_ATTRIBUTE_NAME));
+                }
+            }
         }
     }
 

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
@@ -111,18 +111,18 @@ public class DynamoDbClientWrapper {
                                     .enabled(Objects.nonNull(dynamoStoreSettings.getTtl()))
                                     .build())
                             .build());
-                }
+                } else {
+                    final DescribeTimeToLiveResponse describeTimeToLiveResponse = dynamoDbClient.describeTimeToLive(DescribeTimeToLiveRequest.builder()
+                            .tableName(table.tableName())
+                            .build());
 
-                final DescribeTimeToLiveResponse describeTimeToLiveResponse = dynamoDbClient.describeTimeToLive(DescribeTimeToLiveRequest.builder()
-                        .tableName(table.tableName())
-                        .build());
-
-                if (Objects.isNull(describeTimeToLiveResponse.timeToLiveDescription()) ||
-                    !TTL_ATTRIBUTE_NAME.equals(describeTimeToLiveResponse.timeToLiveDescription().attributeName()) ||
-                    !TimeToLiveStatus.ENABLED.equals(describeTimeToLiveResponse.timeToLiveDescription().timeToLiveStatus())) {
-                    throw new RuntimeException(String.format("TTL is set for the DynamoDb source coordination store, " +
-                            "but the necessary TTL is not enabled on the table. To use TTL with source coordination to clean up COMPLETED partitions, " +
-                            "the table must have TTL enabled on the %s attribute.", TTL_ATTRIBUTE_NAME));
+                    if (Objects.isNull(describeTimeToLiveResponse.timeToLiveDescription()) ||
+                            !TTL_ATTRIBUTE_NAME.equals(describeTimeToLiveResponse.timeToLiveDescription().attributeName()) ||
+                            !TimeToLiveStatus.ENABLED.equals(describeTimeToLiveResponse.timeToLiveDescription().timeToLiveStatus())) {
+                        throw new RuntimeException(String.format("TTL is set for the DynamoDb source coordination store, " +
+                                "but the necessary TTL is not enabled on the table. To use TTL with source coordination to clean up COMPLETED partitions, " +
+                                "the table must have TTL enabled on the %s attribute.", TTL_ATTRIBUTE_NAME));
+                    }
                 }
             }
         }

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourcePartitionItem.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourcePartitionItem.java
@@ -29,6 +29,7 @@ public class DynamoDbSourcePartitionItem implements SourcePartitionStoreItem {
     private Long closedCount;
     private String sourceStatusCombinationKey;
     private String partitionPriority;
+    private Long expirationTime;
 
     @Override
     @DynamoDbPartitionKey
@@ -51,6 +52,8 @@ public class DynamoDbSourcePartitionItem implements SourcePartitionStoreItem {
     public String getPartitionPriority() {
         return partitionPriority;
     }
+
+    public Long getExpirationTime() { return expirationTime; }
 
     @Override
     public String getPartitionOwner() {
@@ -128,5 +131,9 @@ public class DynamoDbSourcePartitionItem implements SourcePartitionStoreItem {
 
     public void setPartitionPriority(final String partitionPriority) {
         this.partitionPriority = partitionPriority;
+    }
+
+    public void setExpirationTime(final Long expirationTime) {
+        this.expirationTime = expirationTime;
     }
 }

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoStoreSettings.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoStoreSettings.java
@@ -9,6 +9,7 @@ package org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.time.Duration;
 import java.util.Objects;
 
 /**
@@ -23,23 +24,32 @@ public class DynamoStoreSettings {
     private final String tableName;
     private final String region;
     private final String stsRoleArn;
+    private final Duration ttl;
+
 
     private Long provisionedReadCapacityUnits = DEFAULT_PROVISIONED_READ_CAPACITY_UNITS;
     private Long provisionedWriteCapacityUnits = DEFAULT_PROVISIONED_WRITE_CAPACITY_UNITS;
+    private Boolean skipTableCreation = false;
 
     @JsonCreator
     public DynamoStoreSettings(@JsonProperty("table_name") final String tableName,
                                @JsonProperty("region") final String region,
                                @JsonProperty("sts_role_arn") final String stsRoleArn,
+                               @JsonProperty("skip_table_creation") final Boolean skipTableCreation,
                                @JsonProperty("provisioned_read_capacity_units") final Long provisionedReadCapacityUnits,
-                               @JsonProperty("provisioned_write_capacity_units") final Long provisionedWriteCapacityUnits) {
+                               @JsonProperty("provisioned_write_capacity_units") final Long provisionedWriteCapacityUnits,
+                               @JsonProperty("ttl") final Duration ttl) {
         Objects.requireNonNull(tableName, "table_name is required for dynamo store settings");
         Objects.requireNonNull(region, "region is required for dynamo store settings");
-        Objects.requireNonNull(stsRoleArn, "sts_role_arn is required for dynamo store settings");
 
         this.tableName = tableName;
         this.region = region;
         this.stsRoleArn = stsRoleArn;
+        this.ttl = ttl;
+
+        if (Objects.nonNull(skipTableCreation)) {
+            this.skipTableCreation = skipTableCreation;
+        }
 
         if (Objects.nonNull(provisionedReadCapacityUnits)) {
             this.provisionedReadCapacityUnits = provisionedReadCapacityUnits;
@@ -68,5 +78,13 @@ public class DynamoStoreSettings {
 
     public Long getProvisionedWriteCapacityUnits() {
         return provisionedWriteCapacityUnits;
+    }
+
+    public Duration getTtl() {
+        return ttl;
+    }
+
+    public Boolean skipTableCreation() {
+        return skipTableCreation;
     }
 }

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientFactoryTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientFactoryTest.java
@@ -13,7 +13,6 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
@@ -39,9 +38,6 @@ public class DynamoDbClientFactoryTest {
     @Mock
     private DynamoDbClient dynamoDbClient;
 
-    @Mock
-    private DynamoDbEnhancedClient dynamoDbEnhancedClient;
-
     @BeforeEach
     void setup() {
         region = "us-east-1";
@@ -49,12 +45,11 @@ public class DynamoDbClientFactoryTest {
     }
 
     @Test
-    void provideDynamoDbEnhancedClient_with_null_stsRole_creates_client_with_default_credentials() {
+    void provideDynamoDbClient_with_null_stsRole_creates_client_with_default_credentials() {
 
         try (final MockedStatic<Region> regionMockedStatic = mockStatic(Region.class);
              final MockedStatic<DynamoDbClient> dynamoDbClientMockedStatic = mockStatic(DynamoDbClient.class);
-             final MockedStatic<DefaultCredentialsProvider> defaultCredentialsProviderMockedStatic = mockStatic(DefaultCredentialsProvider.class);
-             final MockedStatic<DynamoDbEnhancedClient> dynamoDbEnhancedClientMockedStatic = mockStatic(DynamoDbEnhancedClient.class)) {
+             final MockedStatic<DefaultCredentialsProvider> defaultCredentialsProviderMockedStatic = mockStatic(DefaultCredentialsProvider.class)) {
             regionMockedStatic.when(() -> Region.of(region)).thenReturn(Region.US_EAST_1);
             final DynamoDbClientBuilder dynamoDbClientBuilder = mock(DynamoDbClientBuilder.class);
             dynamoDbClientMockedStatic.when(DynamoDbClient::builder).thenReturn(dynamoDbClientBuilder);
@@ -66,15 +61,9 @@ public class DynamoDbClientFactoryTest {
             when(dynamoDbClientBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class))).thenReturn(dynamoDbClientBuilder);
             when(dynamoDbClientBuilder.build()).thenReturn(dynamoDbClient);
 
-            final DynamoDbEnhancedClient.Builder builder = mock(DynamoDbEnhancedClient.Builder.class);
+            final DynamoDbClient provideDynamoDbClient = DynamoDbClientFactory.provideDynamoDbClient(region, null);
 
-            dynamoDbEnhancedClientMockedStatic.when(DynamoDbEnhancedClient::builder).thenReturn(builder);
-            when(builder.dynamoDbClient(dynamoDbClient)).thenReturn(builder);
-            when(builder.build()).thenReturn(dynamoDbEnhancedClient);
-
-            final DynamoDbEnhancedClient enhancedClient = DynamoDbClientFactory.provideDynamoDbEnhancedClient(region, null);
-
-            assertThat(enhancedClient, equalTo(dynamoDbEnhancedClient));
+            assertThat(provideDynamoDbClient, equalTo(dynamoDbClient));
         }
     }
 
@@ -85,8 +74,7 @@ public class DynamoDbClientFactoryTest {
              final MockedStatic<DynamoDbClient> dynamoDbClientMockedStatic = mockStatic(DynamoDbClient.class);
              final MockedStatic<StsClient> stsClientMockedStatic = mockStatic(StsClient.class);
              final MockedStatic<AssumeRoleRequest> assumeRoleRequestMockedStatic = mockStatic(AssumeRoleRequest.class);
-             final MockedStatic<StsAssumeRoleCredentialsProvider> stsAssumeRoleCredentialsProviderMockedStatic = mockStatic(StsAssumeRoleCredentialsProvider.class);
-             final MockedStatic<DynamoDbEnhancedClient> dynamoDbEnhancedClientMockedStatic = mockStatic(DynamoDbEnhancedClient.class)) {
+             final MockedStatic<StsAssumeRoleCredentialsProvider> stsAssumeRoleCredentialsProviderMockedStatic = mockStatic(StsAssumeRoleCredentialsProvider.class)) {
             regionMockedStatic.when(() -> Region.of(region)).thenReturn(Region.US_EAST_1);
             final DynamoDbClientBuilder dynamoDbClientBuilder = mock(DynamoDbClientBuilder.class);
             dynamoDbClientMockedStatic.when(DynamoDbClient::builder).thenReturn(dynamoDbClientBuilder);
@@ -119,15 +107,9 @@ public class DynamoDbClientFactoryTest {
             when(dynamoDbClientBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class))).thenReturn(dynamoDbClientBuilder);
             when(dynamoDbClientBuilder.build()).thenReturn(dynamoDbClient);
 
-            final DynamoDbEnhancedClient.Builder builder = mock(DynamoDbEnhancedClient.Builder.class);
+            final DynamoDbClient providedDynamoDbClient = DynamoDbClientFactory.provideDynamoDbClient(region, stsRoleArn);
 
-            dynamoDbEnhancedClientMockedStatic.when(DynamoDbEnhancedClient::builder).thenReturn(builder);
-            when(builder.dynamoDbClient(dynamoDbClient)).thenReturn(builder);
-            when(builder.build()).thenReturn(dynamoDbEnhancedClient);
-
-            final DynamoDbEnhancedClient enhancedClient = DynamoDbClientFactory.provideDynamoDbEnhancedClient(region, stsRoleArn);
-
-            assertThat(enhancedClient, equalTo(dynamoDbEnhancedClient));
+            assertThat(providedDynamoDbClient, equalTo(dynamoDbClient));
         }
     }
 }

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
@@ -131,28 +131,28 @@ public class DynamoDbClientWrapperTest {
 
         doNothing().when(table).createTable(any(CreateTableEnhancedRequest.class));
 
+        final DynamoDbWaiter dynamoDbWaiter = mock(DynamoDbWaiter.class);
+        final WaiterResponse waiterResponse = mock(WaiterResponse.class);
+        final ResponseOrException<DescribeTableResponse> response = mock(ResponseOrException.class);
+        final DescribeTableResponse describeTableResponse = mock(DescribeTableResponse.class);
+        given(response.response()).willReturn(Optional.of(describeTableResponse));
+        given(dynamoDbWaiter.waitUntilTableExists(any(DescribeTableRequest.class))).willReturn(waiterResponse);
+
+        given(waiterResponse.matched()).willReturn(response);
+        final TableDescription tableDescription = mock(TableDescription.class);
+        given(describeTableResponse.table()).willReturn(tableDescription);
+        given(tableDescription.tableName()).willReturn(tableName);
+
+        given(dynamoDbClient.updateTimeToLive(any(UpdateTimeToLiveRequest.class))).willReturn(mock(UpdateTimeToLiveResponse.class));
+        final DescribeTimeToLiveResponse describeTimeToLiveResponse = mock(DescribeTimeToLiveResponse.class);
+        final TimeToLiveDescription timeToLiveDescription = mock(TimeToLiveDescription.class);
+        given(timeToLiveDescription.attributeName()).willReturn(TTL_ATTRIBUTE_NAME);
+        given(timeToLiveDescription.timeToLiveStatus()).willReturn(TimeToLiveStatus.ENABLED);
+        given(describeTimeToLiveResponse.timeToLiveDescription()).willReturn(timeToLiveDescription);
+        given(dynamoDbClient.describeTimeToLive(any(DescribeTimeToLiveRequest.class))).willReturn(describeTimeToLiveResponse);
+
         try (MockedStatic<DynamoDbWaiter> dynamoDbWaiterMockedStatic = mockStatic(DynamoDbWaiter.class)) {
-            final DynamoDbWaiter dynamoDbWaiter = mock(DynamoDbWaiter.class);
             dynamoDbWaiterMockedStatic.when(DynamoDbWaiter::create).thenReturn(dynamoDbWaiter);
-            final WaiterResponse waiterResponse = mock(WaiterResponse.class);
-            final ResponseOrException<DescribeTableResponse> response = mock(ResponseOrException.class);
-            final DescribeTableResponse describeTableResponse = mock(DescribeTableResponse.class);
-            given(response.response()).willReturn(Optional.of(describeTableResponse));
-            given(dynamoDbWaiter.waitUntilTableExists(any(DescribeTableRequest.class))).willReturn(waiterResponse);
-
-            given(waiterResponse.matched()).willReturn(response);
-            final TableDescription tableDescription = mock(TableDescription.class);
-            given(describeTableResponse.table()).willReturn(tableDescription);
-            given(tableDescription.tableName()).willReturn(tableName);
-
-            given(dynamoDbClient.updateTimeToLive(any(UpdateTimeToLiveRequest.class))).willReturn(mock(UpdateTimeToLiveResponse.class));
-            final DescribeTimeToLiveResponse describeTimeToLiveResponse = mock(DescribeTimeToLiveResponse.class);
-            final TimeToLiveDescription timeToLiveDescription = mock(TimeToLiveDescription.class);
-            given(timeToLiveDescription.attributeName()).willReturn(TTL_ATTRIBUTE_NAME);
-            given(timeToLiveDescription.timeToLiveStatus()).willReturn(TimeToLiveStatus.ENABLED);
-            given(describeTimeToLiveResponse.timeToLiveDescription()).willReturn(timeToLiveDescription);
-            given(dynamoDbClient.describeTimeToLive(any(DescribeTimeToLiveRequest.class))).willReturn(describeTimeToLiveResponse);
-
             objectUnderTest.initializeTable(dynamoStoreSettings, provisionedThroughput);
         }
     }
@@ -173,22 +173,20 @@ public class DynamoDbClientWrapperTest {
 
         doThrow(ResourceInUseException.class).when(table).createTable(any(CreateTableEnhancedRequest.class));
 
+        final DynamoDbWaiter dynamoDbWaiter = mock(DynamoDbWaiter.class);
+        final WaiterResponse waiterResponse = mock(WaiterResponse.class);
+        final ResponseOrException<DescribeTableResponse> response = mock(ResponseOrException.class);
+        final DescribeTableResponse describeTableResponse = mock(DescribeTableResponse.class);
+        given(response.response()).willReturn(Optional.of(describeTableResponse));
+        given(dynamoDbWaiter.waitUntilTableExists(any(DescribeTableRequest.class))).willReturn(waiterResponse);
+        given(waiterResponse.matched()).willReturn(response);
+        final TableDescription tableDescription = mock(TableDescription.class);
+        given(describeTableResponse.table()).willReturn(tableDescription);
+        given(tableDescription.tableName()).willReturn(tableName);
+
         try (MockedStatic<DynamoDbWaiter> dynamoDbWaiterMockedStatic = mockStatic(DynamoDbWaiter.class)) {
-            final DynamoDbWaiter dynamoDbWaiter = mock(DynamoDbWaiter.class);
             dynamoDbWaiterMockedStatic.when(DynamoDbWaiter::create).thenReturn(dynamoDbWaiter);
-            final WaiterResponse waiterResponse = mock(WaiterResponse.class);
-            final ResponseOrException<DescribeTableResponse> response = mock(ResponseOrException.class);
-            final DescribeTableResponse describeTableResponse = mock(DescribeTableResponse.class);
-            given(response.response()).willReturn(Optional.of(describeTableResponse));
-            given(dynamoDbWaiter.waitUntilTableExists(any(DescribeTableRequest.class))).willReturn(waiterResponse);
-
-            given(waiterResponse.matched()).willReturn(response);
-            final TableDescription tableDescription = mock(TableDescription.class);
-            given(describeTableResponse.table()).willReturn(tableDescription);
-            given(tableDescription.tableName()).willReturn(tableName);
-
             objectUnderTest.initializeTable(dynamoStoreSettings, provisionedThroughput);
-
             verifyNoInteractions(dynamoDbClient);
         }
     }
@@ -206,15 +204,15 @@ public class DynamoDbClientWrapperTest {
         final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
         given(dynamoDbEnhancedClient.table(eq(tableName), any(BeanTableSchema.class))).willReturn(table);
 
-        try (MockedStatic<DynamoDbWaiter> dynamoDbWaiterMockedStatic = mockStatic(DynamoDbWaiter.class)) {
-            final DynamoDbWaiter dynamoDbWaiter = mock(DynamoDbWaiter.class);
-            dynamoDbWaiterMockedStatic.when(DynamoDbWaiter::create).thenReturn(dynamoDbWaiter);
-            final WaiterResponse waiterResponse = mock(WaiterResponse.class);
-            final ResponseOrException<DescribeTableResponse> response = mock(ResponseOrException.class);
-            given(response.response()).willReturn(Optional.empty());
-            given(dynamoDbWaiter.waitUntilTableExists(any(DescribeTableRequest.class))).willReturn(waiterResponse);
+        final DynamoDbWaiter dynamoDbWaiter = mock(DynamoDbWaiter.class);
+        final WaiterResponse waiterResponse = mock(WaiterResponse.class);
+        final ResponseOrException<DescribeTableResponse> response = mock(ResponseOrException.class);
+        given(response.response()).willReturn(Optional.empty());
+        given(dynamoDbWaiter.waitUntilTableExists(any(DescribeTableRequest.class))).willReturn(waiterResponse);
+        given(waiterResponse.matched()).willReturn(response);
 
-            given(waiterResponse.matched()).willReturn(response);
+        try (MockedStatic<DynamoDbWaiter> dynamoDbWaiterMockedStatic = mockStatic(DynamoDbWaiter.class)) {
+            dynamoDbWaiterMockedStatic.when(DynamoDbWaiter::create).thenReturn(dynamoDbWaiter);
 
             assertThrows(RuntimeException.class, () -> objectUnderTest.initializeTable(dynamoStoreSettings, provisionedThroughput));
         }
@@ -236,26 +234,28 @@ public class DynamoDbClientWrapperTest {
         final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
         given(dynamoDbEnhancedClient.table(eq(tableName), any(BeanTableSchema.class))).willReturn(table);
 
+        final DynamoDbWaiter dynamoDbWaiter = mock(DynamoDbWaiter.class);
+
+        final WaiterResponse waiterResponse = mock(WaiterResponse.class);
+        final ResponseOrException<DescribeTableResponse> response = mock(ResponseOrException.class);
+        final DescribeTableResponse describeTableResponse = mock(DescribeTableResponse.class);
+        given(response.response()).willReturn(Optional.of(describeTableResponse));
+        given(dynamoDbWaiter.waitUntilTableExists(any(DescribeTableRequest.class))).willReturn(waiterResponse);
+
+        given(waiterResponse.matched()).willReturn(response);
+        final TableDescription tableDescription = mock(TableDescription.class);
+        given(describeTableResponse.table()).willReturn(tableDescription);
+        given(tableDescription.tableName()).willReturn(tableName);
+
+        final DescribeTimeToLiveResponse describeTimeToLiveResponse = mock(DescribeTimeToLiveResponse.class);
+        final TimeToLiveDescription timeToLiveDescription = mock(TimeToLiveDescription.class);
+        given(timeToLiveDescription.attributeName()).willReturn(TTL_ATTRIBUTE_NAME);
+        given(timeToLiveDescription.timeToLiveStatus()).willReturn(TimeToLiveStatus.DISABLED);
+        given(describeTimeToLiveResponse.timeToLiveDescription()).willReturn(timeToLiveDescription);
+        given(dynamoDbClient.describeTimeToLive(any(DescribeTimeToLiveRequest.class))).willReturn(describeTimeToLiveResponse);
+
         try (MockedStatic<DynamoDbWaiter> dynamoDbWaiterMockedStatic = mockStatic(DynamoDbWaiter.class)) {
-            final DynamoDbWaiter dynamoDbWaiter = mock(DynamoDbWaiter.class);
             dynamoDbWaiterMockedStatic.when(DynamoDbWaiter::create).thenReturn(dynamoDbWaiter);
-            final WaiterResponse waiterResponse = mock(WaiterResponse.class);
-            final ResponseOrException<DescribeTableResponse> response = mock(ResponseOrException.class);
-            final DescribeTableResponse describeTableResponse = mock(DescribeTableResponse.class);
-            given(response.response()).willReturn(Optional.of(describeTableResponse));
-            given(dynamoDbWaiter.waitUntilTableExists(any(DescribeTableRequest.class))).willReturn(waiterResponse);
-
-            given(waiterResponse.matched()).willReturn(response);
-            final TableDescription tableDescription = mock(TableDescription.class);
-            given(describeTableResponse.table()).willReturn(tableDescription);
-            given(tableDescription.tableName()).willReturn(tableName);
-
-            final DescribeTimeToLiveResponse describeTimeToLiveResponse = mock(DescribeTimeToLiveResponse.class);
-            final TimeToLiveDescription timeToLiveDescription = mock(TimeToLiveDescription.class);
-            given(timeToLiveDescription.attributeName()).willReturn(TTL_ATTRIBUTE_NAME);
-            given(timeToLiveDescription.timeToLiveStatus()).willReturn(TimeToLiveStatus.DISABLED);
-            given(describeTimeToLiveResponse.timeToLiveDescription()).willReturn(timeToLiveDescription);
-            given(dynamoDbClient.describeTimeToLive(any(DescribeTimeToLiveRequest.class))).willReturn(describeTimeToLiveResponse);
 
             assertThrows(RuntimeException.class, () -> objectUnderTest.initializeTable(dynamoStoreSettings, provisionedThroughput));
 

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
@@ -30,12 +30,19 @@ import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTimeToLiveRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTimeToLiveResponse;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 import software.amazon.awssdk.services.dynamodb.model.ResourceInUseException;
 import software.amazon.awssdk.services.dynamodb.model.TableDescription;
+import software.amazon.awssdk.services.dynamodb.model.TimeToLiveDescription;
+import software.amazon.awssdk.services.dynamodb.model.TimeToLiveStatus;
+import software.amazon.awssdk.services.dynamodb.model.UpdateTimeToLiveRequest;
+import software.amazon.awssdk.services.dynamodb.model.UpdateTimeToLiveResponse;
 import software.amazon.awssdk.services.dynamodb.waiters.DynamoDbWaiter;
 
 import java.lang.reflect.Field;
@@ -60,12 +67,15 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb.DynamoDbClientWrapper.ITEM_DOES_NOT_EXIST_EXPRESSION;
 import static org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb.DynamoDbClientWrapper.ITEM_EXISTS_AND_HAS_LATEST_VERSION;
 import static org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb.DynamoDbClientWrapper.SOURCE_STATUS_COMBINATION_KEY_GLOBAL_SECONDARY_INDEX;
+import static org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb.DynamoDbClientWrapper.TTL_ATTRIBUTE_NAME;
 import static org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb.DynamoDbSourceCoordinationStore.SOURCE_STATUS_COMBINATION_KEY_FORMAT;
 
 @ExtendWith(MockitoExtension.class)
@@ -73,6 +83,12 @@ public class DynamoDbClientWrapperTest {
 
     @Mock
     private DynamoDbEnhancedClient dynamoDbEnhancedClient;
+
+    @Mock
+    private DynamoDbClient dynamoDbClient;
+
+    @Mock
+    private DynamoStoreSettings dynamoStoreSettings;
 
     private String region;
     private String stsRoleArn;
@@ -86,19 +102,29 @@ public class DynamoDbClientWrapperTest {
     }
 
     private DynamoDbClientWrapper createObjectUnderTest() {
-        try (final MockedStatic<DynamoDbClientFactory> dynamoDbClientFactoryMockedStatic = mockStatic(DynamoDbClientFactory.class)) {
-              dynamoDbClientFactoryMockedStatic.when(() -> DynamoDbClientFactory.provideDynamoDbEnhancedClient(region, stsRoleArn)).thenReturn(dynamoDbEnhancedClient);
+        try (final MockedStatic<DynamoDbClientFactory> dynamoDbClientFactoryMockedStatic = mockStatic(DynamoDbClientFactory.class);
+             final MockedStatic<DynamoDbEnhancedClient> dynamoDbEnhancedClientMockedStatic = mockStatic(DynamoDbEnhancedClient.class)) {
+              dynamoDbClientFactoryMockedStatic.when(() -> DynamoDbClientFactory.provideDynamoDbClient(region, stsRoleArn)).thenReturn(dynamoDbClient);
+            final DynamoDbEnhancedClient.Builder builder = mock(DynamoDbEnhancedClient.Builder.class);
+
+            dynamoDbEnhancedClientMockedStatic.when(DynamoDbEnhancedClient::builder).thenReturn(builder);
+            when(builder.dynamoDbClient(dynamoDbClient)).thenReturn(builder);
+            when(builder.build()).thenReturn(dynamoDbEnhancedClient);
             return DynamoDbClientWrapper.create(region, stsRoleArn);
         }
     }
 
     @Test
-    void tryCreateTableWithNonExistingTable_creates_table() {
+    void initializeTableWithNonExistingTable_creates_table() {
 
         final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
 
         final String tableName = UUID.randomUUID().toString();
         final ProvisionedThroughput provisionedThroughput = mock(ProvisionedThroughput.class);
+
+        given(dynamoStoreSettings.getTableName()).willReturn(tableName);
+        given(dynamoStoreSettings.skipTableCreation()).willReturn(false);
+        given(dynamoStoreSettings.getTtl()).willReturn(Duration.ofSeconds(30));
 
         final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
         given(dynamoDbEnhancedClient.table(eq(tableName), any(BeanTableSchema.class))).willReturn(table);
@@ -119,16 +145,28 @@ public class DynamoDbClientWrapperTest {
             given(describeTableResponse.table()).willReturn(tableDescription);
             given(tableDescription.tableName()).willReturn(tableName);
 
-            objectUnderTest.tryCreateTable(tableName, provisionedThroughput);
+            given(dynamoDbClient.updateTimeToLive(any(UpdateTimeToLiveRequest.class))).willReturn(mock(UpdateTimeToLiveResponse.class));
+            final DescribeTimeToLiveResponse describeTimeToLiveResponse = mock(DescribeTimeToLiveResponse.class);
+            final TimeToLiveDescription timeToLiveDescription = mock(TimeToLiveDescription.class);
+            given(timeToLiveDescription.attributeName()).willReturn(TTL_ATTRIBUTE_NAME);
+            given(timeToLiveDescription.timeToLiveStatus()).willReturn(TimeToLiveStatus.ENABLED);
+            given(describeTimeToLiveResponse.timeToLiveDescription()).willReturn(timeToLiveDescription);
+            given(dynamoDbClient.describeTimeToLive(any(DescribeTimeToLiveRequest.class))).willReturn(describeTimeToLiveResponse);
+
+            objectUnderTest.initializeTable(dynamoStoreSettings, provisionedThroughput);
         }
     }
 
     @Test
-    void tryCreateTable_does_not_create_table_when_createTable_throws_ResourceInUseException() {
+    void initializeTable_with_null_ttl_and_create_table_when_createTable_throws_ResourceInUseException() {
         final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
 
         final String tableName = UUID.randomUUID().toString();
         final ProvisionedThroughput provisionedThroughput = mock(ProvisionedThroughput.class);
+
+        given(dynamoStoreSettings.getTableName()).willReturn(tableName);
+        given(dynamoStoreSettings.skipTableCreation()).willReturn(false);
+        given(dynamoStoreSettings.getTtl()).willReturn(null);
 
         final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
         given(dynamoDbEnhancedClient.table(eq(tableName), any(BeanTableSchema.class))).willReturn(table);
@@ -149,21 +187,24 @@ public class DynamoDbClientWrapperTest {
             given(describeTableResponse.table()).willReturn(tableDescription);
             given(tableDescription.tableName()).willReturn(tableName);
 
-            objectUnderTest.tryCreateTable(tableName, provisionedThroughput);
+            objectUnderTest.initializeTable(dynamoStoreSettings, provisionedThroughput);
+
+            verifyNoInteractions(dynamoDbClient);
         }
     }
 
     @Test
-    void tryCreateTableThrows_runtime_exception_when_waiter_returns_empty_describe_response() {
+    void initializeTable_Throws_runtime_exception_when_waiter_returns_empty_describe_response_and_skips_table_creation() {
         final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
 
         final String tableName = UUID.randomUUID().toString();
         final ProvisionedThroughput provisionedThroughput = mock(ProvisionedThroughput.class);
 
+        given(dynamoStoreSettings.getTableName()).willReturn(tableName);
+        given(dynamoStoreSettings.skipTableCreation()).willReturn(true);
+
         final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
         given(dynamoDbEnhancedClient.table(eq(tableName), any(BeanTableSchema.class))).willReturn(table);
-
-        doThrow(ResourceInUseException.class).when(table).createTable(any(CreateTableEnhancedRequest.class));
 
         try (MockedStatic<DynamoDbWaiter> dynamoDbWaiterMockedStatic = mockStatic(DynamoDbWaiter.class)) {
             final DynamoDbWaiter dynamoDbWaiter = mock(DynamoDbWaiter.class);
@@ -175,7 +216,51 @@ public class DynamoDbClientWrapperTest {
 
             given(waiterResponse.matched()).willReturn(response);
 
-            assertThrows(RuntimeException.class, () -> objectUnderTest.tryCreateTable(tableName, provisionedThroughput));
+            assertThrows(RuntimeException.class, () -> objectUnderTest.initializeTable(dynamoStoreSettings, provisionedThroughput));
+        }
+
+        verify(table, never()).createTable(any(CreateTableEnhancedRequest.class));
+    }
+
+    @Test
+    void skip_table_creation_true_does_not_attempt_to_create_the_table_or_enable_ttl() {
+        final DynamoDbClientWrapper objectUnderTest = createObjectUnderTest();
+
+        final String tableName = UUID.randomUUID().toString();
+        final ProvisionedThroughput provisionedThroughput = mock(ProvisionedThroughput.class);
+
+        given(dynamoStoreSettings.getTableName()).willReturn(tableName);
+        given(dynamoStoreSettings.skipTableCreation()).willReturn(true);
+        given(dynamoStoreSettings.getTtl()).willReturn(Duration.ofSeconds(30));
+
+        final DynamoDbTable<DynamoDbSourcePartitionItem> table = mock(DynamoDbTable.class);
+        given(dynamoDbEnhancedClient.table(eq(tableName), any(BeanTableSchema.class))).willReturn(table);
+
+        try (MockedStatic<DynamoDbWaiter> dynamoDbWaiterMockedStatic = mockStatic(DynamoDbWaiter.class)) {
+            final DynamoDbWaiter dynamoDbWaiter = mock(DynamoDbWaiter.class);
+            dynamoDbWaiterMockedStatic.when(DynamoDbWaiter::create).thenReturn(dynamoDbWaiter);
+            final WaiterResponse waiterResponse = mock(WaiterResponse.class);
+            final ResponseOrException<DescribeTableResponse> response = mock(ResponseOrException.class);
+            final DescribeTableResponse describeTableResponse = mock(DescribeTableResponse.class);
+            given(response.response()).willReturn(Optional.of(describeTableResponse));
+            given(dynamoDbWaiter.waitUntilTableExists(any(DescribeTableRequest.class))).willReturn(waiterResponse);
+
+            given(waiterResponse.matched()).willReturn(response);
+            final TableDescription tableDescription = mock(TableDescription.class);
+            given(describeTableResponse.table()).willReturn(tableDescription);
+            given(tableDescription.tableName()).willReturn(tableName);
+
+            final DescribeTimeToLiveResponse describeTimeToLiveResponse = mock(DescribeTimeToLiveResponse.class);
+            final TimeToLiveDescription timeToLiveDescription = mock(TimeToLiveDescription.class);
+            given(timeToLiveDescription.attributeName()).willReturn(TTL_ATTRIBUTE_NAME);
+            given(timeToLiveDescription.timeToLiveStatus()).willReturn(TimeToLiveStatus.DISABLED);
+            given(describeTimeToLiveResponse.timeToLiveDescription()).willReturn(timeToLiveDescription);
+            given(dynamoDbClient.describeTimeToLive(any(DescribeTimeToLiveRequest.class))).willReturn(describeTimeToLiveResponse);
+
+            assertThrows(RuntimeException.class, () -> objectUnderTest.initializeTable(dynamoStoreSettings, provisionedThroughput));
+
+            verify(dynamoDbClient, never()).updateTimeToLive(any(UpdateTimeToLiveRequest.class));
+            verify(table, never()).createTable(any(CreateTableEnhancedRequest.class));
         }
     }
 

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
@@ -144,17 +144,13 @@ public class DynamoDbClientWrapperTest {
         given(tableDescription.tableName()).willReturn(tableName);
 
         given(dynamoDbClient.updateTimeToLive(any(UpdateTimeToLiveRequest.class))).willReturn(mock(UpdateTimeToLiveResponse.class));
-        final DescribeTimeToLiveResponse describeTimeToLiveResponse = mock(DescribeTimeToLiveResponse.class);
-        final TimeToLiveDescription timeToLiveDescription = mock(TimeToLiveDescription.class);
-        given(timeToLiveDescription.attributeName()).willReturn(TTL_ATTRIBUTE_NAME);
-        given(timeToLiveDescription.timeToLiveStatus()).willReturn(TimeToLiveStatus.ENABLED);
-        given(describeTimeToLiveResponse.timeToLiveDescription()).willReturn(timeToLiveDescription);
-        given(dynamoDbClient.describeTimeToLive(any(DescribeTimeToLiveRequest.class))).willReturn(describeTimeToLiveResponse);
 
         try (MockedStatic<DynamoDbWaiter> dynamoDbWaiterMockedStatic = mockStatic(DynamoDbWaiter.class)) {
             dynamoDbWaiterMockedStatic.when(DynamoDbWaiter::create).thenReturn(dynamoDbWaiter);
             objectUnderTest.initializeTable(dynamoStoreSettings, provisionedThroughput);
         }
+
+        verify(dynamoDbClient, never()).describeTimeToLive(any(DescribeTimeToLiveRequest.class));
     }
 
     @Test

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
@@ -8,8 +8,6 @@ package org.opensearch.dataprepper.plugins.sourcecoordinator.dynamodb;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -120,46 +118,63 @@ public class DynamoDbSourceCoordinationStoreTest {
         assertThat(createdItem.getPartitionPriority(), notNullValue());
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"UNASSIGNED", "ASSIGNED" ,"CLOSED", "COMPLETED" })
-    void tryUpdateSourcePartitionItem_calls_dynamoClientWrapper_correctly_for_different_statuses(final String sourcePartitionStatus) {
+    @Test
+    void tryUpdateSourcePartitionItem_calls_dynamoClientWrapper_correctly_for_assigned_status() {
         final String sourceIdentifier = UUID.randomUUID().toString();
 
         final SourcePartitionStoreItem updateItem = mock(DynamoDbSourcePartitionItem.class);
         given(updateItem.getSourceIdentifier()).willReturn(sourceIdentifier);
-        given(updateItem.getSourcePartitionStatus()).willReturn(SourcePartitionStatus.valueOf(sourcePartitionStatus));
+        given(updateItem.getSourcePartitionStatus()).willReturn(SourcePartitionStatus.ASSIGNED);
 
         doNothing().when(dynamoDbClientWrapper).tryUpdatePartitionItem((DynamoDbSourcePartitionItem) updateItem);
 
-        if (sourcePartitionStatus.equals(SourcePartitionStatus.ASSIGNED.toString())) {
-            final Instant partitionOwnershipTimeout = Instant.now();
-            given(updateItem.getPartitionOwnershipTimeout()).willReturn(partitionOwnershipTimeout);
-            doNothing().when((DynamoDbSourcePartitionItem)updateItem).setPartitionPriority(partitionOwnershipTimeout.toString());
-            createObjectUnderTest().tryUpdateSourcePartitionItem(updateItem);
-        } else if (sourcePartitionStatus.equals(SourcePartitionStatus.CLOSED.toString())) {
-            final Instant reOpenAtTime = Instant.now();
-            given(updateItem.getReOpenAt()).willReturn(reOpenAtTime);
-            doNothing().when((DynamoDbSourcePartitionItem) updateItem).setPartitionPriority(reOpenAtTime.toString());
-            createObjectUnderTest().tryUpdateSourcePartitionItem(updateItem);
-        } else if (sourcePartitionStatus.equals(SourcePartitionStatus.COMPLETED.toString())) {
-            final ArgumentCaptor<Long> argumentCaptor = ArgumentCaptor.forClass(Long.class);
-            final Duration ttl = Duration.ofSeconds(30);
-            final Long nowPlusTtl = Instant.now().plus(ttl).getEpochSecond();
-            given(dynamoStoreSettings.getTtl()).willReturn(ttl);
-            doNothing().when((DynamoDbSourcePartitionItem) updateItem).setExpirationTime(argumentCaptor.capture());
-            createObjectUnderTest().tryUpdateSourcePartitionItem(updateItem);
+        final Instant partitionOwnershipTimeout = Instant.now();
+        given(updateItem.getPartitionOwnershipTimeout()).willReturn(partitionOwnershipTimeout);
+        doNothing().when((DynamoDbSourcePartitionItem)updateItem).setPartitionPriority(partitionOwnershipTimeout.toString());
+        createObjectUnderTest().tryUpdateSourcePartitionItem(updateItem);
 
-            final Long expirationTimeResult = argumentCaptor.getValue();
-            assertThat(expirationTimeResult, greaterThanOrEqualTo(nowPlusTtl));
-        } else {
-            createObjectUnderTest().tryUpdateSourcePartitionItem(updateItem);
-        }
+        verify((DynamoDbSourcePartitionItem) updateItem).setSourceStatusCombinationKey(sourceIdentifier + "|" + SourcePartitionStatus.ASSIGNED);
+    }
 
-        verify((DynamoDbSourcePartitionItem) updateItem).setSourceStatusCombinationKey(sourceIdentifier + "|" + sourcePartitionStatus);
+    @Test
+    void tryUpdateSourcePartitionItem_calls_dynamoClientWrapper_correctly_for_closed_status() {
+        final String sourceIdentifier = UUID.randomUUID().toString();
 
-        if (sourcePartitionStatus.equals(SourcePartitionStatus.UNASSIGNED) || sourcePartitionStatus.equals(SourcePartitionStatus.COMPLETED)) {
-            verify((DynamoDbSourcePartitionItem) updateItem, never()).setPartitionPriority(anyString());
-        }
+        final SourcePartitionStoreItem updateItem = mock(DynamoDbSourcePartitionItem.class);
+        given(updateItem.getSourceIdentifier()).willReturn(sourceIdentifier);
+        given(updateItem.getSourcePartitionStatus()).willReturn(SourcePartitionStatus.CLOSED);
+
+        doNothing().when(dynamoDbClientWrapper).tryUpdatePartitionItem((DynamoDbSourcePartitionItem) updateItem);
+        final Instant reOpenAtTime = Instant.now();
+        given(updateItem.getReOpenAt()).willReturn(reOpenAtTime);
+        doNothing().when((DynamoDbSourcePartitionItem) updateItem).setPartitionPriority(reOpenAtTime.toString());
+        createObjectUnderTest().tryUpdateSourcePartitionItem(updateItem);
+
+        verify((DynamoDbSourcePartitionItem) updateItem).setSourceStatusCombinationKey(sourceIdentifier + "|" + SourcePartitionStatus.CLOSED);
+    }
+
+    @Test
+    void tryUpdateSourcePartitionItem_calls_dynamoClientWrapper_correctly_for_completed_status() {
+        final String sourceIdentifier = UUID.randomUUID().toString();
+
+        final SourcePartitionStoreItem updateItem = mock(DynamoDbSourcePartitionItem.class);
+        given(updateItem.getSourceIdentifier()).willReturn(sourceIdentifier);
+        given(updateItem.getSourcePartitionStatus()).willReturn(SourcePartitionStatus.COMPLETED);
+
+        doNothing().when(dynamoDbClientWrapper).tryUpdatePartitionItem((DynamoDbSourcePartitionItem) updateItem);
+
+        final ArgumentCaptor<Long> argumentCaptor = ArgumentCaptor.forClass(Long.class);
+        final Duration ttl = Duration.ofSeconds(30);
+        final Long nowPlusTtl = Instant.now().plus(ttl).getEpochSecond();
+        given(dynamoStoreSettings.getTtl()).willReturn(ttl);
+        doNothing().when((DynamoDbSourcePartitionItem) updateItem).setExpirationTime(argumentCaptor.capture());
+        createObjectUnderTest().tryUpdateSourcePartitionItem(updateItem);
+
+        final Long expirationTimeResult = argumentCaptor.getValue();
+        assertThat(expirationTimeResult, greaterThanOrEqualTo(nowPlusTtl));
+
+        verify((DynamoDbSourcePartitionItem) updateItem).setSourceStatusCombinationKey(sourceIdentifier + "|" + SourcePartitionStatus.COMPLETED);
+        verify((DynamoDbSourcePartitionItem) updateItem, never()).setPartitionPriority(anyString());
     }
 
     @Test

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -73,7 +73,7 @@ task integrationTest(type: Test) {
 jacocoTestReport {
     dependsOn test
     reports {
-        xml.enabled true
+        xml.required
     }
     afterEvaluate {
         classDirectories.from = files(classDirectories.files.collect {


### PR DESCRIPTION
### Description
This adds an an optional TTL for COMPLETED partitions in the ddb source coordination store. 
If TTL is set in the `data-prepper-config`

```
source_coordination:
   store:
      dynamodb:
         ttl: "PT5D"
``` 

the store will be created with ttl on the `expirationTime` field of the item. 

the dynamo store now has an option `skip_table_creation`, which will skip the step that attempts to create the table and enable time to live on the table. This defaults to false.

```
source_coordination:
   store:
      dynamodb:
         ttl: "PT5D"
         skip_table_creation: true
```
 
### Issues Resolved
Related to #2412 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
