### PR TITLE
Update the OpenSearch sink and the OTel Trace Group processor to use …

### DIFF
--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation project(':data-prepper-plugins:common')
     implementation project(':data-prepper-plugins:failures-common')
+    implementation project(':data-prepper-plugins:aws-plugin-api')
     implementation libs.opensearch.client
     implementation libs.opensearch.rhlc
     implementation libs.opensearch.java

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchIT.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -16,6 +17,7 @@ import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class OpenSearchIT {
     @Test
@@ -30,7 +32,8 @@ public class OpenSearchIT {
             builder.withUsername(user);
             builder.withPassword(password);
         }
-        final RestHighLevelClient client = builder.build().createClient();
+        final AwsCredentialsSupplier awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
+        final RestHighLevelClient client = builder.build().createClient(awsCredentialsSupplier);
 
         // TODO: Even with the REST High Level client in OpenSearch 1.1, the standard API
         // does not work with ODFE

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.sink.opensearch;
 
 import org.mockito.Mock;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.MetricNames;
 import org.opensearch.dataprepper.metrics.MetricsTestUtil;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
@@ -101,8 +102,11 @@ public class OpenSearchSinkIT {
   @Mock
   private PluginFactory pluginFactory;
 
+  @Mock
+  private AwsCredentialsSupplier awsCredentialsSupplier;
+
   public OpenSearchSink createObjectUnderTest(PluginSetting pluginSetting, boolean doInitialize) {
-    OpenSearchSink sink = new OpenSearchSink(pluginSetting, pluginFactory);
+    OpenSearchSink sink = new OpenSearchSink(pluginSetting, pluginFactory, awsCredentialsSupplier);
     if (doInitialize) {
         sink.doInitialize();
     }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;
 
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.MetricNames;
 import org.opensearch.dataprepper.plugins.dlq.DlqProvider;
 import org.opensearch.dataprepper.plugins.dlq.DlqWriter;
@@ -74,6 +75,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
 
   private static final Logger LOG = LoggerFactory.getLogger(OpenSearchSink.class);
   private static final int INITIALIZE_RETRY_WAIT_TIME_MS = 5000;
+  private final AwsCredentialsSupplier awsCredentialsSupplier;
 
   private DlqWriter dlqWriter;
   private BufferedWriter dlqFileWriter;
@@ -107,8 +109,10 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
 
   @DataPrepperPluginConstructor
   public OpenSearchSink(final PluginSetting pluginSetting,
-                        final PluginFactory pluginFactory) {
+                        final PluginFactory pluginFactory,
+                        final AwsCredentialsSupplier awsCredentialsSupplier) {
     super(pluginSetting, Integer.MAX_VALUE, INITIALIZE_RETRY_WAIT_TIME_MS);
+    this.awsCredentialsSupplier = awsCredentialsSupplier;
     bulkRequestTimer = pluginMetrics.timer(BULKREQUEST_LATENCY);
     bulkRequestErrorsCounter = pluginMetrics.counter(BULKREQUEST_ERRORS);
     dynamicIndexDroppedEvents = pluginMetrics.counter(DYNAMIC_INDEX_DROPPED_EVENTS);
@@ -160,8 +164,8 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
 
   private void doInitializeInternal() throws IOException {
     LOG.info("Initializing OpenSearch sink");
-    restHighLevelClient = openSearchSinkConfig.getConnectionConfiguration().createClient();
-    openSearchClient = openSearchSinkConfig.getConnectionConfiguration().createOpenSearchClient(restHighLevelClient);
+    restHighLevelClient = openSearchSinkConfig.getConnectionConfiguration().createClient(awsCredentialsSupplier);
+    openSearchClient = openSearchSinkConfig.getConnectionConfiguration().createOpenSearchClient(restHighLevelClient, awsCredentialsSupplier);
     configuredIndexAlias = openSearchSinkConfig.getIndexConfiguration().getIndexAlias();
     final TemplateStrategy templateStrategy = TemplateType.V1.createTemplateStrategy(openSearchClient);
     indexManager = indexManagerFactory.getIndexManager(indexType, openSearchClient, restHighLevelClient,

--- a/data-prepper-plugins/otel-trace-group-processor/build.gradle
+++ b/data-prepper-plugins/otel-trace-group-processor/build.gradle
@@ -6,6 +6,7 @@
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:opensearch')
+    implementation project(':data-prepper-plugins:aws-plugin-api')
     implementation libs.opensearch.rhlc
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'

--- a/data-prepper-plugins/otel-trace-group-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltracegroup/OTelTraceGroupProcessor.java
+++ b/data-prepper-plugins/otel-trace-group-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/oteltracegroup/OTelTraceGroupProcessor.java
@@ -5,7 +5,9 @@
 
 package org.opensearch.dataprepper.plugins.processor.oteltracegroup;
 
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
@@ -60,10 +62,11 @@ public class OTelTraceGroupProcessor extends AbstractProcessor<Record<Span>, Rec
     private final Counter recordsOutFixedTraceGroupCounter;
     private final Counter recordsOutMissingTraceGroupCounter;
 
-    public OTelTraceGroupProcessor(final PluginSetting pluginSetting) {
+    @DataPrepperPluginConstructor
+    public OTelTraceGroupProcessor(final PluginSetting pluginSetting, final AwsCredentialsSupplier awsCredentialsSupplier) {
         super(pluginSetting);
         otelTraceGroupProcessorConfig = OTelTraceGroupProcessorConfig.buildConfig(pluginSetting);
-        restHighLevelClient = otelTraceGroupProcessorConfig.getEsConnectionConfig().createClient();
+        restHighLevelClient = otelTraceGroupProcessorConfig.getEsConnectionConfig().createClient(awsCredentialsSupplier);
 
         recordsInMissingTraceGroupCounter = pluginMetrics.counter(RECORDS_IN_MISSING_TRACE_GROUP);
         recordsOutFixedTraceGroupCounter = pluginMetrics.counter(RECORDS_OUT_FIXED_TRACE_GROUP);

--- a/data-prepper-plugins/otel-trace-group-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/oteltracegroup/OTelTraceGroupProcessorTests.java
+++ b/data-prepper-plugins/otel-trace-group-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/oteltracegroup/OTelTraceGroupProcessorTests.java
@@ -22,6 +22,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.common.document.DocumentField;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.MetricNames;
 import org.opensearch.dataprepper.metrics.MetricsTestUtil;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
@@ -112,13 +113,16 @@ public class OTelTraceGroupProcessorTests {
     @Mock(lenient = true)
     private SearchHit testSearchHit2;
 
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
+
     @BeforeEach
     public void setUp() throws Exception{
         MetricsTestUtil.initMetrics();
         connectionConfigurationMockedStatic = Mockito.mockStatic(ConnectionConfiguration.class);
         connectionConfigurationMockedStatic.when(() -> ConnectionConfiguration.readConnectionConfiguration(any(PluginSetting.class)))
                 .thenReturn(connectionConfigurationMock);
-        when(connectionConfigurationMock.createClient()).thenReturn(restHighLevelClient);
+        when(connectionConfigurationMock.createClient(awsCredentialsSupplier)).thenReturn(restHighLevelClient);
         when(restHighLevelClient.search(any(SearchRequest.class), any(RequestOptions.class))).thenReturn(testSearchResponse);
         doNothing().when(restHighLevelClient).close();
         when(testSearchResponse.getHits()).thenReturn(testSearchHits);
@@ -151,7 +155,7 @@ public class OTelTraceGroupProcessorTests {
         final PluginSetting testPluginSetting = mock(PluginSetting.class);
         when(testPluginSetting.getName()).thenReturn(PLUGIN_NAME);
         when(testPluginSetting.getPipelineName()).thenReturn(TEST_PIPELINE_NAME);
-        otelTraceGroupProcessor = new OTelTraceGroupProcessor(testPluginSetting);
+        otelTraceGroupProcessor = new OTelTraceGroupProcessor(testPluginSetting, awsCredentialsSupplier);
         executorService = Executors.newFixedThreadPool(TEST_NUM_WORKERS);
     }
 

--- a/e2e-test/log/build.gradle
+++ b/e2e-test/log/build.gradle
@@ -190,6 +190,7 @@ dependencies {
     integrationTestImplementation project(':data-prepper-plugins:common')
     integrationTestImplementation project(':data-prepper-plugins:log-generator-source')
     integrationTestImplementation project(':data-prepper-plugins:opensearch')
+    integrationTestImplementation project(':data-prepper-plugins:aws-plugin-api')
     integrationTestImplementation libs.armeria.core
     integrationTestImplementation testLibs.awaitility
     integrationTestImplementation libs.opensearch.rhlc

--- a/e2e-test/log/src/integrationTest/java/org/opensearch/dataprepper/integration/log/EndToEndBasicLogTest.java
+++ b/e2e-test/log/src/integrationTest/java/org/opensearch/dataprepper/integration/log/EndToEndBasicLogTest.java
@@ -15,7 +15,6 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
 import io.netty.util.AsciiString;
-import org.junit.Assert;
 import org.junit.Test;
 import org.opensearch.action.admin.indices.refresh.RefreshRequest;
 import org.opensearch.action.search.SearchRequest;
@@ -42,6 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EndToEndBasicLogTest {
     private static final int HTTP_SOURCE_PORT = 2021;
@@ -69,7 +69,7 @@ public class EndToEndBasicLogTest {
                     );
                     final SearchResponse searchResponse = restHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
                     final List<Map<String, Object>> foundSources = getSourcesFromSearchHits(searchResponse.getHits());
-                    Assert.assertEquals(5, foundSources.size());
+                    assertEquals(5, foundSources.size());
                     retrievedDocs.addAll(foundSources);
                 }
         );
@@ -88,7 +88,7 @@ public class EndToEndBasicLogTest {
                 Collections.singletonList("https://127.0.0.1:9200"));
         builder.withUsername("admin");
         builder.withPassword("admin");
-        return builder.build().createClient();
+        return builder.build().createClient(null);
     }
 
     private void sendHttpRequestToSource(final int port, final HttpData httpData) {

--- a/e2e-test/log/src/integrationTest/java/org/opensearch/dataprepper/integration/log/ParallelGrokStringSubstituteLogTest.java
+++ b/e2e-test/log/src/integrationTest/java/org/opensearch/dataprepper/integration/log/ParallelGrokStringSubstituteLogTest.java
@@ -22,6 +22,7 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -39,6 +40,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
 
 public class ParallelGrokStringSubstituteLogTest {
     private static final int HTTP_SOURCE_PORT = 2021;
@@ -98,7 +100,8 @@ public class ParallelGrokStringSubstituteLogTest {
                 Collections.singletonList("https://127.0.0.1:9200"));
         builder.withUsername("admin");
         builder.withPassword("admin");
-        return builder.build().createClient();
+        final AwsCredentialsSupplier awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
+        return builder.build().createClient(awsCredentialsSupplier);
     }
 
     private void sendHttpRequestToSource(final int port, final HttpData httpData) {

--- a/e2e-test/peerforwarder/build.gradle
+++ b/e2e-test/peerforwarder/build.gradle
@@ -203,6 +203,7 @@ dependencies {
     integrationTestImplementation project(':data-prepper-plugins:common')
     integrationTestImplementation project(':data-prepper-plugins:log-generator-source')
     integrationTestImplementation project(':data-prepper-plugins:opensearch')
+    integrationTestImplementation project(':data-prepper-plugins:aws-plugin-api')
     integrationTestImplementation project(':data-prepper-plugins:otel-trace-group-processor')
     integrationTestImplementation 'org.awaitility:awaitility:4.2.0'
     integrationTestImplementation libs.opentelemetry.proto

--- a/e2e-test/peerforwarder/src/integrationTest/java/org/opensearch/dataprepper/integration/peerforwarder/EndToEndLogMetricsTest.java
+++ b/e2e-test/peerforwarder/src/integrationTest/java/org/opensearch/dataprepper/integration/peerforwarder/EndToEndLogMetricsTest.java
@@ -21,6 +21,7 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration;
 import org.opensearch.dataprepper.plugins.source.loggenerator.ApacheLogFaker;
 import org.opensearch.search.SearchHits;
@@ -48,6 +49,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
 
 public class EndToEndLogMetricsTest {
     private static final int HTTP_SOURCE_PORT_1 = 2021;
@@ -179,7 +181,8 @@ public class EndToEndLogMetricsTest {
                 Collections.singletonList("https://127.0.0.1:9200"));
         builder.withUsername("admin");
         builder.withPassword("admin");
-        return builder.build().createClient();
+        final AwsCredentialsSupplier awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
+        return builder.build().createClient(awsCredentialsSupplier);
     }
 
     private void sendHttpRequestToSource(final int port, final HttpData httpData) {

--- a/e2e-test/peerforwarder/src/integrationTest/java/org/opensearch/dataprepper/integration/peerforwarder/EndToEndPeerForwarderTest.java
+++ b/e2e-test/peerforwarder/src/integrationTest/java/org/opensearch/dataprepper/integration/peerforwarder/EndToEndPeerForwarderTest.java
@@ -22,6 +22,7 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration;
 import org.opensearch.dataprepper.plugins.source.loggenerator.ApacheLogFaker;
 import org.opensearch.search.SearchHits;
@@ -44,6 +45,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
 
 public class EndToEndPeerForwarderTest {
     private static final int HTTP_SOURCE_PORT_1 = 2021;
@@ -115,7 +117,8 @@ public class EndToEndPeerForwarderTest {
                 Collections.singletonList("https://127.0.0.1:9200"));
         builder.withUsername("admin");
         builder.withPassword("admin");
-        return builder.build().createClient();
+        final AwsCredentialsSupplier awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
+        return builder.build().createClient(awsCredentialsSupplier);
     }
 
     private void sendHttpRequestToSource(final int port, final HttpData httpData) {

--- a/e2e-test/trace/build.gradle
+++ b/e2e-test/trace/build.gradle
@@ -231,6 +231,7 @@ dependencies {
     integrationTestImplementation project(':data-prepper-api')
     integrationTestImplementation project(':data-prepper-plugins:common')
     integrationTestImplementation project(':data-prepper-plugins:opensearch')
+    integrationTestImplementation project(':data-prepper-plugins:aws-plugin-api')
     integrationTestImplementation project(':data-prepper-plugins:otel-trace-group-processor')
     integrationTestImplementation testLibs.awaitility
     integrationTestImplementation "io.opentelemetry.proto:opentelemetry-proto:${targetOpenTelemetryVersion}"

--- a/e2e-test/trace/src/integrationTest/java/org/opensearch/dataprepper/integration/trace/EndToEndRawSpanTest.java
+++ b/e2e-test/trace/src/integrationTest/java/org/opensearch/dataprepper/integration/trace/EndToEndRawSpanTest.java
@@ -115,7 +115,7 @@ public class EndToEndRawSpanTest {
                 Collections.singletonList("https://127.0.0.1:9200"));
         builder.withUsername("admin");
         builder.withPassword("admin");
-        final RestHighLevelClient restHighLevelClient = builder.build().createClient();
+        final RestHighLevelClient restHighLevelClient = builder.build().createClient(null);
         // Wait for data to flow through pipeline and be indexed by ES
         await().atLeast(3, TimeUnit.SECONDS).atMost(20, TimeUnit.SECONDS).untilAsserted(
                 () -> {

--- a/e2e-test/trace/src/integrationTest/java/org/opensearch/dataprepper/integration/trace/EndToEndServiceMapTest.java
+++ b/e2e-test/trace/src/integrationTest/java/org/opensearch/dataprepper/integration/trace/EndToEndServiceMapTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.integration.trace;
 
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.plugins.sink.opensearch.ConnectionConfiguration;
 import com.google.protobuf.ByteString;
 import com.linecorp.armeria.client.Clients;
@@ -41,6 +42,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
 
 public class EndToEndServiceMapTest {
     private static final String TEST_TRACEID_1 = "ABC";
@@ -79,7 +81,8 @@ public class EndToEndServiceMapTest {
                 Collections.singletonList("https://127.0.0.1:9200"));
         builder.withUsername("admin");
         builder.withPassword("admin");
-        final RestHighLevelClient restHighLevelClient = builder.build().createClient();
+        final AwsCredentialsSupplier awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
+        final RestHighLevelClient restHighLevelClient = builder.build().createClient(awsCredentialsSupplier);
 
         // Wait for service map processor by 2 * window_duration
         await().atMost(45, TimeUnit.SECONDS).untilAsserted(


### PR DESCRIPTION
### Description

Updates the `opensearch` sink and the `otel_trace_group` processor to the use the AWS plugin for loading credentials. These two share a common bit of code on this part.
 
### Issues Resolved

Resolves #2765
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
