### PR TITLE
Acquire Global State Item to create partitions, pass globalStateMap to partition creation supplier function

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/PartitionIdentifier.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/PartitionIdentifier.java
@@ -6,10 +6,9 @@
 package org.opensearch.dataprepper.model.source.coordinator;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 
 /**
- * The model class to be passed to {@link SourceCoordinator#getNextPartition(Supplier)}.
+ * The model class to be passed to {@link SourceCoordinator#getNextPartition(java.util.function.Function)}.
  * The partitionKey should uniquely identify the partition
  * @since 2.2
  */

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartition.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartition.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.model.source.coordinator;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * The class that will be provided to {@link org.opensearch.dataprepper.model.source.Source} plugins
@@ -29,8 +30,8 @@ public class SourcePartition<T> {
         return partitionKey;
     }
 
-    public T getPartitionState() {
-        return partitionState;
+    public Optional<T> getPartitionState() {
+        return Optional.ofNullable(partitionState);
     }
 
     public static <T> Builder<T> builder(Class<T> clazz) {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartition.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartition.java
@@ -6,12 +6,11 @@
 package org.opensearch.dataprepper.model.source.coordinator;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 
 /**
  * The class that will be provided to {@link org.opensearch.dataprepper.model.source.Source} plugins
  * that implement {@link UsesSourceCoordination} to identify the partition of
- * data that the source should process. This is returned in a call to {@link SourceCoordinator#getNextPartition(Supplier)}.
+ * data that the source should process. This is returned in a call to {@link SourceCoordinator#getNextPartition(java.util.function.Function)}.
  * @since 2.2
  */
 public class SourcePartition<T> {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/exceptions/PartitionNotFoundException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/exceptions/PartitionNotFoundException.java
@@ -9,12 +9,10 @@ package org.opensearch.dataprepper.model.source.coordinator.exceptions;
 import org.opensearch.dataprepper.model.annotations.SkipTestCoverageGenerated;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
 
-import java.util.function.Supplier;
-
 /**
  * This exception is thrown by a {@link org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator} when the source makes a call to perform an action on a
  * partition, but that partition could not be found in the distributed store. The recommended approach to handling this exception is to get a new partition from
- * {@link SourceCoordinator#getNextPartition(Supplier)}
+ * {@link SourceCoordinator#getNextPartition(java.util.function.Function)}
  */
 @SkipTestCoverageGenerated
 public class PartitionNotFoundException extends RuntimeException {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/exceptions/PartitionNotOwnedException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/exceptions/PartitionNotOwnedException.java
@@ -8,12 +8,10 @@ package org.opensearch.dataprepper.model.source.coordinator.exceptions;
 import org.opensearch.dataprepper.model.annotations.SkipTestCoverageGenerated;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
 
-import java.util.function.Supplier;
-
 /**
  * This exception is thrown when a call to {@link SourceCoordinator} is made by a source for a partition
  * that is not owned by this instance of Data Prepper. If this exception gets thrown,
- * the recommended approach is to call {@link SourceCoordinator#getNextPartition(Supplier)}
+ * the recommended approach is to call {@link SourceCoordinator#getNextPartition(java.util.function.Function)}
  * to grab a new partition to process
  * @since 2.2
  */

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartitionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/SourcePartitionTest.java
@@ -39,6 +39,7 @@ public class SourcePartitionTest {
 
         assertThat(sourcePartition, notNullValue());
         assertThat(sourcePartition.getPartitionKey(), equalTo(partitionKey));
-        assertThat(sourcePartition.getPartitionState(), equalTo(partitionState));
+        assertThat(sourcePartition.getPartitionState().isPresent(), equalTo(true));
+        assertThat(sourcePartition.getPartitionState().get(), equalTo(partitionState));
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinator.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper.sourcecoordination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.Counter;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -26,10 +28,12 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
 
@@ -52,7 +56,9 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     static final Duration DEFAULT_LEASE_TIMEOUT = Duration.ofMinutes(10);
 
     private static final String hostName;
-    static final String PARTITION_TYPE = "PARTITION";
+    static final String PARTITION_TYPE = "|PARTITION";
+    static final String GLOBAL_STATE_TYPE = "|GLOBAL_STATE";
+    static final String GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS = "GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS";
 
     private final SourceCoordinationConfig sourceCoordinationConfig;
     private final SourceCoordinationStore sourceCoordinationStore;
@@ -97,8 +103,8 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
         this.partitionProgressStateClass = partitionProgressStateClass;
         this.partitionManager = partitionManager;
         this.sourceIdentifier = Objects.nonNull(sourceCoordinationConfig.getPartitionPrefix()) ?
-                sourceCoordinationConfig.getPartitionPrefix() + "|" + sourceIdentifier + "|" + PARTITION_TYPE :
-                sourceIdentifier + "|" + PARTITION_TYPE;
+                sourceCoordinationConfig.getPartitionPrefix() + "|" + sourceIdentifier :
+                sourceIdentifier;
         this.ownerId = sourceIdentifier + ":" + hostName;
         this.pluginMetrics = pluginMetrics;
         this.partitionCreationSupplierInvocationsCounter = pluginMetrics.counter(PARTITION_CREATION_SUPPLIER_INVOCATION_COUNT);
@@ -120,25 +126,33 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     public void initialize() {
         sourceCoordinationStore.initializeStore();
         initialized = true;
+        sourceCoordinationStore.tryCreatePartitionItem(sourceIdentifier + GLOBAL_STATE_TYPE, GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS, SourcePartitionStatus.UNASSIGNED, 0L, null);
     }
 
     @Override
-    public Optional<SourcePartition<T>> getNextPartition(final Supplier<List<PartitionIdentifier>> partitionsCreatorSupplier) {
+    public Optional<SourcePartition<T>> getNextPartition(final Function<Map<String, Object>, List<PartitionIdentifier>> partitionCreationSupplier) {
         validateIsInitialized();
 
         if (partitionManager.getActivePartition().isPresent()) {
             return partitionManager.getActivePartition();
         }
 
-        Optional<SourcePartitionStoreItem> ownedPartitions = sourceCoordinationStore.tryAcquireAvailablePartition(sourceIdentifier, ownerId, DEFAULT_LEASE_TIMEOUT);
+        Optional<SourcePartitionStoreItem> ownedPartitions = sourceCoordinationStore.tryAcquireAvailablePartition(sourceIdentifier + PARTITION_TYPE, ownerId, DEFAULT_LEASE_TIMEOUT);
 
         if (ownedPartitions.isEmpty()) {
-            LOG.info("Partition owner {} did not acquire any partitions. Running partition creation supplier to create more partitions", ownerId);
 
-            createPartitions(partitionsCreatorSupplier.get());
-            partitionCreationSupplierInvocationsCounter.increment();
+            final Optional<SourcePartitionStoreItem> acquiredGlobalStateForPartitionCreation = acquireGlobalStateForPartitionCreation();
 
-            ownedPartitions = sourceCoordinationStore.tryAcquireAvailablePartition(sourceIdentifier, ownerId, DEFAULT_LEASE_TIMEOUT);
+            if (acquiredGlobalStateForPartitionCreation.isPresent()) {
+                final Map<String, Object> globalStateMap = convertStringToGlobalStateMap(acquiredGlobalStateForPartitionCreation.get().getPartitionProgressState());
+                LOG.info("Partition owner {} did not acquire any partitions. Running partition creation supplier to create more partitions", ownerId);
+                createPartitions(partitionCreationSupplier.apply(globalStateMap));
+                partitionCreationSupplierInvocationsCounter.increment();
+
+                giveUpAndSaveGlobalStateForPartitionCreation(acquiredGlobalStateForPartitionCreation.get(), globalStateMap);
+            }
+
+            ownedPartitions = sourceCoordinationStore.tryAcquireAvailablePartition(sourceIdentifier + PARTITION_TYPE, ownerId, DEFAULT_LEASE_TIMEOUT);
         }
 
         if (ownedPartitions.isEmpty()) {
@@ -161,14 +175,14 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
 
     private void createPartitions(final List<PartitionIdentifier> partitionIdentifiers) {
         for (final PartitionIdentifier partitionIdentifier : partitionIdentifiers) {
-            final Optional<SourcePartitionStoreItem> optionalPartitionItem = sourceCoordinationStore.getSourcePartitionItem(sourceIdentifier, partitionIdentifier.getPartitionKey());
+            final Optional<SourcePartitionStoreItem> optionalPartitionItem = sourceCoordinationStore.getSourcePartitionItem(sourceIdentifier + PARTITION_TYPE, partitionIdentifier.getPartitionKey());
 
             if (optionalPartitionItem.isPresent()) {
                 return;
             }
 
             final boolean partitionCreated = sourceCoordinationStore.tryCreatePartitionItem(
-                    sourceIdentifier,
+                    sourceIdentifier + PARTITION_TYPE,
                     partitionIdentifier.getPartitionKey(),
                     SourcePartitionStatus.UNASSIGNED,
                     0L,
@@ -280,7 +294,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
 
         final Optional<SourcePartition<T>> activePartition = partitionManager.getActivePartition();
         if (activePartition.isPresent()) {
-            final Optional<SourcePartitionStoreItem> optionalItem = sourceCoordinationStore.getSourcePartitionItem(sourceIdentifier, activePartition.get().getPartitionKey());
+            final Optional<SourcePartitionStoreItem> optionalItem = sourceCoordinationStore.getSourcePartitionItem(sourceIdentifier + PARTITION_TYPE, activePartition.get().getPartitionKey());
             if (optionalItem.isPresent()) {
                 final SourcePartitionStoreItem updateItem = optionalItem.get();
                 validatePartitionOwnership(updateItem);
@@ -304,11 +318,38 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     }
 
     private T convertStringToPartitionProgressStateClass(final String serializedPartitionProgressState) {
-        return objectMapper.convertValue(serializedPartitionProgressState, partitionProgressStateClass);
+        if (Objects.isNull(serializedPartitionProgressState)) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(serializedPartitionProgressState, partitionProgressStateClass);
+        } catch (final JsonProcessingException e) {
+            LOG.error("Unable to convert string to partition progress state class {}", partitionProgressStateClass.getName(), e);
+            return null;
+        }
     }
 
     private String convertPartitionProgressStateClasstoString(final T partitionProgressState) {
-        return objectMapper.convertValue(partitionProgressState, String.class);
+        try {
+            return objectMapper.writeValueAsString(partitionProgressState);
+        } catch (final JsonProcessingException e) {
+            LOG.error("Unable to convert partition progress state class {} to string", partitionProgressStateClass.getName(), e);
+            return null;
+        }
+    }
+
+    private Map<String, Object> convertStringToGlobalStateMap(final String serializedGlobalState) {
+        if (Objects.isNull(serializedGlobalState)) {
+            return new HashMap<>();
+        }
+
+        try {
+            return objectMapper.readValue(serializedGlobalState, new TypeReference<>() {});
+        } catch (final JsonProcessingException e) {
+            LOG.error("Unable to convert global state string to Map<String, Object>", e);
+            return new HashMap<>();
+        }
     }
 
     private boolean isActivelyOwnedPartition(final String partitionKey) {
@@ -317,7 +358,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     }
 
     private void validatePartitionOwnership(final SourcePartitionStoreItem item) {
-        if (Objects.isNull(item.getPartitionOwner()) || !item.getPartitionOwner().equals(ownerId)) {
+        if (Objects.isNull(item.getPartitionOwner()) || !ownerId.equals(item.getPartitionOwner())) {
             partitionManager.removeActivePartition();
             partitionNotOwnedErrorCounter.increment();
             throw new PartitionNotOwnedException(String.format("The partition is no longer owned by this instance of Data Prepper. " +
@@ -334,7 +375,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
             );
         }
 
-        final Optional<SourcePartitionStoreItem> optionalPartitionItem = sourceCoordinationStore.getSourcePartitionItem(sourceIdentifier, partitionKey);
+        final Optional<SourcePartitionStoreItem> optionalPartitionItem = sourceCoordinationStore.getSourcePartitionItem(sourceIdentifier + PARTITION_TYPE, partitionKey);
 
         if (optionalPartitionItem.isEmpty()) {
             partitionNotFoundErrorCounter.increment();
@@ -347,6 +388,52 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     private void validateIsInitialized() {
         if (!initialized) {
             throw new UninitializedSourceCoordinatorException("The initialize method has not been called on this source coordinator. initialize() must be called before further interactions with the SourceCoordinator");
+        }
+    }
+
+    private Optional<SourcePartitionStoreItem> acquireGlobalStateForPartitionCreation() {
+        final Optional<SourcePartitionStoreItem> globalStateItemForPartitionCreation = sourceCoordinationStore.getSourcePartitionItem(
+                sourceIdentifier + GLOBAL_STATE_TYPE, GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS);
+
+        if (globalStateItemForPartitionCreation.isPresent()) {
+
+            if (SourcePartitionStatus.ASSIGNED.equals(globalStateItemForPartitionCreation.get().getSourcePartitionStatus()) &&
+                    (Objects.isNull(globalStateItemForPartitionCreation.get().getPartitionOwnershipTimeout()) ||
+                            Instant.now().isAfter(globalStateItemForPartitionCreation.get().getPartitionOwnershipTimeout()) ||
+                            ownerId.equals(globalStateItemForPartitionCreation.get().getPartitionOwner()))
+            ) {
+                LOG.warn("The global state item for partition creation is owned by {}, but the ownership has expired. Attempting to acquire global state for owner {}",
+                        globalStateItemForPartitionCreation.get().getPartitionOwner(), ownerId);
+            } else if (Objects.nonNull(globalStateItemForPartitionCreation.get().getPartitionOwner()) && !ownerId.equals(globalStateItemForPartitionCreation.get().getPartitionOwner())
+                   || !SourcePartitionStatus.UNASSIGNED.equals(globalStateItemForPartitionCreation.get().getSourcePartitionStatus())) {
+                return Optional.empty();
+            }
+
+            try {
+                globalStateItemForPartitionCreation.get().setSourcePartitionStatus(SourcePartitionStatus.ASSIGNED);
+                globalStateItemForPartitionCreation.get().setPartitionOwner(ownerId);
+                globalStateItemForPartitionCreation.get().setPartitionOwnershipTimeout(Instant.now().plus(DEFAULT_LEASE_TIMEOUT));
+                sourceCoordinationStore.tryUpdateSourcePartitionItem(globalStateItemForPartitionCreation.get());
+            } catch (final PartitionUpdateException e) {
+                LOG.debug("Owner %s was not able to acquire the global state item to create new partitions. This means that another instance of Data Prepper has gained the responsibility of creating partitions at this time");
+                return Optional.empty();
+            }
+        }
+
+        return globalStateItemForPartitionCreation;
+    }
+
+    private void giveUpAndSaveGlobalStateForPartitionCreation(final SourcePartitionStoreItem globalStateItemForPartitionCreation, final Map<String, Object> globalStateMap) {
+
+        globalStateItemForPartitionCreation.setSourcePartitionStatus(SourcePartitionStatus.UNASSIGNED);
+        globalStateItemForPartitionCreation.setPartitionOwner(null);
+        globalStateItemForPartitionCreation.setPartitionOwnershipTimeout(null);
+
+        try {
+            globalStateItemForPartitionCreation.setPartitionProgressState(objectMapper.writeValueAsString(globalStateMap));
+            sourceCoordinationStore.tryUpdateSourcePartitionItem(globalStateItemForPartitionCreation);
+        } catch (final JsonProcessingException | PartitionUpdateException e) {
+            LOG.warn("There was an error saving global state after creating partitions.", e);
         }
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinatorTest.java
@@ -34,9 +34,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Supplier;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -53,6 +54,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.DEFAULT_LEASE_TIMEOUT;
+import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS;
+import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.GLOBAL_STATE_TYPE;
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.NO_PARTITIONS_ACQUIRED_COUNT;
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.PARTITIONS_ACQUIRED_COUNT;
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.PARTITIONS_CLOSED_COUNT;
@@ -123,15 +126,20 @@ public class LeaseBasedSourceCoordinatorTest {
     @Mock
     private Counter completePartitionUpdateErrorCounter;
 
+    @Mock
+    private SourcePartitionStoreItem globalStateForPartitionCreationItem;
+
     private String sourceIdentifier;
     private String partitionPrefix;
-    private String fullSourceIdentifier;
+    private String fullSourceIdentifierForPartition;
+    private String fullSourceIdentifierForGlobalState;
 
     @BeforeEach
     void setup() {
         sourceIdentifier = UUID.randomUUID().toString();
         partitionPrefix = UUID.randomUUID().toString();
-        fullSourceIdentifier = partitionPrefix + "|" + sourceIdentifier + "|" + PARTITION_TYPE;
+        fullSourceIdentifierForPartition = partitionPrefix + "|" + sourceIdentifier + PARTITION_TYPE;
+        this.fullSourceIdentifierForGlobalState = partitionPrefix + "|" + sourceIdentifier + GLOBAL_STATE_TYPE;
         given(sourceCoordinationConfig.getPartitionPrefix()).willReturn(partitionPrefix);
         given(pluginMetrics.counter(PARTITION_CREATION_SUPPLIER_INVOCATION_COUNT)).willReturn(partitionCreationSupplierInvocationsCounter);
         given(pluginMetrics.counter(NO_PARTITIONS_ACQUIRED_COUNT)).willReturn(noPartitionsAcquiredCounter);
@@ -151,6 +159,9 @@ public class LeaseBasedSourceCoordinatorTest {
     private SourceCoordinator<String> createObjectUnderTest() {
         final SourceCoordinator<String> objectUnderTest = new LeaseBasedSourceCoordinator<>(String.class, sourceCoordinationStore, sourceCoordinationConfig, partitionManager, sourceIdentifier, pluginMetrics);
         doNothing().when(sourceCoordinationStore).initializeStore();
+        given(sourceCoordinationStore.tryCreatePartitionItem(
+                fullSourceIdentifierForGlobalState, GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS,
+                SourcePartitionStatus.UNASSIGNED, 0L, null)).willReturn(true);
         objectUnderTest.initialize();
         return objectUnderTest;
     }
@@ -161,12 +172,14 @@ public class LeaseBasedSourceCoordinatorTest {
         objectUnderTest.initialize();
 
         verify(sourceCoordinationStore).initializeStore();
+        verify(sourceCoordinationStore).tryCreatePartitionItem(fullSourceIdentifierForGlobalState, GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS,
+                SourcePartitionStatus.UNASSIGNED, 0L, null);
     }
 
     @Test
     void getNextPartition_throws_UninitializedSourceCoordinatorException_when_called_before_initialize() {
         final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
-        final Supplier<List<PartitionIdentifier>> partitionCreationSupplier = () -> List.of(partitionIdentifier);
+        final Function<Map<String, Object>, List<PartitionIdentifier>> partitionCreationSupplier = (map) -> List.of(partitionIdentifier);
 
         final SourceCoordinator<String> objectUnderTest = new LeaseBasedSourceCoordinator<>(String.class, sourceCoordinationStore, sourceCoordinationConfig, partitionManager, sourceIdentifier, pluginMetrics);
         assertThrows(UninitializedSourceCoordinatorException.class, () -> objectUnderTest.getNextPartition(partitionCreationSupplier));
@@ -175,15 +188,23 @@ public class LeaseBasedSourceCoordinatorTest {
     @Test
     void getNextPartition_calls_supplier_and_creates_partition_with_non_existing_item_when_partition_exists_and_is_created_successfully() {
         final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
-        final Supplier<List<PartitionIdentifier>> partitionCreationSupplier = () -> List.of(partitionIdentifier);
+        final Function<Map<String, Object>, List<PartitionIdentifier>> partitionCreationSupplier = (map) -> List.of(partitionIdentifier);
 
         given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), anyString(), any())).willReturn(Optional.empty()).willReturn( Optional.empty());
-        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, partitionIdentifier.getPartitionKey())).willReturn(Optional.empty());
-        given(sourceCoordinationStore.tryCreatePartitionItem(fullSourceIdentifier, partitionIdentifier.getPartitionKey(), SourcePartitionStatus.UNASSIGNED, 0L, null)).willReturn(true);
+        given(globalStateForPartitionCreationItem.getSourcePartitionStatus()).willReturn(SourcePartitionStatus.UNASSIGNED);
+        given(globalStateForPartitionCreationItem.getPartitionOwner()).willReturn(null);
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForGlobalState, GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS)).willReturn(Optional.of(globalStateForPartitionCreationItem));
+        doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(globalStateForPartitionCreationItem);
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, partitionIdentifier.getPartitionKey())).willReturn(Optional.empty());
+        given(sourceCoordinationStore.tryCreatePartitionItem(fullSourceIdentifierForPartition, partitionIdentifier.getPartitionKey(), SourcePartitionStatus.UNASSIGNED, 0L, null)).willReturn(true);
 
         final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition(partitionCreationSupplier);
 
         assertThat(result.isEmpty(), equalTo(true));
+
+        verify(globalStateForPartitionCreationItem).setPartitionOwner(anyString());
+        verify(globalStateForPartitionCreationItem).setPartitionOwnershipTimeout(any(Instant.class));
+        verify(globalStateForPartitionCreationItem).setSourcePartitionStatus(SourcePartitionStatus.ASSIGNED);
 
         verify(partitionCreationSupplierInvocationsCounter).increment();
         verify(noPartitionsAcquiredCounter).increment();
@@ -205,10 +226,13 @@ public class LeaseBasedSourceCoordinatorTest {
     @Test
     void getNextPartition_calls_supplier_which_returns_existing_partition_does_not_create_the_existing_partition() {
         final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
-        final Supplier<List<PartitionIdentifier>> partitionCreationSupplier = () -> List.of(partitionIdentifier);
+        final Function<Map<String, Object>, List<PartitionIdentifier>> partitionCreationSupplier = (map) -> List.of(partitionIdentifier);
 
         given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), anyString(), any())).willReturn(Optional.empty()).willReturn( Optional.empty());
-        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, partitionIdentifier.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(globalStateForPartitionCreationItem.getSourcePartitionStatus()).willReturn(SourcePartitionStatus.ASSIGNED);
+        given(globalStateForPartitionCreationItem.getPartitionOwnershipTimeout()).willReturn(Instant.now().minusSeconds(120));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForGlobalState, GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS)).willReturn(Optional.of(globalStateForPartitionCreationItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, partitionIdentifier.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition(partitionCreationSupplier);
 
@@ -234,13 +258,16 @@ public class LeaseBasedSourceCoordinatorTest {
     }
 
     @Test
-    void getNextPartition_with_non_existing_item_and_create_attempt_fails_will_do_nothing() {
+    void getNextPartition_with_non_existing_item_and_create_attempt_fails_will_do_nothing() throws UnknownHostException {
         final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
-        final Supplier<List<PartitionIdentifier>> partitionCreationSupplier = () -> List.of(partitionIdentifier);
+        final Function<Map<String, Object>, List<PartitionIdentifier>> partitionCreationSupplier = (map) -> List.of(partitionIdentifier);
 
         given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), anyString(), any())).willReturn(Optional.empty()).willReturn( Optional.empty());
-        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, partitionIdentifier.getPartitionKey())).willReturn(Optional.empty());
-        given(sourceCoordinationStore.tryCreatePartitionItem(fullSourceIdentifier, partitionIdentifier.getPartitionKey(), SourcePartitionStatus.UNASSIGNED, 0L, null)).willReturn(false);
+        given(globalStateForPartitionCreationItem.getSourcePartitionStatus()).willReturn(SourcePartitionStatus.ASSIGNED);
+        given(globalStateForPartitionCreationItem.getPartitionOwner()).willReturn(sourceIdentifier + ":" + InetAddress.getLocalHost().getHostName());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForGlobalState, GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS)).willReturn(Optional.of(globalStateForPartitionCreationItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, partitionIdentifier.getPartitionKey())).willReturn(Optional.empty());
+        given(sourceCoordinationStore.tryCreatePartitionItem(fullSourceIdentifierForPartition, partitionIdentifier.getPartitionKey(), SourcePartitionStatus.UNASSIGNED, 0L, null)).willReturn(false);
 
         final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition(partitionCreationSupplier);
 
@@ -274,7 +301,7 @@ public class LeaseBasedSourceCoordinatorTest {
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
 
-        final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition(Collections::emptyList);
+        final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition((map) -> Collections.emptyList());
 
         assertThat(result.isPresent(), equalTo(true));
         assertThat(result.get().getPartitionKey(), equalTo(sourcePartition.getPartitionKey()));
@@ -301,17 +328,23 @@ public class LeaseBasedSourceCoordinatorTest {
     @Test
     void getNextPartition_with_no_active_partition_and_unsuccessful_tryAcquireAvailablePartition_returns_empty_Optional() {
         given(partitionManager.getActivePartition()).willReturn(Optional.empty());
+        given(globalStateForPartitionCreationItem.getSourcePartitionStatus()).willReturn(SourcePartitionStatus.ASSIGNED);
+        given(globalStateForPartitionCreationItem.getPartitionOwnershipTimeout()).willReturn(Instant.now().plusSeconds(120));
+        given(globalStateForPartitionCreationItem.getPartitionOwner()).willReturn(UUID.randomUUID().toString());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForGlobalState, GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS)).willReturn(Optional.of(globalStateForPartitionCreationItem));
         given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), anyString(), any())).willReturn(Optional.empty()).willReturn(Optional.empty());
 
 
-        final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition(Collections::emptyList);
+        final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition((map) -> Collections.emptyList());
 
         assertThat(result.isEmpty(), equalTo(true));
 
-        verify(partitionCreationSupplierInvocationsCounter).increment();
+        verify(sourceCoordinationStore, never()).tryUpdateSourcePartitionItem(globalStateForPartitionCreationItem);
+
         verify(noPartitionsAcquiredCounter).increment();
 
         verifyNoInteractions(
+                partitionCreationSupplierInvocationsCounter,
                 partitionsCreatedCounter,
                 partitionsAcquiredCounter,
                 partitionsCompletedCounter,
@@ -329,18 +362,20 @@ public class LeaseBasedSourceCoordinatorTest {
     void getNextPartition_with_no_active_partition_and_successful_tryAcquireAvailablePartition_returns_expected_SourcePartition() {
         given(partitionManager.getActivePartition()).willReturn(Optional.empty());
         given(sourcePartitionStoreItem.getSourcePartitionKey()).willReturn(UUID.randomUUID().toString());
-        given(sourcePartitionStoreItem.getPartitionProgressState()).willReturn(UUID.randomUUID().toString());
+        final String partitionProgressStateValue = UUID.randomUUID().toString();
+        given(sourcePartitionStoreItem.getPartitionProgressState()).willReturn("\"" + partitionProgressStateValue + "\"");
         given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), anyString(), any())).willReturn(Optional.of(sourcePartitionStoreItem));
 
-        final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition(Collections::emptyList);
+        final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition((map) -> Collections.emptyList());
 
 
         assertThat(result.isPresent(), equalTo(true));
         assertThat(result.get().getPartitionKey(), equalTo(sourcePartitionStoreItem.getSourcePartitionKey()));
-        assertThat(result.get().getPartitionState(), equalTo(sourcePartitionStoreItem.getPartitionProgressState()));
+        assertThat(result.get().getPartitionState(), equalTo(partitionProgressStateValue));
 
         verify(partitionManager).setActivePartition(result.get());
         verify(sourceCoordinationStore, never()).getSourcePartitionItem(anyString(), anyString());
+        verify(sourceCoordinationStore, never()).tryUpdateSourcePartitionItem(any(SourcePartitionStoreItem.class));
         verify(sourceCoordinationStore, never()).tryCreatePartitionItem(anyString(), anyString(), any(), anyLong(), anyString());
 
         verify(partitionsAcquiredCounter).increment();
@@ -349,6 +384,37 @@ public class LeaseBasedSourceCoordinatorTest {
                 partitionCreationSupplierInvocationsCounter,
                 partitionsCreatedCounter,
                 noPartitionsAcquiredCounter,
+                partitionsCompletedCounter,
+                partitionsClosedCounter,
+                saveProgressStateInvocationSuccessCounter,
+                partitionsGivenUpCounter,
+                partitionNotFoundErrorCounter,
+                partitionNotOwnedErrorCounter,
+                saveStatePartitionUpdateErrorCounter,
+                closePartitionUpdateErrorCounter,
+                completePartitionUpdateErrorCounter);
+    }
+
+    @Test
+    void getNextPartition_does_not_run_partition_supplier_when_update_to_acquire_throws() {
+        given(partitionManager.getActivePartition()).willReturn(Optional.empty());
+        given(globalStateForPartitionCreationItem.getSourcePartitionStatus()).willReturn(SourcePartitionStatus.UNASSIGNED);
+        given(globalStateForPartitionCreationItem.getPartitionOwner()).willReturn(null);
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForGlobalState, GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS)).willReturn(Optional.of(globalStateForPartitionCreationItem));
+        doThrow(PartitionUpdateException.class).when(sourceCoordinationStore).tryUpdateSourcePartitionItem(globalStateForPartitionCreationItem);
+        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), anyString(), any())).willReturn(Optional.empty()).willReturn(Optional.empty());
+
+
+        final Optional<SourcePartition<String>> result = createObjectUnderTest().getNextPartition((map) -> Collections.emptyList());
+
+        assertThat(result.isEmpty(), equalTo(true));
+
+        verify(noPartitionsAcquiredCounter).increment();
+
+        verifyNoInteractions(
+                partitionCreationSupplierInvocationsCounter,
+                partitionsCreatedCounter,
+                partitionsAcquiredCounter,
                 partitionsCompletedCounter,
                 partitionsClosedCounter,
                 saveProgressStateInvocationSuccessCounter,
@@ -396,7 +462,7 @@ public class LeaseBasedSourceCoordinatorTest {
                 .build();
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
-        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.empty());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.empty());
 
         assertThrows(PartitionNotFoundException.class, () -> createObjectUnderTest().completePartition(sourcePartition.getPartitionKey()));
 
@@ -427,7 +493,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
         given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(UUID.randomUUID().toString());
         given(sourcePartitionStoreItem.getSourcePartitionKey()).willReturn(sourcePartition.getPartitionKey());
-        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         assertThrows(PartitionNotOwnedException.class, () -> createObjectUnderTest().completePartition(sourcePartition.getPartitionKey()));
 
@@ -461,7 +527,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
         given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(sourceIdentifier + ":" + InetAddress.getLocalHost().getHostName());
 
-        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         if (updatedItemSuccessfully) {
             doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);
@@ -534,7 +600,7 @@ public class LeaseBasedSourceCoordinatorTest {
                 .build();
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
-        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.empty());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.empty());
 
         assertThrows(PartitionNotFoundException.class, () -> createObjectUnderTest().closePartition(sourcePartition.getPartitionKey(), Duration.ofMinutes(2), 1));
 
@@ -565,7 +631,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
         given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(UUID.randomUUID().toString());
         given(sourcePartitionStoreItem.getSourcePartitionKey()).willReturn(sourcePartition.getPartitionKey());
-        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         assertThrows(PartitionNotOwnedException.class, () -> createObjectUnderTest().closePartition(sourcePartition.getPartitionKey(), Duration.ofMinutes(2), 1));
 
@@ -600,7 +666,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(sourceIdentifier + ":" + InetAddress.getLocalHost().getHostName());
         given(sourcePartitionStoreItem.getClosedCount()).willReturn(closedCount);
 
-        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         final int maxClosedCount = 2;
 
@@ -690,7 +756,7 @@ public class LeaseBasedSourceCoordinatorTest {
                 .build();
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
-        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.empty());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.empty());
 
         assertThrows(PartitionNotFoundException.class, () -> createObjectUnderTest().saveProgressStateForPartition(sourcePartition.getPartitionKey(), UUID.randomUUID().toString()));
 
@@ -721,7 +787,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
         given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(UUID.randomUUID().toString());
         given(sourcePartitionStoreItem.getSourcePartitionKey()).willReturn(sourcePartition.getPartitionKey());
-        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         assertThrows(PartitionNotOwnedException.class, () -> createObjectUnderTest().saveProgressStateForPartition(sourcePartition.getPartitionKey(), UUID.randomUUID().toString()));
 
@@ -757,7 +823,7 @@ public class LeaseBasedSourceCoordinatorTest {
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
         given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(sourceIdentifier + ":" + InetAddress.getLocalHost().getHostName());
-        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         if (updatedItemSuccessfully) {
             doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);
@@ -768,7 +834,7 @@ public class LeaseBasedSourceCoordinatorTest {
             final Instant newPartitionOwnershipTimeout = argumentCaptorForPartitionOwnershipTimeout.getValue();
             assertThat(newPartitionOwnershipTimeout.isAfter(beforeSave.plus(DEFAULT_LEASE_TIMEOUT)), equalTo(true));
 
-            verify(sourcePartitionStoreItem).setPartitionProgressState(newProgressState);
+            verify(sourcePartitionStoreItem).setPartitionProgressState("\"" + newProgressState + "\"");
 
             verify(saveProgressStateInvocationSuccessCounter).increment();
             verifyNoInteractions(saveStatePartitionUpdateErrorCounter);
@@ -825,7 +891,7 @@ public class LeaseBasedSourceCoordinatorTest {
                 .build();
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
-        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.empty());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.empty());
 
         createObjectUnderTest().giveUpPartitions();
 
@@ -860,7 +926,7 @@ public class LeaseBasedSourceCoordinatorTest {
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
         given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(sourceIdentifier + ":" + InetAddress.getLocalHost().getHostName());
-        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifier, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         if (updatedItemSuccessfully) {
             doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplier.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplier.java
@@ -19,11 +19,12 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-import java.util.function.Supplier;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class S3ScanPartitionCreationSupplier implements Supplier<List<PartitionIdentifier>> {
+public class S3ScanPartitionCreationSupplier implements Function<Map<String, Object>, List<PartitionIdentifier>> {
 
     private static final String BUCKET_OBJECT_PARTITION_KEY_FORMAT = "%s|%s";
 
@@ -40,7 +41,8 @@ public class S3ScanPartitionCreationSupplier implements Supplier<List<PartitionI
     }
 
     @Override
-    public List<PartitionIdentifier> get() {
+    public List<PartitionIdentifier> apply(final Map<String, Object> globalStateMap) {
+
         final List<PartitionIdentifier> objectsToProcess = new ArrayList<>();
 
         for (final ScanOptions scanOptions : scanOptionsList) {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SourceProgressState.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SourceProgressState.java
@@ -5,5 +5,12 @@
 
 package org.opensearch.dataprepper.plugins.source;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public class S3SourceProgressState {
+
+
+    @JsonCreator
+    S3SourceProgressState() {
+    }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/ScanObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/ScanObjectWorker.java
@@ -17,8 +17,9 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 /**
  * Class responsible for processing the s3 scan objects with the help of <code>S3ObjectWorker</code>
@@ -40,7 +41,7 @@ public class ScanObjectWorker implements Runnable{
 
     private final SourceCoordinator<S3SourceProgressState> sourceCoordinator;
 
-    private final Supplier<List<PartitionIdentifier>> partitionCreationSupplier;
+    private final Function<Map<String, Object>, List<PartitionIdentifier>> partitionCreationSupplier;
 
     // Should there be a duration or time that is configured in the source to stop processing? Otherwise will only stop when data prepper is stopped
     private final boolean shouldStopProcessing = false;

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ScanObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ScanObjectWorkerTest.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Supplier;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -77,7 +77,7 @@ class S3ScanObjectWorkerTest {
 
         final SourcePartition<S3SourceProgressState> partitionToProcess = SourcePartition.builder(S3SourceProgressState.class).withPartitionKey(partitionKey).build();
 
-        given(sourceCoordinator.getNextPartition(any(Supplier.class))).willReturn(Optional.of(partitionToProcess));
+        given(sourceCoordinator.getNextPartition(any(Function.class))).willReturn(Optional.of(partitionToProcess));
 
         final ArgumentCaptor<S3ObjectReference> objectReferenceArgumentCaptor = ArgumentCaptor.forClass(S3ObjectReference.class);
         doThrow(exception).when(s3ObjectHandler).parseS3Object(objectReferenceArgumentCaptor.capture(), eq(null));
@@ -97,7 +97,7 @@ class S3ScanObjectWorkerTest {
 
         final SourcePartition<S3SourceProgressState> partitionToProcess = SourcePartition.builder(S3SourceProgressState.class).withPartitionKey(partitionKey).build();
 
-        given(sourceCoordinator.getNextPartition(any(Supplier.class))).willReturn(Optional.of(partitionToProcess));
+        given(sourceCoordinator.getNextPartition(any(Function.class))).willReturn(Optional.of(partitionToProcess));
 
         final ArgumentCaptor<S3ObjectReference> objectReferenceArgumentCaptor = ArgumentCaptor.forClass(S3ObjectReference.class);
         doNothing().when(s3ObjectHandler).parseS3Object(objectReferenceArgumentCaptor.capture(), eq(null));

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplierTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplierTest.java
@@ -25,9 +25,11 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
-import java.util.function.Supplier;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -54,7 +56,7 @@ public class S3ScanPartitionCreationSupplierTest {
     }
 
 
-    private Supplier<List<PartitionIdentifier>> createObjectUnderTest() {
+    private Function<Map<String, Object>, List<PartitionIdentifier>> createObjectUnderTest() {
         return new S3ScanPartitionCreationSupplier(s3Client, bucketOwnerProvider, scanOptionsList);
     }
 
@@ -88,7 +90,7 @@ public class S3ScanPartitionCreationSupplierTest {
         given(secondBucketScanKeyPath.getS3ScanExcludeSuffixOptions()).willReturn(null);
         scanOptionsList.add(secondBucketScanOptions);
 
-        final Supplier<List<PartitionIdentifier>> partitionCreationSupplier = createObjectUnderTest();
+        final Function<Map<String, Object>, List<PartitionIdentifier>> partitionCreationSupplier = createObjectUnderTest();
 
         final List<PartitionIdentifier> expectedPartitionIdentifiers = new ArrayList<>();
 
@@ -123,7 +125,7 @@ public class S3ScanPartitionCreationSupplierTest {
         final ArgumentCaptor<ListObjectsV2Request> listObjectsV2RequestArgumentCaptor = ArgumentCaptor.forClass(ListObjectsV2Request.class);
         given(s3Client.listObjectsV2(listObjectsV2RequestArgumentCaptor.capture())).willReturn(listObjectsResponse);
 
-        final List<PartitionIdentifier> resultingPartitions = partitionCreationSupplier.get();
+        final List<PartitionIdentifier> resultingPartitions = partitionCreationSupplier.apply(new HashMap<>());
 
         assertThat(resultingPartitions, notNullValue());
         assertThat(resultingPartitions.size(), equalTo(expectedPartitionIdentifiers.size()));


### PR DESCRIPTION
### Description
This includes a new type of item to store for source coordination. Partitions returned in the Partition supplier from the source will be created with the sourceIdentifier as the suffix `|PARTITION`.

Global state items will be created with a sourceIdentifier with the suffix `|GLOBAL_STATE`. 

In `getNextPartition`, if no partition is acquired on the first attempt, the partition creation supplier is run. However, now the source coordinator will attempt to acquire (assign ownership to itself) the item for global state for partition creation. If this item is not available, that means that another instance of Data Prepper already owns it, and is handling the partition creation, and the instance will move on and retry. If the item is acquired, then the globalStateMap will be pulled from `partitionProgressState`, and this map will be passed to the partition creation supplier `apply` method to allow the supplier to use the state however it likes (it doesn't have to use it if it doesn't want to). 

Waiting on #2777 to rebase off of
 
### Issues Resolved
Related to #2412 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
