### PR TITLE
Add OpenSearch Sink option to include Event tags in the document

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -165,6 +165,8 @@ If a single record turns out to be larger than the set bulk size, it will be sen
 
 - `document_root_key`: The key in the event that will be used as the root in the document. The default is the root of the event. If the key does not exist the entire event is written as the document. If the value at the `document_root_key` is a basic type (ie String, int, etc), the document will have a structure of `{"data": <value of the document_root_key>}`. For example, If we have the following sample event: 
 
+- `tags_key_name` (optional): The key name to be used to include event tags in the document. By default this is not set. When this option is not used, tags are not included in the document. If the option is used but the event does not have any tags, it stored as empty list in the document.
+
 ```
 {
     status: 200,

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -87,6 +87,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
   private final IndexType indexType;
   private final String documentIdField;
   private final String routingField;
+  private final String tagsKeyName;
   private final String action;
   private final String documentRootKey;
   private String configuredIndexAlias;
@@ -119,6 +120,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     this.indexType = openSearchSinkConfig.getIndexConfiguration().getIndexType();
     this.documentIdField = openSearchSinkConfig.getIndexConfiguration().getDocumentIdField();
     this.routingField = openSearchSinkConfig.getIndexConfiguration().getRoutingField();
+    this.tagsKeyName = openSearchSinkConfig.getIndexConfiguration().getTagsKeyName();
     this.action = openSearchSinkConfig.getIndexConfiguration().getAction();
     this.documentRootKey = openSearchSinkConfig.getIndexConfiguration().getDocumentRootKey();
     this.indexManagerFactory = new IndexManagerFactory(new ClusterSettingsParser());
@@ -268,6 +270,10 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
   private SerializedJson getDocument(final Event event) {
     String docId = (documentIdField != null) ? event.get(documentIdField, String.class) : null;
     String routing = (routingField != null) ? event.get(routingField, String.class) : null;
+
+    if (tagsKeyName != null) {
+        event.put(tagsKeyName, event.getMetadata().getTags());
+    }
 
     final String document = DocumentBuilder.build(event, documentRootKey);
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -37,6 +37,7 @@ public class IndexConfiguration {
     public static final String BULK_SIZE = "bulk_size";
     public static final String DOCUMENT_ID_FIELD = "document_id_field";
     public static final String ROUTING_FIELD = "routing_field";
+    public static final String TAGS_KEY_NAME = "tags_key_name";
     public static final String ISM_POLICY_FILE = "ism_policy_file";
     public static final long DEFAULT_BULK_SIZE = 5L;
     public static final String ACTION = "action";
@@ -51,6 +52,7 @@ public class IndexConfiguration {
     private final Map<String, Object> indexTemplate;
     private final String documentIdField;
     private final String routingField;
+    private final String tagsKeyName;
     private final long bulkSize;
     private final Optional<String> ismPolicyFile;
     private final String action;
@@ -106,6 +108,7 @@ public class IndexConfiguration {
         this.ismPolicyFile = builder.ismPolicyFile;
         this.action = builder.action;
         this.documentRootKey = builder.documentRootKey;
+        this.tagsKeyName = builder.tagsKeyName;
     }
 
     private void determineIndexType(Builder builder) {
@@ -146,6 +149,11 @@ public class IndexConfiguration {
         final String routingField = pluginSetting.getStringOrDefault(ROUTING_FIELD, null);
         if (routingField != null) {
             builder = builder.withRoutingField(routingField);
+        }
+
+        final String tagsKeyName = pluginSetting.getStringOrDefault(TAGS_KEY_NAME, null);
+        if (tagsKeyName != null) {
+            builder = builder.withTagsKeyName(tagsKeyName);
         }
 
         final String ismPolicyFile = pluginSetting.getStringOrDefault(ISM_POLICY_FILE, null);
@@ -193,6 +201,10 @@ public class IndexConfiguration {
 
     public String getRoutingField() {
         return routingField;
+    }
+
+    public String getTagsKeyName() {
+        return tagsKeyName;
     }
 
     public long getBulkSize() {
@@ -272,6 +284,7 @@ public class IndexConfiguration {
         private int numReplicas;
         private String routingField;
         private String documentIdField;
+        private String tagsKeyName;
         private long bulkSize = DEFAULT_BULK_SIZE;
         private Optional<String> ismPolicyFile;
         private String action;
@@ -309,6 +322,11 @@ public class IndexConfiguration {
 
         public Builder withRoutingField(final String routingField) {
             this.routingField = routingField;
+            return this;
+        }
+
+        public Builder withTagsKeyName(final String tagsKeyName) {
+            this.tagsKeyName = tagsKeyName;
             return this;
         }
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -68,15 +68,18 @@ public class IndexConfigurationTests {
                 getClass().getClassLoader().getResource(DEFAULT_TEMPLATE_FILE)).getFile();
 
         final String testIndexAlias = "foo";
+        final String testTagsKeyName = "tags";
         IndexConfiguration indexConfiguration = new IndexConfiguration.Builder()
                 .withIndexAlias(testIndexAlias)
                 .withTemplateFile(defaultTemplateFilePath)
                 .withIsmPolicyFile(TEST_CUSTOM_INDEX_POLICY_FILE)
                 .withBulkSize(10)
+                .withTagsKeyName(testTagsKeyName)
                 .build();
 
         assertEquals(IndexType.CUSTOM, indexConfiguration.getIndexType());
         assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
+        assertEquals(testTagsKeyName, indexConfiguration.getTagsKeyName());
         assertEquals(10, indexConfiguration.getBulkSize());
         assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
 
@@ -115,6 +118,7 @@ public class IndexConfigurationTests {
 
         assertEquals(IndexType.CUSTOM, indexConfiguration.getIndexType());
         assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
+        assertEquals(null, indexConfiguration.getTagsKeyName());
         assertEquals(testS3AwsRegion, indexConfiguration.getS3AwsRegion());
         assertEquals(testS3StsRoleArn, indexConfiguration.getS3AwsStsRoleArn());
     }


### PR DESCRIPTION
### Description
Add OpenSearch Sink option to include Event tags in the document.
This change allows writing events tags to the event document in the opensearch. A new opensearch config option `tags_key_name` is added. When this option is present, the `tags_key_name` value is used as name of the key to store the tags in the document.

Example config
```
- opensearch:                                                                                                                                          
       hosts: ["https://opensearch-node1:9200"]                                                                                                            
       tags_key_name: "tags"                                                                                                                                                                                                                                                                
       index: test_index
```

Example output
```
     {
        "_index": "new_http_logs_may_31",
        "_id": "nugsdYgBRCBJrQoAlWPJ",
        "_score": 1,
        "_source": {
          "message": "wordone wordtwo wordthree",
          "tags": [
            "tag1",
            "tag2"
          ]
        }
      }

```
 
Resolves #629 
### Issues Resolved
Resolves #629 
 
### Check List
- [X ] New functionality includes testing.
- [X ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
