### PR TITLE
FIX: bump opensearch-java version to fix unhelpful log message

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,7 @@ dependencyResolutionManagement {
             library('protobuf-util', 'com.google.protobuf', 'protobuf-java-util').versionRef('protobuf')
             version('opentelemetry', '0.16.0-alpha')
             library('opentelemetry-proto', 'io.opentelemetry.proto', 'opentelemetry-proto').versionRef('opentelemetry')
-            version('opensearchJava', '2.2.0')
+            version('opensearchJava', '2.5.0')
             library('opensearch-java', 'org.opensearch.client', 'opensearch-java').versionRef('opensearchJava')
             version('opensearch', '1.3.8')
             library('opensearch-client', 'org.opensearch.client', 'opensearch-rest-client').versionRef('opensearch')


### PR DESCRIPTION
### Description
Bump the dependency on opensearch-java new release version so that the log message from the client will be more helpful. With this change, we do not have to explicitly catch the exception with ambiguous message and infer the root cause in data-prepper.
 
### Issues Resolved
Resolves #2655 
Resolves #2657 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
