### PR TITLE
Fixes a bug in the S3 sink where events without handles throw NPE

### DIFF
--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/S3SinkService.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/S3SinkService.java
@@ -129,9 +129,8 @@ public class S3SinkService {
                     currentBuffer = bufferFactory.getBuffer();
                 }
             }
-        } catch (NullPointerException | IOException | InterruptedException e) {
+        } catch (IOException | InterruptedException e) {
             LOG.error("Exception while write event into buffer :", e);
-            Thread.currentThread().interrupt();
         }
         reentrantLock.unlock();
     }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/S3SinkService.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/S3SinkService.java
@@ -106,7 +106,9 @@ public class S3SinkService {
                 final byte[] encodedBytes = encodedEvent.getBytes();
 
                 currentBuffer.writeEvent(encodedBytes);
-                bufferedEventHandles.add(event.getEventHandle());
+                if(event.getEventHandle() != null) {
+                    bufferedEventHandles.add(event.getEventHandle());
+                }
                 if (ThresholdCheck.checkThresholdExceed(currentBuffer, maxEvents, maxBytes, maxCollectionDuration)) {
                     final String s3Key = generateKey();
                     LOG.info("Writing {} to S3 with {} events and size of {} bytes.",
@@ -134,7 +136,7 @@ public class S3SinkService {
         reentrantLock.unlock();
     }
 
-    private void releaseEventHandles(boolean result) {
+    private void releaseEventHandles(final boolean result) {
         for (EventHandle eventHandle : bufferedEventHandles) {
             eventHandle.release(result);
         }


### PR DESCRIPTION
### Description

Fixes a bug in the `s3` sink for null Event handles.

```
2023-06-02T22:22:12,052 [performance-alb-pipeline-sink-worker-2-thread-3] ERROR org.opensearch.dataprepper.plugins.sink.S3SinkService - Exception while write event into buffer :
java.lang.NullPointerException: Cannot invoke "org.opensearch.dataprepper.model.event.EventHandle.release(boolean)" because "eventHandle" is null
	at org.opensearch.dataprepper.plugins.sink.S3SinkService.releaseEventHandles(S3SinkService.java:139) ~[s3-sink-2.3.0-SNAPSHOT.jar:?]
	at org.opensearch.dataprepper.plugins.sink.S3SinkService.output(S3SinkService.java:120) ~[s3-sink-2.3.0-SNAPSHOT.jar:?]
	at org.opensearch.dataprepper.plugins.sink.S3Sink.doOutput(S3Sink.java:106) ~[s3-sink-2.3.0-SNAPSHOT.jar:?]
	at org.opensearch.dataprepper.model.sink.AbstractSink.lambda$output$0(AbstractSink.java:64) ~[data-prepper-api-2.3.0-SNAPSHOT.jar:?]
	at io.micrometer.core.instrument.composite.CompositeTimer.record(CompositeTimer.java:141) ~[micrometer-core-1.10.5.jar:1.10.5]
	at org.opensearch.dataprepper.model.sink.AbstractSink.output(AbstractSink.java:64) ~[data-prepper-api-2.3.0-SNAPSHOT.jar:?]
	at org.opensearch.dataprepper.pipeline.Pipeline.lambda$publishToSinks$5(Pipeline.java:336) ~[data-prepper-core-2.3.0-SNAPSHOT.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
```
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
