### PR TITLE
Implement opensearch index partition creation supplier and PitWorker without processing indices

### DIFF
--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchService.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchService.java
@@ -79,7 +79,7 @@ public class OpenSearchService {
         final long waitTimeBeforeStartMillis = startTime.toEpochMilli() - Instant.now().toEpochMilli() < 0 ? 0L :
                 startTime.toEpochMilli() - Instant.now().toEpochMilli();
 
-        LOG.info("The opensearch source will start processing data at {}. It is currently {}", startTime, Instant.now().toString());
+        LOG.info("The opensearch source will start processing data at {}. It is currently {}", startTime, Instant.now());
 
         searchWorkerFuture = scheduledExecutorService.schedule(() -> searchWorker.run(), waitTimeBeforeStartMillis, TimeUnit.MILLISECONDS);
     }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchService.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchService.java
@@ -8,44 +8,66 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.OpenSearchIndexPartitionCreationSupplier;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.PitWorker;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.ScrollWorker;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.SearchWorker;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.ClusterClientFactory;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 public class OpenSearchService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenSearchService.class);
+
+    static final Duration EXECUTOR_SERVICE_SHUTDOWN_TIMEOUT = Duration.ofSeconds(30);
 
     private final SearchAccessor searchAccessor;
     private final OpenSearchSourceConfiguration openSearchSourceConfiguration;
     private final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator;
     private final Buffer<Record<Event>> buffer;
+    private final OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier;
+    private final ScheduledExecutorService scheduledExecutorService;
 
-    private Thread searchWorkerThread;
+    private SearchWorker searchWorker;
+    private ScheduledFuture<?> searchWorkerFuture;
 
     public static OpenSearchService createOpenSearchService(final SearchAccessor searchAccessor,
                                                             final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator,
                                                             final OpenSearchSourceConfiguration openSearchSourceConfiguration,
                                                             final Buffer<Record<Event>> buffer) {
-        return new OpenSearchService(searchAccessor, sourceCoordinator, openSearchSourceConfiguration, buffer);
+        return new OpenSearchService(searchAccessor, sourceCoordinator, openSearchSourceConfiguration, buffer, Executors.newSingleThreadScheduledExecutor());
     }
 
     private OpenSearchService(final SearchAccessor searchAccessor,
                              final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator,
                              final OpenSearchSourceConfiguration openSearchSourceConfiguration,
-                             final Buffer<Record<Event>> buffer) {
+                             final Buffer<Record<Event>> buffer,
+                              final ScheduledExecutorService scheduledExecutorService) {
         this.searchAccessor = searchAccessor;
         this.openSearchSourceConfiguration = openSearchSourceConfiguration;
         this.buffer = buffer;
         this.sourceCoordinator = sourceCoordinator;
         this.sourceCoordinator.initialize();
+        this.openSearchIndexPartitionCreationSupplier = new OpenSearchIndexPartitionCreationSupplier(openSearchSourceConfiguration, (ClusterClientFactory) searchAccessor);
+        this.scheduledExecutorService = scheduledExecutorService;
     }
 
     public void start() {
         switch(searchAccessor.getSearchContextType()) {
             case POINT_IN_TIME:
-                searchWorkerThread = new Thread(new PitWorker(searchAccessor, openSearchSourceConfiguration, sourceCoordinator, buffer));
+                searchWorker = new PitWorker(searchAccessor, openSearchSourceConfiguration, sourceCoordinator, buffer, openSearchIndexPartitionCreationSupplier);
                 break;
             case SCROLL:
-                searchWorkerThread = new Thread(new ScrollWorker(searchAccessor, openSearchSourceConfiguration, sourceCoordinator, buffer));
+                searchWorker = new ScrollWorker(searchAccessor, openSearchSourceConfiguration, sourceCoordinator, buffer, openSearchIndexPartitionCreationSupplier);
                 break;
             default:
                 throw new IllegalArgumentException(
@@ -53,10 +75,29 @@ public class OpenSearchService {
                                 searchAccessor.getSearchContextType()));
         }
 
-        searchWorkerThread.start();
+        final Instant startTime = openSearchSourceConfiguration.getSchedulingParameterConfiguration().getStartTime();
+        final long waitTimeBeforeStartMillis = startTime.toEpochMilli() - Instant.now().toEpochMilli() < 0 ? 0L :
+                startTime.toEpochMilli() - Instant.now().toEpochMilli();
+
+        LOG.info("The opensearch source will start processing data at {}. It is currently {}", startTime, Instant.now().toString());
+
+        searchWorkerFuture = scheduledExecutorService.schedule(() -> searchWorker.run(), waitTimeBeforeStartMillis, TimeUnit.MILLISECONDS);
     }
 
     public void stop() {
+        scheduledExecutorService.shutdown();
+        try {
+            searchWorkerFuture.cancel(true);
+            if (scheduledExecutorService.awaitTermination(EXECUTOR_SERVICE_SHUTDOWN_TIMEOUT.getSeconds(), TimeUnit.SECONDS)) {
+                LOG.info("Successfully waited for the search worker to terminate");
+            } else {
+                LOG.warn("Search worker did not terminate in time, forcing termination");
+                scheduledExecutorService.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            LOG.error("Interrupted while waiting for the search worker to terminate", e);
+            scheduledExecutorService.shutdownNow();
+        }
 
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSource.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSource.java
@@ -16,7 +16,7 @@ import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessor;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessorStrategy;
 
-@DataPrepperPlugin(name="opensearch", pluginType = Source.class , pluginConfigurationType = OpenSearchSourceConfiguration.class )
+@DataPrepperPlugin(name="opensearch", pluginType = Source.class, pluginConfigurationType = OpenSearchSourceConfiguration.class)
 public class OpenSearchSource implements Source<Record<Event>>, UsesSourceCoordination {
 
     private final AwsCredentialsSupplier awsCredentialsSupplier;

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfiguration.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfiguration.java
@@ -51,7 +51,7 @@ public class OpenSearchSourceConfiguration {
 
     @JsonProperty("scheduling")
     @Valid
-    private SchedulingParameterConfiguration schedulingParameterConfiguration;
+    private SchedulingParameterConfiguration schedulingParameterConfiguration = new SchedulingParameterConfiguration();
 
     @JsonProperty("search_options")
     @Valid

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/OpenSearchIndexPartitionCreationSupplier.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/OpenSearchIndexPartitionCreationSupplier.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker;
+
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch.cat.IndicesResponse;
+import org.opensearch.client.opensearch.cat.indices.IndicesRecord;
+import org.opensearch.dataprepper.model.source.coordinator.PartitionIdentifier;
+import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.IndexParametersConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.OpenSearchIndex;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.ClusterClientFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.stream.Collectors;
+
+public class OpenSearchIndexPartitionCreationSupplier implements Function<Map<String, Object>, List<PartitionIdentifier>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenSearchIndexPartitionCreationSupplier.class);
+
+    private final OpenSearchSourceConfiguration openSearchSourceConfiguration;
+    private final OpenSearchClient openSearchClient;
+
+    public OpenSearchIndexPartitionCreationSupplier(final OpenSearchSourceConfiguration openSearchSourceConfiguration,
+                                                    final ClusterClientFactory clusterClientFactory) {
+        this.openSearchSourceConfiguration = openSearchSourceConfiguration;
+
+        final Object client = clusterClientFactory.getClient();
+
+        if (client instanceof OpenSearchClient) {
+            this.openSearchClient = (OpenSearchClient) client;
+        } else {
+            throw new IllegalArgumentException(String.format("ClusterClientFactory provided an invalid client object to the index partition creation supplier. " +
+                    "The client must be of type OpenSearchClient. The client passed is of class %s", client.getClass()));
+        }
+
+    }
+
+    @Override
+    public List<PartitionIdentifier> apply(final Map<String, Object> globalStateMap) {
+
+        if (Objects.nonNull(openSearchClient)) {
+            return applyForOpenSearchClient(globalStateMap);
+        }
+
+        return Collections.emptyList();
+    }
+
+    private List<PartitionIdentifier> applyForOpenSearchClient(final Map<String, Object> globalStateMap) {
+        IndicesResponse indicesResponse;
+        try {
+            indicesResponse = openSearchClient.cat().indices();
+        } catch (IOException | OpenSearchException e) {
+            LOG.error("There was an exception when calling /_cat/indices to create new index partitions", e);
+            return Collections.emptyList();
+        }
+
+        return indicesResponse.valueBody().stream()
+                .filter(this::isIndexIncludedInOneOfTheIncludePatternsAndNotExcludedInAnExcludePattern)
+                .map(indexRecord -> PartitionIdentifier.builder().withPartitionKey(indexRecord.index()).build())
+                .collect(Collectors.toList());
+    }
+
+    private boolean isIndexIncludedInOneOfTheIncludePatternsAndNotExcludedInAnExcludePattern(final IndicesRecord indicesRecord) {
+        if (Objects.isNull(indicesRecord.index())) {
+            return false;
+        }
+
+        final IndexParametersConfiguration indexParametersConfiguration = openSearchSourceConfiguration.getIndexParametersConfiguration();
+
+        if (Objects.isNull(openSearchSourceConfiguration.getIndexParametersConfiguration())) {
+            return true;
+        }
+
+        final List<OpenSearchIndex> includedIndices = indexParametersConfiguration.getIncludedIndices();
+        final List<OpenSearchIndex> excludedIndices = indexParametersConfiguration.getExcludedIndices();
+
+        boolean matchesIncludedPattern = includedIndices.isEmpty();
+
+
+        for (final OpenSearchIndex index : includedIndices) {
+            final Matcher matcher = index.getIndexNamePattern().matcher(indicesRecord.index());
+
+            if (matcher.matches()) {
+                matchesIncludedPattern = true;
+                break;
+            }
+        }
+
+        boolean matchesExcludePattern = false;
+
+        for (final OpenSearchIndex index : excludedIndices) {
+            final Matcher matcher = index.getIndexNamePattern().matcher(indicesRecord.index());
+
+            if (matcher.matches()) {
+                matchesExcludePattern = true;
+                break;
+            }
+        }
+
+
+        return matchesIncludedPattern && !matchesExcludePattern;
+    }
+}

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
@@ -8,32 +8,63 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartition;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchIndexProgressState;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
 
 /**
  * PitWorker polls the source cluster via Point-In-Time contexts.
  */
 public class PitWorker implements SearchWorker, Runnable {
 
+    private static final Logger LOG = LoggerFactory.getLogger(PitWorker.class);
+
     private final SearchAccessor searchAccessor;
     private final OpenSearchSourceConfiguration openSearchSourceConfiguration;
     private final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator;
     private final Buffer<Record<Event>> buffer;
+    private final OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier;
+
+    private static final int STANDARD_BACKOFF_MILLIS = 30_000;
 
     public PitWorker(final SearchAccessor searchAccessor,
                      final OpenSearchSourceConfiguration openSearchSourceConfiguration,
                      final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator,
-                     final Buffer<Record<Event>> buffer) {
+                     final Buffer<Record<Event>> buffer,
+                     final OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier) {
         this.searchAccessor = searchAccessor;
         this.sourceCoordinator = sourceCoordinator;
         this.openSearchSourceConfiguration = openSearchSourceConfiguration;
         this.buffer = buffer;
+        this.openSearchIndexPartitionCreationSupplier = openSearchIndexPartitionCreationSupplier;
     }
 
     @Override
     public void run() {
-        // todo: implement
+        while (!Thread.currentThread().isInterrupted()) {
+            final Optional<SourcePartition<OpenSearchIndexProgressState>> indexPartition = sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier);
+
+            if (indexPartition.isEmpty()) {
+                try {
+                    Thread.sleep(STANDARD_BACKOFF_MILLIS);
+                    continue;
+                } catch (InterruptedException e) {
+                    LOG.info("The PitWorker was interrupted while sleeping after acquiring no indices to process, stopping processing");
+                    return;
+                }
+            }
+
+            // todo: process the index and write to the buffer
+
+            sourceCoordinator.closePartition(
+                    indexPartition.get().getPartitionKey(),
+                    openSearchSourceConfiguration.getSchedulingParameterConfiguration().getRate(),
+                    openSearchSourceConfiguration.getSchedulingParameterConfiguration().getJobCount());
+        }
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
@@ -21,15 +21,18 @@ public class ScrollWorker implements SearchWorker {
     private final OpenSearchSourceConfiguration openSearchSourceConfiguration;
     private final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator;
     private final Buffer<Record<Event>> buffer;
+    private final OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier;
 
     public ScrollWorker(final SearchAccessor searchAccessor,
                         final OpenSearchSourceConfiguration openSearchSourceConfiguration,
                         final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator,
-                        final Buffer<Record<Event>> buffer) {
+                        final Buffer<Record<Event>> buffer,
+                        final OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier) {
         this.searchAccessor = searchAccessor;
         this.openSearchSourceConfiguration = openSearchSourceConfiguration;
         this.sourceCoordinator = sourceCoordinator;
         this.buffer = buffer;
+        this.openSearchIndexPartitionCreationSupplier = openSearchIndexPartitionCreationSupplier;
     }
 
     @Override

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ClusterClientFactory.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ClusterClientFactory.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker.client;
+
+public interface ClusterClientFactory {
+    Object getClient();
+}

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessor.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessor.java
@@ -16,7 +16,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollResponse;
 
-public class ElasticsearchAccessor implements SearchAccessor {
+public class ElasticsearchAccessor implements SearchAccessor, ClusterClientFactory {
     @Override
     public SearchContextType getSearchContextType() {
         // todo: implement
@@ -55,5 +55,10 @@ public class ElasticsearchAccessor implements SearchAccessor {
     @Override
     public void deleteScroll(DeleteScrollRequest deleteScrollRequest) {
         //todo: implement
+    }
+
+    @Override
+    public Object getClient() {
+        return null;
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
@@ -17,7 +17,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollResponse;
 
-public class OpenSearchAccessor implements SearchAccessor {
+public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory {
 
     private final OpenSearchClient openSearchClient;
     private final SearchContextType searchContextType;
@@ -26,7 +26,6 @@ public class OpenSearchAccessor implements SearchAccessor {
         this.openSearchClient = openSearchClient;
         this.searchContextType = searchContextType;
     }
-
 
     @Override
     public SearchContextType getSearchContextType() {
@@ -65,5 +64,10 @@ public class OpenSearchAccessor implements SearchAccessor {
     @Override
     public void deleteScroll(DeleteScrollRequest deleteScrollRequest) {
         //todo: implement
+    }
+
+    @Override
+    public Object getClient() {
+        return openSearchClient;
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchServiceTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchServiceTest.java
@@ -7,15 +7,39 @@ package org.opensearch.dataprepper.plugins.source.opensearch;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
-import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessor;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SchedulingParameterConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.OpenSearchIndexPartitionCreationSupplier;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.PitWorker;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.ScrollWorker;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.SearchWorker;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchContextType;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class OpenSearchServiceTest {
@@ -24,7 +48,7 @@ public class OpenSearchServiceTest {
     private OpenSearchSourceConfiguration openSearchSourceConfiguration;
 
     @Mock
-    private SearchAccessor searchAccessor;
+    private OpenSearchAccessor openSearchAccessor;
 
     @Mock
     private Buffer<Record<Event>> buffer;
@@ -32,13 +56,70 @@ public class OpenSearchServiceTest {
     @Mock
     private SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator;
 
+    @Mock
+    private ScheduledExecutorService scheduledExecutorService;
+
+    @Mock
+    private OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier;
+
+    @Mock
+    private SearchWorker searchWorker;
+
     private OpenSearchService createObjectUnderTest() {
-        return OpenSearchService.createOpenSearchService(searchAccessor, sourceCoordinator, openSearchSourceConfiguration, buffer);
+        try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class);
+             final MockedConstruction<OpenSearchIndexPartitionCreationSupplier> mockedConstruction = mockConstruction(OpenSearchIndexPartitionCreationSupplier.class, (mock, context) -> {
+                 openSearchIndexPartitionCreationSupplier = mock;
+             })) {
+            executorsMockedStatic.when(Executors::newSingleThreadScheduledExecutor).thenReturn(scheduledExecutorService);
+            return OpenSearchService.createOpenSearchService(openSearchAccessor, sourceCoordinator, openSearchSourceConfiguration, buffer);
+        }
     }
 
     @Test
     void source_coordinator_is_initialized_on_construction() {
         createObjectUnderTest();
         verify(sourceCoordinator).initialize();
+    }
+
+    @Test
+    void search_context_types_get_submitted_correctly_for_point_in_time_and_executor_service_with_start_time_in_the_future() {
+        when(openSearchAccessor.getSearchContextType()).thenReturn(SearchContextType.POINT_IN_TIME);
+        final Instant startTime = Instant.now().plusSeconds(60);
+
+        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
+        when(schedulingParameterConfiguration.getStartTime()).thenReturn(startTime);
+        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+
+        try (final MockedConstruction<PitWorker> pitWorkerMockedConstruction = mockConstruction(PitWorker.class, (pitWorker, context) -> {
+            searchWorker = pitWorker;
+        })) {}
+
+        createObjectUnderTest().start();
+
+        final ArgumentCaptor<Long> argumentCaptor = ArgumentCaptor.forClass(Long.class);
+
+        verify(scheduledExecutorService).schedule(ArgumentMatchers.any(Runnable.class), argumentCaptor.capture(), eq(TimeUnit.MILLISECONDS));
+
+        final long waitTimeMillis = argumentCaptor.getValue();
+        assertThat(waitTimeMillis, lessThanOrEqualTo(Duration.ofSeconds(60).toMillis()));
+        assertThat(waitTimeMillis, greaterThan(Duration.ofSeconds(30).toMillis()));
+    }
+
+    @Test
+    void search_context_types_get_submitted_correctly_for_scroll_and_executor_service_with_start_time_in_the_past() {
+        when(openSearchAccessor.getSearchContextType()).thenReturn(SearchContextType.SCROLL);
+        final Instant startTime = Instant.now().minusSeconds(60);
+
+        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
+        when(schedulingParameterConfiguration.getStartTime()).thenReturn(startTime);
+        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+
+        try (final MockedConstruction<ScrollWorker> scrollWorkerMockedConstruction = mockConstruction(ScrollWorker.class, (scrollWorker, context) -> {
+            searchWorker = scrollWorker;
+        })) {}
+
+        createObjectUnderTest().start();
+
+        verify(scheduledExecutorService).schedule(ArgumentMatchers.any(Runnable.class), eq(0L), eq(TimeUnit.MILLISECONDS));
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchIndexPartitionCreationSupplierTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchIndexPartitionCreationSupplierTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker.client;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch.cat.IndicesResponse;
+import org.opensearch.client.opensearch.cat.OpenSearchCatClient;
+import org.opensearch.client.opensearch.cat.indices.IndicesRecord;
+import org.opensearch.dataprepper.model.source.coordinator.PartitionIdentifier;
+import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.IndexParametersConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.OpenSearchIndex;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.OpenSearchIndexPartitionCreationSupplier;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class OpenSearchIndexPartitionCreationSupplierTest {
+
+    @Mock
+    private OpenSearchSourceConfiguration openSearchSourceConfiguration;
+
+    @Mock
+    private ClusterClientFactory clusterClientFactory;
+
+    @Mock
+    private OpenSearchClient openSearchClient;
+
+    private OpenSearchIndexPartitionCreationSupplier createObjectUnderTest() {
+        return new OpenSearchIndexPartitionCreationSupplier(openSearchSourceConfiguration, clusterClientFactory);
+    }
+
+    @Test
+    void clusterClientFactory_that_is_not_OpenSearchClient_throws_IllegalArgumentException() {
+        when(clusterClientFactory.getClient()).thenReturn(mock(Object.class));
+
+        assertThrows(IllegalArgumentException.class, this::createObjectUnderTest);
+    }
+
+    @ParameterizedTest
+    @MethodSource("opensearchCatIndicesExceptions")
+    void apply_with_opensearch_client_cat_indices_throws_exception_returns_empty_list(final Class exception) throws IOException {
+        when(clusterClientFactory.getClient()).thenReturn(openSearchClient);
+
+        final OpenSearchCatClient openSearchCatClient = mock(OpenSearchCatClient.class);
+        when(openSearchCatClient.indices()).thenThrow(exception);
+        when(openSearchClient.cat()).thenReturn(openSearchCatClient);
+
+        final List<PartitionIdentifier> partitionIdentifierList = createObjectUnderTest().apply(Collections.emptyMap());
+
+        assertThat(partitionIdentifierList, notNullValue());
+        assertThat(partitionIdentifierList.isEmpty(), equalTo(true));
+    }
+
+    @Test
+    void apply_with_opensearch_client_with_no_indices_return_empty_list() throws IOException {
+        when(clusterClientFactory.getClient()).thenReturn(openSearchClient);
+
+        final OpenSearchCatClient openSearchCatClient = mock(OpenSearchCatClient.class);
+        final IndicesResponse indicesResponse = mock(IndicesResponse.class);
+        when(indicesResponse.valueBody()).thenReturn(Collections.emptyList());
+        when(openSearchCatClient.indices()).thenReturn(indicesResponse);
+        when(openSearchClient.cat()).thenReturn(openSearchCatClient);
+
+        final List<PartitionIdentifier> partitionIdentifierList = createObjectUnderTest().apply(Collections.emptyMap());
+
+        assertThat(partitionIdentifierList, notNullValue());
+        assertThat(partitionIdentifierList.isEmpty(), equalTo(true));
+    }
+
+    @Test
+    void apply_with_opensearch_client_with_indices_filters_them_correctly() throws IOException {
+        when(clusterClientFactory.getClient()).thenReturn(openSearchClient);
+
+        final OpenSearchCatClient openSearchCatClient = mock(OpenSearchCatClient.class);
+        final IndicesResponse indicesResponse = mock(IndicesResponse.class);
+
+        final IndexParametersConfiguration indexParametersConfiguration = mock(IndexParametersConfiguration.class);
+
+        final List<OpenSearchIndex> includedIndices = new ArrayList<>();
+        final OpenSearchIndex includeIndex = mock(OpenSearchIndex.class);
+        final String includePattern = "my-pattern-[a-c].*";
+        when(includeIndex.getIndexNamePattern()).thenReturn(Pattern.compile(includePattern));
+        includedIndices.add(includeIndex);
+
+        final List<OpenSearchIndex> excludedIndices = new ArrayList<>();
+        final OpenSearchIndex excludeIndex = mock(OpenSearchIndex.class);
+        final String excludePattern = "my-pattern-[a-c]-exclude";
+        when(excludeIndex.getIndexNamePattern()).thenReturn(Pattern.compile(excludePattern));
+        excludedIndices.add(excludeIndex);
+
+        final OpenSearchIndex secondExcludeIndex = mock(OpenSearchIndex.class);
+        final String secondExcludePattern = "second-exclude-.*";
+        when(secondExcludeIndex.getIndexNamePattern()).thenReturn(Pattern.compile(secondExcludePattern));
+        excludedIndices.add(secondExcludeIndex);
+
+        when(indexParametersConfiguration.getIncludedIndices()).thenReturn(includedIndices);
+        when(indexParametersConfiguration.getExcludedIndices()).thenReturn(excludedIndices);
+        when(openSearchSourceConfiguration.getIndexParametersConfiguration()).thenReturn(indexParametersConfiguration);
+
+        final List<IndicesRecord> indicesRecords = new ArrayList<>();
+        final IndicesRecord includedIndex = mock(IndicesRecord.class);
+        when(includedIndex.index()).thenReturn("my-pattern-a-include");
+        final IndicesRecord excludedIndex = mock(IndicesRecord.class);
+        when(excludedIndex.index()).thenReturn("second-exclude-test");
+        final IndicesRecord includedAndThenExcluded = mock(IndicesRecord.class);
+        when(includedAndThenExcluded.index()).thenReturn("my-pattern-a-exclude");
+        final IndicesRecord neitherIncludedOrExcluded = mock(IndicesRecord.class);
+        when(neitherIncludedOrExcluded.index()).thenReturn("random-index");
+
+        indicesRecords.add(includedIndex);
+        indicesRecords.add(excludedIndex);
+        indicesRecords.add(includedAndThenExcluded);
+        indicesRecords.add(neitherIncludedOrExcluded);
+
+        when(indicesResponse.valueBody()).thenReturn(indicesRecords);
+
+        when(openSearchCatClient.indices()).thenReturn(indicesResponse);
+        when(openSearchClient.cat()).thenReturn(openSearchCatClient);
+
+        final List<PartitionIdentifier> partitionIdentifierList = createObjectUnderTest().apply(Collections.emptyMap());
+
+        assertThat(partitionIdentifierList, notNullValue());
+    }
+
+    private static Stream<Arguments> opensearchCatIndicesExceptions() {
+        return Stream.of(Arguments.of(IOException.class),
+                Arguments.of(OpenSearchException.class));
+    }
+}

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/PitWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/PitWorkerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker.client;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartition;
+import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchIndexProgressState;
+import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SchedulingParameterConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.OpenSearchIndexPartitionCreationSupplier;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.PitWorker;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PitWorkerTest {
+
+    @Mock
+    private OpenSearchSourceConfiguration openSearchSourceConfiguration;
+
+    @Mock
+    private OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier;
+
+    @Mock
+    private SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator;
+
+    @Mock
+    private SearchAccessor searchAccessor;
+
+    @Mock
+    private Buffer<Record<Event>> buffer;
+
+    private ExecutorService executorService;
+
+    @BeforeEach
+    void setup() {
+        executorService = Executors.newSingleThreadExecutor();
+    }
+
+    private PitWorker createObjectUnderTest() {
+        return new PitWorker(searchAccessor, openSearchSourceConfiguration, sourceCoordinator, buffer, openSearchIndexPartitionCreationSupplier);
+    }
+
+    @Test
+    void run_with_getNextPartition_returning_empty_will_sleep_and_exit_when_interrupted() throws InterruptedException {
+        when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.empty());
+
+
+        final Future<?> future = executorService.submit(() -> createObjectUnderTest().run());
+        Thread.sleep(100);
+        executorService.shutdown();
+        future.cancel(true);
+        assertThat(future.isCancelled(), equalTo(true));
+
+        assertThat(executorService.awaitTermination(100, TimeUnit.MILLISECONDS), equalTo(true));
+    }
+
+    @Test
+    void run_with_getNextPartition_with_non_empty_partition_closes_that_partition() throws InterruptedException {
+        final SourcePartition<OpenSearchIndexProgressState> sourcePartition = mock(SourcePartition.class);
+        final String partitionKey = UUID.randomUUID().toString();
+        when(sourcePartition.getPartitionKey()).thenReturn(partitionKey);
+
+        when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition));
+
+        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
+        when(schedulingParameterConfiguration.getJobCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getRate()).thenReturn(Duration.ZERO);
+        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+
+        doNothing().when(sourceCoordinator).closePartition(partitionKey,
+                Duration.ZERO, 1);
+
+
+        final Future<?> future = executorService.submit(() -> createObjectUnderTest().run());
+        Thread.sleep(100);
+        executorService.shutdown();
+        future.cancel(true);
+        assertThat(future.isCancelled(), equalTo(true));
+
+        assertThat(executorService.awaitTermination(100, TimeUnit.MILLISECONDS), equalTo(true));
+    }
+}


### PR DESCRIPTION
### Description
Implements the `OpenSearchIndexPartitionSupplier`, which will list all indices of the source cluster and filter them by the include and exclude regex patterns.

Also starts implementation for PitWorker to use the scheduling configuration with source coordinator without processing the object. When calling `getNextPartition` returns empty, the PitWorker will back off and retry in a fixed 30 seconds. The code added for PitWorker here would be essentially the same for ScrollWorker (the interactions with source coordinator will be very similar.

`OpenSearchService` now uses a scheduled executor service instead of spawning new threads directly. This allows scheduling to start at the `start_time`. The `stop` method will let the `SearchWorker` future know to not grab another partition, and will get 30 seconds to complete processing of the index before the executor service shuts it down completely. This means that if 30 seconds is not enough time to finish processing the current partition, duplicate data processing will occur (unless there is a state that can track where to pick up from, at which point the `SearchWorker` could saveState and give up the partition gracefully)

Tested and expected partitions are created and "processed" successfully


 
### Issues Resolved
Related to #1985 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
