### PR TITLE
Fix bug where s3 stream was closing too early.

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3InputStream.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3InputStream.java
@@ -460,7 +460,6 @@ class S3InputStream extends SeekableInputStream {
                 }
             }
             stream = null;
-            closed = true;
         }
     }
 


### PR DESCRIPTION
### Description
Fix bug where s3 input stream was closing too frequently
 
### Issues Resolved
parquet files from s3 not reading correctly.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
