### PR TITLE
Fix CVE in maven-artifact by excluding that dependency

### DIFF
--- a/data-prepper-plugins/opensearch-source/build.gradle
+++ b/data-prepper-plugins/opensearch-source/build.gradle
@@ -14,7 +14,9 @@ dependencies {
     implementation 'org.opensearch.client:opensearch-java:2.5.0'
     implementation 'org.opensearch.client:opensearch-rest-client:2.7.0'
     implementation "org.apache.commons:commons-lang3:3.12.0"
-    implementation 'org.apache.maven:maven-artifact:3.0.3'
+    implementation('org.apache.maven:maven-artifact:3.0.3') {
+        exclude group: 'org.codehaus.plexus'
+    }
     testImplementation testLibs.mockito.inline
 }
 


### PR DESCRIPTION
### Description
Removes the dependency on `org.codehaus.plexus`, which is a dependency of `maven-artifact`, and has a CVE

Dependency graph before

```
cat deps.os.out | grep "org.codehaus"
|    \--- org.codehaus.plexus:plexus-utils:2.0.6
|    \--- org.codehaus.plexus:plexus-utils:2.0.6
|    \--- org.codehaus.plexus:plexus-utils:2.0.6
|    \--- org.codehaus.plexus:plexus-utils:2.0.6
```

Dependency graph after

```
cat deps.os.out | grep "org.codehaus"

```
 
### Issues Resolved
Resolves #2816 
Resolves #2820 
Resolves #2818 
Resolves #2819 
Resolves #2817 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
