### PR TITLE
Os source buffer backoff retry

### DIFF
--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/BufferAccumulator.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/BufferAccumulator.java
@@ -10,6 +10,7 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -28,6 +29,8 @@ import java.util.concurrent.TimeoutException;
  *
  * @param <T> Type of record to accumulate
  */
+// todo: Move this class to its own @DataPrepperPlugin so it can be reused between the s3 and opensearch source, and other sources that may need it (https://github.com/opensearch-project/data-prepper/issues/2855)
+@NotThreadSafe
 public class BufferAccumulator<T extends Record<?>> {
     private static final Logger LOG = LoggerFactory.getLogger(BufferAccumulator.class);
 

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/BufferAccumulator.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/BufferAccumulator.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker;
+
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.record.Record;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Accumulates {@link Record} objects before placing them into a Data Prepper
+ * {@link Buffer}. This class is not thread-safe and should only be used by one
+ * thread at a time.
+ *
+ * @param <T> Type of record to accumulate
+ */
+public class BufferAccumulator<T extends Record<?>> {
+    private static final Logger LOG = LoggerFactory.getLogger(BufferAccumulator.class);
+
+    private static final int MAX_FLUSH_RETRIES_ON_IO_EXCEPTION = Integer.MAX_VALUE;
+    private static final Duration INITIAL_FLUSH_RETRY_DELAY_ON_IO_EXCEPTION = Duration.ofSeconds(5);
+
+    private final Buffer<T> buffer;
+    private final int numberOfRecordsToAccumulate;
+    private final int bufferTimeoutMillis;
+    private int totalWritten = 0;
+
+    private final Collection<T> recordsAccumulated;
+
+    private BufferAccumulator(final Buffer<T> buffer, final int numberOfRecordsToAccumulate, final Duration bufferTimeout) {
+        this.buffer = Objects.requireNonNull(buffer, "buffer must be non-null.");
+        this.numberOfRecordsToAccumulate = numberOfRecordsToAccumulate;
+        Objects.requireNonNull(bufferTimeout, "bufferTimeout must be non-null.");
+        this.bufferTimeoutMillis = (int) bufferTimeout.toMillis();
+
+        if(numberOfRecordsToAccumulate < 1)
+            throw new IllegalArgumentException("numberOfRecordsToAccumulate must be greater than zero.");
+
+        recordsAccumulated = new ArrayList<>(numberOfRecordsToAccumulate);
+    }
+
+    public static <T extends Record<?>> BufferAccumulator<T> create(final Buffer<T> buffer, final int recordsToAccumulate, final Duration bufferTimeout) {
+        return new BufferAccumulator<T>(buffer, recordsToAccumulate, bufferTimeout);
+    }
+
+    void add(final T record) throws Exception {
+        recordsAccumulated.add(record);
+        if (recordsAccumulated.size() >= numberOfRecordsToAccumulate) {
+            flush();
+        }
+    }
+
+    void flush() throws Exception {
+        try {
+            flushAccumulatedToBuffer();
+        } catch (final TimeoutException timeoutException) {
+            flushWithBackoff();
+        }
+    }
+
+    private boolean flushWithBackoff() throws Exception{
+        final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        long nextDelay = INITIAL_FLUSH_RETRY_DELAY_ON_IO_EXCEPTION.toMillis();
+        boolean flushedSuccessfully;
+
+        for (int retryCount = 0; retryCount < MAX_FLUSH_RETRIES_ON_IO_EXCEPTION; retryCount++) {
+            final ScheduledFuture<Boolean> flushBufferFuture = scheduledExecutorService.schedule(() -> {
+                try {
+                    flushAccumulatedToBuffer();
+                    return true;
+                } catch (final TimeoutException e) {
+                    return false;
+                }
+            }, nextDelay, TimeUnit.MILLISECONDS);
+
+            try {
+                flushedSuccessfully = flushBufferFuture.get();
+                if (flushedSuccessfully) {
+                    LOG.info("Successfully flushed the buffer accumulator on retry attempt {}", retryCount + 1);
+                    scheduledExecutorService.shutdownNow();
+                    return true;
+                }
+            } catch (final ExecutionException e) {
+                LOG.warn("Retrying of flushing the buffer accumulator hit an exception: {}", e.getMessage());
+                scheduledExecutorService.shutdownNow();
+                throw e;
+            } catch (final InterruptedException e) {
+                LOG.warn("Retrying of flushing the buffer accumulator was interrupted: {}", e.getMessage());
+                scheduledExecutorService.shutdownNow();
+                throw e;
+            }
+        }
+
+        LOG.warn("Flushing the bufferAccumulator failed after {} attempts", MAX_FLUSH_RETRIES_ON_IO_EXCEPTION);
+        scheduledExecutorService.shutdownNow();
+        return false;
+    }
+
+    private void flushAccumulatedToBuffer() throws Exception {
+        final int currentRecordCountAccumulated = recordsAccumulated.size();
+        if (currentRecordCountAccumulated > 0) {
+            buffer.writeAll(recordsAccumulated, bufferTimeoutMillis);
+            recordsAccumulated.clear();
+            totalWritten += currentRecordCountAccumulated;
+        }
+    }
+
+    /**
+     * Gets the total number of records written to the buffer.
+     *
+     * @return the total number of records written
+     */
+    public int getTotalWritten() {
+        return totalWritten;
+    }
+}

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
@@ -4,7 +4,6 @@
  */
 package org.opensearch.dataprepper.plugins.source.opensearch.worker;
 
-import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
@@ -28,8 +27,6 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 /**
  * PitWorker polls the source cluster via Point-In-Time contexts.
@@ -38,7 +35,6 @@ public class PitWorker implements SearchWorker, Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(PitWorker.class);
 
-    static final int BUFFER_TIMEOUT_MILLIS = 180_000;
     private static final int STANDARD_BACKOFF_MILLIS = 30_000;
     private static final Duration BACKOFF_ON_PIT_LIMIT_REACHED = Duration.ofSeconds(60);
     static final String STARTING_KEEP_ALIVE = "15m";
@@ -47,18 +43,18 @@ public class PitWorker implements SearchWorker, Runnable {
     private final SearchAccessor searchAccessor;
     private final OpenSearchSourceConfiguration openSearchSourceConfiguration;
     private final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator;
-    private final Buffer<Record<Event>> buffer;
+    private final BufferAccumulator<Record<Event>> bufferAccumulator;
     private final OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier;
 
     public PitWorker(final SearchAccessor searchAccessor,
                      final OpenSearchSourceConfiguration openSearchSourceConfiguration,
                      final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator,
-                     final Buffer<Record<Event>> buffer,
+                     final BufferAccumulator<Record<Event>> bufferAccumulator,
                      final OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier) {
         this.searchAccessor = searchAccessor;
         this.sourceCoordinator = sourceCoordinator;
         this.openSearchSourceConfiguration = openSearchSourceConfiguration;
-        this.buffer = buffer;
+        this.bufferAccumulator = bufferAccumulator;
         this.openSearchIndexPartitionCreationSupplier = openSearchIndexPartitionCreationSupplier;
     }
 
@@ -138,9 +134,14 @@ public class PitWorker implements SearchWorker, Runnable {
                         .withPaginationSize(searchConfiguration.getBatchSize())
                         .withSearchAfter(Objects.nonNull(searchPointInTimeResults) ? searchPointInTimeResults.getNextSearchAfter() : null)
                         .build());
-                buffer.writeAll(searchPointInTimeResults.getDocuments().stream().map(Record::new).collect(Collectors.toList()), BUFFER_TIMEOUT_MILLIS);
-            } catch (final TimeoutException e) {
-                // todo: implement backoff and retry, can reuse buffer accumulator code from the s3 source
+
+                searchPointInTimeResults.getDocuments().stream().map(Record::new).forEach(record -> {
+                    try {
+                        bufferAccumulator.add(record);
+                    } catch (Exception e) {
+                        LOG.error("Failed writing OpenSearch documents to buffer due to: {}", e.getMessage());
+                    }
+                });
             } catch (final Exception e) {
                 LOG.error("Received an exception while searching with PIT for index '{}'", indexName);
                 throw new RuntimeException(e);
@@ -150,6 +151,11 @@ public class PitWorker implements SearchWorker, Runnable {
             sourceCoordinator.saveProgressStateForPartition(indexName, openSearchIndexProgressState);
         } while (searchPointInTimeResults.getDocuments().size() == searchConfiguration.getBatchSize());
 
+        try {
+            bufferAccumulator.flush();
+        } catch (final Exception e) {
+            LOG.error("Failed writing remaining OpenSearch documents to buffer due to: {}", e.getMessage());
+        }
 
         // todo: This API call is failing with sigv4 enabled due to a mismatch in the signature. Tracking issue (https://github.com/opensearch-project/opensearch-java/issues/521)
         searchAccessor.deletePit(DeletePointInTimeRequest.builder().withPitId(openSearchIndexProgressState.getPitId()).build());

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
@@ -28,6 +28,9 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_ID_METADATA_ATTRIBUTE_NAME;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.INDEX_METADATA_ATTRIBUTE_NAME;
+
 /**
  * PitWorker polls the source cluster via Point-In-Time contexts.
  */
@@ -139,7 +142,9 @@ public class PitWorker implements SearchWorker, Runnable {
                     try {
                         bufferAccumulator.add(record);
                     } catch (Exception e) {
-                        LOG.error("Failed writing OpenSearch documents to buffer due to: {}", e.getMessage());
+                        LOG.error("Failed writing OpenSearch documents to buffer. The last document created has document id '{}' from index '{}' : {}",
+                                record.getData().getMetadata().getAttribute(DOCUMENT_ID_METADATA_ATTRIBUTE_NAME),
+                                record.getData().getMetadata().getAttribute(INDEX_METADATA_ATTRIBUTE_NAME), e.getMessage());
                     }
                 });
             } catch (final Exception e) {

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
@@ -4,7 +4,6 @@
  */
 package org.opensearch.dataprepper.plugins.source.opensearch.worker;
 
-import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
@@ -20,18 +19,18 @@ public class ScrollWorker implements SearchWorker {
     private final SearchAccessor searchAccessor;
     private final OpenSearchSourceConfiguration openSearchSourceConfiguration;
     private final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator;
-    private final Buffer<Record<Event>> buffer;
+    private final BufferAccumulator<Record<Event>> bufferAccumulator;
     private final OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier;
 
     public ScrollWorker(final SearchAccessor searchAccessor,
                         final OpenSearchSourceConfiguration openSearchSourceConfiguration,
                         final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator,
-                        final Buffer<Record<Event>> buffer,
+                        final BufferAccumulator<Record<Event>> bufferAccumulator,
                         final OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier) {
         this.searchAccessor = searchAccessor;
         this.openSearchSourceConfiguration = openSearchSourceConfiguration;
         this.sourceCoordinator = sourceCoordinator;
-        this.buffer = buffer;
+        this.bufferAccumulator = bufferAccumulator;
         this.openSearchIndexPartitionCreationSupplier = openSearchIndexPartitionCreationSupplier;
     }
 

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
@@ -139,12 +139,8 @@ public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory 
             } else {
                 LOG.warn("Point in time id {} was not deleted successfully. It will expire from keep-alive", deletePointInTimeRequest.getPitId());
             }
-        } catch (final OpenSearchException e) {
-            LOG.error("There was an error deleting the point in time with id {} for OpenSearch: ", deletePointInTimeRequest.getPitId(), e);
-            throw e;
-        } catch (IOException e) {
-            LOG.error("There was an error deleting the point in time with id {} for OpenSearch: {}", deletePointInTimeRequest.getPitId(), e.getMessage());
-            throw new RuntimeException(e);
+        } catch (final IOException | RuntimeException e) {
+            LOG.error("There was an error deleting the point in time with id {} for OpenSearch. It will expire from keep-alive: ", deletePointInTimeRequest.getPitId(), e);
         }
     }
 

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
@@ -45,12 +45,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_ID_METADATA_ATTRIBUTE_NAME;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.INDEX_METADATA_ATTRIBUTE_NAME;
+
 public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenSearchAccessor.class);
-
-    static final String DOCUMENT_ID_METADATA_ATTRIBUTE_NAME = "document_id";
-    static final String INDEX_METADATA_ATTRIBUTE_NAME = "index";
 
     static final String PIT_RESOURCE_LIMIT_ERROR_TYPE = "rejected_execution_exception";
 

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/MetadataKeyAttributes.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/MetadataKeyAttributes.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model;
+
+public class MetadataKeyAttributes {
+    public static final String DOCUMENT_ID_METADATA_ATTRIBUTE_NAME = "document_id";
+    public static final String INDEX_METADATA_ATTRIBUTE_NAME = "index";
+}

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchServiceTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchServiceTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.opensearch;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -18,6 +19,8 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SchedulingParameterConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SearchConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.BufferAccumulator;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.OpenSearchIndexPartitionCreationSupplier;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.PitWorker;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.ScrollWorker;
@@ -40,6 +43,7 @@ import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchService.BUFFER_TIMEOUT;
 
 @ExtendWith(MockitoExtension.class)
 public class OpenSearchServiceTest {
@@ -54,6 +58,9 @@ public class OpenSearchServiceTest {
     private Buffer<Record<Event>> buffer;
 
     @Mock
+    private BufferAccumulator<Record<Event>> bufferAccumulator;
+
+    @Mock
     private SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator;
 
     @Mock
@@ -65,12 +72,22 @@ public class OpenSearchServiceTest {
     @Mock
     private SearchWorker searchWorker;
 
+    @BeforeEach
+    void setup() {
+        final SearchConfiguration searchConfiguration = mock(SearchConfiguration.class);
+        when(searchConfiguration.getBatchSize()).thenReturn(1000);
+
+        when(openSearchSourceConfiguration.getSearchConfiguration()).thenReturn(searchConfiguration);
+    }
+
     private OpenSearchService createObjectUnderTest() {
         try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class);
+             final MockedStatic<BufferAccumulator> bufferAccumulatorMockedStatic = mockStatic(BufferAccumulator.class);
              final MockedConstruction<OpenSearchIndexPartitionCreationSupplier> mockedConstruction = mockConstruction(OpenSearchIndexPartitionCreationSupplier.class, (mock, context) -> {
                  openSearchIndexPartitionCreationSupplier = mock;
              })) {
             executorsMockedStatic.when(Executors::newSingleThreadScheduledExecutor).thenReturn(scheduledExecutorService);
+            bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(buffer, openSearchSourceConfiguration.getSearchConfiguration().getBatchSize(), BUFFER_TIMEOUT)).thenReturn(bufferAccumulator);
             return OpenSearchService.createOpenSearchService(openSearchAccessor, sourceCoordinator, openSearchSourceConfiguration, buffer);
         }
     }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/BufferAccumulatorTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/BufferAccumulatorTest.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class BufferAccumulatorTest {
+    @Mock
+    private Buffer<Record<?>> buffer;
+    private int recordsToAccumulate;
+    private Duration bufferTimeout;
+    private int timeoutMillis;
+
+    @BeforeEach
+    void setUp() {
+        recordsToAccumulate = 20;
+        timeoutMillis = 100;
+        bufferTimeout = Duration.ofMillis(timeoutMillis);
+    }
+
+    private BufferAccumulator createObjectUnderTest() {
+        return BufferAccumulator.create(buffer, recordsToAccumulate, bufferTimeout);
+    }
+
+    @Test
+    void constructor_should_throw_if_buffer_is_null() {
+        buffer = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1, -2, Integer.MIN_VALUE})
+    void constructor_should_throw_if_numberOfRecordsToAccumulate_is_not_positive(int nonPositiveNumber) {
+        recordsToAccumulate = nonPositiveNumber;
+        assertThrows(IllegalArgumentException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void constructor_should_throw_if_bufferTimeout_is_null() {
+        bufferTimeout = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2, 10, 20})
+    void add_should_not_write_to_Buffer(final int accumulationCount) throws Exception {
+        recordsToAccumulate = accumulationCount;
+
+        createObjectUnderTest().add(createRecord());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2, 10, 20})
+    void adding_to_accumulation_count_should_write_to_Buffer(final int accumulationCount) throws Exception {
+        recordsToAccumulate = accumulationCount;
+
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+        final List<Record<?>> knownRecords = new ArrayList<>();
+        for (int i = 0; i < accumulationCount - 1; i++) {
+            final Record record = createRecord();
+            knownRecords.add(record);
+            objectUnderTest.add(record);
+        }
+        verifyNoInteractions(buffer);
+
+        final Collection<Record<?>> actualRecordsWritten = new ArrayList<>();
+        doAnswer(a -> actualRecordsWritten.addAll(a.getArgument(0, Collection.class)))
+                .when(buffer).writeAll(anyCollection(), anyInt());
+
+        final Record record = createRecord();
+        knownRecords.add(record);
+        objectUnderTest.add(record);
+
+        verify(buffer).writeAll(anyCollection(), eq(timeoutMillis));
+
+        assertThat(actualRecordsWritten.size(), equalTo(accumulationCount));
+        assertThat(actualRecordsWritten, equalTo(knownRecords));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2, 10, 20})
+    void adding_past_accumulation_count_should_write_to_Buffer_every_accumulation_count(final int accumulationCount) throws Exception {
+        recordsToAccumulate = accumulationCount;
+
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+        final int expectedWrites = 37;
+
+        final Set<Record<?>> actualRecordsWritten = new HashSet<>();
+        doAnswer(a -> actualRecordsWritten.addAll(a.getArgument(0, Collection.class)))
+                .when(buffer).writeAll(anyCollection(), anyInt());
+
+        final int totalRecordsToWrite = accumulationCount * 37;
+        for (int i = 0; i < totalRecordsToWrite; i++) {
+            objectUnderTest.add(createRecord());
+        }
+        verify(buffer, times(expectedWrites)).writeAll(anyCollection(), eq(timeoutMillis));
+
+        assertThat(actualRecordsWritten.size(), equalTo(totalRecordsToWrite));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {3, 10, 20})
+    void adding_past_accumulation_count_should_trigger_flush(final int accumulationCount) throws Exception {
+        recordsToAccumulate = 2;
+
+        doThrow(new RuntimeException()).when(buffer).writeAll(anyCollection(), anyInt());
+
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+        for (int i = 0; i < accumulationCount; i++) {
+            try {
+                objectUnderTest.add(createRecord());
+            } catch (final RuntimeException e) {
+                // swallow expected exception
+            }
+        }
+
+        doNothing().when(buffer).writeAll(anyCollection(), anyInt());
+        objectUnderTest.add(createRecord());
+
+        verify(buffer, times(accumulationCount)).writeAll(anyCollection(), eq(timeoutMillis));
+        assertThat(objectUnderTest.getTotalWritten(), equalTo(accumulationCount + 1));
+    }
+
+    @Test
+    void adding_past_accumulation_count_timeout_when_flushing_retries() throws Exception {
+        recordsToAccumulate = 1;
+
+        doThrow(new TimeoutException()).doNothing().when(buffer).writeAll(anyCollection(), anyInt());
+
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+        objectUnderTest.add(createRecord());
+
+        verify(buffer, times(2)).writeAll(anyCollection(), eq(timeoutMillis));
+        assertThat(objectUnderTest.getTotalWritten(), equalTo(1));
+    }
+
+    @Test
+    void flush_on_new_buffer_will_not_write() throws Exception {
+        createObjectUnderTest().flush();
+
+        verifyNoInteractions(buffer);
+    }
+
+    @Test
+    void flush_after_add_writes_to_buffer() throws Exception {
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+        final Record record = createRecord();
+        objectUnderTest.add(record);
+
+        verifyNoInteractions(buffer);
+
+        final List<Record<?>> actualRecordsWritten = new ArrayList<>();
+        doAnswer(a -> actualRecordsWritten.addAll(a.getArgument(0, Collection.class)))
+                .when(buffer).writeAll(anyCollection(), anyInt());
+
+        objectUnderTest.flush();
+
+        verify(buffer).writeAll(anyCollection(), eq(timeoutMillis));
+
+        assertThat(actualRecordsWritten.size(), equalTo(1));
+        assertThat(actualRecordsWritten, equalTo(Collections.singletonList(record)));
+    }
+
+    @Test
+    void flush_timeout_exception_backs_off_and_retries() throws Exception {
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+        final Record record = createRecord();
+        objectUnderTest.add(record);
+
+        verifyNoInteractions(buffer);
+
+        final List<Record<?>> actualRecordsWritten = new ArrayList<>();
+        doThrow(new TimeoutException())
+                .doAnswer(a -> actualRecordsWritten.addAll(a.getArgument(0, Collection.class)))
+                .when(buffer).writeAll(anyCollection(), anyInt());
+
+        objectUnderTest.flush();
+
+        verify(buffer, times(2)).writeAll(anyCollection(), eq(timeoutMillis));
+        assertThat(actualRecordsWritten.size(), equalTo(1));
+        assertThat(actualRecordsWritten, equalTo(Collections.singletonList(record)));
+    }
+
+    @Test
+    void flush_timeout_exception_backs_off_and_retries_until_success() throws Exception {
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+        final Record record = createRecord();
+        objectUnderTest.add(record);
+
+        verifyNoInteractions(buffer);
+
+        final List<Record<?>> actualRecordsWritten = new ArrayList<>();
+        doThrow(new TimeoutException())
+                .doThrow(new TimeoutException())
+                .doThrow(new TimeoutException())
+                .doThrow(new TimeoutException())
+                .doAnswer(a -> actualRecordsWritten.addAll(a.getArgument(0, Collection.class)))
+                .when(buffer).writeAll(anyCollection(), anyInt());
+
+        objectUnderTest.flush();
+
+        verify(buffer, times(5)).writeAll(anyCollection(), eq(timeoutMillis));
+        assertThat(actualRecordsWritten.size(), equalTo(1));
+        assertThat(actualRecordsWritten, equalTo(Collections.singletonList(record)));
+    }
+
+    @Test
+    void flush_non_timeout_exception_does_not_retry_throws_exception() throws Exception {
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+        final Record record = createRecord();
+        objectUnderTest.add(record);
+
+        verifyNoInteractions(buffer);
+
+        final List<Record<?>> actualRecordsWritten = new ArrayList<>();
+        doThrow(new RuntimeException()).when(buffer).writeAll(anyCollection(), anyInt());
+
+        assertThrows(RuntimeException.class, () -> objectUnderTest.flush());
+
+        verify(buffer).writeAll(anyCollection(), eq(timeoutMillis));
+        assertThat(actualRecordsWritten.size(), equalTo(0));
+        assertThat(actualRecordsWritten, equalTo(Collections.emptyList()));
+    }
+
+    @Test
+    void flush_non_timeout_exception_during_retry_throws_exception() throws Exception {
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+        final Record record = createRecord();
+        objectUnderTest.add(record);
+
+        verifyNoInteractions(buffer);
+
+        final List<Record<?>> actualRecordsWritten = new ArrayList<>();
+        doThrow(new TimeoutException())
+                .doThrow(new RuntimeException())
+                .when(buffer).writeAll(anyCollection(), anyInt());
+
+        assertThrows(ExecutionException.class, () -> objectUnderTest.flush());
+
+        verify(buffer, times(2)).writeAll(anyCollection(), eq(timeoutMillis));
+        assertThat(actualRecordsWritten.size(), equalTo(0));
+        assertThat(actualRecordsWritten, equalTo(Collections.emptyList()));
+    }
+
+    @Test
+    void getTotalWritten_returns_zero_if_no_writes() throws Exception {
+        assertThat(createObjectUnderTest().getTotalWritten(), equalTo(0));
+    }
+
+    @Test
+    void getTotalWritten_returns_accumulated_after_single_write() throws Exception {
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+        final Record record = createRecord();
+        objectUnderTest.add(record);
+
+        objectUnderTest.flush();
+
+        assertThat(objectUnderTest.getTotalWritten(), equalTo(1));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 20})
+    void getTotalWritten_returns_accumulated_after_single_write(final int recordsInWrite) throws Exception {
+        recordsToAccumulate = recordsInWrite;
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+
+        for (int i = 0; i < recordsInWrite; i++) {
+            objectUnderTest.add(createRecord());
+        }
+
+        assertThat(objectUnderTest.getTotalWritten(), equalTo(recordsInWrite));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2, 10, 20})
+    void getTotalWritten_returns_accumulated_after_multiple_writes(final int recordsInWrite) throws Exception {
+        recordsToAccumulate = 10;
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+
+        objectUnderTest.flush();
+
+        for (int writes = 0; writes < recordsInWrite; writes++) {
+            for (int r = 0; r < recordsToAccumulate; r++) {
+                objectUnderTest.add(createRecord());
+            }
+        }
+
+        assertThat(objectUnderTest.getTotalWritten(), equalTo(recordsInWrite * recordsToAccumulate));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 15})
+    void getTotalWritten_returns_flushed_data(final int accumulationCount) throws Exception {
+        final BufferAccumulator objectUnderTest = createObjectUnderTest();
+
+        for (int i = 0; i < accumulationCount; i++) {
+            objectUnderTest.add(createRecord());
+        }
+
+        objectUnderTest.flush();
+
+        assertThat(objectUnderTest.getTotalWritten(), equalTo(accumulationCount));
+    }
+
+    private Record createRecord() {
+        return mock(Record.class);
+    }
+}

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
@@ -157,7 +157,7 @@ public class OpenSearchAccessorTest {
     }
 
     @Test
-    void delete_pit_throws_opensearch_exception() throws IOException {
+    void delete_pit_does_not_throw_during_opensearch_exception() throws IOException {
         final String pitId = UUID.randomUUID().toString();
 
         final DeletePointInTimeRequest deletePointInTimeRequest = mock(DeletePointInTimeRequest.class);
@@ -165,11 +165,11 @@ public class OpenSearchAccessorTest {
 
         when(openSearchClient.deletePit(any(DeletePitRequest.class))).thenThrow(OpenSearchException.class);
 
-        assertThrows(OpenSearchException.class, () -> createObjectUnderTest().deletePit(deletePointInTimeRequest));
+        createObjectUnderTest().deletePit(deletePointInTimeRequest);
     }
 
     @Test
-    void delete_pit_throws_runtime_exception_when_client_throws_IOException() throws IOException {
+    void delete_pit_does_not_throw_exception_when_client_throws_IOException() throws IOException {
         final String pitId = UUID.randomUUID().toString();
 
         final DeletePointInTimeRequest deletePointInTimeRequest = mock(DeletePointInTimeRequest.class);
@@ -177,7 +177,7 @@ public class OpenSearchAccessorTest {
 
         when(openSearchClient.deletePit(any(DeletePitRequest.class))).thenThrow(IOException.class);
 
-        assertThrows(RuntimeException.class, () -> createObjectUnderTest().deletePit(deletePointInTimeRequest));
+        createObjectUnderTest().deletePit(deletePointInTimeRequest);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Description
This change uses the `BufferAccumulator` class from the s3 source to write and flush documents to the buffer with backoff and retry.

The `records_to_accumulate` is currently the same as the `batch_size` (pagination size) for searching.
 
Waiting on #2847 before rebasing and pushing non-draft PR

### Issues Resolved
Related to #1985 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
