### PR TITLE
Add support for writing tags along with events to Sink

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkModel.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkModel.java
@@ -28,8 +28,8 @@ import java.util.Map;
 @JsonDeserialize(using = SinkModel.SinkModelDeserializer.class)
 public class SinkModel extends PluginModel {
 
-    SinkModel(final String pluginName, final List<String> routes, final Map<String, Object> pluginSettings) {
-        this(pluginName, new SinkInternalJsonModel(routes, pluginSettings));
+    SinkModel(final String pluginName, final List<String> routes, final String tagsTargetKey, final Map<String, Object> pluginSettings) {
+        this(pluginName, new SinkInternalJsonModel(routes, tagsTargetKey, pluginSettings));
     }
 
     private SinkModel(final String pluginName, final SinkInternalJsonModel sinkInnerModel) {
@@ -46,18 +46,30 @@ public class SinkModel extends PluginModel {
         return this.<SinkInternalJsonModel>getInternalJsonModel().routes;
     }
 
+    /**
+     * Gets the tags target key associated with this Sink.
+     *
+     * @return The tags target key
+     * @since 2.4
+     */
+    public String getTagsTargetKey() {
+        return this.<SinkInternalJsonModel>getInternalJsonModel().tagsTargetKey;
+    }
+
     public static class SinkModelBuilder {
 
         private final PluginModel pluginModel;
         private final List<String> routes;
+        private final String tagsTargetKey;
 
         private SinkModelBuilder(final PluginModel pluginModel) {
             this.pluginModel = pluginModel;
             this.routes = Collections.emptyList();
+            this.tagsTargetKey = null;
         }
 
         public SinkModel build() {
-            return new SinkModel(pluginModel.getPluginName(), routes, pluginModel.getPluginSettings());
+            return new SinkModel(pluginModel.getPluginName(), routes, tagsTargetKey, pluginModel.getPluginSettings());
         }
     }
 
@@ -70,21 +82,27 @@ public class SinkModel extends PluginModel {
         @JsonProperty("routes")
         private final List<String> routes;
 
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        @JsonProperty("tags_target_key")
+        private final String tagsTargetKey;
+
         @JsonCreator
-        private SinkInternalJsonModel(@JsonProperty("routes") final List<String> routes) {
+        private SinkInternalJsonModel(@JsonProperty("routes") final List<String> routes, @JsonProperty("tags_target_key") final String tagsTargetKey) {
             super();
             this.routes = routes != null ? routes : new ArrayList<>();
+            this.tagsTargetKey = tagsTargetKey;
         }
 
-        private SinkInternalJsonModel(final List<String> routes, final Map<String, Object> pluginSettings) {
+        private SinkInternalJsonModel(final List<String> routes, final String tagsTargetKey, final Map<String, Object> pluginSettings) {
             super(pluginSettings);
             this.routes = routes != null ? routes : new ArrayList<>();
+            this.tagsTargetKey = tagsTargetKey;
         }
     }
 
     static class SinkModelDeserializer extends AbstractPluginModelDeserializer<SinkModel, SinkInternalJsonModel> {
         SinkModelDeserializer() {
-            super(SinkModel.class, SinkInternalJsonModel.class, SinkModel::new, () -> new SinkInternalJsonModel(null));
+            super(SinkModel.class, SinkInternalJsonModel.class, SinkModel::new, () -> new SinkInternalJsonModel(null, null));
         }
     }
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginFactory.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginFactory.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.model.plugin;
 
+import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 
 import java.util.List;
@@ -26,6 +27,18 @@ public interface PluginFactory {
      * @since 1.2
      */
     <T> T loadPlugin(final Class<T> baseClass, final PluginSetting pluginSetting);
+
+    /**
+     * Loads a new instance of a plugin with SinkContext.
+     *
+     * @param baseClass The class type that the plugin is supporting.
+     * @param pluginSetting The {@link PluginSetting} to configure this plugin
+     * @param sinkContext The {@link SinkContext} to configure this plugin
+     * @param <T> The type
+     * @return A new instance of your plugin, configured
+     * @since 1.2
+     */
+    <T> T loadPlugin(final Class<T> baseClass, final PluginSetting pluginSetting, final SinkContext sinkContext);
 
     /**
      * Loads a specified number of plugin instances. The total number of instances is provided

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkContext.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkContext.java
@@ -7,6 +7,10 @@ package org.opensearch.dataprepper.model.sink;
 
 import java.util.Collection;
 
+/**
+ * Data Prepper Sink Context class. This the class for keeping global
+ * sink configuration as context so that individual sinks may use them.
+ */
 public class SinkContext {
     private final String tagsTargetKey;
     private final Collection<String> routes;
@@ -16,10 +20,18 @@ public class SinkContext {
         this.routes = routes;
     }
     
+    /**
+     * returns the target key name for tags if configured for a given sink
+     * @return tags target key
+     */
     public String getTagsTargetKey() {
         return tagsTargetKey;
     }
 
+    /**
+     * returns routes if configured for a given sink
+     * @return routes
+     */
     public Collection<String> getRoutes() {
         return routes;
     }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkContext.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkContext.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.sink;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+import org.opensearch.dataprepper.metrics.MetricNames;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.util.Collection;
+
+public class SinkContext {
+    private final String tagsTargetKey;
+    private final Collection<String> routes;
+
+    public SinkContext(final String tagsTargetKey, final Collection<String> routes) {
+        this.tagsTargetKey = tagsTargetKey;
+        this.routes = routes;
+    }
+    
+    public String getTagsTargetKey() {
+        return tagsTargetKey;
+    }
+
+    public Collection<String> getRoutes() {
+        return routes;
+    }
+}
+

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkContext.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkContext.java
@@ -5,13 +5,6 @@
 
 package org.opensearch.dataprepper.model.sink;
 
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Timer;
-import org.opensearch.dataprepper.metrics.MetricNames;
-import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
-import org.opensearch.dataprepper.model.record.Record;
-
 import java.util.Collection;
 
 public class SinkContext {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PipelinesDataFlowModelTest.java
@@ -50,7 +50,7 @@ class PipelinesDataFlowModelTest {
 
         final PluginModel source = new PluginModel("testSource", (Map<String, Object>) null);
         final List<PluginModel> processors = Collections.singletonList(new PluginModel("testProcessor", (Map<String, Object>) null));
-        final List<SinkModel> sinks = Collections.singletonList(new SinkModel("testSink", Collections.emptyList(), null));
+        final List<SinkModel> sinks = Collections.singletonList(new SinkModel("testSink", Collections.emptyList(), null, null));
         final PipelineModel pipelineModel = new PipelineModel(source, null, processors, null, sinks, 8, 50);
 
         final PipelinesDataFlowModel pipelinesDataFlowModel = new PipelinesDataFlowModel(Collections.singletonMap(pipelineName, pipelineModel));
@@ -72,7 +72,7 @@ class PipelinesDataFlowModelTest {
         final DataPrepperVersion version = DataPrepperVersion.parse("2.0");
         final PluginModel source = new PluginModel("testSource", (Map<String, Object>) null);
         final List<PluginModel> processors = Collections.singletonList(new PluginModel("testProcessor", (Map<String, Object>) null));
-        final List<SinkModel> sinks = Collections.singletonList(new SinkModel("testSink", Collections.emptyList(), null));
+        final List<SinkModel> sinks = Collections.singletonList(new SinkModel("testSink", Collections.emptyList(), null, null));
         final PipelineModel pipelineModel = new PipelineModel(source, null, processors, null, sinks, 8, 50);
 
         final PipelinesDataFlowModel pipelinesDataFlowModel = new PipelinesDataFlowModel(version, Collections.singletonMap(pipelineName, pipelineModel));
@@ -93,7 +93,7 @@ class PipelinesDataFlowModelTest {
 
         final PluginModel source = new PluginModel("testSource", (Map<String, Object>) null);
         final List<PluginModel> preppers = Collections.singletonList(new PluginModel("testPrepper", (Map<String, Object>) null));
-        final List<SinkModel> sinks = Collections.singletonList(new SinkModel("testSink", Collections.singletonList("my-route"), null));
+        final List<SinkModel> sinks = Collections.singletonList(new SinkModel("testSink", Collections.singletonList("my-route"), null, null));
         final PipelineModel pipelineModel = new PipelineModel(source, null, preppers, Collections.singletonList(new ConditionalRoute("my-route", "/a==b")), sinks, 8, 50);
 
         final PipelinesDataFlowModel pipelinesDataFlowModel = new PipelinesDataFlowModel(Collections.singletonMap(pipelineName, pipelineModel));

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkModelTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkModelTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.apache.commons.lang3.RandomStringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkModelTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/SinkModelTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,6 +26,7 @@ import java.util.UUID;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasKey;
@@ -74,13 +76,15 @@ class SinkModelTest {
         final Map<String, Object> pluginSettings = new LinkedHashMap<>();
         pluginSettings.put("key1", "value1");
         pluginSettings.put("key2", "value2");
-        final SinkModel sinkModel = new SinkModel("customSinkPlugin", Arrays.asList("routeA", "routeB"), pluginSettings);
+        final String tagsTargetKey = "tags";
+        final SinkModel sinkModel = new SinkModel("customSinkPlugin", Arrays.asList("routeA", "routeB"), tagsTargetKey, pluginSettings);
 
         final String actualJson = objectMapper.writeValueAsString(sinkModel);
 
         final String expectedJson = createStringFromInputStream(this.getClass().getResourceAsStream("sink_plugin.yaml"));
 
         assertThat("---\n" + actualJson, equalTo(expectedJson));
+        assertThat(sinkModel.getTagsTargetKey(), equalTo(tagsTargetKey));
     }
 
     @Test
@@ -93,7 +97,8 @@ class SinkModelTest {
         assertAll(
                 () -> assertThat(sinkModel.getPluginName(), equalTo("customPlugin")),
                 () -> assertThat(sinkModel.getPluginSettings(), notNullValue()),
-                () -> assertThat(sinkModel.getRoutes(), notNullValue())
+                () -> assertThat(sinkModel.getRoutes(), notNullValue()),
+                () -> assertThat(sinkModel.getTagsTargetKey(), nullValue())
         );
         assertAll(
                 () -> assertThat(sinkModel.getPluginSettings().size(), equalTo(3)),
@@ -123,7 +128,7 @@ class SinkModelTest {
         pluginSettings.put("key1", "value1");
         pluginSettings.put("key2", "value2");
         pluginSettings.put("key3", "value3");
-        final SinkModel sinkModel = new SinkModel("customPlugin", null, pluginSettings);
+        final SinkModel sinkModel = new SinkModel("customPlugin", null, null, pluginSettings);
 
         final String actualJson = objectMapper.writeValueAsString(sinkModel);
 
@@ -156,6 +161,7 @@ class SinkModelTest {
             assertThat(actualSinkModel.getPluginSettings(), equalTo(pluginSettings));
             assertThat(actualSinkModel.getRoutes(), notNullValue());
             assertThat(actualSinkModel.getRoutes(), empty());
+            assertThat(actualSinkModel.getTagsTargetKey(), nullValue());
         }
     }
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkContextTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/SinkContextTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.sink;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import org.apache.commons.lang3.RandomStringUtils;
+
+
+
+public class SinkContextTest {
+    private SinkContext sinkContext;
+
+    @Test
+    public void testSinkContextBasic() {
+        final String testTagsTargetKey = RandomStringUtils.randomAlphabetic(6);
+        final List<String> testRoutes = Collections.emptyList();
+        sinkContext = new SinkContext(testTagsTargetKey, testRoutes);
+        assertThat(sinkContext.getTagsTargetKey(), equalTo(testTagsTargetKey));
+        assertThat(sinkContext.getRoutes(), equalTo(testRoutes));
+        
+    }
+    
+}
+

--- a/data-prepper-api/src/test/resources/org/opensearch/dataprepper/model/configuration/sink_plugin.yaml
+++ b/data-prepper-api/src/test/resources/org/opensearch/dataprepper/model/configuration/sink_plugin.yaml
@@ -3,5 +3,6 @@ customSinkPlugin:
   routes:
   - "routeA"
   - "routeB"
+  tags_target_key: "tags"
   key1: "value1"
   key2: "value2"

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineConfigurationValidator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineConfigurationValidator.java
@@ -8,7 +8,7 @@ package org.opensearch.dataprepper.parser;
 import org.apache.commons.collections.CollectionUtils;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.parser.model.PipelineConfiguration;
-import org.opensearch.dataprepper.parser.model.RoutedPluginSetting;
+import org.opensearch.dataprepper.parser.model.SinkContextPluginSetting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,7 +82,7 @@ public class PipelineConfigurationValidator {
             final PipelineConfiguration pipelineConfiguration = pipelineConfigurationMap.get(pipeline);
             touchedPipelineSet.add(pipeline);
             //if validation is successful, then there is definitely sink
-            final List<RoutedPluginSetting> connectedPipelinesSettings = pipelineConfiguration.getSinkPluginSettings();
+            final List<SinkContextPluginSetting> connectedPipelinesSettings = pipelineConfiguration.getSinkPluginSettings();
             //Recursively check connected pipelines
             for (PluginSetting pluginSetting : connectedPipelinesSettings) {
                 //Further process only if the sink is of pipeline type
@@ -159,7 +159,7 @@ public class PipelineConfigurationValidator {
                 throw new RuntimeException("Invalid configuration, cannot proceed with ambiguous configuration");
             }
             final PipelineConfiguration pipelineConfiguration = pipelineConfigurationMap.get(currentPipelineName);
-            final List<RoutedPluginSetting> pluginSettings = pipelineConfiguration.getSinkPluginSettings();
+            final List<SinkContextPluginSetting> pluginSettings = pipelineConfiguration.getSinkPluginSettings();
             for (PluginSetting pluginSetting : pluginSettings) {
                 if (PIPELINE_TYPE.equals(pluginSetting.getName()) &&
                         pluginSetting.getAttributeFromSettings(PIPELINE_ATTRIBUTE_NAME) != null) {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
@@ -19,6 +19,7 @@ import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.sink.Sink;
 import org.opensearch.dataprepper.model.source.Source;
+import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
 import org.opensearch.dataprepper.parser.model.PipelineConfiguration;
 import org.opensearch.dataprepper.parser.model.RoutedPluginSetting;
@@ -293,12 +294,12 @@ public class PipelineParser {
     }
 
     private DataFlowComponent<Sink> buildRoutedSinkOrConnector(final RoutedPluginSetting pluginSetting) {
-        final Sink sink = buildSinkOrConnector(pluginSetting);
+        final Sink sink = buildSinkOrConnector(pluginSetting, pluginSetting.getSinkContext());
 
-        return new DataFlowComponent<>(sink, pluginSetting.getRoutes());
+        return new DataFlowComponent<>(sink, pluginSetting.getSinkContext().getRoutes());
     }
 
-    private Sink buildSinkOrConnector(final PluginSetting pluginSetting) {
+    private Sink buildSinkOrConnector(final PluginSetting pluginSetting, final SinkContext sinkContext) {
         LOG.info("Building [{}] as sink component", pluginSetting.getName());
         final Optional<String> pipelineNameOptional = getPipelineNameIfPipelineType(pluginSetting);
         if (pipelineNameOptional.isPresent()) { //update to ifPresentOrElse when using JDK9
@@ -307,7 +308,7 @@ public class PipelineParser {
             sourceConnectorMap.put(pipelineName, pipelineConnector); //TODO retrieve from parent Pipeline using name
             return pipelineConnector;
         } else {
-            return pluginFactory.loadPlugin(Sink.class, pluginSetting);
+            return pluginFactory.loadPlugin(Sink.class, pluginSetting, sinkContext);
         }
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineParser.java
@@ -22,7 +22,7 @@ import org.opensearch.dataprepper.model.source.Source;
 import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
 import org.opensearch.dataprepper.parser.model.PipelineConfiguration;
-import org.opensearch.dataprepper.parser.model.RoutedPluginSetting;
+import org.opensearch.dataprepper.parser.model.SinkContextPluginSetting;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderConfiguration;
 import org.opensearch.dataprepper.peerforwarder.PeerForwarderProvider;
 import org.opensearch.dataprepper.peerforwarder.PeerForwardingProcessorDecorator;
@@ -293,7 +293,7 @@ public class PipelineParser {
         return Optional.empty();
     }
 
-    private DataFlowComponent<Sink> buildRoutedSinkOrConnector(final RoutedPluginSetting pluginSetting) {
+    private DataFlowComponent<Sink> buildRoutedSinkOrConnector(final SinkContextPluginSetting pluginSetting) {
         final Sink sink = buildSinkOrConnector(pluginSetting, pluginSetting.getSinkContext());
 
         return new DataFlowComponent<>(sink, pluginSetting.getSinkContext().getRoutes());
@@ -338,7 +338,7 @@ public class PipelineParser {
                 sourcePipeline, pipelineConfigurationMap, pipelineMap));
 
         //remove sink connected pipelines
-        final List<RoutedPluginSetting> sinkPluginSettings = failedPipelineConfiguration.getSinkPluginSettings();
+        final List<SinkContextPluginSetting> sinkPluginSettings = failedPipelineConfiguration.getSinkPluginSettings();
         sinkPluginSettings.forEach(sinkPluginSetting -> {
             getPipelineNameIfPipelineType(sinkPluginSetting).ifPresent(sinkPipeline -> processRemoveIfRequired(
                     sinkPipeline, pipelineConfigurationMap, pipelineMap));

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/PipelineConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/PipelineConfiguration.java
@@ -10,6 +10,7 @@ import org.opensearch.dataprepper.model.configuration.PipelineModel;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.configuration.SinkModel;
+import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
 
 import java.util.Collections;
@@ -134,7 +135,7 @@ public class PipelineConfiguration {
         final Map<String, Object> settingsMap = Optional
                 .ofNullable(sinkModel.getPluginSettings())
                 .orElseGet(HashMap::new);
-        return new RoutedPluginSetting(sinkModel.getPluginName(), settingsMap, sinkModel.getRoutes());
+        return new RoutedPluginSetting(sinkModel.getPluginName(), settingsMap, new SinkContext(sinkModel.getTagsTargetKey(), sinkModel.getRoutes()));
     }
 
     private Integer getWorkersFromPipelineModel(final PipelineModel pipelineModel) {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/PipelineConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/PipelineConfiguration.java
@@ -31,7 +31,7 @@ public class PipelineConfiguration {
     private final PluginSetting sourcePluginSetting;
     private final PluginSetting bufferPluginSetting;
     private final List<PluginSetting> processorPluginSettings;
-    private final List<RoutedPluginSetting> sinkPluginSettings;
+    private final List<SinkContextPluginSetting> sinkPluginSettings;
 
     private final Integer workers;
     private final Integer readBatchDelay;
@@ -59,7 +59,7 @@ public class PipelineConfiguration {
         return processorPluginSettings;
     }
 
-    public List<RoutedPluginSetting> getSinkPluginSettings() {
+    public List<SinkContextPluginSetting> getSinkPluginSettings() {
         return sinkPluginSettings;
     }
 
@@ -105,12 +105,12 @@ public class PipelineConfiguration {
         return getPluginSettingFromPluginModel(pluginModel);
     }
 
-    private List<RoutedPluginSetting> getSinksFromPluginModel(
+    private List<SinkContextPluginSetting> getSinksFromPluginModel(
             final List<SinkModel> sinkConfigurations) {
         if (sinkConfigurations == null || sinkConfigurations.isEmpty()) {
             throw new IllegalArgumentException("Invalid configuration, at least one sink is required");
         }
-        return sinkConfigurations.stream().map(PipelineConfiguration::getRoutedPluginSettingFromSinkModel)
+        return sinkConfigurations.stream().map(PipelineConfiguration::getSinkContextPluginSettingFromSinkModel)
                 .collect(Collectors.toList());
     }
 
@@ -131,11 +131,11 @@ public class PipelineConfiguration {
         return new PluginSetting(pluginModel.getPluginName(), settingsMap);
     }
 
-    private static RoutedPluginSetting getRoutedPluginSettingFromSinkModel(final SinkModel sinkModel) {
+    private static SinkContextPluginSetting getSinkContextPluginSettingFromSinkModel(final SinkModel sinkModel) {
         final Map<String, Object> settingsMap = Optional
                 .ofNullable(sinkModel.getPluginSettings())
                 .orElseGet(HashMap::new);
-        return new RoutedPluginSetting(sinkModel.getPluginName(), settingsMap, new SinkContext(sinkModel.getTagsTargetKey(), sinkModel.getRoutes()));
+        return new SinkContextPluginSetting(sinkModel.getPluginName(), settingsMap, new SinkContext(sinkModel.getTagsTargetKey(), sinkModel.getRoutes()));
     }
 
     private Integer getWorkersFromPipelineModel(final PipelineModel pipelineModel) {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/RoutedPluginSetting.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/RoutedPluginSetting.java
@@ -6,19 +6,20 @@
 package org.opensearch.dataprepper.parser.model;
 
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.sink.SinkContext;
 
 import java.util.Collection;
 import java.util.Map;
 
 public class RoutedPluginSetting extends PluginSetting {
-    private final Collection<String> routes;
+    private final SinkContext sinkContext;
 
-    public RoutedPluginSetting(final String name, final Map<String, Object> settings, final Collection<String> routes) {
+    public RoutedPluginSetting(final String name, final Map<String, Object> settings, final SinkContext sinkContext) {
         super(name, settings);
-        this.routes = routes;
+        this.sinkContext = sinkContext;
     }
 
-    public Collection<String> getRoutes() {
-        return routes;
+    public SinkContext getSinkContext() {
+        return sinkContext;
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/SinkContextPluginSetting.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/model/SinkContextPluginSetting.java
@@ -8,13 +8,12 @@ package org.opensearch.dataprepper.parser.model;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.sink.SinkContext;
 
-import java.util.Collection;
 import java.util.Map;
 
-public class RoutedPluginSetting extends PluginSetting {
+public class SinkContextPluginSetting extends PluginSetting {
     private final SinkContext sinkContext;
 
-    public RoutedPluginSetting(final String name, final Map<String, Object> settings, final SinkContext sinkContext) {
+    public SinkContextPluginSetting(final String name, final Map<String, Object> settings, final SinkContext sinkContext) {
         super(name, settings);
         this.sinkContext = sinkContext;
     }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContext.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContext.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugin;
 
+import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
@@ -64,6 +65,9 @@ class ComponentPluginArgumentsContext implements PluginArgumentsContext {
         if (builder.acknowledgementSetManager != null) {
             typedArgumentsSuppliers.put(AcknowledgementSetManager.class, () -> builder.acknowledgementSetManager);
         }
+        if (builder.sinkContext != null) {
+            typedArgumentsSuppliers.put(SinkContext.class, () -> builder.sinkContext);
+        }
     }
 
     @Override
@@ -114,6 +118,7 @@ class ComponentPluginArgumentsContext implements PluginArgumentsContext {
         private BeanFactory beanFactory;
         private EventFactory eventFactory;
         private AcknowledgementSetManager acknowledgementSetManager;
+        private SinkContext sinkContext;
 
         Builder withPluginConfiguration(final Object pluginConfiguration) {
             this.pluginConfiguration = pluginConfiguration;
@@ -137,6 +142,11 @@ class ComponentPluginArgumentsContext implements PluginArgumentsContext {
 
         Builder withPluginFactory(final PluginFactory pluginFactory) {
             this.pluginFactory = pluginFactory;
+            return this;
+        }
+
+        Builder withSinkContext(final SinkContext sinkContext) {
+            this.sinkContext = sinkContext;
             return this;
         }
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/PipelineConfigurationTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/PipelineConfigurationTests.java
@@ -58,7 +58,7 @@ class PipelineConfigurationTests {
         final PluginSetting actualSourcePluginSetting = pipelineConfiguration.getSourcePluginSetting();
         final PluginSetting actualBufferPluginSetting = pipelineConfiguration.getBufferPluginSetting();
         final List<PluginSetting> actualProcesserPluginSettings = pipelineConfiguration.getProcessorPluginSettings();
-        final List<RoutedPluginSetting> actualSinkPluginSettings = pipelineConfiguration.getSinkPluginSettings();
+        final List<SinkContextPluginSetting> actualSinkPluginSettings = pipelineConfiguration.getSinkPluginSettings();
 
         comparePluginSettings(actualSourcePluginSetting, TestDataProvider.VALID_PLUGIN_SETTING_1);
         assertThat(pipelineConfiguration.getBufferPluginSetting(), notNullValue());
@@ -99,7 +99,7 @@ class PipelineConfigurationTests {
         final PluginSetting actualSourcePluginSetting = pipelineConfiguration.getSourcePluginSetting();
         final PluginSetting actualBufferPluginSetting = pipelineConfiguration.getBufferPluginSetting();
         final List<PluginSetting> actualProcessorPluginSettings = pipelineConfiguration.getProcessorPluginSettings();
-        final List<RoutedPluginSetting> actualSinkPluginSettings = pipelineConfiguration.getSinkPluginSettings();
+        final List<SinkContextPluginSetting> actualSinkPluginSettings = pipelineConfiguration.getSinkPluginSettings();
 
         comparePluginSettings(actualSourcePluginSetting, TestDataProvider.VALID_PLUGIN_SETTING_1);
         assertThat(pipelineConfiguration.getBufferPluginSetting(), notNullValue());
@@ -221,7 +221,7 @@ class PipelineConfigurationTests {
 
         final PipelineConfiguration pipelineConfiguration = new PipelineConfiguration(pipelineModel);
 
-        final List<RoutedPluginSetting> actualSinkPluginSettings = pipelineConfiguration.getSinkPluginSettings();
+        final List<SinkContextPluginSetting> actualSinkPluginSettings = pipelineConfiguration.getSinkPluginSettings();
 
         assertThat(actualSinkPluginSettings.size(), equalTo(2));
         comparePluginSettings(actualSinkPluginSettings.get(0), TestDataProvider.VALID_PLUGIN_SETTING_1);
@@ -248,7 +248,7 @@ class PipelineConfigurationTests {
 
         final PipelineConfiguration pipelineConfiguration = new PipelineConfiguration(pipelineModel);
 
-        final List<RoutedPluginSetting> actualSinkPluginSettings = pipelineConfiguration.getSinkPluginSettings();
+        final List<SinkContextPluginSetting> actualSinkPluginSettings = pipelineConfiguration.getSinkPluginSettings();
 
         assertThat(actualSinkPluginSettings.size(), equalTo(2));
         comparePluginSettings(actualSinkPluginSettings.get(0), TestDataProvider.VALID_PLUGIN_SETTING_1);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/PipelineConfigurationTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/PipelineConfigurationTests.java
@@ -226,8 +226,35 @@ class PipelineConfigurationTests {
         assertThat(actualSinkPluginSettings.size(), equalTo(2));
         comparePluginSettings(actualSinkPluginSettings.get(0), TestDataProvider.VALID_PLUGIN_SETTING_1);
         comparePluginSettings(actualSinkPluginSettings.get(1), TestDataProvider.VALID_PLUGIN_SETTING_2);
-        assertThat(actualSinkPluginSettings.get(0).getRoutes(), equalTo(orderedSinkRoutes.get(0)));
-        assertThat(actualSinkPluginSettings.get(1).getRoutes(), equalTo(orderedSinkRoutes.get(1)));
+        assertThat(actualSinkPluginSettings.get(0).getSinkContext().getRoutes(), equalTo(orderedSinkRoutes.get(0)));
+        assertThat(actualSinkPluginSettings.get(1).getSinkContext().getRoutes(), equalTo(orderedSinkRoutes.get(1)));
+    }
+
+    @Test
+    void testSinksWithTagsTargetKey() {
+        final List<String> orderedSinkTagTagets = new ArrayList<>();
+        for (final SinkModel sink : sinks) {
+            final String tagsTargetKey = UUID.randomUUID().toString();
+            when(sink.getTagsTargetKey()).thenReturn(tagsTargetKey);
+            orderedSinkTagTagets.add(tagsTargetKey);
+        }
+
+        final PipelineModel pipelineModel = mock(PipelineModel.class);
+        when(pipelineModel.getSource()).thenReturn(source);
+        when(pipelineModel.getSinks()).thenReturn(sinks);
+        when(pipelineModel.getProcessors()).thenReturn(null);
+        when(pipelineModel.getWorkers()).thenReturn(null);
+        when(pipelineModel.getReadBatchDelay()).thenReturn(null);
+
+        final PipelineConfiguration pipelineConfiguration = new PipelineConfiguration(pipelineModel);
+
+        final List<RoutedPluginSetting> actualSinkPluginSettings = pipelineConfiguration.getSinkPluginSettings();
+
+        assertThat(actualSinkPluginSettings.size(), equalTo(2));
+        comparePluginSettings(actualSinkPluginSettings.get(0), TestDataProvider.VALID_PLUGIN_SETTING_1);
+        comparePluginSettings(actualSinkPluginSettings.get(1), TestDataProvider.VALID_PLUGIN_SETTING_2);
+        assertThat(actualSinkPluginSettings.get(0).getSinkContext().getTagsTargetKey(), equalTo(orderedSinkTagTagets.get(0)));
+        assertThat(actualSinkPluginSettings.get(1).getSinkContext().getTagsTargetKey(), equalTo(orderedSinkTagTagets.get(1)));
     }
 
     private void comparePluginSettings(final PluginSetting actual, final PluginSetting expected) {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/RoutedPluginSettingTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/RoutedPluginSettingTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.parser.model;
 
+import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -15,22 +16,23 @@ import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 
 class RoutedPluginSettingTest {
     private String name;
     private Map<String, Object> settings;
-    private Collection<String> routes;
+    private SinkContext sinkContext;
 
     @BeforeEach
     void setUp() {
         name = UUID.randomUUID().toString();
         settings = Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
-        routes = Set.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        sinkContext = mock(SinkContext.class);
 
     }
 
     private RoutedPluginSetting createObjectUnderTest() {
-        return new RoutedPluginSetting(name, settings, routes);
+        return new RoutedPluginSetting(name, settings, sinkContext);
     }
 
     @Test
@@ -44,7 +46,7 @@ class RoutedPluginSettingTest {
     }
 
     @Test
-    void getRoutes_returns_routes_from_constructor() {
-        assertThat(createObjectUnderTest().getRoutes(), equalTo(routes));
+    void getRoutes_returns_sink_context_from_constructor() {
+        assertThat(createObjectUnderTest().getSinkContext(), equalTo(sinkContext));
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/SinkContextPluginSettingTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/model/SinkContextPluginSettingTest.java
@@ -9,16 +9,14 @@ import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
-class RoutedPluginSettingTest {
+class SinkContextPluginSettingTest {
     private String name;
     private Map<String, Object> settings;
     private SinkContext sinkContext;
@@ -31,8 +29,8 @@ class RoutedPluginSettingTest {
 
     }
 
-    private RoutedPluginSetting createObjectUnderTest() {
-        return new RoutedPluginSetting(name, settings, sinkContext);
+    private SinkContextPluginSetting createObjectUnderTest() {
+        return new SinkContextPluginSetting(name, settings, sinkContext);
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContextTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContextTest.java
@@ -10,6 +10,7 @@ import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginDefinitionException;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -96,6 +97,19 @@ class ComponentPluginArgumentsContextTest {
 
         assertThat(objectUnderTest.createArguments(new Class[] { Object.class }),
                 equalTo(new Object[] {mock}));
+    }
+
+    @Test
+    void createArguments_with_single_class_using_sink_context() {
+        final SinkContext sinkContext = mock(SinkContext.class);
+
+        final ComponentPluginArgumentsContext objectUnderTest = new ComponentPluginArgumentsContext.Builder()
+                .withPluginSetting(pluginSetting)
+                .withSinkContext(sinkContext)
+                .build();
+
+        assertThat(objectUnderTest.createArguments(new Class[] { SinkContext.class }),
+                equalTo(new Object[] { sinkContext}));
     }
 
     @Test

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/FileSink.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/FileSink.java
@@ -12,6 +12,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.Sink;
+import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static java.lang.String.format;
@@ -37,6 +39,7 @@ public class FileSink implements Sink<Record<Object>> {
     private final ReentrantLock lock;
     private boolean isStopRequested;
     private boolean initialized;
+    private final String tagsTargetKey;
 
     /**
      * Mandatory constructor for Data Prepper Component - This constructor is used by Data Prepper
@@ -47,11 +50,12 @@ public class FileSink implements Sink<Record<Object>> {
      * @param fileSinkConfig The file sink configuration
      */
     @DataPrepperPluginConstructor
-    public FileSink(final FileSinkConfig fileSinkConfig) {
+    public FileSink(final FileSinkConfig fileSinkConfig, final SinkContext sinkContext) {
         this.outputFilePath = fileSinkConfig.getPath();
         isStopRequested = false;
         initialized = false;
         lock = new ReentrantLock(true);
+        tagsTargetKey = Objects.nonNull(sinkContext) ? sinkContext.getTagsTargetKey() : null;
     }
 
     @Override
@@ -64,7 +68,6 @@ public class FileSink implements Sink<Record<Object>> {
             for (final Record<Object> record : records) {
                 try {
                     checkTypeAndWriteObject(record.getData(), writer);
-                    
                 } catch (final IOException ex) {
                     throw new RuntimeException(format("Encountered exception writing to file %s", outputFilePath), ex);
                 }
@@ -84,7 +87,8 @@ public class FileSink implements Sink<Record<Object>> {
     // TODO: This function should be removed with the completion of: https://github.com/opensearch-project/data-prepper/issues/546
     private void checkTypeAndWriteObject(final Object object, final BufferedWriter writer) throws IOException {
         if (object instanceof Event) {
-            writer.write(((Event) object).toJsonString());
+            String output = ((Event)object).jsonBuilder().includeTags(tagsTargetKey).toJsonString();
+            writer.write(output);
             writer.newLine();
             EventHandle eventHandle = ((Event)object).getEventHandle();
             if (eventHandle != null) {

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/StdOutSink.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/StdOutSink.java
@@ -11,11 +11,14 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.Sink;
+import org.opensearch.dataprepper.model.sink.SinkContext;
 
 import java.util.Collection;
+import java.util.Objects;
 
 @DataPrepperPlugin(name = "stdout", pluginType = Sink.class)
 public class StdOutSink implements Sink<Record<Object>> {
+    private final String tagsTargetKey;
 
     /**
      * Mandatory constructor for Data Prepper Component - This constructor is used by Data Prepper
@@ -25,13 +28,17 @@ public class StdOutSink implements Sink<Record<Object>> {
      *
      * @param pluginSetting instance with metadata information from pipeline pluginSetting file.
      */
-    public StdOutSink(final PluginSetting pluginSetting) {
-        this();
+    public StdOutSink(final PluginSetting pluginSetting, final SinkContext sinkContext) {
+        this(Objects.nonNull(sinkContext) ? sinkContext.getTagsTargetKey() : null);
+    }
+
+    public StdOutSink(final String tagsTargetKey) {
+        this.tagsTargetKey = tagsTargetKey;
     }
 
     public StdOutSink() {
+        this.tagsTargetKey = null;
     }
-
     @Override
     public void output(final Collection<Record<Object>> records) {
         for (final Record<Object> record : records) {
@@ -43,7 +50,8 @@ public class StdOutSink implements Sink<Record<Object>> {
     // TODO: This function should be removed with the completion of: https://github.com/opensearch-project/data-prepper/issues/546
     private void checkTypeAndPrintObject(final Object object) {
         if (object instanceof Event) {
-            System.out.println(((Event) object).toJsonString());
+            String output = ((Event)object).jsonBuilder().includeTags(tagsTargetKey).toJsonString();
+            System.out.println(output);
             EventHandle eventHandle = ((Event)object).getEventHandle();
             if (eventHandle != null) {
                 eventHandle.release(true);

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/sink/StdOutSinkTests.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/sink/StdOutSinkTests.java
@@ -7,7 +7,6 @@ package org.opensearch.dataprepper.plugins.sink;
 
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
-import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.model.record.Record;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/sink/StdOutSinkTests.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/sink/StdOutSinkTests.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.sink;
 
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.model.record.Record;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,7 +52,7 @@ public class StdOutSinkTests {
 
     @Test
     public void testSinkWithEvents() {
-        final StdOutSink stdOutSink = new StdOutSink(new PluginSetting(PLUGIN_NAME, new HashMap<>()));
+        final StdOutSink stdOutSink = new StdOutSink(new PluginSetting(PLUGIN_NAME, new HashMap<>()), null);
         stdOutSink.output(testRecords);
         stdOutSink.shutdown();
     }
@@ -59,7 +60,7 @@ public class StdOutSinkTests {
     // TODO: remove with the completion of: https://github.com/opensearch-project/data-prepper/issues/546
     @Test
     public void testSinkWithCustomType() {
-        final StdOutSink stdOutSink = new StdOutSink(new PluginSetting(PLUGIN_NAME, new HashMap<>()));
+        final StdOutSink stdOutSink = new StdOutSink(new PluginSetting(PLUGIN_NAME, new HashMap<>()), null);
         stdOutSink.output(Collections.singletonList(new Record<Object>(new TestObject())));
     }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -24,6 +24,7 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.model.event.exceptions.EventKeyNotFoundException;
 import org.opensearch.dataprepper.model.failures.DlqObject;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
@@ -57,6 +58,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.locks.ReentrantLock;
@@ -101,6 +103,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
   private ObjectMapper objectMapper;
   private volatile boolean initialized;
   private PluginSetting pluginSetting;
+  private final SinkContext sinkContext;
 
   private FailedBulkOperationConverter failedBulkOperationConverter;
 
@@ -109,9 +112,11 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
   @DataPrepperPluginConstructor
   public OpenSearchSink(final PluginSetting pluginSetting,
                         final PluginFactory pluginFactory,
+                        final SinkContext sinkContext,
                         final AwsCredentialsSupplier awsCredentialsSupplier) {
     super(pluginSetting, Integer.MAX_VALUE, INITIALIZE_RETRY_WAIT_TIME_MS);
     this.awsCredentialsSupplier = awsCredentialsSupplier;
+    this.sinkContext = sinkContext;
     bulkRequestTimer = pluginMetrics.timer(BULKREQUEST_LATENCY);
     bulkRequestErrorsCounter = pluginMetrics.counter(BULKREQUEST_ERRORS);
     dynamicIndexDroppedEvents = pluginMetrics.counter(DYNAMIC_INDEX_DROPPED_EVENTS);
@@ -280,7 +285,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     String docId = (documentIdField != null) ? event.get(documentIdField, String.class) : null;
     String routing = (routingField != null) ? event.get(routingField, String.class) : null;
 
-    final String document = DocumentBuilder.build(event, documentRootKey);
+    final String document = DocumentBuilder.build(event, documentRootKey, Objects.nonNull(sinkContext)?sinkContext.getTagsTargetKey():null);
 
     return SerializedJson.fromStringAndOptionals(document, docId, routing);
   }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DocumentBuilder.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DocumentBuilder.java
@@ -4,7 +4,7 @@ import org.opensearch.dataprepper.model.event.Event;
 
 public final class DocumentBuilder {
 
-    public static String build(final Event event, final String documentRootKey) {
+    public static String build(final Event event, final String documentRootKey, final String tagsTargetKey) {
         if (documentRootKey != null && event.containsKey(documentRootKey)) {
             final String document = event.getAsJsonString(documentRootKey);
             if (document == null || !document.startsWith("{")) {
@@ -12,6 +12,6 @@ public final class DocumentBuilder {
             }
             return document;
         }
-        return event.toJsonString();
+        return event.jsonBuilder().includeTags(tagsTargetKey).toJsonString();
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DocumentBuilderTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DocumentBuilderTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -24,6 +25,8 @@ public class DocumentBuilderTest {
     private String random;
     private Event event;
     private String expectedOutput;
+    private String expectedOutputWithTags;
+    private final String tagsKey = "tags";
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -37,7 +40,9 @@ public class DocumentBuilderTest {
             .withData(data)
             .withEventType("TestEvent")
             .build();
+        event.getMetadata().addTags(List.of("tag1"));
         expectedOutput = objectMapper.writeValueAsString(data);
+        expectedOutputWithTags = event.jsonBuilder().includeTags(tagsKey).toJsonString();
     }
 
     @ParameterizedTest
@@ -45,16 +50,26 @@ public class DocumentBuilderTest {
     @ValueSource(strings = {"missingObject", "/"})
     public void buildWillReturnFullObject(final String documentRootKey) {
 
-        final String doc = DocumentBuilder.build(event, documentRootKey);
+        final String doc = DocumentBuilder.build(event, documentRootKey, null);
 
         assertThat(doc, is(equalTo(expectedOutput)));
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"missingObject", "/"})
+    public void buildWillReturnObjectWithTags(final String documentRootKey) {
+
+        final String doc = DocumentBuilder.build(event, documentRootKey, tagsKey);
+
+        assertThat(doc, is(equalTo(expectedOutputWithTags)));
     }
 
     @ParameterizedTest
     @MethodSource("provideSingleItemKeys")
     public void buildWillReturnSingleObject(final String documentRootKey, final Object expectedResult) {
 
-        final String doc = DocumentBuilder.build(event, documentRootKey);
+        final String doc = DocumentBuilder.build(event, documentRootKey, null);
 
         assertThat(doc, is(equalTo(String.format("{\"data\": %s}", expectedResult))));
     }

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/S3SinkServiceIT.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/S3SinkServiceIT.java
@@ -134,7 +134,7 @@ class S3SinkServiceIT {
     }
 
     private S3SinkService createObjectUnderTest() {
-        return new S3SinkService(s3SinkConfig, bufferFactory, codec, s3Client, pluginMetrics);
+        return new S3SinkService(s3SinkConfig, bufferFactory, codec, s3Client, null, pluginMetrics);
     }
 
     private int gets3ObjectCount() {

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/S3Sink.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/S3Sink.java
@@ -15,6 +15,7 @@ import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationExcepti
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.AbstractSink;
+import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.model.sink.Sink;
 import org.opensearch.dataprepper.plugins.sink.accumulator.BufferFactory;
 import org.opensearch.dataprepper.plugins.sink.accumulator.BufferTypeOptions;
@@ -26,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.Collection;
+import java.util.Objects;
 
 /**
  * Implementation class of s3-sink plugin. It is responsible for receive the collection of
@@ -40,6 +42,7 @@ public class S3Sink extends AbstractSink<Record<Event>> {
     private volatile boolean sinkInitialized;
     private final S3SinkService s3SinkService;
     private final BufferFactory bufferFactory;
+    private final SinkContext sinkContext;
 
     /**
      * @param pluginSetting dp plugin settings.
@@ -50,9 +53,11 @@ public class S3Sink extends AbstractSink<Record<Event>> {
     public S3Sink(final PluginSetting pluginSetting,
                   final S3SinkConfig s3SinkConfig,
                   final PluginFactory pluginFactory,
+                  final SinkContext sinkContext,
                   final AwsCredentialsSupplier awsCredentialsSupplier) {
         super(pluginSetting);
         this.s3SinkConfig = s3SinkConfig;
+        this.sinkContext = sinkContext;
         final PluginModel codecConfiguration = s3SinkConfig.getCodec();
         final PluginSetting codecPluginSettings = new PluginSetting(codecConfiguration.getPluginName(),
                 codecConfiguration.getPluginSettings());
@@ -65,7 +70,7 @@ public class S3Sink extends AbstractSink<Record<Event>> {
             bufferFactory = new InMemoryBufferFactory();
         }
         final S3Client s3Client = ClientFactory.createS3Client(s3SinkConfig, awsCredentialsSupplier);
-        s3SinkService = new S3SinkService(s3SinkConfig, bufferFactory, codec, s3Client, pluginMetrics);
+        s3SinkService = new S3SinkService(s3SinkConfig, bufferFactory, codec, s3Client, Objects.nonNull(sinkContext) ? sinkContext.getTagsTargetKey() : null, pluginMetrics);
     }
 
     @Override

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/S3SinkService.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/S3SinkService.java
@@ -57,6 +57,7 @@ public class S3SinkService {
     private final Counter numberOfRecordsSuccessCounter;
     private final Counter numberOfRecordsFailedCounter;
     private final DistributionSummary s3ObjectSizeSummary;
+    private final String tagsTargetKey;
 
     /**
      * @param s3SinkConfig  s3 sink related configuration.
@@ -66,11 +67,12 @@ public class S3SinkService {
      * @param pluginMetrics metrics.
      */
     public S3SinkService(final S3SinkConfig s3SinkConfig, final BufferFactory bufferFactory,
-                         final Codec codec, final S3Client s3Client, final PluginMetrics pluginMetrics) {
+                         final Codec codec, final S3Client s3Client, final String tagsTargetKey, final PluginMetrics pluginMetrics) {
         this.s3SinkConfig = s3SinkConfig;
         this.bufferFactory = bufferFactory;
         this.codec = codec;
         this.s3Client = s3Client;
+        this.tagsTargetKey = tagsTargetKey;
         reentrantLock = new ReentrantLock();
 
         bufferedEventHandles = new LinkedList<>();
@@ -102,7 +104,7 @@ public class S3SinkService {
 
                 final Event event = record.getData();
                 final String encodedEvent;
-                encodedEvent = codec.parse(event);
+                encodedEvent = codec.parse(event, tagsTargetKey);
                 final byte[] encodedBytes = encodedEvent.getBytes();
 
                 currentBuffer.writeEvent(encodedBytes);

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/codec/Codec.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/codec/Codec.java
@@ -15,8 +15,9 @@ import org.opensearch.dataprepper.model.event.Event;
 public interface Codec {
     /**
      * @param event input data.
+     * @param tagsTargetKey key name for including tags if not null
      * @return parse string.
      * @throws IOException exception.
      */
-    String parse(Event event) throws IOException;
+    String parse(final Event event, final String tagsTargetKey) throws IOException;
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/codec/JsonCodec.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/codec/JsonCodec.java
@@ -19,8 +19,8 @@ public class JsonCodec implements Codec {
      * Generates a serialized json string of the Event
      */
     @Override
-    public String parse(Event event) throws IOException {
+    public String parse(final Event event, final String tagsTargetKey) throws IOException {
         Objects.requireNonNull(event);
-        return event.toJsonString();
+        return event.jsonBuilder().includeTags(tagsTargetKey).toJsonString();
     }
 }

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/S3SinkTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/S3SinkTest.java
@@ -14,6 +14,7 @@ import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.model.types.ByteCount;
 import org.opensearch.dataprepper.plugins.sink.accumulator.BufferTypeOptions;
 import org.opensearch.dataprepper.plugins.sink.codec.Codec;
@@ -49,11 +50,13 @@ class S3SinkTest {
     private PluginSetting pluginSetting;
     private PluginFactory pluginFactory;
     private AwsCredentialsSupplier awsCredentialsSupplier;
+    private SinkContext sinkContext;
 
     @BeforeEach
     void setUp() {
 
         s3SinkConfig = mock(S3SinkConfig.class);
+        sinkContext = mock(SinkContext.class);
         ThresholdOptions thresholdOptions = mock(ThresholdOptions.class);
         AwsAuthenticationOptions awsAuthenticationOptions = mock(AwsAuthenticationOptions.class);
         Codec codec = mock(JsonCodec.class);
@@ -80,7 +83,7 @@ class S3SinkTest {
     }
 
     private S3Sink createObjectUnderTest() {
-        return new S3Sink(pluginSetting, s3SinkConfig, pluginFactory, awsCredentialsSupplier);
+        return new S3Sink(pluginSetting, s3SinkConfig, pluginFactory, sinkContext, awsCredentialsSupplier);
     }
 
     @Test

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/codec/JsonCodecTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/codec/JsonCodecTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,7 @@ class JsonCodecTest {
         String value2 = UUID.randomUUID().toString();
         eventData.put("key2", value2);
         final JacksonEvent event = JacksonLog.builder().withData(eventData).withEventType("LOG").build();
-        String output = createObjectUnderTest().parse(event);
+        String output = createObjectUnderTest().parse(event, null);
         assertNotNull(output);
 
         ObjectMapper objectMapper = new ObjectMapper();
@@ -39,6 +40,31 @@ class JsonCodecTest {
         assertThat(deserializedData.get("key1"), equalTo(value1));
         assertThat(deserializedData.get("key2"), notNullValue());
         assertThat(deserializedData.get("key2"), equalTo(value2));
+    }
+
+    @Test
+    void parse_with_events_output_stream_json_codec_with_tags() throws IOException {
+
+        final Map<String, String> eventData = new HashMap<>();
+        String value1 = UUID.randomUUID().toString();
+        eventData.put("key1", value1);
+        String value2 = UUID.randomUUID().toString();
+        eventData.put("key2", value2);
+        final JacksonEvent event = JacksonLog.builder().withData(eventData).withEventType("LOG").build();
+        List<String> tagsList = List.of("tag1");
+        event.getMetadata().addTags(tagsList);
+        String output = createObjectUnderTest().parse(event, "tags");
+        assertNotNull(output);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map deserializedData = objectMapper.readValue(output, Map.class);
+        assertThat(deserializedData, notNullValue());
+        assertThat(deserializedData.get("key1"), notNullValue());
+        assertThat(deserializedData.get("key1"), equalTo(value1));
+        assertThat(deserializedData.get("key2"), notNullValue());
+        assertThat(deserializedData.get("key2"), equalTo(value2));
+        assertThat(deserializedData.get("tags"), notNullValue());
+        assertThat(deserializedData.get("tags"), equalTo(tagsList));
     }
 
     private JsonCodec createObjectUnderTest() {


### PR DESCRIPTION
### Description
Add support for writing tags along with events to Sink.

Introduces a new option `tags_target_key` to all sinks.
A Sink Context is created and is stored in the PluginSetting which can be used later by the sinks to get any sink related context (global configuration)

Resolves #2827 

### Issues Resolved
Resolves #2827 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
