### PR TITLE
Add end-to-end acknowledgement support to Stdout and File Sinks

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySink.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySink.java
@@ -21,6 +21,7 @@ public class InMemorySink implements Sink<Record<Event>> {
     private final String testingKey;
     private final InMemorySinkAccessor inMemorySinkAccessor;
     private final AcknowledgementSetManager acknowledgementSetManager;
+    private final Boolean acknowledgements;
 
     @DataPrepperPluginConstructor
     public InMemorySink(final InMemoryConfig inMemoryConfig,
@@ -29,6 +30,7 @@ public class InMemorySink implements Sink<Record<Event>> {
         testingKey = inMemoryConfig.getTestingKey();
         this.inMemorySinkAccessor = inMemorySinkAccessor;
         this.acknowledgementSetManager = acknowledgementSetManager;
+        acknowledgements = inMemoryConfig.getAcknowledgements();
     }
 
     @Override
@@ -37,7 +39,9 @@ public class InMemorySink implements Sink<Record<Event>> {
         boolean result = inMemorySinkAccessor.getResult();
         records.stream().forEach((record) -> {
             EventHandle eventHandle = ((Event)record.getData()).getEventHandle();
-            acknowledgementSetManager.releaseEventReference(eventHandle, result);
+            if (acknowledgements) {
+                acknowledgementSetManager.releaseEventReference(eventHandle, result);
+            }
         });
     }
 

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/one-pipeline-ack-expiry-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/one-pipeline-ack-expiry-test.yaml
@@ -8,4 +8,5 @@ pipeline1:
     - stdout:
     - in_memory:
         testing_key: PipelinesWithAcksIT
+        acknowledgments: false
 

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/one-pipeline-three-sinks.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/one-pipeline-three-sinks.yaml
@@ -7,8 +7,11 @@ pipeline1:
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT
+        acknowledgments: true
     - in_memory:
         testing_key: PipelinesWithAcksIT
+        acknowledgments: true
     - in_memory:
         testing_key: PipelinesWithAcksIT
+        acknowledgments: true
 

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/simple-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/simple-test.yaml
@@ -7,3 +7,4 @@ simple-pipeline:
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT
+        acknowledgments: true

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipeline-route-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipeline-route-test.yaml
@@ -24,6 +24,7 @@ pipeline2:
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT
+        acknowledgments: true
 
 pipeline3:
   source:
@@ -32,3 +33,4 @@ pipeline3:
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT
+        acknowledgments: true

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipelines-test-multi-sink.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipelines-test-multi-sink.yaml
@@ -7,6 +7,7 @@ pipeline1:
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT
+        acknowledgments: true
     - pipeline:
         name: "pipeline2"
 
@@ -17,6 +18,7 @@ pipeline2:
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT
+        acknowledgments: true
     - pipeline:
         name: "pipeline3"
 
@@ -27,3 +29,4 @@ pipeline3:
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT
+        acknowledgments: true

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipelines-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipelines-test.yaml
@@ -23,3 +23,4 @@ pipeline3:
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT
+        acknowledgments: true

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/two-parallel-pipelines-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/two-parallel-pipelines-test.yaml
@@ -17,6 +17,7 @@ pipeline2:
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT
+        acknowledgments: true
 
 pipeline3:
   source:
@@ -25,3 +26,4 @@ pipeline3:
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT
+        acknowledgments: true

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/two-pipelines-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/two-pipelines-test.yaml
@@ -15,3 +15,4 @@ pipeline2:
   sink:
     - in_memory:
         testing_key: PipelinesWithAcksIT
+        acknowledgments: true

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/FileSink.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/FileSink.java
@@ -9,6 +9,7 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.Sink;
 import org.slf4j.Logger;
@@ -63,6 +64,10 @@ public class FileSink implements Sink<Record<Object>> {
             for (final Record<Object> record : records) {
                 try {
                     checkTypeAndWriteObject(record.getData(), writer);
+                    EventHandle eventHandle = ((Event)record.getData()).getEventHandle();
+                    if (eventHandle != null) {
+                        eventHandle.release(true);
+                    }
                 } catch (final IOException ex) {
                     throw new RuntimeException(format("Encountered exception writing to file %s", outputFilePath), ex);
                 }

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/FileSink.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/FileSink.java
@@ -64,10 +64,7 @@ public class FileSink implements Sink<Record<Object>> {
             for (final Record<Object> record : records) {
                 try {
                     checkTypeAndWriteObject(record.getData(), writer);
-                    EventHandle eventHandle = ((Event)record.getData()).getEventHandle();
-                    if (eventHandle != null) {
-                        eventHandle.release(true);
-                    }
+                    
                 } catch (final IOException ex) {
                     throw new RuntimeException(format("Encountered exception writing to file %s", outputFilePath), ex);
                 }
@@ -89,6 +86,10 @@ public class FileSink implements Sink<Record<Object>> {
         if (object instanceof Event) {
             writer.write(((Event) object).toJsonString());
             writer.newLine();
+            EventHandle eventHandle = ((Event)object).getEventHandle();
+            if (eventHandle != null) {
+                eventHandle.release(true);
+            }
         } else {
             writer.write(object.toString());
             writer.newLine();

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/StdOutSink.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/StdOutSink.java
@@ -36,10 +36,6 @@ public class StdOutSink implements Sink<Record<Object>> {
     public void output(final Collection<Record<Object>> records) {
         for (final Record<Object> record : records) {
             checkTypeAndPrintObject(record.getData());
-            EventHandle eventHandle = ((Event)record.getData()).getEventHandle();
-            if (eventHandle != null) {
-                eventHandle.release(true);
-            }
         }
     }
 
@@ -48,6 +44,10 @@ public class StdOutSink implements Sink<Record<Object>> {
     private void checkTypeAndPrintObject(final Object object) {
         if (object instanceof Event) {
             System.out.println(((Event) object).toJsonString());
+            EventHandle eventHandle = ((Event)object).getEventHandle();
+            if (eventHandle != null) {
+                eventHandle.release(true);
+            }
         } else {
             System.out.println(object);
         }

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/StdOutSink.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/sink/StdOutSink.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.plugins.sink;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.Sink;
 
@@ -35,6 +36,10 @@ public class StdOutSink implements Sink<Record<Object>> {
     public void output(final Collection<Record<Object>> records) {
         for (final Record<Object> record : records) {
             checkTypeAndPrintObject(record.getData());
+            EventHandle eventHandle = ((Event)record.getData()).getEventHandle();
+            if (eventHandle != null) {
+                eventHandle.release(true);
+            }
         }
     }
 


### PR DESCRIPTION
### Description
Add end-to-end acknowledgement support to Stdout and File Sinks.

Stdout and File sinks are currently not acknowledging e2e acks. This change adds the support to acknowledge e2e acks.
 
Resolves #2859 

### Issues Resolved
Resolves #2859 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
