### PR TITLE
Add STS external ID to all STS configurations.

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
@@ -254,7 +254,7 @@ public class PluginSetting implements PipelineDescription {
     }
 
     private <T> void checkObjectType(final String attribute, final Object object, final Class<T> type) {
-        if (!(type.isAssignableFrom(object.getClass()))){
+        if (object != null && !(type.isAssignableFrom(object.getClass()))){
             throw new IllegalArgumentException(String.format(UNEXPECTED_ATTRIBUTE_TYPE_MSG, object.getClass(), attribute));
         }
     }

--- a/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptions.java
+++ b/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptions.java
@@ -16,11 +16,13 @@ import java.util.Map;
  */
 public class AwsCredentialsOptions {
     private final String stsRoleArn;
+    private final String stsExternalId;
     private final Region region;
     private final Map<String, String> stsHeaderOverrides;
 
     private AwsCredentialsOptions(final Builder builder) {
         this.stsRoleArn = builder.stsRoleArn;
+        this.stsExternalId = builder.stsExternalId;
         this.region = builder.region;
         this.stsHeaderOverrides = builder.stsHeaderOverrides != null ? new HashMap<>(builder.stsHeaderOverrides) : Collections.emptyMap();
     }
@@ -39,6 +41,10 @@ public class AwsCredentialsOptions {
         return stsRoleArn;
     }
 
+    public String getStsExternalId() {
+        return stsExternalId;
+    }
+
     public Region getRegion() {
         return region;
     }
@@ -52,6 +58,7 @@ public class AwsCredentialsOptions {
      */
     public static class Builder {
         private String stsRoleArn;
+        private String stsExternalId;
         private Region region;
         private Map<String, String> stsHeaderOverrides = Collections.emptyMap();
 
@@ -66,6 +73,10 @@ public class AwsCredentialsOptions {
             return this;
         }
 
+        public Builder withStsExternalId(final String stsExternalId) {
+            this.stsExternalId = stsExternalId;
+            return this;
+        }
         /**
          * Sets the AWS region using the model class from the AWS SDK.
          *

--- a/data-prepper-plugins/aws-plugin-api/src/test/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptionsTest.java
+++ b/data-prepper-plugins/aws-plugin-api/src/test/java/org/opensearch/dataprepper/aws/api/AwsCredentialsOptionsTest.java
@@ -41,6 +41,27 @@ class AwsCredentialsOptionsTest {
     }
 
     @Test
+    void without_StsExternalId() {
+        final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                .build();
+
+        assertThat(awsCredentialsOptions, notNullValue());
+        assertThat(awsCredentialsOptions.getStsExternalId(), nullValue());
+    }
+
+    @Test
+    void with_StsExternalId() {
+        final String externalId = UUID.randomUUID().toString();
+        final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
+                .withStsExternalId(externalId)
+                .build();
+
+        assertThat(awsCredentialsOptions, notNullValue());
+        assertThat(awsCredentialsOptions.getStsExternalId(), notNullValue());
+        assertThat(awsCredentialsOptions.getStsExternalId(), equalTo(externalId));
+    }
+
+    @Test
     void without_Region() {
         final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
                 .build();

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
@@ -60,6 +60,10 @@ class CredentialsProviderFactory {
                 .roleSessionName("Data-Prepper-" + UUID.randomUUID())
                 .roleArn(stsRoleArn);
 
+        if (credentialsOptions.getStsExternalId() != null && !credentialsOptions.getStsExternalId().isEmpty()) {
+            assumeRoleRequestBuilder = assumeRoleRequestBuilder.externalId(credentialsOptions.getStsExternalId());
+        }
+
         final Map<String, String> awsStsHeaderOverrides = credentialsOptions.getStsHeaderOverrides();
 
         if(awsStsHeaderOverrides != null && !awsStsHeaderOverrides.isEmpty()) {

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
@@ -62,13 +62,13 @@ public class DynamoDbClientWrapper {
     private DynamoDbTable<DynamoDbSourcePartitionItem> table;
 
 
-    private DynamoDbClientWrapper(final String region, final String stsRoleArn) {
-        this.dynamoDbClient = DynamoDbClientFactory.provideDynamoDbClient(region, stsRoleArn);
+    private DynamoDbClientWrapper(final String region, final String stsRoleArn, final String stsExternalId) {
+        this.dynamoDbClient = DynamoDbClientFactory.provideDynamoDbClient(region, stsRoleArn, stsExternalId);
         this.dynamoDbEnhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build();
     }
 
-    public static DynamoDbClientWrapper create(final String region, final String stsRoleArn) {
-        return new DynamoDbClientWrapper(region, stsRoleArn);
+    public static DynamoDbClientWrapper create(final String region, final String stsRoleArn, final String stsExternalId) {
+        return new DynamoDbClientWrapper(region, stsRoleArn, stsExternalId);
     }
 
     public void initializeTable(final DynamoStoreSettings dynamoStoreSettings,

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStore.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStore.java
@@ -41,7 +41,10 @@ public class DynamoDbSourceCoordinationStore implements SourceCoordinationStore 
     public DynamoDbSourceCoordinationStore(final DynamoStoreSettings dynamoStoreSettings, final PluginMetrics pluginMetrics) {
         this.dynamoStoreSettings = dynamoStoreSettings;
         this.pluginMetrics = pluginMetrics;
-        this.dynamoDbClientWrapper = DynamoDbClientWrapper.create(dynamoStoreSettings.getRegion(), dynamoStoreSettings.getStsRoleArn());
+        this.dynamoDbClientWrapper = DynamoDbClientWrapper.create(
+            dynamoStoreSettings.getRegion(),
+            dynamoStoreSettings.getStsRoleArn(),
+            dynamoStoreSettings.getStsExternalId());
     }
 
     @Override

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoStoreSettings.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoStoreSettings.java
@@ -24,6 +24,7 @@ public class DynamoStoreSettings {
     private final String tableName;
     private final String region;
     private final String stsRoleArn;
+    private final String stsExternalId;
     private final Duration ttl;
 
 
@@ -35,6 +36,7 @@ public class DynamoStoreSettings {
     public DynamoStoreSettings(@JsonProperty("table_name") final String tableName,
                                @JsonProperty("region") final String region,
                                @JsonProperty("sts_role_arn") final String stsRoleArn,
+                               @JsonProperty("sts_external_id") final String stsExternalId,
                                @JsonProperty("skip_table_creation") final Boolean skipTableCreation,
                                @JsonProperty("provisioned_read_capacity_units") final Long provisionedReadCapacityUnits,
                                @JsonProperty("provisioned_write_capacity_units") final Long provisionedWriteCapacityUnits,
@@ -45,6 +47,7 @@ public class DynamoStoreSettings {
         this.tableName = tableName;
         this.region = region;
         this.stsRoleArn = stsRoleArn;
+        this.stsExternalId = stsExternalId;
         this.ttl = ttl;
 
         if (Objects.nonNull(skipTableCreation)) {
@@ -70,6 +73,10 @@ public class DynamoStoreSettings {
 
     public String getStsRoleArn() {
         return stsRoleArn;
+    }
+
+    public String getStsExternalId() {
+        return stsExternalId;
     }
 
     public Long getProvisionedReadCapacityUnits() {

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientFactoryTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientFactoryTest.java
@@ -61,7 +61,7 @@ public class DynamoDbClientFactoryTest {
             when(dynamoDbClientBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class))).thenReturn(dynamoDbClientBuilder);
             when(dynamoDbClientBuilder.build()).thenReturn(dynamoDbClient);
 
-            final DynamoDbClient provideDynamoDbClient = DynamoDbClientFactory.provideDynamoDbClient(region, null);
+            final DynamoDbClient provideDynamoDbClient = DynamoDbClientFactory.provideDynamoDbClient(region, null, null);
 
             assertThat(provideDynamoDbClient, equalTo(dynamoDbClient));
         }
@@ -107,7 +107,7 @@ public class DynamoDbClientFactoryTest {
             when(dynamoDbClientBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class))).thenReturn(dynamoDbClientBuilder);
             when(dynamoDbClientBuilder.build()).thenReturn(dynamoDbClient);
 
-            final DynamoDbClient providedDynamoDbClient = DynamoDbClientFactory.provideDynamoDbClient(region, stsRoleArn);
+            final DynamoDbClient providedDynamoDbClient = DynamoDbClientFactory.provideDynamoDbClient(region, stsRoleArn, null);
 
             assertThat(providedDynamoDbClient, equalTo(dynamoDbClient));
         }

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapperTest.java
@@ -104,13 +104,13 @@ public class DynamoDbClientWrapperTest {
     private DynamoDbClientWrapper createObjectUnderTest() {
         try (final MockedStatic<DynamoDbClientFactory> dynamoDbClientFactoryMockedStatic = mockStatic(DynamoDbClientFactory.class);
              final MockedStatic<DynamoDbEnhancedClient> dynamoDbEnhancedClientMockedStatic = mockStatic(DynamoDbEnhancedClient.class)) {
-              dynamoDbClientFactoryMockedStatic.when(() -> DynamoDbClientFactory.provideDynamoDbClient(region, stsRoleArn)).thenReturn(dynamoDbClient);
+              dynamoDbClientFactoryMockedStatic.when(() -> DynamoDbClientFactory.provideDynamoDbClient(region, stsRoleArn, null)).thenReturn(dynamoDbClient);
             final DynamoDbEnhancedClient.Builder builder = mock(DynamoDbEnhancedClient.Builder.class);
 
             dynamoDbEnhancedClientMockedStatic.when(DynamoDbEnhancedClient::builder).thenReturn(builder);
             when(builder.dynamoDbClient(dynamoDbClient)).thenReturn(builder);
             when(builder.build()).thenReturn(dynamoDbEnhancedClient);
-            return DynamoDbClientWrapper.create(region, stsRoleArn);
+            return DynamoDbClientWrapper.create(region, stsRoleArn, null);
         }
     }
 

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
@@ -55,12 +55,14 @@ public class DynamoDbSourceCoordinationStoreTest {
     void setup() {
         given(dynamoStoreSettings.getRegion()).willReturn(UUID.randomUUID().toString());
         given(dynamoStoreSettings.getStsRoleArn()).willReturn(UUID.randomUUID().toString());
+        given(dynamoStoreSettings.getStsExternalId()).willReturn(UUID.randomUUID().toString());
     }
 
     private DynamoDbSourceCoordinationStore createObjectUnderTest() {
         try (final MockedStatic<DynamoDbClientWrapper> dynamoDbClientWrapperMockedStatic = mockStatic(DynamoDbClientWrapper.class)) {
-            dynamoDbClientWrapperMockedStatic.when(() -> DynamoDbClientWrapper.create(dynamoStoreSettings.getRegion(), dynamoStoreSettings.getStsRoleArn()))
-                            .thenReturn(dynamoDbClientWrapper);
+            dynamoDbClientWrapperMockedStatic.when(() -> DynamoDbClientWrapper.create(dynamoStoreSettings.getRegion(),
+                    dynamoStoreSettings.getStsRoleArn(), dynamoStoreSettings.getStsExternalId()))
+                .thenReturn(dynamoDbClientWrapper);
             return new DynamoDbSourceCoordinationStore(dynamoStoreSettings, pluginMetrics);
         }
     }

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/README.md
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/README.md
@@ -49,6 +49,7 @@ The DLQ file will JSON file with an array of failed [DLQ Objects](#DLQ-Objects).
 * `key_path_prefix` (Optional) : The key_prefix to use in the S3 bucket.  Defaults to “” . This field supports time value patterns variables like: `/%{yyyy}/%{MM}/%{dd}`. The pattern supports all the symbols that represent one hour or above and are listed in [Java DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html). For example, with a pattern like `/%{yyyy}/%{MM}/%{dd}`, the following key prefix will be used: `/2023/01/24`.
 * `region` (Optional) : The AWS region of the S3 Bucket. Defaults to us-east-1.
 * `sts_role_arn` (Optional) : The STS role to assume to write to the AWS S3 bucket. Defaults to null, which will use the standard SDK behavior for credentials. The role or credentials used must have S3:PutObject permissions on the configured S3 Bucket.
+* `sts_external_id` (Optional): The STS external ID to attach to AssumeRole requests.
 
 ### Metrics
 

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfig.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfig.java
@@ -50,6 +50,10 @@ public class S3DlqWriterConfig {
     @Size(min = 20, max = 2048, message = "sts_role_arn length should be between 1 and 2048 characters")
     private String stsRoleArn;
 
+    @JsonProperty("sts_external_id")
+    @Size(min = 2, max = 1224, message = "sts_external_id length should be between 2 and 1224 characters")
+    private String stsExternalId;
+
     public String getBucket() {
         return bucket;
     }
@@ -77,6 +81,10 @@ public class S3DlqWriterConfig {
         AssumeRoleRequest.Builder assumeRoleRequestBuilder = AssumeRoleRequest.builder()
             .roleSessionName("s3-dlq-" + UUID.randomUUID())
             .roleArn(stsRoleArn);
+
+        if (stsExternalId != null && !stsExternalId.isEmpty()) {
+            assumeRoleRequestBuilder = assumeRoleRequestBuilder.externalId(stsExternalId);
+        }
 
         return StsAssumeRoleCredentialsProvider.builder()
             .stsClient(stsClient)

--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfigTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfigTest.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.lang.reflect.Field;
+import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -47,6 +48,17 @@ public class S3DlqWriterConfigTest {
     public void getS3ClientWithValidStsRoleArn(final String stsRoleArn) throws NoSuchFieldException, IllegalAccessException {
         final S3DlqWriterConfig config = new S3DlqWriterConfig();
         reflectivelySetField(config, "stsRoleArn", stsRoleArn);
+        final S3Client s3Client = config.getS3Client();
+        assertThat(s3Client, is(notNullValue()));
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", "arn:aws:iam::123456789012:role/some-role"})
+    public void getS3ClientWithValidStsRoleArnAndExternalId(final String stsRoleArn) throws NoSuchFieldException, IllegalAccessException {
+        final S3DlqWriterConfig config = new S3DlqWriterConfig();
+        reflectivelySetField(config, "stsRoleArn", stsRoleArn);
+        reflectivelySetField(config, "stsExternalId", UUID.randomUUID().toString());
         final S3Client s3Client = config.getS3Client();
         assertThat(s3Client, is(notNullValue()));
     }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/AwsAuthenticationConfiguration.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/AwsAuthenticationConfiguration.java
@@ -21,12 +21,20 @@ public class AwsAuthenticationConfiguration {
     @Size(min = 20, max = 2048, message = "awsStsRoleArn length should be between 1 and 2048 characters")
     private String awsStsRoleArn;
 
+    @JsonProperty("sts_external_id")
+    @Size(min = 2, max = 1224, message = "awsStsExternalId length should be between 2 and 1224 characters")
+    private String awsStsExternalId;
+
     @JsonProperty("sts_header_overrides")
     @Size(max = 5, message = "sts_header_overrides supports a maximum of 5 headers to override")
     private Map<String, String> awsStsHeaderOverrides;
 
     public String getAwsStsRoleArn() {
         return awsStsRoleArn;
+    }
+
+    public String getAwsStsExternalId() {
+        return awsStsExternalId;
     }
 
     public Region getAwsRegion() {

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessorStrategy.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessorStrategy.java
@@ -212,6 +212,7 @@ public class SearchAccessorStrategy {
         final AwsCredentialsProvider awsCredentialsProvider = awsCredentialsSupplier.getProvider(AwsCredentialsOptions.builder()
                 .withRegion(openSearchSourceConfiguration.getAwsAuthenticationOptions().getAwsRegion())
                 .withStsRoleArn(openSearchSourceConfiguration.getAwsAuthenticationOptions().getAwsStsRoleArn())
+                .withStsExternalId(openSearchSourceConfiguration.getAwsAuthenticationOptions().getAwsStsExternalId())
                 .withStsHeaderOverrides(openSearchSourceConfiguration.getAwsAuthenticationOptions().getAwsStsHeaderOverrides())
                 .build());
 

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfigurationTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfigurationTest.java
@@ -78,6 +78,43 @@ public class OpenSearchSourceConfigurationTest {
         assertThat(sourceConfiguration.getPassword(), equalTo(null));
         assertThat(sourceConfiguration.getUsername(), equalTo(null));
         assertThat(sourceConfiguration.getAwsAuthenticationOptions(), notNullValue());
+
+        assertThat(sourceConfiguration.getAwsAuthenticationOptions().getAwsStsRoleArn(),
+            equalTo("arn:aws:iam::123456789012:role/aos-role"));
+    }
+
+    @Test
+    void opensearch_source_aws_sts_external_id() throws JsonProcessingException {
+        final String sourceConfigurationYaml = "max_retries: 5\n" +
+            "hosts: [\"http://localhost:9200\"]\n" +
+            "connection:\n" +
+            "  insecure: true\n" +
+            "  cert: \"cert\"\n" +
+            "indices:\n" +
+            "  include:\n" +
+            "    - index_name_regex: \"regex\"\n" +
+            "    - index_name_regex: \"regex-two\"\n" +
+            "aws:\n" +
+            "  region: \"us-east-1\"\n" +
+            "  sts_role_arn: \"arn:aws:iam::123456789012:role/aos-role\"\n" +
+            "  sts_external_id: \"some-random-id\"\n" +
+            "scheduling:\n" +
+            "  job_count: 3\n" +
+            "search_options:\n" +
+            "  batch_size: 1000\n" +
+            "  query: \"test\"\n";
+
+        final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
+
+        assertThat(sourceConfiguration.validateAwsConfigWithUsernameAndPassword(), equalTo(true));
+        assertThat(sourceConfiguration.getPassword(), equalTo(null));
+        assertThat(sourceConfiguration.getUsername(), equalTo(null));
+        assertThat(sourceConfiguration.getAwsAuthenticationOptions(), notNullValue());
+
+        assertThat(sourceConfiguration.getAwsAuthenticationOptions().getAwsStsRoleArn(),
+            equalTo("arn:aws:iam::123456789012:role/aos-role"));
+        assertThat(sourceConfiguration.getAwsAuthenticationOptions().getAwsStsExternalId(),
+            equalTo("some-random-id"));
     }
 
     @Test

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/AwsAuthenticationConfigurationTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/AwsAuthenticationConfigurationTest.java
@@ -47,6 +47,19 @@ class AwsAuthenticationConfigurationTest {
         assertThat(awsAuthenticationOptions.getAwsRegion(), nullValue());
     }
 
+    @Test
+    void getStsExternalId_notNull() throws NoSuchFieldException, IllegalAccessException {
+        final String externalId = UUID.randomUUID().toString();
+        reflectivelySetField(awsAuthenticationOptions, "awsStsExternalId", externalId);
+        assertThat(awsAuthenticationOptions.getAwsStsExternalId(), equalTo(externalId));
+    }
+
+    @Test
+    void getStsExternalId_Null() throws NoSuchFieldException, IllegalAccessException {
+        reflectivelySetField(awsAuthenticationOptions, "awsStsExternalId", null);
+        assertThat(awsAuthenticationOptions.getAwsStsExternalId(), nullValue());
+    }
+
     private void reflectivelySetField(final AwsAuthenticationConfiguration awsAuthenticationOptions, final String fieldName, final Object value) throws NoSuchFieldException, IllegalAccessException {
         final Field field = AwsAuthenticationConfiguration.class.getDeclaredField(fieldName);
         try {

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -75,6 +75,8 @@ Default is null.
 
 - `aws_sts_role_arn`: A IAM role arn which the sink plugin will assume to sign request to Amazon OpenSearch Service. If not provided the plugin will use the default credentials.
 
+- `aws_sts_external_id`: An optional external ID to use when assuming an IAM role. 
+
 - `aws_sts_header_overrides`: An optional map of header overrides to make when assuming the IAM role for the sink plugin.
 
 - `insecure`: A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Default to `false`.
@@ -160,6 +162,8 @@ If a single record turns out to be larger than the set bulk size, it will be sen
 - `s3_aws_region` (optional): A String represents the region of S3 bucket to read `template_file` or `ism_policy_file`, e.g. us-west-2. Only applies to Amazon OpenSearch Service. Defaults to `us-east-1`.
 
 - `s3_aws_sts_role_arn` (optional): An IAM role arn which the sink plugin will assume to read `template_file` or `ism_policy_file` from S3. If not provided the plugin will use the default credentials.
+
+- `s3_aws_sts_external_id` (optional): An external ID that be attached to Assume Role requests.
 
 - `trace_analytics_raw`: No longer supported starting Data Prepper 2.0. Use `index_type` instead.
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfiguration.java
@@ -78,6 +78,7 @@ public class ConnectionConfiguration {
   public static final String AWS_SIGV4 = "aws_sigv4";
   public static final String AWS_REGION = "aws_region";
   public static final String AWS_STS_ROLE_ARN = "aws_sts_role_arn";
+  public static final String AWS_STS_EXTERNAL_ID = "aws_sts_external_id";
   public static final String AWS_STS_HEADER_OVERRIDES = "aws_sts_header_overrides";
   public static final String PROXY = "proxy";
   public static final String SERVERLESS = "serverless";
@@ -98,6 +99,7 @@ public class ConnectionConfiguration {
   private final boolean awsSigv4;
   private final String awsRegion;
   private final String awsStsRoleArn;
+  private final String awsStsExternalId;
   private final Map<String, String> awsStsHeaderOverrides;
   private final Optional<String> proxy;
   private final String pipelineName;
@@ -158,6 +160,7 @@ public class ConnectionConfiguration {
     this.awsSigv4 = builder.awsSigv4;
     this.awsRegion = builder.awsRegion;
     this.awsStsRoleArn = builder.awsStsRoleArn;
+    this.awsStsExternalId = builder.awsStsExternalId;
     this.awsStsHeaderOverrides = builder.awsStsHeaderOverrides;
     this.proxy = builder.proxy;
     this.serverless = builder.serverless;
@@ -194,6 +197,7 @@ public class ConnectionConfiguration {
         builder.withAwsSigv4(true);
         builder.withAwsRegion((String)(awsOption.getOrDefault(AWS_REGION.substring(4), DEFAULT_AWS_REGION)));
         builder.withAWSStsRoleArn((String)(awsOption.getOrDefault(AWS_STS_ROLE_ARN.substring(4), null)));
+        builder.withAWSStsExternalId((String)(awsOption.getOrDefault(AWS_STS_EXTERNAL_ID.substring(4), null)));
         builder.withAwsStsHeaderOverrides((Map<String, String>)awsOption.get(AWS_STS_HEADER_OVERRIDES.substring(4)));
         builder.withServerless((Boolean)awsOption.getOrDefault(SERVERLESS, false));
     } else {
@@ -208,6 +212,7 @@ public class ConnectionConfiguration {
       builder.withAwsSigv4(true);
       builder.withAwsRegion(pluginSetting.getStringOrDefault(AWS_REGION, DEFAULT_AWS_REGION));
       builder.withAWSStsRoleArn(pluginSetting.getStringOrDefault(AWS_STS_ROLE_ARN, null));
+      builder.withAWSStsExternalId(pluginSetting.getStringOrDefault(AWS_STS_EXTERNAL_ID, null));
       builder.withAwsStsHeaderOverrides(pluginSetting.getTypedMap(AWS_STS_HEADER_OVERRIDES, String.class, String.class));
     }
 
@@ -278,10 +283,11 @@ public class ConnectionConfiguration {
 
   private AwsCredentialsOptions createAwsCredentialsOptions() {
     final AwsCredentialsOptions awsCredentialsOptions = AwsCredentialsOptions.builder()
-            .withStsRoleArn(awsStsRoleArn)
-            .withRegion(awsRegion)
-            .withStsHeaderOverrides(awsStsHeaderOverrides)
-            .build();
+        .withStsRoleArn(awsStsRoleArn)
+        .withStsExternalId(awsStsExternalId)
+        .withRegion(awsRegion)
+        .withStsHeaderOverrides(awsStsHeaderOverrides)
+        .build();
     return awsCredentialsOptions;
   }
 
@@ -439,6 +445,7 @@ public class ConnectionConfiguration {
     private boolean awsSigv4;
     private String awsRegion;
     private String awsStsRoleArn;
+    private String awsStsExternalId;
     private Map<String, String> awsStsHeaderOverrides;
     private Optional<String> proxy = Optional.empty();
     private String pipelineName;
@@ -521,6 +528,12 @@ public class ConnectionConfiguration {
         validateStsRoleArn(awsStsRoleArn);
       }
       this.awsStsRoleArn = awsStsRoleArn;
+      return this;
+    }
+
+    public Builder withAWSStsExternalId(final String awsStsExternalId) {
+      checkArgument(awsStsExternalId == null || awsStsExternalId.length() <= 1224, "awsStsExternalId length cannot exceed 1224");
+      this.awsStsExternalId = awsStsExternalId;
       return this;
     }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -43,6 +43,7 @@ public class IndexConfiguration {
     public static final String ACTION = "action";
     public static final String S3_AWS_REGION = "s3_aws_region";
     public static final String S3_AWS_STS_ROLE_ARN = "s3_aws_sts_role_arn";
+    public static final String S3_AWS_STS_EXTERNAL_ID = "s3_aws_sts_external_id";
     public static final String SERVERLESS = "serverless";
     public static final String AWS_OPTION = "aws";
     public static final String DOCUMENT_ROOT_KEY = "document_root_key";
@@ -58,6 +59,7 @@ public class IndexConfiguration {
     private final String action;
     private final String s3AwsRegion;
     private final String s3AwsStsRoleArn;
+    private final String s3AwsExternalId;
     private final S3Client s3Client;
     private final boolean serverless;
     private final String documentRootKey;
@@ -72,6 +74,7 @@ public class IndexConfiguration {
 
         this.s3AwsRegion = builder.s3AwsRegion;
         this.s3AwsStsRoleArn = builder.s3AwsStsRoleArn;
+        this.s3AwsExternalId = builder.s3AwsStsExternalId;
         this.s3Client = builder.s3Client;
 
         this.templateType = builder.templateType != null ? builder.templateType : TemplateType.V1;
@@ -164,8 +167,10 @@ public class IndexConfiguration {
             || (builder.ismPolicyFile.isPresent() && builder.ismPolicyFile.get().startsWith(S3_PREFIX))) {
             builder.withS3AwsRegion(pluginSetting.getStringOrDefault(S3_AWS_REGION, DEFAULT_AWS_REGION));
             builder.withS3AWSStsRoleArn(pluginSetting.getStringOrDefault(S3_AWS_STS_ROLE_ARN, null));
+            builder.withS3AWSStsExternalId(pluginSetting.getStringOrDefault(S3_AWS_STS_EXTERNAL_ID, null));
 
-            final S3ClientProvider clientProvider = new S3ClientProvider(builder.s3AwsRegion, builder.s3AwsStsRoleArn);
+            final S3ClientProvider clientProvider = new S3ClientProvider(
+                builder.s3AwsRegion, builder.s3AwsStsRoleArn, builder.s3AwsStsExternalId);
             builder.withS3Client(clientProvider.buildS3Client());
         }
 
@@ -224,6 +229,10 @@ public class IndexConfiguration {
 
     public String getS3AwsStsRoleArn() {
         return s3AwsStsRoleArn;
+    }
+
+    public String getS3AwsStsExternalId() {
+        return s3AwsExternalId;
     }
 
     public boolean getServerless() {
@@ -294,6 +303,7 @@ public class IndexConfiguration {
         private String action;
         private String s3AwsRegion;
         private String s3AwsStsRoleArn;
+        private String s3AwsStsExternalId;
         private S3Client s3Client;
         private boolean serverless;
         private String documentRootKey;
@@ -378,6 +388,12 @@ public class IndexConfiguration {
                 }
             }
             this.s3AwsStsRoleArn = s3AwsStsRoleArn;
+            return this;
+        }
+
+        public Builder withS3AWSStsExternalId(final String s3AwsStsExternalId) {
+            checkArgument(s3AwsStsExternalId == null || s3AwsStsExternalId.length() <= 1224, "s3AwsStsExternalId length cannot exceed 1224");
+            this.s3AwsStsExternalId = s3AwsStsExternalId;
             return this;
         }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexManagerFactory.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexManagerFactory.java
@@ -91,7 +91,8 @@ public class IndexManagerFactory {
                 if (ismPolicyFile.get().startsWith(S3_PREFIX)) {
                     final String s3AwsRegion = openSearchSinkConfiguration.getIndexConfiguration().getS3AwsRegion();
                     final String s3AwsStsRoleArn = openSearchSinkConfiguration.getIndexConfiguration().getS3AwsStsRoleArn();
-                    final S3ClientProvider clientProvider = new S3ClientProvider(s3AwsRegion, s3AwsStsRoleArn);
+                    final String s3AwsStsExternalId = openSearchSinkConfiguration.getIndexConfiguration().getS3AwsStsExternalId();
+                    final S3ClientProvider clientProvider = new S3ClientProvider(s3AwsRegion, s3AwsStsRoleArn, s3AwsStsExternalId);
                     s3Client = clientProvider.buildS3Client();
                 }
                 final String indexPolicyName = getIndexPolicyName();

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3ClientProvider.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3ClientProvider.java
@@ -29,12 +29,17 @@ public class S3ClientProvider {
 
     private final String awsRegion;
     private final String awsStsRoleArn;
+    private final String awsStsExternalId;
     private final ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
 
-    public S3ClientProvider(final String awsRegion,
-                          final String awsStsRoleArn) {
+    public S3ClientProvider(
+        final String awsRegion,
+        final String awsStsRoleArn,
+        final String awsStsExternalId
+    ) {
         this.awsRegion = awsRegion;
         this.awsStsRoleArn = awsStsRoleArn;
+        this.awsStsExternalId = awsStsExternalId;
     }
 
     public S3Client buildS3Client() {
@@ -61,10 +66,15 @@ public class S3ClientProvider {
     }
 
     private AssumeRoleRequest getAssumeRoleRequest(final String awsStsRoleArn) {
-        return AssumeRoleRequest.builder()
+        AssumeRoleRequest.Builder builder = AssumeRoleRequest.builder()
                 .roleSessionName("OpenSearch-Sink-S3" + UUID.randomUUID())
-                .roleArn(awsStsRoleArn)
-                .build();
+                .roleArn(awsStsRoleArn);
+
+        if (awsStsExternalId != null && !awsStsExternalId.isEmpty()) {
+            builder = builder.externalId(awsStsExternalId);
+        }
+
+        return builder.build();
     }
 
     private StsClient getStsClient(final String awsRegion) {

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/ConnectionConfigurationTests.java
@@ -89,7 +89,7 @@ class ConnectionConfigurationTests {
     @Test
     void testReadConnectionConfigurationAwsOptionServerlessDefault() {
         final String testArn = TEST_ROLE;
-        final Map<String, Object> configMetadata = generateConfigurationMetadataWithAwsOption(TEST_HOSTS, null, null, null, null, true, false, null, testArn, TEST_CERT_PATH, false, Collections.emptyMap());
+        final Map<String, Object> configMetadata = generateConfigurationMetadataWithAwsOption(TEST_HOSTS, null, null, null, null, true, false, null, testArn, null, TEST_CERT_PATH, false, Collections.emptyMap());
         final PluginSetting pluginSetting = getPluginSettingByConfigurationMetadata(configMetadata);
         final ConnectionConfiguration connectionConfiguration =
                 ConnectionConfiguration.readConnectionConfiguration(pluginSetting);
@@ -350,7 +350,8 @@ class ConnectionConfigurationTests {
         final String headerName2 = UUID.randomUUID().toString();
         final String headerValue2 = UUID.randomUUID().toString();
         final String testArn = TEST_ROLE;
-        final Map<String, Object> configurationMetadata = generateConfigurationMetadataWithAwsOption(TEST_HOSTS, null, null, null, null, false, true, null, testArn, TEST_CERT_PATH, false, Map.of(headerName1, headerValue1, headerName2, headerValue2));
+        final String externalId = UUID.randomUUID().toString();
+        final Map<String, Object> configurationMetadata = generateConfigurationMetadataWithAwsOption(TEST_HOSTS, null, null, null, null, false, true, null, testArn, externalId, null,false, Map.of(headerName1, headerValue1, headerName2, headerValue2));
         final PluginSetting pluginSetting = getPluginSettingByConfigurationMetadata(configurationMetadata);
         final ConnectionConfiguration connectionConfiguration =
                 ConnectionConfiguration.readConnectionConfiguration(pluginSetting);
@@ -369,6 +370,7 @@ class ConnectionConfigurationTests {
         final AwsCredentialsOptions actualOptions = awsCredentialsOptionsArgumentCaptor.getValue();
 
         assertThat(actualOptions.getStsRoleArn(), equalTo(TEST_ROLE));
+        assertThat(actualOptions.getStsExternalId(), equalTo(externalId));
         assertThat(actualOptions.getStsHeaderOverrides(), notNullValue());
         assertThat(actualOptions.getStsHeaderOverrides().size(), equalTo(2));
         assertThat(actualOptions.getStsHeaderOverrides(), hasKey(headerName1));
@@ -384,7 +386,8 @@ class ConnectionConfigurationTests {
         final String headerName2 = UUID.randomUUID().toString();
         final String headerValue2 = UUID.randomUUID().toString();
         final String testArn = TEST_ROLE;
-        final Map<String, Object> configurationMetadata = generateConfigurationMetadataWithAwsOption(TEST_HOSTS, null, null, null, null, false, true, null, testArn, TEST_CERT_PATH, false, Map.of(headerName1, headerValue1, headerName2, headerValue2));
+        final String externalId = UUID.randomUUID().toString();
+        final Map<String, Object> configurationMetadata = generateConfigurationMetadataWithAwsOption(TEST_HOSTS, null, null, null, null, false, true, null, testArn, externalId, TEST_CERT_PATH, false, Map.of(headerName1, headerValue1, headerName2, headerValue2));
         final PluginSetting pluginSetting = getPluginSettingByConfigurationMetadata(configurationMetadata);
         final ConnectionConfiguration connectionConfiguration =
                 ConnectionConfiguration.readConnectionConfiguration(pluginSetting);
@@ -634,7 +637,7 @@ class ConnectionConfigurationTests {
     private Map<String, Object> generateConfigurationMetadataWithAwsOption(
             final List<String> hosts, final String username, final String password,
             final Integer connectTimeout, final Integer socketTimeout, final boolean serverless, final boolean awsSigv4, final String awsRegion,
-            final String awsStsRoleArn, final String certPath, final boolean insecure, Map<String, String> headerOverridesMap) {
+            final String awsStsRoleArn, final String awsStsExternalId, final String certPath, final boolean insecure, Map<String, String> headerOverridesMap) {
         final Map<String, Object> metadata = new HashMap<>();
         final Map<String, Object> awsOptionMetadata = new HashMap<>();
         metadata.put("hosts", hosts);
@@ -647,6 +650,7 @@ class ConnectionConfigurationTests {
         }
         awsOptionMetadata.put("serverless", serverless);
         awsOptionMetadata.put("sts_role_arn", awsStsRoleArn);
+        awsOptionMetadata.put("sts_external_id", awsStsExternalId);
         awsOptionMetadata.put("sts_header_overrides", headerOverridesMap);
         metadata.put("aws", awsOptionMetadata);
         metadata.put("cert", certPath);

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -158,6 +158,7 @@ public class IndexConfigurationTests {
         final String testTemplateFilePath = "s3://folder/file.json";
         final String testS3AwsRegion = "us-east-2";
         final String testS3StsRoleArn = "arn:aws:iam::123456789:user/user-role";
+        final String testS3StsExternalId = UUID.randomUUID().toString();
         final String fileContent = "{}";
         final long CONTENT_LENGTH = 3 * ONE_MB;
 
@@ -172,17 +173,19 @@ public class IndexConfigurationTests {
 
         final String testIndexAlias = UUID.randomUUID().toString();
         IndexConfiguration indexConfiguration = new IndexConfiguration.Builder()
-                .withIndexAlias(testIndexAlias)
-                .withTemplateFile(testTemplateFilePath)
-                .withS3AwsRegion(testS3AwsRegion)
-                .withS3AWSStsRoleArn(testS3StsRoleArn)
-                .withS3Client(s3Client)
-                .build();
+            .withIndexAlias(testIndexAlias)
+            .withTemplateFile(testTemplateFilePath)
+            .withS3AwsRegion(testS3AwsRegion)
+            .withS3AWSStsRoleArn(testS3StsRoleArn)
+            .withS3AWSStsExternalId(testS3StsExternalId)
+            .withS3Client(s3Client)
+            .build();
 
         assertEquals(IndexType.CUSTOM, indexConfiguration.getIndexType());
         assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
         assertEquals(testS3AwsRegion, indexConfiguration.getS3AwsRegion());
         assertEquals(testS3StsRoleArn, indexConfiguration.getS3AwsStsRoleArn());
+        assertEquals(testS3StsExternalId, indexConfiguration.getS3AwsStsExternalId());
     }
 
     @Test

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3ClientProviderTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/s3/S3ClientProviderTest.java
@@ -22,8 +22,10 @@ class S3ClientProviderTest {
     void test_random_region_and_role_should_create_s3client() {
         final String awsRegion = UUID.randomUUID().toString();
         final String awsStsRoleArn = UUID.randomUUID().toString();
+        final String awsExternalId = UUID.randomUUID().toString();
 
-        final S3ClientProvider s3ClientProvider = new S3ClientProvider(awsRegion, awsStsRoleArn);
+        final S3ClientProvider s3ClientProvider =
+            new S3ClientProvider(awsRegion, awsStsRoleArn, awsExternalId);
 
         final S3Client s3Client = s3ClientProvider.buildS3Client();
 
@@ -34,8 +36,9 @@ class S3ClientProviderTest {
     void test_random_region_and_null_role_should_create_s3client_with_DefaultCredentialsProvider() {
         final String awsRegion = UUID.randomUUID().toString();
         final String awsStsRoleArn = null;
+        final String externalId = null;
 
-        final S3ClientProvider s3ClientProvider = new S3ClientProvider(awsRegion, awsStsRoleArn);
+        final S3ClientProvider s3ClientProvider = new S3ClientProvider(awsRegion, awsStsRoleArn, externalId);
 
         final S3Client s3Client = s3ClientProvider.buildS3Client();
 

--- a/data-prepper-plugins/otel-trace-group-processor/README.md
+++ b/data-prepper-plugins/otel-trace-group-processor/README.md
@@ -48,6 +48,8 @@ Default is null.
 
 - `aws_sts_role_arn`: A IAM role arn which the sink plugin will assume to sign request to Amazon OpenSearch Service. If not provided the plugin will use the default credentials.
 
+- `aws_sts_external_id`: The external ID to attach to all AssumeRole requests.
+
 - `aws_sts_header_overrides`: An optional map of header overrides to make when assuming the IAM role for the sink plugin.
 
 - `insecure`: A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Default to `false`.

--- a/data-prepper-plugins/s3-sink/README.md
+++ b/data-prepper-plugins/s3-sink/README.md
@@ -37,6 +37,8 @@ pipeline:
 
 - `sts_role_arn` (Optional) : The AWS STS role to assume for requests to S3. which will use the [standard SDK behavior for credentials](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html). 
 
+- `sts_external_id` (Optional) : The external ID to attach to AssumeRole requests.
+
 - `max_retries` (Optional) : An integer value indicates the maximum number of times that single request should be retired in-order to ingest data to amazon s3. Defaults to `5`.
 
 - `bucket` (Required) : Object storage built to store and retrieve any amount of data from anywhere, User must provide bucket name.

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/ClientFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/ClientFactory.java
@@ -35,9 +35,10 @@ public final class ClientFactory {
 
     private static AwsCredentialsOptions convertToCredentialsOptions(final AwsAuthenticationOptions awsAuthenticationOptions) {
         return AwsCredentialsOptions.builder()
-                .withRegion(awsAuthenticationOptions.getAwsRegion())
-                .withStsRoleArn(awsAuthenticationOptions.getAwsStsRoleArn())
-                .withStsHeaderOverrides(awsAuthenticationOptions.getAwsStsHeaderOverrides())
-                .build();
+            .withRegion(awsAuthenticationOptions.getAwsRegion())
+            .withStsRoleArn(awsAuthenticationOptions.getAwsStsRoleArn())
+            .withStsExternalId(awsAuthenticationOptions.getAwsStsExternalId())
+            .withStsHeaderOverrides(awsAuthenticationOptions.getAwsStsHeaderOverrides())
+            .build();
     }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/configuration/AwsAuthenticationOptions.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/configuration/AwsAuthenticationOptions.java
@@ -20,6 +20,10 @@ public class AwsAuthenticationOptions {
     @Size(min = 20, max = 2048, message = "awsStsRoleArn length should be between 1 and 2048 characters")
     private String awsStsRoleArn;
 
+    @JsonProperty("sts_external_id")
+    @Size(min = 2, max = 1224, message = "awsStsExternalId length should be between 2 and 1224 characters")
+    private String awsStsExternalId;
+
     @JsonProperty("sts_header_overrides")
     @Size(max = 5, message = "sts_header_overrides supports a maximum of 5 headers to override")
     private Map<String, String> awsStsHeaderOverrides;
@@ -30,6 +34,10 @@ public class AwsAuthenticationOptions {
 
     public String getAwsStsRoleArn() {
         return awsStsRoleArn;
+    }
+
+    public String getAwsStsExternalId() {
+        return awsStsExternalId;
     }
 
     public Map<String, String> getAwsStsHeaderOverrides() {

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/ClientFactoryTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/ClientFactoryTest.java
@@ -63,9 +63,11 @@ class ClientFactoryTest {
     void createS3Client_provides_correct_inputs(final String regionString) {
         final Region region = Region.of(regionString);
         final String stsRoleArn = UUID.randomUUID().toString();
+        final String externalId = UUID.randomUUID().toString();
         final Map<String, String> stsHeaderOverrides = Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
         when(awsAuthenticationOptions.getAwsRegion()).thenReturn(region);
         when(awsAuthenticationOptions.getAwsStsRoleArn()).thenReturn(stsRoleArn);
+        when(awsAuthenticationOptions.getAwsStsExternalId()).thenReturn(externalId);
         when(awsAuthenticationOptions.getAwsStsHeaderOverrides()).thenReturn(stsHeaderOverrides);
 
         final AwsCredentialsProvider expectedCredentialsProvider = mock(AwsCredentialsProvider.class);
@@ -94,6 +96,7 @@ class ClientFactoryTest {
         final AwsCredentialsOptions actualCredentialsOptions = optionsArgumentCaptor.getValue();
         assertThat(actualCredentialsOptions.getRegion(), equalTo(region));
         assertThat(actualCredentialsOptions.getStsRoleArn(), equalTo(stsRoleArn));
+        assertThat(actualCredentialsOptions.getStsExternalId(), equalTo(externalId));
         assertThat(actualCredentialsOptions.getStsHeaderOverrides(), equalTo(stsHeaderOverrides));
     }
 }

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/configuration/AwsAuthenticationOptionsTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/configuration/AwsAuthenticationOptionsTest.java
@@ -60,6 +60,21 @@ class AwsAuthenticationOptionsTest {
     }
 
     @Test
+    void getAwsStsExternalId_returns_value_from_deserialized_JSON() {
+        final String stsExternalId = UUID.randomUUID().toString();
+        final Map<String, Object> jsonMap = Map.of("sts_external_id", stsExternalId);
+        final AwsAuthenticationOptions objectUnderTest = objectMapper.convertValue(jsonMap, AwsAuthenticationOptions.class);
+        assertThat(objectUnderTest.getAwsStsExternalId(), equalTo(stsExternalId));
+    }
+
+    @Test
+    void getAwsStsExternalId_returns_null_if_not_in_JSON() {
+        final Map<String, Object> jsonMap = Collections.emptyMap();
+        final AwsAuthenticationOptions objectUnderTest = objectMapper.convertValue(jsonMap, AwsAuthenticationOptions.class);
+        assertThat(objectUnderTest.getAwsStsExternalId(), nullValue());
+    }
+
+    @Test
     void getAwsStsHeaderOverrides_returns_value_from_deserialized_JSON() {
         final Map<String, String> stsHeaderOverrides = Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
         final Map<String, Object> jsonMap = Map.of("sts_header_overrides", stsHeaderOverrides);

--- a/data-prepper-plugins/s3-source/README.md
+++ b/data-prepper-plugins/s3-source/README.md
@@ -160,6 +160,8 @@ The AWS configuration is the same for both SQS and S3.
 
 * `region` (Optional) : The AWS region to use for credentials. Defaults to [standard SDK behavior to determine the region](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html).
 * `sts_role_arn` (Optional) : The AWS STS role to assume for requests to SQS and S3. Defaults to null, which will use the [standard SDK behavior for credentials](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html). 
+* `sts_external_id` (Optional) : The external ID to attach to AssumeRole requests.
+
 The following policy shows the necessary permissions for S3 source. `kms:Decrypt` is required if SQS queue is encrypted with AWS [KMS](https://aws.amazon.com/kms/).
 ```json
 {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/AwsAuthenticationAdapter.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/AwsAuthenticationAdapter.java
@@ -29,6 +29,7 @@ class AwsAuthenticationAdapter {
                 .withStsRoleArn(awsAuthenticationOptions.getAwsStsRoleArn())
                 .withRegion(awsAuthenticationOptions.getAwsRegion())
                 .withStsHeaderOverrides(awsAuthenticationOptions.getAwsStsHeaderOverrides())
+                .withStsExternalId(awsAuthenticationOptions.getAwsStsExternalId())
                 .build();
 
         return awsCredentialsSupplier.getProvider(options);

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/AwsAuthenticationOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/AwsAuthenticationOptions.java
@@ -25,6 +25,10 @@ public class AwsAuthenticationOptions {
     @Size(min = 20, max = 2048, message = "awsStsRoleArn length should be between 1 and 2048 characters")
     private String awsStsRoleArn;
 
+    @JsonProperty("sts_external_id")
+    @Size(min = 2, max = 1224, message = "awsStsExternalId length should be between 2 and 1224 characters")
+    private String awsStsExternalId;
+
     @JsonProperty("sts_header_overrides")
     @Size(max = 5, message = "sts_header_overrides supports a maximum of 5 headers to override")
     private Map<String, String> awsStsHeaderOverrides;
@@ -50,6 +54,10 @@ public class AwsAuthenticationOptions {
 
     public String getAwsStsRoleArn() {
         return awsStsRoleArn;
+    }
+
+    public String getAwsStsExternalId() {
+        return awsStsExternalId;
     }
 
     public Region getAwsRegion() {

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/AwsAuthenticationAdapterTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/AwsAuthenticationAdapterTest.java
@@ -66,10 +66,11 @@ class AwsAuthenticationAdapterTest {
     @ParameterizedTest
     @ValueSource(strings = {"us-east-1", "eu-west-1"})
     void getCredentialsProvider_creates_expected_AwsCredentialsOptions(final String regionString) {
-
+        final String externalId = UUID.randomUUID().toString();
         final Region region = Region.of(regionString);
 
         final Map<String, String> headerOverrides = Collections.singletonMap(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        when(awsAuthenticationOptions.getAwsStsExternalId()).thenReturn(externalId);
         when(awsAuthenticationOptions.getAwsRegion()).thenReturn(region);
         when(awsAuthenticationOptions.getAwsStsHeaderOverrides()).thenReturn(headerOverrides);
 
@@ -82,6 +83,7 @@ class AwsAuthenticationAdapterTest {
 
         assertThat(actualOptions, notNullValue());
         assertThat(actualOptions.getStsRoleArn(), equalTo(stsRoleArn));
+        assertThat(actualOptions.getStsExternalId(), equalTo(externalId));
         assertThat(actualOptions.getRegion(), equalTo(region));
         assertThat(actualOptions.getStsHeaderOverrides(), equalTo(headerOverrides));
     }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/configuration/AwsAuthenticationOptionsTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/configuration/AwsAuthenticationOptionsTest.java
@@ -47,6 +47,19 @@ class AwsAuthenticationOptionsTest {
         assertThat(awsAuthenticationOptions.getAwsRegion(), nullValue());
     }
 
+    @Test
+    void getStsExternalId_notNull() throws NoSuchFieldException, IllegalAccessException {
+        final String externalId = UUID.randomUUID().toString();
+        reflectivelySetField(awsAuthenticationOptions, "awsStsExternalId", externalId);
+        assertThat(awsAuthenticationOptions.getAwsStsExternalId(), equalTo(externalId));
+    }
+
+    @Test
+    void getStsExternalId_Null() throws NoSuchFieldException, IllegalAccessException {
+        reflectivelySetField(awsAuthenticationOptions, "awsStsExternalId", null);
+        assertThat(awsAuthenticationOptions.getAwsStsExternalId(), nullValue());
+    }
+
     private void reflectivelySetField(final AwsAuthenticationOptions awsAuthenticationOptions, final String fieldName, final Object value) throws NoSuchFieldException, IllegalAccessException {
         final Field field = AwsAuthenticationOptions.class.getDeclaredField(fieldName);
         try {


### PR DESCRIPTION
STS external ID is required by some AWS services when making an STS AssumeRole call.

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
