### PR TITLE
Use queue visibility timeout setting when no visibility_timeout is set in the pipeline config, lookup visibility timeout for acknowledgments

### DIFF
--- a/data-prepper-plugins/s3-source/README.md
+++ b/data-prepper-plugins/s3-source/README.md
@@ -150,7 +150,7 @@ All Duration values are a string that represents a duration. They support ISO_86
 
 * `queue_url` (Required) : The SQS queue URL of the queue to read from.
 * `maximum_messages` (Optional) : Duration - The maximum number of messages to read from the queue in any request to the SQS queue. Defaults to 10.
-* `visibility_timeout` (Optional) : Duration - The visibility timeout to apply to messages read from the SQS queue. This should be set to the amount of time that Data Prepper may take to read all the S3 objects in a batch. Defaults to 30 seconds.
+* `visibility_timeout` (Optional) : Duration - The visibility timeout to apply to messages read from the SQS queue. This should be set to the amount of time that Data Prepper may take to read all the S3 objects in a batch. Defaults to use the visibility timeout set on the queue.
 * `wait_time` (Optional) : Duration - The time to wait for long-polling on the SQS API. Defaults to 20 seconds.
 * `poll_delay` (Optional) : Duration - A delay to place between reading and processing a batch of SQS messages and making a subsequent request. Defaults to 0 seconds.
 

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
@@ -10,13 +10,13 @@ import com.linecorp.armeria.client.retry.Backoff;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.plugins.source.configuration.OnErrorOption;
 import org.opensearch.dataprepper.plugins.source.configuration.SqsOptions;
 import org.opensearch.dataprepper.plugins.source.exception.SqsRetriesExhaustedException;
 import org.opensearch.dataprepper.plugins.source.filter.ObjectCreatedFilter;
 import org.opensearch.dataprepper.plugins.source.filter.S3EventFilter;
-import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
-import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -25,8 +25,8 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
-import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResultEntry;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResultEntry;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SqsException;
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -168,7 +169,7 @@ public class SqsWorker implements Runnable {
         return ReceiveMessageRequest.builder()
                 .queueUrl(sqsOptions.getSqsUrl())
                 .maxNumberOfMessages(sqsOptions.getMaximumMessages())
-                .visibilityTimeout((int) sqsOptions.getVisibilityTimeout().getSeconds())
+                .visibilityTimeout(Objects.nonNull(sqsOptions.getVisibilityTimeout()) ? (int) sqsOptions.getVisibilityTimeout().getSeconds() : null)
                 .waitTimeSeconds((int) sqsOptions.getWaitTime().getSeconds())
                 .build();
     }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/SqsOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/SqsOptions.java
@@ -16,7 +16,6 @@ import java.time.Duration;
 
 public class SqsOptions {
     private static final int DEFAULT_MAXIMUM_MESSAGES = 10;
-    private static final Duration DEFAULT_VISIBILITY_TIMEOUT_SECONDS = Duration.ofSeconds(30);
     private static final Duration DEFAULT_WAIT_TIME_SECONDS = Duration.ofSeconds(20);
     private static final Duration DEFAULT_POLL_DELAY_SECONDS = Duration.ofSeconds(0);
 
@@ -32,7 +31,7 @@ public class SqsOptions {
     @JsonProperty("visibility_timeout")
     @DurationMin(seconds = 0)
     @DurationMax(seconds = 43200)
-    private Duration visibilityTimeout = DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
+    private Duration visibilityTimeout;
 
     @JsonProperty("wait_time")
     @DurationMin(seconds = 0)
@@ -61,5 +60,9 @@ public class SqsOptions {
 
     public Duration getPollDelay() {
         return pollDelay;
+    }
+
+    public void setVisibilityTimeout(final Duration visibilityTimeout) {
+        this.visibilityTimeout = visibilityTimeout;
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/SqsServiceTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/SqsServiceTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.plugins.source.configuration.AwsAuthenticationOptions;
+import org.opensearch.dataprepper.plugins.source.configuration.SqsOptions;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.SqsClientBuilder;
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest;
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesResponse;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class SqsServiceTest {
+
+    @Mock
+    private SqsClient sqsClient;
+
+    @Mock
+    private AcknowledgementSetManager acknowledgementSetManager;
+
+    @Mock
+    private S3SourceConfig s3SourceConfig;
+
+    @Mock
+    private S3Service s3Service;
+
+    @Mock
+    private AwsCredentialsProvider awsCredentialsProvider;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void sqsService_does_not_set_visibility_timeout_from_queue_attributes_when_visibility_timeout_is_set(final boolean acknowledgmentsEnabled) {
+        when(s3SourceConfig.getAcknowledgements()).thenReturn(acknowledgmentsEnabled);
+
+        final SqsOptions sqsOptions = mock(SqsOptions.class);
+        lenient().when(sqsOptions.getVisibilityTimeout()).thenReturn(Duration.ofSeconds(100));
+        lenient().when(s3SourceConfig.getSqsOptions()).thenReturn(sqsOptions);
+
+        final SqsClientBuilder sqsClientBuilder = mock(SqsClientBuilder.class);
+        final AwsAuthenticationOptions awsAuthenticationOptions = mock(AwsAuthenticationOptions.class);
+        when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_EAST_1);
+        when(s3SourceConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
+
+        when(sqsClientBuilder.region(Region.US_EAST_1)).thenReturn(sqsClientBuilder);
+        when(sqsClientBuilder.credentialsProvider(awsCredentialsProvider)).thenReturn(sqsClientBuilder);
+        when(sqsClientBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class))).thenReturn(sqsClientBuilder);
+        when(sqsClientBuilder.build()).thenReturn(sqsClient);
+        try (final MockedStatic<SqsClient> sqsClientMockedStatic = mockStatic(SqsClient.class)) {
+            sqsClientMockedStatic.when(SqsClient::builder).thenReturn(sqsClientBuilder);
+
+            final SqsService objectUnderTest = new SqsService(acknowledgementSetManager, s3SourceConfig, s3Service, pluginMetrics, awsCredentialsProvider);
+        }
+
+        verify(sqsClient, never()).getQueueAttributes(any(GetQueueAttributesRequest.class));
+
+    }
+
+    @Test
+    void sqsService_sets_visibility_timeout_from_queue_attributes_when_visibility_timeout_is_not_set_and_acknowledgments_enabled() {
+        when(s3SourceConfig.getAcknowledgements()).thenReturn(true);
+
+        final SqsOptions sqsOptions = mock(SqsOptions.class);
+        when(sqsOptions.getSqsUrl()).thenReturn(UUID.randomUUID().toString());
+        when(sqsOptions.getVisibilityTimeout()).thenReturn(null);
+        when(s3SourceConfig.getSqsOptions()).thenReturn(sqsOptions);
+
+
+        final SqsClientBuilder sqsClientBuilder = mock(SqsClientBuilder.class);
+        final AwsAuthenticationOptions awsAuthenticationOptions = mock(AwsAuthenticationOptions.class);
+        when(awsAuthenticationOptions.getAwsRegion()).thenReturn(Region.US_EAST_1);
+        when(s3SourceConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
+
+        when(sqsClientBuilder.region(Region.US_EAST_1)).thenReturn(sqsClientBuilder);
+        when(sqsClientBuilder.credentialsProvider(awsCredentialsProvider)).thenReturn(sqsClientBuilder);
+        when(sqsClientBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class))).thenReturn(sqsClientBuilder);
+        when(sqsClientBuilder.build()).thenReturn(sqsClient);
+
+        final ArgumentCaptor<GetQueueAttributesRequest> argumentCaptor = ArgumentCaptor.forClass(GetQueueAttributesRequest.class);
+
+        final GetQueueAttributesResponse getQueueAttributesResponse = mock(GetQueueAttributesResponse.class);
+        when(getQueueAttributesResponse.attributes()).thenReturn(Map.of(QueueAttributeName.VISIBILITY_TIMEOUT, "1000"));
+        when(sqsClient.getQueueAttributes(argumentCaptor.capture())).thenReturn(getQueueAttributesResponse);
+        try (final MockedStatic<SqsClient> sqsClientMockedStatic = mockStatic(SqsClient.class)) {
+            sqsClientMockedStatic.when(SqsClient::builder).thenReturn(sqsClientBuilder);
+
+            final SqsService objectUnderTest = new SqsService(acknowledgementSetManager, s3SourceConfig, s3Service, pluginMetrics, awsCredentialsProvider);
+        }
+
+        final GetQueueAttributesRequest getQueueAttributesRequest = argumentCaptor.getValue();
+        assertThat(getQueueAttributesRequest, notNullValue());
+        assertThat(getQueueAttributesRequest.queueUrl(), equalTo(sqsOptions.getSqsUrl()));
+        assertThat(getQueueAttributesRequest.attributeNames(), equalTo(List.of(QueueAttributeName.VISIBILITY_TIMEOUT)));
+
+        verify(sqsOptions).setVisibilityTimeout(Duration.ofSeconds(1000));
+
+    }
+}


### PR DESCRIPTION
### Description
Removes the default `visibility_timeout` of 30 seconds from Data Prepper, and will pass null to the `ReceiveMessageRequest` for the visibility_timeout.

When `acknowledgments` are enabled and visibility_timeout is not set, a `GetQueueAttributes` API call is made to get the queue's visibility timeout. This value is then set in the `SqsOptions`, and will be passed to the `ReceiveMessageRequest` and used for acknowledgments timeout.  
 
### Issues Resolved
Resolves #2484 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
