### PR TITLE
Implement NoSearchContextWorker to search with search_after and not use pit or scroll, allow override with search_context_type parameter

### DIFF
--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchService.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchService.java
@@ -9,6 +9,7 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.NoSearchContextWorker;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.OpenSearchIndexPartitionCreationSupplier;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.PitWorker;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.ScrollWorker;
@@ -75,6 +76,9 @@ public class OpenSearchService {
                 break;
             case SCROLL:
                 searchWorker = new ScrollWorker(searchAccessor, openSearchSourceConfiguration, sourceCoordinator, bufferAccumulator, openSearchIndexPartitionCreationSupplier);
+                break;
+            case NONE:
+                searchWorker = new NoSearchContextWorker(searchAccessor, openSearchSourceConfiguration, sourceCoordinator, bufferAccumulator, openSearchIndexPartitionCreationSupplier);
                 break;
             default:
                 throw new IllegalArgumentException(

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SearchConfiguration.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SearchConfiguration.java
@@ -10,14 +10,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.constraints.AssertTrue;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchContextType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.util.Map;
 
 public class SearchConfiguration {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final Logger LOG = LoggerFactory.getLogger(SearchConfiguration.class);
+
+    // TODO: Should we default this to NONE and remove the version lookup to determine scroll or point-in-time as the default behavior?
+    @JsonProperty("search_context_type")
+    private SearchContextType searchContextType;
 
     @JsonProperty("batch_size")
     private Integer batchSize = 1000;
@@ -28,6 +34,9 @@ public class SearchConfiguration {
     @JsonIgnore
     private Map<String, Object> queryMap;
 
+    public SearchContextType getSearchContextType() {
+        return searchContextType;
+    }
 
     public Integer getBatchSize() {
         return batchSize;

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorker.java
@@ -137,12 +137,12 @@ public class NoSearchContextWorker implements SearchWorker, Runnable {
     }
 
     private List<String> getSearchAfter(final OpenSearchIndexProgressState openSearchIndexProgressState, final SearchWithSearchAfterResults searchWithSearchAfterResults) {
-        if (Objects.isNull(searchWithSearchAfterResults) && Objects.isNull(openSearchIndexProgressState.getSearchAfter())) {
-            return null;
-        }
-
-        if (Objects.isNull(searchWithSearchAfterResults) && Objects.nonNull(openSearchIndexProgressState.getSearchAfter())) {
-            return openSearchIndexProgressState.getSearchAfter();
+        if (Objects.isNull(searchWithSearchAfterResults)) {
+            if (Objects.isNull(openSearchIndexProgressState.getSearchAfter())) {
+                return null;
+            } else {
+                return openSearchIndexProgressState.getSearchAfter();
+            }
         }
 
         return searchWithSearchAfterResults.getNextSearchAfter();

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorker.java
@@ -2,6 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package org.opensearch.dataprepper.plugins.source.opensearch.worker;
 
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
@@ -16,16 +17,11 @@ import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchIndexProgr
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SearchConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessor;
-import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchContextLimitException;
-import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeRequest;
-import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeResponse;
-import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeletePointInTimeRequest;
-import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchPointInTimeRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.NoSearchContextSearchRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchWithSearchAfterResults;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -33,21 +29,11 @@ import java.util.Optional;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_ID_METADATA_ATTRIBUTE_NAME;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.INDEX_METADATA_ATTRIBUTE_NAME;
 
-/**
- * PitWorker polls the source cluster via Point-In-Time contexts.
- */
-public class PitWorker implements SearchWorker, Runnable {
+public class NoSearchContextWorker implements SearchWorker, Runnable {
 
-    private static final Logger LOG = LoggerFactory.getLogger(PitWorker.class);
+    private static final Logger LOG = LoggerFactory.getLogger(NoSearchContextWorker.class);
 
     private static final int STANDARD_BACKOFF_MILLIS = 30_000;
-    private static final Duration BACKOFF_ON_PIT_LIMIT_REACHED = Duration.ofSeconds(60);
-
-    static final String STARTING_KEEP_ALIVE = "15m";
-    private static final Duration STARTING_KEEP_ALIVE_DURATION = Duration.ofMinutes(15);
-
-    static final String EXTEND_KEEP_ALIVE_TIME = "1m";
-    private static final Duration EXTEND_KEEP_ALIVE_DURATION = Duration.ofMinutes(1);
 
     private final SearchAccessor searchAccessor;
     private final OpenSearchSourceConfiguration openSearchSourceConfiguration;
@@ -55,7 +41,7 @@ public class PitWorker implements SearchWorker, Runnable {
     private final BufferAccumulator<Record<Event>> bufferAccumulator;
     private final OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier;
 
-    public PitWorker(final SearchAccessor searchAccessor,
+    public NoSearchContextWorker(final SearchAccessor searchAccessor,
                      final OpenSearchSourceConfiguration openSearchSourceConfiguration,
                      final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator,
                      final BufferAccumulator<Record<Event>> bufferAccumulator,
@@ -77,7 +63,7 @@ public class PitWorker implements SearchWorker, Runnable {
                     Thread.sleep(STANDARD_BACKOFF_MILLIS);
                     continue;
                 } catch (final InterruptedException e) {
-                    LOG.info("The PitWorker was interrupted while sleeping after acquiring no indices to process, stopping processing");
+                    LOG.info("The NoContextSearchWorker was interrupted while sleeping after acquiring no indices to process, stopping processing");
                     return;
                 }
             }
@@ -92,15 +78,6 @@ public class PitWorker implements SearchWorker, Runnable {
             } catch (final PartitionUpdateException | PartitionNotFoundException | PartitionNotOwnedException e) {
                 LOG.warn("PitWorker received an exception from the source coordinator. There is a potential for duplicate data for index {}, giving up partition and getting next partition: {}", indexPartition.get().getPartitionKey(), e.getMessage());
                 sourceCoordinator.giveUpPartitions();
-            } catch (final SearchContextLimitException e) {
-                LOG.warn("Received SearchContextLimitExceeded exception for index {}. Giving up index and waiting {} seconds before retrying: {}",
-                        indexPartition.get().getPartitionKey(), BACKOFF_ON_PIT_LIMIT_REACHED.getSeconds(), e.getMessage());
-                sourceCoordinator.giveUpPartitions();
-                try {
-                    Thread.sleep(BACKOFF_ON_PIT_LIMIT_REACHED.toMillis());
-                } catch (final InterruptedException ex) {
-                    return;
-                }
             } catch (final RuntimeException e) {
                 LOG.error("Unknown exception while processing index '{}':", indexPartition.get().getPartitionKey(), e);
                 sourceCoordinator.giveUpPartitions();
@@ -118,32 +95,17 @@ public class PitWorker implements SearchWorker, Runnable {
 
         final OpenSearchIndexProgressState openSearchIndexProgressState = openSearchIndexProgressStateOptional.get();
 
-        if (!openSearchIndexProgressState.hasValidPointInTime()) {
-            final CreatePointInTimeResponse createPointInTimeResponse = searchAccessor.createPit(CreatePointInTimeRequest.builder()
-                    .withIndex(indexName)
-                    .withKeepAlive(STARTING_KEEP_ALIVE)
-                    .build());
-
-            LOG.debug("Created point in time for index {} with pit id {}", indexName, createPointInTimeResponse.getPitId());
-
-            openSearchIndexProgressState.setPitId(createPointInTimeResponse.getPitId());
-            openSearchIndexProgressState.setPitCreationTime(createPointInTimeResponse.getPitCreationTime());
-            openSearchIndexProgressState.setKeepAlive(STARTING_KEEP_ALIVE_DURATION.toMillis());
-            openSearchIndexProgressState.setSearchAfter(null);
-        }
-
         final SearchConfiguration searchConfiguration = openSearchSourceConfiguration.getSearchConfiguration();
         SearchWithSearchAfterResults searchWithSearchAfterResults = null;
 
         // todo: Pass query and sort options from SearchConfiguration to the search request
         do {
             try {
-                searchWithSearchAfterResults = searchAccessor.searchWithPit(SearchPointInTimeRequest.builder()
-                        .withPitId(openSearchIndexProgressState.getPitId())
-                        .withKeepAlive(EXTEND_KEEP_ALIVE_TIME)
-                        .withPaginationSize(searchConfiguration.getBatchSize())
-                        .withSearchAfter(getSearchAfter(openSearchIndexProgressState, searchWithSearchAfterResults))
-                        .build());
+                searchWithSearchAfterResults = searchAccessor.searchWithoutSearchContext(NoSearchContextSearchRequest.builder()
+                                .withIndex(indexName)
+                                .withPaginationSize(searchConfiguration.getBatchSize())
+                                .withSearchAfter(getSearchAfter(openSearchIndexProgressState, searchWithSearchAfterResults))
+                                .build());
 
                 searchWithSearchAfterResults.getDocuments().stream().map(Record::new).forEach(record -> {
                     try {
@@ -160,7 +122,6 @@ public class PitWorker implements SearchWorker, Runnable {
             }
 
             openSearchIndexProgressState.setSearchAfter(searchWithSearchAfterResults.getNextSearchAfter());
-            openSearchIndexProgressState.setKeepAlive(Duration.ofMillis(openSearchIndexProgressState.getKeepAlive()).plus(EXTEND_KEEP_ALIVE_DURATION).toMillis());
             sourceCoordinator.saveProgressStateForPartition(indexName, openSearchIndexProgressState);
         } while (searchWithSearchAfterResults.getDocuments().size() == searchConfiguration.getBatchSize());
 
@@ -169,9 +130,6 @@ public class PitWorker implements SearchWorker, Runnable {
         } catch (final Exception e) {
             LOG.error("Failed writing remaining OpenSearch documents to buffer due to: {}", e.getMessage());
         }
-
-        // todo: This API call is failing with sigv4 enabled due to a mismatch in the signature. Tracking issue (https://github.com/opensearch-project/opensearch-java/issues/521)
-        searchAccessor.deletePit(DeletePointInTimeRequest.builder().withPitId(openSearchIndexProgressState.getPitId()).build());
     }
 
     private OpenSearchIndexProgressState initializeProgressState() {

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessor.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessor.java
@@ -10,9 +10,10 @@ import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreateScrollResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeletePointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeleteScrollRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.NoSearchContextSearchRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchContextType;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchPointInTimeRequest;
-import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchPointInTimeResults;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchWithSearchAfterResults;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollResponse;
 
@@ -30,7 +31,7 @@ public class ElasticsearchAccessor implements SearchAccessor, ClusterClientFacto
     }
 
     @Override
-    public SearchPointInTimeResults searchWithPit(SearchPointInTimeRequest searchPointInTimeRequest) {
+    public SearchWithSearchAfterResults searchWithPit(SearchPointInTimeRequest searchPointInTimeRequest) {
         //todo: implement
         return null;
     }
@@ -55,6 +56,11 @@ public class ElasticsearchAccessor implements SearchAccessor, ClusterClientFacto
     @Override
     public void deleteScroll(DeleteScrollRequest deleteScrollRequest) {
         //todo: implement
+    }
+
+    @Override
+    public SearchWithSearchAfterResults searchWithoutSearchContext(NoSearchContextSearchRequest noSearchContextSearchRequest) {
+        return null;
     }
 
     @Override

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessor.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessor.java
@@ -10,9 +10,10 @@ import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreateScrollResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeletePointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeleteScrollRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.NoSearchContextSearchRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchContextType;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchPointInTimeRequest;
-import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchPointInTimeResults;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchWithSearchAfterResults;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollResponse;
 
@@ -42,7 +43,7 @@ public interface SearchAccessor {
      * @return
      * @since 2.4
      */
-    SearchPointInTimeResults searchWithPit(SearchPointInTimeRequest searchPointInTimeRequest);
+    SearchWithSearchAfterResults searchWithPit(SearchPointInTimeRequest searchPointInTimeRequest);
 
     /**
      * Deletes PITs
@@ -71,4 +72,9 @@ public interface SearchAccessor {
      * @param deleteScrollRequest payload for deleting scroll contexts
      */
     void deleteScroll(DeleteScrollRequest deleteScrollRequest);
+
+    /**
+     * Searches with sort and search_after without using any search contexts (Point-in-Time or Scroll)
+     */
+    SearchWithSearchAfterResults searchWithoutSearchContext(NoSearchContextSearchRequest noSearchContextSearchRequest);
 }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/NoSearchContextSearchRequest.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/NoSearchContextSearchRequest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model;
+
+import java.util.List;
+
+public class NoSearchContextSearchRequest {
+
+    private final String index;
+    private final List<String> searchAfter;
+    private final Integer paginationSize;
+
+    private NoSearchContextSearchRequest(final NoSearchContextSearchRequest.Builder builder) {
+        this.index = builder.index;
+        this.searchAfter = builder.searchAfter;
+        this.paginationSize = builder.paginationSize;
+    }
+
+    public static NoSearchContextSearchRequest.Builder builder() {
+        return new NoSearchContextSearchRequest.Builder();
+    }
+
+    public String getIndex() {
+        return index;
+    }
+
+    public List<String> getSearchAfter() {
+        return searchAfter;
+    }
+
+    public Integer getPaginationSize() {
+        return paginationSize;
+    }
+
+    public static class Builder {
+
+        private String index;
+        private List<String> searchAfter;
+        private Integer paginationSize;
+
+
+        public Builder() {
+
+        }
+
+        public NoSearchContextSearchRequest.Builder withPaginationSize(final Integer paginationSize) {
+            this.paginationSize = paginationSize;
+            return this;
+        }
+
+        public NoSearchContextSearchRequest.Builder withSearchAfter(final List<String> searchAfter) {
+            this.searchAfter = searchAfter;
+            return this;
+        }
+
+        public NoSearchContextSearchRequest.Builder withIndex(final String index) {
+            this.index = index;
+            return this;
+        }
+
+        public NoSearchContextSearchRequest build() {
+            return new NoSearchContextSearchRequest(this);
+        }
+    }
+}

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SearchContextType.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SearchContextType.java
@@ -5,8 +5,22 @@
 
 package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum SearchContextType {
-    SCROLL,
-    POINT_IN_TIME,
-    NONE
+    SCROLL("scroll"),
+    POINT_IN_TIME("point_in_time"),
+    NONE("none");
+
+    private final String searchContextType;
+
+    SearchContextType(final String searchContextType) {
+        this.searchContextType = searchContextType;
+    }
+
+    @JsonValue
+    public String getSearchContextType() {
+        return searchContextType;
+    }
+
 }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SearchWithSearchAfterResults.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SearchWithSearchAfterResults.java
@@ -8,7 +8,7 @@ import org.opensearch.dataprepper.model.event.Event;
 
 import java.util.List;
 
-public class SearchPointInTimeResults {
+public class SearchWithSearchAfterResults {
 
     private final List<Event> documents;
     private final List<String> nextSearchAfter;
@@ -21,13 +21,13 @@ public class SearchPointInTimeResults {
         return nextSearchAfter;
     }
 
-    private SearchPointInTimeResults(final SearchPointInTimeResults.Builder builder) {
+    private SearchWithSearchAfterResults(final SearchWithSearchAfterResults.Builder builder) {
         this.documents = builder.documents;
         this.nextSearchAfter = builder.nextSearchAfter;
     }
 
-    public static SearchPointInTimeResults.Builder builder() {
-        return new SearchPointInTimeResults.Builder();
+    public static SearchWithSearchAfterResults.Builder builder() {
+        return new SearchWithSearchAfterResults.Builder();
     }
 
     public static class Builder {
@@ -39,19 +39,19 @@ public class SearchPointInTimeResults {
 
         }
 
-        public SearchPointInTimeResults.Builder withDocuments(final List<Event> documents) {
+        public SearchWithSearchAfterResults.Builder withDocuments(final List<Event> documents) {
             this.documents = documents;
             return this;
         }
 
-        public SearchPointInTimeResults.Builder withNextSearchAfter(final List<String> nextSearchAfter) {
+        public SearchWithSearchAfterResults.Builder withNextSearchAfter(final List<String> nextSearchAfter) {
             this.nextSearchAfter = nextSearchAfter;
             return this;
         }
 
 
-        public SearchPointInTimeResults build() {
-            return new SearchPointInTimeResults(this);
+        public SearchWithSearchAfterResults build() {
+            return new SearchWithSearchAfterResults(this);
         }
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorkerTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartition;
+import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchIndexProgressState;
+import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SchedulingParameterConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SearchConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessor;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.NoSearchContextSearchRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchWithSearchAfterResults;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class NoSearchContextWorkerTest {
+
+    @Mock
+    private OpenSearchSourceConfiguration openSearchSourceConfiguration;
+
+    @Mock
+    private OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier;
+
+    @Mock
+    private SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator;
+
+    @Mock
+    private SearchAccessor searchAccessor;
+
+    @Mock
+    private BufferAccumulator<Record<Event>> bufferAccumulator;
+
+    private ExecutorService executorService;
+
+    @BeforeEach
+    void setup() {
+        executorService = Executors.newSingleThreadExecutor();
+    }
+
+    private NoSearchContextWorker createObjectUnderTest() {
+        return new NoSearchContextWorker(searchAccessor, openSearchSourceConfiguration, sourceCoordinator, bufferAccumulator, openSearchIndexPartitionCreationSupplier);
+    }
+
+    @Test
+    void run_with_getNextPartition_returning_empty_will_sleep_and_exit_when_interrupted() throws InterruptedException {
+        when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.empty());
+
+
+        final Future<?> future = executorService.submit(() -> createObjectUnderTest().run());
+        Thread.sleep(100);
+        executorService.shutdown();
+        future.cancel(true);
+        assertThat(future.isCancelled(), equalTo(true));
+
+        assertThat(executorService.awaitTermination(100, TimeUnit.MILLISECONDS), equalTo(true));
+    }
+
+    @Test
+    void run_with_getNextPartition_with_non_empty_partition_processes_and_closes_that_partition() throws Exception {
+        final SourcePartition<OpenSearchIndexProgressState> sourcePartition = mock(SourcePartition.class);
+        final String partitionKey = UUID.randomUUID().toString();
+        when(sourcePartition.getPartitionKey()).thenReturn(partitionKey);
+        when(sourcePartition.getPartitionState()).thenReturn(Optional.empty());
+
+        final SearchConfiguration searchConfiguration = mock(SearchConfiguration.class);
+        when(searchConfiguration.getBatchSize()).thenReturn(2);
+        when(openSearchSourceConfiguration.getSearchConfiguration()).thenReturn(searchConfiguration);
+
+        final SearchWithSearchAfterResults searchWithSearchAfterResults = mock(SearchWithSearchAfterResults.class);
+        when(searchWithSearchAfterResults.getNextSearchAfter()).thenReturn(Collections.singletonList(UUID.randomUUID().toString()));
+        when(searchWithSearchAfterResults.getDocuments()).thenReturn(List.of(mock(Event.class), mock(Event.class))).thenReturn(List.of(mock(Event.class), mock(Event.class)))
+                .thenReturn(List.of(mock(Event.class))).thenReturn(List.of(mock(Event.class)));
+
+        final ArgumentCaptor<NoSearchContextSearchRequest> searchRequestArgumentCaptor = ArgumentCaptor.forClass(NoSearchContextSearchRequest.class);
+        when(searchAccessor.searchWithoutSearchContext(searchRequestArgumentCaptor.capture())).thenReturn(searchWithSearchAfterResults);
+
+        doNothing().when(bufferAccumulator).add(any(Record.class));
+        doNothing().when(bufferAccumulator).flush();
+
+        when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
+
+        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
+        when(schedulingParameterConfiguration.getJobCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getRate()).thenReturn(Duration.ZERO);
+        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+
+        doNothing().when(sourceCoordinator).closePartition(partitionKey,
+                Duration.ZERO, 1);
+
+
+        final Future<?> future = executorService.submit(() -> createObjectUnderTest().run());
+        Thread.sleep(100);
+        executorService.shutdown();
+        future.cancel(true);
+        assertThat(future.isCancelled(), equalTo(true));
+
+        assertThat(executorService.awaitTermination(100, TimeUnit.MILLISECONDS), equalTo(true));
+
+        verify(searchAccessor, times(2)).searchWithoutSearchContext(any(NoSearchContextSearchRequest.class));
+        verify(sourceCoordinator, times(2)).saveProgressStateForPartition(eq(partitionKey), any(OpenSearchIndexProgressState.class));
+
+        final List<NoSearchContextSearchRequest> noSearchContextSearchRequests = searchRequestArgumentCaptor.getAllValues();
+        assertThat(noSearchContextSearchRequests.size(), equalTo(2));
+        assertThat(noSearchContextSearchRequests.get(0), notNullValue());
+        assertThat(noSearchContextSearchRequests.get(0).getIndex(), equalTo(partitionKey));
+        assertThat(noSearchContextSearchRequests.get(0).getPaginationSize(), equalTo(2));
+        assertThat(noSearchContextSearchRequests.get(0).getSearchAfter(), equalTo(null));
+
+        assertThat(noSearchContextSearchRequests.get(1), notNullValue());
+        assertThat(noSearchContextSearchRequests.get(1).getIndex(), equalTo(partitionKey));
+        assertThat(noSearchContextSearchRequests.get(1).getPaginationSize(), equalTo(2));
+        assertThat(noSearchContextSearchRequests.get(1).getSearchAfter(), equalTo(searchWithSearchAfterResults.getNextSearchAfter()));
+    }
+}

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
@@ -26,7 +26,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeletePointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchPointInTimeRequest;
-import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchPointInTimeResults;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchWithSearchAfterResults;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -114,13 +114,13 @@ public class PitWorkerTest {
         when(searchConfiguration.getBatchSize()).thenReturn(2);
         when(openSearchSourceConfiguration.getSearchConfiguration()).thenReturn(searchConfiguration);
 
-        final SearchPointInTimeResults searchPointInTimeResults = mock(SearchPointInTimeResults.class);
-        when(searchPointInTimeResults.getNextSearchAfter()).thenReturn(Collections.singletonList(UUID.randomUUID().toString()));
-        when(searchPointInTimeResults.getDocuments()).thenReturn(List.of(mock(Event.class), mock(Event.class))).thenReturn(List.of(mock(Event.class), mock(Event.class)))
+        final SearchWithSearchAfterResults searchWithSearchAfterResults = mock(SearchWithSearchAfterResults.class);
+        when(searchWithSearchAfterResults.getNextSearchAfter()).thenReturn(Collections.singletonList(UUID.randomUUID().toString()));
+        when(searchWithSearchAfterResults.getDocuments()).thenReturn(List.of(mock(Event.class), mock(Event.class))).thenReturn(List.of(mock(Event.class), mock(Event.class)))
                 .thenReturn(List.of(mock(Event.class))).thenReturn(List.of(mock(Event.class)));
 
         final ArgumentCaptor<SearchPointInTimeRequest> searchPointInTimeRequestArgumentCaptor = ArgumentCaptor.forClass(SearchPointInTimeRequest.class);
-        when(searchAccessor.searchWithPit(searchPointInTimeRequestArgumentCaptor.capture())).thenReturn(searchPointInTimeResults);
+        when(searchAccessor.searchWithPit(searchPointInTimeRequestArgumentCaptor.capture())).thenReturn(searchWithSearchAfterResults);
 
         doNothing().when(bufferAccumulator).add(any(Record.class));
         doNothing().when(bufferAccumulator).flush();
@@ -167,7 +167,7 @@ public class PitWorkerTest {
         assertThat(searchPointInTimeRequestList.get(1).getPitId(), equalTo(pitId));
         assertThat(searchPointInTimeRequestList.get(1).getKeepAlive(), equalTo(EXTEND_KEEP_ALIVE_TIME));
         assertThat(searchPointInTimeRequestList.get(1).getPaginationSize(), equalTo(2));
-        assertThat(searchPointInTimeRequestList.get(1).getSearchAfter(), equalTo(searchPointInTimeResults.getNextSearchAfter()));
+        assertThat(searchPointInTimeRequestList.get(1).getSearchAfter(), equalTo(searchWithSearchAfterResults.getNextSearchAfter()));
 
 
         final DeletePointInTimeRequest deletePointInTimeRequest = deleteRequestArgumentCaptor.getValue();
@@ -193,12 +193,12 @@ public class PitWorkerTest {
         when(searchConfiguration.getBatchSize()).thenReturn(2);
         when(openSearchSourceConfiguration.getSearchConfiguration()).thenReturn(searchConfiguration);
 
-        final SearchPointInTimeResults searchPointInTimeResults = mock(SearchPointInTimeResults.class);
-        when(searchPointInTimeResults.getNextSearchAfter()).thenReturn(Collections.singletonList(UUID.randomUUID().toString()));
-        when(searchPointInTimeResults.getDocuments()).thenReturn(List.of(mock(Event.class), mock(Event.class))).thenReturn(List.of(mock(Event.class), mock(Event.class)))
+        final SearchWithSearchAfterResults searchWithSearchAfterResults = mock(SearchWithSearchAfterResults.class);
+        when(searchWithSearchAfterResults.getNextSearchAfter()).thenReturn(Collections.singletonList(UUID.randomUUID().toString()));
+        when(searchWithSearchAfterResults.getDocuments()).thenReturn(List.of(mock(Event.class), mock(Event.class))).thenReturn(List.of(mock(Event.class), mock(Event.class)))
                 .thenReturn(List.of(mock(Event.class))).thenReturn(List.of(mock(Event.class)));
 
-        when(searchAccessor.searchWithPit(any(SearchPointInTimeRequest.class))).thenReturn(searchPointInTimeResults);
+        when(searchAccessor.searchWithPit(any(SearchPointInTimeRequest.class))).thenReturn(searchWithSearchAfterResults);
 
         doNothing().when(bufferAccumulator).add(any(Record.class));
         doNothing().when(bufferAccumulator).flush();

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
@@ -31,7 +31,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeletePointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchContextType;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchPointInTimeRequest;
-import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchPointInTimeResults;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchWithSearchAfterResults;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -221,12 +221,12 @@ public class OpenSearchAccessorTest {
 
         when(openSearchClient.search(searchRequestArgumentCaptor.capture(), eq(ObjectNode.class))).thenReturn(searchResponse);
 
-        final SearchPointInTimeResults searchPointInTimeResults = createObjectUnderTest().searchWithPit(searchPointInTimeRequest);
+        final SearchWithSearchAfterResults searchWithSearchAfterResults = createObjectUnderTest().searchWithPit(searchPointInTimeRequest);
 
-        assertThat(searchPointInTimeResults, notNullValue());
-        assertThat(searchPointInTimeResults.getDocuments(), notNullValue());
-        assertThat(searchPointInTimeResults.getDocuments().size(), equalTo(2));
+        assertThat(searchWithSearchAfterResults, notNullValue());
+        assertThat(searchWithSearchAfterResults.getDocuments(), notNullValue());
+        assertThat(searchWithSearchAfterResults.getDocuments().size(), equalTo(2));
 
-        assertThat(searchPointInTimeResults.getNextSearchAfter(), equalTo(secondHit.sort()));
+        assertThat(searchWithSearchAfterResults.getNextSearchAfter(), equalTo(secondHit.sort()));
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessStrategyTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessStrategyTest.java
@@ -21,6 +21,7 @@ import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.AwsAuthenticationConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.ConnectionConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SearchConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchContextType;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -32,6 +33,7 @@ import java.util.UUID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -73,6 +75,10 @@ public class SearchAccessStrategyTest {
         when(connectionConfiguration.getConnectTimeout()).thenReturn(null);
         when(connectionConfiguration.isInsecure()).thenReturn(true);
 
+        final SearchConfiguration searchConfiguration = mock(SearchConfiguration.class);
+        when(searchConfiguration.getSearchContextType()).thenReturn(null);
+        when(openSearchSourceConfiguration.getSearchConfiguration()).thenReturn(searchConfiguration);
+
         when(openSearchSourceConfiguration.getAwsAuthenticationOptions()).thenReturn(null);
 
         final InfoResponse infoResponse = mock(InfoResponse.class);
@@ -112,6 +118,10 @@ public class SearchAccessStrategyTest {
         when(awsAuthenticationConfiguration.getAwsStsHeaderOverrides()).thenReturn(Collections.emptyMap());
         when(openSearchSourceConfiguration.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationConfiguration);
 
+        final SearchConfiguration searchConfiguration = mock(SearchConfiguration.class);
+        when(searchConfiguration.getSearchContextType()).thenReturn(null);
+        when(openSearchSourceConfiguration.getSearchConfiguration()).thenReturn(searchConfiguration);
+
         final InfoResponse infoResponse = mock(InfoResponse.class);
         final OpenSearchVersionInfo openSearchVersionInfo = mock(OpenSearchVersionInfo.class);
         when(openSearchVersionInfo.distribution()).thenReturn(OPENSEARCH_DISTRIBUTION);
@@ -130,6 +140,100 @@ public class SearchAccessStrategyTest {
             final SearchAccessor searchAccessor = createObjectUnderTest().getSearchAccessor();
             assertThat(searchAccessor, notNullValue());
             assertThat(searchAccessor.getSearchContextType(), equalTo(SearchContextType.SCROLL));
+
+            final List<OpenSearchClient> constructedClients = openSearchClientMockedConstruction.constructed();
+            assertThat(constructedClients.size(), equalTo(1));
+        }
+
+        final AwsCredentialsOptions awsCredentialsOptions = awsCredentialsOptionsArgumentCaptor.getValue();
+        assertThat(awsCredentialsOptions, notNullValue());
+        assertThat(awsCredentialsOptions.getRegion(), equalTo(Region.US_EAST_1));
+        assertThat(awsCredentialsOptions.getStsHeaderOverrides(), equalTo(Collections.emptyMap()));
+        assertThat(awsCredentialsOptions.getStsRoleArn(), equalTo(stsRoleArn));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1.3.0", "2.4.9", "0.3.2"})
+    void search_context_type_set_to_point_in_time_with_invalid_version_throws_IllegalArgumentException(final String osVersion) {
+        when(connectionConfiguration.getCertPath()).thenReturn(null);
+        when(connectionConfiguration.getSocketTimeout()).thenReturn(null);
+        when(connectionConfiguration.getConnectTimeout()).thenReturn(null);
+
+        final AwsAuthenticationConfiguration awsAuthenticationConfiguration = mock(AwsAuthenticationConfiguration.class);
+        when(awsAuthenticationConfiguration.getAwsRegion()).thenReturn(Region.US_EAST_1);
+        final String stsRoleArn = "arn:aws:iam::123456789012:role/my-role";
+        when(awsAuthenticationConfiguration.getAwsStsRoleArn()).thenReturn(stsRoleArn);
+        when(awsAuthenticationConfiguration.getAwsStsHeaderOverrides()).thenReturn(Collections.emptyMap());
+        when(openSearchSourceConfiguration.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationConfiguration);
+
+        final InfoResponse infoResponse = mock(InfoResponse.class);
+        final OpenSearchVersionInfo openSearchVersionInfo = mock(OpenSearchVersionInfo.class);
+        when(openSearchVersionInfo.distribution()).thenReturn(OPENSEARCH_DISTRIBUTION);
+        when(openSearchVersionInfo.number()).thenReturn(osVersion);
+        when(infoResponse.version()).thenReturn(openSearchVersionInfo);
+
+        final SearchConfiguration searchConfiguration = mock(SearchConfiguration.class);
+        when(searchConfiguration.getSearchContextType()).thenReturn(SearchContextType.POINT_IN_TIME);
+        when(openSearchSourceConfiguration.getSearchConfiguration()).thenReturn(searchConfiguration);
+
+        final ArgumentCaptor<AwsCredentialsOptions> awsCredentialsOptionsArgumentCaptor = ArgumentCaptor.forClass(AwsCredentialsOptions.class);
+        final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
+        when(awsCredentialsSupplier.getProvider(awsCredentialsOptionsArgumentCaptor.capture())).thenReturn(awsCredentialsProvider);
+
+        try (MockedConstruction<OpenSearchClient> openSearchClientMockedConstruction = mockConstruction(OpenSearchClient.class,
+                (clientMock, context) -> {
+                    when(clientMock.info()).thenReturn(infoResponse);
+                })) {
+
+            assertThrows(IllegalArgumentException.class, () -> createObjectUnderTest().getSearchAccessor());
+
+            final List<OpenSearchClient> constructedClients = openSearchClientMockedConstruction.constructed();
+            assertThat(constructedClients.size(), equalTo(1));
+        }
+
+        final AwsCredentialsOptions awsCredentialsOptions = awsCredentialsOptionsArgumentCaptor.getValue();
+        assertThat(awsCredentialsOptions, notNullValue());
+        assertThat(awsCredentialsOptions.getRegion(), equalTo(Region.US_EAST_1));
+        assertThat(awsCredentialsOptions.getStsHeaderOverrides(), equalTo(Collections.emptyMap()));
+        assertThat(awsCredentialsOptions.getStsRoleArn(), equalTo(stsRoleArn));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1.3.0", "2.4.9", "2.5.0"})
+    void search_context_type_set_to_none_uses_that_search_context_regardless_of_version(final String osVersion) {
+        when(connectionConfiguration.getCertPath()).thenReturn(null);
+        when(connectionConfiguration.getSocketTimeout()).thenReturn(null);
+        when(connectionConfiguration.getConnectTimeout()).thenReturn(null);
+
+        final AwsAuthenticationConfiguration awsAuthenticationConfiguration = mock(AwsAuthenticationConfiguration.class);
+        when(awsAuthenticationConfiguration.getAwsRegion()).thenReturn(Region.US_EAST_1);
+        final String stsRoleArn = "arn:aws:iam::123456789012:role/my-role";
+        when(awsAuthenticationConfiguration.getAwsStsRoleArn()).thenReturn(stsRoleArn);
+        when(awsAuthenticationConfiguration.getAwsStsHeaderOverrides()).thenReturn(Collections.emptyMap());
+        when(openSearchSourceConfiguration.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationConfiguration);
+
+        final InfoResponse infoResponse = mock(InfoResponse.class);
+        final OpenSearchVersionInfo openSearchVersionInfo = mock(OpenSearchVersionInfo.class);
+        when(openSearchVersionInfo.distribution()).thenReturn(OPENSEARCH_DISTRIBUTION);
+        when(openSearchVersionInfo.number()).thenReturn(osVersion);
+        when(infoResponse.version()).thenReturn(openSearchVersionInfo);
+
+        final SearchConfiguration searchConfiguration = mock(SearchConfiguration.class);
+        when(searchConfiguration.getSearchContextType()).thenReturn(SearchContextType.NONE);
+        when(openSearchSourceConfiguration.getSearchConfiguration()).thenReturn(searchConfiguration);
+
+        final ArgumentCaptor<AwsCredentialsOptions> awsCredentialsOptionsArgumentCaptor = ArgumentCaptor.forClass(AwsCredentialsOptions.class);
+        final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
+        when(awsCredentialsSupplier.getProvider(awsCredentialsOptionsArgumentCaptor.capture())).thenReturn(awsCredentialsProvider);
+
+        try (MockedConstruction<OpenSearchClient> openSearchClientMockedConstruction = mockConstruction(OpenSearchClient.class,
+                (clientMock, context) -> {
+                    when(clientMock.info()).thenReturn(infoResponse);
+                })) {
+
+            final SearchAccessor searchAccessor = createObjectUnderTest().getSearchAccessor();
+            assertThat(searchAccessor, notNullValue());
+            assertThat(searchAccessor.getSearchContextType(), equalTo(SearchContextType.NONE));
 
             final List<OpenSearchClient> constructedClients = openSearchClientMockedConstruction.constructed();
             assertThat(constructedClients.size(), equalTo(1));


### PR DESCRIPTION
### Description
* Implements `NoSearchContextWorker`, which will process indices using sort and search_after without creating search contexts via scroll or point in time
* Adds a new parameter to `search_options`, the `search_context_type`. 

The `search_context_type` can be set to `none`, `point_in_time`, or `scroll`. By default, point in time will be used for versions that can support it, and scroll will be used for versions that don't support point in time. 

However, there is a consideration to make the default just be `none`, and just use the version lookup to validate that point in time can be used if the `search_context_type` is set to `point_in_time`.
 
### Issues Resolved
Related to #1985 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
