### PR TITLE
Throw exception when Gzip encoding specified but file does not contain gzip header.

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/GZipDecompressionEngine.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/codec/GZipDecompressionEngine.java
@@ -10,13 +10,25 @@ import org.opensearch.dataprepper.model.codec.DecompressionEngine;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PushbackInputStream;
 
 public class GZipDecompressionEngine implements DecompressionEngine {
     @Override
-    public InputStream createInputStream(final InputStream responseInputStream) throws IOException {
+    public InputStream createInputStream(final InputStream inputStream) throws IOException {
+        final PushbackInputStream pushbackStream = new PushbackInputStream(inputStream, 2);
+        final byte[] signature = new byte[2];
+        //read the signature
+        final int len = pushbackStream.read(signature);
+        //push back the signature to the stream
+        pushbackStream.unread(signature, 0, len);
+        //check if matches standard gzip magic number
+        if(!GzipCompressorInputStream.matches(signature, len)) {
+            throw new IOException("GZIP encoding specified but data did contain gzip magic header");
+        }
+
         // We are using GzipCompressorInputStream here to decompress because GZIPInputStream doesn't decompress concatenated .gz files
         // it stops after the first member and silently ignores the rest.
         // It doesn't leave the read position to point to the beginning of the next member.
-        return new GzipCompressorInputStream(responseInputStream, true);
+        return new GzipCompressorInputStream(pushbackStream, true);
     }
 }

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/codec/GZipDecompressionEngineTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/codec/GZipDecompressionEngineTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import java.util.zip.GZIPOutputStream;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -54,5 +55,21 @@ class GZipDecompressionEngineTest {
 
         assertThat(inputStream, instanceOf(GzipCompressorInputStream.class));
         assertThat(inputStream.readAllBytes(), equalTo(testStringBytes));
+    }
+
+    @Test
+    void createInputStream_without_gzip_should_throw_exception() throws IOException {
+        decompressionEngine = new GZipDecompressionEngine();
+
+        final String testString = UUID.randomUUID().toString();
+        final byte[] testStringBytes = testString.getBytes(StandardCharsets.UTF_8);
+
+        final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        byteOut.write(testStringBytes, 0, testStringBytes.length);
+        byteOut.close();
+        final byte[] bites = byteOut.toByteArray();
+        final ByteArrayInputStream byteInStream = new ByteArrayInputStream(bites);
+
+        assertThrows(IOException.class, () -> decompressionEngine.createInputStream(byteInStream));
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorkerTest.java
@@ -234,6 +234,23 @@ class S3ObjectWorkerTest {
     }
 
     @Test
+    void parseS3Object_codec_parse_exception() throws Exception {
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
+        when(s3ObjectPluginMetrics.getS3ObjectsFailedCounter()).thenReturn(s3ObjectsFailedCounter);
+
+        doThrow(IOException.class).when(codec).parse(any(InputFile.class), any(DecompressionEngine.class), any(Consumer.class));
+
+        assertThrows(
+            IOException.class,
+            () -> createObjectUnderTest(s3ObjectPluginMetrics).parseS3Object(s3ObjectReference, acknowledgementSet));
+
+        final ArgumentCaptor<InputFile> inputFileArgumentCaptor = ArgumentCaptor.forClass(InputFile.class);
+        verify(codec).parse(inputFileArgumentCaptor.capture(), any(DecompressionEngine.class), any(Consumer.class));
+        final InputFile actualInputFile = inputFileArgumentCaptor.getValue();
+        assertThat(actualInputFile, instanceOf(S3InputFile.class));
+    }
+
+    @Test
     void parseS3Object_calls_Codec_parse_with_Consumer_that_adds_to_BufferAccumulator() throws Exception {
         when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
         when(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).thenReturn(s3ObjectEventsSummary);


### PR DESCRIPTION
### Description
Throw exception when gzip is specified but the data is not specified.
 
### Issues Resolved
Exception not being thrown when gzip encoding specified but files are not gzip.
 
### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
