### PR TITLE
S3 Scan time range improvements

### DIFF
--- a/data-prepper-plugins/s3-source/README.md
+++ b/data-prepper-plugins/s3-source/README.md
@@ -53,6 +53,8 @@ source-pipeline:
     s3:
       notification_type: sqs
       compression: none
+      codec:
+        newline:
       s3_select:
         expression: "select * from s3object s LIMIT 10000"
         expression_type: SQL
@@ -71,7 +73,6 @@ source-pipeline:
         sts_role_arn: "arn:aws:iam::123456789012:role/Data-Prepper"
       scan:
         start_time: 2023-01-21T18:00:00
-        range: P90DT3H4M
         end_time: 2023-04-21T18:00:00
         buckets:
           - bucket:
@@ -88,41 +89,7 @@ source-pipeline:
 
 All Duration values are a string that represents a duration. They support ISO_8601 notation string ("PT20.345S", "PT15M", etc.) as well as simple notation Strings for seconds ("60s") and milliseconds ("1500ms").
 
-* `s3_select` : S3 Select Configuration.
-
-* `expression` (Required if s3_select enabled) : Provide s3 select query to process the data using S3 select for the particular bucket.
-
-* `expression_type` (Optional if s3_select enabled) : Provide s3 select query type to process the data using S3 select for the particular bucket.
-
-* `compression_type` (Optional if s3_select enabled) : The compression algorithm to apply. May be one of: `none`, `gzip`. Defaults to `none`.
-
-* `input_serialization` (Required if s3_select enabled) : Provide the s3 select file format (csv/json/Apache Parquet) Amazon S3 uses this format to parse object data into records and returns only records that match the specified SQL expression. You must also specify the data serialization format for the response.
-
-* `csv` (Optional) : Provide the csv configuration to process the csv data.
-
-* `file_header_info` (Required if csv block is enabled) : Provide CSV Header example : `use` , `none` , `ignore`. Default is `use`.
-
-* `quote_escape` (Optional) : Provide quote_escape attribute example : `,` , `.`.
-
-* `comments` (Optional) : Provide comments attribute example : `#`. Default is `#`.
-
-* `json` (Optional) : Provide the json configuration to process the json data.
-
-* `type` (Optional) : Provide the type attribute to process the json type data example: `Lines` , `Document` Default is `Document`.
-
-* `bucket_name` : Provide S3 bucket name.
-
-* `key_prefix` (Optional) : Provide include and exclude the list items.
-
-* `include` (Optional) : Provide the list of include key path prefix.
-
-* `exclude_suffix` (Optional) : Provide the list of suffix to exclude items. 
-
-* `start_time` (Optional) : Provide the start time to scan the data. for example the files updated between start_time and end_time will be scanned. example : `2023-01-23T10:00:00`.
-
-* `end_time` (Optional) : Provide the end time to scan the data. for example the files updated between start_time and end_time will be scanned. example : `2023-01-23T10:00:00`.
-
-* `range` (Optional) : Provide the duration to scan the data example : `day` , `week` , `month` , `year`.
+* `s3_select` : S3 Select Configuration. See [S3 Select Configuration](#s3_select_configuration) for details
 
 * `notification_type` (Optional) : Must be `sqs`.
 
@@ -131,6 +98,8 @@ All Duration values are a string that represents a duration. They support ISO_86
 * `codec` (Required) : The codec to apply. Must be either `newline`, `csv` or `json`.
 
 * `sqs` (Optional) : The SQS configuration. See [SQS Configuration](#sqs_configuration) for details.
+
+* `scan` (Optional): S3 Scan Configuration. See [S3 Scan Configuration](#s3_scan_configuration) for details
 
 * `aws` (Optional) : AWS configurations. See [AWS Configuration](#aws_configuration) for details.
 
@@ -146,6 +115,28 @@ All Duration values are a string that represents a duration. They support ISO_86
 
 * `disable_bucket_ownership_validation` (Optional) : Boolean - If set to true, then the S3 Source will not attempt to validate that the bucket is owned by the expected account. The only expected account is the same account which owns the SQS queue. Defaults to `false`.
 
+### <a name="s3_select_configuration">S3 Select Configuration</a>
+
+* `expression` (Required if s3_select enabled) : Provide s3 select query to process the data using S3 select for the particular bucket.
+
+* `expression_type` (Optional if s3_select enabled) : Provide s3 select query type to process the data using S3 select for the particular bucket.
+
+* `compression_type` (Optional if s3_select enabled) : The compression algorithm to apply. May be one of: `none`, `gzip`. Defaults to `none`.
+
+* `input_serialization` (Required if s3_select enabled) : Provide the s3 select file format (csv/json/Apache Parquet) Amazon S3 uses this format to parse object data into records and returns only records that match the specified SQL expression. You must also specify the data serialization format for the response.
+
+* `csv` (Optional) : Provide the csv configuration to process the csv data.
+
+  * `file_header_info` (Required if csv block is enabled) : Provide CSV Header example : `use` , `none` , `ignore`. Default is `use`.
+
+  * `quote_escape` (Optional) : Provide quote_escape attribute example : `,` , `.`.
+
+  * `comments` (Optional) : Provide comments attribute example : `#`. Default is `#`.
+
+* `json` (Optional) : Provide the json configuration to process the json data.
+
+  * `type` (Optional) : Provide the type attribute to process the json type data example: `Lines` , `Document` Default is `Document`.
+
 ### <a name="sqs_configuration">SQS Configuration</a>
 
 * `queue_url` (Required) : The SQS queue URL of the queue to read from.
@@ -153,6 +144,21 @@ All Duration values are a string that represents a duration. They support ISO_86
 * `visibility_timeout` (Optional) : Duration - The visibility timeout to apply to messages read from the SQS queue. This should be set to the amount of time that Data Prepper may take to read all the S3 objects in a batch. Defaults to 30 seconds.
 * `wait_time` (Optional) : Duration - The time to wait for long-polling on the SQS API. Defaults to 20 seconds.
 * `poll_delay` (Optional) : Duration - A delay to place between reading and processing a batch of SQS messages and making a subsequent request. Defaults to 0 seconds.
+
+### <a name="s3_scan_configuration">S3 Scan Configuration</a>
+* `start_time` (Optional) : Provide the start time to scan objects from all the buckets. This parameter defines a time range together with either end_time or range. Example: `2023-01-23T10:00:00`.
+* `end_time` (Optional) : Provide the end time to scan objects from all the buckets. This parameter defines a time range together with either start_time or range. Example: `2023-01-23T10:00:00`.
+* `range` (Optional) : Provide the duration to scan objects from all the buckets. This parameter defines a time range together with either start_time or end_time.
+* `bucket`: Provide S3 bucket information
+  * `name` (Required if bucket block is used): Provide S3 bucket name.
+  * `key_prefix` (Optional) : Provide include and exclude the list items.
+    * `include` (Optional) : Provide the list of include key path prefix.
+    * `exclude_suffix` (Optional) : Provide the list of suffix to exclude items.
+    * `start_time` (Optional) : Provide the start time to scan objects from the current bucket. This parameter defines a time range together with either end_time or range. Example: `2023-01-23T10:00:00`.
+    * `end_time` (Optional) : Provide the end time to scan objects from the current bucket. This parameter defines a time range together with either start_time or range. Example: `2023-01-23T10:00:00`.
+    * `range` (Optional) : Provide the duration to scan objects from the current bucket. This parameter defines a time range together with either start_time or end_time.
+
+> Note: If a time range is not specified, all objects will be included by default. To set a time range, specify any two and only two configurations from start_time, end_time and range. The time range configured on a specific bucket will override the time range specified on the top level
 
 ### <a name="aws_configuration">AWS Configuration</a>
 

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplier.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplier.java
@@ -47,10 +47,10 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
 
         for (final ScanOptions scanOptions : scanOptionsList) {
             final List<String> excludeItems = new ArrayList<>();
-            final S3ScanKeyPathOption s3ScanKeyPathOption = scanOptions.getS3ScanKeyPathOption();
+            final S3ScanKeyPathOption s3ScanKeyPathOption = scanOptions.getBucketOption().getkeyPrefix();
             final ListObjectsV2Request.Builder listObjectsV2Request = ListObjectsV2Request.builder()
-                    .bucket(scanOptions.getBucket());
-            bucketOwnerProvider.getBucketOwner(scanOptions.getBucket())
+                    .bucket(scanOptions.getBucketOption().getName());
+            bucketOwnerProvider.getBucketOwner(scanOptions.getBucketOption().getName())
                     .ifPresent(listObjectsV2Request::expectedBucketOwner);
 
             if (Objects.nonNull(s3ScanKeyPathOption) && Objects.nonNull(s3ScanKeyPathOption.getS3ScanExcludeSuffixOptions()))
@@ -59,12 +59,12 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
             if (Objects.nonNull(s3ScanKeyPathOption) && Objects.nonNull(s3ScanKeyPathOption.getS3scanIncludeOptions()))
                 s3ScanKeyPathOption.getS3scanIncludeOptions().forEach(includePath -> {
                     listObjectsV2Request.prefix(includePath);
-                    objectsToProcess.addAll(listFilteredS3ObjectsForBucket(excludeItems, listObjectsV2Request, scanOptions.getBucket(),
-                            scanOptions.getUseStartDateTime(), scanOptions.getUseEndDateTime()));
+                    objectsToProcess.addAll(listFilteredS3ObjectsForBucket(excludeItems, listObjectsV2Request,
+                            scanOptions.getBucketOption().getName(), scanOptions.getUseStartDateTime(), scanOptions.getUseEndDateTime()));
                 });
             else
-                objectsToProcess.addAll(listFilteredS3ObjectsForBucket(excludeItems, listObjectsV2Request, scanOptions.getBucket(),
-                        scanOptions.getUseStartDateTime(), scanOptions.getUseEndDateTime()));
+                objectsToProcess.addAll(listFilteredS3ObjectsForBucket(excludeItems, listObjectsV2Request,
+                        scanOptions.getBucketOption().getName(), scanOptions.getUseStartDateTime(), scanOptions.getUseEndDateTime()));
         }
 
         return objectsToProcess;
@@ -106,6 +106,9 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
     private boolean isKeyMatchedBetweenTimeRange(final LocalDateTime lastModifiedTime,
                                                  final LocalDateTime startDateTime,
                                                  final LocalDateTime endDateTime){
+        if (Objects.isNull(startDateTime) || Objects.isNull(endDateTime)) {
+            return true;
+        }
         return lastModifiedTime.isAfter(startDateTime) && lastModifiedTime.isBefore(endDateTime);
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ScanService.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ScanService.java
@@ -5,7 +5,6 @@
 package org.opensearch.dataprepper.plugins.source;
 
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
-import org.opensearch.dataprepper.plugins.source.configuration.S3ScanBucketOption;
 import org.opensearch.dataprepper.plugins.source.configuration.S3ScanBucketOptions;
 import org.opensearch.dataprepper.plugins.source.ownership.BucketOwnerProvider;
 
@@ -67,12 +66,11 @@ public class S3ScanService {
     }
 
     private void buildScanOptions(final List<ScanOptions> scanOptionsList, final S3ScanBucketOptions scanBucketOptions) {
-        final S3ScanBucketOption s3ScanBucketOption = scanBucketOptions.getS3ScanBucketOption();
-        scanOptionsList.add(new ScanOptions.Builder()
+        scanOptionsList.add(ScanOptions.builder()
                 .setStartDateTime(startDateTime)
                 .setEndDateTime(endDateTime)
                 .setRange(range)
-                .setBucket(s3ScanBucketOption.getName())
-                .setS3ScanKeyPathOption(s3ScanBucketOption.getkeyPrefix()).build());
+                .setBucketOption(scanBucketOptions.getS3ScanBucketOption())
+                .build());
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SourceConfig.java
@@ -35,6 +35,7 @@ public class S3SourceConfig {
     private PluginModel codec;
 
     @JsonProperty("sqs")
+    @Valid
     private SqsOptions sqsOptions;
 
     @JsonProperty("aws")
@@ -60,9 +61,11 @@ public class S3SourceConfig {
     @JsonProperty("metadata_root_key")
     private String metadataRootKey = DEFAULT_METADATA_ROOT_KEY;
     @JsonProperty("s3_select")
+    @Valid
     private S3SelectOptions s3SelectOptions;
 
     @JsonProperty("scan")
+    @Valid
     private S3ScanScanOptions s3ScanScanOptions;
 
     @AssertTrue(message = "A codec is required for reading objects.")

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOption.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOption.java
@@ -11,9 +11,12 @@ import com.fasterxml.jackson.datatype.jsr310.deser.DurationDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.DurationSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import jakarta.validation.constraints.AssertTrue;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  * Class consists the bucket related configuration properties.
@@ -39,6 +42,11 @@ public class S3ScanBucketOption {
 
     @JsonProperty("key_prefix")
     private S3ScanKeyPathOption keyPrefix;
+
+    @AssertTrue(message = "At most two options from start_time, end_time and range can be specified at the same time")
+    public boolean hasValidTimeOptions() {
+        return Stream.of(startTime, endTime, range).filter(Objects::nonNull).count() < 3;
+    }
 
     public String getName() {
         return name;

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOption.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOption.java
@@ -5,6 +5,15 @@
 package org.opensearch.dataprepper.plugins.source.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.DurationDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.DurationSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
 
 /**
  * Class consists the bucket related configuration properties.
@@ -12,11 +21,39 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class S3ScanBucketOption {
     @JsonProperty("name")
     private String name;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonProperty("start_time")
+    private LocalDateTime startTime;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonProperty("end_time")
+    private LocalDateTime endTime;
+
+    @JsonSerialize(using = DurationSerializer.class)
+    @JsonDeserialize(using = DurationDeserializer.class)
+    @JsonProperty("range")
+    private Duration range;
+
     @JsonProperty("key_prefix")
     private S3ScanKeyPathOption keyPrefix;
 
     public String getName() {
         return name;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public Duration getRange() {
+        return range;
     }
 
     public S3ScanKeyPathOption getkeyPrefix() {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanScanOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanScanOptions.java
@@ -11,10 +11,14 @@ import com.fasterxml.jackson.datatype.jsr310.deser.DurationDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.DurationSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import jakarta.validation.constraints.AssertTrue;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
 /**
  * Class consists the scan options list bucket configuration properties.
  */
@@ -37,6 +41,11 @@ public class S3ScanScanOptions {
 
     @JsonProperty("buckets")
     private List<S3ScanBucketOptions> buckets;
+
+    @AssertTrue(message = "At most two options from start_time, end_time and range can be specified at the same time")
+    public boolean hasValidTimeOptions() {
+        return Stream.of(startTime, endTime, range).filter(Objects::nonNull).count() < 3;
+    }
 
     public Duration getRange() {
         return range;

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplierTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplierTest.java
@@ -13,6 +13,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.source.coordinator.PartitionIdentifier;
+import org.opensearch.dataprepper.plugins.source.configuration.S3ScanBucketOption;
 import org.opensearch.dataprepper.plugins.source.configuration.S3ScanKeyPathOption;
 import org.opensearch.dataprepper.plugins.source.ownership.BucketOwnerProvider;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -71,21 +72,25 @@ public class S3ScanPartitionCreationSupplierTest {
 
 
         final ScanOptions firstBucketScanOptions = mock(ScanOptions.class);
-        given(firstBucketScanOptions.getBucket()).willReturn(firstBucket);
+        final S3ScanBucketOption firstBucketScanBucketOption = mock(S3ScanBucketOption.class);
+        given(firstBucketScanOptions.getBucketOption()).willReturn(firstBucketScanBucketOption);
+        given(firstBucketScanBucketOption.getName()).willReturn(firstBucket);
         given(firstBucketScanOptions.getUseStartDateTime()).willReturn(LocalDateTime.ofInstant(startTime, ZoneId.systemDefault()));
         given(firstBucketScanOptions.getUseEndDateTime()).willReturn(LocalDateTime.ofInstant(endTime, ZoneId.systemDefault()));
         final S3ScanKeyPathOption firstBucketScanKeyPath = mock(S3ScanKeyPathOption.class);
-        given(firstBucketScanOptions.getS3ScanKeyPathOption()).willReturn(firstBucketScanKeyPath);
+        given(firstBucketScanBucketOption.getkeyPrefix()).willReturn(firstBucketScanKeyPath);
         given(firstBucketScanKeyPath.getS3scanIncludeOptions()).willReturn(List.of(UUID.randomUUID().toString()));
         given(firstBucketScanKeyPath.getS3ScanExcludeSuffixOptions()).willReturn(List.of(".invalid"));
         scanOptionsList.add(firstBucketScanOptions);
 
         final ScanOptions secondBucketScanOptions = mock(ScanOptions.class);
-        given(secondBucketScanOptions.getBucket()).willReturn(secondBucket);
+        final S3ScanBucketOption secondBucketScanBucketOption = mock(S3ScanBucketOption.class);
+        given(secondBucketScanOptions.getBucketOption()).willReturn(secondBucketScanBucketOption);
+        given(secondBucketScanBucketOption.getName()).willReturn(secondBucket);
         given(secondBucketScanOptions.getUseStartDateTime()).willReturn(LocalDateTime.ofInstant(startTime, ZoneId.systemDefault()));
         given(secondBucketScanOptions.getUseEndDateTime()).willReturn(LocalDateTime.ofInstant(endTime, ZoneId.systemDefault()));
         final S3ScanKeyPathOption secondBucketScanKeyPath = mock(S3ScanKeyPathOption.class);
-        given(secondBucketScanOptions.getS3ScanKeyPathOption()).willReturn(secondBucketScanKeyPath);
+        given(secondBucketScanBucketOption.getkeyPrefix()).willReturn(secondBucketScanKeyPath);
         given(secondBucketScanKeyPath.getS3scanIncludeOptions()).willReturn(null);
         given(secondBucketScanKeyPath.getS3ScanExcludeSuffixOptions()).willReturn(null);
         scanOptionsList.add(secondBucketScanOptions);

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ScanServiceTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ScanServiceTest.java
@@ -35,7 +35,7 @@ public class S3ScanServiceTest {
     }
 
     @Test
-    public void scan_service_with_s3_select_Configuration_test_and_verify() {
+    public void scan_service_with_valid_s3_scan_configuration_test_and_verify() {
         final String bucketName="my-bucket-5";
         final LocalDateTime startDateTime = LocalDateTime.parse("2023-03-07T10:00:00");
         final Duration range = Duration.parse("P2DT1H");
@@ -49,16 +49,71 @@ public class S3ScanServiceTest {
         when(s3ScanBucketOption.getName()).thenReturn(bucketName);
         S3ScanKeyPathOption s3ScanKeyPathOption = mock(S3ScanKeyPathOption.class);
         when(s3ScanKeyPathOption.getS3scanIncludeOptions()).thenReturn(includeKeyPathList);
+        when(s3ScanBucketOption.getRange()).thenReturn(null);
         when(s3ScanBucketOption.getkeyPrefix()).thenReturn(s3ScanKeyPathOption);
         when(bucket.getS3ScanBucketOption()).thenReturn(s3ScanBucketOption);
-        when(s3ScanScanOptions.getBuckets()).thenReturn( List.of(bucket));
+        when(s3ScanScanOptions.getBuckets()).thenReturn(List.of(bucket));
         when(s3SourceConfig.getS3ScanScanOptions()).thenReturn(s3ScanScanOptions);
         S3ScanService service = new S3ScanService(s3SourceConfig,mock(S3ClientBuilderFactory.class),
                 mock(S3ObjectHandler.class),mock(BucketOwnerProvider.class), mock(SourceCoordinator.class));
         final List<ScanOptions> scanOptionsBuilder = service.getScanOptions();
-        assertThat(scanOptionsBuilder.get(0).getS3ScanKeyPathOption().getS3scanIncludeOptions(),sameInstance(includeKeyPathList));
-        assertThat(scanOptionsBuilder.get(0).getBucket(),sameInstance(bucketName));
-        assertThat(scanOptionsBuilder.get(0).getRange(),equalTo(range));
+        assertThat(scanOptionsBuilder.get(0).getBucketOption().getkeyPrefix().getS3scanIncludeOptions(),sameInstance(includeKeyPathList));
+        assertThat(scanOptionsBuilder.get(0).getBucketOption().getName(),sameInstance(bucketName));
         assertThat(scanOptionsBuilder.get(0).getUseStartDateTime(),equalTo(startDateTime));
+        assertThat(scanOptionsBuilder.get(0).getUseEndDateTime(),equalTo(startDateTime.plus(range)));
+    }
+
+    @Test
+    public void scan_service_with_valid_bucket_time_range_configuration_test_and_verify() {
+        final String bucketName="my-bucket-5";
+        final LocalDateTime startDateTime = LocalDateTime.parse("2023-03-07T10:00:00");
+        final Duration range = Duration.parse("P2DT1H");
+        final List<String> includeKeyPathList = List.of("file1.csv","file2.csv");
+        final S3SourceConfig s3SourceConfig = mock(S3SourceConfig.class);
+        final S3ScanScanOptions s3ScanScanOptions = mock(S3ScanScanOptions.class);
+        S3ScanBucketOptions bucket = mock(S3ScanBucketOptions.class);
+        final S3ScanBucketOption s3ScanBucketOption = mock(S3ScanBucketOption.class);
+        when(s3ScanBucketOption.getName()).thenReturn(bucketName);
+        S3ScanKeyPathOption s3ScanKeyPathOption = mock(S3ScanKeyPathOption.class);
+        when(s3ScanKeyPathOption.getS3scanIncludeOptions()).thenReturn(includeKeyPathList);
+        when(s3ScanBucketOption.getStartTime()).thenReturn(startDateTime);
+        when(s3ScanBucketOption.getRange()).thenReturn(range);
+        when(s3ScanBucketOption.getkeyPrefix()).thenReturn(s3ScanKeyPathOption);
+        when(bucket.getS3ScanBucketOption()).thenReturn(s3ScanBucketOption);
+        when(s3ScanScanOptions.getBuckets()).thenReturn(List.of(bucket));
+        when(s3SourceConfig.getS3ScanScanOptions()).thenReturn(s3ScanScanOptions);
+        S3ScanService service = new S3ScanService(s3SourceConfig,mock(S3ClientBuilderFactory.class),
+                mock(S3ObjectHandler.class),mock(BucketOwnerProvider.class), mock(SourceCoordinator.class));
+        final List<ScanOptions> scanOptionsBuilder = service.getScanOptions();
+        assertThat(scanOptionsBuilder.get(0).getBucketOption().getkeyPrefix().getS3scanIncludeOptions(),sameInstance(includeKeyPathList));
+        assertThat(scanOptionsBuilder.get(0).getBucketOption().getName(),sameInstance(bucketName));
+        assertThat(scanOptionsBuilder.get(0).getUseStartDateTime(),equalTo(startDateTime));
+        assertThat(scanOptionsBuilder.get(0).getUseEndDateTime(),equalTo(startDateTime.plus(range)));
+    }
+
+    @Test
+    public void scan_service_with_no_time_range_configuration_test_and_verify() {
+        final String bucketName="my-bucket-5";
+        final List<String> includeKeyPathList = List.of("file1.csv","file2.csv");
+        final S3SourceConfig s3SourceConfig = mock(S3SourceConfig.class);
+        final S3ScanScanOptions s3ScanScanOptions = mock(S3ScanScanOptions.class);
+        when(s3ScanScanOptions.getRange()).thenReturn(null);
+        S3ScanBucketOptions bucket = mock(S3ScanBucketOptions.class);
+        final S3ScanBucketOption s3ScanBucketOption = mock(S3ScanBucketOption.class);
+        when(s3ScanBucketOption.getName()).thenReturn(bucketName);
+        when(s3ScanBucketOption.getRange()).thenReturn(null);
+        S3ScanKeyPathOption s3ScanKeyPathOption = mock(S3ScanKeyPathOption.class);
+        when(s3ScanKeyPathOption.getS3scanIncludeOptions()).thenReturn(includeKeyPathList);
+        when(s3ScanBucketOption.getkeyPrefix()).thenReturn(s3ScanKeyPathOption);
+        when(bucket.getS3ScanBucketOption()).thenReturn(s3ScanBucketOption);
+        when(s3ScanScanOptions.getBuckets()).thenReturn(List.of(bucket));
+        when(s3SourceConfig.getS3ScanScanOptions()).thenReturn(s3ScanScanOptions);
+        S3ScanService service = new S3ScanService(s3SourceConfig,mock(S3ClientBuilderFactory.class),
+                mock(S3ObjectHandler.class),mock(BucketOwnerProvider.class), mock(SourceCoordinator.class));
+        final List<ScanOptions> scanOptionsBuilder = service.getScanOptions();
+        assertThat(scanOptionsBuilder.get(0).getBucketOption().getkeyPrefix().getS3scanIncludeOptions(),sameInstance(includeKeyPathList));
+        assertThat(scanOptionsBuilder.get(0).getBucketOption().getName(),sameInstance(bucketName));
+        assertThat(scanOptionsBuilder.get(0).getUseStartDateTime(),equalTo(null));
+        assertThat(scanOptionsBuilder.get(0).getUseEndDateTime(),equalTo(null));
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ScanOptionsTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ScanOptionsTest.java
@@ -5,11 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.source;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -23,50 +18,51 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
 class ScanOptionsTest {
-
-    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS));
 
     @ParameterizedTest
     @MethodSource("validGlobalTimeRangeOptions")
     public void s3scan_options_with_valid_global_time_range_build_success(
             LocalDateTime startDateTime, LocalDateTime endDateTime, Duration range,
-            LocalDateTime useStartDateTime, LocalDateTime useEndDateTime) throws JsonProcessingException {
-        final String buketOptionYaml = "name: bucket_name";
+            LocalDateTime useStartDateTime, LocalDateTime useEndDateTime) {
         final ScanOptions scanOptions = ScanOptions.builder()
                 .setStartDateTime(startDateTime)
                 .setEndDateTime(endDateTime)
                 .setRange(range)
-                .setBucketOption(objectMapper.readValue(buketOptionYaml, S3ScanBucketOption.class))
+                .setBucketOption(new S3ScanBucketOption())
                 .build();
 
         assertThat(scanOptions.getUseStartDateTime(), equalTo(useStartDateTime));
         assertThat(scanOptions.getUseEndDateTime(), equalTo(useEndDateTime));
         assertThat(scanOptions.getBucketOption(), instanceOf(S3ScanBucketOption.class));
-        assertThat(scanOptions.getBucketOption().getName(), equalTo("bucket_name"));
     }
 
     @ParameterizedTest
-    @MethodSource("invalidGlobalTimeRangeOptions")
+    @MethodSource("invalidTimeRangeOptions")
     public void s3scan_options_with_invalid_global_time_range_throws_exception_when_build(
             LocalDateTime startDateTime, LocalDateTime endDateTime, Duration range) {
-        final String buketOptionYaml = "name: bucket_name";
         assertThrows(IllegalArgumentException.class, () -> ScanOptions.builder()
                 .setStartDateTime(startDateTime)
                 .setEndDateTime(endDateTime)
                 .setRange(range)
-                .setBucketOption(objectMapper.readValue(buketOptionYaml, S3ScanBucketOption.class))
+                .setBucketOption(new S3ScanBucketOption())
                 .build());
     }
-
 
     @ParameterizedTest
     @MethodSource("validBucketTimeRangeOptions")
     public void s3scan_options_with_valid_bucket_time_range_build_success(
-            String bucketOptionYaml, LocalDateTime useStartDateTime, LocalDateTime useEndDateTime) throws JsonProcessingException {
+            LocalDateTime bucketStartDateTime, LocalDateTime bucketEndDateTime, Duration bucketRange,
+            LocalDateTime useStartDateTime, LocalDateTime useEndDateTime) throws NoSuchFieldException, IllegalAccessException {
+        S3ScanBucketOption bucketOption = new S3ScanBucketOption();
+        setField(S3ScanBucketOption.class, bucketOption, "name", "bucket_name");
+        setField(S3ScanBucketOption.class, bucketOption, "startTime", bucketStartDateTime);
+        setField(S3ScanBucketOption.class, bucketOption, "endTime", bucketEndDateTime);
+        setField(S3ScanBucketOption.class, bucketOption, "range", bucketRange);
         final ScanOptions scanOptions = ScanOptions.builder()
-                .setBucketOption(objectMapper.readValue(bucketOptionYaml, S3ScanBucketOption.class))
+                .setBucketOption(bucketOption)
                 .build();
 
         assertThat(scanOptions.getUseStartDateTime(), equalTo(useStartDateTime));
@@ -75,21 +71,63 @@ class ScanOptionsTest {
         assertThat(scanOptions.getBucketOption().getName(), equalTo("bucket_name"));
     }
 
-    @Test
-    public void bucket_time_range_options_overrides_global_time_range_options() throws JsonProcessingException {
-        final String bucketOptionYaml = "name: bucket_name\n" +
-                "start_time: 2023-01-21T18:00:00\n" +
-                "end_time: 2023-01-24T18:00:00";
+    @ParameterizedTest
+    @MethodSource("validCombinedTimeRangeOptions")
+    public void s3scan_options_with_valid_combined_time_range_build_success(
+            LocalDateTime globalStartDateTime, LocalDateTime globeEndDateTime, Duration globalRange,
+            LocalDateTime bucketStartDateTime, LocalDateTime bucketEndDateTime, Duration bucketRange,
+            LocalDateTime useStartDateTime, LocalDateTime useEndDateTime) throws NoSuchFieldException, IllegalAccessException {
+        S3ScanBucketOption bucketOption = new S3ScanBucketOption();
+        setField(S3ScanBucketOption.class, bucketOption, "name", "bucket_name");
+        setField(S3ScanBucketOption.class, bucketOption, "startTime", bucketStartDateTime);
+        setField(S3ScanBucketOption.class, bucketOption, "endTime", bucketEndDateTime);
+        setField(S3ScanBucketOption.class, bucketOption, "range", bucketRange);
         final ScanOptions scanOptions = ScanOptions.builder()
-                .setStartDateTime(LocalDateTime.parse("2022-05-10T18:00:00"))
-                .setEndDateTime(LocalDateTime.parse("2022-05-24T18:00:00"))
-                .setBucketOption(objectMapper.readValue(bucketOptionYaml, S3ScanBucketOption.class))
+                .setStartDateTime(globalStartDateTime)
+                .setEndDateTime(globeEndDateTime)
+                .setRange(globalRange)
+                .setBucketOption(bucketOption)
                 .build();
 
-        assertThat(scanOptions.getUseStartDateTime(), equalTo(LocalDateTime.parse("2023-01-21T18:00:00")));
-        assertThat(scanOptions.getUseEndDateTime(), equalTo(LocalDateTime.parse("2023-01-24T18:00:00")));
+        assertThat(scanOptions.getUseStartDateTime(), equalTo(useStartDateTime));
+        assertThat(scanOptions.getUseEndDateTime(), equalTo(useEndDateTime));
         assertThat(scanOptions.getBucketOption(), instanceOf(S3ScanBucketOption.class));
         assertThat(scanOptions.getBucketOption().getName(), equalTo("bucket_name"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidTimeRangeOptions")
+    public void s3scan_options_with_valid_combined_time_range_build_success(
+            LocalDateTime bucketStartDateTime, LocalDateTime bucketEndDateTime, Duration bucketRange
+    ) throws NoSuchFieldException, IllegalAccessException {
+        S3ScanBucketOption bucketOption = new S3ScanBucketOption();
+        setField(S3ScanBucketOption.class, bucketOption, "name", "bucket_name");
+        setField(S3ScanBucketOption.class, bucketOption, "startTime", bucketStartDateTime);
+        setField(S3ScanBucketOption.class, bucketOption, "endTime", bucketEndDateTime);
+        setField(S3ScanBucketOption.class, bucketOption, "range", bucketRange);
+        assertThrows(IllegalArgumentException.class, () -> ScanOptions.builder()
+                .setBucketOption(bucketOption)
+                .build());
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidCombinedTimeRangeOptions")
+    public void s3scan_options_with_invalid_combined_time_range_throws_exception_when_build(
+            LocalDateTime globalStartDateTime, LocalDateTime globeEndDateTime, Duration globalRange,
+            LocalDateTime bucketStartDateTime, LocalDateTime bucketEndDateTime, Duration bucketRange
+    ) throws NoSuchFieldException, IllegalAccessException {
+        S3ScanBucketOption bucketOption = new S3ScanBucketOption();
+        setField(S3ScanBucketOption.class, bucketOption, "name", "bucket_name");
+        setField(S3ScanBucketOption.class, bucketOption, "startTime", bucketStartDateTime);
+        setField(S3ScanBucketOption.class, bucketOption, "endTime", bucketEndDateTime);
+        setField(S3ScanBucketOption.class, bucketOption, "range", bucketRange);
+
+        assertThrows(IllegalArgumentException.class, () -> ScanOptions.builder()
+                .setStartDateTime(globalStartDateTime)
+                .setEndDateTime(globeEndDateTime)
+                .setRange(globalRange)
+                .setBucketOption(bucketOption)
+                .build());
     }
     
     private static Stream<Arguments> validGlobalTimeRangeOptions() {
@@ -105,7 +143,7 @@ class ScanOptionsTest {
         );
     }
 
-    private static Stream<Arguments> invalidGlobalTimeRangeOptions() {
+    private static Stream<Arguments> invalidTimeRangeOptions() {
         return Stream.of(
                 Arguments.of(LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-04-21T18:00:00"),
                         Duration.parse("P90DT3H4M")),
@@ -116,22 +154,65 @@ class ScanOptionsTest {
     }
 
     private static Stream<Arguments> validBucketTimeRangeOptions() {
-        final String bucket1 = "name: bucket_name\n" +
-                "start_time: 2023-01-21T18:00:00\n" +
-                "end_time: 2023-01-24T18:00:00";
-        final String bucket2 = "name: bucket_name\n" +
-                "start_time: 2023-01-21T18:00:00\n" +
-                "range: P3D";
-        final String bucket3 = "name: bucket_name\n" +
-                "range: P3D\n" +
-                "end_time: 2023-01-24T18:00:00";
-        final String bucket4 = "name: bucket_name";
         return Stream.of(
-                Arguments.of(bucket1, LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
-                Arguments.of(bucket2, LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
-                Arguments.of(bucket3, LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
-                Arguments.of(bucket4, null, null)
+                Arguments.of(LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00"), null,
+                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
+                Arguments.of(LocalDateTime.parse("2023-01-21T18:00:00"), null, Duration.ofDays(3L),
+                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
+                Arguments.of(null, LocalDateTime.parse("2023-01-24T18:00:00"), Duration.ofDays(3L),
+                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
+                Arguments.of(null, null, null, null, null)
         );
     }
-    
+
+    private static Stream<Arguments> validCombinedTimeRangeOptions() {
+        return Stream.of(
+                Arguments.of(
+                        LocalDateTime.parse("2023-05-21T18:00:00"), null, null,
+                        null, LocalDateTime.parse("2023-05-24T18:00:00"), null,
+                        LocalDateTime.parse("2023-05-21T18:00:00"), LocalDateTime.parse("2023-05-24T18:00:00")),
+                Arguments.of(
+                        null, LocalDateTime.parse("2023-05-24T18:00:00"), null,
+                        LocalDateTime.parse("2023-05-21T18:00:00"), null, null,
+                        LocalDateTime.parse("2023-05-21T18:00:00"), LocalDateTime.parse("2023-05-24T18:00:00")),
+                Arguments.of(
+                        LocalDateTime.parse("2023-05-21T18:00:00"), null, null,
+                        null, null, Duration.ofDays(3L),
+                        LocalDateTime.parse("2023-05-21T18:00:00"), LocalDateTime.parse("2023-05-24T18:00:00")),
+                Arguments.of(
+                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00"), null,
+                        LocalDateTime.parse("2023-05-21T18:00:00"), LocalDateTime.parse("2023-05-24T18:00:00"), null,
+                        LocalDateTime.parse("2023-05-21T18:00:00"), LocalDateTime.parse("2023-05-24T18:00:00")),
+                Arguments.of(
+                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00"), null,
+                        LocalDateTime.parse("2023-05-21T18:00:00"), null, Duration.ofDays(3L),
+                        LocalDateTime.parse("2023-05-21T18:00:00"), LocalDateTime.parse("2023-05-24T18:00:00"))
+        );
+    }
+
+    private static Stream<Arguments> invalidCombinedTimeRangeOptions() {
+        return Stream.of(
+                Arguments.of(
+                        LocalDateTime.parse("2023-05-21T18:00:00"), null, null,
+                        LocalDateTime.parse("2023-05-24T18:00:00"), null, null),
+                Arguments.of(
+                        null, LocalDateTime.parse("2023-05-24T18:00:00"), null,
+                        null, LocalDateTime.parse("2023-05-21T18:00:00"), null),
+                Arguments.of(
+                        null, null, Duration.ofDays(3L),
+                        null, null, Duration.ofDays(3L)),
+                Arguments.of(
+                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00"), null,
+                        null, null, Duration.ofDays(3L)),
+                Arguments.of(
+                        LocalDateTime.parse("2023-01-21T18:00:00"), null, Duration.ofDays(3L),
+                        null, LocalDateTime.parse("2023-05-24T18:00:00"), null),
+                Arguments.of(
+                        null, LocalDateTime.parse("2023-01-24T18:00:00"), Duration.ofDays(3L),
+                        LocalDateTime.parse("2023-05-21T18:00:00"), null, null),
+                Arguments.of(
+                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00"), Duration.ofDays(3L),
+                        LocalDateTime.parse("2023-05-21T18:00:00"), LocalDateTime.parse("2023-05-24T18:00:00"), Duration.ofDays(3L))
+        );
+    }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ScanOptionsTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ScanOptionsTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.dataprepper.plugins.source.configuration.S3ScanBucketOption;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ScanOptionsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS));
+
+    @ParameterizedTest
+    @MethodSource("validGlobalTimeRangeOptions")
+    public void s3scan_options_with_valid_global_time_range_build_success(
+            LocalDateTime startDateTime, LocalDateTime endDateTime, Duration range,
+            LocalDateTime useStartDateTime, LocalDateTime useEndDateTime) throws JsonProcessingException {
+        final String buketOptionYaml = "name: bucket_name";
+        final ScanOptions scanOptions = ScanOptions.builder()
+                .setStartDateTime(startDateTime)
+                .setEndDateTime(endDateTime)
+                .setRange(range)
+                .setBucketOption(objectMapper.readValue(buketOptionYaml, S3ScanBucketOption.class))
+                .build();
+
+        assertThat(scanOptions.getUseStartDateTime(), equalTo(useStartDateTime));
+        assertThat(scanOptions.getUseEndDateTime(), equalTo(useEndDateTime));
+        assertThat(scanOptions.getBucketOption(), instanceOf(S3ScanBucketOption.class));
+        assertThat(scanOptions.getBucketOption().getName(), equalTo("bucket_name"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidGlobalTimeRangeOptions")
+    public void s3scan_options_with_invalid_global_time_range_throws_exception_when_build(
+            LocalDateTime startDateTime, LocalDateTime endDateTime, Duration range) {
+        final String buketOptionYaml = "name: bucket_name";
+        assertThrows(IllegalArgumentException.class, () -> ScanOptions.builder()
+                .setStartDateTime(startDateTime)
+                .setEndDateTime(endDateTime)
+                .setRange(range)
+                .setBucketOption(objectMapper.readValue(buketOptionYaml, S3ScanBucketOption.class))
+                .build());
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("validBucketTimeRangeOptions")
+    public void s3scan_options_with_valid_bucket_time_range_build_success(
+            String bucketOptionYaml, LocalDateTime useStartDateTime, LocalDateTime useEndDateTime) throws JsonProcessingException {
+        final ScanOptions scanOptions = ScanOptions.builder()
+                .setBucketOption(objectMapper.readValue(bucketOptionYaml, S3ScanBucketOption.class))
+                .build();
+
+        assertThat(scanOptions.getUseStartDateTime(), equalTo(useStartDateTime));
+        assertThat(scanOptions.getUseEndDateTime(), equalTo(useEndDateTime));
+        assertThat(scanOptions.getBucketOption(), instanceOf(S3ScanBucketOption.class));
+        assertThat(scanOptions.getBucketOption().getName(), equalTo("bucket_name"));
+    }
+
+    @Test
+    public void bucket_time_range_options_overrides_global_time_range_options() throws JsonProcessingException {
+        final String bucketOptionYaml = "name: bucket_name\n" +
+                "start_time: 2023-01-21T18:00:00\n" +
+                "end_time: 2023-01-24T18:00:00";
+        final ScanOptions scanOptions = ScanOptions.builder()
+                .setStartDateTime(LocalDateTime.parse("2022-05-10T18:00:00"))
+                .setEndDateTime(LocalDateTime.parse("2022-05-24T18:00:00"))
+                .setBucketOption(objectMapper.readValue(bucketOptionYaml, S3ScanBucketOption.class))
+                .build();
+
+        assertThat(scanOptions.getUseStartDateTime(), equalTo(LocalDateTime.parse("2023-01-21T18:00:00")));
+        assertThat(scanOptions.getUseEndDateTime(), equalTo(LocalDateTime.parse("2023-01-24T18:00:00")));
+        assertThat(scanOptions.getBucketOption(), instanceOf(S3ScanBucketOption.class));
+        assertThat(scanOptions.getBucketOption().getName(), equalTo("bucket_name"));
+    }
+    
+    private static Stream<Arguments> validGlobalTimeRangeOptions() {
+        return Stream.of(
+                Arguments.of(
+                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00"), null,
+                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
+                Arguments.of(LocalDateTime.parse("2023-01-21T18:00:00"), null, Duration.parse("P3D"),
+                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
+                Arguments.of(null, LocalDateTime.parse("2023-01-24T18:00:00"), Duration.parse("P3D"),
+                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
+                Arguments.of(null, null, null, null, null)
+        );
+    }
+
+    private static Stream<Arguments> invalidGlobalTimeRangeOptions() {
+        return Stream.of(
+                Arguments.of(LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-04-21T18:00:00"),
+                        Duration.parse("P90DT3H4M")),
+                Arguments.of(LocalDateTime.parse("2023-01-21T18:00:00"), null, null),
+                Arguments.of(null, LocalDateTime.parse("2023-04-21T18:00:00"), null),
+                Arguments.of(null, null, Duration.parse("P90DT3H4M"))
+        );
+    }
+
+    private static Stream<Arguments> validBucketTimeRangeOptions() {
+        final String bucket1 = "name: bucket_name\n" +
+                "start_time: 2023-01-21T18:00:00\n" +
+                "end_time: 2023-01-24T18:00:00";
+        final String bucket2 = "name: bucket_name\n" +
+                "start_time: 2023-01-21T18:00:00\n" +
+                "range: P3D";
+        final String bucket3 = "name: bucket_name\n" +
+                "range: P3D\n" +
+                "end_time: 2023-01-24T18:00:00";
+        final String bucket4 = "name: bucket_name";
+        return Stream.of(
+                Arguments.of(bucket1, LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
+                Arguments.of(bucket2, LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
+                Arguments.of(bucket3, LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
+                Arguments.of(bucket4, null, null)
+        );
+    }
+    
+}

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ScanOptionsTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ScanOptionsTest.java
@@ -72,6 +72,21 @@ class ScanOptionsTest {
     }
 
     @ParameterizedTest
+    @MethodSource("invalidTimeRangeOptions")
+    public void s3scan_options_with_invalid_bucket_time_range_throws_exception_when_build(
+            LocalDateTime bucketStartDateTime, LocalDateTime bucketEndDateTime, Duration bucketRange
+    ) throws NoSuchFieldException, IllegalAccessException {
+        S3ScanBucketOption bucketOption = new S3ScanBucketOption();
+        setField(S3ScanBucketOption.class, bucketOption, "name", "bucket_name");
+        setField(S3ScanBucketOption.class, bucketOption, "startTime", bucketStartDateTime);
+        setField(S3ScanBucketOption.class, bucketOption, "endTime", bucketEndDateTime);
+        setField(S3ScanBucketOption.class, bucketOption, "range", bucketRange);
+        assertThrows(IllegalArgumentException.class, () -> ScanOptions.builder()
+                .setBucketOption(bucketOption)
+                .build());
+    }
+
+    @ParameterizedTest
     @MethodSource("validCombinedTimeRangeOptions")
     public void s3scan_options_with_valid_combined_time_range_build_success(
             LocalDateTime globalStartDateTime, LocalDateTime globeEndDateTime, Duration globalRange,
@@ -93,21 +108,6 @@ class ScanOptionsTest {
         assertThat(scanOptions.getUseEndDateTime(), equalTo(useEndDateTime));
         assertThat(scanOptions.getBucketOption(), instanceOf(S3ScanBucketOption.class));
         assertThat(scanOptions.getBucketOption().getName(), equalTo("bucket_name"));
-    }
-
-    @ParameterizedTest
-    @MethodSource("invalidTimeRangeOptions")
-    public void s3scan_options_with_valid_combined_time_range_build_success(
-            LocalDateTime bucketStartDateTime, LocalDateTime bucketEndDateTime, Duration bucketRange
-    ) throws NoSuchFieldException, IllegalAccessException {
-        S3ScanBucketOption bucketOption = new S3ScanBucketOption();
-        setField(S3ScanBucketOption.class, bucketOption, "name", "bucket_name");
-        setField(S3ScanBucketOption.class, bucketOption, "startTime", bucketStartDateTime);
-        setField(S3ScanBucketOption.class, bucketOption, "endTime", bucketEndDateTime);
-        setField(S3ScanBucketOption.class, bucketOption, "range", bucketRange);
-        assertThrows(IllegalArgumentException.class, () -> ScanOptions.builder()
-                .setBucketOption(bucketOption)
-                .build());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Description
This PR made the following changes:
- Makes time range settings optional (start_time, end_time, range). When they are not set, scan all objects
- Allows setting time range on specific bucket, and it will override top-level time range settings
 
### Issues Resolved
Resolves #2737 
Resolves #2735 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
