### PR TITLE
Fix silent dropping of data when index format has null keys, write to dlq if configured

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.commons.lang3.StringUtils;
+import org.opensearch.dataprepper.model.event.exceptions.EventKeyNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -309,7 +310,7 @@ public class JacksonEvent implements Event {
             String name = format.substring(position + 2, endPosition);
             Object val = this.get(name, Object.class);
             if (val == null) {
-                return null;
+                throw new EventKeyNotFoundException(String.format("The key %s could not be found in the Event when formatting", name));
             }
             result += val.toString();
             fromIndex = endPosition + 1;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/exceptions/EventKeyNotFoundException.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/exceptions/EventKeyNotFoundException.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.event.exceptions;
+
+public class EventKeyNotFoundException extends RuntimeException {
+    public EventKeyNotFoundException(final String message) {
+        super(message);
+    }
+}

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.model.event.exceptions.EventKeyNotFoundException;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -554,7 +555,7 @@ public class JacksonEventTest {
                 .withData(jsonString)
                 .getThis()
                 .build();
-        assertThat(event.formatString("test-${boo}-string"), is(equalTo(null)));
+        assertThrows(EventKeyNotFoundException.class, () -> event.formatString("test-${boo}-string"));
     }
 
     @Test

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessor.java
@@ -10,6 +10,7 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.exceptions.EventKeyNotFoundException;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.record.Record;
@@ -55,7 +56,11 @@ public class AddEntryProcessor extends AbstractProcessor<Record<Event>, Record<E
                     if (!Objects.isNull(entry.getValueExpression())) {
                         value = expressionEvaluator.evaluate(entry.getValueExpression(), recordEvent);
                     } else if (!Objects.isNull(entry.getFormat())) {
-                        value = recordEvent.formatString(entry.getFormat());
+                        try {
+                            value = recordEvent.formatString(entry.getFormat());
+                        } catch (final EventKeyNotFoundException e) {
+                            value = null;
+                        }
                     } else {
                         value = entry.getValue();
                     }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -24,6 +24,7 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.exceptions.EventKeyNotFoundException;
 import org.opensearch.dataprepper.model.failures.DlqObject;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
@@ -182,7 +183,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     final int maxRetries = openSearchSinkConfig.getRetryConfiguration().getMaxRetries();
     bulkRetryStrategy = new BulkRetryStrategy(
             bulkRequest -> openSearchClient.bulk(bulkRequest.getRequest()),
-            this::logFailure,
+            this::logFailureForBulkRequests,
             pluginMetrics,
             maxRetries,
             bulkRequestSupplier,
@@ -214,8 +215,16 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
       String indexName = configuredIndexAlias;
       try {
           indexName = indexManager.getIndexName(event.formatString(indexName));
-      } catch (IOException e) {
+      } catch (IOException | EventKeyNotFoundException e) {
+          LOG.error(SENSITIVE, "There was an exception when constructing the index name for Event[{}]: {}", event.toJsonString(), e.getMessage());
           dynamicIndexDroppedEvents.increment();
+          logFailureForDlqObjects(List.of(DlqObject.builder()
+                  .withEventHandle(event.getEventHandle())
+                  .withFailedData(FailedDlqData.builder().withDocument(event.toJsonString()).withIndex(indexName).withMessage(e.getMessage()).build())
+                  .withPluginName(pluginSetting.getName())
+                  .withPipelineName(pluginSetting.getPipelineName())
+                  .withPluginId(pluginSetting.getName())
+                  .build()), e);
           continue;
       }
 
@@ -290,19 +299,23 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     });
   }
 
-  private void logFailure(final List<FailedBulkOperation> failedBulkOperations, final Throwable failure) {
+  private void logFailureForBulkRequests(final List<FailedBulkOperation> failedBulkOperations, final Throwable failure) {
 
     final List<DlqObject> dlqObjects = failedBulkOperations.stream()
         .map(failedBulkOperationConverter::convertToDlqObject)
         .collect(Collectors.toList());
 
+    logFailureForDlqObjects(dlqObjects, failure);
+  }
+
+  private void logFailureForDlqObjects(final List<DlqObject> dlqObjects, final Throwable failure) {
     if (dlqFileWriter != null) {
       dlqObjects.forEach(dlqObject -> {
         final FailedDlqData failedDlqData = (FailedDlqData) dlqObject.getFailedData();
         final String message = failure == null ? failedDlqData.getMessage() : failure.getMessage();
         try {
           dlqFileWriter.write(String.format("{\"Document\": [%s], \"failure\": %s}\n",
-              BulkOperationWriter.dlqObjectToString(dlqObject), message));
+                  BulkOperationWriter.dlqObjectToString(dlqObject), message));
           dlqObject.releaseEventHandle(true);
         } catch (final IOException e) {
           LOG.error(SENSITIVE, "DLQ failure for Document[{}]", dlqObject.getFailedData(), e);

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DynamicIndexManagerTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DynamicIndexManagerTests.java
@@ -5,35 +5,34 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;
 
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.opensearch.client.IndicesClient;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.cluster.GetClusterSettingsResponse;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.event.exceptions.EventKeyNotFoundException;
 import org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSinkConfiguration;
 
 import java.io.IOException;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Optional;
-import java.time.format.DateTimeFormatter;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
-
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertThrows;
-import org.apache.commons.lang3.RandomStringUtils;
 
 public class DynamicIndexManagerTests {
 
@@ -164,6 +163,6 @@ public class DynamicIndexManagerTests {
         String configuredIndexAlias = openSearchSinkConfiguration.getIndexConfiguration().getIndexAlias();
 
         JacksonEvent event = JacksonEvent.builder().withEventType(EVENT_TYPE).withData(Map.of(RandomStringUtils.randomAlphabetic(10), DYNAMIC)).build();
-        assertThrows(IOException.class, () -> dynamicIndexManager.getIndexName(event.formatString(configuredIndexAlias)));
+        assertThrows(EventKeyNotFoundException.class, () -> dynamicIndexManager.getIndexName(event.formatString(configuredIndexAlias)));
     }
 }


### PR DESCRIPTION
### Description
This change fixes an issue where the opensearch sink was dropping Events without logging an error or writing the Events to the dlq when the `index` format contained keys that did not exist in the Event. 

Now any exception during index name constructed will not drop the Event silently, but will log the error and write to the dlq if it exists

 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
