### PR TITLE
Updated s3 sink metrics

### DIFF
--- a/data-prepper-plugins/s3-sink/README.md
+++ b/data-prepper-plugins/s3-sink/README.md
@@ -59,6 +59,19 @@ pipeline:
 
 - `buffer_type` (Optional) : Records stored temporary before flushing into s3 bucket. Possible values are `local_file` and `in_memory`. Defaults to `in_memory`.
 
+## Metrics
+
+### Counters
+
+* `s3SinkObjectsSucceeded` - The number of S3 objects that the S3 sink has successfully written to S3.
+* `s3SinkObjectsFailed` - The number of S3 objects that the S3 sink failed to write to S3.
+* `s3SinkObjectsEventsSucceeded` - The number of records that the S3 sink has successfully written to S3.
+* `s3SinkObjectsEventsFailed` - The number of records that the S3 sink has failed to write to S3.
+
+### Distribution Summaries
+
+* `s3SinkObjectSizeBytes` - Measures the distribution of the S3 request's payload size in bytes.
+
 
 ## Developer Guide
 

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/S3SinkService.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/S3SinkService.java
@@ -35,11 +35,11 @@ import java.util.concurrent.locks.ReentrantLock;
 public class S3SinkService {
 
     private static final Logger LOG = LoggerFactory.getLogger(S3SinkService.class);
-    public static final String OBJECTS_SUCCEEDED = "s3ObjectsSucceeded";
-    public static final String OBJECTS_FAILED = "s3ObjectsFailed";
-    public static final String NUMBER_OF_RECORDS_FLUSHED_TO_S3_SUCCESS = "s3ObjectsEventsSucceeded";
-    public static final String NUMBER_OF_RECORDS_FLUSHED_TO_S3_FAILED = "s3ObjectsEventsFailed";
-    static final String S3_OBJECTS_SIZE = "s3ObjectSizeBytes";
+    public static final String OBJECTS_SUCCEEDED = "s3SinkObjectsSucceeded";
+    public static final String OBJECTS_FAILED = "s3SinkObjectsFailed";
+    public static final String NUMBER_OF_RECORDS_FLUSHED_TO_S3_SUCCESS = "s3SinkObjectsEventsSucceeded";
+    public static final String NUMBER_OF_RECORDS_FLUSHED_TO_S3_FAILED = "s3SinkObjectsEventsFailed";
+    static final String S3_OBJECTS_SIZE = "s3SinkObjectSizeBytes";
     private final S3SinkConfig s3SinkConfig;
     private final Lock reentrantLock;
     private final BufferFactory bufferFactory;


### PR DESCRIPTION
### Description
Rename s3 sink metrics because of naming conflict with S3 source
 
### Issues Resolved
Resolves #2887
 
### Check List
- [ ] New functionality includes testing.
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
