### PR TITLE
Do not suppress logs when there are exception in s3 source.

### DIFF
--- a/data-prepper-plugins/parquet-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetInputCodecTest.java
+++ b/data-prepper-plugins/parquet-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetInputCodecTest.java
@@ -157,8 +157,6 @@ public class ParquetInputCodecTest {
 
         final List<Record<Event>> actualRecords = recordArgumentCaptor.getAllValues();
         for (final Record<Event> record: actualRecords) {
-            String s = record.getData().toString();
-            System.out.println(s);
             final String arch = record.getData().get("architecture", String.class);
             assertThat(arch, startsWith("x86"));
         }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3InputFile.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3InputFile.java
@@ -6,21 +6,24 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
-import java.util.concurrent.atomic.LongAdder;
-
 public class S3InputFile implements InputFile {
 
-    private S3Client s3Client;
+    private final S3Client s3Client;
 
-    private S3ObjectReference s3ObjectReference;
+    private final S3ObjectReference s3ObjectReference;
 
-    private LongAdder bytesCounter;
+    private final S3ObjectPluginMetrics s3ObjectPluginMetrics;
 
     private HeadObjectResponse metadata;
 
-    public S3InputFile(final S3Client s3Client, final S3ObjectReference s3ObjectReference) {
+    public S3InputFile(
+        final S3Client s3Client,
+        final S3ObjectReference s3ObjectReference,
+        final S3ObjectPluginMetrics s3ObjectPluginMetrics
+    ) {
         this.s3Client = s3Client;
         this.s3ObjectReference = s3ObjectReference;
+        this.s3ObjectPluginMetrics = s3ObjectPluginMetrics;
     }
 
     /**
@@ -39,21 +42,8 @@ public class S3InputFile implements InputFile {
      */
     @Override
     public SeekableInputStream newStream() {
-        bytesCounter = new LongAdder();
 
-        return new S3InputStream(s3Client, s3ObjectReference, getMetadata(), bytesCounter);
-    }
-
-    /**
-     * Get the count of bytes read from the S3 object
-     * @return
-     */
-    public long getBytesCount() {
-        if (bytesCounter == null) {
-            return 0;
-        }
-
-        return bytesCounter.longValue();
+        return new S3InputStream(s3Client, s3ObjectReference, getMetadata(), s3ObjectPluginMetrics);
     }
 
     /**

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorker.java
@@ -15,9 +15,7 @@ import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import org.opensearch.dataprepper.plugins.source.ownership.BucketOwnerProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -76,7 +74,7 @@ class S3ObjectWorker implements S3ObjectHandler {
 
         LOG.info("Read S3 object: {}", s3ObjectReference);
 
-        final S3InputFile inputFile = new S3InputFile(s3Client, s3ObjectReference);
+        final S3InputFile inputFile = new S3InputFile(s3Client, s3ObjectReference, s3ObjectPluginMetrics);
 
         final CompressionOption fileCompressionOption = compressionOption != CompressionOption.AUTOMATIC ?
                 compressionOption : CompressionOption.fromFileName(s3ObjectReference.getKey());
@@ -95,13 +93,9 @@ class S3ObjectWorker implements S3ObjectHandler {
                     LOG.error("Failed writing S3 objects to buffer due to: {}", e.getMessage());
                 }
             });
-            totalBytesRead = inputFile.getBytesCount();
         } catch (final Exception ex) {
             s3ObjectPluginMetrics.getS3ObjectsFailedCounter().increment();
-            if (ex instanceof S3Exception) {
-                LOG.error("Error reading from S3 object: s3ObjectReference={}. {}", s3ObjectReference, ex.getMessage());
-                recordS3Exception((S3Exception) ex);
-            }
+            LOG.error("Error reading from S3 object: s3ObjectReference={}. {}", s3ObjectReference, ex.getMessage());
             throw ex;
         }
 
@@ -118,15 +112,6 @@ class S3ObjectWorker implements S3ObjectHandler {
             s3ObjectPluginMetrics.getS3ObjectNoRecordsFound().increment();
         }
         s3ObjectPluginMetrics.getS3ObjectSizeSummary().record(s3ObjectSize);
-        s3ObjectPluginMetrics.getS3ObjectSizeProcessedSummary().record(totalBytesRead);
         s3ObjectPluginMetrics.getS3ObjectEventsSummary().record(recordsWritten);
-    }
-
-    private void recordS3Exception(final S3Exception ex) {
-        if (ex.statusCode() == HttpStatusCode.NOT_FOUND) {
-            s3ObjectPluginMetrics.getS3ObjectsFailedNotFoundCounter().increment();
-        } else if (ex.statusCode() == HttpStatusCode.FORBIDDEN) {
-            s3ObjectPluginMetrics.getS3ObjectsFailedAccessDeniedCounter().increment();
-        }
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3InputFileTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3InputFileTest.java
@@ -3,16 +3,9 @@ package org.opensearch.dataprepper.plugins.source;
 import org.apache.parquet.io.SeekableInputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -26,14 +19,16 @@ public class S3InputFileTest {
 
     private S3Client s3Client;
     private S3ObjectReference s3ObjectReference;
+    private S3ObjectPluginMetrics s3ObjectPluginMetrics;
     private S3InputFile s3InputFile;
 
     @BeforeEach
     public void setUp() {
         s3Client = mock(S3Client.class);
         s3ObjectReference = mock(S3ObjectReference.class);
+        s3ObjectPluginMetrics = mock(S3ObjectPluginMetrics.class);
 
-        s3InputFile = new S3InputFile(s3Client, s3ObjectReference);
+        s3InputFile = new S3InputFile(s3Client, s3ObjectReference, s3ObjectPluginMetrics);
     }
 
     @Test
@@ -58,29 +53,4 @@ public class S3InputFileTest {
         assertThat(seekableInputStream.getClass(), equalTo(S3InputStream.class));
     }
 
-    @Test
-    public void testGetBytesCount_beforeNewStream() {
-        long bytesCount = s3InputFile.getBytesCount();
-
-        assertThat(bytesCount, equalTo(0L));
-    }
-
-    @Test
-    public void testGetBytesCount_afterNewStream() throws IOException {
-        HeadObjectResponse headObjectResponse = mock(HeadObjectResponse.class);
-        when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
-        when(headObjectResponse.contentLength()).thenReturn(9L);
-        SeekableInputStream seekableInputStream = s3InputFile.newStream();
-
-        // Perform read operations with the seekableInputStream to update the bytesCounter
-        InputStream inputStream = new ByteArrayInputStream("Test data".getBytes(StandardCharsets.UTF_8));
-        when(s3Client.getObject(any(GetObjectRequest.class), any(ResponseTransformer.class))).thenReturn(inputStream);
-        final byte[] buffer = new byte[9];
-        int read = seekableInputStream.read(buffer);
-
-        assertThat(read, equalTo(9));
-
-        long bytesCount = s3InputFile.getBytesCount();
-        assertThat(bytesCount, equalTo(9L));
-    }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorkerTest.java
@@ -175,7 +175,6 @@ class S3ObjectWorkerTest {
     void parseS3Object_calls_getObject_with_correct_GetObjectRequest() throws IOException {
         when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
         when(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).thenReturn(s3ObjectEventsSummary);
-        when(s3ObjectPluginMetrics.getS3ObjectSizeProcessedSummary()).thenReturn(s3ObjectSizeProcessedSummary);
         when(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).thenReturn(s3ObjectsSucceededCounter);
         when(s3ObjectPluginMetrics.getS3ObjectSizeSummary()).thenReturn(s3ObjectSizeSummary);
         when(s3ObjectPluginMetrics.getS3ObjectNoRecordsFound()).thenReturn(s3ObjectNoRecordsFound);
@@ -187,7 +186,6 @@ class S3ObjectWorkerTest {
     void parseS3Object_calls_getObject_with_correct_GetObjectRequest_with_AcknowledgementSet() throws IOException {
         when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
         when(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).thenReturn(s3ObjectEventsSummary);
-        when(s3ObjectPluginMetrics.getS3ObjectSizeProcessedSummary()).thenReturn(s3ObjectSizeProcessedSummary);
         when(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).thenReturn(s3ObjectsSucceededCounter);
         when(s3ObjectPluginMetrics.getS3ObjectSizeSummary()).thenReturn(s3ObjectSizeSummary);
 
@@ -209,7 +207,6 @@ class S3ObjectWorkerTest {
         final String bucketOwner = UUID.randomUUID().toString();
         lenient().when(bucketOwnerProvider.getBucketOwner(bucketName)).thenReturn(Optional.of(bucketOwner));
         when(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).thenReturn(s3ObjectEventsSummary);
-        when(s3ObjectPluginMetrics.getS3ObjectSizeProcessedSummary()).thenReturn(s3ObjectSizeProcessedSummary);
         when(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).thenReturn(s3ObjectsSucceededCounter);
         when(s3ObjectPluginMetrics.getS3ObjectSizeSummary()).thenReturn(s3ObjectSizeSummary);
         when(s3ObjectPluginMetrics.getS3ObjectNoRecordsFound()).thenReturn(s3ObjectNoRecordsFound);
@@ -220,7 +217,6 @@ class S3ObjectWorkerTest {
     void parseS3Object_calls_Codec_parse_on_S3InputStream() throws Exception {
         when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
         when(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).thenReturn(s3ObjectEventsSummary);
-        when(s3ObjectPluginMetrics.getS3ObjectSizeProcessedSummary()).thenReturn(s3ObjectSizeProcessedSummary);
         when(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).thenReturn(s3ObjectsSucceededCounter);
         when(s3ObjectPluginMetrics.getS3ObjectSizeSummary()).thenReturn(s3ObjectSizeSummary);
         when(s3ObjectPluginMetrics.getS3ObjectNoRecordsFound()).thenReturn(s3ObjectNoRecordsFound);
@@ -254,7 +250,6 @@ class S3ObjectWorkerTest {
     void parseS3Object_calls_Codec_parse_with_Consumer_that_adds_to_BufferAccumulator() throws Exception {
         when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
         when(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).thenReturn(s3ObjectEventsSummary);
-        when(s3ObjectPluginMetrics.getS3ObjectSizeProcessedSummary()).thenReturn(s3ObjectSizeProcessedSummary);
         when(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).thenReturn(s3ObjectsSucceededCounter);
         when(s3ObjectPluginMetrics.getS3ObjectSizeSummary()).thenReturn(s3ObjectSizeSummary);
         when(s3ObjectPluginMetrics.getS3ObjectNoRecordsFound()).thenReturn(s3ObjectNoRecordsFound);
@@ -286,7 +281,6 @@ class S3ObjectWorkerTest {
     void parseS3Object_calls_BufferAccumulator_flush_after_Codec_parse() throws Exception {
         when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
         when(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).thenReturn(s3ObjectEventsSummary);
-        when(s3ObjectPluginMetrics.getS3ObjectSizeProcessedSummary()).thenReturn(s3ObjectSizeProcessedSummary);
         when(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).thenReturn(s3ObjectsSucceededCounter);
         when(s3ObjectPluginMetrics.getS3ObjectSizeSummary()).thenReturn(s3ObjectSizeSummary);
         when(s3ObjectPluginMetrics.getS3ObjectNoRecordsFound()).thenReturn(s3ObjectNoRecordsFound);
@@ -309,7 +303,6 @@ class S3ObjectWorkerTest {
         when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
         when(s3ObjectPluginMetrics.getS3ObjectReadTimer()).thenReturn(s3ObjectReadTimer);
         when(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).thenReturn(s3ObjectEventsSummary);
-        when(s3ObjectPluginMetrics.getS3ObjectSizeProcessedSummary()).thenReturn(s3ObjectSizeProcessedSummary);
         when(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).thenReturn(s3ObjectsSucceededCounter);
         when(s3ObjectPluginMetrics.getS3ObjectSizeSummary()).thenReturn(s3ObjectSizeSummary);
         when(s3ObjectPluginMetrics.getS3ObjectNoRecordsFound()).thenReturn(s3ObjectNoRecordsFound);
@@ -360,49 +353,9 @@ class S3ObjectWorkerTest {
     }
 
     @Test
-    void parseS3Object_throws_Exception_and_increments_NotFound_counter_when_GetObject_from_S3_is_404() {
-        final S3Exception expectedException = mock(S3Exception.class);
-        when(expectedException.statusCode()).thenReturn(404);
-        when(s3Client.headObject(any(HeadObjectRequest.class))).thenThrow(expectedException);
-        when(s3ObjectPluginMetrics.getS3ObjectsFailedCounter()).thenReturn(s3ObjectsFailedCounter);
-        when(s3ObjectPluginMetrics.getS3ObjectsFailedNotFoundCounter()).thenReturn(s3ObjectsFailedNotFoundCounter);
-
-        final S3ObjectHandler objectUnderTest = createObjectUnderTest(s3ObjectPluginMetrics);
-        final S3Exception actualException = assertThrows(S3Exception.class, () -> objectUnderTest.parseS3Object(s3ObjectReference, acknowledgementSet));
-
-        assertThat(actualException, sameInstance(expectedException));
-
-        verify(s3ObjectsFailedCounter).increment();
-        verify(s3ObjectsFailedNotFoundCounter).increment();
-        verifyNoInteractions(s3ObjectsSucceededCounter);
-        verifyNoInteractions(s3ObjectsFailedAccessDeniedCounter);
-        assertThat(exceptionThrownByCallable, sameInstance(expectedException));
-    }
-
-    @Test
-    void parseS3Object_throws_Exception_and_increments_NotFound_counter_when_GetObject_from_S3_is_403() {
-        final S3Exception expectedException = mock(S3Exception.class);
-        when(expectedException.statusCode()).thenReturn(403);
-        when(s3Client.headObject(any(HeadObjectRequest.class))).thenThrow(expectedException);
-        when(s3ObjectPluginMetrics.getS3ObjectsFailedCounter()).thenReturn(s3ObjectsFailedCounter);
-        when(s3ObjectPluginMetrics.getS3ObjectsFailedAccessDeniedCounter()).thenReturn(s3ObjectsFailedAccessDeniedCounter);
-        final S3ObjectHandler objectUnderTest = createObjectUnderTest(s3ObjectPluginMetrics);
-        final S3Exception actualException = assertThrows(S3Exception.class, () -> objectUnderTest.parseS3Object(s3ObjectReference, acknowledgementSet));
-
-        assertThat(actualException, sameInstance(expectedException));
-
-        verify(s3ObjectsFailedCounter).increment();
-        verify(s3ObjectsFailedAccessDeniedCounter).increment();
-        verifyNoInteractions(s3ObjectsSucceededCounter);
-        verifyNoInteractions(s3ObjectsFailedNotFoundCounter);
-        assertThat(exceptionThrownByCallable, sameInstance(expectedException));
-    }
-
-    @Test
     void parseS3Object_calls_HeadObject_after_Callable() throws Exception {
         when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
         when(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).thenReturn(s3ObjectEventsSummary);
-        when(s3ObjectPluginMetrics.getS3ObjectSizeProcessedSummary()).thenReturn(s3ObjectSizeProcessedSummary);
         when(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).thenReturn(s3ObjectsSucceededCounter);
         when(s3ObjectPluginMetrics.getS3ObjectSizeSummary()).thenReturn(s3ObjectSizeSummary);
         when(s3ObjectPluginMetrics.getS3ObjectNoRecordsFound()).thenReturn(s3ObjectNoRecordsFound);
@@ -421,7 +374,6 @@ class S3ObjectWorkerTest {
         when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
 
         when(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).thenReturn(s3ObjectEventsSummary);
-        when(s3ObjectPluginMetrics.getS3ObjectSizeProcessedSummary()).thenReturn(s3ObjectSizeProcessedSummary);
         when(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).thenReturn(s3ObjectsSucceededCounter);
         when(s3ObjectPluginMetrics.getS3ObjectSizeSummary()).thenReturn(s3ObjectSizeSummary);
 
@@ -441,7 +393,6 @@ class S3ObjectWorkerTest {
     void parseS3Object_records_S3_ObjectSize() throws IOException {
         when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
         when(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).thenReturn(s3ObjectEventsSummary);
-        when(s3ObjectPluginMetrics.getS3ObjectSizeProcessedSummary()).thenReturn(s3ObjectSizeProcessedSummary);
         when(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).thenReturn(s3ObjectsSucceededCounter);
         when(s3ObjectPluginMetrics.getS3ObjectSizeSummary()).thenReturn(s3ObjectSizeSummary);
         when(s3ObjectPluginMetrics.getS3ObjectNoRecordsFound()).thenReturn(s3ObjectNoRecordsFound);
@@ -455,7 +406,6 @@ class S3ObjectWorkerTest {
     void parseS3Object_records_S3_Object_No_Records_Found() throws IOException {
         when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
         when(s3ObjectPluginMetrics.getS3ObjectEventsSummary()).thenReturn(s3ObjectEventsSummary);
-        when(s3ObjectPluginMetrics.getS3ObjectSizeProcessedSummary()).thenReturn(s3ObjectSizeProcessedSummary);
         when(s3ObjectPluginMetrics.getS3ObjectsSucceededCounter()).thenReturn(s3ObjectsSucceededCounter);
         when(s3ObjectPluginMetrics.getS3ObjectSizeSummary()).thenReturn(s3ObjectSizeSummary);
         when(s3ObjectPluginMetrics.getS3ObjectNoRecordsFound()).thenReturn(s3ObjectNoRecordsFound);


### PR DESCRIPTION
### Description
Do not suppress logs when there is an exception when reading from S3
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
