### PR TITLE
Implement searching with scroll contexts for OpenSearch

### DIFF
--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
@@ -167,7 +167,7 @@ public class PitWorker implements SearchWorker, Runnable {
         try {
             bufferAccumulator.flush();
         } catch (final Exception e) {
-            LOG.error("Failed writing remaining OpenSearch documents to buffer due to: {}", e.getMessage());
+            LOG.error("Failed flushing remaining OpenSearch documents to buffer due to: {}", e.getMessage());
         }
 
         // todo: This API call is failing with sigv4 enabled due to a mismatch in the signature. Tracking issue (https://github.com/opensearch-project/opensearch-java/issues/521)

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
@@ -8,14 +8,39 @@ import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartition;
+import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionNotFoundException;
+import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionNotOwnedException;
+import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionUpdateException;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchIndexProgressState;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessor;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchContextLimitException;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreateScrollRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreateScrollResponse;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeleteScrollRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_ID_METADATA_ATTRIBUTE_NAME;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.INDEX_METADATA_ATTRIBUTE_NAME;
 
 /**
  * ScrollWorker polls the source cluster via scroll contexts.
  */
 public class ScrollWorker implements SearchWorker {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ScrollWorker.class);
+    private static final int STANDARD_BACKOFF_MILLIS = 30_000;
+    private static final Duration BACKOFF_ON_SCROLL_LIMIT_REACHED = Duration.ofSeconds(120);
+    static final String SCROLL_TIME_PER_BATCH = "1m";
 
     private final SearchAccessor searchAccessor;
     private final OpenSearchSourceConfiguration openSearchSourceConfiguration;
@@ -37,6 +62,102 @@ public class ScrollWorker implements SearchWorker {
 
     @Override
     public void run() {
-        // todo: implement
+        while (!Thread.currentThread().isInterrupted()) {
+            final Optional<SourcePartition<OpenSearchIndexProgressState>> indexPartition = sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier);
+
+            if (indexPartition.isEmpty()) {
+                try {
+                    Thread.sleep(STANDARD_BACKOFF_MILLIS);
+                    continue;
+                } catch (final InterruptedException e) {
+                    LOG.info("The PitWorker was interrupted while sleeping after acquiring no indices to process, stopping processing");
+                    return;
+                }
+            }
+
+            try {
+                processIndex(indexPartition.get());
+
+                sourceCoordinator.closePartition(
+                        indexPartition.get().getPartitionKey(),
+                        openSearchSourceConfiguration.getSchedulingParameterConfiguration().getRate(),
+                        openSearchSourceConfiguration.getSchedulingParameterConfiguration().getJobCount());
+            } catch (final PartitionUpdateException | PartitionNotFoundException | PartitionNotOwnedException e) {
+                LOG.warn("ScrollWorker received an exception from the source coordinator. There is a potential for duplicate data for index {}, giving up partition and getting next partition: {}", indexPartition.get().getPartitionKey(), e.getMessage());
+                sourceCoordinator.giveUpPartitions();
+            } catch (final SearchContextLimitException e) {
+                LOG.warn("Received SearchContextLimitExceeded exception for index {}. Giving up index and waiting {} seconds before retrying: {}",
+                        indexPartition.get().getPartitionKey(), BACKOFF_ON_SCROLL_LIMIT_REACHED.getSeconds(), e.getMessage());
+                sourceCoordinator.giveUpPartitions();
+                try {
+                    Thread.sleep(BACKOFF_ON_SCROLL_LIMIT_REACHED.toMillis());
+                } catch (final InterruptedException ex) {
+                    return;
+                }
+            } catch (final RuntimeException e) {
+                LOG.error("Unknown exception while processing index '{}':", indexPartition.get().getPartitionKey(), e);
+                sourceCoordinator.giveUpPartitions();
+            }
+        }
+    }
+
+    private void processIndex(final SourcePartition<OpenSearchIndexProgressState> openSearchIndexPartition) {
+        final String indexName = openSearchIndexPartition.getPartitionKey();
+
+        final Integer batchSize = openSearchSourceConfiguration.getSearchConfiguration().getBatchSize();
+
+        final CreateScrollResponse createScrollResponse = searchAccessor.createScroll(CreateScrollRequest.builder()
+                .withScrollTime(SCROLL_TIME_PER_BATCH)
+                .withSize(openSearchSourceConfiguration.getSearchConfiguration().getBatchSize())
+                .withIndex(indexName)
+                .build());
+
+        writeDocumentsToBuffer(createScrollResponse.getDocuments());
+
+        SearchScrollResponse searchScrollResponse = null;
+
+        if (createScrollResponse.getDocuments().size() == batchSize) {
+            do {
+                try {
+                    searchScrollResponse = searchAccessor.searchWithScroll(SearchScrollRequest.builder()
+                            .withScrollId(Objects.nonNull(searchScrollResponse) && Objects.nonNull(searchScrollResponse.getScrollId()) ? searchScrollResponse.getScrollId() : createScrollResponse.getScrollId())
+                            .withScrollTime(SCROLL_TIME_PER_BATCH)
+                            .build());
+
+                    writeDocumentsToBuffer(searchScrollResponse.getDocuments());
+                    sourceCoordinator.saveProgressStateForPartition(indexName, null);
+                } catch (final Exception e) {
+                    deleteScroll(createScrollResponse.getScrollId());
+                    throw e;
+                }
+            } while (searchScrollResponse.getDocuments().size() == batchSize);
+        }
+
+        deleteScroll(createScrollResponse.getScrollId());
+
+        try {
+            bufferAccumulator.flush();
+        } catch (final Exception e) {
+            LOG.error("Failed flushing remaining OpenSearch documents to buffer due to: {}", e.getMessage());
+        }
+    }
+
+    private void writeDocumentsToBuffer(final List<Event> documents) {
+        documents.stream().map(Record::new).forEach(record -> {
+            try {
+                bufferAccumulator.add(record);
+            } catch (Exception e) {
+                LOG.error("Failed writing OpenSearch documents to buffer. The last document created has document id '{}' from index '{}' : {}",
+                        record.getData().getMetadata().getAttribute(DOCUMENT_ID_METADATA_ATTRIBUTE_NAME),
+                        record.getData().getMetadata().getAttribute(INDEX_METADATA_ATTRIBUTE_NAME), e.getMessage());
+            }
+        });
+    }
+
+    // todo: This API call is failing with sigv4 enabled due to a mismatch in the signature. Tracking issue (https://github.com/opensearch-project/opensearch-java/issues/521)
+    private void deleteScroll(final String scrollId) {
+        searchAccessor.deleteScroll(DeleteScrollRequest.builder()
+                .withScrollId(scrollId)
+                .build());
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/CreateScrollRequest.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/CreateScrollRequest.java
@@ -6,6 +6,55 @@ package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model
 
 public class CreateScrollRequest {
 
-    // todo: model after https://opensearch.org/docs/latest/api-reference/scroll/ &
-    // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html
+    private final String index;
+    private final String scrollTime;
+    private final Integer size;
+
+    public String getIndex() {
+        return index;
+    }
+
+    public Integer getSize() { return size; }
+
+    public String getScrollTime() { return scrollTime; }
+
+    private CreateScrollRequest(final CreateScrollRequest.Builder builder) {
+        this.index = builder.index;
+        this.size = builder.size;
+        this.scrollTime = builder.scrollTime;
+    }
+
+    public static CreateScrollRequest.Builder builder() {
+        return new CreateScrollRequest.Builder();
+    }
+
+    public static class Builder {
+
+        private String index;
+        private Integer size;
+        private String scrollTime;
+
+        public Builder() {
+
+        }
+
+        public CreateScrollRequest.Builder withSize(final Integer size) {
+            this.size = size;
+            return this;
+        }
+
+        public CreateScrollRequest.Builder withIndex(final String index) {
+            this.index = index;
+            return this;
+        }
+
+        public CreateScrollRequest.Builder withScrollTime(final String scrollTime) {
+            this.scrollTime = scrollTime;
+            return this;
+        }
+
+        public CreateScrollRequest build() {
+            return new CreateScrollRequest(this);
+        }
+    }
 }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/CreateScrollResponse.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/CreateScrollResponse.java
@@ -4,8 +4,63 @@
  */
 package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model;
 
+import org.opensearch.dataprepper.model.event.Event;
+
+import java.util.List;
+
 public class CreateScrollResponse {
 
-    // todo: model after https://opensearch.org/docs/latest/api-reference/scroll/ &
-    // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html
+    private final String scrollId;
+    private final Long scrollCreationTime;
+    private final List<Event> documents;
+
+    public List<Event> getDocuments() {
+        return documents;
+    }
+
+    public String getScrollId() {
+        return scrollId;
+    }
+
+    public Long getScrollCreationTime() { return scrollCreationTime; }
+
+    private CreateScrollResponse(final CreateScrollResponse.Builder builder) {
+        this.scrollId = builder.scrollId;
+        this.scrollCreationTime = builder.scrollCreationTime;
+        this.documents = builder.documents;
+    }
+
+    public static CreateScrollResponse.Builder builder() {
+        return new CreateScrollResponse.Builder();
+    }
+
+    public static class Builder {
+
+        private List<Event> documents;
+        private String scrollId;
+        private Long scrollCreationTime;
+
+        public Builder() {
+
+        }
+
+        public CreateScrollResponse.Builder withDocuments(final List<Event> documents) {
+            this.documents = documents;
+            return this;
+        }
+
+        public CreateScrollResponse.Builder withScrollId(final String scrollId) {
+            this.scrollId = scrollId;
+            return this;
+        }
+
+        public CreateScrollResponse.Builder withCreationTime(final Long scrollCreationTime) {
+            this.scrollCreationTime = scrollCreationTime;
+            return this;
+        }
+
+        public CreateScrollResponse build() {
+            return new CreateScrollResponse(this);
+        }
+    }
 }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/DeleteScrollRequest.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/DeleteScrollRequest.java
@@ -1,11 +1,40 @@
 /*
- * Copyright OpenSearch Contributors
+ * Copyright OpenDelete Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model;
 
 public class DeleteScrollRequest {
 
-    // todo: model after https://opensearch.org/docs/latest/api-reference/scroll/ &
-    // https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html
+    private final String scrollId;
+
+    public String getScrollId() {
+        return scrollId;
+    }
+
+    private DeleteScrollRequest(final DeleteScrollRequest.Builder builder) {
+        this.scrollId = builder.scrollId;
+    }
+
+    public static DeleteScrollRequest.Builder builder() {
+        return new DeleteScrollRequest.Builder();
+    }
+
+    public static class Builder {
+
+        private String scrollId;
+
+        public Builder() {
+
+        }
+
+        public DeleteScrollRequest.Builder withScrollId(final String scrollId) {
+            this.scrollId = scrollId;
+            return this;
+        }
+
+        public DeleteScrollRequest build() {
+            return new DeleteScrollRequest(this);
+        }
+    }
 }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SearchScrollRequest.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SearchScrollRequest.java
@@ -6,6 +6,45 @@ package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model
 
 public class SearchScrollRequest {
 
-    // todo: model after: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html
-    // & https://opensearch.org/docs/latest/api-reference/scroll/
+    private final String scrollId;
+    private final String scrollTime;
+
+    public String getScrollId() {
+        return scrollId;
+    }
+
+    public String getScrollTime() { return scrollTime; }
+
+    private SearchScrollRequest(final SearchScrollRequest.Builder builder) {
+        this.scrollId = builder.scrollId;
+        this.scrollTime = builder.scrollTime;
+    }
+
+    public static SearchScrollRequest.Builder builder() {
+        return new SearchScrollRequest.Builder();
+    }
+
+    public static class Builder {
+
+        private String scrollId;
+        private String scrollTime;
+
+        public Builder() {
+
+        }
+
+        public SearchScrollRequest.Builder withScrollId(final String scrollId) {
+            this.scrollId = scrollId;
+            return this;
+        }
+
+        public SearchScrollRequest.Builder withScrollTime(final String scrollTime) {
+            this.scrollTime = scrollTime;
+            return this;
+        }
+
+        public SearchScrollRequest build() {
+            return new SearchScrollRequest(this);
+        }
+    }
 }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SearchScrollResponse.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/SearchScrollResponse.java
@@ -4,8 +4,51 @@
  */
 package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model;
 
+import org.opensearch.dataprepper.model.event.Event;
+
+import java.util.List;
+
 public class SearchScrollResponse {
 
-    // todo: model after: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html
-    // & https://opensearch.org/docs/latest/api-reference/scroll/
+    private final String scrollId;
+    private final List<Event> documents;
+
+    public String getScrollId() {
+        return scrollId;
+    }
+
+    public List<Event> getDocuments() { return documents; }
+
+    private SearchScrollResponse(final SearchScrollResponse.Builder builder) {
+        this.scrollId = builder.scrollId;
+        this.documents = builder.documents;
+    }
+
+    public static SearchScrollResponse.Builder builder() {
+        return new SearchScrollResponse.Builder();
+    }
+
+    public static class Builder {
+
+        private String scrollId;
+        private List<Event> documents;
+
+        public Builder() {
+
+        }
+
+        public SearchScrollResponse.Builder withScrollId(final String scrollId) {
+            this.scrollId = scrollId;
+            return this;
+        }
+
+        public SearchScrollResponse.Builder withDocuments(final List<Event> documents) {
+            this.documents = documents;
+            return this;
+        }
+
+        public SearchScrollResponse build() {
+            return new SearchScrollResponse(this);
+        }
+    }
 }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorkerTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.SourcePartition;
+import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchIndexProgressState;
+import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SchedulingParameterConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SearchConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessor;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchContextLimitException;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreateScrollRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreateScrollResponse;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeleteScrollRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollResponse;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.ScrollWorker.SCROLL_TIME_PER_BATCH;
+
+@ExtendWith(MockitoExtension.class)
+public class ScrollWorkerTest {
+
+    @Mock
+    private OpenSearchSourceConfiguration openSearchSourceConfiguration;
+
+    @Mock
+    private OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier;
+
+    @Mock
+    private SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator;
+
+    @Mock
+    private SearchAccessor searchAccessor;
+
+    @Mock
+    private BufferAccumulator<Record<Event>> bufferAccumulator;
+
+    private ExecutorService executorService;
+
+    @BeforeEach
+    void setup() {
+        executorService = Executors.newSingleThreadExecutor();
+    }
+
+    private ScrollWorker createObjectUnderTest() {
+        return new ScrollWorker(searchAccessor, openSearchSourceConfiguration, sourceCoordinator, bufferAccumulator, openSearchIndexPartitionCreationSupplier);
+    }
+
+    @Test
+    void run_with_getNextPartition_returning_empty_will_sleep_and_exit_when_interrupted() throws InterruptedException {
+        when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.empty());
+
+
+        final Future<?> future = executorService.submit(() -> createObjectUnderTest().run());
+        Thread.sleep(100);
+        executorService.shutdown();
+        future.cancel(true);
+        assertThat(future.isCancelled(), equalTo(true));
+
+        assertThat(executorService.awaitTermination(100, TimeUnit.MILLISECONDS), equalTo(true));
+    }
+
+    @Test
+    void run_with_getNextPartition_with_non_empty_partition_creates_and_deletes_scroll_and_closes_that_partition() throws Exception {
+        final SourcePartition<OpenSearchIndexProgressState> sourcePartition = mock(SourcePartition.class);
+        final String partitionKey = UUID.randomUUID().toString();
+        when(sourcePartition.getPartitionKey()).thenReturn(partitionKey);
+
+        final String scrollId = UUID.randomUUID().toString();
+        final ArgumentCaptor<CreateScrollRequest> requestArgumentCaptor = ArgumentCaptor.forClass(CreateScrollRequest.class);
+        final CreateScrollResponse createScrollResponse = mock(CreateScrollResponse.class);
+        when(createScrollResponse.getScrollId()).thenReturn(scrollId);
+        when(createScrollResponse.getDocuments()).thenReturn(List.of(mock(Event.class), mock(Event.class)));
+        when(searchAccessor.createScroll(requestArgumentCaptor.capture())).thenReturn(createScrollResponse);
+
+        final SearchConfiguration searchConfiguration = mock(SearchConfiguration.class);
+        when(searchConfiguration.getBatchSize()).thenReturn(2);
+        when(openSearchSourceConfiguration.getSearchConfiguration()).thenReturn(searchConfiguration);
+
+        final SearchScrollResponse searchScrollResponse = mock(SearchScrollResponse.class);
+        when(searchScrollResponse.getScrollId()).thenReturn(scrollId);
+        when(searchScrollResponse.getDocuments()).thenReturn(List.of(mock(Event.class), mock(Event.class)))
+                .thenReturn(List.of(mock(Event.class), mock(Event.class))).thenReturn(List.of(mock(Event.class))).thenReturn(List.of(mock(Event.class)));
+
+        final ArgumentCaptor<SearchScrollRequest> searchScrollRequestArgumentCaptor = ArgumentCaptor.forClass(SearchScrollRequest.class);
+        when(searchAccessor.searchWithScroll(searchScrollRequestArgumentCaptor.capture())).thenReturn(searchScrollResponse);
+
+        doNothing().when(bufferAccumulator).add(any(Record.class));
+        doNothing().when(bufferAccumulator).flush();
+
+        final ArgumentCaptor<DeleteScrollRequest> deleteRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteScrollRequest.class);
+        doNothing().when(searchAccessor).deleteScroll(deleteRequestArgumentCaptor.capture());
+
+        when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
+
+        final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
+        when(schedulingParameterConfiguration.getJobCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getRate()).thenReturn(Duration.ZERO);
+        when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
+
+        doNothing().when(sourceCoordinator).closePartition(partitionKey,
+                Duration.ZERO, 1);
+
+
+        final Future<?> future = executorService.submit(() -> createObjectUnderTest().run());
+        Thread.sleep(100);
+        executorService.shutdown();
+        future.cancel(true);
+        assertThat(future.isCancelled(), equalTo(true));
+
+        assertThat(executorService.awaitTermination(100, TimeUnit.MILLISECONDS), equalTo(true));
+
+        final CreateScrollRequest createScrollRequest = requestArgumentCaptor.getValue();
+        assertThat(createScrollRequest, notNullValue());
+        assertThat(createScrollRequest.getSize(), equalTo(2));
+        assertThat(createScrollRequest.getIndex(), equalTo(partitionKey));
+        assertThat(createScrollRequest.getScrollTime(), equalTo(SCROLL_TIME_PER_BATCH));
+
+        verify(searchAccessor, times(2)).searchWithScroll(any(SearchScrollRequest.class));
+        verify(sourceCoordinator, times(2)).saveProgressStateForPartition(eq(partitionKey), eq(null));
+
+        final List<SearchScrollRequest> searchScrollRequests = searchScrollRequestArgumentCaptor.getAllValues();
+        assertThat(searchScrollRequests.size(), equalTo(2));
+        assertThat(searchScrollRequests.get(0), notNullValue());
+        assertThat(searchScrollRequests.get(0).getScrollId(), equalTo(scrollId));
+        assertThat(searchScrollRequests.get(0).getScrollTime(), equalTo(SCROLL_TIME_PER_BATCH));
+
+        assertThat(searchScrollRequests.get(1), notNullValue());
+        assertThat(searchScrollRequests.get(1).getScrollId(), equalTo(scrollId));
+        assertThat(searchScrollRequests.get(1).getScrollTime(), equalTo(SCROLL_TIME_PER_BATCH));
+
+
+        final DeleteScrollRequest deleteScrollRequest = deleteRequestArgumentCaptor.getValue();
+        assertThat(deleteScrollRequest, notNullValue());
+        assertThat(deleteScrollRequest.getScrollId(), equalTo(scrollId));
+    }
+
+    @Test
+    void run_gives_up_partitions_and_waits_when_createScroll_throws_SearchContextLimitException() throws InterruptedException {
+        final SourcePartition<OpenSearchIndexProgressState> sourcePartition = mock(SourcePartition.class);
+        final String partitionKey = UUID.randomUUID().toString();
+        when(sourcePartition.getPartitionKey()).thenReturn(partitionKey);
+
+        final SearchConfiguration searchConfiguration = mock(SearchConfiguration.class);
+        when(searchConfiguration.getBatchSize()).thenReturn(2);
+        when(openSearchSourceConfiguration.getSearchConfiguration()).thenReturn(searchConfiguration);
+
+        when(searchAccessor.createScroll(any(CreateScrollRequest.class))).thenThrow(SearchContextLimitException.class);
+
+        when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition));
+
+
+        final Future<?> future = executorService.submit(() -> createObjectUnderTest().run());
+        Thread.sleep(100);
+        executorService.shutdown();
+        future.cancel(true);
+        assertThat(future.isCancelled(), equalTo(true));
+
+        assertThat(executorService.awaitTermination(100, TimeUnit.MILLISECONDS), equalTo(true));
+
+        verifyNoMoreInteractions(searchAccessor);
+        verify(sourceCoordinator).giveUpPartitions();
+        verify(sourceCoordinator, never()).closePartition(anyString(), any(Duration.class), anyInt());
+    }
+
+}

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
@@ -16,6 +16,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.ErrorCause;
 import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch.core.ClearScrollRequest;
+import org.opensearch.client.opensearch.core.ClearScrollResponse;
+import org.opensearch.client.opensearch.core.ScrollRequest;
+import org.opensearch.client.opensearch.core.ScrollResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.pit.CreatePitRequest;
@@ -28,9 +32,14 @@ import org.opensearch.client.opensearch.core.search.HitsMetadata;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchContextLimitException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeResponse;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreateScrollRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreateScrollResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeletePointInTimeRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeleteScrollRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchContextType;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchPointInTimeRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchWithSearchAfterResults;
 
 import java.io.IOException;
@@ -49,6 +58,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor.PIT_RESOURCE_LIMIT_ERROR_TYPE;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor.SCROLL_RESOURCE_LIMIT_EXCEPTION_MESSAGE;
 
 @ExtendWith(MockitoExtension.class)
 public class OpenSearchAccessorTest {
@@ -84,6 +94,50 @@ public class OpenSearchAccessorTest {
     }
 
     @Test
+    void create_scroll_returns_expected_create_scroll_response() throws IOException {
+        final String indexName = UUID.randomUUID().toString();
+        final String scrollTime = UUID.randomUUID().toString();
+        final Integer size = new Random().nextInt(10);
+
+        final CreateScrollRequest createScrollRequest = mock(CreateScrollRequest.class);
+        when(createScrollRequest.getIndex()).thenReturn(indexName);
+        when(createScrollRequest.getScrollTime()).thenReturn(scrollTime);
+        when(createScrollRequest.getSize()).thenReturn(size);
+
+        final String scrollId = UUID.randomUUID().toString();
+        final SearchResponse<ObjectNode> searchResponse = mock(SearchResponse.class);
+        when(searchResponse.scrollId()).thenReturn(scrollId);
+
+        final HitsMetadata<ObjectNode> hitsMetadata = mock(HitsMetadata.class);
+        final List<Hit<ObjectNode>> hits = new ArrayList<>();
+        final Hit<ObjectNode> firstHit = mock(Hit.class);
+        when(firstHit.id()).thenReturn(UUID.randomUUID().toString());
+        when(firstHit.index()).thenReturn(UUID.randomUUID().toString());
+        when(firstHit.source()).thenReturn(mock(ObjectNode.class));
+
+        final Hit<ObjectNode> secondHit = mock(Hit.class);
+        when(secondHit.id()).thenReturn(UUID.randomUUID().toString());
+        when(secondHit.index()).thenReturn(UUID.randomUUID().toString());
+        when(secondHit.source()).thenReturn(mock(ObjectNode.class));
+
+        hits.add(firstHit);
+        hits.add(secondHit);
+
+        when(hitsMetadata.hits()).thenReturn(hits);
+        when(searchResponse.hits()).thenReturn(hitsMetadata);
+
+        final ArgumentCaptor<SearchRequest> searchRequestArgumentCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+
+        when(openSearchClient.search(searchRequestArgumentCaptor.capture(), eq(ObjectNode.class))).thenReturn(searchResponse);
+
+        final CreateScrollResponse createScrollResponse = createObjectUnderTest().createScroll(createScrollRequest);
+        assertThat(createScrollResponse, notNullValue());
+        assertThat(createScrollResponse.getScrollId(), equalTo(scrollId));
+        assertThat(createScrollResponse.getDocuments(), notNullValue());
+        assertThat(createScrollResponse.getDocuments().size(), equalTo(2));
+    }
+
+    @Test
     void create_pit_with_exception_for_pit_limit_throws_SearchContextLimitException() throws IOException {
         final String indexName = UUID.randomUUID().toString();
         final String keepAlive = UUID.randomUUID().toString();
@@ -106,6 +160,25 @@ public class OpenSearchAccessorTest {
     }
 
     @Test
+    void create_scroll_with_exception_for_scroll_limit_throws_SearchContextLimitException() throws IOException {
+        final String indexName = UUID.randomUUID().toString();
+        final String scrollTime = UUID.randomUUID().toString();
+        final Integer size = new Random().nextInt(10);
+
+        final CreateScrollRequest createScrollRequest = mock(CreateScrollRequest.class);
+        when(createScrollRequest.getIndex()).thenReturn(indexName);
+        when(createScrollRequest.getScrollTime()).thenReturn(scrollTime);
+        when(createScrollRequest.getSize()).thenReturn(size);
+
+        final IOException exception = mock(IOException.class);
+        when(exception.getMessage()).thenReturn(UUID.randomUUID() + SCROLL_RESOURCE_LIMIT_EXCEPTION_MESSAGE + UUID.randomUUID());
+
+        when(openSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
+
+        assertThrows(SearchContextLimitException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+    }
+
+    @Test
     void createPit_throws_OpenSearch_exception_throws_that_exception() throws IOException {
         final String indexName = UUID.randomUUID().toString();
         final String keepAlive = UUID.randomUUID().toString();
@@ -125,6 +198,24 @@ public class OpenSearchAccessorTest {
     }
 
     @Test
+    void createScroll_throws_OpenSearch_exception_throws_that_exception() throws IOException {
+        final String indexName = UUID.randomUUID().toString();
+        final String scrollTime = UUID.randomUUID().toString();
+        final Integer size = new Random().nextInt(10);
+
+        final CreateScrollRequest createScrollRequest = mock(CreateScrollRequest.class);
+        when(createScrollRequest.getIndex()).thenReturn(indexName);
+        when(createScrollRequest.getScrollTime()).thenReturn(scrollTime);
+        when(createScrollRequest.getSize()).thenReturn(size);
+
+        final OpenSearchException exception = mock(OpenSearchException.class);
+
+        when(openSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
+
+        assertThrows(OpenSearchException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+    }
+
+    @Test
     void createPit_throws_runtime_exception_throws_IO_Exception() throws IOException {
         final String indexName = UUID.randomUUID().toString();
         final String keepAlive = UUID.randomUUID().toString();
@@ -136,6 +227,26 @@ public class OpenSearchAccessorTest {
         when(openSearchClient.createPit(any(CreatePitRequest.class))).thenThrow(IOException.class);
 
         assertThrows(RuntimeException.class, () -> createObjectUnderTest().createPit(createPointInTimeRequest));
+    }
+
+    @Test
+    void createScroll_throws_runtime_exception_when_throws_IO_Exception_that_is_not_search_context() throws IOException {
+        final String indexName = UUID.randomUUID().toString();
+        final String scrollTime = UUID.randomUUID().toString();
+        final Integer size = new Random().nextInt(10);
+
+        final CreateScrollRequest createScrollRequest = mock(CreateScrollRequest.class);
+        when(createScrollRequest.getIndex()).thenReturn(indexName);
+        when(createScrollRequest.getScrollTime()).thenReturn(scrollTime);
+        when(createScrollRequest.getSize()).thenReturn(size);
+
+        final IOException exception = mock(IOException.class);
+        when(exception.getMessage()).thenReturn(UUID.randomUUID().toString());
+
+        when(openSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
+
+        final RuntimeException exceptionThrown = assertThrows(RuntimeException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+        assertThat(exceptionThrown instanceof SearchContextLimitException, equalTo(false));
     }
 
     @ParameterizedTest
@@ -156,6 +267,23 @@ public class OpenSearchAccessorTest {
         createObjectUnderTest().deletePit(deletePointInTimeRequest);
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void delete_scroll_with_no_exception_does_not_throw(final boolean successful) throws IOException {
+        final String scrollId = UUID.randomUUID().toString();
+
+        final DeleteScrollRequest deleteScrollRequest = mock(DeleteScrollRequest.class);
+        when(deleteScrollRequest.getScrollId()).thenReturn(scrollId);
+
+        final ClearScrollResponse clearScrollResponse = mock(ClearScrollResponse.class);
+        when(clearScrollResponse.succeeded()).thenReturn(successful);
+
+
+        when(openSearchClient.clearScroll(any(ClearScrollRequest.class))).thenReturn(clearScrollResponse);
+
+        createObjectUnderTest().deleteScroll(deleteScrollRequest);
+    }
+
     @Test
     void delete_pit_does_not_throw_during_opensearch_exception() throws IOException {
         final String pitId = UUID.randomUUID().toString();
@@ -169,6 +297,19 @@ public class OpenSearchAccessorTest {
     }
 
     @Test
+    void delete_scroll_does_not_throw_during_opensearch_exception() throws IOException {
+        final String scrollId = UUID.randomUUID().toString();
+
+        final DeleteScrollRequest deleteScrollRequest = mock(DeleteScrollRequest.class);
+        when(deleteScrollRequest.getScrollId()).thenReturn(scrollId);
+
+
+        when(openSearchClient.clearScroll(any(ClearScrollRequest.class))).thenThrow(OpenSearchException.class);
+
+        createObjectUnderTest().deleteScroll(deleteScrollRequest);
+    }
+
+    @Test
     void delete_pit_does_not_throw_exception_when_client_throws_IOException() throws IOException {
         final String pitId = UUID.randomUUID().toString();
 
@@ -178,6 +319,19 @@ public class OpenSearchAccessorTest {
         when(openSearchClient.deletePit(any(DeletePitRequest.class))).thenThrow(IOException.class);
 
         createObjectUnderTest().deletePit(deletePointInTimeRequest);
+    }
+
+    @Test
+    void delete_scroll_does_not_throw_during_IO_exception() throws IOException {
+        final String scrollId = UUID.randomUUID().toString();
+
+        final DeleteScrollRequest deleteScrollRequest = mock(DeleteScrollRequest.class);
+        when(deleteScrollRequest.getScrollId()).thenReturn(scrollId);
+
+
+        when(openSearchClient.clearScroll(any(ClearScrollRequest.class))).thenThrow(IOException.class);
+
+        createObjectUnderTest().deleteScroll(deleteScrollRequest);
     }
 
     @ParameterizedTest
@@ -228,5 +382,46 @@ public class OpenSearchAccessorTest {
         assertThat(searchWithSearchAfterResults.getDocuments().size(), equalTo(2));
 
         assertThat(searchWithSearchAfterResults.getNextSearchAfter(), equalTo(secondHit.sort()));
+    }
+
+    @Test
+    void search_with_scroll_returns_expected_SearchScrollResponse() throws IOException {
+        final String scrollId = UUID.randomUUID().toString();
+        final String scrollTime = UUID.randomUUID().toString();
+
+        final SearchScrollRequest searchScrollRequest = mock(SearchScrollRequest.class);
+        when(searchScrollRequest.getScrollId()).thenReturn(scrollId);
+        when(searchScrollRequest.getScrollTime()).thenReturn(scrollTime);
+
+        final ScrollResponse<ObjectNode> searchResponse = mock(ScrollResponse.class);
+        final HitsMetadata<ObjectNode> hitsMetadata = mock(HitsMetadata.class);
+        final List<Hit<ObjectNode>> hits = new ArrayList<>();
+        final Hit<ObjectNode> firstHit = mock(Hit.class);
+        when(firstHit.id()).thenReturn(UUID.randomUUID().toString());
+        when(firstHit.index()).thenReturn(UUID.randomUUID().toString());
+        when(firstHit.source()).thenReturn(mock(ObjectNode.class));
+
+        final Hit<ObjectNode> secondHit = mock(Hit.class);
+        when(secondHit.id()).thenReturn(UUID.randomUUID().toString());
+        when(secondHit.index()).thenReturn(UUID.randomUUID().toString());
+        when(secondHit.source()).thenReturn(mock(ObjectNode.class));
+
+        hits.add(firstHit);
+        hits.add(secondHit);
+
+        when(hitsMetadata.hits()).thenReturn(hits);
+        when(searchResponse.hits()).thenReturn(hitsMetadata);
+        when(searchResponse.scrollId()).thenReturn(scrollId);
+
+        final ArgumentCaptor<ScrollRequest> searchRequestArgumentCaptor = ArgumentCaptor.forClass(ScrollRequest.class);
+
+        when(openSearchClient.scroll(searchRequestArgumentCaptor.capture(), eq(ObjectNode.class))).thenReturn(searchResponse);
+
+        final SearchScrollResponse searchScrollResponse = createObjectUnderTest().searchWithScroll(searchScrollRequest);
+
+        assertThat(searchScrollResponse, notNullValue());
+        assertThat(searchScrollResponse.getDocuments(), notNullValue());
+        assertThat(searchScrollResponse.getDocuments().size(), equalTo(2));
+        assertThat(searchScrollResponse.getScrollId(), equalTo(scrollId));
     }
 }


### PR DESCRIPTION
### Description
This change implements searching with `scroll` for OpenSearch clusters. This will be the default behavior for OpenSearch clusters with version less than 2.5.0. It can also be explicitly used by setting `search_context_type` to `scroll`
 
### Issues Resolved
Related to #1985 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
