### PR TITLE
Implement scroll apis for ElasticSearch Accessor

### DIFF
--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessorTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessorTest.java
@@ -8,10 +8,14 @@ package org.opensearch.dataprepper.plugins.source.opensearch.worker.client;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.ErrorCause;
+import co.elastic.clients.elasticsearch.core.ClearScrollRequest;
+import co.elastic.clients.elasticsearch.core.ClearScrollResponse;
 import co.elastic.clients.elasticsearch.core.ClosePointInTimeRequest;
 import co.elastic.clients.elasticsearch.core.ClosePointInTimeResponse;
 import co.elastic.clients.elasticsearch.core.OpenPointInTimeRequest;
 import co.elastic.clients.elasticsearch.core.OpenPointInTimeResponse;
+import co.elastic.clients.elasticsearch.core.ScrollRequest;
+import co.elastic.clients.elasticsearch.core.ScrollResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
@@ -27,10 +31,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchContextLimitException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeResponse;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreateScrollRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreateScrollResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeletePointInTimeRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeleteScrollRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.NoSearchContextSearchRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchContextType;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchPointInTimeRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchWithSearchAfterResults;
 
 import java.io.IOException;
@@ -51,6 +60,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor.PIT_RESOURCE_LIMIT_ERROR_TYPE;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor.SCROLL_RESOURCE_LIMIT_EXCEPTION_MESSAGE;
 
 @ExtendWith(MockitoExtension.class)
 public class ElasticsearchAccessorTest {
@@ -84,6 +94,50 @@ public class ElasticsearchAccessorTest {
     }
 
     @Test
+    void create_scroll_returns_expected_create_scroll_response() throws IOException {
+        final String indexName = UUID.randomUUID().toString();
+        final String scrollTime = UUID.randomUUID().toString();
+        final Integer size = new Random().nextInt(10);
+
+        final CreateScrollRequest createScrollRequest = mock(CreateScrollRequest.class);
+        when(createScrollRequest.getIndex()).thenReturn(indexName);
+        when(createScrollRequest.getScrollTime()).thenReturn(scrollTime);
+        when(createScrollRequest.getSize()).thenReturn(size);
+
+        final String scrollId = UUID.randomUUID().toString();
+        final SearchResponse<ObjectNode> searchResponse = mock(SearchResponse.class);
+        when(searchResponse.scrollId()).thenReturn(scrollId);
+
+        final HitsMetadata<ObjectNode> hitsMetadata = mock(HitsMetadata.class);
+        final List<Hit<ObjectNode>> hits = new ArrayList<>();
+        final Hit<ObjectNode> firstHit = mock(Hit.class);
+        when(firstHit.id()).thenReturn(UUID.randomUUID().toString());
+        when(firstHit.index()).thenReturn(UUID.randomUUID().toString());
+        when(firstHit.source()).thenReturn(mock(ObjectNode.class));
+
+        final Hit<ObjectNode> secondHit = mock(Hit.class);
+        when(secondHit.id()).thenReturn(UUID.randomUUID().toString());
+        when(secondHit.index()).thenReturn(UUID.randomUUID().toString());
+        when(secondHit.source()).thenReturn(mock(ObjectNode.class));
+
+        hits.add(firstHit);
+        hits.add(secondHit);
+
+        when(hitsMetadata.hits()).thenReturn(hits);
+        when(searchResponse.hits()).thenReturn(hitsMetadata);
+
+        final ArgumentCaptor<SearchRequest> searchRequestArgumentCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+
+        when(elasticSearchClient.search(searchRequestArgumentCaptor.capture(), eq(ObjectNode.class))).thenReturn(searchResponse);
+
+        final CreateScrollResponse createScrollResponse = createObjectUnderTest().createScroll(createScrollRequest);
+        assertThat(createScrollResponse, notNullValue());
+        assertThat(createScrollResponse.getScrollId(), equalTo(scrollId));
+        assertThat(createScrollResponse.getDocuments(), notNullValue());
+        assertThat(createScrollResponse.getDocuments().size(), equalTo(2));
+    }
+
+    @Test
     void create_pit_with_exception_for_pit_limit_throws_SearchContextLimitException() throws IOException {
         final String indexName = UUID.randomUUID().toString();
         final String keepAlive = UUID.randomUUID().toString();
@@ -106,6 +160,25 @@ public class ElasticsearchAccessorTest {
     }
 
     @Test
+    void create_scroll_with_exception_for_scroll_limit_throws_SearchContextLimitException() throws IOException {
+        final String indexName = UUID.randomUUID().toString();
+        final String scrollTime = UUID.randomUUID().toString();
+        final Integer size = new Random().nextInt(10);
+
+        final CreateScrollRequest createScrollRequest = mock(CreateScrollRequest.class);
+        when(createScrollRequest.getIndex()).thenReturn(indexName);
+        when(createScrollRequest.getScrollTime()).thenReturn(scrollTime);
+        when(createScrollRequest.getSize()).thenReturn(size);
+
+        final IOException exception = mock(IOException.class);
+        when(exception.getMessage()).thenReturn(UUID.randomUUID() + SCROLL_RESOURCE_LIMIT_EXCEPTION_MESSAGE + UUID.randomUUID());
+
+        when(elasticSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
+
+        assertThrows(SearchContextLimitException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+    }
+
+    @Test
     void createPit_throws_Elasticsearch_exception_throws_that_exception() throws IOException {
         final String indexName = UUID.randomUUID().toString();
         final String keepAlive = UUID.randomUUID().toString();
@@ -125,6 +198,24 @@ public class ElasticsearchAccessorTest {
     }
 
     @Test
+    void createScroll_throws_Elasticsearch_exception_throws_that_exception() throws IOException {
+        final String indexName = UUID.randomUUID().toString();
+        final String scrollTime = UUID.randomUUID().toString();
+        final Integer size = new Random().nextInt(10);
+
+        final CreateScrollRequest createScrollRequest = mock(CreateScrollRequest.class);
+        when(createScrollRequest.getIndex()).thenReturn(indexName);
+        when(createScrollRequest.getScrollTime()).thenReturn(scrollTime);
+        when(createScrollRequest.getSize()).thenReturn(size);
+
+        final ElasticsearchException exception = mock(ElasticsearchException.class);
+
+        when(elasticSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
+
+        assertThrows(ElasticsearchException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+    }
+
+    @Test
     void createPit_throws_runtime_exception_throws_IO_Exception() throws IOException {
         final String indexName = UUID.randomUUID().toString();
         final String keepAlive = UUID.randomUUID().toString();
@@ -136,6 +227,26 @@ public class ElasticsearchAccessorTest {
         when(elasticSearchClient.openPointInTime(any(OpenPointInTimeRequest.class))).thenThrow(IOException.class);
 
         assertThrows(RuntimeException.class, () -> createObjectUnderTest().createPit(createPointInTimeRequest));
+    }
+
+    @Test
+    void createScroll_throws_runtime_exception_when_throws_IO_Exception_that_is_not_search_context() throws IOException {
+        final String indexName = UUID.randomUUID().toString();
+        final String scrollTime = UUID.randomUUID().toString();
+        final Integer size = new Random().nextInt(10);
+
+        final CreateScrollRequest createScrollRequest = mock(CreateScrollRequest.class);
+        when(createScrollRequest.getIndex()).thenReturn(indexName);
+        when(createScrollRequest.getScrollTime()).thenReturn(scrollTime);
+        when(createScrollRequest.getSize()).thenReturn(size);
+
+        final IOException exception = mock(IOException.class);
+        when(exception.getMessage()).thenReturn(UUID.randomUUID().toString());
+
+        when(elasticSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
+
+        final RuntimeException exceptionThrown = assertThrows(RuntimeException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+        assertThat(exceptionThrown instanceof SearchContextLimitException, equalTo(false));
     }
 
     @ParameterizedTest
@@ -154,6 +265,23 @@ public class ElasticsearchAccessorTest {
         createObjectUnderTest().deletePit(deletePointInTimeRequest);
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void delete_scroll_with_no_exception_does_not_throw(final boolean successful) throws IOException {
+        final String scrollId = UUID.randomUUID().toString();
+
+        final DeleteScrollRequest deleteScrollRequest = mock(DeleteScrollRequest.class);
+        when(deleteScrollRequest.getScrollId()).thenReturn(scrollId);
+
+        final ClearScrollResponse clearScrollResponse = mock(ClearScrollResponse.class);
+        when(clearScrollResponse.succeeded()).thenReturn(successful);
+
+
+        when(elasticSearchClient.clearScroll(any(ClearScrollRequest.class))).thenReturn(clearScrollResponse);
+
+        createObjectUnderTest().deleteScroll(deleteScrollRequest);
+    }
+
     @Test
     void delete_pit_does_not_throw_during_opensearch_exception() throws IOException {
         final String pitId = UUID.randomUUID().toString();
@@ -167,6 +295,19 @@ public class ElasticsearchAccessorTest {
     }
 
     @Test
+    void delete_scroll_does_not_throw_during_elasticsearch_exception() throws IOException {
+        final String scrollId = UUID.randomUUID().toString();
+
+        final DeleteScrollRequest deleteScrollRequest = mock(DeleteScrollRequest.class);
+        when(deleteScrollRequest.getScrollId()).thenReturn(scrollId);
+
+
+        when(elasticSearchClient.clearScroll(any(ClearScrollRequest.class))).thenThrow(ElasticsearchException.class);
+
+        createObjectUnderTest().deleteScroll(deleteScrollRequest);
+    }
+
+    @Test
     void delete_pit_does_not_throw_exception_when_client_throws_IOException() throws IOException {
         final String pitId = UUID.randomUUID().toString();
 
@@ -176,6 +317,19 @@ public class ElasticsearchAccessorTest {
         when(elasticSearchClient.closePointInTime(any(ClosePointInTimeRequest.class))).thenThrow(IOException.class);
 
         createObjectUnderTest().deletePit(deletePointInTimeRequest);
+    }
+
+    @Test
+    void delete_scroll_does_not_throw_during_IO_exception() throws IOException {
+        final String scrollId = UUID.randomUUID().toString();
+
+        final DeleteScrollRequest deleteScrollRequest = mock(DeleteScrollRequest.class);
+        when(deleteScrollRequest.getScrollId()).thenReturn(scrollId);
+
+
+        when(elasticSearchClient.clearScroll(any(ClearScrollRequest.class))).thenThrow(IOException.class);
+
+        createObjectUnderTest().deleteScroll(deleteScrollRequest);
     }
 
     @ParameterizedTest
@@ -277,5 +431,46 @@ public class ElasticsearchAccessorTest {
         assertThat(searchWithSearchAfterResults.getDocuments().size(), equalTo(2));
 
         assertThat(searchWithSearchAfterResults.getNextSearchAfter(), equalTo(secondHit.sort()));
+    }
+
+    @Test
+    void search_with_scroll_returns_expected_SearchScrollResponse() throws IOException {
+        final String scrollId = UUID.randomUUID().toString();
+        final String scrollTime = UUID.randomUUID().toString();
+
+        final SearchScrollRequest searchScrollRequest = mock(SearchScrollRequest.class);
+        when(searchScrollRequest.getScrollId()).thenReturn(scrollId);
+        when(searchScrollRequest.getScrollTime()).thenReturn(scrollTime);
+
+        final ScrollResponse<ObjectNode> searchResponse = mock(ScrollResponse.class);
+        final HitsMetadata<ObjectNode> hitsMetadata = mock(HitsMetadata.class);
+        final List<Hit<ObjectNode>> hits = new ArrayList<>();
+        final Hit<ObjectNode> firstHit = mock(Hit.class);
+        when(firstHit.id()).thenReturn(UUID.randomUUID().toString());
+        when(firstHit.index()).thenReturn(UUID.randomUUID().toString());
+        when(firstHit.source()).thenReturn(mock(ObjectNode.class));
+
+        final Hit<ObjectNode> secondHit = mock(Hit.class);
+        when(secondHit.id()).thenReturn(UUID.randomUUID().toString());
+        when(secondHit.index()).thenReturn(UUID.randomUUID().toString());
+        when(secondHit.source()).thenReturn(mock(ObjectNode.class));
+
+        hits.add(firstHit);
+        hits.add(secondHit);
+
+        when(hitsMetadata.hits()).thenReturn(hits);
+        when(searchResponse.hits()).thenReturn(hitsMetadata);
+        when(searchResponse.scrollId()).thenReturn(scrollId);
+
+        final ArgumentCaptor<ScrollRequest> searchRequestArgumentCaptor = ArgumentCaptor.forClass(ScrollRequest.class);
+
+        when(elasticSearchClient.scroll(searchRequestArgumentCaptor.capture(), eq(ObjectNode.class))).thenReturn(searchResponse);
+
+        final SearchScrollResponse searchScrollResponse = createObjectUnderTest().searchWithScroll(searchScrollRequest);
+
+        assertThat(searchScrollResponse, notNullValue());
+        assertThat(searchScrollResponse.getDocuments(), notNullValue());
+        assertThat(searchScrollResponse.getDocuments().size(), equalTo(2));
+        assertThat(searchScrollResponse.getScrollId(), equalTo(scrollId));
     }
 }


### PR DESCRIPTION
### Description
This change follows from the work done in #2923 by implementing for Elasticsearch with scroll instead of just OpenSearch.
 
### Issues Resolved
Related to #1985 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
