### PR TITLE
Fix DLQ writer writing empty list

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -258,6 +258,10 @@ public final class BulkRetryStrategy {
 
     private BulkOperationRequestResponse handleRetry(final AccumulatingBulkRequest request, final BulkResponse response, int retryCount) throws InterruptedException {
         final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequestForRetry = createBulkRequestForRetry(request, response);
+        if (bulkRequestForRetry.getOperationsCount() == 0) {
+            return null;
+        }
+
         final BulkResponse bulkResponse;
         try {
             bulkResponse = requestFunction.apply(bulkRequestForRetry);


### PR DESCRIPTION
### Description
Fix DLQ writer writing empty list.

DQL writer is writing empty list like this sometimes. Upon investigation, found that bulkOperation is being tried even the operations count is zero. This is resulting in writing empty DLQ List when the bulk operation fails.
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
