### PR TITLE
Add disable_authentication flag to the opensearch source

### DIFF
--- a/data-prepper-plugins/opensearch-source/README.md
+++ b/data-prepper-plugins/opensearch-source/README.md
@@ -114,6 +114,9 @@ opensearch-source-pipeline:
 - `password` (Optional) : A String of password used in the internal users of OpenSearch cluster. Default is null.
 
 
+- `disable_authentication` (Optional) : A boolean that can disable authentication if the cluster supports it. Defaults to false.
+
+
 - `aws` (Optional) : AWS configurations. See [AWS Configuration](#aws_configuration) for details. SigV4 is enabled by default when this option is used.
 
 

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSource.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSource.java
@@ -31,6 +31,8 @@ public class OpenSearchSource implements Source<Record<Event>>, UsesSourceCoordi
                             final AwsCredentialsSupplier awsCredentialsSupplier) {
         this.openSearchSourceConfiguration = openSearchSourceConfiguration;
         this.awsCredentialsSupplier = awsCredentialsSupplier;
+
+        openSearchSourceConfiguration.validateAwsConfigWithUsernameAndPassword();
     }
 
     @Override

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchClientFactory.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchClientFactory.java
@@ -133,8 +133,7 @@ public class OpenSearchClientFactory {
 
         final RestClientBuilder restClientBuilder = RestClient.builder(httpHosts);
 
-        LOG.info("Using username and password for auth for the OpenSearch source");
-        attachUsernamePassword(restClientBuilder, openSearchSourceConfiguration);
+        attachBasicAuth(restClientBuilder, openSearchSourceConfiguration);
 
         setConnectAndSocketTimeout(restClientBuilder, openSearchSourceConfiguration);
 
@@ -161,33 +160,36 @@ public class OpenSearchClientFactory {
                 new BasicHeader("Content-type", "application/json")
         });
 
-        LOG.info("Using username and password for auth for the OpenSearch source");
-        attachUsernamePassword(restClientBuilder, openSearchSourceConfiguration);
-
+        attachBasicAuth(restClientBuilder, openSearchSourceConfiguration);
         setConnectAndSocketTimeout(restClientBuilder, openSearchSourceConfiguration);
 
         return restClientBuilder.build();
     }
 
-    private void attachUsernamePassword(final RestClientBuilder restClientBuilder, final OpenSearchSourceConfiguration openSearchSourceConfiguration) {
-        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-        credentialsProvider.setCredentials(AuthScope.ANY,
-                new UsernamePasswordCredentials(openSearchSourceConfiguration.getUsername(), openSearchSourceConfiguration.getPassword()));
+    private void attachBasicAuth(final RestClientBuilder restClientBuilder, final OpenSearchSourceConfiguration openSearchSourceConfiguration) {
 
         restClientBuilder.setHttpClientConfigCallback(httpClientBuilder -> {
-            httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+            if (!openSearchSourceConfiguration.isAuthenticationDisabled()) {
+                attachUsernameAndPassword(httpClientBuilder, openSearchSourceConfiguration);
+            } else {
+                LOG.warn("Authentication was explicitly disabled for the OpenSearch source");
+            }
+
             attachSSLContext(httpClientBuilder, openSearchSourceConfiguration);
             return httpClientBuilder;
         });
     }
 
-    private void attachUsernamePassword(final org.elasticsearch.client.RestClientBuilder restClientBuilder, final OpenSearchSourceConfiguration openSearchSourceConfiguration) {
-        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-        credentialsProvider.setCredentials(AuthScope.ANY,
-                new UsernamePasswordCredentials(openSearchSourceConfiguration.getUsername(), openSearchSourceConfiguration.getPassword()));
+    private void attachBasicAuth(final org.elasticsearch.client.RestClientBuilder restClientBuilder, final OpenSearchSourceConfiguration openSearchSourceConfiguration) {
 
         restClientBuilder.setHttpClientConfigCallback(httpClientBuilder -> {
-            httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+
+            if (!openSearchSourceConfiguration.isAuthenticationDisabled()) {
+                attachUsernameAndPassword(httpClientBuilder, openSearchSourceConfiguration);
+            } else {
+                LOG.warn("Authentication was explicitly disabled for the OpenSearch source");
+            }
+
             attachSSLContext(httpClientBuilder, openSearchSourceConfiguration);
             httpClientBuilder.addInterceptorLast(
                     (HttpResponseInterceptor)
@@ -209,6 +211,15 @@ public class OpenSearchClientFactory {
 
             return requestConfigBuilder;
         });
+    }
+
+    private void attachUsernameAndPassword(final HttpAsyncClientBuilder httpClientBuilder, final OpenSearchSourceConfiguration openSearchSourceConfiguration) {
+        LOG.info("Using username and password for auth for the OpenSearch source");
+
+        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(AuthScope.ANY,
+                new UsernamePasswordCredentials(openSearchSourceConfiguration.getUsername(), openSearchSourceConfiguration.getPassword()));
+        httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
     }
 
     private void setConnectAndSocketTimeout(final org.elasticsearch.client.RestClientBuilder restClientBuilder, final OpenSearchSourceConfiguration openSearchSourceConfiguration) {

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfigurationTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfigurationTest.java
@@ -9,10 +9,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OpenSearchSourceConfigurationTest {
 
@@ -21,7 +23,7 @@ public class OpenSearchSourceConfigurationTest {
     @Test
     void open_search_source_username_password_only() throws JsonProcessingException {
 
-        final String sourceConfigurationYaml = "max_retries: 5\n" +
+        final String sourceConfigurationYaml =
                 "hosts: [\"http://localhost:9200\"]\n" +
                 "username: test\n" +
                 "password: test\n" +
@@ -44,18 +46,49 @@ public class OpenSearchSourceConfigurationTest {
         assertThat(sourceConfiguration.getIndexParametersConfiguration(), notNullValue());
         assertThat(sourceConfiguration.getSchedulingParameterConfiguration(), notNullValue());
         assertThat(sourceConfiguration.getHosts(), notNullValue());
-        assertThat(sourceConfiguration.getMaxRetries(), equalTo(5));
 
-        assertThat(sourceConfiguration.validateAwsConfigWithUsernameAndPassword(), equalTo(true));
+        sourceConfiguration.validateAwsConfigWithUsernameAndPassword();
         assertThat(sourceConfiguration.getPassword(), equalTo("test"));
         assertThat(sourceConfiguration.getUsername(), equalTo("test"));
         assertThat(sourceConfiguration.getAwsAuthenticationOptions(), equalTo(null));
     }
 
     @Test
-    void opensearch_source_aws_only() throws JsonProcessingException {
-        final String sourceConfigurationYaml = "max_retries: 5\n" +
+    void open_search_disabled_authentication() throws JsonProcessingException {
+
+        final String sourceConfigurationYaml =
                 "hosts: [\"http://localhost:9200\"]\n" +
+                        "disable_authentication: true\n" +
+                        "connection:\n" +
+                        "  insecure: true\n" +
+                        "  cert: \"cert\"\n" +
+                        "indices:\n" +
+                        "  include:\n" +
+                        "    - index_name_regex: \"regex\"\n" +
+                        "    - index_name_regex: \"regex-two\"\n" +
+                        "scheduling:\n" +
+                        "  job_count: 3\n" +
+                        "search_options:\n" +
+                        "  batch_size: 1000\n" +
+                        "  query: \"test\"\n";
+        final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
+
+        assertThat(sourceConfiguration.getSearchConfiguration(), notNullValue());
+        assertThat(sourceConfiguration.getConnectionConfiguration(), notNullValue());
+        assertThat(sourceConfiguration.getIndexParametersConfiguration(), notNullValue());
+        assertThat(sourceConfiguration.getSchedulingParameterConfiguration(), notNullValue());
+        assertThat(sourceConfiguration.getHosts(), notNullValue());
+
+        sourceConfiguration.validateAwsConfigWithUsernameAndPassword();
+        assertThat(sourceConfiguration.isAuthenticationDisabled(), equalTo(true));
+        assertThat(sourceConfiguration.getPassword(), equalTo(null));
+        assertThat(sourceConfiguration.getUsername(), equalTo(null));
+        assertThat(sourceConfiguration.getAwsAuthenticationOptions(), equalTo(null));
+    }
+
+    @Test
+    void opensearch_source_aws_only() throws JsonProcessingException {
+        final String sourceConfigurationYaml = "hosts: [\"http://localhost:9200\"]\n" +
                 "connection:\n" +
                 "  insecure: true\n" +
                 "  cert: \"cert\"\n" +
@@ -74,7 +107,7 @@ public class OpenSearchSourceConfigurationTest {
 
         final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
 
-        assertThat(sourceConfiguration.validateAwsConfigWithUsernameAndPassword(), equalTo(true));
+        sourceConfiguration.validateAwsConfigWithUsernameAndPassword();
         assertThat(sourceConfiguration.getPassword(), equalTo(null));
         assertThat(sourceConfiguration.getUsername(), equalTo(null));
         assertThat(sourceConfiguration.getAwsAuthenticationOptions(), notNullValue());
@@ -85,8 +118,7 @@ public class OpenSearchSourceConfigurationTest {
 
     @Test
     void opensearch_source_aws_sts_external_id() throws JsonProcessingException {
-        final String sourceConfigurationYaml = "max_retries: 5\n" +
-            "hosts: [\"http://localhost:9200\"]\n" +
+        final String sourceConfigurationYaml = "hosts: [\"http://localhost:9200\"]\n" +
             "connection:\n" +
             "  insecure: true\n" +
             "  cert: \"cert\"\n" +
@@ -106,7 +138,7 @@ public class OpenSearchSourceConfigurationTest {
 
         final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
 
-        assertThat(sourceConfiguration.validateAwsConfigWithUsernameAndPassword(), equalTo(true));
+        sourceConfiguration.validateAwsConfigWithUsernameAndPassword();
         assertThat(sourceConfiguration.getPassword(), equalTo(null));
         assertThat(sourceConfiguration.getUsername(), equalTo(null));
         assertThat(sourceConfiguration.getAwsAuthenticationOptions(), notNullValue());
@@ -141,14 +173,12 @@ public class OpenSearchSourceConfigurationTest {
 
         final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
 
-        assertThat(sourceConfiguration.validateAwsConfigWithUsernameAndPassword(), equalTo(false));
-        assertThat(sourceConfiguration.getMaxRetries(), equalTo(0));
+        assertThrows(InvalidPluginConfigurationException.class, sourceConfiguration::validateAwsConfigWithUsernameAndPassword);
     }
 
     @Test
-    void one_of_username_password_or_aws_config_is_required() throws JsonProcessingException {
+    void one_of_username_password_or_aws_config_or_authDisabled_is_required() throws JsonProcessingException {
         final String sourceConfigurationYaml =
-                "max_retries: 5\n" +
                         "hosts: [\"http://localhost:9200\"]\n" +
                         "connection:\n" +
                         "  insecure: true\n" +
@@ -165,6 +195,6 @@ public class OpenSearchSourceConfigurationTest {
 
         final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
 
-        assertThat(sourceConfiguration.validateAwsConfigWithUsernameAndPassword(), equalTo(false));
+        assertThrows(InvalidPluginConfigurationException.class, sourceConfiguration::validateAwsConfigWithUsernameAndPassword);
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchClientFactoryTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchClientFactoryTest.java
@@ -29,6 +29,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -118,5 +120,39 @@ public class OpenSearchClientFactoryTest {
         assertThat(awsCredentialsOptions.getRegion(), equalTo(Region.US_EAST_1));
         assertThat(awsCredentialsOptions.getStsHeaderOverrides(), equalTo(Collections.emptyMap()));
         assertThat(awsCredentialsOptions.getStsRoleArn(), equalTo(stsRoleArn));
+    }
+
+    @Test
+    void provideElasticSearchClient_with_auth_disabled() {
+        when(openSearchSourceConfiguration.isAuthenticationDisabled()).thenReturn(true);
+
+        when(connectionConfiguration.getCertPath()).thenReturn(null);
+        when(connectionConfiguration.getSocketTimeout()).thenReturn(null);
+        when(connectionConfiguration.getConnectTimeout()).thenReturn(null);
+        when(connectionConfiguration.isInsecure()).thenReturn(true);
+
+        final ElasticsearchClient elasticsearchClient = createObjectUnderTest().provideElasticSearchClient(openSearchSourceConfiguration);
+        assertThat(elasticsearchClient, notNullValue());
+
+        verifyNoInteractions(awsCredentialsSupplier);
+        verify(openSearchSourceConfiguration, never()).getUsername();
+        verify(openSearchSourceConfiguration, never()).getPassword();
+    }
+
+    @Test
+    void provideOpenSearchClient_with_auth_disabled() {
+        when(openSearchSourceConfiguration.isAuthenticationDisabled()).thenReturn(true);
+
+        when(connectionConfiguration.getCertPath()).thenReturn(null);
+        when(connectionConfiguration.getSocketTimeout()).thenReturn(null);
+        when(connectionConfiguration.getConnectTimeout()).thenReturn(null);
+        when(connectionConfiguration.isInsecure()).thenReturn(true);
+
+        final OpenSearchClient openSearchClient = createObjectUnderTest().provideOpenSearchClient(openSearchSourceConfiguration);
+        assertThat(openSearchClient, notNullValue());
+
+        verifyNoInteractions(awsCredentialsSupplier);
+        verify(openSearchSourceConfiguration, never()).getUsername();
+        verify(openSearchSourceConfiguration, never()).getPassword();
     }
 }


### PR DESCRIPTION
### Description
Adds a `disable_authentication` flag to the OpenSearch source, which allows auth to be skipped if desired. Defaults to false.
 
### Issues Resolved
Resolves #2939 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
