### PR TITLE
-Support for kafka-sink

### DIFF
--- a/data-prepper-plugins/kafka-plugins/build.gradle
+++ b/data-prepper-plugins/kafka-plugins/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.apache.kafka:kafka-clients:3.4.0:test'
     testImplementation 'org.apache.kafka:connect-json:3.4.0'
+    implementation group: 'org.apache.kafka', name: 'connect-json', version: '3.4.0'
+    implementation project(':data-prepper-plugins:failures-common')
+    testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
 }
 
 test {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/AwsDLQConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/AwsDLQConfig.java
@@ -1,0 +1,36 @@
+package org.opensearch.dataprepper.plugins.kafka.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public class AwsDLQConfig {
+
+    @JsonProperty("bucket")
+    @NotNull
+    @NotEmpty
+    private String bucket;
+
+    @JsonProperty("sts_role_arn")
+    @NotNull
+    @NotEmpty
+    @Size(min = 20, max = 2048, message = "awsStsRoleArn length should be between 1 and 2048 characters")
+    private String roleArn;
+
+    @JsonProperty("region")
+    @Size(min = 1, message = "Region cannot be empty string")
+    private String region;
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public String getRoleArn() {
+        return roleArn;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSinkConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSinkConfig.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * * A helper class that helps to read user configuration values from
+ * pipelines.yaml
+ */
+
+public class KafkaSinkConfig {
+
+    @JsonProperty("bootstrap_servers")
+    @NotNull
+    @Size(min = 1, message = "Bootstrap servers can't be empty")
+    private List<String> bootStrapServers;
+
+    @JsonProperty("aws")
+    @NotNull
+    AwsDLQConfig dlqConfig;
+
+    @JsonProperty("thread_wait_time")
+    private Long threadWaitTime;
+
+    @JsonProperty("compression_type")
+    private String compressionType;
+
+    @JsonProperty("batch_size")
+    private Long batchSize;
+
+    @JsonProperty("max_request_size")
+    private String maxRequestSize;
+
+    @JsonProperty("acks")
+    private String acks;
+
+    @JsonProperty("topics")
+    private List<TopicConfig> topics;
+
+    @JsonProperty("authentication")
+    private AuthConfig authConfig;
+
+    @JsonProperty("schema")
+    @NotNull
+    @Valid
+    private SchemaConfig schemaConfig;
+
+    @JsonProperty(value = "serde_format",defaultValue = "plaintext")
+    private String serdeFormat;
+
+
+    public SchemaConfig getSchemaConfig() {
+        return schemaConfig;
+    }
+
+    public String getCompressionType() {
+        return compressionType;
+    }
+
+    public Long getBatchSize() {
+        return batchSize;
+    }
+
+    public String getMaxRequestSize() {
+        return maxRequestSize;
+    }
+
+    public String getAcks() {
+        return acks;
+    }
+
+
+    public List<TopicConfig> getTopics() {
+        return topics;
+    }
+
+
+    public AuthConfig getAuthConfig() {
+        return authConfig;
+    }
+
+
+    public List<String> getBootStrapServers() {
+        return bootStrapServers;
+    }
+
+    public AwsDLQConfig getDlqConfig() {
+        return dlqConfig;
+    }
+
+    public String getSerdeFormat() {
+        return serdeFormat;
+    }
+
+
+
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaSinkProducer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaSinkProducer.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.producer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSinkConfig;
+import org.opensearch.dataprepper.plugins.kafka.sink.DLQSink;
+import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
+
+
+/**
+ * * A helper class which helps takes the buffer data
+ * and produce it to a given kafka topic
+ */
+
+public class KafkaSinkProducer<T> {
+
+    private final Producer<String, T> producer;
+
+    private final KafkaSinkConfig kafkaSinkConfig;
+
+    private final DLQSink dlqSink;
+
+    private final CachedSchemaRegistryClient schemaRegistryClient;
+
+
+    public KafkaSinkProducer(final Producer producer,
+                             final KafkaSinkConfig kafkaSinkConfig,
+                             final DLQSink dlqSink) {
+        this.producer = producer;
+        this.kafkaSinkConfig = kafkaSinkConfig;
+        this.dlqSink=dlqSink;;
+        schemaRegistryClient=getSchemaRegistryClient();
+    }
+
+
+    public void produceRecords(final Record<Event> record) {
+        kafkaSinkConfig.getTopics().forEach(topic -> {
+            Object dataForDlq = null;
+            try {
+                String serdeFormat=kafkaSinkConfig.getSerdeFormat();
+                if (MessageFormat.JSON.toString().equalsIgnoreCase(serdeFormat)) {
+                    JsonNode dataNode = new ObjectMapper().convertValue(record.getData().toJsonString(), JsonNode.class);
+                    dataForDlq = dataNode;
+                    producer.send(new ProducerRecord(topic.getName(), dataNode));
+                }
+                else if (MessageFormat.AVRO.toString().equalsIgnoreCase(serdeFormat)) {
+                    final String valueToParse = schemaRegistryClient.
+                            getLatestSchemaMetadata(topic.getName() + "-value").getSchema();
+                    Schema schema =new Schema.Parser().parse(valueToParse);
+                    GenericRecord genericRecord = getGenericRecord(record.getData(),schema);
+                    dataForDlq = genericRecord;
+                    producer.send(new ProducerRecord(topic.getName(), genericRecord));
+                } else {
+                    dataForDlq = record.getData().toJsonString();
+                    producer.send(new ProducerRecord(topic.getName(), record.getData().toJsonString()));
+                }
+            } catch (Exception e) {
+               dlqSink.perform(dataForDlq);
+            }
+        });
+
+
+    }
+
+    private CachedSchemaRegistryClient getSchemaRegistryClient(){
+        return new CachedSchemaRegistryClient(kafkaSinkConfig.getSchemaConfig().getRegistryURL(),
+                100);
+    }
+
+    //TODO: we need feedback if this is suffient or there will be complex objects that will need conversion.
+    //TODO: This code is coming from sink-codec. Because below code was part of a private method in class
+    private GenericRecord getGenericRecord(Event event, Schema schema) {
+        final GenericRecord record = new GenericData.Record(schema);
+        for (final String key : event.toMap().keySet()) {
+            record.put(key, event.toMap().get(key));
+        }
+        return record;
+    }
+
+
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/ProducerWorker.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/ProducerWorker.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.producer;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+
+/**
+ * * A Multithreaded helper class which helps to produce the records to multiple topics in an
+ * asynchronous way.
+ */
+
+public class ProducerWorker implements Runnable {
+
+    private final Record<Event> record;
+    private final KafkaSinkProducer producer;
+
+
+    public ProducerWorker(final KafkaSinkProducer producer,
+                          final Record<Event> record) {
+        this.record = record;
+        this.producer=producer;
+    }
+
+    @Override
+    public void run() {
+            producer.produceRecords(record);
+    }
+
+ }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/DLQSink.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/DLQSink.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.dataprepper.plugins.kafka.sink;
+
+import org.opensearch.dataprepper.metrics.MetricNames;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.failures.DlqObject;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.plugins.dlq.DlqProvider;
+import org.opensearch.dataprepper.plugins.dlq.DlqWriter;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSinkConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.*;
+
+import static java.util.UUID.randomUUID;
+
+
+/**
+ * *This class which helps log failed data to AWS S3 bucket
+ */
+
+public class DLQSink {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DLQSink.class);
+
+    private static final String BUCKET = "bucket";
+    private static final String ROLE_ARN = "sts_role_arn";
+    private static final String REGION = "region";
+    private static final String S3_PLUGIN_NAME = "s3";
+    private final DlqProvider dlqProvider;
+    final PluginSetting pluginSetting;
+
+    public DLQSink(final PluginFactory pluginFactory, final KafkaSinkConfig kafkaSinkConfig,final PluginSetting pluginSetting) {
+         this.dlqProvider = getDlqProvider(pluginFactory, kafkaSinkConfig);
+         this.pluginSetting=pluginSetting;
+
+    }
+
+    public  void perform(final Object failedData) {
+        DlqWriter dlqWriter = getDlqWriter(pluginSetting.getPipelineName());
+        try {
+            String pluginId = randomUUID().toString();
+            DlqObject dlqObject = DlqObject.builder()
+                    .withPluginId(pluginId)
+                    .withPluginName(pluginSetting.getName())
+                    .withPipelineName(pluginSetting.getPipelineName())
+                    .withFailedData(failedData)
+                    .build();
+
+            dlqWriter.write(Arrays.asList(dlqObject), pluginSetting.getPipelineName(), pluginId);
+        } catch (final IOException io) {
+            LOG.error("Error occured while performing DLQ operation ",io);
+        }
+    }
+
+    private  DlqWriter getDlqWriter( final String writerPipelineName) {
+        Optional<DlqWriter> potentialDlq = dlqProvider.getDlqWriter(new StringJoiner(MetricNames.DELIMITER)
+                .add(writerPipelineName).toString());
+        DlqWriter dlqWriter = potentialDlq.isPresent() ? potentialDlq.get() : null;
+        return dlqWriter;
+    }
+
+    private  DlqProvider getDlqProvider(final PluginFactory pluginFactory, final KafkaSinkConfig kafkaSinkConfig) {
+        final Map<String, Object> props = new HashMap<>();
+        props.put(BUCKET, kafkaSinkConfig.getDlqConfig().getBucket());
+        props.put(ROLE_ARN, kafkaSinkConfig.getDlqConfig().getRoleArn());
+        props.put(REGION, kafkaSinkConfig.getDlqConfig().getRegion());
+        final PluginSetting dlqPluginSetting = new PluginSetting(S3_PLUGIN_NAME, props);
+        DlqProvider dlqProvider = pluginFactory.loadPlugin(DlqProvider.class, dlqPluginSetting);
+        return dlqProvider;
+    }
+}
+

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSink.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSink.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.sink;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.sink.AbstractSink;
+import org.opensearch.dataprepper.model.sink.Sink;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSinkConfig;
+import org.opensearch.dataprepper.plugins.kafka.producer.KafkaSinkProducer;
+import org.opensearch.dataprepper.plugins.kafka.producer.ProducerWorker;
+import org.opensearch.dataprepper.plugins.kafka.util.SinkPropertyConfigurer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implementation class of kafka--sink plugin. It is responsible for receive the collection of
+ * {@link Event} and produce it to different kafka topics.
+ */
+@DataPrepperPlugin(name = "kafka-sink", pluginType = Sink.class, pluginConfigurationType = KafkaSinkConfig.class)
+public class KafkaSink extends AbstractSink<Record<Event>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaSink.class);
+
+    private final KafkaSinkConfig kafkaSinkConfig;
+
+    private volatile boolean sinkInitialized;
+
+    private static final Integer totalWorkers = 1;
+
+    private ProducerWorker producerWorker;
+
+    private ExecutorService executorService;
+
+    private final PluginFactory pluginFactory;
+
+    private final PluginSetting pluginSetting;
+
+
+    @DataPrepperPluginConstructor
+    public KafkaSink(final PluginSetting pluginSetting, final KafkaSinkConfig kafkaSinkConfig, final PluginFactory pluginFactory) {
+        super(pluginSetting);
+        this.pluginSetting = pluginSetting;
+        this.kafkaSinkConfig = kafkaSinkConfig;
+        this.pluginFactory = pluginFactory;
+
+    }
+
+
+    @Override
+    public void doInitialize() {
+        try {
+            doInitializeInternal();
+        } catch (InvalidPluginConfigurationException e) {
+            LOG.error("Invalid plugin configuration, Hence failed to initialize kafka-sink plugin.");
+            this.shutdown();
+            throw e;
+        } catch (Exception e) {
+            LOG.error("Failed to initialize kafka-sink plugin.");
+            this.shutdown();
+            throw e;
+        }
+    }
+
+    private void doInitializeInternal() {
+        executorService = Executors.newFixedThreadPool(totalWorkers);
+        sinkInitialized = Boolean.TRUE;
+    }
+
+    @Override
+    public void doOutput(Collection<Record<Event>> records) {
+        if (records.isEmpty()) {
+            return;
+        }
+        try {
+            final KafkaSinkProducer producer = createProducer();
+            records.forEach(record -> {
+                producerWorker = new ProducerWorker(producer, record);
+                //TODO: uncomment this line after testing as this is the right way to do things
+                //executorService.submit(producerWorker);
+                //TODO: remove this line after testing as it executes the thread immediately
+                executorService.execute(producerWorker);
+            });
+
+        } catch (Exception e) {
+            LOG.error("Failed to setup the Kafka sink Plugin.", e);
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    public KafkaSinkProducer createProducer() {
+        Properties properties = SinkPropertyConfigurer.getProducerProperties(kafkaSinkConfig);
+        properties = Objects.requireNonNull(properties);
+        return new KafkaSinkProducer(new KafkaProducer<>(properties),
+                kafkaSinkConfig, new DLQSink(pluginFactory, kafkaSinkConfig,pluginSetting));
+    }
+
+    @Override
+    public void shutdown() {
+        try {
+            if (!executorService.awaitTermination(
+                    calculateLongestThreadWaitingTime(), TimeUnit.MILLISECONDS)) {
+                executorService.shutdownNow();
+            }
+            LOG.info("Sink threads are waiting for shutting down...");
+        } catch (InterruptedException e) {
+            if (e.getCause() instanceof InterruptedException) {
+                LOG.error("Interrupted during sink shutdown, exiting uncleanly...");
+                executorService.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+        super.shutdown();
+        LOG.info("Producer shutdown successfully...");
+    }
+
+    private long calculateLongestThreadWaitingTime() {
+        return kafkaSinkConfig.getThreadWaitTime();
+    }
+
+
+    @Override
+    public boolean isReady() {
+        return sinkInitialized;
+    }
+
+}
+

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/AuthenticationPropertyConfigurer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/AuthenticationPropertyConfigurer.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.kafka.util;
+
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSinkConfig;
+
+import java.util.Base64;
+import java.util.Properties;
+
+/**
+ * * This is static property configurer dedicated to authencation related information given in pipeline.yml
+ */
+
+public class AuthenticationPropertyConfigurer {
+
+    private static final String SESSION_TIMEOUT_MS_CONFIG = "30000";
+
+    private static final String SASL_MECHANISM = "sasl.mechanism";
+
+    private static final String SASL_SECURITY_PROTOCOL = "security.protocol";
+
+    private static final String SASL_JAS_CONFIG = "sasl.jaas.config";
+
+    private static final String SASL_CALLBACK_HANDLER_CLASS = "sasl.login.callback.handler.class";
+
+    private static final String SASL_JWKS_ENDPOINT_URL = "sasl.oauthbearer.jwks.endpoint.url";
+
+    private static final String SASL_TOKEN_ENDPOINT_URL = "sasl.oauthbearer.token.endpoint.url";
+
+    private static final String PLAINTEXT_JAASCONFIG = "org.apache.kafka.common.security.plain.PlainLoginModule required username= \"%s\" password=  " +
+            " \"%s\";";
+    private static final String OAUTH_JAASCONFIG = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId='"
+            + "%s" + "' clientSecret='" + "%s" + "' scope='" + "%s" + "' OAUTH_LOGIN_SERVER='" + "%s" +
+            "' OAUTH_LOGIN_ENDPOINT='" + "%s" + "' OAUT_LOGIN_GRANT_TYPE=" + "%s" +
+            " OAUTH_LOGIN_SCOPE=%s OAUTH_AUTHORIZATION='Basic " + "%s" + "';";
+
+    private static final String INSTROSPECT_SERVER_PROPERTIES = " OAUTH_INTROSPECT_SERVER='"
+            + "%s" + "' OAUTH_INTROSPECT_ENDPOINT='" + "%s" + "' " +
+            "OAUTH_INTROSPECT_AUTHORIZATION='Basic " + "%s";
+
+    private static final String PLAIN_MECHANISM = "PLAIN";
+
+    private static final String SASL_PLAINTEXT_PROTOCOL = "SASL_PLAINTEXT";
+
+
+    public static void setSaslPlainTextProperties(final KafkaSinkConfig kafkaSinkConfig,
+                                                  final Properties properties) {
+
+        String username = kafkaSinkConfig.getAuthConfig().getPlainTextAuthConfig().getUsername();
+        String password = kafkaSinkConfig.getAuthConfig().getPlainTextAuthConfig().getPassword();
+        properties.put(SASL_MECHANISM, PLAIN_MECHANISM);
+        properties.put(SASL_JAS_CONFIG, String.format(PLAINTEXT_JAASCONFIG, username, password));
+        properties.put(SASL_SECURITY_PROTOCOL, SASL_PLAINTEXT_PROTOCOL);
+    }
+
+    public static void setOauthProperties(final KafkaSinkConfig kafkaSinkConfig,
+                                          final Properties properties) {
+        String oauthClientId = kafkaSinkConfig.getAuthConfig().getoAuthConfig().getOauthClientId();
+        String oauthClientSecret = kafkaSinkConfig.getAuthConfig().getoAuthConfig().getOauthClientSecret();
+        String oauthLoginServer = kafkaSinkConfig.getAuthConfig().getoAuthConfig().getOauthLoginServer();
+        String oauthLoginEndpoint = kafkaSinkConfig.getAuthConfig().getoAuthConfig().getOauthLoginEndpoint();
+        String oauthLoginGrantType = kafkaSinkConfig.getAuthConfig().getoAuthConfig().getOauthLoginGrantType();
+        String oauthLoginScope = kafkaSinkConfig.getAuthConfig().getoAuthConfig().getOauthLoginScope();
+        String oauthAuthorizationToken = Base64.getEncoder().encodeToString((oauthClientId + ":" + oauthClientSecret).getBytes());
+        String oauthIntrospectEndpoint = kafkaSinkConfig.getAuthConfig().getoAuthConfig().getOauthIntrospectEndpoint();
+        String tokenEndPointURL = kafkaSinkConfig.getAuthConfig().getoAuthConfig().getOauthTokenEndpointURL();
+        String saslMechanism = kafkaSinkConfig.getAuthConfig().getoAuthConfig().getOauthSaslMechanism();
+        String securityProtocol = kafkaSinkConfig.getAuthConfig().getoAuthConfig().getOauthSecurityProtocol();
+        String loginCallBackHandler = kafkaSinkConfig.getAuthConfig().getoAuthConfig().getOauthSaslLoginCallbackHandlerClass();
+        String oauthJwksEndpointURL = kafkaSinkConfig.getAuthConfig().getoAuthConfig().getOauthJwksEndpointURL();
+        String introspectServer = kafkaSinkConfig.getAuthConfig().getoAuthConfig().getOauthIntrospectServer();
+
+
+        properties.put(SASL_MECHANISM, saslMechanism);
+        properties.put(SASL_SECURITY_PROTOCOL, securityProtocol);
+        properties.put(SASL_TOKEN_ENDPOINT_URL, tokenEndPointURL);
+        properties.put(SASL_CALLBACK_HANDLER_CLASS, loginCallBackHandler);
+        if (oauthJwksEndpointURL != null && !oauthJwksEndpointURL.isEmpty() && !oauthJwksEndpointURL.isBlank()) {
+            properties.put(SASL_JWKS_ENDPOINT_URL, oauthJwksEndpointURL);
+        }
+
+        String instrospect_properties = "";
+        if (oauthJwksEndpointURL != null && !oauthIntrospectEndpoint.isBlank() && !oauthIntrospectEndpoint.isEmpty()) {
+            instrospect_properties = String.format(INSTROSPECT_SERVER_PROPERTIES, introspectServer, oauthIntrospectEndpoint, oauthAuthorizationToken);
+        }
+
+        String jass_config = String.format(OAUTH_JAASCONFIG, oauthClientId, oauthClientSecret, oauthLoginScope, oauthLoginServer,
+                oauthLoginEndpoint, oauthLoginGrantType, oauthLoginScope, oauthAuthorizationToken, instrospect_properties);
+
+        properties.put(SASL_JAS_CONFIG, jass_config);
+    }
+}
+

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/SinkPropertyConfigurer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/SinkPropertyConfigurer.java
@@ -1,0 +1,67 @@
+package org.opensearch.dataprepper.plugins.kafka.util;
+
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.connect.json.JsonSerializer;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSinkConfig;
+
+import java.util.Properties;
+
+public class SinkPropertyConfigurer {
+
+    private static final String VALUE_SERIALIZER = "value.serializer";
+
+    private static final String KEY_SERIALIZER = "key.serializer";
+
+    private static final String SESSION_TIMEOUT_MS_CONFIG = "30000";
+
+    private static final String REGISTRY_URL = "schema.registry.url";
+
+    public static  Properties getProducerProperties(final KafkaSinkConfig kafkaSinkConfig) {
+        Properties properties = new Properties();
+        setCommonServerProperties(properties,kafkaSinkConfig);
+        setPropertiesForSerializer(properties, kafkaSinkConfig.getSerdeFormat(),kafkaSinkConfig);
+        if (kafkaSinkConfig.getAuthConfig().getPlainTextAuthConfig() != null) {
+            AuthenticationPropertyConfigurer.setSaslPlainTextProperties(kafkaSinkConfig, properties);
+        } else if (kafkaSinkConfig.getAuthConfig().getoAuthConfig() != null) {
+            AuthenticationPropertyConfigurer.setOauthProperties(kafkaSinkConfig, properties);
+        }
+        return properties;
+    }
+
+    private static void setCommonServerProperties(final Properties properties,final KafkaSinkConfig kafkaSinkConfig) {
+        properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, kafkaSinkConfig.getBootStrapServers());
+        properties.put(CommonClientConfigs.SESSION_TIMEOUT_MS_CONFIG, SESSION_TIMEOUT_MS_CONFIG);
+    }
+
+    private static void setPropertiesForSerializer(Properties properties, final String serdeFormat,final KafkaSinkConfig kafkaSinkConfig) {
+        properties.put(KEY_SERIALIZER, StringSerializer.class.getName());
+        validateForRegistryURL(kafkaSinkConfig);
+        if (serdeFormat.equalsIgnoreCase(MessageFormat.JSON.toString())) {
+            properties.put(VALUE_SERIALIZER, JsonSerializer.class.getName());
+            properties.put(REGISTRY_URL, kafkaSinkConfig.getSchemaConfig().getRegistryURL());
+        } else if (serdeFormat.equalsIgnoreCase(MessageFormat.AVRO.toString())) {
+            properties.put(VALUE_SERIALIZER, KafkaAvroSerializer.class.getName());
+            properties.put(REGISTRY_URL, kafkaSinkConfig.getSchemaConfig().getRegistryURL());
+        } else {
+            properties.put(VALUE_SERIALIZER, StringSerializer.class.getName());
+        }
+    }
+
+    private static void validateForRegistryURL(KafkaSinkConfig kafkaSinkConfig) {
+       final String serdeFormat=kafkaSinkConfig.getSerdeFormat();
+        if(serdeFormat.equalsIgnoreCase(MessageFormat.AVRO.toString())){
+            if(kafkaSinkConfig.getSchemaConfig()==null ||kafkaSinkConfig.getSchemaConfig().getRegistryURL()==null||
+                    kafkaSinkConfig.getSchemaConfig().getRegistryURL().isBlank()||kafkaSinkConfig.getSchemaConfig().getRegistryURL().isEmpty()){
+                throw new RuntimeException("Schema registry is mandatory when serde type is avro");
+            }
+        }
+        if(serdeFormat.equalsIgnoreCase(MessageFormat.PLAINTEXT.toString())){
+            if(kafkaSinkConfig.getSchemaConfig()!=null &&
+                    kafkaSinkConfig.getSchemaConfig().getRegistryURL()!=null){
+                throw new RuntimeException("Schema registry is not required for type plaintext");
+            }
+        }
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/AwsDlqConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/AwsDlqConfigTest.java
@@ -1,0 +1,55 @@
+package org.opensearch.dataprepper.plugins.kafka.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class AwsDlqConfigTest {
+
+
+	AwsDLQConfig awsDLQConfig;
+
+	List<String> bootstrapServers;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		//Added to load Yaml file - Start
+		Yaml yaml = new Yaml();
+		FileReader fileReader = new FileReader(getClass().getClassLoader().getResource("sample-pipelines-sink.yaml").getFile());
+		Object data = yaml.load(fileReader);
+		if(data instanceof Map){
+			Map<String, Object> propertyMap = (Map<String, Object>) data;
+			Map<String, Object> logPipelineMap = (Map<String, Object>) propertyMap.get("log-pipeline");
+			Map<String, Object> sinkeMap = (Map<String, Object>) logPipelineMap.get("sink");
+			Map<String, Object> kafkaConfigMap = (Map<String, Object>) sinkeMap.get("kafka-sink");
+			ObjectMapper mapper = new ObjectMapper();
+			mapper.registerModule(new JavaTimeModule());
+			String json = mapper.writeValueAsString(kafkaConfigMap);
+			Reader reader = new StringReader(json);
+			awsDLQConfig = mapper.readValue(reader, KafkaSinkConfig.class).getDlqConfig();
+		}
+	}
+	@Test
+	void test_aws_props(){
+		assertThat(awsDLQConfig.getBucket(), notNullValue());
+		assertThat(awsDLQConfig.getRegion(), notNullValue());
+		assertThat(awsDLQConfig.getRoleArn(), notNullValue());
+
+	}
+
+
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSinkConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSinkConfigTest.java
@@ -1,0 +1,99 @@
+package org.opensearch.dataprepper.plugins.kafka.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class KafkaSinkConfigTest {
+
+
+	KafkaSinkConfig kafkaSinkConfig;
+
+	List<String> bootstrapServers;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		//Added to load Yaml file - Start
+		Yaml yaml = new Yaml();
+		FileReader fileReader = new FileReader(getClass().getClassLoader().getResource("sample-pipelines-sink.yaml").getFile());
+		Object data = yaml.load(fileReader);
+		if(data instanceof Map){
+			Map<String, Object> propertyMap = (Map<String, Object>) data;
+			Map<String, Object> logPipelineMap = (Map<String, Object>) propertyMap.get("log-pipeline");
+			Map<String, Object> sinkeMap = (Map<String, Object>) logPipelineMap.get("sink");
+			Map<String, Object> kafkaConfigMap = (Map<String, Object>) sinkeMap.get("kafka-sink");
+			ObjectMapper mapper = new ObjectMapper();
+			mapper.registerModule(new JavaTimeModule());
+			String json = mapper.writeValueAsString(kafkaConfigMap);
+			Reader reader = new StringReader(json);
+			kafkaSinkConfig = mapper.readValue(reader, KafkaSinkConfig.class);
+		}
+	}
+
+	@Test
+	void test_kafka_config_not_null() {
+		assertThat(kafkaSinkConfig, notNullValue());
+	}
+
+	@Test
+	void test_bootStrapServers_not_null(){
+		assertThat(kafkaSinkConfig.getBootStrapServers(), notNullValue());
+		List<String> servers = kafkaSinkConfig.getBootStrapServers();
+		bootstrapServers = servers.stream().
+				flatMap(str -> Arrays.stream(str.split(","))).
+				map(String::trim).
+				collect(Collectors.toList());
+		assertThat(bootstrapServers.size(), equalTo(1));
+		assertThat(bootstrapServers, hasItem("localhost:29092"));
+	}
+
+	@Test
+	void test_topics_not_null(){
+		assertThat(kafkaSinkConfig.getTopics(), notNullValue());
+	}
+	@Test
+	void test_schema_not_null(){
+		assertThat(kafkaSinkConfig.getSchemaConfig(), notNullValue());
+	}
+	@Test
+	void test_authentication_not_null(){
+		assertThat(kafkaSinkConfig.getAuthConfig(), notNullValue());
+	}
+	@Test
+	void test_batch_size_not_null(){
+		assertThat(kafkaSinkConfig.getBatchSize(), notNullValue());
+	}
+	@Test
+	void test_compression_type_not_null(){
+		assertThat(kafkaSinkConfig.getCompressionType(), notNullValue());
+	}
+	@Test
+	void test_acks_null(){
+		assertThat(kafkaSinkConfig.getAcks(), notNullValue());
+	}
+
+	@Test
+	void test_dlq_config_null(){
+		assertThat(kafkaSinkConfig.getDlqConfig(), notNullValue());
+	}
+
+	@Test
+	void test_thread_wait_time_null(){
+		assertThat(kafkaSinkConfig.getThreadWaitTime(), notNullValue());
+	}
+
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaSinkProducerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaSinkProducerTest.java
@@ -1,0 +1,122 @@
+package org.opensearch.dataprepper.plugins.kafka.producer;
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.connect.json.JsonSerializer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSinkConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.TopicConfig;
+import org.opensearch.dataprepper.plugins.kafka.sink.DLQSink;
+import org.powermock.api.mockito.PowerMockito;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class KafkaSinkProducerTest {
+
+    private KafkaSinkProducer producer;
+
+    @Mock
+    private KafkaSinkConfig kafkaSinkConfig;
+
+    List<TopicConfig> topics = new ArrayList<TopicConfig>();
+
+
+    private Record<Event> record;
+
+    KafkaSinkProducer sinkProducer;
+
+    @Mock
+    private DLQSink dlqSink;
+
+    private Event event;
+    @BeforeEach
+    public void setUp(){
+
+        event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        record=new Record<>(event);
+        final TopicConfig topicConfig = new TopicConfig();
+        topicConfig.setName("test-topic");
+        topics.add(topicConfig);
+
+        when(kafkaSinkConfig.getTopics()).thenReturn(topics);
+        when(kafkaSinkConfig.getSchemaConfig()).thenReturn(mock(SchemaConfig.class));
+        when(kafkaSinkConfig.getSchemaConfig().getRegistryURL()).thenReturn("http://localhost:8085/");
+
+    }
+    @Test
+    public void producePlainTextRecordsTest() {
+        when(kafkaSinkConfig.getSerdeFormat()).thenReturn("plaintext");
+        MockProducer mockProducer = new MockProducer<>(true, new StringSerializer(), new StringSerializer());
+        producer = new KafkaSinkProducer(mockProducer, kafkaSinkConfig,dlqSink);
+        sinkProducer = spy(producer);
+        sinkProducer.produceRecords(record);
+        verify(sinkProducer).produceRecords(record);
+
+    }
+
+    @Test
+    public void produceJsonRecordsTest()  {
+        when(kafkaSinkConfig.getSerdeFormat()).thenReturn("json");
+        MockProducer mockProducer = new MockProducer<>(true, new StringSerializer(), new JsonSerializer());
+        producer=new KafkaSinkProducer(mockProducer, kafkaSinkConfig,dlqSink);
+        sinkProducer=spy(producer);
+        sinkProducer.produceRecords(record);
+        verify(sinkProducer).produceRecords(record);
+
+    }
+
+    @Test
+    public void produceAvroRecordsTest() throws Exception {
+        when(kafkaSinkConfig.getSerdeFormat()).thenReturn("avro");
+        CachedSchemaRegistryClient schemaRegistryClient=PowerMockito.mock(CachedSchemaRegistryClient.class);
+        whenNew(CachedSchemaRegistryClient.class).withArguments(kafkaSinkConfig.getSchemaConfig().getRegistryURL(), 100)
+                .thenReturn(schemaRegistryClient);
+
+        MockProducer mockProducer = new MockProducer<>(true, new StringSerializer(), new KafkaAvroSerializer());
+        producer = new KafkaSinkProducer(mockProducer, kafkaSinkConfig,dlqSink);
+        sinkProducer = spy(producer);
+        sinkProducer.produceRecords(record);
+        verify(sinkProducer).produceRecords(record);
+
+    }
+
+    @Test
+    public void testGetGenericRecord() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        producer=new KafkaSinkProducer(new MockProducer(), kafkaSinkConfig,dlqSink);
+        final Schema schema = createMockSchema();
+        Method privateMethod = KafkaSinkProducer.class.getDeclaredMethod("getGenericRecord", Event.class, Schema.class);
+        privateMethod.setAccessible(true);
+        GenericRecord result = (GenericRecord) privateMethod.invoke(producer, event,schema);
+        Assertions.assertNotNull(result);
+    }
+
+    private Schema createMockSchema() {
+        String schemaDefinition = "{\"type\":\"record\",\"name\":\"MyRecord\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}";
+        return new Schema.Parser().parse(schemaDefinition);
+    }
+}
+

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/producer/ProducerWorkerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/producer/ProducerWorkerTest.java
@@ -1,0 +1,48 @@
+package org.opensearch.dataprepper.plugins.kafka.producer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSinkConfig;
+
+import static org.mockito.Mockito.*;
+
+
+class ProducerWorkerTest {
+
+    @Mock
+    ProducerWorker multithreadedProducer;
+
+    @Mock
+    KafkaSinkConfig kafkaSinkConfig;
+
+    private Record<Event> record;
+
+
+    @BeforeEach
+    public void setUp(){
+        Event event= JacksonEvent.fromMessage("Testing multithreaded producer");
+        record=new Record<>(event);
+    }
+
+
+    private ProducerWorker createObjectUnderTest(){
+           return new ProducerWorker(mock(KafkaSinkProducer.class),record);
+    }
+
+    @Test
+    void testWritingToTopic()  {
+        multithreadedProducer = createObjectUnderTest();
+        Thread spySink = spy(new Thread(multithreadedProducer));
+        spySink.start();
+        verify(spySink).start();
+    }
+
+
+
+
+
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/sink/DLQSinkTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/sink/DLQSinkTest.java
@@ -1,0 +1,85 @@
+package org.opensearch.dataprepper.plugins.kafka.sink;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.plugins.dlq.DlqProvider;
+import org.opensearch.dataprepper.plugins.dlq.DlqWriter;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSinkConfig;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+public class DLQSinkTest {
+
+    @Mock
+    private PluginFactory pluginFactory;
+
+
+    private KafkaSinkConfig kafkaSinkConfig;
+
+    @Mock
+    private DlqProvider dlqProvider;
+
+    @Mock
+    private DlqWriter dlqWriter;
+
+
+    private PluginSetting pluginSetting;
+
+    private DLQSink dlqSink;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        MockitoAnnotations.initMocks(this);
+        when(pluginFactory.loadPlugin(any(Class.class), any(PluginSetting.class))).thenReturn(dlqProvider);
+        when(dlqProvider.getDlqWriter(anyString())).thenReturn(Optional.of(dlqWriter));
+        pluginSetting=new PluginSetting("kafka-sink",new HashMap<>());
+
+
+
+        Yaml yaml = new Yaml();
+        FileReader fileReader = new FileReader(getClass().getClassLoader().getResource("sample-pipelines-sink.yaml").getFile());
+        Object data = yaml.load(fileReader);
+        if(data instanceof Map){
+            Map<String, Object> propertyMap = (Map<String, Object>) data;
+            Map<String, Object> logPipelineMap = (Map<String, Object>) propertyMap.get("log-pipeline");
+            Map<String, Object> sinkeMap = (Map<String, Object>) logPipelineMap.get("sink");
+            Map<String, Object> kafkaConfigMap = (Map<String, Object>) sinkeMap.get("kafka-sink");
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new JavaTimeModule());
+            String json = mapper.writeValueAsString(kafkaConfigMap);
+            Reader reader = new StringReader(json);
+            kafkaSinkConfig = mapper.readValue(reader, KafkaSinkConfig.class);
+
+
+        }
+        dlqSink = new DLQSink(pluginFactory, kafkaSinkConfig, pluginSetting);
+    }
+
+    @Test
+    public void testPerform() throws IOException {
+        Object failedData = new Object();
+        ReflectionTestUtils.setField(pluginSetting,"pipelineName","test");
+        doNothing().when(dlqWriter).write(anyList(), anyString(), anyString());
+        dlqSink.perform(failedData);
+        verify(dlqWriter).write(anyList(), anyString(), anyString());
+    }
+
+
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkasinkTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkasinkTest.java
@@ -1,0 +1,191 @@
+package org.opensearch.dataprepper.plugins.kafka.sink;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.kafka.configuration.*;
+import org.opensearch.dataprepper.plugins.kafka.producer.ProducerWorker;
+import org.opensearch.dataprepper.plugins.kafka.util.SinkPropertyConfigurer;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.FileReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class KafkasinkTest {
+
+
+    KafkaSink kafkaSink;
+
+    // @Mock
+    KafkaSinkConfig kafkaSinkConfig;
+
+
+    ExecutorService executorService;
+
+
+    private SchemaConfig schemaConfig;
+
+    @Mock
+    PluginSetting pluginSetting;
+
+    @Mock
+    FutureTask futureTask;
+
+    @Mock
+    AuthConfig authConfig;
+
+    Event event;
+
+    KafkaSink spySink;
+
+    private static final Integer totalWorkers = 1;
+
+    MockedStatic<Executors> executorsMockedStatic;
+
+    MockedStatic<SinkPropertyConfigurer> propertyConfigurerMockedStatic;
+
+    @Mock
+    PlainTextAuthConfig plainTextAuthConfig;
+
+    @Mock
+    OAuthConfig oAuthConfig;
+
+    @Mock
+    private PluginSetting pluginSettingMock;
+
+    @Mock
+    private KafkaSinkConfig kafkaSinkConfigMock;
+
+    @Mock
+    private PluginFactory pluginFactoryMock;
+
+    Properties props;
+
+    @Mock
+    AwsDLQConfig dlqConfig;
+
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Yaml yaml = new Yaml();
+        FileReader fileReader = new FileReader(getClass().getClassLoader().getResource("sample-pipelines-sink.yaml").getFile());
+        Object data = yaml.load(fileReader);
+        if (data instanceof Map) {
+            Map<String, Object> propertyMap = (Map<String, Object>) data;
+            Map<String, Object> logPipelineMap = (Map<String, Object>) propertyMap.get("log-pipeline");
+            Map<String, Object> sinkeMap = (Map<String, Object>) logPipelineMap.get("sink");
+            Map<String, Object> kafkaConfigMap = (Map<String, Object>) sinkeMap.get("kafka-sink");
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new JavaTimeModule());
+            String json = mapper.writeValueAsString(kafkaConfigMap);
+            Reader reader = new StringReader(json);
+            kafkaSinkConfig = mapper.readValue(reader, KafkaSinkConfig.class);
+        }
+        executorService = mock(ExecutorService.class);
+        when(pluginSetting.getPipelineName()).thenReturn("Kafka-sink");
+        event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        kafkaSink = new KafkaSink(pluginSetting, kafkaSinkConfig, pluginFactoryMock);
+        spySink = spy(kafkaSink);
+        executorsMockedStatic = mockStatic(Executors.class);
+        props = new Properties();
+        props.put("bootstrap.servers", "127.0.0.1:9093");
+        props.put("key.serializer", StringSerializer.class.getName());
+        props.put("value.serializer", StringSerializer.class.getName());
+        ReflectionTestUtils.setField(spySink, "executorService", executorService);
+
+
+    }
+
+    @AfterEach
+    public void after() {
+        executorsMockedStatic.close();
+    }
+
+    @Test
+    public void doOutputTest() {
+        when(executorService.submit(any(ProducerWorker.class))).thenReturn(futureTask);
+        final Collection records = Arrays.asList(new Record(event));
+        spySink.doOutput(records);
+        verify(spySink).doOutput(records);
+    }
+
+
+    @Test
+    public void doOutputExceptionTest() {
+        final Collection records = Arrays.asList(new Record(event));
+        when(executorService.submit(any(ProducerWorker.class))).thenThrow(new RuntimeException());
+        assertThrows(RuntimeException.class, () -> spySink.doOutput(records));
+    }
+
+    @Test
+    public void doOutputEmptyRecordsTest() {
+        final Collection records = Arrays.asList();
+        spySink.doOutput(records);
+        verify(spySink).doOutput(records);
+
+    }
+
+    @Test
+    public void shutdownTest() throws InterruptedException {
+        spySink.shutdown();
+        verify(spySink).shutdown();
+    }
+
+    @Test
+    public void shutdownExceptionTest() throws InterruptedException {
+        final InterruptedException interruptedException = new InterruptedException();
+        interruptedException.initCause(new InterruptedException());
+
+        when(executorService.awaitTermination(
+                1000L, TimeUnit.MILLISECONDS)).thenThrow(interruptedException);
+        spySink.shutdown();
+
+    }
+
+
+    @Test
+    public void doInitializeTest() {
+        spySink.doInitialize();
+        verify(spySink).doInitialize();
+    }
+
+    @Test
+    public void doInitializeNullPointerExceptionTest() {
+        when(Executors.newFixedThreadPool(totalWorkers)).thenThrow(NullPointerException.class);
+        assertThrows(NullPointerException.class, () -> spySink.doInitialize());
+    }
+
+
+    @Test
+    public void isReadyTest() {
+        ReflectionTestUtils.setField(kafkaSink, "sinkInitialized", true);
+        assertEquals(true, kafkaSink.isReady());
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/AuthenticationPropertyConfigurerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/AuthenticationPropertyConfigurerTest.java
@@ -1,0 +1,63 @@
+package org.opensearch.dataprepper.plugins.kafka.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSinkConfig;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Map;
+import java.util.Properties;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthenticationPropertyConfigurerTest {
+
+
+
+    KafkaSinkConfig kafkaSinkConfig;
+
+
+
+
+    private KafkaSinkConfig createKafkaSinkConfig(String fileName) throws IOException {
+        Yaml yaml = new Yaml();
+        FileReader fileReader = new FileReader(getClass().getClassLoader().getResource(fileName).getFile());
+        Object data = yaml.load(fileReader);
+        if(data instanceof Map){
+            Map<String, Object> propertyMap = (Map<String, Object>) data;
+            Map<String, Object> logPipelineMap = (Map<String, Object>) propertyMap.get("log-pipeline");
+            Map<String, Object> sinkeMap = (Map<String, Object>) logPipelineMap.get("sink");
+            Map<String, Object> kafkaConfigMap = (Map<String, Object>) sinkeMap.get("kafka-sink");
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new JavaTimeModule());
+            String json = mapper.writeValueAsString(kafkaConfigMap);
+            Reader reader = new StringReader(json);
+            return  mapper.readValue(reader, KafkaSinkConfig.class);
+        }
+        return null;
+
+    }
+
+    @Test
+     public void testSetSaslPlainTextProperties() throws IOException {
+        Properties props=new Properties();
+        kafkaSinkConfig=createKafkaSinkConfig("sample-pipelines-sink.yaml");
+        AuthenticationPropertyConfigurer.setSaslPlainTextProperties(kafkaSinkConfig,props);
+        Assertions.assertEquals("PLAIN",props.getProperty("sasl.mechanism"));
+     }
+    @Test
+    public void testSetSaslOauthProperties() throws IOException {
+        Properties props=new Properties();
+        kafkaSinkConfig=createKafkaSinkConfig("sample-pipelines-sink-oauth.yaml");
+        AuthenticationPropertyConfigurer.setOauthProperties(kafkaSinkConfig,props);
+        Assertions.assertEquals("OAUTHBEARER",props.getProperty("sasl.mechanism"));
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/SinkPropertyConfigurerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/SinkPropertyConfigurerTest.java
@@ -1,0 +1,79 @@
+package org.opensearch.dataprepper.plugins.kafka.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSinkConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaConfig;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Map;
+import java.util.Properties;
+
+@ExtendWith(MockitoExtension.class)
+public class SinkPropertyConfigurerTest {
+
+
+
+    KafkaSinkConfig kafkaSinkConfig;
+
+
+    @BeforeEach
+    public void setUp() throws IOException {
+
+        Yaml yaml = new Yaml();
+        FileReader fileReader = new FileReader(getClass().getClassLoader().getResource("sample-pipelines-sink.yaml").getFile());
+        Object data = yaml.load(fileReader);
+        if(data instanceof Map){
+            Map<String, Object> propertyMap = (Map<String, Object>) data;
+            Map<String, Object> logPipelineMap = (Map<String, Object>) propertyMap.get("log-pipeline");
+            Map<String, Object> sinkeMap = (Map<String, Object>) logPipelineMap.get("sink");
+            Map<String, Object> kafkaConfigMap = (Map<String, Object>) sinkeMap.get("kafka-sink");
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new JavaTimeModule());
+            String json = mapper.writeValueAsString(kafkaConfigMap);
+            Reader reader = new StringReader(json);
+            kafkaSinkConfig = mapper.readValue(reader, KafkaSinkConfig.class);
+        }
+    }
+
+    @Test
+     public void testGetProducerPropertiesForJson(){
+        Properties props=SinkPropertyConfigurer.getProducerProperties(kafkaSinkConfig);
+        Assertions.assertEquals("30000",props.getProperty("session.timeout.ms"));
+     }
+
+    @Test
+    public void testGetProducerPropertiesForPlainText(){
+        ReflectionTestUtils.setField(kafkaSinkConfig,"serdeFormat","plaintext");
+        Assertions.assertThrows(RuntimeException.class,()->SinkPropertyConfigurer.getProducerProperties(kafkaSinkConfig));
+
+    }
+    @Test
+    public void testGetProducerPropertiesForAvro(){
+        ReflectionTestUtils.setField(kafkaSinkConfig,"serdeFormat","avro");
+        SchemaConfig schemaConfig=kafkaSinkConfig.getSchemaConfig();
+        ReflectionTestUtils.setField(kafkaSinkConfig,"schemaConfig",null);
+        Assertions.assertThrows(RuntimeException.class,()->SinkPropertyConfigurer.getProducerProperties(kafkaSinkConfig));
+        ReflectionTestUtils.setField(kafkaSinkConfig,"schemaConfig",schemaConfig);
+        Assertions.assertEquals("30000",SinkPropertyConfigurer.getProducerProperties(kafkaSinkConfig).getProperty("session.timeout.ms"));
+
+    }
+
+    @Test
+    public void testGetProducerPropertiesForNoSerde(){
+        ReflectionTestUtils.setField(kafkaSinkConfig,"serdeFormat",null);
+        Assertions.assertThrows(RuntimeException.class,()->SinkPropertyConfigurer.getProducerProperties(kafkaSinkConfig));
+
+    }
+
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines-sink-oauth.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines-sink-oauth.yaml
@@ -1,0 +1,37 @@
+log-pipeline :
+  source :
+    random :
+  sink :
+       kafka-sink :
+        bootstrap_servers :
+          - "localhost:29092"
+        batch_size: 100
+        acks: "acks"
+        compression_type: "none"
+        thread_wait_time: 1000
+        aws:
+          bucket: "mydlqtestbucket"
+          sts_role_arn: "arn:aws:iam::045129910014:role/dataprepper"
+          region: "ap-south-1"
+        serde_format: json
+        topics:
+          - name: my-test-topic2
+        schema:
+          registry_url: http://localhost:8085/
+          version: 1
+        authentication:
+         sasl_oauth:
+           oauth_client_id: XXXXXXXXXXXXXXX
+           oauth_client_secret: XXXXXXXXXXXXXXX
+           oauth_login_server: https://dev-XXXXXXXXXXXXXXX.okta.com
+           oauth_login_endpoint: /oauth2/default/v1/token
+           oauth_login_grant_type: refresh_token
+           oauth_login_scope: kafka
+           oauth_introspect_server: https://dev-XXXXXXXXXXXXXXX.okta.com
+           oauth_introspect_endpoint: /oauth2/default/v1/introspect
+           oauth_token_endpoint_url: https://dev-XXXXXXXXXXXXXXX.okta.com/oauth2/default/v1/token
+           oauth_sasl_mechanism: OAUTHBEARER
+           oauth_security_protocol: SASL_PLAINTEXT
+           oauth_sasl_login_callback_handler_class: org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler
+           oauth_jwks_endpoint_url: https://dev-XXXXXXXXXXXXXXX.okta.com/oauth2/default/v1/keys
+

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines-sink.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines-sink.yaml
@@ -1,0 +1,26 @@
+log-pipeline :
+  source :
+    random :
+  sink :
+       kafka-sink :
+        bootstrap_servers :
+          - "localhost:29092"
+        batch_size: 100
+        acks: "acks"
+        compression_type: "none"
+        thread_wait_time: 1000
+        aws:
+          bucket: "mydlqtestbucket"
+          sts_role_arn: "arn:aws:iam::045129910014:role/dataprepper"
+          region: "ap-south-1"
+        serde_format: json
+        topics:
+          - name: my-test-topic2
+        schema:
+          registry_url: http://localhost:8085/
+          version: 1
+        authentication:
+          sasl_plaintext:
+            username: "broker"
+            password: "broker"
+


### PR DESCRIPTION
Signed-off-by: rajeshLovesToCode <rajesh.dharamdasani3021@gmail.com>

### Description
Kafk Sink  with SASL_PLAINTEXT, OAuth, schema registry, multithreaded producer and DLQ.
 
### Issues Resolved
Github issue https://github.com/opensearch-project/data-prepper/issues/1986
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
