### PR TITLE
Translate Plugin - Added functionality for iterate_on, default, exact options

### DIFF
--- a/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/RegexParameterConfiguration.java
+++ b/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/RegexParameterConfiguration.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public class RegexParameterConfiguration {
 
-    private static final boolean DEFAULT_EXACT = true;
+    public final boolean DEFAULT_EXACT = true;
     @NotNull
     @JsonProperty("patterns")
     private Map<String, String> patterns;

--- a/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/RegexParameterConfiguration.java
+++ b/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/RegexParameterConfiguration.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public class RegexParameterConfiguration {
 
-    public final boolean DEFAULT_EXACT = true;
+    final boolean DEFAULT_EXACT = true;
     @NotNull
     @JsonProperty("patterns")
     private Map<String, String> patterns;

--- a/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorConfig.java
+++ b/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorConfig.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -18,8 +20,7 @@ public class TranslateProcessorConfig {
 
     @JsonProperty("source")
     @NotNull
-    @NotEmpty
-    private String source;
+    private Object source;
 
     @JsonProperty("target")
     @NotNull
@@ -28,39 +29,60 @@ public class TranslateProcessorConfig {
 
     @JsonProperty("map")
     private Map<String, String> map;
+
     @JsonProperty("file_path")
     private String filePath;
 
-    @JsonProperty("map_when")
-    private String mapWhen;
+    @JsonProperty("default")
+    private String defaultValue;
+
+    @JsonProperty("translate_when")
+    private String translateWhen;
+
+    @JsonProperty("iterate_on")
+    private String iterateOn;
 
     @JsonProperty("regex")
     private RegexParameterConfiguration regexParameterConfiguration;
 
 
-    public String getSource() { return source; }
+    public Object getSource() { return source; }
 
     public String getTarget() { return target; }
 
     public Map<String, String> getMap() { return map; }
 
+    public String getDefaultValue() { return defaultValue; }
+
     public String getFilePath() { return filePath; }
 
-    public String getMapWhen() { return mapWhen; }
+    public String getTranslateWhen() { return translateWhen; }
+
+    public String getIterateOn() { return iterateOn; }
 
     public RegexParameterConfiguration getRegexParameterConfiguration(){ return regexParameterConfiguration; }
 
 
-    @AssertTrue(message = "Either of map / patterns / file_path options need to be configured. (pattern option is mandatory while configuring regex option)")
-    public boolean hasMappings() {
-        return (Stream.of(map, filePath, regexParameterConfiguration).filter(n -> n!=null).count() != 0) && checkPatternUnderRegex();
+    @AssertTrue(message = "source field must be a string or list of strings")
+    public boolean isSourceFieldValid(){
+        if(source instanceof String){
+            return true;
+        }
+        if(source instanceof List<?>){
+            List<?>  sourceList = (List<?>) source;
+            return sourceList.stream().allMatch(sourceItem -> sourceItem instanceof String);
+        }
+        return false;
     }
 
-    public boolean checkPatternUnderRegex(){
-        if(regexParameterConfiguration!=null && regexParameterConfiguration.getPatterns()==null){
-            return false;
-        }
-        return true;
+    @AssertTrue(message = "Either of map or patterns or file_path options need to be configured.")
+    public boolean hasMappings() {
+        return Stream.of(map, filePath, regexParameterConfiguration).filter(n -> n!=null).count() != 0;
+    }
+
+    @AssertTrue(message = "pattern option is mandatory while configuring regex option")
+    public boolean isPatternPresent(){
+        return regexParameterConfiguration == null || regexParameterConfiguration.getPatterns() != null;
     }
 
 }

--- a/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/RegexParameterConfigurationTest.java
+++ b/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/RegexParameterConfigurationTest.java
@@ -22,7 +22,7 @@ class RegexParameterConfigurationTest {
     }
 
     @Test
-    public void test_get_patterns() throws NoSuchFieldException, IllegalAccessException{
+    void test_get_patterns() throws NoSuchFieldException, IllegalAccessException{
         final Map<String, String> patternMap = Collections.singletonMap("key1", "val1");
         setField(RegexParameterConfiguration.class, regexParameterConfiguration, "patterns", patternMap);
         assertThat(regexParameterConfiguration.getPatterns(), is(patternMap));

--- a/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorConfigTest.java
+++ b/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorConfigTest.java
@@ -4,8 +4,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
 
@@ -54,6 +59,42 @@ class TranslateProcessorConfigTest {
         setField(RegexParameterConfiguration.class, regexParameterConfiguration, "exact", true);
         setField(TranslateProcessorConfig.class, translateProcessorConfig, "map", Collections.singletonMap("key1", "val1"));
         setField(TranslateProcessorConfig.class, translateProcessorConfig, "regexParameterConfiguration", regexParameterConfiguration);
-        assertFalse(translateProcessorConfig.hasMappings());
+        assertFalse(translateProcessorConfig.isPatternPresent());
+    }
+
+    @Test
+    void test_source_field_valid_types() throws NoSuchFieldException, IllegalAccessException{
+        setField(TranslateProcessorConfig.class, translateProcessorConfig, "source", "key1");
+        assertTrue(translateProcessorConfig.isSourceFieldValid());
+        assertThat(translateProcessorConfig.getSource(), is("key1"));
+        setField(TranslateProcessorConfig.class, translateProcessorConfig, "source", List.of("key1", "key2", "key3"));
+        assertTrue(translateProcessorConfig.isSourceFieldValid());
+        assertThat(translateProcessorConfig.getSource(), is(List.of("key1", "key2", "key3")));
+    }
+
+    @Test
+    void test_source_field_invalid_types() throws NoSuchFieldException, IllegalAccessException{
+        setField(TranslateProcessorConfig.class, translateProcessorConfig, "source", 200);
+        assertFalse(translateProcessorConfig.isSourceFieldValid());
+        setField(TranslateProcessorConfig.class, translateProcessorConfig, "source", false);
+        assertFalse(translateProcessorConfig.isSourceFieldValid());
+        setField(TranslateProcessorConfig.class, translateProcessorConfig, "source", 20.1);
+        assertFalse(translateProcessorConfig.isSourceFieldValid());
+        setField(TranslateProcessorConfig.class, translateProcessorConfig, "source", List.of("key1", 200));
+        assertFalse(translateProcessorConfig.isSourceFieldValid());
+    }
+
+    @Test
+    void test_get_default() throws NoSuchFieldException, IllegalAccessException{
+        assertNull(translateProcessorConfig.getDefaultValue());
+        setField(TranslateProcessorConfig.class, translateProcessorConfig, "defaultValue", "No match");
+        assertThat(translateProcessorConfig.getDefaultValue(),is("No match"));
+    }
+
+    @Test
+    void test_get_iterate_on() throws NoSuchFieldException, IllegalAccessException{
+        assertNull(translateProcessorConfig.getIterateOn());
+        setField(TranslateProcessorConfig.class, translateProcessorConfig, "iterateOn", "iteratorField");
+        assertThat(translateProcessorConfig.getIterateOn(),is("iteratorField"));
     }
 }

--- a/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorTest.java
+++ b/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorTest.java
@@ -12,12 +12,13 @@ import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.record.Record;
 
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Collections;
-import java.util.AbstractMap;
-import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -43,13 +44,14 @@ class TranslateProcessorTest {
     private ExpressionEvaluator expressionEvaluator;
 
     @BeforeEach
-    void setup(){
+    void setup() {
         lenient().when(mockConfig.getSource()).thenReturn("sourceField");
         lenient().when(mockConfig.getTarget()).thenReturn("targetField");
+        lenient().when(mockRegexConfig.getExact()).thenReturn(mockRegexConfig.DEFAULT_EXACT);
     }
 
     @Test
-    public void test_string_keys_in_map(){
+    void test_string_keys_in_map(){
         when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("key1","mappedValue1")));
         final TranslateProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("key1");
@@ -60,8 +62,8 @@ class TranslateProcessorTest {
     }
 
     @Test
-    public void test_integer_keys_in_map(){
-        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("123","mappedValue1")));
+    void test_integer_keys_in_map() {
+        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("123", "mappedValue1")));
         final TranslateProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("123");
         final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
@@ -71,8 +73,8 @@ class TranslateProcessorTest {
     }
 
     @Test
-    public void test_integer_range_keys_in_map(){
-        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("1-10","mappedValue1")));
+    void test_integer_range_keys_in_map() {
+        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("1-10", "mappedValue1")));
         final TranslateProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("5");
         final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
@@ -83,11 +85,11 @@ class TranslateProcessorTest {
     }
 
     @Test
-    public void test_comma_separated_keys_in_map(){
-        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("key1,key2, key3","mappedValue1")));
+    void test_comma_separated_keys_in_map() {
+        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("key1,key2, key3", "mappedValue1")));
         final TranslateProcessor processor = createObjectUnderTest();
 
-        for(String key : Arrays.asList("key1","key2","key3")){
+        for (String key : Arrays.asList("key1", "key2", "key3")) {
             final Record<Event> record = getEvent(key);
             final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
@@ -102,11 +104,11 @@ class TranslateProcessorTest {
     }
 
     @Test
-    public void test_comma_separated_range_keys_in_map(){
-        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("1-10,11-20, 21-30","mappedValue1")));
+    void test_comma_separated_range_keys_in_map() {
+        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("1-10,11-20, 21-30", "mappedValue1")));
         final TranslateProcessor processor = createObjectUnderTest();
 
-        for(String key : Arrays.asList("5","15","25")){
+        for (String key : Arrays.asList("5", "15", "25")) {
             final Record<Event> record = getEvent(key);
             final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
@@ -121,8 +123,8 @@ class TranslateProcessorTest {
     }
 
     @Test
-    public void test_float_source(){
-        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("1-10,11-20, 21-30","mappedValue1")));
+    void test_float_source() {
+        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("1-10,11-20, 21-30", "mappedValue1")));
         final TranslateProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("11.1");
         final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
@@ -137,8 +139,8 @@ class TranslateProcessorTest {
     }
 
     @Test
-    public void test_comma_separated_integer_ranges_and_string_keys(){
-        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("1-10,key1","mappedValue1")));
+    void test_comma_separated_integer_ranges_and_string_keys() {
+        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("1-10,key1", "mappedValue1")));
         final TranslateProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("5.2");
         final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
@@ -154,8 +156,8 @@ class TranslateProcessorTest {
     }
 
     @Test
-    public void test_multiple_dashes_in_keys_should_be_treated_as_string_literal(){
-        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("1-10-20","mappedValue1")));
+    void test_multiple_dashes_in_keys_should_be_treated_as_string_literal() {
+        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("1-10-20", "mappedValue1")));
         final TranslateProcessor processor = createObjectUnderTest();
         final Record<Event> failureRecord = getEvent("1-10-20");
         final List<Record<Event>> failingTranslatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(failureRecord));
@@ -170,23 +172,23 @@ class TranslateProcessorTest {
     }
 
     @Test
-    public void test_overlapping_ranges_should_fail_when_overlapping(){
-        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("1-10","mappedValue1"), createMapping("10-20", "mappedValue2")));
+    void test_overlapping_ranges_should_fail_when_overlapping() {
+        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("1-10", "mappedValue1"), createMapping("10-20", "mappedValue2")));
 
-        assertThrows(InvalidPluginConfigurationException.class,() -> createObjectUnderTest());
+        assertThrows(InvalidPluginConfigurationException.class, () -> createObjectUnderTest());
     }
 
     @Test
-    public void test_overlapping_key_and_range_in_map_option(){
-        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("1-10","mappedValue1"), createMapping("5.3", "mappedValue2")));
+    void test_overlapping_key_and_range_in_map_option() {
+        when(mockConfig.getMap()).thenReturn(createMapEntries(createMapping("1-10", "mappedValue1"), createMapping("5.3", "mappedValue2")));
 
-        assertThrows(InvalidPluginConfigurationException.class,() -> createObjectUnderTest());
+        assertThrows(InvalidPluginConfigurationException.class, () -> createObjectUnderTest());
     }
 
     @Test
-    public void test_string_literal_in_pattern_option(){
+    void test_string_literal_in_pattern_option() {
         when(mockConfig.getRegexParameterConfiguration()).thenReturn(mockRegexConfig);
-        when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(createMapping("key1","mappedValue1")));
+        when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(createMapping("key1", "mappedValue1")));
 
         final TranslateProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("key1");
@@ -202,10 +204,9 @@ class TranslateProcessorTest {
     }
 
     @Test
-    public void test_matching_of_regex_pattern_in_pattern_option(){
+    void test_matching_of_regex_pattern_in_pattern_option() {
         when(mockConfig.getRegexParameterConfiguration()).thenReturn(mockRegexConfig);
         when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(createMapping("^(1[0-9]|20)$", "patternValue1"))); //Range between 10-20
-
         final TranslateProcessor processor = createObjectUnderTest();
         final Record<Event> record = getEvent("15");
         final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
@@ -220,7 +221,7 @@ class TranslateProcessorTest {
     }
 
     @Test
-    public void test_pattern_matching_when_no_match_in_map(){
+    void test_pattern_matching_when_no_match_in_map() {
         when(mockConfig.getRegexParameterConfiguration()).thenReturn(mockRegexConfig);
         when(mockConfig.getMap()).thenReturn((createMapEntries(createMapping("key1", "mappedValue1"), createMapping("key2", "mappedValue2"))));
         when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(createMapping("patternKey1", "patternValue1")));
@@ -240,7 +241,7 @@ class TranslateProcessorTest {
     }
 
     @Test
-    public void test_map_matching_when_overlapping_ranges_in_map_and_pattern(){
+    void test_map_matching_when_overlapping_ranges_in_map_and_pattern() {
         when(mockConfig.getRegexParameterConfiguration()).thenReturn(mockRegexConfig);
         when(mockConfig.getMap()).thenReturn((createMapEntries(createMapping("400", "mappedValue1"))));
         when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(createMapping("^(400|404)$", "patternValue1"))); // Matches 400 or 404
@@ -259,6 +260,152 @@ class TranslateProcessorTest {
         assertThat(translatedPatternKeyRecords.get(0).getData().get("targetField", String.class), is("patternValue1"));
     }
 
+    @Test
+    void test_source_array_single_key() {
+        when(mockConfig.getSource()).thenReturn(new ArrayList(List.of("sourceField")));
+        when(mockConfig.getMap()).thenReturn((createMapEntries(createMapping("400", "mappedValue1"))));
+
+        final TranslateProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("400");
+        final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(translatedRecords.get(0).getData().containsKey("targetField"));
+        assertThat(translatedRecords.get(0).getData().get("targetField", ArrayList.class), is(new ArrayList(List.of("mappedValue1"))));
+    }
+
+    @Test
+    void test_source_array_multiple_keys() {
+        when(mockConfig.getSource()).thenReturn(new ArrayList(List.of("sourceField1", "sourceField2")));
+        when(mockConfig.getMap()).thenReturn((createMapEntries(createMapping("key1", "mappedValue1"), createMapping("key2", "mappedValue2"), createMapping("key3", "mappedValue3"))));
+
+        final TranslateProcessor processor = createObjectUnderTest();
+        final Record<Event> record = buildRecordWithEvent(Map.of("sourceField1", "key1", "sourceField2", "key3"));
+        final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(translatedRecords.get(0).getData().containsKey("targetField"));
+        assertThat(translatedRecords.get(0).getData().get("targetField", ArrayList.class), is(new ArrayList(List.of("mappedValue1", "mappedValue3"))));
+    }
+
+    @Test
+    void test_source_array_with_partial_match_without_default() {
+        when(mockConfig.getSource()).thenReturn(new ArrayList(List.of("sourceField1", "sourceField2")));
+        when(mockConfig.getMap()).thenReturn((createMapEntries(createMapping("key1", "mappedValue1"), createMapping("key2", "mappedValue2"), createMapping("key3", "mappedValue3"))));
+
+        final TranslateProcessor processor = createObjectUnderTest();
+        final Record<Event> record = buildRecordWithEvent(Map.of("sourceField1", "key1", "sourceField2", "key4"));
+        final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(translatedRecords.get(0).getData().containsKey("targetField"));
+        assertThat(translatedRecords.get(0).getData().get("targetField", ArrayList.class), is(new ArrayList(List.of("mappedValue1"))));
+    }
+
+    @Test
+    void test_source_array_with_partial_match_with_default() {
+        final String defaultValue = "No Match Found";
+        when(mockConfig.getSource()).thenReturn(new ArrayList(List.of("sourceField1", "sourceField2")));
+        when(mockConfig.getDefaultValue()).thenReturn(defaultValue);
+        when(mockConfig.getMap()).thenReturn((createMapEntries(createMapping("key1", "mappedValue1"), createMapping("key2", "mappedValue2"), createMapping("key3", "mappedValue3"))));
+
+        final TranslateProcessor processor = createObjectUnderTest();
+        final Record<Event> record = buildRecordWithEvent(Map.of("sourceField1", "key1", "sourceField2", "key4"));
+        final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(translatedRecords.get(0).getData().containsKey("targetField"));
+        assertThat(translatedRecords.get(0).getData().get("targetField", ArrayList.class), is(new ArrayList(List.of("mappedValue1", defaultValue))));
+    }
+
+    @Test
+    void test_non_exact_matching() {
+        when(mockConfig.getRegexParameterConfiguration()).thenReturn(mockRegexConfig);
+        when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(
+                createMapping("^(1[0-9]|20)$", "patternValue1"),
+                createMapping("footer", "bar2")));
+        when(mockRegexConfig.getExact()).thenReturn(false);
+
+        final TranslateProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("foo");
+        final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(translatedRecords.get(0).getData().containsKey("targetField"));
+        assertThat(translatedRecords.get(0).getData().get("targetField", String.class), is("bar2"));
+
+        final Record<Event> regexRecord = getEvent("15");
+        final List<Record<Event>> TranslatedRegexRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(regexRecord));
+
+        assertTrue(TranslatedRegexRecords.get(0).getData().containsKey("targetField"));
+        assertThat(TranslatedRegexRecords.get(0).getData().get("targetField", String.class), is("patternValue1"));
+    }
+
+    @Test
+    void test_nested_records_with_default_value() {
+        final Map<String, Object> testJson = Map.of("collection", List.of(
+                Map.of("sourceField", "key1"),
+                Map.of("sourceField", "key2"),
+                Map.of("sourceField", "key3")));
+        final List<Map<String, Object>> outputJson = List.of(
+                Map.of("sourceField", "key1", "targetField", "mappedValue1"),
+                Map.of("sourceField", "key2", "targetField", "mappedValue2"),
+                Map.of("sourceField", "key3", "targetField", "No Match"));
+
+        when(mockConfig.getRegexParameterConfiguration()).thenReturn(mockRegexConfig);
+        when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(
+                createMapping("key1", "mappedValue1"),
+                createMapping("key2", "mappedValue2")));
+        when(mockConfig.getDefaultValue()).thenReturn("No Match");
+        when(mockConfig.getIterateOn()).thenReturn("collection");
+
+        final TranslateProcessor processor = createObjectUnderTest();
+        final Record<Event> record = buildRecordWithEvent(testJson);
+        final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(translatedRecords.get(0).getData().get("collection", ArrayList.class), is(outputJson));
+    }
+
+    @Test
+    void test_nested_records_without_default_value() {
+        final Map<String, Object> testJson = Map.of("collection", List.of(
+                Map.of("sourceField", "key1"),
+                Map.of("sourceField", "key2"),
+                Map.of("sourceField", "key3")));
+        final List<Map<String, Object>> outputJson = List.of(
+                Map.of("sourceField", "key1", "targetField", "mappedValue1"),
+                Map.of("sourceField", "key2", "targetField", "mappedValue2"),
+                Map.of("sourceField", "key3"));
+
+        when(mockConfig.getRegexParameterConfiguration()).thenReturn(mockRegexConfig);
+        when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(
+                createMapping("key1", "mappedValue1"),
+                createMapping("key2", "mappedValue2")));
+        when(mockConfig.getIterateOn()).thenReturn("collection");
+
+        final TranslateProcessor processor = createObjectUnderTest();
+        final Record<Event> record = buildRecordWithEvent(testJson);
+        final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(translatedRecords.get(0).getData().get("collection", ArrayList.class), is(outputJson));
+    }
+
+    @Test
+    void test_nested_records_no_match() {
+        final Map<String, Object> testJson = Map.of("collection", List.of(
+                Map.of("sourceField", "key1"),
+                Map.of("sourceField", "key2"),
+                Map.of("sourceField", "key3")));
+        final List<Map<String, Object>> outputJson = List.of(
+                Map.of("sourceField", "key1"),
+                Map.of("sourceField", "key2"),
+                Map.of("sourceField", "key3"));
+
+        when(mockConfig.getRegexParameterConfiguration()).thenReturn(mockRegexConfig);
+        when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(createMapping("key4", "mappedValue1")));
+        when(mockConfig.getIterateOn()).thenReturn("collection");
+
+        final TranslateProcessor processor = createObjectUnderTest();
+        final Record<Event> record = buildRecordWithEvent(testJson);
+        final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(translatedRecords.get(0).getData().get("collection", ArrayList.class), is(outputJson));
+    }
 
 
 
@@ -272,6 +419,7 @@ class TranslateProcessorTest {
         testData.put("targetField", targetValue);
         return buildRecordWithEvent(testData);
     }
+
     private Record<Event> getEvent(Object sourceField) {
         final Map<String, Object> testData = new HashMap<>();
         testData.put("sourceField", sourceField);
@@ -285,13 +433,13 @@ class TranslateProcessorTest {
                 .build());
     }
 
-    public Map.Entry<String, String> createMapping(String key, String value){
+    private Map.Entry<String, String> createMapping(String key, String value) {
         return new AbstractMap.SimpleEntry<>(key, value);
     }
 
-    public Map<String, String> createMapEntries(Map.Entry<String, String>... mappings){
+    private Map<String, String> createMapEntries(Map.Entry<String, String>... mappings) {
         final Map<String, String> finalMap = new HashMap<>();
-        for(Map.Entry<String, String> mapping : mappings){
+        for (Map.Entry<String, String> mapping : mappings) {
             finalMap.put(mapping.getKey(), mapping.getValue());
         }
 

--- a/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorTest.java
+++ b/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorTest.java
@@ -319,21 +319,26 @@ class TranslateProcessorTest {
         when(mockConfig.getRegexParameterConfiguration()).thenReturn(mockRegexConfig);
         when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(
                 createMapping("^(1[0-9]|20)$", "patternValue1"),
-                createMapping("footer", "bar2")));
+                createMapping("foo", "bar2")));
         when(mockRegexConfig.getExact()).thenReturn(false);
 
         final TranslateProcessor processor = createObjectUnderTest();
-        final Record<Event> record = getEvent("foo");
+        final Record<Event> record = getEvent("footer");
         final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
         assertTrue(translatedRecords.get(0).getData().containsKey("targetField"));
         assertThat(translatedRecords.get(0).getData().get("targetField", String.class), is("bar2"));
 
         final Record<Event> regexRecord = getEvent("15");
-        final List<Record<Event>> TranslatedRegexRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(regexRecord));
+        final List<Record<Event>> translatedRegexRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(regexRecord));
 
-        assertTrue(TranslatedRegexRecords.get(0).getData().containsKey("targetField"));
-        assertThat(TranslatedRegexRecords.get(0).getData().get("targetField", String.class), is("patternValue1"));
+        assertTrue(translatedRegexRecords.get(0).getData().containsKey("targetField"));
+        assertThat(translatedRegexRecords.get(0).getData().get("targetField", String.class), is("patternValue1"));
+
+        final Record<Event> negativeRecord = getEvent("fo");
+        final List<Record<Event>> translatedNegativeRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(negativeRecord));
+
+        assertFalse(translatedNegativeRecords.get(0).getData().containsKey("targetField"));
     }
 
     @Test


### PR DESCRIPTION
### Description
Implemented the functionality for Iterate_on option along with default and exact options. source option can now take either string or list of strings. Addressed previous PR comments. Added testcases for all the options implemented.
 
### Issues Resolved
https://github.com/opensearch-project/data-prepper/issues/1914
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
