### PR TITLE
Podman compat: adding registry to image value in docker-compose.yaml

### DIFF
--- a/examples/log-ingestion/docker-compose.yaml
+++ b/examples/log-ingestion/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 services:
   fluent-bit:
     container_name: fluent-bit
-    image: fluent/fluent-bit
+    image: docker.io/fluent/fluent-bit
     volumes:
       - ./fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf
       - ./test.log:/var/log/test.log
@@ -10,7 +10,7 @@ services:
       - opensearch-net
   opensearch:
     container_name: opensearch
-    image: opensearchproject/opensearch:latest
+    image: docker.io/opensearchproject/opensearch:latest
     environment:
       - discovery.type=single-node
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
@@ -28,7 +28,7 @@ services:
     networks:
       - opensearch-net
   dashboards:
-    image: opensearchproject/opensearch-dashboards:latest
+    image: docker.io/opensearchproject/opensearch-dashboards:latest
     container_name: opensearch-dashboards
     ports:
       - 5601:5601


### PR DESCRIPTION
Podman requires the registry url in order to pull out the image (for the first run)

### Description
By default if you don't have specified registries in /etc/containers/registries.conf, at the first run, podman-compose cannot get the image. You will get this following error message 

```bash
Error: short-name "fluent/fluent-bit" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
exit code: 125
```

By adding the registry such as `docker.io` to the `image` value like below:
```yaml
 image: docker.io/fluent/fluent-bit
```
Podman will be able to pull the image

```bash
Trying to pull docker.io/fluent/fluent-bit:latest...
Getting image source signatures
Copying blob e8c73c638ae9 done
Copying blob fe5ca62666f0 done
...
Copying blob 35f5792110f6 done
Copying config 4348c58bc7 done
Writing manifest to image destination
Storing signatures
aae8ebcc3fb5ee914fbd7e10b2fae765bc67d42586b0c2efd4be81bdf0abe71d
exit code: 0
```

**Additional info**
```bash
podman-compose version
podman-compose version: 1.0.6
['podman', '--version', '']
using podman version: 3.4.4
podman-compose version 1.0.6
podman --version
podman version 3.4.4
exit code: 0
```
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
