### PR TITLE
Fix S3 errors around end of file behavior.

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3InputStream.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3InputStream.java
@@ -129,11 +129,15 @@ class S3InputStream extends SeekableInputStream {
         Preconditions.checkState(!closed, "Cannot read: already closed");
         positionStream();
 
-        pos += 1;
-        next += 1;
-        bytesCounter.increment();
+        final int byteRead = stream.read();
 
-        return stream.read();
+        if (byteRead != -1) {
+            pos += 1;
+            next += 1;
+            bytesCounter.increment();
+        }
+
+        return byteRead;
     }
 
     /**
@@ -161,10 +165,13 @@ class S3InputStream extends SeekableInputStream {
         Preconditions.checkState(!closed, "Cannot read: already closed");
         positionStream();
 
-        int bytesRead = stream.read(b, off, len);
-        pos += bytesRead;
-        next += bytesRead;
-        bytesCounter.add(bytesRead);
+        final int bytesRead = stream.read(b, off, len);
+
+        if (bytesRead > 0) {
+            pos += bytesRead;
+            next += bytesRead;
+            bytesCounter.add(bytesRead);
+        }
 
         return bytesRead;
     }
@@ -203,9 +210,11 @@ class S3InputStream extends SeekableInputStream {
 
         final int bytesRead = stream.readNBytes(b, off, len);
 
-        pos += bytesRead;
-        next += bytesRead;
-        bytesCounter.add(bytesRead);
+        if (bytesRead > 0) {
+            pos += bytesRead;
+            next += bytesRead;
+            bytesCounter.add(bytesRead);
+        }
 
         return bytesRead;
     }
@@ -325,9 +334,11 @@ class S3InputStream extends SeekableInputStream {
 
         int bytesRead = readFully(stream, bytes, start, len);
 
-        this.pos += bytesRead;
-        this.next += bytesRead;
-        this.bytesCounter.add(bytesRead);
+        if (bytesRead > 0) {
+            this.pos += bytesRead;
+            this.next += bytesRead;
+            this.bytesCounter.add(bytesRead);
+        }
     }
 
     /**
@@ -354,9 +365,11 @@ class S3InputStream extends SeekableInputStream {
             bytesRead = readDirectBuffer(stream, buf, temp);
         }
 
-        this.pos += bytesRead;
-        this.next += bytesRead;
-        this.bytesCounter.add(bytesRead);
+        if (bytesRead > 0) {
+            this.pos += bytesRead;
+            this.next += bytesRead;
+            this.bytesCounter.add(bytesRead);
+        }
 
         return bytesRead;
     }
@@ -385,9 +398,11 @@ class S3InputStream extends SeekableInputStream {
             bytesRead = readFullyDirectBuffer(stream, buf, temp);
         }
 
-        this.pos += bytesRead;
-        this.next += bytesRead;
-        this.bytesCounter.add(bytesRead);
+        if (bytesRead > 0) {
+            this.pos += bytesRead;
+            this.next += bytesRead;
+            this.bytesCounter.add(bytesRead);
+        }
     }
 
     /**
@@ -478,7 +493,7 @@ class S3InputStream extends SeekableInputStream {
      */
     private void abortStream() {
         try {
-            if (stream instanceof Abortable && stream.read() != -1) {
+            if (stream instanceof Abortable) {
                 ((Abortable) stream).abort();
             }
         } catch (Exception e) {


### PR DESCRIPTION
### Description
Correctly abort stream and handle internal counters correctly when end of file is reached
 
### Issues Resolved

 
### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
