### PR TITLE
Introduce option to measure bulk sizes with or without compression

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -93,6 +93,8 @@ Default is null.
 
 - `proxy`(optional): A String of the address of a forward HTTP proxy. The format is like "<host-name-or-ip>:\<port\>". Examples: "example.com:8100", "http://example.com:8100", "112.112.112.112:8100". Note: port number cannot be omitted.
 
+- `enable_request_compression` (optional): A boolean that enables or disables request compression when sending requests to OpenSearch. Default is true.
+
 - `index_type` (optional): a String from the list [`custom`, `trace-analytics-raw`, `trace-analytics-service-map`, `management_disabled`], which represents an index type. Defaults to `custom` if `serverless` is `false` in [AWS Configuration](#aws_configuration), otherwise defaults to `management_disabled`. This index_type instructs Sink plugin what type of data it is handling. 
 
 ```
@@ -152,6 +154,14 @@ If not provided, the sink will try to push the data to OpenSearch server indefin
 - `bulk_size` (optional): A long of bulk size in bulk requests in MB. Default to 5 MB. If set to be less than 0,
 all the records received from the upstream prepper at a time will be sent as a single bulk request.
 If a single record turns out to be larger than the set bulk size, it will be sent as a bulk request of a single document.
+
+- `estimate_bulk_size_using_compression` (optional): A boolean dictating whether to compress the bulk requests when estimating
+the size. This option is ignored if request compression is not enabled for the OpenSearch client. This is an experimental 
+feature and makes no guarantees about the accuracy of the estimation. Default is false.
+
+- `max_local_compressions_for_estimation` (optional): An integer of the maximum number of times to compress a partially packed
+bulk request when estimating its size. Bulk size accuracy increases with this value but performance degrades. This setting is experimental
+and is ignored unless `estimate_bulk_size_using_compression` is enabled. Default is 2.
 
 - `flush_timeout` (optional): A long of the millisecond duration to try packing a bulk request up to the bulk_size before flushing.
 If this timeout expires before a bulk request has reached the bulk_size, the request will be flushed as-is. Set to -1 to disable

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -49,7 +49,6 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConstants;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexType;
 import org.apache.commons.lang3.RandomStringUtils;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.when;
 
 import javax.ws.rs.HttpMethod;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -196,7 +196,8 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     final boolean isEstimateBulkSizeUsingCompression = openSearchSinkConfig.getIndexConfiguration().isEstimateBulkSizeUsingCompression();
     final boolean isRequestCompressionEnabled = openSearchSinkConfig.getConnectionConfiguration().isRequestCompressionEnabled();
     if (isEstimateBulkSizeUsingCompression && isRequestCompressionEnabled) {
-      bulkRequestSupplier = () -> new JavaClientAccumulatingCompressedBulkRequest(new BulkRequest.Builder(), bulkSize);
+      final int maxLocalCompressionsForEstimation = openSearchSinkConfig.getIndexConfiguration().getMaxLocalCompressionsForEstimation();
+      bulkRequestSupplier = () -> new JavaClientAccumulatingCompressedBulkRequest(new BulkRequest.Builder(), bulkSize, maxLocalCompressionsForEstimation);
     } else if (isEstimateBulkSizeUsingCompression) {
       LOG.warn("Estimate bulk request size using compression was enabled but request compression is disabled. " +
               "Estimating bulk request size without compression.");

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -329,7 +329,6 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     bulkRequestTimer.record(() -> {
       try {
         LOG.debug("Sending data to OpenSearch");
-        LOG.warn("Flushing batch with {} operations", accumulatingBulkRequest.getOperationsCount());
         bulkRetryStrategy.execute(accumulatingBulkRequest);
         bulkRequestSizeBytesSummary.record(accumulatingBulkRequest.getEstimatedSizeInBytes());
       } catch (final InterruptedException e) {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingCompressedBulkRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingCompressedBulkRequest.java
@@ -155,7 +155,7 @@ public class JavaClientAccumulatingCompressedBulkRequest implements Accumulating
             LOG.debug("Found remaining percentage of {}, current size {}, target size {}. Skipping further estimations",
                     remainingBytesAsPercentage, currentBulkSize, targetBulkSize);
             // If we have packed at least 90% of the bulk request already, assume the sampled operation size is sufficient
-            // and continue with that estimate rather than eating the overhead of more local compressions
+            // and continue with that estimate rather than adding the overhead of more local compressions
             return;
         }
 
@@ -164,7 +164,7 @@ public class JavaClientAccumulatingCompressedBulkRequest implements Accumulating
         if (estimatedRemainingOperationsUntilFull < 100d) {
             LOG.debug("Found estimated remaining operations of {}. Skipping further estimations", estimatedRemainingOperationsUntilFull);
             // If we have less than 100 estimated operations until the bulk request is full, assume the sampled operation size is sufficient
-            // and continue with that estimate rather than eating the overhead of more local compressions
+            // and continue with that estimate rather than adding the overhead of more local compressions
             return;
         }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingCompressedBulkRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingCompressedBulkRequest.java
@@ -5,9 +5,10 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.bulk;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
 import org.opensearch.client.opensearch.core.BulkRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
@@ -18,31 +19,29 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPOutputStream;
 
-public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> {
+public class JavaClientAccumulatingCompressedBulkRequest implements AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> {
+    private static final Logger LOG = LoggerFactory.getLogger(JavaClientAccumulatingCompressedBulkRequest.class);
+
     private final List<BulkOperationWrapper> bulkOperations;
-    private final int sampleSize;
+    private long sampleSize;
+    private final long targetBulkSize;
     private BulkRequest.Builder bulkRequestBuilder;
     private long currentBulkSize = 0L;
-    private long sampledOperationSize = 0L;
+    private double sampledOperationSize = 0.0;
     private int operationCount = 0;
     private BulkRequest builtRequest;
 
-    public JavaClientAccumulatingBulkRequest(BulkRequest.Builder bulkRequestBuilder) {
+    public JavaClientAccumulatingCompressedBulkRequest(final BulkRequest.Builder bulkRequestBuilder, final long targetBulkSize) {
         this.bulkRequestBuilder = bulkRequestBuilder;
         bulkOperations = new ArrayList<>();
-        this.sampleSize = 5000;
-    }
-
-    @VisibleForTesting
-    JavaClientAccumulatingBulkRequest(BulkRequest.Builder bulkRequestBuilder, final int sampleSize) {
-        this.bulkRequestBuilder = bulkRequestBuilder;
-        bulkOperations = new ArrayList<>();
-        this.sampleSize = sampleSize;
+        this.targetBulkSize = targetBulkSize;
+        // Set the initial sample threshold by assuming each doc size is 5KB when compressed
+        this.sampleSize = 10;
     }
 
     @Override
     public long estimateSizeInBytesWithDocument(BulkOperationWrapper documentOrOperation) {
-        return currentBulkSize + sampledOperationSize;
+        return currentBulkSize + (long) sampledOperationSize;
     }
 
     @Override
@@ -54,7 +53,8 @@ public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkReques
 
         if (bulkOperations.size() == sampleSize) {
             currentBulkSize = estimateBulkSize();
-            sampledOperationSize = currentBulkSize / sampleSize;
+            sampledOperationSize = (double) currentBulkSize / (double) bulkOperations.size();
+            updateTargetSampleSize();
         } else {
             currentBulkSize += sampledOperationSize;
         }
@@ -129,5 +129,33 @@ public class JavaClientAccumulatingBulkRequest implements AccumulatingBulkReques
         }
 
         return anyDocument;
+    }
+
+    private void updateTargetSampleSize() {
+        final long remainingBytes = targetBulkSize - currentBulkSize;
+        final double remainingBytesAsPercentage = ((double) remainingBytes / (double) targetBulkSize) * 100d;
+
+        if (remainingBytesAsPercentage < 10d) {
+            LOG.warn("Found remaining percentage of {}, current size {}, target size {}. Skipping further estimations",
+                    remainingBytesAsPercentage, currentBulkSize, targetBulkSize);
+            // If we have packed at least 90% of the bulk request already, assume the sampled operation size is sufficient
+            // and continue with that estimate rather than eating the overhead of more local compressions
+            return;
+        }
+
+        final double estimatedRemainingOperationsUntilFull = (double) remainingBytes / sampledOperationSize;
+
+        if (estimatedRemainingOperationsUntilFull < 100d) {
+            LOG.warn("Found estimated remaining operations of {}. Skipping further estimations", estimatedRemainingOperationsUntilFull);
+            // If we have less than 100 estimated operations until the bulk request is full, assume the sampled operation size is sufficient
+            // and continue with that estimate rather than eating the overhead of more local compressions
+            return;
+        }
+
+        final double operationsUntilNextSample = estimatedRemainingOperationsUntilFull / 2d;
+        LOG.warn("{} bytes remaining to {}. Average size so far {}, checking again in {} ops", targetBulkSize - currentBulkSize, targetBulkSize,
+                sampledOperationSize, operationsUntilNextSample);
+
+        sampleSize += operationsUntilNextSample;
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingUncompressedBulkRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingUncompressedBulkRequest.java
@@ -1,0 +1,97 @@
+package org.opensearch.dataprepper.plugins.sink.opensearch.bulk;
+
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
+import org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class JavaClientAccumulatingUncompressedBulkRequest implements AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> {
+    private static final Logger LOG = LoggerFactory.getLogger(JavaClientAccumulatingUncompressedBulkRequest.class);
+
+    static final int OPERATION_OVERHEAD = 50;
+
+    private final List<BulkOperationWrapper> bulkOperations;
+    private BulkRequest.Builder bulkRequestBuilder;
+    private long currentBulkSize = 0L;
+    private int operationCount = 0;
+    private BulkRequest builtRequest;
+
+    public JavaClientAccumulatingUncompressedBulkRequest(BulkRequest.Builder bulkRequestBuilder) {
+        this.bulkRequestBuilder = bulkRequestBuilder;
+        bulkOperations = new ArrayList<>();
+    }
+
+    @Override
+    public long estimateSizeInBytesWithDocument(BulkOperationWrapper documentOrOperation) {
+        return currentBulkSize + estimateBulkOperationSize(documentOrOperation);
+    }
+
+    @Override
+    public void addOperation(BulkOperationWrapper bulkOperation) {
+        final Long documentLength = estimateBulkOperationSize(bulkOperation);
+
+        currentBulkSize += documentLength;
+        LOG.warn("Current bulk size: {}", currentBulkSize);
+
+        bulkRequestBuilder = bulkRequestBuilder.operations(bulkOperation.getBulkOperation());
+
+        operationCount++;
+        bulkOperations.add(bulkOperation);
+    }
+
+    @Override
+    public BulkOperationWrapper getOperationAt(int index) {
+        return bulkOperations.get(index);
+    }
+
+    @Override
+    public long getEstimatedSizeInBytes() {
+        return currentBulkSize;
+    }
+    @Override
+    public int getOperationsCount() {
+        return operationCount;
+    }
+
+    @Override
+    public List<BulkOperationWrapper> getOperations() {
+        return Collections.unmodifiableList(bulkOperations);
+    }
+
+    @Override
+    public BulkRequest getRequest() {
+        if(builtRequest == null)
+            builtRequest = bulkRequestBuilder.build();
+        return builtRequest;
+    }
+
+    private long estimateBulkOperationSize(BulkOperationWrapper bulkOperation) {
+
+        Object anyDocument;
+
+        if (bulkOperation.getBulkOperation().isIndex()) {
+            anyDocument = bulkOperation.getBulkOperation().index().document();
+        } else if (bulkOperation.getBulkOperation().isCreate()) {
+            anyDocument = bulkOperation.getBulkOperation().create().document();
+        } else {
+            throw new UnsupportedOperationException("Only index or create operations are supported currently. " + bulkOperation);
+        }
+
+        if (anyDocument == null)
+            return OPERATION_OVERHEAD;
+
+        if (!(anyDocument instanceof SizedDocument)) {
+            throw new IllegalArgumentException("Only SizedDocument is permitted for accumulating bulk requests. " + bulkOperation);
+        }
+
+        SizedDocument sizedDocument = (SizedDocument) anyDocument;
+
+        final long documentLength = sizedDocument.getDocumentSize();
+        return documentLength + OPERATION_OVERHEAD;
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingUncompressedBulkRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingUncompressedBulkRequest.java
@@ -2,7 +2,6 @@ package org.opensearch.dataprepper.plugins.sink.opensearch.bulk;
 
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
-import org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingUncompressedBulkRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingUncompressedBulkRequest.java
@@ -35,7 +35,6 @@ public class JavaClientAccumulatingUncompressedBulkRequest implements Accumulati
         final Long documentLength = estimateBulkOperationSize(bulkOperation);
 
         currentBulkSize += documentLength;
-        LOG.warn("Current bulk size: {}", currentBulkSize);
 
         bulkRequestBuilder = bulkRequestBuilder.operations(bulkOperation.getBulkOperation());
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -36,13 +36,13 @@ public class IndexConfiguration {
     public static final String NUM_SHARDS = "number_of_shards";
     public static final String NUM_REPLICAS = "number_of_replicas";
     public static final String BULK_SIZE = "bulk_size";
-    public static final String BULK_SAMPLE_SIZE = "bulk_sample_size";
+    public static final String ESTIMATE_BULK_SIZE_USING_COMPRESSION = "estimate_bulk_size_using_compression";
     public static final String FLUSH_TIMEOUT = "flush_timeout";
     public static final String DOCUMENT_ID_FIELD = "document_id_field";
     public static final String ROUTING_FIELD = "routing_field";
     public static final String ISM_POLICY_FILE = "ism_policy_file";
     public static final long DEFAULT_BULK_SIZE = 5L;
-    public static final int DEFAULT_BULK_SAMPLE_SIZE = 5000;
+    public static final boolean DEFAULT_ESTIMATE_BULK_SIZE_USING_COMPRESSION = false;
     public static final long DEFAULT_FLUSH_TIMEOUT = 60_000L;
     public static final String ACTION = "action";
     public static final String S3_AWS_REGION = "s3_aws_region";
@@ -59,7 +59,7 @@ public class IndexConfiguration {
     private final String documentIdField;
     private final String routingField;
     private final long bulkSize;
-    private final int bulkSampleSize;
+    private final boolean estimateBulkSizeUsingCompression;
     private final long flushTimeout;
     private final Optional<String> ismPolicyFile;
     private final String action;
@@ -106,7 +106,7 @@ public class IndexConfiguration {
         }
         this.indexAlias = indexAlias;
         this.bulkSize = builder.bulkSize;
-        this.bulkSampleSize = builder.bulkSampleSize;
+        this.estimateBulkSizeUsingCompression = builder.estimateBulkSizeUsingCompression;
         this.flushTimeout = builder.flushTimeout;
         this.routingField = builder.routingField;
 
@@ -157,8 +157,9 @@ public class IndexConfiguration {
         builder = builder.withNumReplicas(pluginSetting.getIntegerOrDefault(NUM_REPLICAS, 0));
         final Long batchSize = pluginSetting.getLongOrDefault(BULK_SIZE, DEFAULT_BULK_SIZE);
         builder = builder.withBulkSize(batchSize);
-        final int bulkSampleSize = pluginSetting.getIntegerOrDefault(BULK_SAMPLE_SIZE, DEFAULT_BULK_SAMPLE_SIZE);
-        builder = builder.withBulkSampleSize(bulkSampleSize);
+        final boolean estimateBulkSizeUsingCompression =
+                pluginSetting.getBooleanOrDefault(ESTIMATE_BULK_SIZE_USING_COMPRESSION, DEFAULT_ESTIMATE_BULK_SIZE_USING_COMPRESSION);
+        builder = builder.withEstimateBulkSizeUsingCompression(estimateBulkSizeUsingCompression);
         final long flushTimeout = pluginSetting.getLongOrDefault(FLUSH_TIMEOUT, DEFAULT_FLUSH_TIMEOUT);
         builder = builder.withFlushTimeout(flushTimeout);
         final String documentId = pluginSetting.getStringOrDefault(DOCUMENT_ID_FIELD, null);
@@ -227,10 +228,9 @@ public class IndexConfiguration {
         return bulkSize;
     }
 
-    public int getBulkSampleSize() {
-        return bulkSampleSize;
+    public boolean isEstimateBulkSizeUsingCompression() {
+        return estimateBulkSizeUsingCompression;
     }
-
 
     public long getFlushTimeout() {
         return flushTimeout;
@@ -320,7 +320,7 @@ public class IndexConfiguration {
         private String routingField;
         private String documentIdField;
         private long bulkSize = DEFAULT_BULK_SIZE;
-        private int bulkSampleSize = DEFAULT_BULK_SAMPLE_SIZE;
+        private boolean estimateBulkSizeUsingCompression = DEFAULT_ESTIMATE_BULK_SIZE_USING_COMPRESSION;
         private long flushTimeout = DEFAULT_FLUSH_TIMEOUT;
         private Optional<String> ismPolicyFile;
         private String action;
@@ -374,8 +374,8 @@ public class IndexConfiguration {
             return this;
         }
 
-        public Builder withBulkSampleSize(final int bulkSampleSize) {
-            this.bulkSampleSize = bulkSampleSize;
+        public Builder withEstimateBulkSizeUsingCompression(final boolean estimateBulkSizeUsingCompression) {
+            this.estimateBulkSizeUsingCompression = estimateBulkSizeUsingCompression;
             return this;
         }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -37,12 +37,14 @@ public class IndexConfiguration {
     public static final String NUM_REPLICAS = "number_of_replicas";
     public static final String BULK_SIZE = "bulk_size";
     public static final String ESTIMATE_BULK_SIZE_USING_COMPRESSION = "estimate_bulk_size_using_compression";
+    public static final String MAX_LOCAL_COMPRESSIONS_FOR_ESTIMATION = "max_local_compressions_for_estimation";
     public static final String FLUSH_TIMEOUT = "flush_timeout";
     public static final String DOCUMENT_ID_FIELD = "document_id_field";
     public static final String ROUTING_FIELD = "routing_field";
     public static final String ISM_POLICY_FILE = "ism_policy_file";
     public static final long DEFAULT_BULK_SIZE = 5L;
     public static final boolean DEFAULT_ESTIMATE_BULK_SIZE_USING_COMPRESSION = false;
+    public static final int DEFAULT_MAX_LOCAL_COMPRESSIONS_FOR_ESTIMATION = 2;
     public static final long DEFAULT_FLUSH_TIMEOUT = 60_000L;
     public static final String ACTION = "action";
     public static final String S3_AWS_REGION = "s3_aws_region";
@@ -60,6 +62,7 @@ public class IndexConfiguration {
     private final String routingField;
     private final long bulkSize;
     private final boolean estimateBulkSizeUsingCompression;
+    private int maxLocalCompressionsForEstimation;
     private final long flushTimeout;
     private final Optional<String> ismPolicyFile;
     private final String action;
@@ -107,6 +110,7 @@ public class IndexConfiguration {
         this.indexAlias = indexAlias;
         this.bulkSize = builder.bulkSize;
         this.estimateBulkSizeUsingCompression = builder.estimateBulkSizeUsingCompression;
+        this.maxLocalCompressionsForEstimation = builder.maxLocalCompressionsForEstimation;
         this.flushTimeout = builder.flushTimeout;
         this.routingField = builder.routingField;
 
@@ -160,6 +164,11 @@ public class IndexConfiguration {
         final boolean estimateBulkSizeUsingCompression =
                 pluginSetting.getBooleanOrDefault(ESTIMATE_BULK_SIZE_USING_COMPRESSION, DEFAULT_ESTIMATE_BULK_SIZE_USING_COMPRESSION);
         builder = builder.withEstimateBulkSizeUsingCompression(estimateBulkSizeUsingCompression);
+
+        final int maxLocalCompressionsForEstimation =
+                pluginSetting.getIntegerOrDefault(MAX_LOCAL_COMPRESSIONS_FOR_ESTIMATION, DEFAULT_MAX_LOCAL_COMPRESSIONS_FOR_ESTIMATION);
+        builder = builder.withMaxLocalCompressionsForEstimation(maxLocalCompressionsForEstimation);
+
         final long flushTimeout = pluginSetting.getLongOrDefault(FLUSH_TIMEOUT, DEFAULT_FLUSH_TIMEOUT);
         builder = builder.withFlushTimeout(flushTimeout);
         final String documentId = pluginSetting.getStringOrDefault(DOCUMENT_ID_FIELD, null);
@@ -230,6 +239,10 @@ public class IndexConfiguration {
 
     public boolean isEstimateBulkSizeUsingCompression() {
         return estimateBulkSizeUsingCompression;
+    }
+
+    public int getMaxLocalCompressionsForEstimation() {
+        return maxLocalCompressionsForEstimation;
     }
 
     public long getFlushTimeout() {
@@ -321,6 +334,7 @@ public class IndexConfiguration {
         private String documentIdField;
         private long bulkSize = DEFAULT_BULK_SIZE;
         private boolean estimateBulkSizeUsingCompression = DEFAULT_ESTIMATE_BULK_SIZE_USING_COMPRESSION;
+        private int maxLocalCompressionsForEstimation = DEFAULT_MAX_LOCAL_COMPRESSIONS_FOR_ESTIMATION;
         private long flushTimeout = DEFAULT_FLUSH_TIMEOUT;
         private Optional<String> ismPolicyFile;
         private String action;
@@ -376,6 +390,11 @@ public class IndexConfiguration {
 
         public Builder withEstimateBulkSizeUsingCompression(final boolean estimateBulkSizeUsingCompression) {
             this.estimateBulkSizeUsingCompression = estimateBulkSizeUsingCompression;
+            return this;
+        }
+
+        public Builder withMaxLocalCompressionsForEstimation(final int maxLocalCompressionsForEstimation) {
+            this.maxLocalCompressionsForEstimation = maxLocalCompressionsForEstimation;
             return this;
         }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -36,11 +36,13 @@ public class IndexConfiguration {
     public static final String NUM_SHARDS = "number_of_shards";
     public static final String NUM_REPLICAS = "number_of_replicas";
     public static final String BULK_SIZE = "bulk_size";
+    public static final String BULK_SAMPLE_SIZE = "bulk_sample_size";
     public static final String FLUSH_TIMEOUT = "flush_timeout";
     public static final String DOCUMENT_ID_FIELD = "document_id_field";
     public static final String ROUTING_FIELD = "routing_field";
     public static final String ISM_POLICY_FILE = "ism_policy_file";
     public static final long DEFAULT_BULK_SIZE = 5L;
+    public static final int DEFAULT_BULK_SAMPLE_SIZE = 5000;
     public static final long DEFAULT_FLUSH_TIMEOUT = 60_000L;
     public static final String ACTION = "action";
     public static final String S3_AWS_REGION = "s3_aws_region";
@@ -57,6 +59,7 @@ public class IndexConfiguration {
     private final String documentIdField;
     private final String routingField;
     private final long bulkSize;
+    private final int bulkSampleSize;
     private final long flushTimeout;
     private final Optional<String> ismPolicyFile;
     private final String action;
@@ -103,6 +106,7 @@ public class IndexConfiguration {
         }
         this.indexAlias = indexAlias;
         this.bulkSize = builder.bulkSize;
+        this.bulkSampleSize = builder.bulkSampleSize;
         this.flushTimeout = builder.flushTimeout;
         this.routingField = builder.routingField;
 
@@ -153,6 +157,8 @@ public class IndexConfiguration {
         builder = builder.withNumReplicas(pluginSetting.getIntegerOrDefault(NUM_REPLICAS, 0));
         final Long batchSize = pluginSetting.getLongOrDefault(BULK_SIZE, DEFAULT_BULK_SIZE);
         builder = builder.withBulkSize(batchSize);
+        final int bulkSampleSize = pluginSetting.getIntegerOrDefault(BULK_SAMPLE_SIZE, DEFAULT_BULK_SAMPLE_SIZE);
+        builder = builder.withBulkSampleSize(bulkSampleSize);
         final long flushTimeout = pluginSetting.getLongOrDefault(FLUSH_TIMEOUT, DEFAULT_FLUSH_TIMEOUT);
         builder = builder.withFlushTimeout(flushTimeout);
         final String documentId = pluginSetting.getStringOrDefault(DOCUMENT_ID_FIELD, null);
@@ -220,6 +226,11 @@ public class IndexConfiguration {
     public long getBulkSize() {
         return bulkSize;
     }
+
+    public int getBulkSampleSize() {
+        return bulkSampleSize;
+    }
+
 
     public long getFlushTimeout() {
         return flushTimeout;
@@ -309,6 +320,7 @@ public class IndexConfiguration {
         private String routingField;
         private String documentIdField;
         private long bulkSize = DEFAULT_BULK_SIZE;
+        private int bulkSampleSize = DEFAULT_BULK_SAMPLE_SIZE;
         private long flushTimeout = DEFAULT_FLUSH_TIMEOUT;
         private Optional<String> ismPolicyFile;
         private String action;
@@ -359,6 +371,11 @@ public class IndexConfiguration {
 
         public Builder withBulkSize(final long bulkSize) {
             this.bulkSize = bulkSize;
+            return this;
+        }
+
+        public Builder withBulkSampleSize(final int bulkSampleSize) {
+            this.bulkSampleSize = bulkSampleSize;
             return this;
         }
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
@@ -24,7 +24,7 @@ import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.AccumulatingBulkRequest;
-import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.JavaClientAccumulatingBulkRequest;
+import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.JavaClientAccumulatingUncompressedBulkRequest;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.SerializedJson;
 import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedBulkOperation;
 import org.opensearch.rest.RestStatus;
@@ -141,13 +141,13 @@ public class BulkRetryStrategyTests {
 
         final BulkRetryStrategy bulkRetryStrategy = new BulkRetryStrategy(
                 client::bulk, logFailureConsumer, pluginMetrics, Integer.MAX_VALUE,
-                () -> new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder()), pluginSetting);
+                () -> new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder()), pluginSetting);
 
         final IndexOperation<SerializedJson> indexOperation1 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("1").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation2 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("2").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
-        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder());
+        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build(), eventHandle1));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build(), eventHandle2));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build(), eventHandle3));
@@ -180,12 +180,12 @@ public class BulkRetryStrategyTests {
         numEventsFailed = 0;
         final BulkRetryStrategy bulkRetryStrategy = new BulkRetryStrategy(
                 client::bulk, logFailureConsumer, pluginMetrics, Integer.MAX_VALUE,
-                () -> new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder()), pluginSetting);
+                () -> new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder()), pluginSetting);
         final IndexOperation<SerializedJson> indexOperation1 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("1").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation2 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("2").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
-        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder());
+        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build(), eventHandle1));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build(), eventHandle2));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build(), eventHandle3));
@@ -243,12 +243,12 @@ public class BulkRetryStrategyTests {
         numEventsFailed = 0;
         final BulkRetryStrategy bulkRetryStrategy = new BulkRetryStrategy(
                 client::bulk, logFailureConsumer, pluginMetrics, Integer.MAX_VALUE,
-                () -> new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder()), pluginSetting);
+                () -> new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder()), pluginSetting);
         final IndexOperation<SerializedJson> indexOperation1 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("1").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation2 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("2").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
-        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder());
+        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build(), eventHandle1));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build(), eventHandle2));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build(), eventHandle3));
@@ -308,12 +308,12 @@ public class BulkRetryStrategyTests {
         logFailureConsumer = this::logFailureMaxRetries;
         final BulkRetryStrategy bulkRetryStrategy = new BulkRetryStrategy(
                 client::bulk, logFailureConsumer, pluginMetrics, MAX_RETRIES,
-                () -> new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder()), pluginSetting);
+                () -> new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder()), pluginSetting);
         final IndexOperation<SerializedJson> indexOperation1 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("1").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation2 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("2").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
-        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder());
+        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build(), eventHandle1));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build(), eventHandle2));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build(), eventHandle3));
@@ -338,12 +338,12 @@ public class BulkRetryStrategyTests {
         logFailureConsumer = this::logFailureMaxRetries;
         final BulkRetryStrategy bulkRetryStrategy = new BulkRetryStrategy(
                 client::bulk, logFailureConsumer, pluginMetrics, MAX_RETRIES,
-                () -> new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder()), pluginSetting);
+                () -> new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder()), pluginSetting);
         final IndexOperation<SerializedJson> indexOperation1 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("1").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation2 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("2").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
-        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder());
+        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build(), eventHandle1));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build(), eventHandle2));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build(), eventHandle3));
@@ -368,12 +368,12 @@ public class BulkRetryStrategyTests {
         logFailureConsumer = this::logFailureMaxRetries;
         final BulkRetryStrategy bulkRetryStrategy = new BulkRetryStrategy(
                 client::bulk, logFailureConsumer, pluginMetrics, MAX_RETRIES,
-                () -> new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder()), pluginSetting);
+                () -> new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder()), pluginSetting);
         final IndexOperation<SerializedJson> indexOperation1 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("1").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation2 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("2").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
-        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder());
+        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build(), eventHandle1));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build(), eventHandle2));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build(), eventHandle3));
@@ -395,12 +395,12 @@ public class BulkRetryStrategyTests {
         numEventsFailed = 0;
         final BulkRetryStrategy bulkRetryStrategy = new BulkRetryStrategy(
                 client::bulk, logFailureConsumer, pluginMetrics, Integer.MAX_VALUE,
-                () -> new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder()), pluginSetting);
+                () -> new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder()), pluginSetting);
         final IndexOperation<SerializedJson> indexOperation1 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("1").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation2 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("2").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
-        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingBulkRequest(new BulkRequest.Builder());
+        final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build(), eventHandle1));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build(), eventHandle2));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build(), eventHandle3));

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingCompressedBulkRequestTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingCompressedBulkRequestTest.java
@@ -47,7 +47,7 @@ class JavaClientAccumulatingCompressedBulkRequestTest {
     }
 
     private JavaClientAccumulatingCompressedBulkRequest createObjectUnderTest() {
-        return new JavaClientAccumulatingCompressedBulkRequest(bulkRequestBuilder, 5 * 1024 * 1024, 1);
+        return new JavaClientAccumulatingCompressedBulkRequest(bulkRequestBuilder, 5 * 1024 * 1024, 2, 1);
     }
 
     @Test

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -283,6 +283,7 @@ public class IndexConfigurationTests {
         assertEquals(5, indexConfiguration.getBulkSize());
         assertEquals(60_000L, indexConfiguration.getFlushTimeout());
         assertEquals(false, indexConfiguration.isEstimateBulkSizeUsingCompression());
+        assertEquals(2, indexConfiguration.getMaxLocalCompressionsForEstimation());
         assertEquals("spanId", indexConfiguration.getDocumentIdField());
     }
 
@@ -308,6 +309,7 @@ public class IndexConfigurationTests {
         assertEquals(5, indexConfiguration.getBulkSize());
         assertEquals(60_000L, indexConfiguration.getFlushTimeout());
         assertEquals(false, indexConfiguration.isEstimateBulkSizeUsingCompression());
+        assertEquals(2, indexConfiguration.getMaxLocalCompressionsForEstimation());
         assertEquals("hashId", indexConfiguration.getDocumentIdField());
     }
 
@@ -322,6 +324,7 @@ public class IndexConfigurationTests {
         final PluginSetting pluginSetting = generatePluginSetting(
                 null, testIndexAlias, defaultTemplateFilePath, testBulkSize, testFlushTimeout, testIdField);
         pluginSetting.getSettings().put(IndexConfiguration.ESTIMATE_BULK_SIZE_USING_COMPRESSION, true);
+        pluginSetting.getSettings().put(IndexConfiguration.MAX_LOCAL_COMPRESSIONS_FOR_ESTIMATION, 5);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         assertEquals(IndexType.CUSTOM, indexConfiguration.getIndexType());
         assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
@@ -329,6 +332,7 @@ public class IndexConfigurationTests {
         assertEquals(testBulkSize, indexConfiguration.getBulkSize());
         assertEquals(testFlushTimeout, indexConfiguration.getFlushTimeout());
         assertEquals(true, indexConfiguration.isEstimateBulkSizeUsingCompression());
+        assertEquals(5, indexConfiguration.getMaxLocalCompressionsForEstimation());
         assertEquals(testIdField, indexConfiguration.getDocumentIdField());
     }
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -282,6 +282,7 @@ public class IndexConfigurationTests {
         assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
         assertEquals(5, indexConfiguration.getBulkSize());
         assertEquals(60_000L, indexConfiguration.getFlushTimeout());
+        assertEquals(false, indexConfiguration.isEstimateBulkSizeUsingCompression());
         assertEquals("spanId", indexConfiguration.getDocumentIdField());
     }
 
@@ -306,6 +307,7 @@ public class IndexConfigurationTests {
         assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
         assertEquals(5, indexConfiguration.getBulkSize());
         assertEquals(60_000L, indexConfiguration.getFlushTimeout());
+        assertEquals(false, indexConfiguration.isEstimateBulkSizeUsingCompression());
         assertEquals("hashId", indexConfiguration.getDocumentIdField());
     }
 
@@ -319,12 +321,14 @@ public class IndexConfigurationTests {
         final String testIdField = "someId";
         final PluginSetting pluginSetting = generatePluginSetting(
                 null, testIndexAlias, defaultTemplateFilePath, testBulkSize, testFlushTimeout, testIdField);
+        pluginSetting.getSettings().put(IndexConfiguration.ESTIMATE_BULK_SIZE_USING_COMPRESSION, true);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         assertEquals(IndexType.CUSTOM, indexConfiguration.getIndexType());
         assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
         assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
         assertEquals(testBulkSize, indexConfiguration.getBulkSize());
         assertEquals(testFlushTimeout, indexConfiguration.getFlushTimeout());
+        assertEquals(true, indexConfiguration.isEstimateBulkSizeUsingCompression());
         assertEquals(testIdField, indexConfiguration.getDocumentIdField());
     }
 


### PR DESCRIPTION
### Description
This PR introduces 2 implementations of the JavaClientAccumulatingBulkRequest, 1 to measure the uncompressed size of the bulk request, and a second to measure the compressed size of the bulk request. It also restores the default behavior to measure the uncompressed size.

The compressed sizing implementation is tweaked to use a logarithmic algorithm for measuring the compressed bulk size to increase the accuracy of the measurement.

As part of this change, 3 new settings are exposed:
1. `enable_request_compression` - controls whether request compression is enabled at the TransportClient level
2. `estimate_bulk_size_using_compression` - controls which of the two implementations above are used
3. `max_local_compressions_for_estimation` - a lever for trading between accuracy and performance when measuring bulk size with compression
 
### Issues Resolved
#2954 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
