### PR TITLE
Fix SqsWorker error messages

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
@@ -269,6 +269,9 @@ public class SqsWorker implements Runnable {
     }
 
     private void deleteSqsMessages(final List<DeleteMessageBatchRequestEntry> deleteMessageBatchRequestEntryCollection) {
+        if (deleteMessageBatchRequestEntryCollection.size() == 0) {
+            return;
+        }
         final DeleteMessageBatchRequest deleteMessageBatchRequest = buildDeleteMessageBatchRequest(deleteMessageBatchRequestEntryCollection);
         try {
             final DeleteMessageBatchResponse deleteMessageBatchResponse = sqsClient.deleteMessageBatch(deleteMessageBatchRequest);
@@ -288,7 +291,7 @@ public class SqsWorker implements Runnable {
 
                 if(LOG.isErrorEnabled()) {
                     final String failedMessages = deleteMessageBatchResponse.failed().stream()
-                            .map(failed -> toString())
+                            .map(failed -> failed.toString())
                             .collect(Collectors.joining(", "));
                     LOG.error("Failed to delete {} messages from SQS with errors: [{}].", failedDeleteCount, failedMessages);
                 }


### PR DESCRIPTION
### Description
Fix SqsWorker error messages.
1. SQSWorker tries to delete empty list of objects which results in error message that's misleading. This fix avoids that by check for empty message list before invoking delete
2. SQS worker message when deletion fails has is constructed incorrectly. Fixed it by constructing the error message correctly.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
