### PR TITLE
Fix race condition in SqsWorker when acknowledgements are enabled

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSet.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSet.java
@@ -50,4 +50,12 @@ public interface AcknowledgementSet {
      * @since 2.2
      */
     public boolean release(final EventHandle eventHandle, final boolean result);
+
+    /**
+      * Indicates that the addition of initial set of events to
+      * the acknowledgement set is completed.
+      * It is possible that more events are added to the set as the 
+      * initial events are going through the pipeline line.
+     */
+    public void complete();
 }

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySource.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySource.java
@@ -114,6 +114,10 @@ public class InMemorySource implements Source<Record<Event>> {
             while (!isStopped) {
                 try {
                     final List<Record<Event>> records = inMemorySourceAccessor.read(testingKey);
+                    if (records.size() == 0) {
+                        Thread.sleep(1000);
+                        continue;
+                    }
                     AcknowledgementSet ackSet =
                             acknowledgementSetManager.create((result) ->
                                 {
@@ -121,6 +125,7 @@ public class InMemorySource implements Source<Record<Event>> {
                                 },
                                 Duration.ofSeconds(15));
                     records.stream().forEach((record) -> { ackSet.add(record.getData()); });
+                    ackSet.complete();
                     writeToBuffer(records);
                 } catch (final Exception ex) {
                     LOG.error("Error during source loop.", ex);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetManagerTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetManagerTests.java
@@ -64,6 +64,7 @@ class DefaultAcknowledgementSetManagerTests {
         AcknowledgementSet acknowledgementSet1 = acknowledgementSetManager.create((flag) -> { result = flag; }, TEST_TIMEOUT_MS);
         acknowledgementSet1.add(event1);
         acknowledgementSet1.add(event2);
+        acknowledgementSet1.complete();
     }
 
     DefaultAcknowledgementSetManager createObjectUnderTest() {
@@ -98,6 +99,7 @@ class DefaultAcknowledgementSetManagerTests {
 
         AcknowledgementSet acknowledgementSet2 = acknowledgementSetManager.create((flag) -> { result = flag; }, TEST_TIMEOUT_MS);
         acknowledgementSet2.add(event3);
+        acknowledgementSet2.complete();
 
         acknowledgementSetManager.releaseEventReference(eventHandle2, true);
         acknowledgementSetManager.releaseEventReference(eventHandle3, true);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetTests.java
@@ -89,6 +89,7 @@ class DefaultAcknowledgementSetTests {
     @Test
     void testDefaultAcknowledgementSetBasic() throws Exception {
         defaultAcknowledgementSet.add(event);
+        defaultAcknowledgementSet.complete();
         assertThat(handle, not(equalTo(null)));
         assertThat(handle.getAcknowledgementSet(), equalTo(defaultAcknowledgementSet));
         assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(true));
@@ -97,6 +98,7 @@ class DefaultAcknowledgementSetTests {
     @Test
     void testDefaultAcknowledgementSetMultipleAcquireAndRelease() throws Exception {
         defaultAcknowledgementSet.add(event);
+        defaultAcknowledgementSet.complete();
         assertThat(handle, not(equalTo(null)));
         assertThat(handle.getAcknowledgementSet(), equalTo(defaultAcknowledgementSet));
         defaultAcknowledgementSet.acquire(handle);
@@ -111,6 +113,7 @@ class DefaultAcknowledgementSetTests {
     @Test
     void testDefaultAcknowledgementInvalidAcquire() {
         defaultAcknowledgementSet.add(event);
+        defaultAcknowledgementSet.complete();
         DefaultAcknowledgementSet secondAcknowledgementSet = createObjectUnderTest();
         DefaultEventHandle handle2 = new DefaultEventHandle(secondAcknowledgementSet);
         defaultAcknowledgementSet.acquire(handle2);
@@ -120,6 +123,7 @@ class DefaultAcknowledgementSetTests {
     @Test
     void testDefaultAcknowledgementInvalidRelease() {
         defaultAcknowledgementSet.add(event);
+        defaultAcknowledgementSet.complete();
         DefaultAcknowledgementSet secondAcknowledgementSet = createObjectUnderTest();
         DefaultEventHandle handle2 = new DefaultEventHandle(secondAcknowledgementSet);
         assertThat(defaultAcknowledgementSet.release(handle2, true), equalTo(false));
@@ -129,6 +133,7 @@ class DefaultAcknowledgementSetTests {
     @Test
     void testDefaultAcknowledgementDuplicateReleaseError() throws Exception {
         defaultAcknowledgementSet.add(event);
+        defaultAcknowledgementSet.complete();
         assertThat(handle, not(equalTo(null)));
         assertThat(handle.getAcknowledgementSet(), equalTo(defaultAcknowledgementSet));
         assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(true));
@@ -144,6 +149,7 @@ class DefaultAcknowledgementSetTests {
             }        
         );
         defaultAcknowledgementSet.add(event);
+        defaultAcknowledgementSet.complete();
         assertThat(handle, not(equalTo(null)));
         assertThat(handle.getAcknowledgementSet(), equalTo(defaultAcknowledgementSet));
         assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(true));
@@ -162,6 +168,7 @@ class DefaultAcknowledgementSetTests {
             }        
         );
         defaultAcknowledgementSet.add(event);
+        defaultAcknowledgementSet.complete();
         assertThat(handle, not(equalTo(null)));
         assertThat(handle.getAcknowledgementSet(), equalTo(defaultAcknowledgementSet));
         defaultAcknowledgementSet.acquire(handle);
@@ -190,6 +197,7 @@ class DefaultAcknowledgementSetTests {
             }        
         );
         defaultAcknowledgementSet.add(event);
+        defaultAcknowledgementSet.complete();
         assertThat(handle, not(equalTo(null)));
         assertThat(handle.getAcknowledgementSet(), equalTo(defaultAcknowledgementSet));
         assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(true));

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaSourceCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaSourceCustomConsumer.java
@@ -147,6 +147,8 @@ public class KafkaSourceCustomConsumer implements Runnable, ConsumerRebalanceLis
             if (!acknowledgementsEnabled) {
                 offsets.forEach((partition, offsetRange) ->
                     updateOffsetsToCommit(partition, new OffsetAndMetadata(offsetRange.getMaximum() + 1)));
+            } else {
+                acknowledgementSet.complete();
             }
         }
     }

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/SqsWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/SqsWorkerIT.java
@@ -149,7 +149,7 @@ class SqsWorkerIT {
 
     @ParameterizedTest
     @ValueSource(ints = {1})
-    void processSqsMessages_should_return_at_least_one_message_with_acks_with_callback_invoked_after_processS3Object_finishes(final int numberOfObjectsToWrite) throws IOException {
+    void processSqsMessages_should_return_at_least_one_message_with_acks_with_callback_invoked_after_processS3Object_finishes(final int numberOfObjectsToWrite) throws IOException, InterruptedException {
         writeToS3(numberOfObjectsToWrite);
 
         when(s3SourceConfig.getAcknowledgements()).thenReturn(true);
@@ -205,9 +205,7 @@ class SqsWorkerIT {
             ready.set(true);
             this.notify();
         }
-        try {
-            Thread.sleep(10000);
-        } catch (Exception e){}
+        Thread.sleep(10000);
 
         assertThat(deletedCount, equalTo((double)1.0));
         assertThat(ackCallbackCount, equalTo((double)1.0));
@@ -215,7 +213,7 @@ class SqsWorkerIT {
 
     @ParameterizedTest
     @ValueSource(ints = {1})
-    void processSqsMessages_should_return_at_least_one_message_with_acks_with_callback_invoked_before_processS3Object_finishes(final int numberOfObjectsToWrite) throws IOException {
+    void processSqsMessages_should_return_at_least_one_message_with_acks_with_callback_invoked_before_processS3Object_finishes(final int numberOfObjectsToWrite) throws IOException, InterruptedException {
         writeToS3(numberOfObjectsToWrite);
 
         when(s3SourceConfig.getAcknowledgements()).thenReturn(true);
@@ -277,10 +275,7 @@ class SqsWorkerIT {
         sinkThread.start();
         final int sqsMessagesProcessed = objectUnderTest.processSqsMessages();
 
-        try {
-            Thread.sleep(10000);
-        } catch (Exception e){}
-
+        Thread.sleep(10000);
 
         assertThat(deletedCount, equalTo((double)1.0));
         assertThat(ackCallbackCount, equalTo((double)1.0));

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/SqsWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/SqsWorkerIT.java
@@ -13,6 +13,10 @@ import org.opensearch.dataprepper.plugins.source.configuration.NotificationSourc
 import org.opensearch.dataprepper.plugins.source.configuration.OnErrorOption;
 import org.opensearch.dataprepper.plugins.source.configuration.SqsOptions;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.acknowledgements.DefaultAcknowledgementSetManager;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.AfterEach;
@@ -28,6 +32,9 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -36,14 +43,22 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doAnswer;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class SqsWorkerIT {
     private SqsClient sqsClient;
+    @Mock
     private S3Service s3Service;
     private S3SourceConfig s3SourceConfig;
     private PluginMetrics pluginMetrics;
@@ -51,6 +66,11 @@ class SqsWorkerIT {
     private String bucket;
     private Backoff backoff;
     private AcknowledgementSetManager acknowledgementSetManager;
+    private Double receivedCount = 0.0;
+    private Double deletedCount = 0.0;
+    private Double ackCallbackCount = 0.0;
+    private Event event;
+    private AtomicBoolean ready = new AtomicBoolean(false);
 
     @BeforeEach
     void setUp() {
@@ -76,8 +96,8 @@ class SqsWorkerIT {
         final DistributionSummary distributionSummary = mock(DistributionSummary.class);
         final Timer sqsMessageDelayTimer = mock(Timer.class);
 
-        when(pluginMetrics.counter(anyString())).thenReturn(sharedCounter);
-        when(pluginMetrics.summary(anyString())).thenReturn(distributionSummary);
+        lenient().when(pluginMetrics.counter(anyString())).thenReturn(sharedCounter);
+        lenient().when(pluginMetrics.summary(anyString())).thenReturn(distributionSummary);
         when(pluginMetrics.timer(anyString())).thenReturn(sqsMessageDelayTimer);
 
         final SqsOptions sqsOptions = mock(SqsOptions.class);
@@ -86,7 +106,7 @@ class SqsWorkerIT {
         when(sqsOptions.getMaximumMessages()).thenReturn(10);
         when(sqsOptions.getWaitTime()).thenReturn(Duration.ofSeconds(10));
         when(s3SourceConfig.getSqsOptions()).thenReturn(sqsOptions);
-        when(s3SourceConfig.getOnErrorOption()).thenReturn(OnErrorOption.DELETE_MESSAGES);
+        lenient().when(s3SourceConfig.getOnErrorOption()).thenReturn(OnErrorOption.DELETE_MESSAGES);
         when(s3SourceConfig.getNotificationSource()).thenReturn(NotificationSourceOption.S3);
     }
 
@@ -125,6 +145,145 @@ class SqsWorkerIT {
         assertThat(s3ObjectReferenceArgumentCaptor.getValue().getKey(), startsWith("s3 source/sqs/"));
         assertThat(sqsMessagesProcessed, greaterThanOrEqualTo(1));
         assertThat(sqsMessagesProcessed, lessThanOrEqualTo(numberOfObjectsToWrite));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1})
+    void processSqsMessages_should_return_at_least_one_message_with_acks_with_callback_invoked_after_processS3Object_finishes(final int numberOfObjectsToWrite) throws IOException {
+        writeToS3(numberOfObjectsToWrite);
+
+        when(s3SourceConfig.getAcknowledgements()).thenReturn(true);
+        final Counter receivedCounter = mock(Counter.class);
+        final Counter deletedCounter = mock(Counter.class);
+        final Counter ackCallbackCounter = mock(Counter.class);
+        when(pluginMetrics.counter(SqsWorker.SQS_MESSAGES_RECEIVED_METRIC_NAME)).thenReturn(receivedCounter);
+        when(pluginMetrics.counter(SqsWorker.SQS_MESSAGES_DELETED_METRIC_NAME)).thenReturn(deletedCounter);
+        when(pluginMetrics.counter(SqsWorker.ACKNOWLEDGEMENT_SET_CALLACK_METRIC_NAME)).thenReturn(ackCallbackCounter);
+        lenient().doAnswer((val) -> {
+            receivedCount += (double)val.getArgument(0);
+            return null;
+        }).when(receivedCounter).increment(any(Double.class));
+        lenient().doAnswer((val) -> {
+            if (val.getArgument(0) != null) {
+                deletedCount += (double)val.getArgument(0);
+            }
+            return null;
+        }).when(deletedCounter).increment(any(Double.class));
+        lenient().doAnswer((val) -> {
+            ackCallbackCount += 1;
+            return null;
+        }).when(ackCallbackCounter).increment();
+
+        doAnswer((val) -> {
+            AcknowledgementSet ackSet = val.getArgument(1);
+            S3ObjectReference s3ObjectReference = val.getArgument(0);
+            assertThat(s3ObjectReference.getBucketName(), equalTo(bucket));
+            assertThat(s3ObjectReference.getKey(), startsWith("s3 source/sqs/"));
+            event = (Event)JacksonEvent.fromMessage(val.getArgument(0).toString());
+            ackSet.add(event);
+            return null;
+        }).when(s3Service).addS3Object(any(S3ObjectReference.class), any(AcknowledgementSet.class));
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        acknowledgementSetManager = new  DefaultAcknowledgementSetManager(executor);
+        final SqsWorker objectUnderTest = createObjectUnderTest();
+        Thread sinkThread = new Thread(() -> {
+            try {
+                synchronized(this) {
+                    while (!ready.get()) {
+                        Thread.sleep(100);
+                        this.wait();
+                    }
+                    if (event.getEventHandle() != null) {
+                        event.getEventHandle().release(true);
+                    }
+                }
+            } catch (Exception e){}
+        });
+        sinkThread.start();
+        final int sqsMessagesProcessed = objectUnderTest.processSqsMessages();
+        synchronized(this) {
+            ready.set(true);
+            this.notify();
+        }
+        try {
+            Thread.sleep(10000);
+        } catch (Exception e){}
+
+        assertThat(deletedCount, equalTo((double)1.0));
+        assertThat(ackCallbackCount, equalTo((double)1.0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1})
+    void processSqsMessages_should_return_at_least_one_message_with_acks_with_callback_invoked_before_processS3Object_finishes(final int numberOfObjectsToWrite) throws IOException {
+        writeToS3(numberOfObjectsToWrite);
+
+        when(s3SourceConfig.getAcknowledgements()).thenReturn(true);
+        final Counter receivedCounter = mock(Counter.class);
+        final Counter deletedCounter = mock(Counter.class);
+        final Counter ackCallbackCounter = mock(Counter.class);
+        when(pluginMetrics.counter(SqsWorker.SQS_MESSAGES_RECEIVED_METRIC_NAME)).thenReturn(receivedCounter);
+        when(pluginMetrics.counter(SqsWorker.SQS_MESSAGES_DELETED_METRIC_NAME)).thenReturn(deletedCounter);
+        when(pluginMetrics.counter(SqsWorker.ACKNOWLEDGEMENT_SET_CALLACK_METRIC_NAME)).thenReturn(ackCallbackCounter);
+        lenient().doAnswer((val) -> {
+            receivedCount += (double)val.getArgument(0);
+            return null;
+        }).when(receivedCounter).increment(any(Double.class));
+        lenient().doAnswer((val) -> {
+            if (val.getArgument(0) != null) {
+                deletedCount += (double)val.getArgument(0);
+            }
+            return null;
+        }).when(deletedCounter).increment(any(Double.class));
+        lenient().doAnswer((val) -> {
+            ackCallbackCount += 1;
+            return null;
+        }).when(ackCallbackCounter).increment();
+
+        doAnswer((val) -> {
+            AcknowledgementSet ackSet = val.getArgument(1);
+            S3ObjectReference s3ObjectReference = val.getArgument(0);
+            assertThat(s3ObjectReference.getBucketName(), equalTo(bucket));
+            assertThat(s3ObjectReference.getKey(), startsWith("s3 source/sqs/"));
+            event = (Event)JacksonEvent.fromMessage(val.getArgument(0).toString());
+
+            ackSet.add(event);
+            synchronized(this) {
+                ready.set(true);
+                this.notify();
+            }
+            try {
+                Thread.sleep(4000);
+            } catch (Exception e){}
+
+            return null;
+        }).when(s3Service).addS3Object(any(S3ObjectReference.class), any(AcknowledgementSet.class));
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        acknowledgementSetManager = new  DefaultAcknowledgementSetManager(executor);
+        final SqsWorker objectUnderTest = createObjectUnderTest();
+        Thread sinkThread = new Thread(() -> {
+            try {
+                synchronized(this) {
+                    while (!ready.get()) {
+                        Thread.sleep(100);
+                        this.wait();
+                    }
+                    if (event.getEventHandle() != null) {
+                        event.getEventHandle().release(true);
+                    }
+                }
+            } catch (Exception e){}
+        });
+        sinkThread.start();
+        final int sqsMessagesProcessed = objectUnderTest.processSqsMessages();
+
+        try {
+            Thread.sleep(10000);
+        } catch (Exception e){}
+
+
+        assertThat(deletedCount, equalTo((double)1.0));
+        assertThat(ackCallbackCount, equalTo((double)1.0));
     }
 
     /** The EventBridge test is disabled by default

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
@@ -43,7 +43,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SqsWorker implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(SqsWorker.class);

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
@@ -227,7 +227,6 @@ public class SqsWorker implements Runnable {
         for (ParsedMessage parsedMessage : parsedMessagesToRead) {
             List<DeleteMessageBatchRequestEntry> waitingForAcknowledgements = new ArrayList<>();
             AcknowledgementSet acknowledgementSet = null;
-            AtomicBoolean acknowledgementSetReady = new AtomicBoolean(false);
             if (endToEndAcknowledgementsEnabled) {
                 // Acknowledgement Set timeout is slightly smaller than the visibility timeout;
                 int timeout = (int) sqsOptions.getVisibilityTimeout().getSeconds() - 2;


### PR DESCRIPTION
### Description
Fix race condition in SqsWorker when acknowledgements are enabled
When E2E acknowledgements are enabled, S3 Source need to synchronize between the callback thread and the main thread because main thread may not have got chance to fully populate the waitingForAcknowledgements list
 
Resolves #3000 
### Issues Resolved
#3000 
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
