### PR TITLE
Fix bucket ownership validation in S3 source

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ObjectWorker.java
@@ -74,7 +74,7 @@ class S3ObjectWorker implements S3ObjectHandler {
 
         LOG.info("Read S3 object: {}", s3ObjectReference);
 
-        final S3InputFile inputFile = new S3InputFile(s3Client, s3ObjectReference, s3ObjectPluginMetrics);
+        final S3InputFile inputFile = new S3InputFile(s3Client, s3ObjectReference, bucketOwnerProvider, s3ObjectPluginMetrics);
 
         final CompressionOption fileCompressionOption = compressionOption != CompressionOption.AUTOMATIC ?
                 compressionOption : CompressionOption.fromFileName(s3ObjectReference.getKey());

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3InputFileTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3InputFileTest.java
@@ -3,12 +3,19 @@ package org.opensearch.dataprepper.plugins.source;
 import org.apache.parquet.io.SeekableInputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.opensearch.dataprepper.plugins.source.ownership.BucketOwnerProvider;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -20,15 +27,24 @@ public class S3InputFileTest {
     private S3Client s3Client;
     private S3ObjectReference s3ObjectReference;
     private S3ObjectPluginMetrics s3ObjectPluginMetrics;
-    private S3InputFile s3InputFile;
+    private String bucketName;
+    private String key;
+    private BucketOwnerProvider bucketOwnerProvider;
 
     @BeforeEach
     public void setUp() {
         s3Client = mock(S3Client.class);
         s3ObjectReference = mock(S3ObjectReference.class);
         s3ObjectPluginMetrics = mock(S3ObjectPluginMetrics.class);
+        bucketOwnerProvider = mock(BucketOwnerProvider.class);
+        bucketName = UUID.randomUUID().toString();
+        key = UUID.randomUUID().toString();
+        when(s3ObjectReference.getBucketName()).thenReturn(bucketName);
+        when(s3ObjectReference.getKey()).thenReturn(key);
+    }
 
-        s3InputFile = new S3InputFile(s3Client, s3ObjectReference, s3ObjectPluginMetrics);
+    private S3InputFile createObjectUnderTest() {
+        return new S3InputFile(s3Client, s3ObjectReference, bucketOwnerProvider, s3ObjectPluginMetrics);
     }
 
     @Test
@@ -37,10 +53,42 @@ public class S3InputFileTest {
         when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
         when(headObjectResponse.contentLength()).thenReturn(12345L);
 
-        long length = s3InputFile.getLength();
+        long length = createObjectUnderTest().getLength();
 
         assertThat(length, equalTo(12345L));
-        verify(s3Client, times(1)).headObject(any(HeadObjectRequest.class));
+        final ArgumentCaptor<HeadObjectRequest> headObjectRequestArgumentCaptor = ArgumentCaptor.forClass(HeadObjectRequest.class);
+        verify(s3Client, times(1)).headObject(headObjectRequestArgumentCaptor.capture());
+
+        final HeadObjectRequest actualHeadObjectRequest = headObjectRequestArgumentCaptor.getValue();
+        assertAll(
+                () -> assertThat(actualHeadObjectRequest.bucket(), equalTo(bucketName)),
+                () -> assertThat(actualHeadObjectRequest.key(), equalTo(key)),
+                () -> assertThat(actualHeadObjectRequest.expectedBucketOwner(), nullValue())
+        );
+    }
+
+    @Test
+    public void getLength_requests_head_for_bucket_key_and_owner_when_bucket_has_owner() {
+        final HeadObjectResponse headObjectResponse = mock(HeadObjectResponse.class);
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
+        when(headObjectResponse.contentLength()).thenReturn(12345L);
+
+        final String owner = UUID.randomUUID().toString();
+        when(bucketOwnerProvider.getBucketOwner(bucketName)).thenReturn(Optional.of(owner));
+
+        long length = createObjectUnderTest().getLength();
+
+        assertThat(length, equalTo(12345L));
+
+        final ArgumentCaptor<HeadObjectRequest> headObjectRequestArgumentCaptor = ArgumentCaptor.forClass(HeadObjectRequest.class);
+        verify(s3Client, times(1)).headObject(headObjectRequestArgumentCaptor.capture());
+
+        final HeadObjectRequest actualHeadObjectRequest = headObjectRequestArgumentCaptor.getValue();
+        assertAll(
+                () -> assertThat(actualHeadObjectRequest.bucket(), equalTo(bucketName)),
+                () -> assertThat(actualHeadObjectRequest.key(), equalTo(key)),
+                () -> assertThat(actualHeadObjectRequest.expectedBucketOwner(), equalTo(owner))
+        );
     }
 
     @Test
@@ -48,7 +96,7 @@ public class S3InputFileTest {
         HeadObjectResponse headObjectResponse = mock(HeadObjectResponse.class);
         when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
 
-        SeekableInputStream seekableInputStream = s3InputFile.newStream();
+        SeekableInputStream seekableInputStream = createObjectUnderTest().newStream();
 
         assertThat(seekableInputStream.getClass(), equalTo(S3InputStream.class));
     }


### PR DESCRIPTION
### Description

Fixes bucket ownership validation in the `s3` source.
 
### Issues Resolved

Resolves #3005
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
