### PR TITLE
New configurations in the S3 source to configure bucket ownership

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3SourceConfig.java
@@ -20,6 +20,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.Duration;
+import java.util.Map;
 
 public class S3SourceConfig {
     static final Duration DEFAULT_BUFFER_TIMEOUT = Duration.ofSeconds(10);
@@ -61,6 +62,12 @@ public class S3SourceConfig {
 
     @JsonProperty("disable_bucket_ownership_validation")
     private boolean disableBucketOwnershipValidation = false;
+
+    @JsonProperty("bucket_owners")
+    private Map<String, String> bucketOwners;
+
+    @JsonProperty("default_bucket_owner")
+    private String defaultBucketOwner;
 
     @JsonProperty("metadata_root_key")
     private String metadataRootKey = DEFAULT_METADATA_ROOT_KEY;
@@ -135,4 +142,11 @@ public class S3SourceConfig {
         return s3ScanScanOptions;
     }
 
+    public Map<String, String> getBucketOwners() {
+        return bucketOwners;
+    }
+
+    public String getDefaultBucketOwner() {
+        return defaultBucketOwner;
+    }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/ownership/MappedBucketOwnerProvider.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/ownership/MappedBucketOwnerProvider.java
@@ -1,0 +1,31 @@
+package org.opensearch.dataprepper.plugins.source.ownership;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Implements {@link BucketOwnerProvider} using a mapping of bucket
+ * names to account Ids for the bucket owners. Uses a delegate
+ * {@link BucketOwnerProvider} as a fallback when the bucket is not
+ * found in the map.
+ */
+class MappedBucketOwnerProvider implements BucketOwnerProvider {
+    private final Map<String, String> bucketOwnershipMap;
+    private final BucketOwnerProvider fallbackProvider;
+
+    MappedBucketOwnerProvider(Map<String, String> bucketOwnershipMap, BucketOwnerProvider fallbackProvider) {
+        this.bucketOwnershipMap = new HashMap<>(Objects.requireNonNull(bucketOwnershipMap));
+        this.fallbackProvider = Objects.requireNonNull(fallbackProvider);
+    }
+
+    @Override
+    public Optional<String> getBucketOwner(String bucket) {
+        String account = bucketOwnershipMap.get(bucket);
+        if(account != null) {
+            return Optional.of(account);
+        }
+        return fallbackProvider.getBucketOwner(bucket);
+    }
+}

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ownership/MappedBucketOwnerProviderTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ownership/MappedBucketOwnerProviderTest.java
@@ -1,0 +1,120 @@
+package org.opensearch.dataprepper.plugins.source.ownership;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MappedBucketOwnerProviderTest {
+    private Map<String, String> bucketOwnershipMap;
+    @Mock
+    private BucketOwnerProvider fallbackProvider;
+
+    private MappedBucketOwnerProvider createObjectUnderTest() {
+        return new MappedBucketOwnerProvider(bucketOwnershipMap, fallbackProvider);
+    }
+
+    @Test
+    void constructor_throws_with_null_ownership_map() {
+        bucketOwnershipMap = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void constructor_throws_with_null_fallback() {
+        bucketOwnershipMap = Collections.emptyMap();
+        fallbackProvider = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Nested
+    class WithEmptyOwnersMap {
+        private String bucket;
+        @BeforeEach
+        void setUp() {
+            bucketOwnershipMap = Collections.emptyMap();
+            bucket = UUID.randomUUID().toString();
+        }
+
+        @Test
+        void getBucketOwner_returns_owner_from_fallback_when_not_in_map() {
+            String fallbackAccount = UUID.randomUUID().toString();
+            when(fallbackProvider.getBucketOwner(bucket)).thenReturn(Optional.of(fallbackAccount));
+
+            Optional<String> optionalOwner = createObjectUnderTest().getBucketOwner(bucket);
+            assertThat(optionalOwner, notNullValue());
+            assertThat(optionalOwner.isPresent(), equalTo(true));
+            assertThat(optionalOwner.get(), equalTo(fallbackAccount));
+        }
+
+        @Test
+        void getBucketOwner_returns_empty_when_not_in_map_nor_in_fallback() {
+            when(fallbackProvider.getBucketOwner(bucket)).thenReturn(Optional.empty());
+
+            Optional<String> optionalOwner = createObjectUnderTest().getBucketOwner(bucket);
+            assertThat(optionalOwner, notNullValue());
+            assertThat(optionalOwner.isPresent(), equalTo(false));
+        }
+    }
+
+    @Nested
+    class WithOwnersMap {
+        private String knownBucket;
+        private String knownBucketAccount;
+
+        @BeforeEach
+        void setUp() {
+            knownBucket = UUID.randomUUID().toString();
+            knownBucketAccount = UUID.randomUUID().toString();
+            bucketOwnershipMap = Map.of(
+                    UUID.randomUUID().toString(), UUID.randomUUID().toString(),
+                    UUID.randomUUID().toString(), UUID.randomUUID().toString(),
+                    knownBucket, knownBucketAccount,
+                    UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        }
+
+        @Test
+        void getBucketOwner_returns_owner_from_map_when_found() {
+            Optional<String> optionalOwner = createObjectUnderTest().getBucketOwner(knownBucket);
+            assertThat(optionalOwner, notNullValue());
+            assertThat(optionalOwner.isPresent(), equalTo(true));
+            assertThat(optionalOwner.get(), equalTo(knownBucketAccount));
+        }
+
+        @Test
+        void getBucketOwner_returns_owner_from_fallback_when_not_in_map() {
+            String otherBucket = UUID.randomUUID().toString();
+            String fallbackAccount = UUID.randomUUID().toString();
+            when(fallbackProvider.getBucketOwner(otherBucket)).thenReturn(Optional.of(fallbackAccount));
+
+            Optional<String> optionalOwner = createObjectUnderTest().getBucketOwner(otherBucket);
+            assertThat(optionalOwner, notNullValue());
+            assertThat(optionalOwner.isPresent(), equalTo(true));
+            assertThat(optionalOwner.get(), equalTo(fallbackAccount));
+        }
+
+        @Test
+        void getBucketOwner_returns_empty_when_not_in_map_nor_in_fallback() {
+            String otherBucket = UUID.randomUUID().toString();
+            when(fallbackProvider.getBucketOwner(otherBucket)).thenReturn(Optional.empty());
+
+            Optional<String> optionalOwner = createObjectUnderTest().getBucketOwner(otherBucket);
+            assertThat(optionalOwner, notNullValue());
+            assertThat(optionalOwner.isPresent(), equalTo(false));
+        }
+    }
+}


### PR DESCRIPTION
### Description

This adds two new configurations to allow users to define bucket ownership:

* `bucket_owners` - A map of bucket names to expected account Ids
* `default_bucket_owner` - An account Id to use for buckets by default. This effectively overrides the existing default which is to use the SQS queue account.
 
### Issues Resolved

Resolves #2012
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
