### PR TITLE
Work to reduce test time by reducing some repeated tests, using Awaitility, and reducing delays

### DIFF
--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/AbstractSinkTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/AbstractSinkTest.java
@@ -14,12 +14,15 @@ import org.opensearch.dataprepper.metrics.MetricsTestUtil;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.record.Record;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.UUID;
+
+import static org.awaitility.Awaitility.await;
 
 public class AbstractSinkTest {
     @Test
@@ -51,8 +54,8 @@ public class AbstractSinkTest {
         Assert.assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(elapsedTimeMeasurements, Statistic.COUNT).getValue(), 0);
         Assert.assertTrue(MetricsTestUtil.isBetween(
                 MetricsTestUtil.getMeasurementFromList(elapsedTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
-                0.5,
-                0.6));
+                0.2,
+                0.3));
         Assert.assertEquals(abstractSink.getRetryThreadState(), null);
         abstractSink.shutdown();
     }
@@ -71,14 +74,8 @@ public class AbstractSinkTest {
         // Do another intialize to make sure the sink is still not ready
         abstractSink.initialize();
         Assert.assertEquals(abstractSink.isReady(), false);
-        while (!abstractSink.isReady()) {
-            try {
-                Thread.sleep(1000);
-            } catch (Exception e) {}
-        }
-        try {
-            Thread.sleep(2000);
-        } catch (Exception e) {}
+        await().atMost(Duration.ofSeconds(5))
+                .until(abstractSink::isReady);
         Assert.assertEquals(abstractSink.getRetryThreadState(), Thread.State.TERMINATED);
         abstractSink.shutdown();
     }
@@ -92,7 +89,7 @@ public class AbstractSinkTest {
         @Override
         public void doOutput(Collection<Record<String>> records) {
             try {
-                Thread.sleep(500);
+                Thread.sleep(200);
             } catch (InterruptedException e) {
 
             }
@@ -126,7 +123,7 @@ public class AbstractSinkTest {
         @Override
         public void doOutput(Collection<Record<String>> records) {
             try {
-                Thread.sleep(500);
+                Thread.sleep(100);
             } catch (InterruptedException e) {
 
             }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/AcknowledgementSetMonitorTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/AcknowledgementSetMonitorTests.java
@@ -20,7 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 public class AcknowledgementSetMonitorTests {
-    private static final int DEFAULT_WAIT_TIME_MS = 2000;
+    private static final int DEFAULT_WAIT_TIME_MS = 500;
     @Mock
     DefaultAcknowledgementSet acknowledgementSet1;
     @Mock

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugins/TestSink.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugins/TestSink.java
@@ -9,6 +9,7 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.Sink;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -29,11 +30,11 @@ public class TestSink implements Sink<Record<String>> {
         this.ready = true;
     }
 
-    public TestSink(int readyAfterSecs) {
+    public TestSink(Duration readyAfter) {
         this.ready = false;
         this.failSinkForTest = false;
         this.collectedRecords = new ArrayList<>();
-        this.readyTime = Instant.now().plusSeconds(readyAfterSecs);
+        this.readyTime = Instant.now().plus(readyAfter);
     }
 
     public TestSink(boolean failSinkForTest) {

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
@@ -137,7 +137,7 @@ public class AggregateProcessorIT {
         return new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, expressionEvaluator);
     }
 
-    @RepeatedTest(value = 10)
+    @RepeatedTest(value = 2)
     void aggregateWithNoConcludingGroupsReturnsExpectedResult() throws InterruptedException {
         aggregateAction = new RemoveDuplicatesAggregateAction();
         when(pluginFactory.loadPlugin(eq(AggregateAction.class), any(PluginSetting.class)))
@@ -260,7 +260,7 @@ public class AggregateProcessorIT {
     }
 
     @ParameterizedTest
-    @ValueSource(doubles = {5.0, 15.0, 33.0, 55.0, 70.0, 85.0, 92.0, 99.0})
+    @ValueSource(doubles = {5.0, 15.0, 55.0, 92.0, 99.0})
     void aggregateWithPercentSamplerAction(double testPercent) throws InterruptedException, NoSuchFieldException, IllegalAccessException {
         PercentSamplerAggregateActionConfig percentSamplerAggregateActionConfig = new PercentSamplerAggregateActionConfig();
         setField(PercentSamplerAggregateActionConfig.class, percentSamplerAggregateActionConfig, "percent", testPercent);

--- a/data-prepper-plugins/log-generator-source/src/test/java/org/opensearch/dataprepper/plugins/source/loggenerator/LogGeneratorSourceTest.java
+++ b/data-prepper-plugins/log-generator-source/src/test/java/org/opensearch/dataprepper/plugins/source/loggenerator/LogGeneratorSourceTest.java
@@ -84,14 +84,15 @@ public class LogGeneratorSourceTest {
 
         BlockingBuffer<Record<Event>> spyBuffer = spy(new BlockingBuffer<Record<Event>>("SamplePipeline"));
 
-        lenient().when(sourceConfig.getInterval()).thenReturn(Duration.ofSeconds(1)); // interval of 1 second
+        Duration interval = Duration.ofMillis(100);
+
+        lenient().when(sourceConfig.getInterval()).thenReturn(interval);
         lenient().when(sourceConfig.getCount()).thenReturn(INFINITE_LOG_COUNT); // no limit to log count
 
         logGeneratorSource.start(spyBuffer);
-        Thread.sleep(1500);
-
+        Thread.sleep((long) (interval.toMillis() * 1.5));
         verify(spyBuffer, atLeast(1)).write(any(Record.class), anyInt());
-        Thread.sleep(700);
+        Thread.sleep((long) (interval.toMillis() * 0.7));
         verify(spyBuffer, atLeast(2)).write(any(Record.class), anyInt());
     }
 
@@ -102,16 +103,18 @@ public class LogGeneratorSourceTest {
 
         BlockingBuffer<Record<Event>> spyBuffer = spy(new BlockingBuffer<Record<Event>>("SamplePipeline"));
 
-        lenient().when(sourceConfig.getInterval()).thenReturn(Duration.ofSeconds(1)); // interval of 1 second
+        Duration interval = Duration.ofMillis(100);
+
+        lenient().when(sourceConfig.getInterval()).thenReturn(interval);
         lenient().when(sourceConfig.getCount()).thenReturn(1); // max log count of 1 in logGeneratorSource
 
         assertEquals(spyBuffer.isEmpty(), true);
         logGeneratorSource.start(spyBuffer);
-        Thread.sleep(1100);
+        Thread.sleep((long) (interval.toMillis() * 1.1));
 
         verify(spyBuffer, times(1)).write(any(Record.class), anyInt());
 
-        Thread.sleep(1000);
+        Thread.sleep(interval.toMillis());
         verify(spyBuffer, times(1)).write(any(Record.class), anyInt());
     }
 }

--- a/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RSSSource.java
+++ b/data-prepper-plugins/rss-source/src/main/java/org/opensearch/dataprepper/plugins/source/rss/RSSSource.java
@@ -45,7 +45,8 @@ public class RSSSource implements Source<Record<Document>> {
             throw new IllegalStateException("Buffer is null");
         }
         rssReaderTask = new RssReaderTask(rssReader, rssSourceConfig.getUrl(), buffer);
-        scheduledExecutorService.scheduleAtFixedRate(rssReaderTask, 0, 5, TimeUnit.SECONDS);
+        scheduledExecutorService.scheduleAtFixedRate(rssReaderTask, 0,
+                rssSourceConfig.getPollingFrequency().toMillis(), TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
@@ -42,12 +43,14 @@ class RSSSourceTest {
     private PluginMetrics pluginMetrics;
 
     private RSSSource rssSource;
+    private Duration pollingFrequency;
 
     @BeforeEach
     void setUp() {
         pluginMetrics = PluginMetrics.fromNames(PLUGIN_NAME, PIPELINE_NAME);
+        pollingFrequency = Duration.ofMillis(1800);
         lenient().when(rssSourceConfig.getUrl()).thenReturn(VALID_RSS_URL);
-        lenient().when(rssSourceConfig.getPollingFrequency()).thenReturn(Duration.ofSeconds(5));
+        lenient().when(rssSourceConfig.getPollingFrequency()).thenReturn(pollingFrequency);
         rssSource = new RSSSource(pluginMetrics, rssSourceConfig);
     }
 
@@ -59,9 +62,9 @@ class RSSSourceTest {
     @Test
     void test_ExecutorService_keep_writing_Events_to_Buffer() throws Exception {
         rssSource.start(buffer);
-        Thread.sleep(5000);
+        Thread.sleep(pollingFrequency.toMillis());
         verify(buffer, atLeastOnce()).writeAll(anyCollection(), anyInt());
-        Thread.sleep(5000);
-        verify(buffer, atLeastOnce()).writeAll(anyCollection(), anyInt());
+        Thread.sleep(pollingFrequency.toMillis());
+        verify(buffer, atLeast(2)).writeAll(anyCollection(), anyInt());
     }
 }

--- a/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
+++ b/data-prepper-plugins/rss-source/src/test/java/org/opensearch/dataprepper/plugins/source/rss/RSSSourceTest.java
@@ -18,6 +18,7 @@ import org.opensearch.dataprepper.model.record.Record;
 
 import java.time.Duration;
 
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.atLeast;
@@ -62,9 +63,15 @@ class RSSSourceTest {
     @Test
     void test_ExecutorService_keep_writing_Events_to_Buffer() throws Exception {
         rssSource.start(buffer);
-        Thread.sleep(pollingFrequency.toMillis());
+        await().atMost(pollingFrequency.multipliedBy(2))
+                        .untilAsserted(() -> {
+                            verify(buffer, atLeastOnce()).writeAll(anyCollection(), anyInt());
+                        });
         verify(buffer, atLeastOnce()).writeAll(anyCollection(), anyInt());
-        Thread.sleep(pollingFrequency.toMillis());
+        await().atMost(pollingFrequency.multipliedBy(2))
+                .untilAsserted(() -> {
+                    verify(buffer, atLeast(2)).writeAll(anyCollection(), anyInt());
+                });
         verify(buffer, atLeast(2)).writeAll(anyCollection(), anyInt());
     }
 }


### PR DESCRIPTION
### Description

This PR includes some attempts to improve our test times.

* Adds use of Awaitility instead of Thread.sleep in some locations.
* Reduces repeated tests in AggregateProcessorIT, which is a particularly slow test.
* Reduces some delays/timeouts.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
