### PR TITLE
Improves timeouts for the peer forwarder tests to reduce test time

### DIFF
--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderReceiveBufferTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarderReceiveBufferTest.java
@@ -32,7 +32,7 @@ class PeerForwarderReceiveBufferTest {
     private static final int TEST_BATCH_SIZE = 3;
     private static final int TEST_BUFFER_SIZE = 13;
     private static final int TEST_WRITE_TIMEOUT = 100;
-    private static final int TEST_BATCH_READ_TIMEOUT = 5_000;
+    private static final int TEST_BATCH_READ_TIMEOUT = 200;
     private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
     private static final String PIPELINE_NAME = UUID.randomUUID().toString();
     private static final String PLUGIN_ID = UUID.randomUUID().toString();
@@ -204,7 +204,7 @@ class PeerForwarderReceiveBufferTest {
         final Collection<Record<String>> testRecords2 = generateBatchRecords(1);
         EXECUTOR.submit(() -> {
             try {
-                Thread.sleep(1000);
+                Thread.sleep(TEST_BATCH_READ_TIMEOUT / 5);
                 peerForwarderReceiveBuffer.writeAll(testRecords2, TEST_WRITE_TIMEOUT);
             } catch (final Exception e) {
                 throw new RuntimeException(e);
@@ -229,7 +229,7 @@ class PeerForwarderReceiveBufferTest {
         final Collection<Record<String>> testRecords2 = generateBatchRecords(1);
         EXECUTOR.submit(() -> {
             try {
-                Thread.sleep(1000);
+                Thread.sleep(TEST_BATCH_READ_TIMEOUT / 5);
                 peerForwarderReceiveBuffer.writeAll(testRecords2, TEST_WRITE_TIMEOUT);
             } catch (final Exception e) {
                 throw new RuntimeException(e);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -151,7 +151,7 @@ class PeerForwarder_ClientServerIT {
         assertThat(pluginBufferMap, notNullValue());
         final PeerForwarderReceiveBuffer<Record<Event>> receiveBuffer = pluginBufferMap.get(pluginId);
 
-        final Map.Entry<Collection<Record<Event>>, CheckpointState> bufferEntry = receiveBuffer.read(1000);
+        final Map.Entry<Collection<Record<Event>>, CheckpointState> bufferEntry = receiveBuffer.read(400);
         return bufferEntry.getKey();
     }
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarderTest.java
@@ -66,12 +66,12 @@ import org.apache.commons.lang3.RandomStringUtils;
 class RemotePeerForwarderTest {
     private static final int TEST_BUFFER_CAPACITY = 20;
     private static final int TEST_BATCH_SIZE = 20;
-    private static final int TEST_BATCH_DELAY = 3_000;
-    private static final int TEST_LOCAL_WRITE_TIMEOUT = 500;
-    private static final int TEST_TIMEOUT_IN_MILLIS = 500;
+    private static final int TEST_BATCH_DELAY = 800;
+    private static final int TEST_LOCAL_WRITE_TIMEOUT = 400;
+    private static final int TEST_TIMEOUT_IN_MILLIS = 400;
     private static final int FORWARDING_BATCH_SIZE = 5;
     private static final int FORWARDING_BATCH_QUEUE_DEPTH = 1;
-    private static final Duration FORWARDING_BATCH_TIMEOUT = Duration.of(3, ChronoUnit.SECONDS);
+    private static final Duration FORWARDING_BATCH_TIMEOUT = Duration.of(800, ChronoUnit.MILLIS);
     private static final int PIPELINE_WORKER_THREADS = 3;
     private static final String PIPELINE_NAME = UUID.randomUUID().toString();
     private static final String PLUGIN_ID = UUID.randomUUID().toString();


### PR DESCRIPTION
### Description

This PR reduces some of the timeouts and waits which are part of the peer-forwarder tests to reduce testing time. The changes to `PeerForwarderReceiveBufferTest` in particular were quite significant in my testing, knocking a minute from the build time.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
