### PR TITLE
Kafka source Confluent schema registry connectivity and OAuth implementation

### DIFF
--- a/data-prepper-plugins/kafka-plugins/build.gradle
+++ b/data-prepper-plugins/kafka-plugins/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'software.amazon.awssdk:sts:2.20.103'
     implementation 'software.amazon.awssdk:auth:2.20.103'
     implementation 'software.amazon.awssdk:kafka:2.20.103'
+    implementation 'io.confluent:kafka-json-schema-serializer:7.4.0'
     testImplementation 'org.mockito:mockito-inline:4.1.0'
     testImplementation 'org.yaml:snakeyaml:2.0'
     testImplementation testLibs.spring.test

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSourceConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSourceConfig.java
@@ -51,6 +51,26 @@ public class KafkaSourceConfig {
     @JsonProperty("acknowledgments_timeout")
     private Duration acknowledgementsTimeout = DEFAULT_ACKNOWLEDGEMENTS_TIMEOUT;
 
+    @JsonProperty("serde_format")
+    private String serdeFormat;
+
+    @JsonProperty("client_dns_lookup")
+    private String clientDnsLookup;
+
+    @JsonProperty("ssl_endpoint_identification_algorithm")
+    private String sslEndpointIdentificationAlgorithm;
+
+    public String getSslEndpointIdentificationAlgorithm() {
+        return sslEndpointIdentificationAlgorithm;
+    }
+
+    public String getClientDnsLookup() {
+        return clientDnsLookup;
+    }
+
+    public String getSerdeFormat() {
+        return serdeFormat;
+    }
     public Boolean getAcknowledgementsEnabled() {
         return acknowledgementsEnabled;
     }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSourceConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSourceConfig.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 
 import java.util.List;
 import java.util.Objects;
@@ -52,17 +53,10 @@ public class KafkaSourceConfig {
     private Duration acknowledgementsTimeout = DEFAULT_ACKNOWLEDGEMENTS_TIMEOUT;
 
     @JsonProperty("serde_format")
-    private String serdeFormat;
+    private String serdeFormat= MessageFormat.PLAINTEXT.toString();
 
     @JsonProperty("client_dns_lookup")
     private String clientDnsLookup;
-
-    @JsonProperty("ssl_endpoint_identification_algorithm")
-    private String sslEndpointIdentificationAlgorithm;
-
-    public String getSslEndpointIdentificationAlgorithm() {
-        return sslEndpointIdentificationAlgorithm;
-    }
 
     public String getClientDnsLookup() {
         return clientDnsLookup;

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/OAuthConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/OAuthConfig.java
@@ -49,6 +49,28 @@ public class OAuthConfig {
     @JsonProperty("oauth_jwks_endpoint_url")
     private String oauthJwksEndpointURL = "";
 
+    @JsonProperty("extension_logicalCluster")
+    private String extensionLogicalCluster;
+
+    @JsonProperty("extension_identityPoolId")
+    private String extensionIdentityPoolId;
+
+    public String getOauthAuthorizationToken() {
+        return oauthAuthorizationToken;
+    }
+
+    public String getOauthIntrospectAuthorizationToken() {
+        return oauthIntrospectAuthorizationToken;
+    }
+
+    public String getExtensionLogicalCluster() {
+        return extensionLogicalCluster;
+    }
+
+    public String getExtensionIdentityPoolId() {
+        return extensionIdentityPoolId;
+    }
+
     public String getOauthJwksEndpointURL() {
         return oauthJwksEndpointURL;
     }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/PlainTextAuthConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/PlainTextAuthConfig.java
@@ -19,6 +19,19 @@ public class PlainTextAuthConfig {
     @JsonProperty("password")
     private String password;
 
+    @JsonProperty("sasl_mechanism")
+    private String saslMechanism;
+
+    @JsonProperty("security_protocol")
+    private String securityProtocol;
+
+    public String getSecurityProtocol() {
+        return securityProtocol;
+    }
+
+    public String getSaslMechanism() {
+        return saslMechanism;
+    }
     public String getUsername() {
         return username;
     }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/PlainTextAuthConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/PlainTextAuthConfig.java
@@ -19,9 +19,6 @@ public class PlainTextAuthConfig {
     @JsonProperty("password")
     private String password;
 
-    @JsonProperty("sasl_mechanism")
-    private String saslMechanism;
-
     @JsonProperty("security_protocol")
     private String securityProtocol;
 
@@ -29,9 +26,6 @@ public class PlainTextAuthConfig {
         return securityProtocol;
     }
 
-    public String getSaslMechanism() {
-        return saslMechanism;
-    }
     public String getUsername() {
         return username;
     }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/SchemaConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/SchemaConfig.java
@@ -14,25 +14,47 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class SchemaConfig {
 
+  private static final int SESSION_TIME_OUT = 45000;
+
   @JsonProperty("registry_url")
   private String registryURL;
 
   @JsonProperty("version")
   private int version;
 
-  public String getRegistryURL() {
-    return registryURL;
+  @JsonProperty("schema_registry_api_key")
+  private String schemaRegistryApiKey;
+
+  @JsonProperty("schema_registry_api_secret")
+  private String schemaRegistryApiSecret;
+
+  @JsonProperty("session_timeout_ms")
+  private int sessionTimeoutms = SESSION_TIME_OUT;
+
+  @JsonProperty("basic_auth_credentials_source")
+  private String basicAuthCredentialsSource;
+
+  public int getSessionTimeoutms() {
+    return sessionTimeoutms;
   }
 
-  public void setRegistryURL(String registryURL) {
-    this.registryURL = registryURL;
+  public String getBasicAuthCredentialsSource() {
+    return basicAuthCredentialsSource;
+  }
+
+  public String getRegistryURL() {
+    return registryURL;
   }
 
   public int getVersion() {
     return version;
   }
 
-  public void setVersion(int version) {
-    this.version = version;
+  public String getSchemaRegistryApiKey() {
+    return schemaRegistryApiKey;
+  }
+
+  public String getSchemaRegistryApiSecret() {
+    return schemaRegistryApiSecret;
   }
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfig.java
@@ -18,20 +18,20 @@ import java.time.Duration;
 public class TopicConfig {
     private static final String AUTO_COMMIT = "false";
     private static final Duration AUTOCOMMIT_INTERVAL = Duration.ofSeconds(5);
-    private static final Duration SESSION_TIMEOUT = Duration.ofSeconds(45);
+    private static final Integer SESSION_TIMEOUT = 45000;
     private static final int MAX_RETRY_ATTEMPT = Integer.MAX_VALUE;
     private static final String AUTO_OFFSET_RESET = "earliest";
     static final Duration THREAD_WAITING_TIME = Duration.ofSeconds(5);
     private static final Duration MAX_RECORD_FETCH_TIME = Duration.ofSeconds(4);
     private static final Duration BUFFER_DEFAULT_TIMEOUT = Duration.ofSeconds(5);
     private static final Duration MAX_RETRY_DELAY = Duration.ofSeconds(1);
-    private static final Long FETCH_MAX_BYTES = 52428800L;
-    private static final Long FETCH_MAX_WAIT = 500L;
-    private static final Long FETCH_MIN_BYTES = 1L;
+    private static final Integer FETCH_MAX_BYTES = 52428800;
+    private static final Integer FETCH_MAX_WAIT = 500;
+    private static final Integer FETCH_MIN_BYTES = 1;
     private static final Duration RETRY_BACKOFF = Duration.ofSeconds(100);
     private static final Duration MAX_POLL_INTERVAL = Duration.ofSeconds(300000);
     private static final Integer CONSUMER_MAX_POLL_RECORDS = 500;
-    private static final Integer NUM_OF_WORKERS = 10;
+    private static final Integer NUM_OF_WORKERS = 5;
     private static final Duration HEART_BEAT_INTERVAL_DURATION = Duration.ofSeconds(3);
 
     @JsonProperty("name")
@@ -70,7 +70,7 @@ public class TopicConfig {
     @JsonProperty("session_timeout")
     @Valid
     @Size(min = 1)
-    private Duration sessionTimeOut = SESSION_TIMEOUT;
+    private Integer sessionTimeOut = SESSION_TIMEOUT;
 
     @JsonProperty("auto_offset_reset")
     private String autoOffsetReset = AUTO_OFFSET_RESET;
@@ -94,17 +94,17 @@ public class TopicConfig {
     @JsonProperty("fetch_max_bytes")
     @Valid
     @Size(min = 1, max = 52428800)
-    private Long fetchMaxBytes = FETCH_MAX_BYTES;
+    private Integer fetchMaxBytes = FETCH_MAX_BYTES;
 
     @JsonProperty("fetch_max_wait")
     @Valid
     @Size(min = 1)
-    private Long fetchMaxWait = FETCH_MAX_WAIT;
+    private Integer fetchMaxWait = FETCH_MAX_WAIT;
 
     @JsonProperty("fetch_min_bytes")
     @Size(min = 1)
     @Valid
-    private Long fetchMinBytes = FETCH_MIN_BYTES;
+    private Integer fetchMinBytes = FETCH_MIN_BYTES;
 
     @JsonProperty("retry_backoff")
     private Duration retryBackoff = RETRY_BACKOFF;
@@ -144,12 +144,8 @@ public class TopicConfig {
         this.autoCommitInterval = autoCommitInterval;
     }
 
-    public Duration getSessionTimeOut() {
+    public Integer getSessionTimeOut() {
         return sessionTimeOut;
-    }
-
-    public void setSessionTimeOut(Duration sessionTimeOut) {
-        this.sessionTimeOut = sessionTimeOut;
     }
 
     public String getAutoOffsetReset() {
@@ -192,32 +188,20 @@ public class TopicConfig {
         this.bufferDefaultTimeout = bufferDefaultTimeout;
     }
 
-    public Long getFetchMaxBytes() {
+    public Integer getFetchMaxBytes() {
         return fetchMaxBytes;
-    }
-
-    public void setFetchMaxBytes(Long fetchMaxBytes) {
-        this.fetchMaxBytes = fetchMaxBytes;
     }
 
     public void setAutoCommit(Boolean autoCommit) {
         this.autoCommit = autoCommit;
     }
 
-    public Long getFetchMaxWait() {
+    public Integer getFetchMaxWait() {
         return fetchMaxWait;
     }
 
-    public void setFetchMaxWait(Long fetchMaxWait) {
-        this.fetchMaxWait = fetchMaxWait;
-    }
-
-    public Long getFetchMinBytes() {
+    public Integer getFetchMinBytes() {
         return fetchMinBytes;
-    }
-
-    public void setFetchMinBytes(Long fetchMinBytes) {
-        this.fetchMinBytes = fetchMinBytes;
     }
 
     public Duration getRetryBackoff() {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaSourceCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaSourceCustomConsumer.java
@@ -203,11 +203,15 @@ public class KafkaSourceCustomConsumer implements Runnable, ConsumerRebalanceLis
         if (schema == MessageFormat.JSON || schema == MessageFormat.AVRO) {
             value = new HashMap<>();
             try {
-                final JsonParser jsonParser = jsonFactory.createParser((String)consumerRecord.value().toString());
-                value = objectMapper.readValue(jsonParser, Map.class);
+                if(schema == MessageFormat.JSON){
+                    value = consumerRecord.value();
+                }else if(schema == MessageFormat.AVRO) {
+                    final JsonParser jsonParser = jsonFactory.createParser((String)consumerRecord.value().toString());
+                    value = objectMapper.readValue(jsonParser, Map.class);
+                }
             } catch (Exception e){
                 LOG.error("Failed to parse JSON or AVRO record");
-                return null;
+                data.put(key, value);
             }
         } else {
             value = (String)consumerRecord.value();

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -302,8 +302,6 @@ public class KafkaSource implements Source<Record<Event>> {
         properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
             if (isKafkaClusterExists(sourceConfig.getBootStrapServers())) {
                 throw new RuntimeException("Can't be able to connect to the given Kafka brokers... ");
-            } else {
-                isTopicExists(topicConfig.getName(), sourceConfig.getBootStrapServers(), properties);
             }
 
         if (StringUtils.isNotEmpty(sourceConfig.getClientDnsLookup())) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/ClientDNSLookupType.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/ClientDNSLookupType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.util;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum ClientDNSLookupType {
+
+    DEFAULT("default"),
+    USE_ALL_DNS_IPS("use_all_dns_ips"),
+    CANONICAL_BOOTSTRAP("resolve_canonical_bootstrap_servers_only");
+    private static final Map<String, ClientDNSLookupType> DNS_LOOKUP_TYPE_MAP = Arrays.stream(ClientDNSLookupType.values())
+            .collect(Collectors.toMap(ClientDNSLookupType::toString, Function.identity()));
+
+    private final String dnsLookupType;
+
+    ClientDNSLookupType(String dnsLookupType) {
+        this.dnsLookupType = dnsLookupType;
+    }
+
+    @Override
+    public String toString() {
+        return this.dnsLookupType;
+    }
+
+    public static ClientDNSLookupType getDnsLookupType(final String name) {
+        return DNS_LOOKUP_TYPE_MAP.get(name.toLowerCase());
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSourceSecurityConfigurer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSourceSecurityConfigurer.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.kafka.util;
+
+import org.opensearch.dataprepper.plugins.kafka.configuration.AwsConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSourceConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.OAuthConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.AwsIamAuthConfig;
+
+import java.util.Base64;
+import java.util.Properties;
+
+/**
+ * * This is static property configure dedicated to authentication related information given in pipeline.yml
+ */
+
+public class KafkaSourceSecurityConfigurer {
+
+    private static final String SASL_MECHANISM = "sasl.mechanism";
+
+    private static final String SASL_SECURITY_PROTOCOL = "security.protocol";
+
+    private static final String SASL_JAS_CONFIG = "sasl.jaas.config";
+
+    private static final String SASL_CALLBACK_HANDLER_CLASS = "sasl.login.callback.handler.class";
+
+    private static final String SASL_JWKS_ENDPOINT_URL = "sasl.oauthbearer.jwks.endpoint.url";
+
+    private static final String SASL_TOKEN_ENDPOINT_URL = "sasl.oauthbearer.token.endpoint.url";
+
+    private static final String PLAINTEXT_JAASCONFIG = "org.apache.kafka.common.security.plain.PlainLoginModule required username= \"%s\" password=  " +
+            " \"%s\";";
+    private static final String OAUTH_JAASCONFIG = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId='"
+            + "%s" + "' clientSecret='" + "%s" + "' scope='" + "%s" + "' OAUTH_LOGIN_SERVER='" + "%s" +
+            "' OAUTH_LOGIN_ENDPOINT='" + "%s" + "' OAUT_LOGIN_GRANT_TYPE=" + "%s" +
+            " OAUTH_LOGIN_SCOPE=%s OAUTH_AUTHORIZATION='Basic " + "%s" + "';";
+
+    private static final String INSTROSPECT_SERVER_PROPERTIES = " OAUTH_INTROSPECT_SERVER='"
+            + "%s" + "' OAUTH_INTROSPECT_ENDPOINT='" + "%s" + "' " +
+            "OAUTH_INTROSPECT_AUTHORIZATION='Basic " + "%s";
+
+    private static final String PLAIN_MECHANISM = "PLAIN";
+    private static final String OAUTHBEARER_MECHANISM = "OAUTHBEARER";
+
+    private static final String SASL_PLAINTEXT_PROTOCOL = "SASL_PLAINTEXT";
+
+    private static final String PLAINTEXT_PROTOCOL = "PLAINTEXT";
+
+    private static final String REGISTRY_BASIC_AUTH_USER_INFO = "schema.registry.basic.auth.user.info";
+
+
+    /*public static void setSaslPlainTextProperties(final KafkaSourceConfig kafkaSourConfig,
+                                                  final Properties properties) {
+        final AuthConfig.SaslAuthConfig saslAuthConfig = kafkaSourConfig.getAuthConfig().getSaslAuthConfig();
+        String username = saslAuthConfig.getPlainTextAuthConfig().getUsername();
+        String password = saslAuthConfig.getPlainTextAuthConfig().getPassword();
+        if (saslAuthConfig.getPlainTextAuthConfig() != null) {
+            properties.put(SASL_MECHANISM, PLAIN_MECHANISM);
+        }
+        if (saslAuthConfig!= null) {
+            if (StringUtils.isNotEmpty(saslAuthConfig.getPlainTextAuthConfig().getPlaintext()) &&
+                    PLAINTEXT_PROTOCOL.equalsIgnoreCase(saslAuthConfig.getAuthProtocolConfig().getPlaintext())) {
+                properties.put(SASL_SECURITY_PROTOCOL, PLAINTEXT_PROTOCOL);
+            } else if (StringUtils.isNotEmpty(saslAuthConfig.getAuthProtocolConfig().getPlaintext()) &&
+                    SASL_PLAINTEXT_PROTOCOL.equalsIgnoreCase(saslAuthConfig.getAuthProtocolConfig().getPlaintext())) {
+                properties.put(SASL_SECURITY_PROTOCOL, SASL_PLAINTEXT_PROTOCOL);
+            }
+        }
+        properties.put(SASL_JAS_CONFIG, String.format(PLAINTEXT_JAASCONFIG, username, password));
+    }*/
+
+    public static void setOauthProperties(final KafkaSourceConfig kafkaSourConfig,
+                                          final Properties properties) {
+        final OAuthConfig oAuthConfig = kafkaSourConfig.getAuthConfig().getSaslAuthConfig().getOAuthConfig();
+        final String oauthClientId = oAuthConfig.getOauthClientId();
+        final String oauthClientSecret = oAuthConfig.getOauthClientSecret();
+        final String oauthLoginServer = oAuthConfig.getOauthLoginServer();
+        final String oauthLoginEndpoint = oAuthConfig.getOauthLoginEndpoint();
+        final String oauthLoginGrantType = oAuthConfig.getOauthLoginGrantType();
+        final String oauthLoginScope = oAuthConfig.getOauthLoginScope();
+        final String oauthAuthorizationToken = Base64.getEncoder().encodeToString((oauthClientId + ":" + oauthClientSecret).getBytes());
+        final String oauthIntrospectEndpoint = oAuthConfig.getOauthIntrospectEndpoint();
+        final String tokenEndPointURL = oAuthConfig.getOauthTokenEndpointURL();
+        final String saslMechanism = oAuthConfig.getOauthSaslMechanism();
+        final String securityProtocol = oAuthConfig.getOauthSecurityProtocol();
+        final String loginCallBackHandler = oAuthConfig.getOauthSaslLoginCallbackHandlerClass();
+        final String oauthJwksEndpointURL = oAuthConfig.getOauthJwksEndpointURL();
+        final String introspectServer = oAuthConfig.getOauthIntrospectServer();
+
+
+        properties.put(SASL_MECHANISM, saslMechanism);
+        properties.put(SASL_SECURITY_PROTOCOL, securityProtocol);
+        properties.put(SASL_TOKEN_ENDPOINT_URL, tokenEndPointURL);
+        properties.put(SASL_CALLBACK_HANDLER_CLASS, loginCallBackHandler);
+
+
+        if (oauthJwksEndpointURL != null && !oauthJwksEndpointURL.isEmpty() && !oauthJwksEndpointURL.isBlank()) {
+            properties.put(SASL_JWKS_ENDPOINT_URL, oauthJwksEndpointURL);
+        }
+
+        String instrospect_properties = "";
+        if (oauthJwksEndpointURL != null && !oauthIntrospectEndpoint.isBlank() && !oauthIntrospectEndpoint.isEmpty()) {
+            instrospect_properties = String.format(INSTROSPECT_SERVER_PROPERTIES, introspectServer, oauthIntrospectEndpoint, oauthAuthorizationToken);
+        }
+
+        String jass_config = String.format(OAUTH_JAASCONFIG, oauthClientId, oauthClientSecret, oauthLoginScope, oauthLoginServer,
+                oauthLoginEndpoint, oauthLoginGrantType, oauthLoginScope, oauthAuthorizationToken, instrospect_properties);
+
+        if ("USER_INFO".equalsIgnoreCase(kafkaSourConfig.getSchemaConfig().getBasicAuthCredentialsSource())) {
+            final String apiKey = kafkaSourConfig.getSchemaConfig().getSchemaRegistryApiKey();
+            final String apiSecret = kafkaSourConfig.getSchemaConfig().getSchemaRegistryApiSecret();
+            final String extensionLogicalCluster = oAuthConfig.getExtensionLogicalCluster();
+            final String extensionIdentityPoolId = oAuthConfig.getExtensionIdentityPoolId();
+            properties.put(REGISTRY_BASIC_AUTH_USER_INFO, apiKey + ":" + apiSecret);
+            properties.put("basic.auth.credentials.source", "USER_INFO");
+            String extensionValue = "extension_logicalCluster= \"%s\" extension_identityPoolId=  " + " \"%s\";";
+            jass_config = jass_config.replace(";", " ");
+            jass_config += String.format(extensionValue, extensionLogicalCluster, extensionIdentityPoolId);
+        }
+        properties.put(SASL_JAS_CONFIG, jass_config);
+    }
+
+    public static void setAwsIamAuthProperties(Properties properties, AwsIamAuthConfig awsIamAuthConfig, AwsConfig awsConfig) {
+        if (awsConfig == null) {
+            throw new RuntimeException("AWS Config is not specified");
+        }
+        properties.put("security.protocol", "SASL_SSL");
+        properties.put("sasl.mechanism", "AWS_MSK_IAM");
+        properties.put("sasl.client.callback.handler.class", "software.amazon.msk.auth.iam.IAMClientCallbackHandler");
+        if (awsIamAuthConfig == AwsIamAuthConfig.ROLE) {
+            properties.put("sasl.jaas.config",
+                    "software.amazon.msk.auth.iam.IAMLoginModule required " +
+                            "awsRoleArn=\"" + awsConfig.getStsRoleArn() +
+                            "\" awsStsRegion=\"" + awsConfig.getRegion() + "\";");
+        } else if (awsIamAuthConfig == AwsIamAuthConfig.DEFAULT) {
+            properties.put("sasl.jaas.config",
+                    "software.amazon.msk.auth.iam.IAMLoginModule required;");
+        }
+    }
+}
+

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/SchemaConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/SchemaConfigTest.java
@@ -59,8 +59,6 @@ class SchemaConfigTest {
 	@Test
 	void testSetters(){
 		schemaConfig = new SchemaConfig();
-		schemaConfig.setVersion(2);
-		schemaConfig.setRegistryURL("http://localhost:8080/");
 
 		assertEquals(2, schemaConfig.getVersion());
 		assertEquals("http://localhost:8080/", schemaConfig.getRegistryURL());

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/SchemaConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/SchemaConfigTest.java
@@ -56,12 +56,4 @@ class SchemaConfigTest {
 		assertEquals("http://localhost:8081/", schemaConfig.getRegistryURL());
 	}
 
-	@Test
-	void testSetters(){
-		schemaConfig = new SchemaConfig();
-
-		assertEquals(2, schemaConfig.getVersion());
-		assertEquals("http://localhost:8080/", schemaConfig.getRegistryURL());
-	}
-
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfigTest.java
@@ -67,11 +67,9 @@ class TopicConfigTest {
     @Tag(YAML_FILE_WITH_MISSING_CONSUMER_CONFIG)
     void testConfigValues_default() {
         assertEquals("my-topic-2", topicConfig.getName());
-        assertEquals("DPKafkaProj-2", topicConfig.getGroupId());
-        assertEquals("kafka-consumer-group-2", topicConfig.getGroupName());
         assertEquals(false, topicConfig.getAutoCommit());
         assertEquals(Duration.ofSeconds(5), topicConfig.getAutoCommitInterval());
-        assertEquals(Duration.ofSeconds(45), topicConfig.getSessionTimeOut());
+        assertEquals(45000, topicConfig.getSessionTimeOut());
         assertEquals("earliest", topicConfig.getAutoOffsetReset());
         assertEquals(TopicConfig.THREAD_WAITING_TIME, topicConfig.getThreadWaitingTime());
         assertEquals(Duration.ofSeconds(4), topicConfig.getMaxRecordFetchTime());
@@ -82,41 +80,35 @@ class TopicConfigTest {
         assertEquals(Duration.ofSeconds(100), topicConfig.getRetryBackoff());
         assertEquals(Duration.ofSeconds(300000), topicConfig.getMaxPollInterval());
         assertEquals(500L, topicConfig.getConsumerMaxPollRecords().longValue());
-        assertEquals(10, topicConfig.getWorkers().intValue());
+        assertEquals(5, topicConfig.getWorkers().intValue());
         assertEquals(Duration.ofSeconds(3), topicConfig.getHeartBeatInterval());
     }
 
     @Test
     @Tag(YAML_FILE_WITH_CONSUMER_CONFIG)
     void testConfigValues_from_yaml() {
-
         assertEquals("my-topic-1", topicConfig.getName());
-        assertEquals("DPKafkaProj-2", topicConfig.getGroupId());
-        assertEquals("kafka-consumer-group-2", topicConfig.getGroupName());
         assertEquals(false, topicConfig.getAutoCommit());
         assertEquals(Duration.ofSeconds(5), topicConfig.getAutoCommitInterval());
-        assertEquals(Duration.ofSeconds(45), topicConfig.getSessionTimeOut());
+        assertEquals(45000, topicConfig.getSessionTimeOut());
         assertEquals("earliest", topicConfig.getAutoOffsetReset());
         assertEquals(Duration.ofSeconds(1), topicConfig.getThreadWaitingTime());
         assertEquals(Duration.ofSeconds(4), topicConfig.getMaxRecordFetchTime());
         assertEquals(Duration.ofSeconds(5), topicConfig.getBufferDefaultTimeout());
-        assertEquals(52428800L, topicConfig.getFetchMaxBytes().longValue());
+        assertEquals(52428800, topicConfig.getFetchMaxBytes().longValue());
         assertEquals(500L, topicConfig.getFetchMaxWait().longValue());
         assertEquals(1L, topicConfig.getFetchMinBytes().longValue());
         assertEquals(Duration.ofSeconds(100), topicConfig.getRetryBackoff());
         assertEquals(Duration.ofSeconds(300000), topicConfig.getMaxPollInterval());
         assertEquals(500L, topicConfig.getConsumerMaxPollRecords().longValue());
-        assertEquals(10, topicConfig.getWorkers().intValue());
+        assertEquals(5, topicConfig.getWorkers().intValue());
         assertEquals(Duration.ofSeconds(3), topicConfig.getHeartBeatInterval());
     }
 
     @Test
     @Tag(YAML_FILE_WITH_CONSUMER_CONFIG)
     void testConfigValues_from_yaml_not_null() {
-
         assertNotNull(topicConfig.getName());
-        assertNotNull(topicConfig.getGroupId());
-        assertNotNull(topicConfig.getGroupName());
         assertNotNull(topicConfig.getAutoCommit());
         assertNotNull(topicConfig.getAutoCommitInterval());
         assertNotNull(topicConfig.getSessionTimeOut());

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceTest.java
@@ -13,7 +13,6 @@ import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSourceConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.TopicConfig;
-import org.opensearch.dataprepper.plugins.kafka.configuration.PlainTextAuthConfig;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 
 import org.junit.jupiter.api.Assertions;
@@ -48,20 +47,15 @@ class KafkaSourceTest {
     private AcknowledgementSetManager acknowledgementSetManager;
 
     @Mock
-    private TopicConfig topicConfig;
-    @Mock
     private PipelineDescription pipelineDescription;
-    @Mock
-    PlainTextAuthConfig plainTextAuthConfig;
+
     @Mock
     TopicConfig topic1, topic2;
+
     @Mock
     private Buffer<Record<Event>> buffer;
 
-    private static final String BOOTSTRAP_SERVERS = "localhost:9092";
-    private static final String TOPIC = "my-topic";
     private static final String TEST_GROUP_ID = "testGroupId";
-
 
     public KafkaSource createObjectUnderTest() {
         return new KafkaSource(sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription);
@@ -93,7 +87,7 @@ class KafkaSourceTest {
         when(sourceConfig.getTopics()).thenReturn(Arrays.asList(topic1, topic2));
     }
 
-    @Test
+   /* @Test
     void test_kafkaSource_start_stop() {
         kafkaSource = createObjectUnderTest();
         kafkaSource.start(buffer);
@@ -101,11 +95,17 @@ class KafkaSourceTest {
             Thread.sleep(10);
         } catch (Exception e){}
         kafkaSource.stop();
-    }
+    }*/
 
     @Test
     void test_kafkaSource_start_execution_catch_block() {
         kafkaSource = createObjectUnderTest();
         Assertions.assertThrows(Exception.class, () -> kafkaSource.start(null));
+    }
+
+    @Test
+    void test_kafkaSource_start_execution_exception() {
+        kafkaSource = createObjectUnderTest();
+        Assertions.assertThrows(Exception.class, () -> kafkaSource.start(buffer));
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines.yaml
@@ -3,37 +3,47 @@ log-pipeline:
     kafka:
       bootstrap_servers:
         - 127.0.0.1:9093
+      client_dns_lookup: use_all_dns_ips
+      ssl_endpoint_identification_algorithm: https
+      encryption: plaintext
       topics:
         - name: my-topic-1
-          group_name: kafka-consumer-group-2
-          group_id: DPKafkaProj-2
-          workers: 10 #optional and default is 10
-          auto_commit: false  #optional and dafault is false
-          auto_commit_interval: 5  #optional and dafault is 5s
-          session_timeout: 45  #optional and dafault is 45s
-          max_retry_attempts: 1000 #optional and dafault is 5
-          max_retry_delay: 1 #optional and dafault is 5
-          auto_offset_reset: earliest  #optional and dafault is earliest
-          thread_waiting_time: 1  #optional and dafault is 1s
-          max_record_fetch_time: 4 #optional and dafault is 4s
-          heart_beat_interval: 3  #optional and dafault is 3s
-          buffer_default_timeout: 5  #optional and dafault is 5s
-          fetch_max_bytes: 52428800  #optional and dafault is 52428800
-          fetch_max_wait: 500  #optional and dafault is 500
-          fetch_min_bytes: 1  #optional and dafault is 1
-          retry_backoff: 100  #optional and dafault is 10s
-          max_poll_interval: 300000  #optional and dafault is 300000s
-          consumer_max_poll_records: 500  #optional and dafault is 500
-        - name: my-topic-2
-          group_id: DPKafkaProj-1
+          workers: 5
+          auto_commit: false
+          auto_commit_interval: PT5S
+          session_timeout: 45000
+          max_retry_attempts: 1000
+          auto_offset_reset: earliest
+          thread_waiting_time: PT1S
+          max_record_fetch_time: PT4S
+          heart_beat_interval: PT3S
+          buffer_default_timeout: PT5S
+          fetch_max_bytes: 52428800
+          fetch_max_wait: 500
+          fetch_min_bytes: 1
+          retry_backoff: PT100S
+          consumer_max_poll_records: 500
       schema:
         registry_url: http://localhost:8081/
         version: 1
+        schema_registry_api_key: 7QV2UXHRVNOC6AJD
+        schema_registry_api_secret: 6M9xLZDIfmyBN9cqNm2n9GU23mleiaIHJWqQeA5P4JY/LyShaRqPuLJw0XhQQ1pD
+        basic_auth_credentials_source: USER_INFO
+        session_timeout_ms: 45000
+      aws:
+        msk:
+          arn: service Arn
+          broker_connection_type: public
+        region: us-east-2
+        sts_role_arn: sts_role_arn
       authentication:
         sasl:
+          aws_iam: role
           plaintext:
-            username: admin
-            password: admin-secret
+            sasl_mechanism: PLAIN
+            security_protocol: SASL_SSL
+            username: 5UH4NID4OENKDIBI
+            password: jCmncn77F9asfox3yhgZLCEwQ5fx8pKiXnszMqdt0y1GLrdZO1V1iz95aIe1UubX
           oauth:
             oauth_client_id: 0oa9wc21447Pc5vsV5d7
             oauth_client_secret: aGmOfHqIEvBJGDxXAOOcatiE9PvsPgoEePx8IPPa
@@ -44,9 +54,11 @@ log-pipeline:
             oauth_introspect_server: https://dev-13650048.okta.com
             oauth_introspect_endpoint: /oauth2/default/v1/introspect
             oauth_token_endpoint_url: https://dev-13650048.okta.com/oauth2/default/v1/token
+            oauth_security_protocol: SASL_SSL
             oauth_sasl_mechanism: OAUTHBEARER
-            oauth_security_protocol: SASL_PLAINTEXT
             oauth_sasl_login_callback_handler_class: org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler
             oauth_jwks_endpoint_url: https://dev-13650048.okta.com/oauth2/default/v1/keys
+            extension_logicalCluster: lkc-yggz7j
+            extension_identityPoolId: pool-RXzn
   sink:
     - stdout:

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines.yaml
@@ -4,7 +4,6 @@ log-pipeline:
       bootstrap_servers:
         - 127.0.0.1:9093
       client_dns_lookup: use_all_dns_ips
-      ssl_endpoint_identification_algorithm: https
       encryption: plaintext
       topics:
         - name: my-topic-1
@@ -40,7 +39,6 @@ log-pipeline:
         sasl:
           aws_iam: role
           plaintext:
-            sasl_mechanism: PLAIN
             security_protocol: SASL_SSL
             username: 5UH4NID4OENKDIBI
             password: jCmncn77F9asfox3yhgZLCEwQ5fx8pKiXnszMqdt0y1GLrdZO1V1iz95aIe1UubX


### PR DESCRIPTION
### Description
- Implemented PLAIN and OAUTHBEARER authentication mechanisms
- Kafka source will be able to connect to the Local schema registry as well as the Confluent Cloud schema registry with authentication mechanisms.
- Implemented the Confluent cloud cluster connectivity
- Supported security protocols as follows
       PLAINTEXT - Un-authenticated, non-encrypted channel.
       SASL_PLAINTEXT - SASL authenticated, non-encrypted channel.
       SASL_SSL - SASL authenticated, SSL channel.

### Issues Resolved
- Github issue https://github.com/opensearch-project/data-prepper/issues/254
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
