### PR TITLE
Consolidate logic related to extracting data from a BulkOperation

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
@@ -7,9 +7,34 @@ package org.opensearch.dataprepper.plugins.sink.opensearch;
 
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.dataprepper.model.event.EventHandle;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class BulkOperationWrapper {
+    private static final Predicate<BulkOperation> IS_INDEX_OPERATION = BulkOperation::isIndex;
+    private static final Predicate<BulkOperation> IS_CREATE_OPERATION = BulkOperation::isCreate;
+
+    private static final Map<Predicate<BulkOperation>, Function<BulkOperation, Object>> BULK_OPERATION_TO_DOCUMENT_CONVERTERS = Map.of(
+            IS_INDEX_OPERATION, operation -> operation.index().document(),
+            IS_CREATE_OPERATION, operation -> operation.create().document()
+    );
+
+    private static final Map<Predicate<BulkOperation>, Function<BulkOperation, String>> BULK_OPERATION_TO_INDEX_NAME_CONVERTERS = Map.of(
+            IS_INDEX_OPERATION, operation -> operation.index().index(),
+            IS_CREATE_OPERATION, operation -> operation.create().index()
+    );
+
+    private static final Map<Predicate<BulkOperation>, Function<BulkOperation, String>> BULK_OPERATION_TO_ID_CONVERTERS = Map.of(
+            IS_INDEX_OPERATION, operation -> operation.index().id(),
+            IS_CREATE_OPERATION, operation -> operation.create().id()
+    );
+
     private final EventHandle eventHandle;
     private final BulkOperation bulkOperation;
 
@@ -36,5 +61,30 @@ public class BulkOperationWrapper {
         if (eventHandle != null) {
             eventHandle.release(result);
         }
+    }
+
+    public Object getDocument() {
+        return getValueFromConverter(BULK_OPERATION_TO_DOCUMENT_CONVERTERS);
+    }
+
+    public String getIndex() {
+        return getValueFromConverter(BULK_OPERATION_TO_INDEX_NAME_CONVERTERS);
+    }
+
+    public String getId() {
+        return getValueFromConverter(BULK_OPERATION_TO_ID_CONVERTERS);
+    }
+
+    private <T> T getValueFromConverter(final Map<Predicate<BulkOperation>, Function<BulkOperation, T>> converters) {
+        final List<T> values = converters.entrySet().stream()
+                .filter(entry -> entry.getKey().test(bulkOperation))
+                .map(entry -> entry.getValue().apply(bulkOperation))
+                .collect(Collectors.toList());
+
+        if (values.size() != 1) {
+            throw new UnsupportedOperationException("Only index or create operations are supported currently." + bulkOperation);
+        }
+
+        return values.get(0);
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/BulkOperationWriter.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/BulkOperationWriter.java
@@ -34,9 +34,9 @@ package org.opensearch.dataprepper.plugins.sink.opensearch.bulk;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.dataprepper.model.failures.DlqObject;
+import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
 import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedDlqData;
 
 /**
@@ -47,10 +47,10 @@ public class BulkOperationWriter {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    public static String bulkOperationToString(BulkOperation bulkOperation) {
-        String index = bulkOperation.index().index();
+    public static String bulkOperationToString(BulkOperationWrapper bulkOperation) {
+        String index = bulkOperation.getIndex();
         String source = extractDocumentSource(bulkOperation);
-        String id = bulkOperation.index().id();
+        String id = bulkOperation.getId();
 
         String sSource = "_na_";
         try {
@@ -86,8 +86,8 @@ public class BulkOperationWriter {
         }
     }
 
-    private static String extractDocumentSource(BulkOperation bulkOperation) {
-        final SerializedJson document = (SerializedJson) bulkOperation.index().document();
+    private static String extractDocumentSource(BulkOperationWrapper bulkOperation) {
+        final SerializedJson document = (SerializedJson) bulkOperation.getDocument();
 
         return new String(document.getSerializedJson());
     }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingCompressedBulkRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingCompressedBulkRequest.java
@@ -126,15 +126,7 @@ public class JavaClientAccumulatingCompressedBulkRequest implements Accumulating
     }
 
     private Object mapBulkOperationToDocument(final BulkOperationWrapper bulkOperation) {
-        Object anyDocument;
-
-        if (bulkOperation.getBulkOperation().isIndex()) {
-            anyDocument = bulkOperation.getBulkOperation().index().document();
-        } else if (bulkOperation.getBulkOperation().isCreate()) {
-            anyDocument = bulkOperation.getBulkOperation().create().document();
-        } else {
-            throw new UnsupportedOperationException("Only index or create operations are supported currently. " + bulkOperation);
-        }
+        final Object anyDocument = bulkOperation.getDocument();
 
         if (anyDocument == null) {
             return new SerializedJsonImpl(null);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingUncompressedBulkRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingUncompressedBulkRequest.java
@@ -69,16 +69,7 @@ public class JavaClientAccumulatingUncompressedBulkRequest implements Accumulati
     }
 
     private long estimateBulkOperationSize(BulkOperationWrapper bulkOperation) {
-
-        Object anyDocument;
-
-        if (bulkOperation.getBulkOperation().isIndex()) {
-            anyDocument = bulkOperation.getBulkOperation().index().document();
-        } else if (bulkOperation.getBulkOperation().isCreate()) {
-            anyDocument = bulkOperation.getBulkOperation().create().document();
-        } else {
-            throw new UnsupportedOperationException("Only index or create operations are supported currently. " + bulkOperation);
-        }
+        final Object anyDocument = bulkOperation.getDocument();
 
         if (anyDocument == null)
             return OPERATION_OVERHEAD;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationConverter.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationConverter.java
@@ -2,7 +2,6 @@ package org.opensearch.dataprepper.plugins.sink.opensearch.dlq;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 import org.opensearch.dataprepper.model.failures.DlqObject;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.SerializedJson;
@@ -34,14 +33,13 @@ public class FailedBulkOperationConverter {
     public DlqObject convertToDlqObject(final FailedBulkOperation failedBulkOperation) {
 
         final BulkOperationWrapper bulkOperationWithHandle = failedBulkOperation.getBulkOperation();
-        final BulkOperation bulkOperation = bulkOperationWithHandle.getBulkOperation();
         final BulkResponseItem bulkResponseItem = failedBulkOperation.getBulkResponseItem();
 
-        final Object document = convertDocumentToGenericMap(bulkOperation);
+        final Object document = convertDocumentToGenericMap(bulkOperationWithHandle);
 
         final FailedDlqData.Builder failedDlqDataBuilder = FailedDlqData.builder()
-            .withIndex(bulkOperation.index().index())
-            .withIndexId(bulkOperation.index().id())
+            .withIndex(bulkOperationWithHandle.getIndex())
+            .withIndexId(bulkOperationWithHandle.getId())
             .withDocument(document);
 
         if (bulkResponseItem != null) {
@@ -61,8 +59,8 @@ public class FailedBulkOperationConverter {
             .build();
     }
 
-    private Object convertDocumentToGenericMap(final BulkOperation bulkOperation) {
-        final SerializedJson document = (SerializedJson) bulkOperation.index().document();
+    private Object convertDocumentToGenericMap(final BulkOperationWrapper bulkOperation) {
+        final SerializedJson document = (SerializedJson) bulkOperation.getDocument();
         final byte[] documentBytes = document.getSerializedJson();
         final String jsonString = new String(documentBytes, StandardCharsets.UTF_8);
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapperTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapperTests.java
@@ -5,18 +5,34 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.client.opensearch.core.bulk.CreateOperation;
+import org.opensearch.client.opensearch.core.bulk.DeleteOperation;
+import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Stream;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 public class BulkOperationWrapperTests {
+    private static final String ID = UUID.randomUUID().toString();
+    private static final String INDEX = UUID.randomUUID().toString();
+    private static final String DOCUMENT = UUID.randomUUID().toString();
+
     private BulkOperation bulkOperation;
 
-    BulkOperationWrapper createObjectUnderTest(EventHandle eventHandle) {
-        bulkOperation = mock(BulkOperation.class);
+    BulkOperationWrapper createObjectUnderTest(final EventHandle eventHandle, BulkOperation aBulkOperation) {
+        bulkOperation = Objects.isNull(aBulkOperation) ? mock(BulkOperation.class) : aBulkOperation;
         if (eventHandle == null) {
             return new BulkOperationWrapper(bulkOperation);
         }
@@ -25,7 +41,7 @@ public class BulkOperationWrapperTests {
 
     @Test
     public void testConstructorWithOneArgument() {
-        BulkOperationWrapper bulkOperationWithHandle = createObjectUnderTest(null);
+        BulkOperationWrapper bulkOperationWithHandle = createObjectUnderTest(null, null);
         assertThat(bulkOperationWithHandle.getBulkOperation(), equalTo(bulkOperation));
         assertThat(bulkOperationWithHandle.getEventHandle(), equalTo(null));
     }
@@ -33,8 +49,84 @@ public class BulkOperationWrapperTests {
     @Test
     public void testConstructorWithTwoArguments() {
         EventHandle eventHandle = mock(EventHandle.class);
-        BulkOperationWrapper bulkOperationWithHandle = createObjectUnderTest(eventHandle);
+        BulkOperationWrapper bulkOperationWithHandle = createObjectUnderTest(eventHandle, null);
         assertThat(bulkOperationWithHandle.getBulkOperation(), equalTo(bulkOperation));
         assertThat(bulkOperationWithHandle.getEventHandle(), equalTo(eventHandle));
+    }
+
+    @ParameterizedTest
+    @MethodSource("bulkOperationProvider")
+    public void testGetId(final BulkOperation bulkOperation) {
+        final BulkOperationWrapper bulkOperationWrapper = createObjectUnderTest(null, bulkOperation);
+        assertThat(bulkOperationWrapper.getId(), equalTo(ID));
+    }
+
+    @Test
+    public void testGetIdUnsupportedAction() {
+        final BulkOperationWrapper bulkOperationWrapper = createObjectUnderTest(null, getDeleteBulkOperation());
+        assertThrows(UnsupportedOperationException.class, bulkOperationWrapper::getId);
+    }
+
+    @ParameterizedTest
+    @MethodSource("bulkOperationProvider")
+    public void testGetIndex(final BulkOperation bulkOperation) {
+        final BulkOperationWrapper bulkOperationWrapper = createObjectUnderTest(null, bulkOperation);
+        assertThat(bulkOperationWrapper.getIndex(), equalTo(INDEX));
+    }
+
+    @Test
+    public void testGetIndexUnsupportedAction() {
+        final BulkOperationWrapper bulkOperationWrapper = createObjectUnderTest(null, getDeleteBulkOperation());
+        assertThrows(UnsupportedOperationException.class, bulkOperationWrapper::getIndex);
+    }
+
+    @ParameterizedTest
+    @MethodSource("bulkOperationProvider")
+    public void testGetDocument(final BulkOperation bulkOperation) {
+        final BulkOperationWrapper bulkOperationWrapper = createObjectUnderTest(null, bulkOperation);
+        assertThat(bulkOperationWrapper.getDocument(), equalTo(DOCUMENT));
+    }
+
+    @Test
+    public void testGetDocumentUnsupportedAction() {
+        final BulkOperationWrapper bulkOperationWrapper = createObjectUnderTest(null, getDeleteBulkOperation());
+        assertThrows(UnsupportedOperationException.class, bulkOperationWrapper::getDocument);
+    }
+
+    private static Stream<Arguments> bulkOperationProvider() {
+        final IndexOperation indexOperation = new IndexOperation.Builder<>()
+                .id(ID)
+                .index(INDEX)
+                .document(DOCUMENT)
+                .build();
+        final BulkOperation indexBulkOperation = (BulkOperation) new BulkOperation.Builder()
+                .index(indexOperation)
+                .build();
+
+        final CreateOperation createOperation = new CreateOperation.Builder<>()
+                .id(ID)
+                .index(INDEX)
+                .document(DOCUMENT)
+                .build();
+        final BulkOperation createBulkOperation = (BulkOperation) new BulkOperation.Builder()
+                .create(createOperation)
+                .build();
+
+        return Stream.of(
+                Arguments.of(
+                        indexBulkOperation,
+                        createBulkOperation
+                )
+        );
+    }
+
+    private BulkOperation getDeleteBulkOperation() {
+        final DeleteOperation deleteOperation = new DeleteOperation.Builder()
+                .id(ID)
+                .index(INDEX)
+                .build();
+        return new BulkOperation.Builder()
+                .delete(deleteOperation)
+                .build();
     }
 }


### PR DESCRIPTION
### Description
With the addition of the create action, there is need to branch when extracting data from a BulkOperation. This adds helper methods to BulkOperationWrapper to consolidate this logic in a single place. It also resolves a bug with the create action and writing to a DLQ
 
### Issues Resolved
#3040 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
