### PR TITLE
Translate Processor: Changed non-exact matching logic

### DIFF
--- a/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessor.java
+++ b/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessor.java
@@ -164,8 +164,12 @@ public class TranslateProcessor extends AbstractProcessor<Record<Event>, Record<
         final boolean exact = targetConfig.getRegexParameterConfiguration().getExact();
         for (Pattern pattern : compiledPatterns.keySet()) {
             Matcher matcher = pattern.matcher(sourceValue);
-            if (matcher.matches() || (!exact && matcher.find())) {
+            if (matcher.matches()) {
                 return Optional.of(compiledPatterns.get(pattern));
+            }
+            if(!exact && matcher.find()) {
+                String targetValue = (String)compiledPatterns.get(pattern);
+                return Optional.of(matcher.replaceAll(targetValue));
             }
         }
         return Optional.empty();

--- a/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorTest.java
+++ b/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorTest.java
@@ -391,7 +391,7 @@ class TranslateProcessorTest {
         when(mockRegexConfig.getExact()).thenReturn(false);
         when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(
                 createMapping("^(1[0-9]|20)$", "patternValue1"),
-                createMapping("foo", "bar2")));
+                createMapping("foo", "bar")));
         targetsParameterConfig = new TargetsParameterConfig(null, "targetField", mockRegexConfig, null, null, null);
         when(mappingsParameterConfig.getTargetsParameterConfigs()).thenReturn(List.of(targetsParameterConfig));
 
@@ -400,7 +400,13 @@ class TranslateProcessorTest {
         final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
 
         assertTrue(translatedRecords.get(0).getData().containsKey("targetField"));
-        assertThat(translatedRecords.get(0).getData().get("targetField", String.class), is("bar2"));
+        assertThat(translatedRecords.get(0).getData().get("targetField", String.class), is("barter"));
+
+        final Record<Event> replaceAllRecord = getEvent("foofoo");
+        final List<Record<Event>> translatedReplaceAllRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(replaceAllRecord));
+
+        assertTrue(translatedReplaceAllRecords.get(0).getData().containsKey("targetField"));
+        assertThat(translatedReplaceAllRecords.get(0).getData().get("targetField", String.class), is("barbar"));
 
         final Record<Event> regexRecord = getEvent("15");
         final List<Record<Event>> translatedRegexRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(regexRecord));


### PR DESCRIPTION
### Description
Previously when `exact` option is `false`, if there is a non-exact match, the `target` field will be populated with mapped value. This logic has been changed to:
If there is a non-exact match, the mapped value will be replaced in the source value in all occurences and placed in the target field.

For the following config:
```yaml
  translate - 
    mappings:
      - source: status
        targets:
          - target: result
            regex:
              exact: false
              patterns:
                foo: bar
      - source: status2
        targets:
          - target: result2
            regex:
              exact: false
              patterns:
                foo: bar
```
Log:
```json
{ 
  "status" : "footer", 
  "status2" : "foofoo"
}
```
Will be translated to: 

```json
{ 
  "status" : "footer", 
  "status2" : "foofoo",
  "result" : "barter", 
  "result2" : "barbar"
}
```
 
### Issues Resolved
https://github.com/opensearch-project/data-prepper/issues/1914
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
