### PR TITLE
Translate Plugin - Added functionality to provide full path to the source field

### DIFF
--- a/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/JsonExtractor.java
+++ b/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/JsonExtractor.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.translate;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * JsonExtractor class is a utility for handling JSON paths and extracting specific fields or objects from
+ * JSON structures represented as Java objects. It provides a way to work with nested JSON structures and
+ * retrieve the relevant data based on the provided paths.
+ */
+public class JsonExtractor {
+
+    /**
+     * Default delimiter between the fields when providing the path
+     */
+    private static final String DELIMITER = "/";
+
+    /**
+     * @param fullPath full path to the leaf field
+     * @return the first field from the full path, returns empty string "" if the path is empty
+     */
+    public String getRootField(String fullPath) {
+        final List<String> fieldsInPath = getFieldsInPath(fullPath);
+        return fieldsInPath.isEmpty() ? "" : fieldsInPath.get(0);
+    }
+
+    /**
+     * @param fullPath full path to the leaf field
+     * @return the last field from the full path, returns empty string "" if the path is empty
+     */
+    public String getLeafField(String fullPath) {
+        String strippedPath = getStrippedPath(fullPath);
+        final String[] fields = strippedPath.split(DELIMITER);
+        return fields.length==0 ? "" : fields[fields.length - 1].strip();
+    }
+
+    /**
+     * @param fullPath full path to the leaf field
+     * @return the path leading up to the lead field, returns empty string "" if there is no parent path
+     */
+    public String getParentPath(String fullPath) {
+        String strippedPath = getStrippedPath(fullPath);
+        final String[] fields = strippedPath.split(DELIMITER);
+        if (fields.length <= 1) {
+            return "";
+        }
+        return Arrays.stream(fields, 0, fields.length - 1).collect(Collectors.joining(DELIMITER));
+    }
+
+    /**
+     * @param path full path to the leaf field
+     * @param rootObject Java Object in which root field is located. Can be either a List or Map
+     * @return all the Java Objects that are associated with the provided path .
+     * Path : field1/field2/field3 gives the value of field3.
+     */
+    public List<Object> getObjectFromPath(String path, Object rootObject) {
+        final List<String> fieldsInPath = getFieldsInPath(path);
+        if (fieldsInPath.isEmpty()) {
+            return List.of(rootObject);
+        }
+        return getLeafObjects(fieldsInPath, 0, rootObject);
+    }
+
+    /**
+     * @param path path from one field to another
+     * @return the list of fields in the provided path
+     */
+    private List<String> getFieldsInPath(String path) {
+        String strippedPath = getStrippedPath(path);
+        if (strippedPath.isEmpty()) {
+            return List.of();
+        }
+        return new ArrayList<>(Arrays.asList(strippedPath.split(DELIMITER)));
+    }
+
+    /**
+     * @param fieldsInPath list of fields in a path
+     * @param level current level inside the nested object with reference to the root level
+     * @param rootObject Java Object in which root field is located. Can be either a List or Map
+     * @return all the Java Objects that satisfy the fields hierarchy in fieldsInPath
+     */
+    private List<Object> getLeafObjects(List<String> fieldsInPath, int level, Object rootObject) {
+        if (Objects.isNull(rootObject)) {
+            return List.of();
+        }
+
+        if (rootObject instanceof List) {
+            return ((List<?>) rootObject).stream()
+                    .flatMap(arrayObject -> getLeafObjects(fieldsInPath, level, arrayObject).stream())
+                    .collect(Collectors.toList());
+        } else if (rootObject instanceof Map) {
+            if (level >= fieldsInPath.size()) {
+                return List.of(rootObject);
+            } else {
+                String field = fieldsInPath.get(level);
+                Object outObj = ((Map<?, ?>) rootObject).get(field);
+                return getLeafObjects(fieldsInPath, level + 1, outObj);
+            }
+        }
+        return List.of();
+    }
+
+    /**
+     * @param path path from one field to another
+     * @return path stripped of whitespaces
+     */
+    private String getStrippedPath(String path){
+        checkNotNull(path, "path cannot be null");
+        return path.strip();
+    }
+}

--- a/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessor.java
+++ b/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessor.java
@@ -12,6 +12,7 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
@@ -39,6 +40,8 @@ public class TranslateProcessor extends AbstractProcessor<Record<Event>, Record<
     private static final Logger LOG = LoggerFactory.getLogger(TranslateProcessor.class);
     private final ExpressionEvaluator expressionEvaluator;
     private final List<MappingsParameterConfig> mappingsConfig;
+    private final JacksonEvent.Builder eventBuilder= JacksonEvent.builder();
+    private final JsonExtractor jsonExtractor = new JsonExtractor();
 
     @DataPrepperPluginConstructor
     public TranslateProcessor(PluginMetrics pluginMetrics, final TranslateProcessorConfig translateProcessorConfig, final ExpressionEvaluator expressionEvaluator) {
@@ -58,21 +61,10 @@ public class TranslateProcessor extends AbstractProcessor<Record<Event>, Record<
             final Event recordEvent = record.getData();
             for (MappingsParameterConfig mappingConfig : mappingsConfig) {
                 try {
-                    String iterateOn = mappingConfig.getIterateOn();
                     List<TargetsParameterConfig> targetsConfig = mappingConfig.getTargetsParameterConfigs();
                     for (TargetsParameterConfig targetConfig : targetsConfig) {
-                        String translateWhen = targetConfig.getTranslateWhen();
                         Object sourceObject = mappingConfig.getSource();
-                        if (Objects.nonNull(translateWhen) && !expressionEvaluator.evaluateConditional(translateWhen, recordEvent)) {
-                            continue;
-                        }
-                        if (Objects.nonNull(iterateOn)) {
-                            List<Map<String, Object>> objectsToIterate = recordEvent.get(iterateOn, List.class);
-                            objectsToIterate.forEach(recordObject -> performMappings(recordObject, sourceObject, targetConfig));
-                            recordEvent.put(iterateOn, objectsToIterate);
-                        } else {
-                            performMappings(recordEvent, sourceObject, targetConfig);
-                        }
+                        translateSource(sourceObject, recordEvent, targetConfig);
                     }
                 } catch (Exception ex) {
                     LOG.error(EVENT, "Error mapping the source [{}] of entry [{}]", mappingConfig.getSource(),
@@ -83,12 +75,57 @@ public class TranslateProcessor extends AbstractProcessor<Record<Event>, Record<
         return records;
     }
 
-    private String getSourceValue(Object recordObject, String sourceKey) {
-        if (recordObject instanceof Map) {
-            return (String) ((Map<?, ?>) recordObject).get(sourceKey);
+    private List<String> getSourceKeys(Object sourceObject){
+        List<String> sourceKeys;
+        if (sourceObject instanceof List<?>) {
+            sourceKeys = (ArrayList<String>) sourceObject;
+        } else if (sourceObject instanceof String) {
+            sourceKeys = List.of((String) sourceObject);
         } else {
-            return ((Event) recordObject).get(sourceKey, String.class);
+            String exceptionMsg = "source option configured incorrectly. source can only be a String or list of Strings";
+            throw new InvalidPluginConfigurationException(exceptionMsg);
         }
+        return sourceKeys;
+    }
+
+    private void translateSource(Object sourceObject, Event recordEvent, TargetsParameterConfig targetConfig) {
+        Map<String, Object> recordObject =  recordEvent.toMap();
+        List<String> sourceKeysPaths = getSourceKeys(sourceObject);
+        if(Objects.isNull(recordObject) || sourceKeysPaths.isEmpty()){
+            return;
+        }
+
+        List<String> sourceKeys = new ArrayList<>();
+        for(String sourceKeyPath: sourceKeysPaths){
+            sourceKeys.add(jsonExtractor.getLeafField(sourceKeyPath));
+        }
+
+        String commonPath = jsonExtractor.getParentPath(sourceKeysPaths.get(0));
+        if(commonPath.isEmpty()) {
+            performMappings(recordEvent, sourceKeys, sourceObject, targetConfig);
+            return;
+        }
+
+        String rootField = jsonExtractor.getRootField(commonPath);
+        if(!recordObject.containsKey(rootField)){
+            return;
+        }
+
+        List<Object> targetObjects = jsonExtractor.getObjectFromPath(commonPath, recordObject);
+        if(!targetObjects.isEmpty()) {
+            targetObjects.forEach(targetObj -> performMappings(targetObj, sourceKeys, sourceObject, targetConfig));
+            recordEvent.put(rootField, recordObject.get(rootField));
+        }
+    }
+
+    private String getSourceValue(Object recordObject, String sourceKey) {
+        Optional<Object> sourceValue;
+        if (recordObject instanceof Map) {
+            sourceValue = Optional.ofNullable(((Map<?, ?>) recordObject).get(sourceKey));
+        } else {
+            sourceValue = Optional.ofNullable(((Event) recordObject).get(sourceKey, String.class));
+        }
+        return sourceValue.map(Object::toString).orElse(null);
     }
 
     private Object getTargetValue(Object sourceObject, List<Object> targetValues, TargetsParameterConfig targetConfig) {
@@ -102,17 +139,18 @@ public class TranslateProcessor extends AbstractProcessor<Record<Event>, Record<
                 .collect(Collectors.toList());
     }
 
-    private void performMappings(Object recordObject, Object sourceObject, TargetsParameterConfig targetConfig) {
-        List<Object> targetValues = new ArrayList<>();
-        List<String> sourceKeys;
-        if (sourceObject instanceof List<?>) {
-            sourceKeys = (ArrayList<String>) sourceObject;
-        } else if (sourceObject instanceof String) {
-            sourceKeys = List.of((String) sourceObject);
-        } else {
-            String exceptionMsg = "source option configured incorrectly. source can only be a String or list of Strings";
-            throw new InvalidPluginConfigurationException(exceptionMsg);
+    private void performMappings(Object recordObject, List<String> sourceKeys, Object sourceObject, TargetsParameterConfig targetConfig) {
+        if (Objects.isNull(recordObject) ||
+            Objects.isNull(sourceObject) ||
+            Objects.isNull(targetConfig) ||
+            sourceKeys.isEmpty()) {
+            return;
         }
+        String translateWhen = targetConfig.getTranslateWhen();
+        if(!isExpressionValid(translateWhen, recordObject)){
+            return;
+        }
+        List<Object> targetValues = new ArrayList<>();
         for (String sourceKey : sourceKeys) {
             String sourceValue = getSourceValue(recordObject, sourceKey);
             if(sourceValue!=null){
@@ -121,6 +159,16 @@ public class TranslateProcessor extends AbstractProcessor<Record<Event>, Record<
             }
         }
         addTargetToRecords(sourceObject, targetValues, recordObject, targetConfig);
+    }
+
+    private boolean isExpressionValid(String translateWhen, Object recordObject){
+        Event recordEvent;
+        if (recordObject instanceof Map) {
+            recordEvent = eventBuilder.withData(recordObject).withEventType("event").build();
+        } else {
+            recordEvent = (Event)recordObject;
+        }
+        return (translateWhen == null) || expressionEvaluator.evaluateConditional(translateWhen, recordEvent);
     }
 
     private Optional<Object> getTargetValueForSource(final String sourceValue, TargetsParameterConfig targetConfig) {

--- a/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/MappingsParameterConfigTest.java
+++ b/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/MappingsParameterConfigTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.core.Is.is;
 import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -19,13 +18,6 @@ class MappingsParameterConfigTest {
     void setup() throws NoSuchFieldException, IllegalAccessException{
         mappingsParameterConfig = new MappingsParameterConfig();
         setField(MappingsParameterConfig.class, mappingsParameterConfig, "source", "sourceKey");
-    }
-
-    @Test
-    void test_get_iterate_on() throws NoSuchFieldException, IllegalAccessException{
-        assertNull(mappingsParameterConfig.getIterateOn());
-        setField(MappingsParameterConfig.class, mappingsParameterConfig, "iterateOn", "iteratorField");
-        assertThat(mappingsParameterConfig.getIterateOn(),is("iteratorField"));
     }
 
     @Test
@@ -62,6 +54,33 @@ class MappingsParameterConfigTest {
         setField(MappingsParameterConfig.class, mappingsParameterConfig, "source", 20.1);
         assertFalse(mappingsParameterConfig.isSourceFieldValid());
         setField(MappingsParameterConfig.class, mappingsParameterConfig, "source", List.of("key1", 200));
+        assertFalse(mappingsParameterConfig.isSourceFieldValid());
+    }
+
+    @Test
+    void test_valid_source_array() throws NoSuchFieldException, IllegalAccessException {
+        List<String> sourceList = List.of("sourceField1", "sourceField2");
+        setField(MappingsParameterConfig.class, mappingsParameterConfig, "source", sourceList);
+        assertTrue(mappingsParameterConfig.isSourceFieldValid());
+    }
+
+    @Test
+    void test_invalid_source_array_not_string_type() throws NoSuchFieldException, IllegalAccessException {
+        List<Object> sourceList = List.of("sourceField1", 1);
+        setField(MappingsParameterConfig.class, mappingsParameterConfig, "source", sourceList);
+        assertFalse(mappingsParameterConfig.isSourceFieldValid());
+    }
+
+    @Test
+    void test_valid_source_array_valid_common_path() throws NoSuchFieldException, IllegalAccessException {
+        List<String> sourceList = List.of("field1/field2/sourceField1", "field1/field2/sourceField2");
+        setField(MappingsParameterConfig.class, mappingsParameterConfig, "source", sourceList);
+        assertTrue(mappingsParameterConfig.isSourceFieldValid());
+    }
+    @Test
+    void test_invalid_source_array_invalid_common_path() throws NoSuchFieldException, IllegalAccessException {
+        List<String> sourceList = List.of("field1/field2/sourceField1", "field1/sourceField2");
+        setField(MappingsParameterConfig.class, mappingsParameterConfig, "source", sourceList);
         assertFalse(mappingsParameterConfig.isSourceFieldValid());
     }
 

--- a/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorTest.java
+++ b/data-prepper-plugins/translate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessorTest.java
@@ -428,7 +428,7 @@ class TranslateProcessorTest {
         when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(
                 createMapping("key1", "mappedValue1"),
                 createMapping("key2", "mappedValue2")));
-        when(mappingsParameterConfig.getIterateOn()).thenReturn("collection");
+        when(mappingsParameterConfig.getSource()).thenReturn("collection/sourceField");
         targetsParameterConfig = new TargetsParameterConfig(null, "targetField", mockRegexConfig, null, "No Match",
                                                             null);
         when(mappingsParameterConfig.getTargetsParameterConfigs()).thenReturn(List.of(targetsParameterConfig));
@@ -454,7 +454,7 @@ class TranslateProcessorTest {
         when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(
                 createMapping("key1", "mappedValue1"),
                 createMapping("key2", "mappedValue2")));
-        when(mappingsParameterConfig.getIterateOn()).thenReturn("collection");
+        when(mappingsParameterConfig.getSource()).thenReturn("collection/sourceField");
         targetsParameterConfig = new TargetsParameterConfig(null, "targetField", mockRegexConfig, null, null, null);
         when(mappingsParameterConfig.getTargetsParameterConfigs()).thenReturn(List.of(targetsParameterConfig));
 
@@ -477,7 +477,83 @@ class TranslateProcessorTest {
                 Map.of("sourceField", "key3"));
 
         when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(createMapping("key4", "mappedValue1")));
-        when(mappingsParameterConfig.getIterateOn()).thenReturn("collection");
+        when(mappingsParameterConfig.getSource()).thenReturn("collection/sourceField");
+        targetsParameterConfig = new TargetsParameterConfig(null, "targetField", mockRegexConfig, null, null, null);
+        when(mappingsParameterConfig.getTargetsParameterConfigs()).thenReturn(List.of(targetsParameterConfig));
+
+        final TranslateProcessor processor = createObjectUnderTest();
+        final Record<Event> record = buildRecordWithEvent(testJson);
+        final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(translatedRecords.get(0).getData().get("collection", ArrayList.class), is(outputJson));
+    }
+
+    @Test
+    void test_nested_multiple_levels() {
+        final Map<String, Object> testJson = Map.of("collection", List.of(
+                Map.of("sourceField1", List.of(Map.of("sourceField2", "key1")))));
+        final List<Map<String, Object>> outputJson = List.of(
+                Map.of("sourceField1", List.of(Map.of("sourceField2", "key1", "targetField","mappedValue1"))));
+
+        when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(createMapping("key1", "mappedValue1")));
+        when(mappingsParameterConfig.getSource()).thenReturn("collection/sourceField1/sourceField2");
+        targetsParameterConfig = new TargetsParameterConfig(null, "targetField", mockRegexConfig, null, null, null);
+        when(mappingsParameterConfig.getTargetsParameterConfigs()).thenReturn(List.of(targetsParameterConfig));
+
+        final TranslateProcessor processor = createObjectUnderTest();
+        final Record<Event> record = buildRecordWithEvent(testJson);
+        final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(translatedRecords.get(0).getData().get("collection", ArrayList.class), is(outputJson));
+    }
+
+    @Test
+    void test_no_path_found_with_wrong_field() {
+        final Map<String, Object> testJson = Map.of("collection", List.of(
+                Map.of("sourceField1", List.of(Map.of("sourceField2", "key1")))));
+        final List<Map<String, Object>> outputJson = List.of(
+                Map.of("sourceField1", List.of(Map.of("sourceField2", "key1"))));
+
+        when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(createMapping("key1", "mappedValue1")));
+        when(mappingsParameterConfig.getSource()).thenReturn("collection/noSource/sourceField2");
+        targetsParameterConfig = new TargetsParameterConfig(null, "targetField", mockRegexConfig, null, null, null);
+        when(mappingsParameterConfig.getTargetsParameterConfigs()).thenReturn(List.of(targetsParameterConfig));
+
+        final TranslateProcessor processor = createObjectUnderTest();
+        final Record<Event> record = buildRecordWithEvent(testJson);
+        final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(translatedRecords.get(0).getData().get("collection", ArrayList.class), is(outputJson));
+    }
+
+    @Test
+    void test_no_path_found_with_no_list() {
+        final Map<String, Object> testJson = Map.of("collection", List.of(
+                Map.of("sourceField1", "key1","sourceField2", "key1")));
+        final List<Map<String, Object>> outputJson = List.of(
+                Map.of("sourceField1", "key1","sourceField2", "key1"));
+
+        when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(createMapping("key1", "mappedValue1")));
+        when(mappingsParameterConfig.getSource()).thenReturn("collection/sourceField1/sourceField2");
+        targetsParameterConfig = new TargetsParameterConfig(null, "targetField", mockRegexConfig, null, null, null);
+        when(mappingsParameterConfig.getTargetsParameterConfigs()).thenReturn(List.of(targetsParameterConfig));
+
+        final TranslateProcessor processor = createObjectUnderTest();
+        final Record<Event> record = buildRecordWithEvent(testJson);
+        final List<Record<Event>> translatedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(translatedRecords.get(0).getData().get("collection", ArrayList.class), is(outputJson));
+    }
+
+    @Test
+    void test_path_with_whitespaces() {
+        final Map<String, Object> testJson = Map.of("collection", List.of(
+                Map.of("sourceField1", List.of(Map.of("sourceField2", "key1")))));
+        final List<Map<String, Object>> outputJson = List.of(
+                Map.of("sourceField1", List.of(Map.of("sourceField2", "key1", "targetField","mappedValue1"))));
+
+        when(mockRegexConfig.getPatterns()).thenReturn(createMapEntries(createMapping("key1", "mappedValue1")));
+        when(mappingsParameterConfig.getSource()).thenReturn(" collection/sourceField1/sourceField2  ");
         targetsParameterConfig = new TargetsParameterConfig(null, "targetField", mockRegexConfig, null, null, null);
         when(mappingsParameterConfig.getTargetsParameterConfigs()).thenReturn(List.of(targetsParameterConfig));
 
@@ -539,6 +615,7 @@ class TranslateProcessorTest {
         assertTrue(translatedRecords.get(0).getData().containsKey("targetField"));
         assertThat(translatedRecords.get(0).getData().get("targetField", Double.class), is(20.3));
     }
+
     @Nested
     class FilePathTests {
         private File testMappingsFile;


### PR DESCRIPTION
### Description
Removed the iterateOn option. Now the iterateOn functionality will be taken care by source option with the help of full path to the source.

### Configuring `source` option with path
* The source provided can be full path to the field in the log that requires translation.  
* If the source path is something like `field1/field2/source`, all the objects that satisfy the path will be translated based on the provided mappings and the targets fields will be placed in the object along the path `field1/field2/target`.  
* The fields (`field1`, `field2`) leading up to the source field in the path must be JSON arrays or JSON objects. It is important to note that other JSON data types cannot be iterated in this context.
* The `translate_when` expression if configured will only be applied for the JSON objects with reference to the path `field1/field2`.
* As `source` option supports multiple sources to be configured, it is required for all the sources in the array to have a common root path.

  ```yaml
  mappings:
    - source: ["/field1/field2/source1", "field1/field2/source2"]
      targets:
        - target: "targetField"
           map:
            foo: bar
            
  ```

  Let the pipeline configuration be:

  ```yaml
  processor:
  - translate:
      mappings:
        - source: collection/status
          targets:
            - target: result
              map:
                foo: bar
        - source: collection/status/http
          targets:
            - target: result
              map:
                120: "success"
                404: "failure"
  ```
  Let the contents of `logs_json.log` be:
  ```json
  {
    "collection": [
      {
        "status": "foo"
      },
      {
        "status": [
          {
            "http": 120
          }
        ]
      }
    ]
  }
  ```
  The translated log would look like this:
  ```json
  {
    "collection": [
      {
        "status": "foo",
        "result": "bar"
      },
      {
        "status": [
          {
            "http": 120,
            "result": "success"
          }
        ]
      }
    ]
  }

  ```
 
### Issues Resolved
https://github.com/opensearch-project/data-prepper/issues/1914
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
