### PR TITLE
Fix bug where exception is thrown when csv source key does not exist …

### DIFF
--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
@@ -59,6 +59,11 @@ public class CsvProcessor extends AbstractProcessor<Record<Event>, Record<Event>
             final Event event = record.getData();
 
             final String message = event.get(config.getSource(), String.class);
+
+            if (Objects.isNull(message)) {
+                continue;
+            }
+
             final boolean userDidSpecifyHeaderEventKey = Objects.nonNull(config.getColumnNamesSourceKey());
             final boolean thisEventHasHeaderSource = userDidSpecifyHeaderEventKey && event.containsKey(config.getColumnNamesSourceKey());
 

--- a/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorTest.java
+++ b/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -57,6 +58,18 @@ class CsvProcessorTest {
 
     private CsvProcessor createObjectUnderTest() {
         return new CsvProcessor(pluginMetrics, processorConfig);
+    }
+
+    @Test
+    void do_nothing_when_source_is_null_value_or_does_not_exist_in_the_Event() {
+        final Record<Event> eventUnderTest = createMessageEvent("");
+        when(processorConfig.getSource()).thenReturn(UUID.randomUUID().toString());
+
+
+        final List<Record<Event>> editedEvents = (List<Record<Event>>) csvProcessor.doExecute(Collections.singletonList(eventUnderTest));
+        final Event parsedEvent = getSingleEvent(editedEvents);
+
+        assertThat(parsedEvent, equalTo(eventUnderTest.getData()));
     }
 
     @Test


### PR DESCRIPTION
…or is null

### Description
If the `source` specified in the csv processor does not exist in the Event or contains a null value in the Event, an exception is thrown and the Events are dropped

```
ava.lang.IllegalArgumentException: argument "content" is null
    at com.fasterxml.jackson.databind.ObjectReader._assertNotNull(ObjectReader.java:2456) ~[jackson-databind-2.15.2.jar:2.15.2]
    at com.fasterxml.jackson.databind.ObjectReader.createParser(ObjectReader.java:1154) ~[jackson-databind-2.15.2.jar:2.15.2]
    at com.fasterxml.jackson.databind.ObjectReader.readValues(ObjectReader.java:1943) ~[jackson-databind-2.15.2.jar:2.15.2]
    at org.opensearch.dataprepper.plugins.processor.csv.CsvProcessor.doExecute(CsvProcessor.java:66) ~[csv-processor-2.4.0-SNAPSHOT.jar:?]
    at org.ope
```

This fixes that bug so that it is a no-op and the Event continues processing through the pipeline
 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
