### PR TITLE
FIX: missing request index

### DIFF
--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/Es6BulkApiWrapperTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/Es6BulkApiWrapperTest.java
@@ -1,8 +1,12 @@
 package org.opensearch.dataprepper.plugins.sink.opensearch.bulk;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -11,17 +15,24 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.ErrorResponse;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.client.opensearch.core.bulk.CreateOperation;
+import org.opensearch.client.opensearch.core.bulk.DeleteOperation;
+import org.opensearch.client.opensearch.core.bulk.IndexOperation;
+import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
 import org.opensearch.client.transport.JsonEndpoint;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.TransportOptions;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,14 +52,39 @@ class Es6BulkApiWrapperTest {
     @Mock
     private BulkRequest bulkRequest;
 
+    @Mock
+    private BulkOperation bulkOperation;
+
+    @Mock
+    private IndexOperation indexOperation;
+
+    @Mock
+    private CreateOperation createOperation;
+
+    @Mock
+    private UpdateOperation updateOperation;
+
+    @Mock
+    private DeleteOperation deleteOperation;
+
     @Captor
     private ArgumentCaptor<JsonEndpoint<BulkRequest, BulkResponse, ErrorResponse>> jsonEndpointArgumentCaptor;
 
     private Es6BulkApiWrapper objectUnderTest;
+    private String testIndex;
 
     @BeforeEach
     void setUp() {
         objectUnderTest = new Es6BulkApiWrapper(openSearchClient);
+        testIndex = RandomStringUtils.randomAlphabetic(5);
+        lenient().when(bulkOperation.index()).thenReturn(indexOperation);
+        lenient().when(bulkOperation.create()).thenReturn(createOperation);
+        lenient().when(bulkOperation.update()).thenReturn(updateOperation);
+        lenient().when(bulkOperation.delete()).thenReturn(deleteOperation);
+        lenient().when(indexOperation.index()).thenReturn(testIndex);
+        lenient().when(createOperation.index()).thenReturn(testIndex);
+        lenient().when(updateOperation.index()).thenReturn(testIndex);
+        lenient().when(deleteOperation.index()).thenReturn(testIndex);
     }
 
     @Test
@@ -65,16 +101,33 @@ class Es6BulkApiWrapperTest {
         assertThat(endpoint.requestUrl(bulkRequest), equalTo(expectedURI));
     }
 
-    @Test
-    void testBulkThrowsException_when_request_missing_index() throws IOException {
+    @ParameterizedTest
+    @MethodSource("getTypeFlags")
+    void testBulk_when_request_index_missing(final boolean isIndex, final boolean isCreate,
+                                             final boolean isUpdate, final boolean isDelete) throws IOException {
         when(openSearchClient._transport()).thenReturn(openSearchTransport);
         when(openSearchClient._transportOptions()).thenReturn(transportOptions);
         when(bulkRequest.index()).thenReturn(null);
+        when(bulkRequest.operations()).thenReturn(List.of(bulkOperation));
+        lenient().when(bulkOperation.isIndex()).thenReturn(isIndex);
+        lenient().when(bulkOperation.isCreate()).thenReturn(isCreate);
+        lenient().when(bulkOperation.isUpdate()).thenReturn(isUpdate);
+        lenient().when(bulkOperation.isDelete()).thenReturn(isDelete);
         objectUnderTest.bulk(bulkRequest);
 
         verify(openSearchTransport).performRequest(
                 any(BulkRequest.class), jsonEndpointArgumentCaptor.capture(), eq(transportOptions));
         final JsonEndpoint<BulkRequest, BulkResponse, ErrorResponse> endpoint = jsonEndpointArgumentCaptor.getValue();
-        assertThrows(IllegalArgumentException.class, () -> endpoint.requestUrl(bulkRequest));
+        final String expectedURI = String.format(ES6_URI_PATTERN, testIndex);
+        assertThat(endpoint.requestUrl(bulkRequest), equalTo(expectedURI));
+    }
+
+    private static Stream<Arguments> getTypeFlags() {
+        return Stream.of(
+                Arguments.of(true, false, false, false),
+                Arguments.of(false, true, false, false),
+                Arguments.of(false, false, true, false),
+                Arguments.of(false, false, false, true)
+        );
     }
 }


### PR DESCRIPTION
### Description
This fix is a follow up of #3045 . It tackles the generic missing index in bulk request by extracting index value from the first bulk operation.

Bug
```
2023-07-24T16:51:57,655 [log-pipeline-sink-worker-2-thread-1] WARN  org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSink - Document [FailedDlqData{index='test-bulk', indexId='null', status='0', message='Bulk request index cannot be missing', document={log=test log, @timestamp=2023-07-24T16:51:36.582-05:00}}] has failure. DLQ not configured
java.lang.IllegalArgumentException: Bulk request index cannot be missing
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
