### PR TITLE
Centralize exception handling and fix behavior for RequestTimeoutException

### DIFF
--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/GrpcRequestExceptionHandler.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/GrpcRequestExceptionHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper;
+
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.grpc.GrpcStatusFunction;
+import com.linecorp.armeria.server.RequestTimeoutException;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.exceptions.BadRequestException;
+import org.opensearch.dataprepper.exceptions.BufferWriteException;
+import org.opensearch.dataprepper.exceptions.RequestCancelledException;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeoutException;
+
+public class GrpcRequestExceptionHandler implements GrpcStatusFunction {
+    private static final Logger LOG = LoggerFactory.getLogger(GrpcRequestExceptionHandler.class);
+    public static final String REQUEST_TIMEOUTS = "requestTimeouts";
+    public static final String BAD_REQUESTS = "badRequests";
+    public static final String REQUESTS_TOO_LARGE = "requestsTooLarge";
+    public static final String INTERNAL_SERVER_ERROR = "internalServerError";
+
+    private final Counter requestTimeoutsCounter;
+    private final Counter badRequestsCounter;
+    private final Counter requestsTooLargeCounter;
+    private final Counter internalServerErrorCounter;
+
+    public GrpcRequestExceptionHandler(final PluginMetrics pluginMetrics) {
+        requestTimeoutsCounter = pluginMetrics.counter(REQUEST_TIMEOUTS);
+        badRequestsCounter = pluginMetrics.counter(BAD_REQUESTS);
+        requestsTooLargeCounter = pluginMetrics.counter(REQUESTS_TOO_LARGE);
+        internalServerErrorCounter = pluginMetrics.counter(INTERNAL_SERVER_ERROR);
+    }
+
+    @Override
+    public @Nullable Status apply(final RequestContext context, final Throwable exception, final Metadata metadata) {
+        final Throwable exceptionCause = exception instanceof BufferWriteException ? exception.getCause() : exception;
+
+        return handleExceptions(exceptionCause);
+    }
+
+    private Status handleExceptions(final Throwable e) {
+        if (e instanceof RequestTimeoutException || e instanceof TimeoutException) {
+            requestTimeoutsCounter.increment();
+            return createStatus(e, Status.RESOURCE_EXHAUSTED);
+        } else if (e instanceof SizeOverflowException) {
+            requestsTooLargeCounter.increment();
+            return createStatus(e, Status.RESOURCE_EXHAUSTED);
+        } else if (e instanceof BadRequestException) {
+            badRequestsCounter.increment();
+            return createStatus(e, Status.INVALID_ARGUMENT);
+        } else if (e instanceof RequestCancelledException) {
+            requestTimeoutsCounter.increment();
+            return createStatus(e, Status.CANCELLED);
+        }
+
+        internalServerErrorCounter.increment();
+        return createStatus(e, Status.INTERNAL);
+    }
+
+    private Status createStatus(final Throwable e, final Status status) {
+        return status.withDescription(e.getMessage());
+    }
+}

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/GrpcRequestExceptionHandler.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/GrpcRequestExceptionHandler.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeoutException;
 
 public class GrpcRequestExceptionHandler implements GrpcStatusFunction {
     static final String ARMERIA_REQUEST_TIMEOUT_MESSAGE = "Timeout waiting for request to be served. This is usually due to the buffer being full.";
-    static final String DEFAULT_MESSAGE = "";
 
     public static final String REQUEST_TIMEOUTS = "requestTimeouts";
     public static final String BAD_REQUESTS = "badRequests";
@@ -72,7 +71,7 @@ public class GrpcRequestExceptionHandler implements GrpcStatusFunction {
         if (e instanceof RequestTimeoutException) {
             message = ARMERIA_REQUEST_TIMEOUT_MESSAGE;
         } else {
-            message = e.getMessage() == null ? DEFAULT_MESSAGE : e.getMessage();
+            message = e.getMessage() == null ? status.getCode().name() : e.getMessage();
         }
 
         return status.withDescription(message);

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/GrpcRequestExceptionHandler.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/GrpcRequestExceptionHandler.java
@@ -17,13 +17,10 @@ import org.opensearch.dataprepper.exceptions.BufferWriteException;
 import org.opensearch.dataprepper.exceptions.RequestCancelledException;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeoutException;
 
 public class GrpcRequestExceptionHandler implements GrpcStatusFunction {
-    private static final Logger LOG = LoggerFactory.getLogger(GrpcRequestExceptionHandler.class);
     public static final String REQUEST_TIMEOUTS = "requestTimeouts";
     public static final String BAD_REQUESTS = "badRequests";
     public static final String REQUESTS_TOO_LARGE = "requestsTooLarge";
@@ -68,6 +65,13 @@ public class GrpcRequestExceptionHandler implements GrpcStatusFunction {
     }
 
     private Status createStatus(final Throwable e, final Status status) {
-        return status.withDescription(e.getMessage());
+        final String message;
+        if (e instanceof RequestTimeoutException) {
+            message = "Timeout waiting for request to be served. This is usually due to the buffer being full.";
+        } else {
+            message = e.getMessage() == null ? "" : e.getMessage();
+        }
+
+        return status.withDescription(message);
     }
 }

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/GrpcRequestExceptionHandler.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/GrpcRequestExceptionHandler.java
@@ -21,6 +21,9 @@ import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
 import java.util.concurrent.TimeoutException;
 
 public class GrpcRequestExceptionHandler implements GrpcStatusFunction {
+    static final String ARMERIA_REQUEST_TIMEOUT_MESSAGE = "Timeout waiting for request to be served. This is usually due to the buffer being full.";
+    static final String DEFAULT_MESSAGE = "";
+
     public static final String REQUEST_TIMEOUTS = "requestTimeouts";
     public static final String BAD_REQUESTS = "badRequests";
     public static final String REQUESTS_TOO_LARGE = "requestsTooLarge";
@@ -67,9 +70,9 @@ public class GrpcRequestExceptionHandler implements GrpcStatusFunction {
     private Status createStatus(final Throwable e, final Status status) {
         final String message;
         if (e instanceof RequestTimeoutException) {
-            message = "Timeout waiting for request to be served. This is usually due to the buffer being full.";
+            message = ARMERIA_REQUEST_TIMEOUT_MESSAGE;
         } else {
-            message = e.getMessage() == null ? "" : e.getMessage();
+            message = e.getMessage() == null ? DEFAULT_MESSAGE : e.getMessage();
         }
 
         return status.withDescription(message);

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/HttpRequestExceptionHandler.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/HttpRequestExceptionHandler.java
@@ -21,6 +21,9 @@ import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 
 public class HttpRequestExceptionHandler implements ExceptionHandlerFunction {
+    static final String ARMERIA_REQUEST_TIMEOUT_MESSAGE = "Timeout waiting for request to be served. This is usually due to the buffer being full.";
+    static final String DEFAULT_MESSAGE = "";
+
     public static final String REQUEST_TIMEOUTS = "requestTimeouts";
     public static final String BAD_REQUESTS = "badRequests";
     public static final String REQUESTS_TOO_LARGE = "requestsTooLarge";
@@ -42,15 +45,15 @@ public class HttpRequestExceptionHandler implements ExceptionHandlerFunction {
     public HttpResponse handleException(final ServiceRequestContext ctx, final HttpRequest req, final Throwable cause) {
         final String message;
         if (cause instanceof RequestTimeoutException) {
-            message = "Timeout waiting for request to be served. This is usually due to the buffer being full.";
+            message = ARMERIA_REQUEST_TIMEOUT_MESSAGE;
         } else {
-            message = cause.getMessage() == null ? "" : cause.getMessage();
+            message = cause.getMessage() == null ? DEFAULT_MESSAGE : cause.getMessage();
         }
 
         return handleException(cause, message);
     }
 
-    public HttpResponse handleException(final Throwable e, final String message) {
+    private HttpResponse handleException(final Throwable e, final String message) {
         Objects.requireNonNull(message);
         if (e instanceof IOException) {
             badRequestsCounter.increment();

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/HttpRequestExceptionHandler.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/HttpRequestExceptionHandler.java
@@ -15,15 +15,12 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import io.micrometer.core.instrument.Counter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 
 public class HttpRequestExceptionHandler implements ExceptionHandlerFunction {
-    private static final Logger LOG = LoggerFactory.getLogger(HttpRequestExceptionHandler.class);
     public static final String REQUEST_TIMEOUTS = "requestTimeouts";
     public static final String BAD_REQUESTS = "badRequests";
     public static final String REQUESTS_TOO_LARGE = "requestsTooLarge";

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/exceptions/BadRequestException.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/exceptions/BadRequestException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.exceptions;
 
 public class BadRequestException extends RuntimeException {

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/exceptions/BadRequestException.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/exceptions/BadRequestException.java
@@ -1,0 +1,7 @@
+package org.opensearch.dataprepper.exceptions;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/exceptions/BufferWriteException.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/exceptions/BufferWriteException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.exceptions;
 
 public class BufferWriteException extends RuntimeException {

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/exceptions/BufferWriteException.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/exceptions/BufferWriteException.java
@@ -1,0 +1,7 @@
+package org.opensearch.dataprepper.exceptions;
+
+public class BufferWriteException extends RuntimeException {
+    public BufferWriteException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/exceptions/RequestCancelledException.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/exceptions/RequestCancelledException.java
@@ -1,0 +1,7 @@
+package org.opensearch.dataprepper.exceptions;
+
+public class RequestCancelledException extends RuntimeException {
+    public RequestCancelledException(final String message) {
+        super(message);
+    }
+}

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/exceptions/RequestCancelledException.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/exceptions/RequestCancelledException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.exceptions;
 
 public class RequestCancelledException extends RuntimeException {

--- a/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/GrpcRequestExceptionHandlerTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/GrpcRequestExceptionHandlerTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper;
 
 import com.linecorp.armeria.common.RequestContext;

--- a/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/GrpcRequestExceptionHandlerTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/GrpcRequestExceptionHandlerTest.java
@@ -1,0 +1,161 @@
+package org.opensearch.dataprepper;
+
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.server.RequestTimeoutException;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.micrometer.core.instrument.Counter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.exceptions.BadRequestException;
+import org.opensearch.dataprepper.exceptions.BufferWriteException;
+import org.opensearch.dataprepper.exceptions.RequestCancelledException;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.GrpcRequestExceptionHandler.ARMERIA_REQUEST_TIMEOUT_MESSAGE;
+import static org.opensearch.dataprepper.GrpcRequestExceptionHandler.DEFAULT_MESSAGE;
+
+@ExtendWith(MockitoExtension.class)
+public class GrpcRequestExceptionHandlerTest {
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private Counter requestTimeoutsCounter;
+
+    @Mock
+    private Counter badRequestsCounter;
+
+    @Mock
+    private Counter requestsTooLargeCounter;
+
+    @Mock
+    private Counter internalServerErrorCounter;
+
+    @Mock
+    private RequestContext requestContext;
+
+    @Mock
+    private Metadata metadata;
+
+    private GrpcRequestExceptionHandler grpcRequestExceptionHandler;
+
+    @BeforeEach
+    public void setUp() {
+        when(pluginMetrics.counter(HttpRequestExceptionHandler.REQUEST_TIMEOUTS)).thenReturn(requestTimeoutsCounter);
+        when(pluginMetrics.counter(HttpRequestExceptionHandler.BAD_REQUESTS)).thenReturn(badRequestsCounter);
+        when(pluginMetrics.counter(HttpRequestExceptionHandler.REQUESTS_TOO_LARGE)).thenReturn(requestsTooLargeCounter);
+        when(pluginMetrics.counter(HttpRequestExceptionHandler.INTERNAL_SERVER_ERROR)).thenReturn(internalServerErrorCounter);
+
+        grpcRequestExceptionHandler = new GrpcRequestExceptionHandler(pluginMetrics);
+    }
+
+    @Test
+    public void testHandleBadRequestException() {
+        final BadRequestException badRequestExceptionNoMessage = new BadRequestException(null, new IOException());
+        final String exceptionMessage = UUID.randomUUID().toString();
+        final BadRequestException badRequestExceptionWithMessage = new BadRequestException(exceptionMessage, new IOException());
+
+        final Status noMessageStatus = grpcRequestExceptionHandler.apply(requestContext, badRequestExceptionNoMessage, metadata);
+        assertThat(noMessageStatus.getCode(), equalTo(Status.Code.INVALID_ARGUMENT));
+        assertThat(noMessageStatus.getDescription(), equalTo(DEFAULT_MESSAGE));
+
+        final Status messageStatus = grpcRequestExceptionHandler.apply(requestContext, badRequestExceptionWithMessage, metadata);
+        assertThat(messageStatus.getCode(), equalTo(Status.Code.INVALID_ARGUMENT));
+        assertThat(messageStatus.getDescription(), equalTo(exceptionMessage));
+
+        verify(badRequestsCounter, times(2)).increment();
+    }
+
+    @Test
+    public void testHandleTimeoutException() {
+        final BufferWriteException timeoutExceptionNoMessage = new BufferWriteException(null, new TimeoutException());
+        final String exceptionMessage = UUID.randomUUID().toString();
+        final BufferWriteException timeoutExceptionWithMessage = new BufferWriteException(exceptionMessage, new TimeoutException(exceptionMessage));
+
+        final Status noMessageStatus = grpcRequestExceptionHandler.apply(requestContext, timeoutExceptionNoMessage, metadata);
+        assertThat(noMessageStatus.getCode(), equalTo(Status.Code.RESOURCE_EXHAUSTED));
+        assertThat(noMessageStatus.getDescription(), equalTo(DEFAULT_MESSAGE));
+
+        final Status messageStatus = grpcRequestExceptionHandler.apply(requestContext, timeoutExceptionWithMessage, metadata);
+        assertThat(messageStatus.getCode(), equalTo(Status.Code.RESOURCE_EXHAUSTED));
+        assertThat(messageStatus.getDescription(), equalTo(exceptionMessage));
+
+        verify(requestTimeoutsCounter, times(2)).increment();
+    }
+
+    @Test
+    public void testHandleArmeriaTimeoutException() {
+        final RequestTimeoutException timeoutExceptionNoMessage = RequestTimeoutException.get();
+
+        final Status noMessageStatus = grpcRequestExceptionHandler.apply(requestContext, timeoutExceptionNoMessage, metadata);
+        assertThat(noMessageStatus.getCode(), equalTo(Status.Code.RESOURCE_EXHAUSTED));
+        assertThat(noMessageStatus.getDescription(), equalTo(ARMERIA_REQUEST_TIMEOUT_MESSAGE));
+
+        verify(requestTimeoutsCounter, times(1)).increment();
+    }
+
+    @Test
+    public void testHandleSizeOverflowException() {
+        final BufferWriteException sizeOverflowExceptionNoMessage = new BufferWriteException(null, new SizeOverflowException(null));
+        final String exceptionMessage = UUID.randomUUID().toString();
+        final BufferWriteException sizeOverflowExceptionWithMessage = new BufferWriteException(exceptionMessage, new SizeOverflowException(exceptionMessage));
+
+        final Status noMessageStatus = grpcRequestExceptionHandler.apply(requestContext, sizeOverflowExceptionNoMessage, metadata);
+        assertThat(noMessageStatus.getCode(), equalTo(Status.Code.RESOURCE_EXHAUSTED));
+        assertThat(noMessageStatus.getDescription(), equalTo(DEFAULT_MESSAGE));
+
+        final Status messageStatus = grpcRequestExceptionHandler.apply(requestContext, sizeOverflowExceptionWithMessage, metadata);
+        assertThat(messageStatus.getCode(), equalTo(Status.Code.RESOURCE_EXHAUSTED));
+        assertThat(messageStatus.getDescription(), equalTo(exceptionMessage));
+
+        verify(requestsTooLargeCounter, times(2)).increment();
+    }
+
+    @Test
+    public void testHandleRequestCancelledException() {
+        final RequestCancelledException requestCancelledExceptionNoMessage = new RequestCancelledException(null);
+        final String exceptionMessage = UUID.randomUUID().toString();
+        final RequestCancelledException requestCancelledExceptionWithMessage = new RequestCancelledException(exceptionMessage);
+
+        final Status noMessageStatus = grpcRequestExceptionHandler.apply(requestContext, requestCancelledExceptionNoMessage, metadata);
+        assertThat(noMessageStatus.getCode(), equalTo(Status.Code.CANCELLED));
+        assertThat(noMessageStatus.getDescription(), equalTo(DEFAULT_MESSAGE));
+
+        final Status messageStatus = grpcRequestExceptionHandler.apply(requestContext, requestCancelledExceptionWithMessage, metadata);
+        assertThat(messageStatus.getCode(), equalTo(Status.Code.CANCELLED));
+        assertThat(messageStatus.getDescription(), equalTo(exceptionMessage));
+
+        verify(requestTimeoutsCounter, times(2)).increment();
+    }
+
+    @Test
+    public void testHandleInternalServerException() {
+        final RuntimeException runtimeExceptionNoMessage = new RuntimeException();
+        final String exceptionMessage = UUID.randomUUID().toString();
+        final RuntimeException runtimeExceptionWithMessage = new RuntimeException(exceptionMessage);
+
+        final Status noMessageStatus = grpcRequestExceptionHandler.apply(requestContext, runtimeExceptionNoMessage, metadata);
+        assertThat(noMessageStatus.getCode(), equalTo(Status.Code.INTERNAL));
+        assertThat(noMessageStatus.getDescription(), equalTo(DEFAULT_MESSAGE));
+
+        final Status messageStatus = grpcRequestExceptionHandler.apply(requestContext, runtimeExceptionWithMessage, metadata);
+        assertThat(messageStatus.getCode(), equalTo(Status.Code.INTERNAL));
+        assertThat(messageStatus.getDescription(), equalTo(exceptionMessage));
+
+        verify(internalServerErrorCounter, times(2)).increment();
+    }
+}

--- a/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/GrpcRequestExceptionHandlerTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/GrpcRequestExceptionHandlerTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.GrpcRequestExceptionHandler.ARMERIA_REQUEST_TIMEOUT_MESSAGE;
-import static org.opensearch.dataprepper.GrpcRequestExceptionHandler.DEFAULT_MESSAGE;
 
 @ExtendWith(MockitoExtension.class)
 public class GrpcRequestExceptionHandlerTest {
@@ -76,7 +75,7 @@ public class GrpcRequestExceptionHandlerTest {
 
         final Status noMessageStatus = grpcRequestExceptionHandler.apply(requestContext, badRequestExceptionNoMessage, metadata);
         assertThat(noMessageStatus.getCode(), equalTo(Status.Code.INVALID_ARGUMENT));
-        assertThat(noMessageStatus.getDescription(), equalTo(DEFAULT_MESSAGE));
+        assertThat(noMessageStatus.getDescription(), equalTo(Status.Code.INVALID_ARGUMENT.name()));
 
         final Status messageStatus = grpcRequestExceptionHandler.apply(requestContext, badRequestExceptionWithMessage, metadata);
         assertThat(messageStatus.getCode(), equalTo(Status.Code.INVALID_ARGUMENT));
@@ -93,7 +92,7 @@ public class GrpcRequestExceptionHandlerTest {
 
         final Status noMessageStatus = grpcRequestExceptionHandler.apply(requestContext, timeoutExceptionNoMessage, metadata);
         assertThat(noMessageStatus.getCode(), equalTo(Status.Code.RESOURCE_EXHAUSTED));
-        assertThat(noMessageStatus.getDescription(), equalTo(DEFAULT_MESSAGE));
+        assertThat(noMessageStatus.getDescription(), equalTo(Status.Code.RESOURCE_EXHAUSTED.name()));
 
         final Status messageStatus = grpcRequestExceptionHandler.apply(requestContext, timeoutExceptionWithMessage, metadata);
         assertThat(messageStatus.getCode(), equalTo(Status.Code.RESOURCE_EXHAUSTED));
@@ -121,7 +120,7 @@ public class GrpcRequestExceptionHandlerTest {
 
         final Status noMessageStatus = grpcRequestExceptionHandler.apply(requestContext, sizeOverflowExceptionNoMessage, metadata);
         assertThat(noMessageStatus.getCode(), equalTo(Status.Code.RESOURCE_EXHAUSTED));
-        assertThat(noMessageStatus.getDescription(), equalTo(DEFAULT_MESSAGE));
+        assertThat(noMessageStatus.getDescription(), equalTo(Status.Code.RESOURCE_EXHAUSTED.name()));
 
         final Status messageStatus = grpcRequestExceptionHandler.apply(requestContext, sizeOverflowExceptionWithMessage, metadata);
         assertThat(messageStatus.getCode(), equalTo(Status.Code.RESOURCE_EXHAUSTED));
@@ -138,7 +137,7 @@ public class GrpcRequestExceptionHandlerTest {
 
         final Status noMessageStatus = grpcRequestExceptionHandler.apply(requestContext, requestCancelledExceptionNoMessage, metadata);
         assertThat(noMessageStatus.getCode(), equalTo(Status.Code.CANCELLED));
-        assertThat(noMessageStatus.getDescription(), equalTo(DEFAULT_MESSAGE));
+        assertThat(noMessageStatus.getDescription(), equalTo(Status.Code.CANCELLED.name()));
 
         final Status messageStatus = grpcRequestExceptionHandler.apply(requestContext, requestCancelledExceptionWithMessage, metadata);
         assertThat(messageStatus.getCode(), equalTo(Status.Code.CANCELLED));
@@ -155,7 +154,7 @@ public class GrpcRequestExceptionHandlerTest {
 
         final Status noMessageStatus = grpcRequestExceptionHandler.apply(requestContext, runtimeExceptionNoMessage, metadata);
         assertThat(noMessageStatus.getCode(), equalTo(Status.Code.INTERNAL));
-        assertThat(noMessageStatus.getDescription(), equalTo(DEFAULT_MESSAGE));
+        assertThat(noMessageStatus.getDescription(), equalTo(Status.Code.INTERNAL.name()));
 
         final Status messageStatus = grpcRequestExceptionHandler.apply(requestContext, runtimeExceptionWithMessage, metadata);
         assertThat(messageStatus.getCode(), equalTo(Status.Code.INTERNAL));

--- a/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/HttpRequestExceptionHandlerTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/HttpRequestExceptionHandlerTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugins.source.loghttp;
+package org.opensearch.dataprepper;
 
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class RequestExceptionHandlerTest {
+class HttpRequestExceptionHandlerTest {
     @Mock
     private PluginMetrics pluginMetrics;
 
@@ -43,16 +43,16 @@ class RequestExceptionHandlerTest {
     @Mock
     private Counter internalServerErrorCounter;
 
-    private RequestExceptionHandler requestExceptionHandler;
+    private HttpRequestExceptionHandler httpRequestExceptionHandler;
 
     @BeforeEach
     public void setUp() {
-        when(pluginMetrics.counter(RequestExceptionHandler.REQUEST_TIMEOUTS)).thenReturn(requestTimeoutsCounter);
-        when(pluginMetrics.counter(RequestExceptionHandler.BAD_REQUESTS)).thenReturn(badRequestsCounter);
-        when(pluginMetrics.counter(RequestExceptionHandler.REQUESTS_TOO_LARGE)).thenReturn(requestsTooLargeCounter);
-        when(pluginMetrics.counter(RequestExceptionHandler.INTERNAL_SERVER_ERROR)).thenReturn(internalServerErrorCounter);
+        when(pluginMetrics.counter(HttpRequestExceptionHandler.REQUEST_TIMEOUTS)).thenReturn(requestTimeoutsCounter);
+        when(pluginMetrics.counter(HttpRequestExceptionHandler.BAD_REQUESTS)).thenReturn(badRequestsCounter);
+        when(pluginMetrics.counter(HttpRequestExceptionHandler.REQUESTS_TOO_LARGE)).thenReturn(requestsTooLargeCounter);
+        when(pluginMetrics.counter(HttpRequestExceptionHandler.INTERNAL_SERVER_ERROR)).thenReturn(internalServerErrorCounter);
 
-        requestExceptionHandler = new RequestExceptionHandler(pluginMetrics);
+        httpRequestExceptionHandler = new HttpRequestExceptionHandler(pluginMetrics);
     }
 
     @Test
@@ -63,14 +63,14 @@ class RequestExceptionHandlerTest {
         final IOException testExceptionWithMessage = new IOException(testMessage);
 
         // When
-        HttpResponse httpResponse = requestExceptionHandler.handleException(testExceptionNullMessage);
+        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(testExceptionNullMessage);
 
         // Then
         AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
         assertEquals(HttpStatus.BAD_REQUEST, aggregatedHttpResponse.status());
 
         // When
-        httpResponse = requestExceptionHandler.handleException(testExceptionWithMessage);
+        httpResponse = httpRequestExceptionHandler.handleException(testExceptionWithMessage);
 
         // Then
         aggregatedHttpResponse = httpResponse.aggregate().get();
@@ -78,7 +78,7 @@ class RequestExceptionHandlerTest {
         assertEquals(testMessage, aggregatedHttpResponse.contentUtf8());
 
         // When
-        httpResponse = requestExceptionHandler.handleException(testExceptionNullMessage, testMessage);
+        httpResponse = httpRequestExceptionHandler.handleException(testExceptionNullMessage, testMessage);
 
         // Then
         aggregatedHttpResponse = httpResponse.aggregate().get();
@@ -96,14 +96,14 @@ class RequestExceptionHandlerTest {
         final TimeoutException testExceptionWithMessage = new TimeoutException(testMessage);
 
         // When
-        HttpResponse httpResponse = requestExceptionHandler.handleException(testExceptionNullMessage);
+        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(testExceptionNullMessage);
 
         // Then
         AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
         assertEquals(HttpStatus.REQUEST_TIMEOUT, aggregatedHttpResponse.status());
 
         // When
-        httpResponse = requestExceptionHandler.handleException(testExceptionWithMessage);
+        httpResponse = httpRequestExceptionHandler.handleException(testExceptionWithMessage);
 
         // Then
         aggregatedHttpResponse = httpResponse.aggregate().get();
@@ -111,7 +111,7 @@ class RequestExceptionHandlerTest {
         assertEquals(testMessage, aggregatedHttpResponse.contentUtf8());
 
         // When
-        httpResponse = requestExceptionHandler.handleException(testExceptionNullMessage, testMessage);
+        httpResponse = httpRequestExceptionHandler.handleException(testExceptionNullMessage, testMessage);
 
         // Then
         aggregatedHttpResponse = httpResponse.aggregate().get();
@@ -129,14 +129,14 @@ class RequestExceptionHandlerTest {
         final SizeOverflowException testExceptionWithMessage = new SizeOverflowException(testMessage);
 
         // When
-        HttpResponse httpResponse = requestExceptionHandler.handleException(testExceptionEmptyMessage);
+        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(testExceptionEmptyMessage);
 
         // Then
         AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
         assertEquals(HttpStatus.REQUEST_ENTITY_TOO_LARGE, aggregatedHttpResponse.status());
 
         // When
-        httpResponse = requestExceptionHandler.handleException(testExceptionWithMessage);
+        httpResponse = httpRequestExceptionHandler.handleException(testExceptionWithMessage);
 
         // Then
         aggregatedHttpResponse = httpResponse.aggregate().get();
@@ -144,7 +144,7 @@ class RequestExceptionHandlerTest {
         assertEquals(testMessage, aggregatedHttpResponse.contentUtf8());
 
         // When
-        httpResponse = requestExceptionHandler.handleException(testExceptionEmptyMessage, testMessage);
+        httpResponse = httpRequestExceptionHandler.handleException(testExceptionEmptyMessage, testMessage);
 
         // Then
         aggregatedHttpResponse = httpResponse.aggregate().get();
@@ -162,14 +162,14 @@ class RequestExceptionHandlerTest {
         final UnknownException testExceptionWithMessage = new UnknownException(testMessage);
 
         // When
-        HttpResponse httpResponse = requestExceptionHandler.handleException(testExceptionEmptyMessage);
+        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(testExceptionEmptyMessage);
 
         // Then
         AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, aggregatedHttpResponse.status());
 
         // When
-        httpResponse = requestExceptionHandler.handleException(testExceptionWithMessage);
+        httpResponse = httpRequestExceptionHandler.handleException(testExceptionWithMessage);
 
         // Then
         aggregatedHttpResponse = httpResponse.aggregate().get();
@@ -177,7 +177,7 @@ class RequestExceptionHandlerTest {
         assertEquals(testMessage, aggregatedHttpResponse.contentUtf8());
 
         // When
-        httpResponse = requestExceptionHandler.handleException(testExceptionEmptyMessage, testMessage);
+        httpResponse = httpRequestExceptionHandler.handleException(testExceptionEmptyMessage, testMessage);
 
         // Then
         aggregatedHttpResponse = httpResponse.aggregate().get();

--- a/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/HttpRequestExceptionHandlerTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/HttpRequestExceptionHandlerTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.HttpRequestExceptionHandler.ARMERIA_REQUEST_TIMEOUT_MESSAGE;
-import static org.opensearch.dataprepper.HttpRequestExceptionHandler.DEFAULT_MESSAGE;
 
 @ExtendWith(MockitoExtension.class)
 class HttpRequestExceptionHandlerTest {
@@ -79,7 +78,7 @@ class HttpRequestExceptionHandlerTest {
         // Then
         AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
         assertEquals(HttpStatus.BAD_REQUEST, aggregatedHttpResponse.status());
-        assertEquals(DEFAULT_MESSAGE, aggregatedHttpResponse.contentUtf8());
+        assertEquals(HttpStatus.BAD_REQUEST.reasonPhrase(), aggregatedHttpResponse.contentUtf8());
 
         // When
         httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionWithMessage);
@@ -106,7 +105,7 @@ class HttpRequestExceptionHandlerTest {
         // Then
         AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
         assertEquals(HttpStatus.REQUEST_TIMEOUT, aggregatedHttpResponse.status());
-        assertEquals(DEFAULT_MESSAGE, aggregatedHttpResponse.contentUtf8());
+        assertEquals(HttpStatus.REQUEST_TIMEOUT.reasonPhrase(), aggregatedHttpResponse.contentUtf8());
 
         // When
         httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionWithMessage);
@@ -140,17 +139,17 @@ class HttpRequestExceptionHandlerTest {
     @Test
     public void testHandleSizeOverflowException() throws ExecutionException, InterruptedException {
         // Prepare
-        final SizeOverflowException testExceptionEmptyMessage = new SizeOverflowException("");
+        final SizeOverflowException testExceptionNoMessage = new SizeOverflowException(null);
         final String testMessage = "test exception message";
         final SizeOverflowException testExceptionWithMessage = new SizeOverflowException(testMessage);
 
         // When
-        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionEmptyMessage);
+        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionNoMessage);
 
         // Then
         AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
         assertEquals(HttpStatus.REQUEST_ENTITY_TOO_LARGE, aggregatedHttpResponse.status());
-        assertEquals(DEFAULT_MESSAGE, aggregatedHttpResponse.contentUtf8());
+        assertEquals(HttpStatus.REQUEST_ENTITY_TOO_LARGE.reasonPhrase(), aggregatedHttpResponse.contentUtf8());
 
         // When
         httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionWithMessage);
@@ -167,17 +166,17 @@ class HttpRequestExceptionHandlerTest {
     @Test
     public void testHandleUnknownException() throws ExecutionException, InterruptedException {
         // Prepare
-        final UnknownException testExceptionEmptyMessage = new UnknownException("");
+        final UnknownException testExceptionNoMessage = new UnknownException(null);
         final String testMessage = "test exception message";
         final UnknownException testExceptionWithMessage = new UnknownException(testMessage);
 
         // When
-        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionEmptyMessage);
+        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionNoMessage);
 
         // Then
         AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, aggregatedHttpResponse.status());
-        assertEquals(DEFAULT_MESSAGE, aggregatedHttpResponse.contentUtf8());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.reasonPhrase(), aggregatedHttpResponse.contentUtf8());
 
         // When
         httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionWithMessage);

--- a/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/HttpRequestExceptionHandlerTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/HttpRequestExceptionHandlerTest.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper;
 
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.server.ServiceRequestContext;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -43,6 +45,12 @@ class HttpRequestExceptionHandlerTest {
     @Mock
     private Counter internalServerErrorCounter;
 
+    @Mock
+    private ServiceRequestContext serviceRequestContext;
+
+    @Mock
+    private HttpRequest httpRequest;
+
     private HttpRequestExceptionHandler httpRequestExceptionHandler;
 
     @BeforeEach
@@ -63,14 +71,14 @@ class HttpRequestExceptionHandlerTest {
         final IOException testExceptionWithMessage = new IOException(testMessage);
 
         // When
-        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(testExceptionNullMessage);
+        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionNullMessage);
 
         // Then
         AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
         assertEquals(HttpStatus.BAD_REQUEST, aggregatedHttpResponse.status());
 
         // When
-        httpResponse = httpRequestExceptionHandler.handleException(testExceptionWithMessage);
+        httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionWithMessage);
 
         // Then
         aggregatedHttpResponse = httpResponse.aggregate().get();
@@ -96,14 +104,14 @@ class HttpRequestExceptionHandlerTest {
         final TimeoutException testExceptionWithMessage = new TimeoutException(testMessage);
 
         // When
-        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(testExceptionNullMessage);
+        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionNullMessage);
 
         // Then
         AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
         assertEquals(HttpStatus.REQUEST_TIMEOUT, aggregatedHttpResponse.status());
 
         // When
-        httpResponse = httpRequestExceptionHandler.handleException(testExceptionWithMessage);
+        httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionWithMessage);
 
         // Then
         aggregatedHttpResponse = httpResponse.aggregate().get();
@@ -129,14 +137,14 @@ class HttpRequestExceptionHandlerTest {
         final SizeOverflowException testExceptionWithMessage = new SizeOverflowException(testMessage);
 
         // When
-        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(testExceptionEmptyMessage);
+        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionEmptyMessage);
 
         // Then
         AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
         assertEquals(HttpStatus.REQUEST_ENTITY_TOO_LARGE, aggregatedHttpResponse.status());
 
         // When
-        httpResponse = httpRequestExceptionHandler.handleException(testExceptionWithMessage);
+        httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionWithMessage);
 
         // Then
         aggregatedHttpResponse = httpResponse.aggregate().get();
@@ -162,14 +170,14 @@ class HttpRequestExceptionHandlerTest {
         final UnknownException testExceptionWithMessage = new UnknownException(testMessage);
 
         // When
-        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(testExceptionEmptyMessage);
+        HttpResponse httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionEmptyMessage);
 
         // Then
         AggregatedHttpResponse aggregatedHttpResponse = httpResponse.aggregate().get();
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, aggregatedHttpResponse.status());
 
         // When
-        httpResponse = httpRequestExceptionHandler.handleException(testExceptionWithMessage);
+        httpResponse = httpRequestExceptionHandler.handleException(serviceRequestContext, httpRequest, testExceptionWithMessage);
 
         // Then
         aggregatedHttpResponse = httpResponse.aggregate().get();

--- a/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.loghttp;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
+import org.opensearch.dataprepper.HttpRequestExceptionHandler;
 import org.opensearch.dataprepper.metrics.MetricNames;
 import org.opensearch.dataprepper.metrics.MetricsTestUtil;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -146,13 +147,13 @@ class HTTPSourceTest {
                         .add(LogHTTPService.SUCCESS_REQUESTS).toString());
         requestTimeoutsMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(metricNamePrefix)
-                        .add(RequestExceptionHandler.REQUEST_TIMEOUTS).toString());
+                        .add(HttpRequestExceptionHandler.REQUEST_TIMEOUTS).toString());
         badRequestsMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(metricNamePrefix)
-                        .add(RequestExceptionHandler.BAD_REQUESTS).toString());
+                        .add(HttpRequestExceptionHandler.BAD_REQUESTS).toString());
         requestsTooLargeMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(metricNamePrefix)
-                        .add(RequestExceptionHandler.REQUESTS_TOO_LARGE).toString());
+                        .add(HttpRequestExceptionHandler.REQUESTS_TOO_LARGE).toString());
         rejectedRequestsMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(metricNamePrefix)
                         .add(LogThrottlingRejectHandler.REQUESTS_REJECTED).toString());

--- a/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPServiceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPServiceTest.java
@@ -5,9 +5,10 @@
 
 package org.opensearch.dataprepper.plugins.source.loghttp;
 
-import org.opensearch.dataprepper.HttpRequestExceptionHandler;
+import com.linecorp.armeria.server.ServiceRequestContext;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
 import org.opensearch.dataprepper.model.log.Log;
 import org.opensearch.dataprepper.model.record.Record;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -34,15 +35,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 import org.opensearch.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Supplier;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -61,19 +65,7 @@ class LogHTTPServiceTest {
     private Counter requestsReceivedCounter;
 
     @Mock
-    private Counter requestTimeoutsCounter;
-
-    @Mock
     private Counter successRequestsCounter;
-
-    @Mock
-    private Counter badRequestsCounter;
-
-    @Mock
-    private Counter requestsTooLargeCounter;
-
-    @Mock
-    private Counter internalServerErrorCounter;
 
     @Mock
     private DistributionSummary payloadSizeSummary;
@@ -81,24 +73,24 @@ class LogHTTPServiceTest {
     @Mock
     private Timer requestProcessDuration;
 
+    @Mock
+    private ServiceRequestContext serviceRequestContext;
+
     private LogHTTPService logHTTPService;
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws Exception {
         when(pluginMetrics.counter(LogHTTPService.REQUESTS_RECEIVED)).thenReturn(requestsReceivedCounter);
-        when(pluginMetrics.counter(HttpRequestExceptionHandler.REQUEST_TIMEOUTS)).thenReturn(requestTimeoutsCounter);
         when(pluginMetrics.counter(LogHTTPService.SUCCESS_REQUESTS)).thenReturn(successRequestsCounter);
-        when(pluginMetrics.counter(HttpRequestExceptionHandler.BAD_REQUESTS)).thenReturn(badRequestsCounter);
-        when(pluginMetrics.counter(HttpRequestExceptionHandler.REQUESTS_TOO_LARGE)).thenReturn(requestsTooLargeCounter);
-        when(pluginMetrics.counter(HttpRequestExceptionHandler.INTERNAL_SERVER_ERROR)).thenReturn(internalServerErrorCounter);
         when(pluginMetrics.summary(LogHTTPService.PAYLOAD_SIZE)).thenReturn(payloadSizeSummary);
         when(pluginMetrics.timer(LogHTTPService.REQUEST_PROCESS_DURATION)).thenReturn(requestProcessDuration);
-        when(requestProcessDuration.record(ArgumentMatchers.<Supplier<HttpResponse>>any())).thenAnswer(
+        when(serviceRequestContext.isTimedOut()).thenReturn(false);
+        when(requestProcessDuration.recordCallable(ArgumentMatchers.<Callable<HttpResponse>>any())).thenAnswer(
                 (Answer<HttpResponse>) invocation -> {
                     final Object[] args = invocation.getArguments();
                     @SuppressWarnings("unchecked")
-                    final Supplier<HttpResponse> supplier = (Supplier<HttpResponse>) args[0];
-                    return supplier.get();
+                    final Callable<HttpResponse> callable = (Callable<HttpResponse>) args[0];
+                    return callable.call();
                 }
         );
 
@@ -107,90 +99,75 @@ class LogHTTPServiceTest {
     }
 
     @Test
-    public void testHTTPRequestSuccess() throws InterruptedException, ExecutionException, JsonProcessingException {
+    public void testHTTPRequestSuccess() throws Exception {
         // Prepare
         AggregatedHttpRequest testRequest = generateRandomValidHTTPRequest(2);
 
         // When
-        AggregatedHttpResponse postResponse = logHTTPService.doPost(testRequest).aggregate().get();
+        AggregatedHttpResponse postResponse = logHTTPService.doPost(serviceRequestContext, testRequest).aggregate().get();
 
         // Then
         assertEquals(HttpStatus.OK, postResponse.status());
         verify(requestsReceivedCounter, times(1)).increment();
-        verify(requestTimeoutsCounter, never()).increment();
         verify(successRequestsCounter, times(1)).increment();
-        verify(badRequestsCounter, never()).increment();
-        verify(requestsTooLargeCounter, never()).increment();
         final ArgumentCaptor<Double> payloadLengthCaptor = ArgumentCaptor.forClass(Double.class);
         verify(payloadSizeSummary, times(1)).record(payloadLengthCaptor.capture());
         assertEquals(testRequest.content().length(), Math.round(payloadLengthCaptor.getValue()));
-        verify(requestProcessDuration, times(1)).record(ArgumentMatchers.<Supplier<HttpResponse>>any());
+        verify(requestProcessDuration, times(1)).recordCallable(ArgumentMatchers.<Callable<HttpResponse>>any());
     }
 
     @Test
-    public void testHTTPRequestBadRequest() throws ExecutionException, InterruptedException {
+    public void testHTTPRequestBadRequest() throws Exception {
         // Prepare
         AggregatedHttpRequest testBadRequest = generateBadHTTPRequest();
 
         // When
-        AggregatedHttpResponse postResponse = logHTTPService.doPost(testBadRequest).aggregate().get();
+        assertThrows(IOException.class, () -> logHTTPService.doPost(serviceRequestContext, testBadRequest).aggregate().get());
 
         // Then
-        assertEquals(HttpStatus.BAD_REQUEST, postResponse.status());
         verify(requestsReceivedCounter, times(1)).increment();
-        verify(requestTimeoutsCounter, never()).increment();
         verify(successRequestsCounter, never()).increment();
-        verify(badRequestsCounter, times(1)).increment();
-        verify(requestsTooLargeCounter, never()).increment();
         final ArgumentCaptor<Double> payloadLengthCaptor = ArgumentCaptor.forClass(Double.class);
         verify(payloadSizeSummary, times(1)).record(payloadLengthCaptor.capture());
         assertEquals(testBadRequest.content().length(), Math.round(payloadLengthCaptor.getValue()));
-        verify(requestProcessDuration, times(1)).record(ArgumentMatchers.<Supplier<HttpResponse>>any());
+        verify(requestProcessDuration, times(1)).recordCallable(ArgumentMatchers.<Callable<HttpResponse>>any());
     }
 
     @Test
-    public void testHTTPRequestEntityTooLarge() throws ExecutionException, InterruptedException, JsonProcessingException {
+    public void testHTTPRequestEntityTooLarge() throws Exception {
         // Prepare
         AggregatedHttpRequest testTooLargeRequest = generateRandomValidHTTPRequest(TEST_BUFFER_CAPACITY + 1);
 
         // When
-        AggregatedHttpResponse postResponse = logHTTPService.doPost(testTooLargeRequest).aggregate().get();
+        assertThrows(SizeOverflowException.class, () -> logHTTPService.doPost(serviceRequestContext, testTooLargeRequest).aggregate().get());
 
         // Then
-        assertEquals(HttpStatus.REQUEST_ENTITY_TOO_LARGE, postResponse.status());
         verify(requestsReceivedCounter, times(1)).increment();
-        verify(requestTimeoutsCounter, never()).increment();
         verify(successRequestsCounter, never()).increment();
-        verify(badRequestsCounter, never()).increment();
-        verify(requestsTooLargeCounter, times(1)).increment();
         final ArgumentCaptor<Double> payloadLengthCaptor = ArgumentCaptor.forClass(Double.class);
         verify(payloadSizeSummary, times(1)).record(payloadLengthCaptor.capture());
         assertEquals(testTooLargeRequest.content().length(), Math.round(payloadLengthCaptor.getValue()));
-        verify(requestProcessDuration, times(1)).record(ArgumentMatchers.<Supplier<HttpResponse>>any());
+        verify(requestProcessDuration, times(1)).recordCallable(ArgumentMatchers.<Callable<HttpResponse>>any());
     }
 
     @Test
-    public void testHTTPRequestTimeout() throws InterruptedException, ExecutionException, JsonProcessingException {
+    public void testHTTPRequestTimeout() throws Exception {
         // Prepare
         AggregatedHttpRequest populateDataRequest = generateRandomValidHTTPRequest(3);
-        AggregatedHttpResponse goodResponse = logHTTPService.doPost(populateDataRequest).aggregate().get();
+        AggregatedHttpResponse goodResponse = logHTTPService.doPost(serviceRequestContext, populateDataRequest).aggregate().get();
         assertEquals(HttpStatus.OK, goodResponse.status());
         AggregatedHttpRequest timeoutRequest = generateRandomValidHTTPRequest(2);
 
         // When
-        AggregatedHttpResponse timeoutPostResponse = logHTTPService.doPost(timeoutRequest).aggregate().get();
+        assertThrows(TimeoutException.class, () -> logHTTPService.doPost(serviceRequestContext, timeoutRequest).aggregate().get());
 
         // Then
-        assertEquals(HttpStatus.REQUEST_TIMEOUT, timeoutPostResponse.status());
         verify(requestsReceivedCounter, times(2)).increment();
-        verify(requestTimeoutsCounter, times(1)).increment();
         verify(successRequestsCounter, times(1)).increment();
-        verify(badRequestsCounter, never()).increment();
-        verify(requestsTooLargeCounter, never()).increment();
         final ArgumentCaptor<Double> payloadLengthCaptor = ArgumentCaptor.forClass(Double.class);
         verify(payloadSizeSummary, times(2)).record(payloadLengthCaptor.capture());
         assertEquals(timeoutRequest.content().length(), Math.round(payloadLengthCaptor.getValue()));
-        verify(requestProcessDuration, times(2)).record(ArgumentMatchers.<Supplier<HttpResponse>>any());
+        verify(requestProcessDuration, times(2)).recordCallable(ArgumentMatchers.<Callable<HttpResponse>>any());
     }
 
     private AggregatedHttpRequest generateRandomValidHTTPRequest(int numJson) throws JsonProcessingException,

--- a/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPServiceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPServiceTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.loghttp;
 
+import org.opensearch.dataprepper.HttpRequestExceptionHandler;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.log.Log;
@@ -85,11 +86,11 @@ class LogHTTPServiceTest {
     @BeforeEach
     public void setUp() {
         when(pluginMetrics.counter(LogHTTPService.REQUESTS_RECEIVED)).thenReturn(requestsReceivedCounter);
-        when(pluginMetrics.counter(RequestExceptionHandler.REQUEST_TIMEOUTS)).thenReturn(requestTimeoutsCounter);
+        when(pluginMetrics.counter(HttpRequestExceptionHandler.REQUEST_TIMEOUTS)).thenReturn(requestTimeoutsCounter);
         when(pluginMetrics.counter(LogHTTPService.SUCCESS_REQUESTS)).thenReturn(successRequestsCounter);
-        when(pluginMetrics.counter(RequestExceptionHandler.BAD_REQUESTS)).thenReturn(badRequestsCounter);
-        when(pluginMetrics.counter(RequestExceptionHandler.REQUESTS_TOO_LARGE)).thenReturn(requestsTooLargeCounter);
-        when(pluginMetrics.counter(RequestExceptionHandler.INTERNAL_SERVER_ERROR)).thenReturn(internalServerErrorCounter);
+        when(pluginMetrics.counter(HttpRequestExceptionHandler.BAD_REQUESTS)).thenReturn(badRequestsCounter);
+        when(pluginMetrics.counter(HttpRequestExceptionHandler.REQUESTS_TOO_LARGE)).thenReturn(requestsTooLargeCounter);
+        when(pluginMetrics.counter(HttpRequestExceptionHandler.INTERNAL_SERVER_ERROR)).thenReturn(internalServerErrorCounter);
         when(pluginMetrics.summary(LogHTTPService.PAYLOAD_SIZE)).thenReturn(payloadSizeSummary);
         when(pluginMetrics.timer(LogHTTPService.REQUEST_PROCESS_DURATION)).thenReturn(requestProcessDuration);
         when(requestProcessDuration.record(ArgumentMatchers.<Supplier<HttpResponse>>any())).thenAnswer(

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
@@ -66,8 +66,6 @@ public class OTelLogsGrpcService extends LogsServiceGrpc.LogsServiceImplBase {
 
     @Override
     public void export(ExportLogsServiceRequest request, StreamObserver<ExportLogsServiceResponse> responseObserver) {
-        LOG.error("Got here");
-
         requestsReceivedCounter.increment();
         payloadSizeSummary.record(request.getSerializedSize());
 
@@ -94,7 +92,6 @@ public class OTelLogsGrpcService extends LogsServiceGrpc.LogsServiceImplBase {
 
         final List<Record<Object>> records = logs.stream().map(log -> new Record<Object>(log)).collect(Collectors.toList());
         try {
-            LOG.error("Got here with records: {}", records);
             buffer.writeAll(records, bufferWriteTimeoutInMillis);
         } catch (Exception e) {
             if (ServiceRequestContext.current().isTimedOut()) {

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
@@ -7,7 +7,6 @@ package org.opensearch.dataprepper.plugins.source.otellogs;
 
 import com.linecorp.armeria.server.ServiceRequestContext;
 import io.grpc.Context;
-import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
@@ -15,13 +14,11 @@ import io.micrometer.core.instrument.Timer;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse;
 import io.opentelemetry.proto.collector.logs.v1.LogsServiceGrpc;
-import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import org.opensearch.dataprepper.exceptions.BadRequestException;
 import org.opensearch.dataprepper.exceptions.BufferWriteException;
 import org.opensearch.dataprepper.exceptions.RequestCancelledException;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
-import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
 import org.opensearch.dataprepper.model.log.OpenTelemetryLog;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCodec;
@@ -29,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 public class OTelLogsGrpcService extends LogsServiceGrpc.LogsServiceImplBase {

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.otellogs;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.grpc.GrpcStatusFunction;
 import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import org.opensearch.dataprepper.plugins.health.HealthGrpcService;
 import org.opensearch.dataprepper.plugins.source.otellogs.certificate.CertificateProviderFactory;
@@ -474,6 +475,7 @@ class OTelLogsSourceTest {
             grpcServerMock.when(GrpcService::builder).thenReturn(grpcServiceBuilder);
             when(grpcServiceBuilder.addService(any(ServerServiceDefinition.class))).thenReturn(grpcServiceBuilder);
             when(grpcServiceBuilder.useClientTimeoutHeader(anyBoolean())).thenReturn(grpcServiceBuilder);
+            when(grpcServiceBuilder.exceptionMapping(any(GrpcStatusFunction.class))).thenReturn(grpcServiceBuilder);
 
             when(server.stop()).thenReturn(completableFuture);
             final Path certFilePath = Path.of("data/certificate/test_cert.crt");
@@ -515,6 +517,7 @@ class OTelLogsSourceTest {
             grpcServerMock.when(GrpcService::builder).thenReturn(grpcServiceBuilder);
             when(grpcServiceBuilder.addService(any(ServerServiceDefinition.class))).thenReturn(grpcServiceBuilder);
             when(grpcServiceBuilder.useClientTimeoutHeader(anyBoolean())).thenReturn(grpcServiceBuilder);
+            when(grpcServiceBuilder.exceptionMapping(any(GrpcStatusFunction.class))).thenReturn(grpcServiceBuilder);
 
             when(server.stop()).thenReturn(completableFuture);
             final Path certFilePath = Path.of("data/certificate/test_cert.crt");

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcService.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcService.java
@@ -7,7 +7,6 @@ package org.opensearch.dataprepper.plugins.source.otelmetrics;
 
 import com.linecorp.armeria.server.ServiceRequestContext;
 import io.grpc.Context;
-import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
@@ -15,7 +14,6 @@ import io.micrometer.core.instrument.Timer;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
 import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
-import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import org.opensearch.dataprepper.exceptions.BufferWriteException;
 import org.opensearch.dataprepper.exceptions.RequestCancelledException;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -23,8 +21,6 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.record.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.TimeoutException;
 
 public class OTelMetricsGrpcService extends MetricsServiceGrpc.MetricsServiceImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(OTelMetricsGrpcService.class);

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcService.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcService.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.otelmetrics;
 
+import com.linecorp.armeria.server.ServiceRequestContext;
 import io.grpc.Context;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
@@ -14,6 +15,9 @@ import io.micrometer.core.instrument.Timer;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
 import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import org.opensearch.dataprepper.exceptions.BufferWriteException;
+import org.opensearch.dataprepper.exceptions.RequestCancelledException;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.record.Record;
@@ -25,7 +29,6 @@ import java.util.concurrent.TimeoutException;
 public class OTelMetricsGrpcService extends MetricsServiceGrpc.MetricsServiceImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(OTelMetricsGrpcService.class);
 
-    public static final String REQUEST_TIMEOUTS = "requestTimeouts";
     public static final String REQUESTS_RECEIVED = "requestsReceived";
     public static final String SUCCESS_REQUESTS = "successRequests";
     public static final String PAYLOAD_SIZE = "payloadSize";
@@ -34,7 +37,6 @@ public class OTelMetricsGrpcService extends MetricsServiceGrpc.MetricsServiceImp
     private final int bufferWriteTimeoutInMillis;
     private final Buffer<Record<ExportMetricsServiceRequest>> buffer;
 
-    private final Counter requestTimeoutCounter;
     private final Counter requestsReceivedCounter;
     private final Counter successRequestsCounter;
     private final DistributionSummary payloadSizeSummary;
@@ -47,7 +49,6 @@ public class OTelMetricsGrpcService extends MetricsServiceGrpc.MetricsServiceImp
         this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
         this.buffer = buffer;
 
-        requestTimeoutCounter = pluginMetrics.counter(REQUEST_TIMEOUTS);
         requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED);
         successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS);
         payloadSizeSummary = pluginMetrics.summary(PAYLOAD_SIZE);
@@ -57,30 +58,40 @@ public class OTelMetricsGrpcService extends MetricsServiceGrpc.MetricsServiceImp
 
     @Override
     public void export(final ExportMetricsServiceRequest request, final StreamObserver<ExportMetricsServiceResponse> responseObserver) {
+        requestsReceivedCounter.increment();
+        payloadSizeSummary.record(request.getSerializedSize());
+
+        if (ServiceRequestContext.current().isTimedOut()) {
+            return;
+        }
+
+        if (Context.current().isCancelled()) {
+            throw new RequestCancelledException("Cancelled by client");
+        }
+
         requestProcessDuration.record(() -> processRequest(request, responseObserver));
     }
 
     private void processRequest(final ExportMetricsServiceRequest request, final StreamObserver<ExportMetricsServiceResponse> responseObserver) {
-        requestsReceivedCounter.increment();
-        payloadSizeSummary.record(request.getSerializedSize());
+        try {
+            buffer.write(new Record<>(request), bufferWriteTimeoutInMillis);
+        } catch (Exception e) {
+            if (ServiceRequestContext.current().isTimedOut()) {
+                LOG.warn("Exception writing to buffer but request already timed out.", e);
+                return;
+            }
 
-        if (Context.current().isCancelled()) {
-            requestTimeoutCounter.increment();
-            responseObserver.onError(Status.CANCELLED.withDescription("Cancelled by client").asRuntimeException());
+            LOG.error("Failed to write the request of size {} due to:", request.toString().length(), e);
+            throw new BufferWriteException(e.getMessage(), e);
+        }
+
+        if (ServiceRequestContext.current().isTimedOut()) {
+            LOG.warn("Buffer write completed successfully but request already timed out.");
             return;
         }
 
-        try {
-            buffer.write(new Record<>(request), bufferWriteTimeoutInMillis);
-            successRequestsCounter.increment();
-            responseObserver.onNext(ExportMetricsServiceResponse.newBuilder().build());
-            responseObserver.onCompleted();
-        } catch (TimeoutException e) {
-            LOG.error("Buffer is full, unable to write");
-            requestTimeoutCounter.increment();
-            responseObserver
-                    .onError(Status.RESOURCE_EXHAUSTED.withDescription("Buffer is full, request timed out.")
-                            .asException());
-        }
+        successRequestsCounter.increment();
+        responseObserver.onNext(ExportMetricsServiceResponse.newBuilder().build());
+        responseObserver.onCompleted();
     }
 }

--- a/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceTest.java
+++ b/data-prepper-plugins/otel-metrics-source/src/test/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceTest.java
@@ -20,6 +20,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.grpc.GrpcStatusFunction;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
@@ -183,6 +184,7 @@ class OTelMetricsSourceTest {
         lenient().when(grpcServiceBuilder.addService(any(BindableService.class))).thenReturn(grpcServiceBuilder);
         lenient().when(grpcServiceBuilder.useClientTimeoutHeader(anyBoolean())).thenReturn(grpcServiceBuilder);
         lenient().when(grpcServiceBuilder.useBlockingTaskExecutor(anyBoolean())).thenReturn(grpcServiceBuilder);
+        lenient().when(grpcServiceBuilder.exceptionMapping(any(GrpcStatusFunction.class))).thenReturn(grpcServiceBuilder);
         lenient().when(grpcServiceBuilder.build()).thenReturn(grpcService);
         pluginMetrics = PluginMetrics.fromNames("otel_metrics", "pipeline");
 
@@ -978,7 +980,7 @@ class OTelMetricsSourceTest {
         public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
             return Stream.of(
                     arguments(TimeoutException.class, Status.Code.RESOURCE_EXHAUSTED),
-                    arguments(RuntimeException.class, Status.Code.UNKNOWN)
+                    arguments(RuntimeException.class, Status.Code.INTERNAL)
             );
         }
     }

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -20,6 +20,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.grpc.GrpcStatusFunction;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -196,6 +197,7 @@ class OTelTraceSourceTest {
         lenient().when(grpcServiceBuilder.addService(any(BindableService.class))).thenReturn(grpcServiceBuilder);
         lenient().when(grpcServiceBuilder.useClientTimeoutHeader(anyBoolean())).thenReturn(grpcServiceBuilder);
         lenient().when(grpcServiceBuilder.useBlockingTaskExecutor(anyBoolean())).thenReturn(grpcServiceBuilder);
+        lenient().when(grpcServiceBuilder.exceptionMapping(any(GrpcStatusFunction.class))).thenReturn(grpcServiceBuilder);
         lenient().when(grpcServiceBuilder.build()).thenReturn(grpcService);
 
         lenient().when(authenticationProvider.getHttpAuthenticationService()).thenCallRealMethod();


### PR DESCRIPTION
When a request hits an Armeria server and cannot be processed within the request_timeout, a RequestTimeoutException occurs. Currently this case returns a 503 to the client. This PR fixes that by adding a custom exception handler to the push-based sources that properly handles RequestTimeoutExceptions.

As part of this work, I stumbled upon a couple other issues/quirks of the Armeria servers
* Requests that are queued in the backend service's BlockingTaskExecutor will still be executed even if the request has already timed out. This adds unnecessary load to the pipeline by trying to process requests that have already returned a 503 (now 408/429 depending on http vs grpc) to the client. Added a check that a request is not timed out before attempting to process it.
* The HTTP source gives 80% of the request_timeout to write to the buffer. This makes sense as there is additional work necessary after the write finishes that needs to complete before returning a 200 back to the client. The OTEL sources did not follow this pattern and instead gave 100% of the request_timeout to write to the buffer. Adjusted this to be 80% to align with HTTP source. I also noticed that the Armeria requests don't timeout exactly at the request_timeout so there's no apparent benefit in terms of unnecessary work reduction by having the buffer write timeout and request_timeout match as requests that will timeout still get picked up.
* The OTEL sources have nearly identical exception handling and metric emission. Pulled that out into a central class for code reuse
 
### Check List
- [x] New functionality includes testing.
- [N/A] New functionality has been documented.
  - [N/A] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
