### PR TITLE
ENH: support index template for serverless

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -216,7 +216,7 @@ With the `document_root_key` set to `status`. The document structure would be `{
 * `region` (Optional) : The AWS region to use for credentials. Defaults to [standard SDK behavior to determine the region](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html).
 * `sts_role_arn` (Optional) : The STS role to assume for requests to AWS. Defaults to null, which will use the [standard SDK behavior for credentials](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html).
 * `sts_header_overrides` (Optional): A map of header overrides to make when assuming the IAM role for the sink plugin.
-* `serverless` (Optional): A boolean flag to indicate the OpenSearch backend is Amazon OpenSearch Serverless. Default to `false`.
+* `serverless` (Optional): A boolean flag to indicate the OpenSearch backend is Amazon OpenSearch Serverless. Default to `false`. Notice that [ISM policies.](https://opensearch.org/docs/latest/im-plugin/ism/policies/) is not supported in Amazon OpenSearch Serverless and thus any ISM related configuration value has no effect, i.e. `ism_policy_file`. 
 
 ## Metrics
 ### Management Disabled Index Type

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/AbstractIndexManager.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/AbstractIndexManager.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.sink.opensearch.index;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
+import org.apache.http.HttpStatus;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
@@ -39,6 +40,7 @@ public abstract class AbstractIndexManager implements IndexManager {
             = "Invalid alias name [%s], an index exists with the same name as the alias";
     public static final String INVALID_INDEX_ALIAS_ERROR
             = "invalid_index_name_exception";
+    static final Set<Integer> NON_RETRYABLE_HTTP_STATUS = Set.of(HttpStatus.SC_NOT_FOUND, HttpStatus.SC_BAD_REQUEST);
     private static final String TIME_PATTERN_STARTING_SYMBOLS = "%{";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     protected RestHighLevelClient restHighLevelClient;
@@ -178,9 +180,16 @@ public abstract class AbstractIndexManager implements IndexManager {
         final GetClusterSettingsRequest request = new GetClusterSettingsRequest.Builder()
                 .includeDefaults(true)
                 .build();
-        final GetClusterSettingsResponse response = openSearchClient.cluster().getSettings(request);
-        final String enabled = getISMEnabled(response);
-        return enabled != null && enabled.equals("true");
+        try {
+            final GetClusterSettingsResponse response = openSearchClient.cluster().getSettings(request);
+            final String enabled = getISMEnabled(response);
+            return enabled != null && enabled.equals("true");
+        } catch (OpenSearchException ex) {
+            if (NON_RETRYABLE_HTTP_STATUS.contains(ex.status())) {
+                return false;
+            }
+            throw ex;
+        }
     }
 
     private String getISMEnabled(final GetClusterSettingsResponse response) {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -57,7 +57,7 @@ public class IndexConfiguration {
     public static final String DOCUMENT_ROOT_KEY = "document_root_key";
 
     private IndexType indexType;
-    private final TemplateType templateType;
+    private TemplateType templateType;
     private final String indexAlias;
     private final Map<String, Object> indexTemplate;
     private final String documentIdField;
@@ -90,7 +90,7 @@ public class IndexConfiguration {
         this.s3AwsExternalId = builder.s3AwsStsExternalId;
         this.s3Client = builder.s3Client;
 
-        this.templateType = builder.templateType != null ? builder.templateType : TemplateType.V1;
+        determineTemplateType(builder);
         this.indexTemplate = readIndexTemplate(builder.templateFile, indexType, templateType);
 
         if (builder.numReplicas > 0) {
@@ -140,6 +140,14 @@ public class IndexConfiguration {
             this.indexType = IndexType.MANAGEMENT_DISABLED;
         } else {
             this.indexType  = IndexType.CUSTOM;
+        }
+    }
+
+    private void determineTemplateType(Builder builder) {
+        if (builder.serverless) {
+            templateType = TemplateType.INDEX_TEMPLATE;
+        } else {
+            templateType = builder.templateType != null ? builder.templateType : TemplateType.V1;
         }
     }
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -365,6 +365,7 @@ public class IndexConfigurationTests {
         final Map<String, Object> metadata = initializeConfigMetaData(
                 null, testIndexAlias, null, null, null, null);
         metadata.put(AWS_OPTION, Map.of(SERVERLESS, true));
+        metadata.put(TEMPLATE_TYPE, TemplateType.V1.getTypeName());
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         assertEquals(IndexType.MANAGEMENT_DISABLED, indexConfiguration.getIndexType());
@@ -377,10 +378,12 @@ public class IndexConfigurationTests {
         final Map<String, Object> metadata = initializeConfigMetaData(
                 IndexType.CUSTOM.getValue(), testIndexAlias, null, null, null, null);
         metadata.put(AWS_OPTION, Map.of(SERVERLESS, true));
+        metadata.put(TEMPLATE_TYPE, TemplateType.V1.getTypeName());
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         assertEquals(IndexType.CUSTOM, indexConfiguration.getIndexType());
         assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
+        assertEquals(TemplateType.INDEX_TEMPLATE, indexConfiguration.getTemplateType());
         assertEquals(true, indexConfiguration.getServerless());
     }
 


### PR DESCRIPTION
### Description
This PR resurrects support for composable index template for opensearch sink serverless ingestion. Thus allowing user to configure `index_type: custom` under `serverless: true`.

Note: Amazon OpenSearch Serverless does not support ISM policy plugin as well as the /_cluster/settings API. Thus the fix on `checkISMEnabled`.
 
### Issues Resolved
#3048 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
