### PR TITLE
Adding cardinality key support for AD processor

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizer.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.plugins.processor.aggregate;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.event.Event;
 import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.plugins.hasher.IdentificationKeysHasher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +50,7 @@ class AggregateActionSynchronizer {
         this.actionConcludeGroupEventsProcessingErrors = pluginMetrics.counter(ACTION_CONCLUDE_GROUP_EVENTS_PROCESSING_ERRORS);
     }
 
-    AggregateActionOutput concludeGroup(final AggregateIdentificationKeysHasher.IdentificationKeysMap hash, final AggregateGroup aggregateGroup, final boolean forceConclude) {
+    AggregateActionOutput concludeGroup(final IdentificationKeysHasher.IdentificationKeysMap hash, final AggregateGroup aggregateGroup, final boolean forceConclude) {
         final Lock concludeGroupLock = aggregateGroup.getConcludeGroupLock();
         final Lock handleEventForGroupLock = aggregateGroup.getHandleEventForGroupLock();
 
@@ -74,7 +75,7 @@ class AggregateActionSynchronizer {
         return actionOutput;
     }
 
-    AggregateActionResponse handleEventForGroup(final Event event, final AggregateIdentificationKeysHasher.IdentificationKeysMap hash, final AggregateGroup aggregateGroup) {
+    AggregateActionResponse handleEventForGroup(final Event event, final IdentificationKeysHasher.IdentificationKeysMap hash, final AggregateGroup aggregateGroup) {
         final Lock concludeGroupLock = aggregateGroup.getConcludeGroupLock();
         final Lock handleEventForGroupLock = aggregateGroup.getHandleEventForGroupLock();
 

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManager.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.processor.aggregate;
 
 import com.google.common.collect.Maps;
+import org.opensearch.dataprepper.plugins.hasher.IdentificationKeysHasher;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -14,20 +15,20 @@ import java.util.Map;
 
 class AggregateGroupManager {
 
-    private final Map<AggregateIdentificationKeysHasher.IdentificationKeysMap, AggregateGroup> allGroups = Maps.newConcurrentMap();
+    private final Map<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup> allGroups = Maps.newConcurrentMap();
     private final Duration groupDuration;
 
     AggregateGroupManager(final Duration groupDuration) {
         this.groupDuration = groupDuration;
     }
 
-    AggregateGroup getAggregateGroup(final AggregateIdentificationKeysHasher.IdentificationKeysMap identificationKeysMap) {
+    AggregateGroup getAggregateGroup(final IdentificationKeysHasher.IdentificationKeysMap identificationKeysMap) {
         return allGroups.computeIfAbsent(identificationKeysMap, (hash) -> new AggregateGroup(identificationKeysMap.getKeyMap()));
     }
 
-    List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>> getGroupsToConclude(final boolean forceConclude) {
-        final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>> groupsToConclude = new ArrayList<>();
-        for (final Map.Entry<AggregateIdentificationKeysHasher.IdentificationKeysMap, AggregateGroup> groupEntry : allGroups.entrySet()) {
+    List<Map.Entry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>> getGroupsToConclude(final boolean forceConclude) {
+        final List<Map.Entry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>> groupsToConclude = new ArrayList<>();
+        for (final Map.Entry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup> groupEntry : allGroups.entrySet()) {
             if (groupEntry.getValue().shouldConcludeGroup(groupDuration) || forceConclude) {
                 groupsToConclude.add(groupEntry);
             }
@@ -35,12 +36,12 @@ class AggregateGroupManager {
         return groupsToConclude;
     }
 
-    void closeGroup(final AggregateIdentificationKeysHasher.IdentificationKeysMap hashKeyMap, final AggregateGroup group) {
+    void closeGroup(final IdentificationKeysHasher.IdentificationKeysMap hashKeyMap, final AggregateGroup group) {
         allGroups.remove(hashKeyMap, group);
         group.resetGroup();
     }
 
-    void putGroupWithHash(final AggregateIdentificationKeysHasher.IdentificationKeysMap hashKeyMap, final AggregateGroup group) {
+    void putGroupWithHash(final IdentificationKeysHasher.IdentificationKeysMap hashKeyMap, final AggregateGroup group) {
         allGroups.put(hashKeyMap, group);
     }
 

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateIdentificationKeysHasher.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateIdentificationKeysHasher.java
@@ -12,13 +12,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-class AggregateIdentificationKeysHasher {
+public class AggregateIdentificationKeysHasher {
     private final List<String> identificationKeys;
-    AggregateIdentificationKeysHasher(final List<String> identificationKeys) {
+    public AggregateIdentificationKeysHasher(final List<String> identificationKeys) {
         this.identificationKeys = identificationKeys;
     }
 
-    IdentificationKeysMap createIdentificationKeysMapFromEvent(final Event event) {
+    public IdentificationKeysMap createIdentificationKeysMapFromEvent(final Event event) {
         final Map<Object, Object> identificationKeysMap = new HashMap<>();
         for (final String identificationKey : identificationKeys) {
             identificationKeysMap.put(identificationKey, event.get(identificationKey, Object.class));

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizerTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateActionSynchronizerTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.opensearch.dataprepper.plugins.hasher.IdentificationKeysHasher;
 
 import java.time.Duration;
 import java.util.List;
@@ -47,7 +48,7 @@ public class AggregateActionSynchronizerTest {
     private AggregateGroup aggregateGroup;
 
     @Mock
-    private AggregateIdentificationKeysHasher.IdentificationKeysMap identificationKeysMap;
+    private IdentificationKeysHasher.IdentificationKeysMap identificationKeysMap;
 
     @Mock
     private AggregateActionResponse aggregateActionResponse;

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateGroupManagerTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.processor.aggregate;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.plugins.hasher.IdentificationKeysHasher;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -28,7 +29,7 @@ public class AggregateGroupManagerTest {
 
     private AggregateGroupManager aggregateGroupManager;
 
-    private AggregateIdentificationKeysHasher.IdentificationKeysMap identificationKeysMap;
+    private IdentificationKeysHasher.IdentificationKeysMap identificationKeysMap;
 
     private static final Duration TEST_GROUP_DURATION = Duration.ofSeconds(new Random().nextInt(10) + 10);
 
@@ -37,7 +38,7 @@ public class AggregateGroupManagerTest {
         final Map<Object, Object> identificationKeysHash = new HashMap<>();
         identificationKeysHash.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
-        identificationKeysMap = new AggregateIdentificationKeysHasher.IdentificationKeysMap(identificationKeysHash);
+        identificationKeysMap = new IdentificationKeysHasher.IdentificationKeysMap(identificationKeysHash);
     }
 
     private AggregateGroupManager createObjectUnderTest() {
@@ -92,16 +93,16 @@ public class AggregateGroupManagerTest {
 
         final AggregateGroup groupToConclude = mock(AggregateGroup.class);
         when(groupToConclude.shouldConcludeGroup(TEST_GROUP_DURATION)).thenReturn(true);
-        final AggregateIdentificationKeysHasher.IdentificationKeysMap hashForGroupToConclude = mock(AggregateIdentificationKeysHasher.IdentificationKeysMap.class);
+        final IdentificationKeysHasher.IdentificationKeysMap hashForGroupToConclude = mock(IdentificationKeysHasher.IdentificationKeysMap.class);
 
         final AggregateGroup groupToNotConclude = mock(AggregateGroup.class);
         when(groupToNotConclude.shouldConcludeGroup(TEST_GROUP_DURATION)).thenReturn(false);
-        final AggregateIdentificationKeysHasher.IdentificationKeysMap hashForGroupToNotConclude = mock(AggregateIdentificationKeysHasher.IdentificationKeysMap.class);
+        final IdentificationKeysHasher.IdentificationKeysMap hashForGroupToNotConclude = mock(IdentificationKeysHasher.IdentificationKeysMap.class);
 
         aggregateGroupManager.putGroupWithHash(hashForGroupToConclude, groupToConclude);
         aggregateGroupManager.putGroupWithHash(hashForGroupToNotConclude, groupToNotConclude);
 
-        final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>> groupsToConclude = aggregateGroupManager.getGroupsToConclude(false);
+        final List<Map.Entry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>> groupsToConclude = aggregateGroupManager.getGroupsToConclude(false);
 
         assertThat(groupsToConclude.size(), equalTo(1));
         assertThat(groupsToConclude.get(0), notNullValue());
@@ -114,15 +115,15 @@ public class AggregateGroupManagerTest {
         aggregateGroupManager = createObjectUnderTest();
 
         final AggregateGroup groupToConclude1 = mock(AggregateGroup.class);
-        final AggregateIdentificationKeysHasher.IdentificationKeysMap hashForGroupToConclude1 = mock(AggregateIdentificationKeysHasher.IdentificationKeysMap.class);
+        final IdentificationKeysHasher.IdentificationKeysMap hashForGroupToConclude1 = mock(IdentificationKeysHasher.IdentificationKeysMap.class);
 
         final AggregateGroup groupToConclude2 = mock(AggregateGroup.class);
-        final AggregateIdentificationKeysHasher.IdentificationKeysMap hashForGroupToConclude2 = mock(AggregateIdentificationKeysHasher.IdentificationKeysMap.class);
+        final IdentificationKeysHasher.IdentificationKeysMap hashForGroupToConclude2 = mock(IdentificationKeysHasher.IdentificationKeysMap.class);
 
         aggregateGroupManager.putGroupWithHash(hashForGroupToConclude1, groupToConclude1);
         aggregateGroupManager.putGroupWithHash(hashForGroupToConclude2, groupToConclude2);
 
-        final List<Map.Entry<AggregateIdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>> groupsToConclude = aggregateGroupManager.getGroupsToConclude(true);
+        final List<Map.Entry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>> groupsToConclude = aggregateGroupManager.getGroupsToConclude(true);
 
         assertThat(groupsToConclude.size(), equalTo(2));
         assertThat(groupsToConclude.get(0), notNullValue());

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.hasher.IdentificationKeysHasher;
 
 import java.util.AbstractMap;
 import java.util.Collection;
@@ -53,10 +54,10 @@ public class AggregateProcessorTest {
     private PluginFactory pluginFactory;
 
     @Mock
-    private AggregateIdentificationKeysHasher aggregateIdentificationKeysHasher;
+    private IdentificationKeysHasher identificationKeysHasher;
 
     @Mock
-    private AggregateIdentificationKeysHasher.IdentificationKeysMap identificationKeysMap;
+    private IdentificationKeysHasher.IdentificationKeysMap identificationKeysMap;
 
     @Mock
     private AggregateProcessorConfig aggregateProcessorConfig;
@@ -115,7 +116,7 @@ public class AggregateProcessorTest {
     private Event event;
 
     private AggregateProcessor createObjectUnderTest() {
-        return new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, aggregateGroupManager, aggregateIdentificationKeysHasher, aggregateActionSynchronizerProvider, expressionEvaluator);
+        return new AggregateProcessor(aggregateProcessorConfig, pluginMetrics, pluginFactory, aggregateGroupManager, identificationKeysHasher, aggregateActionSynchronizerProvider, expressionEvaluator);
     }
 
     @BeforeEach
@@ -160,7 +161,7 @@ public class AggregateProcessorTest {
     class TestDoExecute {
         @BeforeEach
         void setup() {
-            when(aggregateIdentificationKeysHasher.createIdentificationKeysMapFromEvent(event))
+            when(identificationKeysHasher.createIdentificationKeysMapFromEvent(event))
                     .thenReturn(identificationKeysMap);
             when(aggregateGroupManager.getAggregateGroup(identificationKeysMap)).thenReturn(aggregateGroup);
             when(aggregateActionSynchronizer.handleEventForGroup(event, identificationKeysMap, aggregateGroup)).thenReturn(aggregateActionResponse);
@@ -209,7 +210,7 @@ public class AggregateProcessorTest {
                 .build();
 
 
-            when(aggregateIdentificationKeysHasher.createIdentificationKeysMapFromEvent(firstEvent))
+            when(identificationKeysHasher.createIdentificationKeysMapFromEvent(firstEvent))
                     .thenReturn(identificationKeysMap);
             when(aggregateActionSynchronizer.handleEventForGroup(firstEvent, identificationKeysMap, aggregateGroup)).thenReturn(firstAggregateActionResponse);
             when(expressionEvaluator.evaluateConditional(condition, event)).thenReturn(true);
@@ -267,7 +268,7 @@ public class AggregateProcessorTest {
         void concludeGroup_returning_with_no_event_does_not_add_event_to_records_out() {
             final AggregateProcessor objectUnderTest = createObjectUnderTest();
 
-            final Map.Entry<AggregateIdentificationKeysHasher.IdentificationKeysMap, AggregateGroup> groupEntry = new AbstractMap.SimpleEntry<AggregateIdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>(identificationKeysMap, aggregateGroup);
+            final Map.Entry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup> groupEntry = new AbstractMap.SimpleEntry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>(identificationKeysMap, aggregateGroup);
             when(aggregateGroupManager.getGroupsToConclude(eq(false))).thenReturn(Collections.singletonList(groupEntry));
             when(aggregateActionResponse.getEvent()).thenReturn(null);
             when(aggregateActionSynchronizer.concludeGroup(identificationKeysMap, aggregateGroup, false)).thenReturn(new AggregateActionOutput(List.of()));
@@ -289,7 +290,7 @@ public class AggregateProcessorTest {
         void concludeGroup_returning_with_event_adds_event_to_records_out() {
             final AggregateProcessor objectUnderTest = createObjectUnderTest();
 
-            final Map.Entry<AggregateIdentificationKeysHasher.IdentificationKeysMap, AggregateGroup> groupEntry = new AbstractMap.SimpleEntry<AggregateIdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>(identificationKeysMap, aggregateGroup);
+            final Map.Entry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup> groupEntry = new AbstractMap.SimpleEntry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>(identificationKeysMap, aggregateGroup);
             when(aggregateGroupManager.getGroupsToConclude(eq(false))).thenReturn(Collections.singletonList(groupEntry));
             when(aggregateActionResponse.getEvent()).thenReturn(null);
             when(aggregateActionSynchronizer.concludeGroup(identificationKeysMap, aggregateGroup, false)).thenReturn(new AggregateActionOutput(List.of(event)));
@@ -314,7 +315,7 @@ public class AggregateProcessorTest {
             final AggregateProcessor objectUnderTest = createObjectUnderTest();
             objectUnderTest.prepareForShutdown();
 
-            final Map.Entry<AggregateIdentificationKeysHasher.IdentificationKeysMap, AggregateGroup> groupEntry = new AbstractMap.SimpleEntry<AggregateIdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>(identificationKeysMap, aggregateGroup);
+            final Map.Entry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup> groupEntry = new AbstractMap.SimpleEntry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>(identificationKeysMap, aggregateGroup);
             when(aggregateGroupManager.getGroupsToConclude(eq(true))).thenReturn(Collections.singletonList(groupEntry));
             when(aggregateActionResponse.getEvent()).thenReturn(null);
             when(aggregateActionSynchronizer.concludeGroup(identificationKeysMap, aggregateGroup, true)).thenReturn(new AggregateActionOutput(List.of(event)));

--- a/data-prepper-plugins/anomaly-detector-processor/build.gradle
+++ b/data-prepper-plugins/anomaly-detector-processor/build.gradle
@@ -10,6 +10,7 @@ plugins {
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-test-common')
+    implementation project(':data-prepper-plugins:aggregate-processor')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'
     implementation 'software.amazon.randomcutforest:randomcutforest-testutils:3.7.0'

--- a/data-prepper-plugins/anomaly-detector-processor/build.gradle
+++ b/data-prepper-plugins/anomaly-detector-processor/build.gradle
@@ -10,13 +10,13 @@ plugins {
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-test-common')
-    implementation project(':data-prepper-plugins:aggregate-processor')
+    implementation project(':data-prepper-plugins:common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'
-    implementation 'software.amazon.randomcutforest:randomcutforest-testutils:3.7.0'
-    implementation 'software.amazon.randomcutforest:randomcutforest-core:3.7.0'
-    implementation 'software.amazon.randomcutforest:randomcutforest-examples:3.7.0'
-    implementation 'software.amazon.randomcutforest:randomcutforest-parkservices:3.7.0'
+    implementation 'software.amazon.randomcutforest:randomcutforest-testutils:3.8.0'
+    implementation 'software.amazon.randomcutforest:randomcutforest-core:3.8.0'
+    implementation 'software.amazon.randomcutforest:randomcutforest-examples:3.8.0'
+    implementation 'software.amazon.randomcutforest:randomcutforest-parkservices:3.8.0'
     implementation 'software.amazon.randomcutforest:randomcutforest-serialization-json:1.0'
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
 }

--- a/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorMode.java
+++ b/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorMode.java
@@ -20,8 +20,10 @@ public interface AnomalyDetectorMode {
      * 
      * @param keys List of keys which are used as dimensions in the anomaly detector
      * @since 2.1
+     * 
+     * @param verbose Optional, when true, RCF will turn off Auto-Adjust, and anomalies will be continually detected after a level shift
      */
-    void initialize(List<String> keys);
+    void initialize(List<String> keys, boolean verbose);
 
     /**
      * handles a collection of records

--- a/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessor.java
+++ b/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessor.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.processor.anomalydetector;
 
+import io.micrometer.core.instrument.Counter;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -15,19 +16,23 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
-import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateIdentificationKeysHasher;
+import org.opensearch.dataprepper.plugins.hasher.IdentificationKeysHasher;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 @DataPrepperPlugin(name = "anomaly_detector", pluginType = Processor.class, pluginConfigurationType = AnomalyDetectorProcessorConfig.class)
 public class AnomalyDetectorProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
     public static final String DEVIATION_KEY = "deviation_from_expected";
     public static final String GRADE_KEY = "grade";
+    static final String NUMBER_RCF_INSTANCES = "numberRCFInstances";
 
-    private final AggregateIdentificationKeysHasher aggregateIdentificationKeysHasher;
+    private final Boolean verbose;
+    private final IdentificationKeysHasher identificationKeysHasher;
+    private final Counter numberRCFInstances;
     private final List<String> keys;
     private final PluginFactory pluginFactory;
     private final HashMap<Integer, AnomalyDetectorMode> forestMap;
@@ -36,10 +41,12 @@ public class AnomalyDetectorProcessor extends AbstractProcessor<Record<Event>, R
     @DataPrepperPluginConstructor
     public AnomalyDetectorProcessor(final AnomalyDetectorProcessorConfig anomalyDetectorProcessorConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory) {
         super(pluginMetrics);
-        this.aggregateIdentificationKeysHasher = new AggregateIdentificationKeysHasher(anomalyDetectorProcessorConfig.getIdentificationKeys());
+        this.identificationKeysHasher = new IdentificationKeysHasher(anomalyDetectorProcessorConfig.getIdentificationKeys());
         this.anomalyDetectorProcessorConfig = anomalyDetectorProcessorConfig;
         this.pluginFactory = pluginFactory;
-        keys = anomalyDetectorProcessorConfig.getKeys();
+        this.numberRCFInstances = pluginMetrics.counter(NUMBER_RCF_INSTANCES);
+        this.keys = anomalyDetectorProcessorConfig.getKeys();
+        this.verbose = anomalyDetectorProcessorConfig.getVerbose();
         forestMap = new HashMap<>();
     }
 
@@ -57,11 +64,14 @@ public class AnomalyDetectorProcessor extends AbstractProcessor<Record<Event>, R
             final Event event = record.getData();
             // If user has not configured IdentificationKeys, the empty set will always hash to "31",
             // so the same forest will be used, and we don't need to write a special case.
-            final AggregateIdentificationKeysHasher.IdentificationKeysMap identificationKeysMap = aggregateIdentificationKeysHasher.createIdentificationKeysMapFromEvent(event);
-            if (!forestMap.containsKey(identificationKeysMap.hashCode())) {
-                final AnomalyDetectorMode hashMode = loadAnomalyDetectorMode(pluginFactory);
-                hashMode.initialize(keys);
-                forestMap.put(identificationKeysMap.hashCode(), hashMode);
+            final IdentificationKeysHasher.IdentificationKeysMap identificationKeysMap = identificationKeysHasher.createIdentificationKeysMapFromEvent(event);
+            AnomalyDetectorMode forest = forestMap.get(identificationKeysMap.hashCode());
+
+            if (Objects.isNull(forest)) {
+                forest = loadAnomalyDetectorMode(pluginFactory);
+                forest.initialize(keys, verbose);
+                forestMap.put(identificationKeysMap.hashCode(), forest);
+                this.numberRCFInstances.increment();
             }
             recordsOut.addAll(forestMap.get(identificationKeysMap.hashCode()).handleEvents(List.of(record)));
         }

--- a/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessor.java
+++ b/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessor.java
@@ -15,8 +15,11 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateIdentificationKeysHasher;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 
 @DataPrepperPlugin(name = "anomaly_detector", pluginType = Processor.class, pluginConfigurationType = AnomalyDetectorProcessorConfig.class)
@@ -24,17 +27,20 @@ public class AnomalyDetectorProcessor extends AbstractProcessor<Record<Event>, R
     public static final String DEVIATION_KEY = "deviation_from_expected";
     public static final String GRADE_KEY = "grade";
 
+    private final AggregateIdentificationKeysHasher aggregateIdentificationKeysHasher;
     private final List<String> keys;
-    private final AnomalyDetectorMode mode;
+    private final PluginFactory pluginFactory;
+    private final HashMap<Integer, AnomalyDetectorMode> forestMap;
     private final AnomalyDetectorProcessorConfig anomalyDetectorProcessorConfig;
 
     @DataPrepperPluginConstructor
     public AnomalyDetectorProcessor(final AnomalyDetectorProcessorConfig anomalyDetectorProcessorConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory) {
         super(pluginMetrics);
+        this.aggregateIdentificationKeysHasher = new AggregateIdentificationKeysHasher(anomalyDetectorProcessorConfig.getIdentificationKeys());
         this.anomalyDetectorProcessorConfig = anomalyDetectorProcessorConfig;
+        this.pluginFactory = pluginFactory;
         keys = anomalyDetectorProcessorConfig.getKeys();
-        mode = loadAnomalyDetectorMode(pluginFactory);
-        mode.initialize(keys);
+        forestMap = new HashMap<>();
     }
 
     private AnomalyDetectorMode loadAnomalyDetectorMode(final PluginFactory pluginFactory) {
@@ -45,7 +51,21 @@ public class AnomalyDetectorProcessor extends AbstractProcessor<Record<Event>, R
 
     @Override
     public Collection<Record<Event>> doExecute(Collection<Record<Event>> records) {
-        return mode.handleEvents(records);
+        final List<Record<Event>> recordsOut = new LinkedList<>();
+
+        for (final Record<Event> record : records) {
+            final Event event = record.getData();
+            // If user has not configured IdentificationKeys, the empty set will always hash to "31",
+            // so the same forest will be used, and we don't need to write a special case.
+            final AggregateIdentificationKeysHasher.IdentificationKeysMap identificationKeysMap = aggregateIdentificationKeysHasher.createIdentificationKeysMapFromEvent(event);
+            if (!forestMap.containsKey(identificationKeysMap.hashCode())) {
+                final AnomalyDetectorMode hashMode = loadAnomalyDetectorMode(pluginFactory);
+                hashMode.initialize(keys);
+                forestMap.put(identificationKeysMap.hashCode(), hashMode);
+            }
+            recordsOut.addAll(forestMap.get(identificationKeysMap.hashCode()).handleEvents(List.of(record)));
+        }
+        return recordsOut;
     }
 
 

--- a/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessorConfig.java
+++ b/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessorConfig.java
@@ -24,6 +24,9 @@ public class AnomalyDetectorProcessorConfig {
     @JsonProperty("identification_keys")
     private List<String> identificationKeys;
 
+    @JsonProperty("verbose")
+    private Boolean verbose = false;
+
     public PluginModel getDetectorMode() { 
         return detectorMode;
     }
@@ -40,5 +43,9 @@ public class AnomalyDetectorProcessorConfig {
     public List<String> getIdentificationKeys() {
         return identificationKeys;
     }
+    public boolean getVerbose() {
+        return verbose;
+    }
+
 
 }

--- a/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessorConfig.java
+++ b/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessorConfig.java
@@ -21,6 +21,9 @@ public class AnomalyDetectorProcessorConfig {
     @NotEmpty
     private List<String> keys;
 
+    @JsonProperty("identification_keys")
+    private List<String> identificationKeys;
+
     public PluginModel getDetectorMode() { 
         return detectorMode;
     }
@@ -32,6 +35,10 @@ public class AnomalyDetectorProcessorConfig {
             }
         });
         return keys;
+    }
+
+    public List<String> getIdentificationKeys() {
+        return identificationKeys;
     }
 
 }

--- a/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/modes/RandomCutForestMode.java
+++ b/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/modes/RandomCutForestMode.java
@@ -58,7 +58,7 @@ public class RandomCutForestMode implements AnomalyDetectorMode {
     }
     
     @Override
-    public void initialize(List<String> keys) {
+    public void initialize(List<String> keys, boolean verbose) {
         this.keys = keys;
         baseDimensions = keys.size();
 	    Precision precision = Precision.FLOAT_32;
@@ -79,7 +79,8 @@ public class RandomCutForestMode implements AnomalyDetectorMode {
 			        .transformMethod(transformMethod)
                     .outputAfter(outputAfter)
                     .timeDecay(timeDecay / sampleSize)
-			        .initialAcceptFraction(INITIAL_ACCEPT_FRACTION).build();
+			        .initialAcceptFraction(INITIAL_ACCEPT_FRACTION)
+                    .autoAdjust(!verbose).build();
 	    forest.setLowerThreshold(LOWER_THRESHOLD);
 	    forest.setHorizon(HORIZON_VALUE);
     }

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/hasher/IdentificationKeysHasher.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/hasher/IdentificationKeysHasher.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugins.processor.aggregate;
+package org.opensearch.dataprepper.plugins.hasher;
 
 import org.opensearch.dataprepper.model.event.Event;
 
@@ -12,9 +12,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public class AggregateIdentificationKeysHasher {
+public class IdentificationKeysHasher {
     private final List<String> identificationKeys;
-    public AggregateIdentificationKeysHasher(final List<String> identificationKeys) {
+    public IdentificationKeysHasher(final List<String> identificationKeys) {
         this.identificationKeys = identificationKeys;
     }
 
@@ -29,7 +29,7 @@ public class AggregateIdentificationKeysHasher {
     public static class IdentificationKeysMap {
         private final Map<Object, Object> keyMap;
 
-        IdentificationKeysMap(final Map<Object, Object> keyMap) {
+        public IdentificationKeysMap(final Map<Object, Object> keyMap) {
             this.keyMap = keyMap;
         }
 
@@ -46,7 +46,7 @@ public class AggregateIdentificationKeysHasher {
             return Objects.hash(keyMap);
         }
 
-        Map<Object, Object> getKeyMap() {
+        public Map<Object, Object> getKeyMap() {
             return keyMap;
         }
     }

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/hasher/IdentificationKeysHasherTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/hasher/IdentificationKeysHasherTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugins.processor.aggregate;
+package org.opensearch.dataprepper.plugins.hasher;
 
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
@@ -21,10 +21,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class AggregateIdentificationKeysHasherTest {
+public class IdentificationKeysHasherTest {
     private Event event;
     private List<String> identificationKeys;
-    private AggregateIdentificationKeysHasher aggregateIdentificationKeysHasher;
+    private IdentificationKeysHasher identificationKeysHasher;
 
     @BeforeEach
     void setup() {
@@ -33,18 +33,18 @@ public class AggregateIdentificationKeysHasherTest {
         identificationKeys.add("secondIdentificationKey");
     }
 
-    private AggregateIdentificationKeysHasher createObjectUnderTest() {
-        return new AggregateIdentificationKeysHasher(identificationKeys);
+    private IdentificationKeysHasher createObjectUnderTest() {
+        return new IdentificationKeysHasher(identificationKeys);
     }
 
     @Test
     void createIdentificationKeysMapFromEvent_returns_expected_IdentficationKeysMap() {
-        aggregateIdentificationKeysHasher = createObjectUnderTest();
+        identificationKeysHasher = createObjectUnderTest();
         final Map<Object, Object> eventMap = new HashMap<>();
         eventMap.put("firstIdentificationKey", UUID.randomUUID().toString());
         eventMap.put("secondIdentificationKey", UUID.randomUUID().toString());
 
-        final AggregateIdentificationKeysHasher.IdentificationKeysMap expectedResult = new AggregateIdentificationKeysHasher.IdentificationKeysMap(new HashMap<>(eventMap));
+        final IdentificationKeysHasher.IdentificationKeysMap expectedResult = new IdentificationKeysHasher.IdentificationKeysMap(new HashMap<>(eventMap));
 
         eventMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
@@ -53,20 +53,20 @@ public class AggregateIdentificationKeysHasherTest {
                 .withData(eventMap)
                 .build();
 
-        final AggregateIdentificationKeysHasher.IdentificationKeysMap result = aggregateIdentificationKeysHasher.createIdentificationKeysMapFromEvent(event);
+        final IdentificationKeysHasher.IdentificationKeysMap result = identificationKeysHasher.createIdentificationKeysMapFromEvent(event);
         assertThat(result, equalTo(expectedResult));
     }
 
     @Test
     void createIdentificationKeysMapFromEvent_where_Event_does_not_contain_one_of_the_identification_keys_returns_expected_Map() {
-        aggregateIdentificationKeysHasher = createObjectUnderTest();
+        identificationKeysHasher = createObjectUnderTest();
         final Map<Object, Object> eventMap = new HashMap<>();
         eventMap.put("firstIdentificationKey", UUID.randomUUID().toString());
 
         final Map<Object, Object> mapForExpectedHash = new HashMap<>(eventMap);
         mapForExpectedHash.put("secondIdentificationKey", null);
 
-        final AggregateIdentificationKeysHasher.IdentificationKeysMap expectedResult = new AggregateIdentificationKeysHasher.IdentificationKeysMap(mapForExpectedHash);
+        final IdentificationKeysHasher.IdentificationKeysMap expectedResult = new IdentificationKeysHasher.IdentificationKeysMap(mapForExpectedHash);
 
         eventMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
@@ -75,13 +75,13 @@ public class AggregateIdentificationKeysHasherTest {
                 .withData(eventMap)
                 .build();
 
-        final AggregateIdentificationKeysHasher.IdentificationKeysMap result = aggregateIdentificationKeysHasher.createIdentificationKeysMapFromEvent(event);
+        final IdentificationKeysHasher.IdentificationKeysMap result = identificationKeysHasher.createIdentificationKeysMapFromEvent(event);
         assertThat(result, equalTo(expectedResult));
     }
 
     @Test
     void identical_identification_hashes_but_different_objects_are_considered_equal() {
-        aggregateIdentificationKeysHasher = createObjectUnderTest();
+        identificationKeysHasher = createObjectUnderTest();
         final Map<Object, Object> eventMap = new HashMap<>();
         eventMap.put("firstIdentificationKey", UUID.randomUUID().toString());
         eventMap.put("secondIdentificationKey", UUID.randomUUID().toString());
@@ -92,15 +92,15 @@ public class AggregateIdentificationKeysHasherTest {
                 .withData(eventMap)
                 .build();
 
-        final AggregateIdentificationKeysHasher.IdentificationKeysMap result = aggregateIdentificationKeysHasher.createIdentificationKeysMapFromEvent(event);
-        final AggregateIdentificationKeysHasher.IdentificationKeysMap secondResult = aggregateIdentificationKeysHasher.createIdentificationKeysMapFromEvent(event);
+        final IdentificationKeysHasher.IdentificationKeysMap result = identificationKeysHasher.createIdentificationKeysMapFromEvent(event);
+        final IdentificationKeysHasher.IdentificationKeysMap secondResult = identificationKeysHasher.createIdentificationKeysMapFromEvent(event);
 
         assertThat(result, equalTo(secondResult));
     }
 
     @Test
     void different_identification_hashes_are_not_considered_equal() {
-        aggregateIdentificationKeysHasher = createObjectUnderTest();
+        identificationKeysHasher = createObjectUnderTest();
         final Map<Object, Object> eventMap = new HashMap<>();
         eventMap.put("firstIdentificationKey", UUID.randomUUID().toString());
         eventMap.put("secondIdentificationKey", UUID.randomUUID().toString());
@@ -119,8 +119,8 @@ public class AggregateIdentificationKeysHasherTest {
                 .withData(secondEventMap)
                 .build();
 
-        final AggregateIdentificationKeysHasher.IdentificationKeysMap result = aggregateIdentificationKeysHasher.createIdentificationKeysMapFromEvent(event);
-        final AggregateIdentificationKeysHasher.IdentificationKeysMap secondResult = aggregateIdentificationKeysHasher.createIdentificationKeysMapFromEvent(secondEvent);
+        final IdentificationKeysHasher.IdentificationKeysMap result = identificationKeysHasher.createIdentificationKeysMapFromEvent(event);
+        final IdentificationKeysHasher.IdentificationKeysMap secondResult = identificationKeysHasher.createIdentificationKeysMapFromEvent(secondEvent);
 
         assertThat(result, is(not(equalTo(secondResult))));
     }


### PR DESCRIPTION
### Description
Anomaly Detector plugin will now take an optional value identification_keys. This value will act the same as it does in the aggregate processor, and will cause the plugin to create a different forest model for each unique value/combination of identification_keys.
 
### Issues Resolved
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented - will update documentation before merge
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
