### PR TITLE
Default keys

### DIFF
--- a/data-prepper-plugins/key-value-processor/README.md
+++ b/data-prepper-plugins/key-value-processor/README.md
@@ -42,6 +42,10 @@ When run, the processor will parse the message into the following output:
 * `include_keys` - An array specifying the keys which should be added to parse. By default, all keys will be added.
   * Default: `[]`
   * Example: `include_keys` is `["key2"]`. `key1=value1&key2=value2` will parse into `{"key2": "value2"}`
+
+* `default_keys` - A hash specifying the default keys and their values which should be added to the event in case these keys do not exist in the source field being parsed.
+  * Default: `{}`
+  * Example: `default_keys` is `{"defaultkey": "defaultvalue"}`. `key1=value1` will parse into `{"defaultkey": "defaultvalue", "key1": "value1"}`
 * `key_value_delimiter_regex` - A regex specifying the delimiter between a key and a value. Special regex characters such as `[` and `]` must be escaped using `\\`.
   * There is no default.
   * Note: This cannot be defined at the same time as `value_split_characters`

--- a/data-prepper-plugins/key-value-processor/README.md
+++ b/data-prepper-plugins/key-value-processor/README.md
@@ -47,7 +47,7 @@ When run, the processor will parse the message into the following output:
   * Example: `exclude_keys` is `["key2"]`. `key1=value1&key2=value2` will parse into `{"key1": "value1"}`
 * `default_keys` - A hash specifying the default keys and their values which should be added to the event in case these keys do not exist in the source field being parsed.
   * Default: `{}`
-  * Example: `default_keys` is `{"defaultkey": "defaultvalue"}`. `key1=value1` will parse into `{"defaultkey": "defaultvalue", "key1": "value1"}`
+  * Example: `default_keys` is `{"defaultkey": "defaultvalue"}`. `key1=value1` will parse into `{"key1": "value1", "defaultkey": "defaultvalue"}`
 * `key_value_delimiter_regex` - A regex specifying the delimiter between a key and a value. Special regex characters such as `[` and `]` must be escaped using `\\`.
   * There is no default.
   * Note: This cannot be defined at the same time as `value_split_characters`

--- a/data-prepper-plugins/key-value-processor/README.md
+++ b/data-prepper-plugins/key-value-processor/README.md
@@ -49,6 +49,7 @@ When run, the processor will parse the message into the following output:
   * Default: `{}`
   * Example: `default_keys` is `{"defaultkey": "defaultvalue"}`. `key1=value1` will parse into `{"key1": "value1", "defaultkey": "defaultvalue"}`
   * It should be noted that the include_keys filter will be applied to the message first, and then default keys.
+  * Example: `include_keys` is `["key1"]`, and `default_keys` is `{"key2": "value2"}`. `key1=value1&key2=abc` will parse into `{"key1": "value1", "key2": "value2"}`
 * `key_value_delimiter_regex` - A regex specifying the delimiter between a key and a value. Special regex characters such as `[` and `]` must be escaped using `\\`.
   * There is no default.
   * Note: This cannot be defined at the same time as `value_split_characters`

--- a/data-prepper-plugins/key-value-processor/README.md
+++ b/data-prepper-plugins/key-value-processor/README.md
@@ -45,9 +45,11 @@ When run, the processor will parse the message into the following output:
 * `exclude_keys` - An array specifying the parsed keys which should not be added to the event. By default no keys will be excluded.
   * Default: `[]`
   * Example: `exclude_keys` is `["key2"]`. `key1=value1&key2=value2` will parse into `{"key1": "value1"}`
-* `default_keys` - A hash specifying the default keys and their values which should be added to the event in case these keys do not exist in the source field being parsed.
+* `default_values` - A hash specifying the default keys and their values which should be added to the event in case these keys do not exist in the source field being parsed.
   * Default: `{}`
-  * Example: `default_keys` is `{"defaultkey": "defaultvalue"}`. `key1=value1` will parse into `{"key1": "value1", "defaultkey": "defaultvalue"}`
+  * Example: `default_values` is `{"defaultkey": "defaultvalue"}`. `key1=value1` will parse into `{"key1": "value1", "defaultkey": "defaultvalue"}`
+  * If the default key already exists in the message, the value is not changed.
+  * Example: `default_values` is `{"value1": "abc"}`. `key1=value1` will parse into `{"key1": "value1"}`
   * It should be noted that the include_keys filter will be applied to the message first, and then default keys.
   * Example: `include_keys` is `["key1"]`, and `default_keys` is `{"key2": "value2"}`. `key1=value1&key2=abc` will parse into `{"key1": "value1", "key2": "value2"}`
 * `key_value_delimiter_regex` - A regex specifying the delimiter between a key and a value. Special regex characters such as `[` and `]` must be escaped using `\\`.

--- a/data-prepper-plugins/key-value-processor/README.md
+++ b/data-prepper-plugins/key-value-processor/README.md
@@ -48,6 +48,7 @@ When run, the processor will parse the message into the following output:
 * `default_keys` - A hash specifying the default keys and their values which should be added to the event in case these keys do not exist in the source field being parsed.
   * Default: `{}`
   * Example: `default_keys` is `{"defaultkey": "defaultvalue"}`. `key1=value1` will parse into `{"key1": "value1", "defaultkey": "defaultvalue"}`
+  * It should be noted that the include_keys filter will be applied to the message first, and then default keys.
 * `key_value_delimiter_regex` - A regex specifying the delimiter between a key and a value. Special regex characters such as `[` and `]` must be escaped using `\\`.
   * There is no default.
   * Note: This cannot be defined at the same time as `value_split_characters`

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -167,12 +167,12 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
 
         includeIntersectionSet.retainAll(excludeSet);
         if (!includeIntersectionSet.isEmpty()) {
-            throw new IllegalArgumentException("Include keys and exclude keys set cannot have any overlap", null);
+            throw new IllegalArgumentException("Include keys and exclude keys set cannot have any overlap");
         }
 
         defaultIntersectionSet.retainAll(excludeSet);
         if (!defaultIntersectionSet.isEmpty()) {
-            throw new IllegalArgumentException("Cannot exclude a default key!", null);
+            throw new IllegalArgumentException("Cannot exclude a default key!");
         }
     }
 

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -110,8 +110,6 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
         }
 
         validateKeySets(includeKeysSet, excludeKeysSet, defaultValuesSet);
-
-        // look at former logic for removing include from default?
         
         if (!validTransformOptionSet.contains(keyValueProcessorConfig.getTransformKey())) {
             throw new IllegalArgumentException(String.format("The transform_key value: %s is not a valid option", keyValueProcessorConfig.getTransformKey()));

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -110,15 +110,6 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
         }
 
         validateKeySets(includeKeysSet, excludeKeysSet, defaultKeysSet);
-
-        final Set<String> includeDefaultCheckSet = new HashSet<String>(defaultKeysSet);
-        includeDefaultCheckSet.retainAll(includeKeysSet);
-        if (!includeDefaultCheckSet.isEmpty()) {
-            for (final String overlap_key : includeDefaultCheckSet) {
-                defaultKeysMap.remove(overlap_key);
-                defaultKeysSet.remove(overlap_key);
-            }
-        }
         
         if (!validTransformOptionSet.contains(keyValueProcessorConfig.getTransformKey())) {
             throw new IllegalArgumentException(String.format("The transform_key value: %s is not a valid option", keyValueProcessorConfig.getTransformKey()));
@@ -212,7 +203,7 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
                 }
 
                 if (defaultKeysSet.contains(key)) {
-                    LOG.debug(String.format("Skipping already included default key: '%s'", key));
+                    LOG.debug(String.format("Skipping already included default key-value pair: '%s'", key));
                     continue;
                 }
 

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -202,11 +202,6 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
                     continue;
                 }
 
-                if (defaultKeysSet.contains(key)) {
-                    LOG.debug("Skipping already included default key-value pair: '{}'", key);
-                    continue;
-                }
-
                 if(keyValueProcessorConfig.getDeleteKeyRegex() != null && !Objects.equals(keyValueProcessorConfig.getDeleteKeyRegex(), "")) {
                     key = key.replaceAll(keyValueProcessorConfig.getDeleteKeyRegex(), "");
                 }
@@ -217,6 +212,11 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
                 } else {
                     LOG.debug("Unsuccessful match: '{}'", terms[0]);
                     value = keyValueProcessorConfig.getNonMatchValue();
+                }
+
+                if (defaultKeysMap.containsKey(key) && defaultKeysMap.containsValue(value)) {
+                    LOG.debug("Skipping already included default key-value pair: '{}'", key);
+                    continue;
                 }
 
                 if(value != null

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -193,17 +193,17 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
                 Object value;
 
                 if (!includeKeysSet.isEmpty() && !includeKeysSet.contains(key)) {
-                    LOG.debug(String.format("Skipping not included key: '%s'", key));
+                    LOG.debug("Skipping not included key: '{}'", key);
                     continue;
                 }
 
                 if (excludeKeysSet.contains(key)) {
-                    LOG.debug(String.format("Key is being excluded: '%s'", key));
+                    LOG.debug("Key is being excluded: '{}'", key);
                     continue;
                 }
 
                 if (defaultKeysSet.contains(key)) {
-                    LOG.debug(String.format("Skipping already included default key-value pair: '%s'", key));
+                    LOG.debug("Skipping already included default key-value pair: '{}'", key);
                     continue;
                 }
 
@@ -215,7 +215,7 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
                 if (terms.length == 2) {
                     value = terms[1];
                 } else {
-                    LOG.debug(String.format("Unsuccessful match: '%s'", terms[0]));
+                    LOG.debug("Unsuccessful match: '{}'", terms[0]);
                     value = keyValueProcessorConfig.getNonMatchValue();
                 }
 

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -36,6 +36,9 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
     private final Pattern fieldDelimiterPattern;
     private final Pattern keyValueDelimiterPattern;
     private final Set<String> includeKeysSet = new HashSet<String>();
+
+    private final HashMap<String, Object> defaultKeysMap = new HashMap<>();
+    private final Set<String> defaultKeysSet = new HashSet<String>();
     private final String lowercaseKey = "lowercase";
     private final String uppercaseKey = "uppercase";
     private final String capitalizeKey = "capitalize";
@@ -103,6 +106,16 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
             includeKeysSet.addAll(keyValueProcessorConfig.getIncludeKeys());
         }
 
+        // default key check here
+        defaultKeysMap.putAll(keyValueProcessorConfig.getDefaultKeys());
+        defaultKeysSet = defaultKeysMap.keySet();
+
+        // if default and exclude keys have overlap, throw error - "cannot exclude a default key"
+        
+
+        // if include and default keys have overlap, make sure it is added only once
+        
+
         if (!validTransformOptionSet.contains(keyValueProcessorConfig.getTransformKey())) {
             throw new IllegalArgumentException(String.format("The transform_key value: %s is not a valid option", keyValueProcessorConfig.getTransformKey()));
         }
@@ -161,6 +174,9 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
 
             final String groupsRaw = recordEvent.get(keyValueProcessorConfig.getSource(), String.class);
             final String[] groups = fieldDelimiterPattern.split(groupsRaw, 0);
+
+            // parsedMap.putAll(defaultKeysMap); (add this when default check is impl)
+
             for(final String group : groups) {
                 final String[] terms = keyValueDelimiterPattern.split(group, 2);
                 String key = terms[0];

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -111,10 +111,13 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
 
         validateKeySets(includeKeysSet, excludeKeysSet, defaultKeysSet);
 
-        final Set<String> includeDefaultCheckSet = new HashSet<String>(includeKeysSet);
-        includeDefaultCheckSet.retainAll(defaultKeysSet);
+        final Set<String> includeDefaultCheckSet = new HashSet<String>(defaultKeysSet);
+        includeDefaultCheckSet.retainAll(includeKeysSet);
         if (!includeDefaultCheckSet.isEmpty()) {
-            includeKeysSet.removeAll(defaultKeysSet);
+            for (final String overlap_key : includeDefaultCheckSet) {
+                defaultKeysMap.remove(overlap_key);
+                defaultKeysSet.remove(overlap_key);
+            }
         }
         
         if (!validTransformOptionSet.contains(keyValueProcessorConfig.getTransformKey())) {
@@ -203,12 +206,12 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
                     continue;
                 }
 
-                if (!excludeKeysSet.isEmpty() && excludeKeysSet.contains(key)) {
+                if (excludeKeysSet.contains(key)) {
                     LOG.debug(String.format("Key is being excluded: '%s'", key));
                     continue;
                 }
 
-                if (!defaultKeysSet.isEmpty() && defaultKeysSet.contains(key)) {
+                if (defaultKeysSet.contains(key)) {
                     LOG.debug(String.format("Skipping already included default key: '%s'", key));
                     continue;
                 }

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -17,6 +17,8 @@ public class KeyValueProcessorConfig {
     static final String DEFAULT_DESTINATION = "parsed_message";
     public static final String DEFAULT_FIELD_SPLIT_CHARACTERS = "&";
     static final List<String> DEFAULT_INCLUDE_KEYS = new ArrayList<>();
+
+    static final Map<String, String> DEFAULT_DEFAULT_KEYS = Collections.emptyMap();
     public static final String DEFAULT_VALUE_SPLIT_CHARACTERS = "=";
     static final Object DEFAULT_NON_MATCH_VALUE = null;
     static final String DEFAULT_PREFIX = "";
@@ -43,6 +45,11 @@ public class KeyValueProcessorConfig {
     @JsonProperty("include_keys")
     @NotNull
     private List<String> includeKeys = DEFAULT_INCLUDE_KEYS;
+
+
+    @JsonProperty("default_keys")
+    @NotNull
+    private Map<String, String> defaultKeys = DEFAULT_DEFAULT_KEYS;
 
     @JsonProperty("key_value_delimiter_regex")
     private String keyValueDelimiterRegex;
@@ -98,6 +105,11 @@ public class KeyValueProcessorConfig {
 
     public List<String> getIncludeKeys() {
         return includeKeys;
+    }
+
+
+    public Map<String, String> getDefaultKeys() {
+        return defaultKeys;
     }
 
     public String getKeyValueDelimiterRegex() {

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class KeyValueProcessorConfig {
     static final String DEFAULT_SOURCE = "message";
@@ -18,7 +19,7 @@ public class KeyValueProcessorConfig {
     public static final String DEFAULT_FIELD_SPLIT_CHARACTERS = "&";
     static final List<String> DEFAULT_INCLUDE_KEYS = new ArrayList<>();
     static final List<String> DEFAULT_EXCLUDE_KEYS = new ArrayList<>();
-    static final Map<String, Object> DEFAULT_DEFAULT_KEYS = Collections.emptyMap();
+    static final Map<String, Object> DEFAULT_DEFAULT_KEYS = Map.of();
     public static final String DEFAULT_VALUE_SPLIT_CHARACTERS = "=";
     static final Object DEFAULT_NON_MATCH_VALUE = null;
     static final String DEFAULT_PREFIX = "";
@@ -52,7 +53,7 @@ public class KeyValueProcessorConfig {
 
     @JsonProperty("default_keys")
     @NotNull
-    private Map<String, String> defaultKeys = DEFAULT_DEFAULT_KEYS;
+    private Map<String, Object> defaultKeys = DEFAULT_DEFAULT_KEYS;
 
     @JsonProperty("key_value_delimiter_regex")
     private String keyValueDelimiterRegex;
@@ -114,7 +115,7 @@ public class KeyValueProcessorConfig {
         return excludeKeys;
     }
 
-    public Map<String, String> getDefaultKeys() {
+    public Map<String, Object> getDefaultKeys() {
         return defaultKeys;
     }
 

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -19,7 +19,7 @@ public class KeyValueProcessorConfig {
     public static final String DEFAULT_FIELD_SPLIT_CHARACTERS = "&";
     static final List<String> DEFAULT_INCLUDE_KEYS = new ArrayList<>();
     static final List<String> DEFAULT_EXCLUDE_KEYS = new ArrayList<>();
-    static final Map<String, Object> DEFAULT_DEFAULT_KEYS = Map.of();
+    static final Map<String, Object> DEFAULT_DEFAULT_VALUES = Map.of();
     public static final String DEFAULT_VALUE_SPLIT_CHARACTERS = "=";
     static final Object DEFAULT_NON_MATCH_VALUE = null;
     static final String DEFAULT_PREFIX = "";
@@ -51,9 +51,9 @@ public class KeyValueProcessorConfig {
     @NotNull
     private List<String> excludeKeys = DEFAULT_EXCLUDE_KEYS;
 
-    @JsonProperty("default_keys")
+    @JsonProperty("default_values")
     @NotNull
-    private Map<String, Object> defaultKeys = DEFAULT_DEFAULT_KEYS;
+    private Map<String, Object> defaultValues = DEFAULT_DEFAULT_VALUES;
 
     @JsonProperty("key_value_delimiter_regex")
     private String keyValueDelimiterRegex;
@@ -115,8 +115,8 @@ public class KeyValueProcessorConfig {
         return excludeKeys;
     }
 
-    public Map<String, Object> getDefaultKeys() {
-        return defaultKeys;
+    public Map<String, Object> getDefaultValues() {
+        return defaultValues;
     }
 
     public String getKeyValueDelimiterRegex() {

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -18,7 +18,7 @@ public class KeyValueProcessorConfig {
     public static final String DEFAULT_FIELD_SPLIT_CHARACTERS = "&";
     static final List<String> DEFAULT_INCLUDE_KEYS = new ArrayList<>();
 
-    static final Map<String, String> DEFAULT_DEFAULT_KEYS = Collections.emptyMap();
+    static final Map<String, Object> DEFAULT_DEFAULT_KEYS = Collections.emptyMap();
     public static final String DEFAULT_VALUE_SPLIT_CHARACTERS = "=";
     static final Object DEFAULT_NON_MATCH_VALUE = null;
     static final String DEFAULT_PREFIX = "";

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -320,6 +320,24 @@ public class KeyValueProcessorTests {
     void testDefaultKeysKeyValueProcessor() {
         final Map<String, Object> defaultMap = Map.of("dKey", "dValue");
         when(mockConfig.getDefaultKeys()).thenReturn(defaultMap);
+        keyValueProcessor = new KeyValueProcessor(pluginMetrics, mockConfig);
+
+        final Record<Event> record = getMessage("key1=value1");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
+        final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
+
+        assertThat(parsed_message.size(), equalTo(2));
+        assertThatKeyEquals(parsed_message, "key1", "value1");
+        assertThatKeyEquals(parsed_message, "dKey", "dValue");
+    }
+
+    @Test
+    void testDefaultIncludeKeysOverlapKeyValueProcessor() {
+        final Map<String, Object> defaultMap = Map.of("dKey", "dValue");
+        final List<String> includeKeys = List.of("dKey");
+        when(mockConfig.getDefaultKeys()).thenReturn(defaultMap);
+        when(mockConfig.getIncludeKeys()).thenReturn(includeKeys);
+        keyValueProcessor = new KeyValueProcessor(pluginMetrics, mockConfig);
 
         final Record<Event> record = getMessage("key1=value1");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
@@ -334,6 +352,7 @@ public class KeyValueProcessorTests {
     void testDefaultKeysAlreadyInMessageKeyValueProcessor() {
         final Map<String, Object> defaultMap = Map.of("dKey", "dValue");
         when(mockConfig.getDefaultKeys()).thenReturn(defaultMap);
+        keyValueProcessor = new KeyValueProcessor(pluginMetrics, mockConfig);
 
         final Record<Event> record = getMessage("key1=value1&dKey=dValue");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
@@ -344,6 +363,8 @@ public class KeyValueProcessorTests {
         assertThatKeyEquals(parsed_message, "dKey", "dValue");
     }
 
+
+
     @Test
     void testDefaultExcludeKeysOverlapKeyValueProcessor() {
         final Map<String, Object> defaultMap = Map.of("dKey", "dValue");
@@ -352,22 +373,6 @@ public class KeyValueProcessorTests {
         when(mockConfig.getExcludeKeys()).thenReturn(excludeKeys);
 
         assertThrows(IllegalArgumentException.class, () -> new KeyValueProcessor(pluginMetrics, mockConfig));
-    }
-
-    @Test
-    void testDefaultIncludeKeysOverlapKeyValueProcessor() {
-        final Map<String, Object> defaultMap = Map.of("dKey", "dValue");
-        final List<String> includeKeys = List.of("dKey");
-        when(mockConfig.getDefaultKeys()).thenReturn(defaultMap);
-        when(mockConfig.getIncludeKeys()).thenReturn(includeKeys);
-
-        final Record<Event> record = getMessage("key1=value1");
-        final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
-        final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
-
-        assertThat(parsed_message.size(), equalTo(2));
-        assertThatKeyEquals(parsed_message, "key1", "value1");
-        assertThatKeyEquals(parsed_message, "dKey", "dValue");
     }
 
     @Test

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -348,12 +348,45 @@ public class KeyValueProcessorTests {
     }
 
     @Test
+    void testDefaultPrioritizeIncludeKeysKeyValueProcessor() {
+        final Map<String, Object> defaultMap = Map.of("key2", "value2");
+        final List<String> includeKeys = List.of("key1");
+        when(mockConfig.getDefaultKeys()).thenReturn(defaultMap);
+        when(mockConfig.getIncludeKeys()).thenReturn(includeKeys);
+        keyValueProcessor = new KeyValueProcessor(pluginMetrics, mockConfig);
+
+        final Record<Event> record = getMessage("key1=value1&key2=abc");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
+        final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
+
+        assertThat(parsed_message.size(), equalTo(2));
+        assertThatKeyEquals(parsed_message, "key1", "value1");
+        assertThatKeyEquals(parsed_message, "key2", "value2");
+    }
+
+    @Test
+    void testDefaultIncludeKeysNotInKeyValueProcessor() {
+        final Map<String, Object> defaultMap = Map.of("key1", "value1");
+        final List<String> includeKeys = List.of("key1");
+        when(mockConfig.getDefaultKeys()).thenReturn(defaultMap);
+        when(mockConfig.getIncludeKeys()).thenReturn(includeKeys);
+        keyValueProcessor = new KeyValueProcessor(pluginMetrics, mockConfig);
+
+        final Record<Event> record = getMessage("key2=value2");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
+        final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
+
+        assertThat(parsed_message.size(), equalTo(1));
+        assertThatKeyEquals(parsed_message, "key1", "value1");
+    }
+
+    @Test
     void testDefaultKeysAlreadyInMessageKeyValueProcessor() {
         final Map<String, Object> defaultMap = Map.of("dKey", "dValue");
         when(mockConfig.getDefaultKeys()).thenReturn(defaultMap);
         keyValueProcessor = new KeyValueProcessor(pluginMetrics, mockConfig);
 
-        final Record<Event> record = getMessage("key1=value1&dKey=dValue");
+        final Record<Event> record = getMessage("key1=value1&dKey=abc");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
         final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
 
@@ -361,8 +394,6 @@ public class KeyValueProcessorTests {
         assertThatKeyEquals(parsed_message, "key1", "value1");
         assertThatKeyEquals(parsed_message, "dKey", "dValue");
     }
-
-
 
     @Test
     void testDefaultExcludeKeysOverlapKeyValueProcessor() {

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -13,6 +13,8 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -317,7 +319,7 @@ public class KeyValueProcessorTests {
     }
 
     @Test
-    void testDefaultKeysKeyValueProcessor() {
+    void testDefaultKeysNoOverlapsBetweenEventKvProcessor() {
         final Map<String, Object> defaultMap = Map.of("dKey", "dValue");
         when(mockConfig.getDefaultValues()).thenReturn(defaultMap);
         keyValueProcessor = new KeyValueProcessor(pluginMetrics, mockConfig);
@@ -331,10 +333,12 @@ public class KeyValueProcessorTests {
         assertThatKeyEquals(parsed_message, "dKey", "dValue");
     }
 
-    @Test
-    void testDefaultKeysAlreadyInMessageKeyValueProcessor() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testDefaultKeysAlreadyInMessageKvProcessor(boolean skipDuplicateValues) {
         final Map<String, Object> defaultMap = Map.of("dKey", "dValue");
         when(mockConfig.getDefaultValues()).thenReturn(defaultMap);
+        when(mockConfig.getSkipDuplicateValues()).thenReturn(skipDuplicateValues);
         keyValueProcessor = new KeyValueProcessor(pluginMetrics, mockConfig);
 
         final Record<Event> record = getMessage("key1=value1&dKey=abc");
@@ -346,12 +350,14 @@ public class KeyValueProcessorTests {
         assertThatKeyEquals(parsed_message, "dKey", "abc");
     }
 
-    @Test
-    void testDefaultIncludeKeysOverlapKeyValueProcessor() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testDefaultIncludeKeysOverlapKvProcessor(boolean skipDuplicateValues) {
         final Map<String, Object> defaultMap = Map.of("key1", "abc");
         final List<String> includeKeys = List.of("key1");
         when(mockConfig.getDefaultValues()).thenReturn(defaultMap);
         when(mockConfig.getIncludeKeys()).thenReturn(includeKeys);
+        when(mockConfig.getSkipDuplicateValues()).thenReturn(skipDuplicateValues);
         keyValueProcessor = new KeyValueProcessor(pluginMetrics, mockConfig);
 
         final Record<Event> record = getMessage("key1=value1&key2=value2");
@@ -362,12 +368,14 @@ public class KeyValueProcessorTests {
         assertThatKeyEquals(parsed_message, "key1", "value1");
     }
 
-    @Test
-    void testDefaultPrioritizeIncludeKeysKeyValueProcessor() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testDefaultPrioritizeIncludeKeysKvProcessor(boolean skipDuplicateValues) {
         final Map<String, Object> defaultMap = Map.of("key2", "value2");
         final List<String> includeKeys = List.of("key1");
         when(mockConfig.getDefaultValues()).thenReturn(defaultMap);
         when(mockConfig.getIncludeKeys()).thenReturn(includeKeys);
+        when(mockConfig.getSkipDuplicateValues()).thenReturn(skipDuplicateValues);
         keyValueProcessor = new KeyValueProcessor(pluginMetrics, mockConfig);
 
         final Record<Event> record = getMessage("key1=value1&key2=abc");
@@ -379,12 +387,14 @@ public class KeyValueProcessorTests {
         assertThatKeyEquals(parsed_message, "key2", "value2");
     }
 
-    @Test
-    void testIncludeKeysNotInRecordMessageKeyValueProcessor() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testIncludeKeysNotInRecordMessageKvProcessor(boolean skipDuplicateValues) {
         final Map<String, Object> defaultMap = Map.of("key2", "value2");
         final List<String> includeKeys = List.of("key1");
         when(mockConfig.getDefaultValues()).thenReturn(defaultMap);
         when(mockConfig.getIncludeKeys()).thenReturn(includeKeys);
+        when(mockConfig.getSkipDuplicateValues()).thenReturn(skipDuplicateValues);
         keyValueProcessor = new KeyValueProcessor(pluginMetrics, mockConfig);
 
         final Record<Event> record = getMessage("key2=abc");
@@ -534,10 +544,10 @@ public class KeyValueProcessorTests {
 
         final Record<Event> record = getMessage("key1=value1");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
-        final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
+        final LinkedHashMap<String, Object> parsedMessage = getLinkedHashMap(editedRecords);
 
-        assertThat(parsed_message.size(), equalTo(1));
-        assertThatKeyEquals(parsed_message, "KEY1", "value1");
+        assertThat(parsedMessage.size(), equalTo(1));
+        assertThatKeyEquals(parsedMessage, "KEY1", "value1");
     }
 
     @Test

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -348,7 +348,7 @@ public class KeyValueProcessorTests {
 
     @Test
     void testDefaultIncludeKeysOverlapKeyValueProcessor() {
-        final Map<String, Object> defaultMap = Map.of("key1", "value1");
+        final Map<String, Object> defaultMap = Map.of("key1", "abc");
         final List<String> includeKeys = List.of("key1");
         when(mockConfig.getDefaultValues()).thenReturn(defaultMap);
         when(mockConfig.getIncludeKeys()).thenReturn(includeKeys);

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -365,7 +365,7 @@ public class KeyValueProcessorTests {
     }
 
     @Test
-    void testDefaultIncludeKeysNotInKeyValueProcessor() {
+    void testIncludeKeysNotInRecordMessageKeyValueProcessor() {
         final Map<String, Object> defaultMap = Map.of("key1", "value1");
         final List<String> includeKeys = List.of("key1");
         when(mockConfig.getDefaultKeys()).thenReturn(defaultMap);

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -333,19 +333,18 @@ public class KeyValueProcessorTests {
 
     @Test
     void testDefaultIncludeKeysOverlapKeyValueProcessor() {
-        final Map<String, Object> defaultMap = Map.of("dKey", "dValue");
-        final List<String> includeKeys = List.of("dKey");
+        final Map<String, Object> defaultMap = Map.of("key1", "value1");
+        final List<String> includeKeys = List.of("key1");
         when(mockConfig.getDefaultKeys()).thenReturn(defaultMap);
         when(mockConfig.getIncludeKeys()).thenReturn(includeKeys);
         keyValueProcessor = new KeyValueProcessor(pluginMetrics, mockConfig);
 
-        final Record<Event> record = getMessage("key1=value1");
+        final Record<Event> record = getMessage("key1=value1&key2=value2");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
         final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
 
-        assertThat(parsed_message.size(), equalTo(2));
+        assertThat(parsed_message.size(), equalTo(1));
         assertThatKeyEquals(parsed_message, "key1", "value1");
-        assertThatKeyEquals(parsed_message, "dKey", "dValue");
     }
 
     @Test

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -406,22 +406,6 @@ public class KeyValueProcessorTests {
     }
 
     @Test
-    void testDefaultDuplicateKeysKeyValueProcessor() {
-        final Map<String, Object> defaultMap = Map.of("key2", "value2");
-        when(mockConfig.getDefaultValues()).thenReturn(defaultMap);
-        when(mockConfig.getSkipDuplicateValues()).thenReturn(true);
-        keyValueProcessor = new KeyValueProcessor(pluginMetrics, mockConfig);
-
-        final Record<Event> record = getMessage("key1=value1&key2=altvalue");
-        final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
-        final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
-
-        assertThat(parsed_message.size(), equalTo(2));
-        assertThatKeyEquals(parsed_message, "key1", "value1");
-        assertThatKeyEquals(parsed_message, "key2", "altvalue");
-    }
-
-    @Test
     void testCustomPrefixKvProcessor() {
         when(mockConfig.getPrefix()).thenReturn("TEST_");
 


### PR DESCRIPTION
### Description
A hash specifying the default keys and their values which should be added to the event in case these keys do not exist in the source field being parsed.
 
### Issues Resolved
#891 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
