### PR TITLE
Added Dissect Processor Functionality

### DIFF
--- a/data-prepper-plugins/dissect-processor/README.md
+++ b/data-prepper-plugins/dissect-processor/README.md
@@ -1,0 +1,130 @@
+# Dissect Processor
+
+The Dissect processor is useful when dealing with log files or messages that have a known pattern or structure. It extracts specific pieces of information from the text and map them to individual fields based on the defined Dissect patterns.
+
+
+## Basic Usage
+
+To get started with dissect processor using Data Prepper, create the following `pipeline.yaml`.
+```yaml
+dissect-pipeline:
+  source:
+    file:
+      path: "/full/path/to/dissect_logs_json.log"
+      record_type: "event"
+      format: "json"
+  processor:
+    - dissect:
+        map:
+          log: "%{Date} %{Time} %{Log_Type}: %{Message}"
+  sink:
+    - stdout:
+```
+
+Create the following file named `dissect_logs_json.log` and replace the `path` in the file source of your `pipeline.yaml` with the path of this file.
+
+```
+{"log": "07-25-2023 10:00:00 ERROR: Some error"}
+```
+
+The Dissect processor will retrieve the necessary fields from the `log` message, such as `Date`, `Time`, `Log_Type`, and `Message`, with the help of the pattern `%{Date} %{Time} %{Type}: %{Message}`, configured in the pipeline.
+
+When you run Data Prepper with this `pipeline.yaml` passed in, you should see the following standard output.
+
+```
+{
+    "log" : "07-25-2023 10:00:00 ERROR: Some error",
+    "Date" : "07-25-2023"
+    "Time" : "10:00:00"
+    "Log_Type" : "ERROR"
+    "Message" : "Some error"
+}
+```
+
+The fields `Date`, `Time`, `Log_Type`, and `Message` have been extracted from `log` value.
+
+## Configuration
+* `map` (Required): `map` is required to specify the dissect patterns. It takes a `Map<String, String>` with fields as keys and respective dissect patterns as values.
+
+
+* `target_types` (Optional): A `Map<String, String>` that specifies what the target type of specific field should be. By default, all the values are `string`. Target types will be changed after the dissection process.
+
+
+* `dissect_when` (Optional): When a conditional statement is configured with `dissect_when`, the processor will evaluate the statement before proceeding with the dissection process.
+If the statement evaluates to `true`, the processor will perform the dissection. Else, skipped.
+
+## Field Notations
+
+Symbols like `?, +, ->, /, &`  can be  used to perform logical extraction of data.
+
+* **Normal Field** : The field without a suffix or prefix. The field will be directly added to the output Event.
+
+    Ex: `%{field_name}`
+
+
+* **Skip Field** : ? can be used as a prefix to key to skip that field in the output JSON.  
+    * Skip Field : `%{}`  
+    * Named skip field  : `%{?field_name}` 
+
+    
+
+
+* **Append Field** : To append multiple values and put the final value in the field, we can use + before the field name in the dissect pattern
+    * **Usage**:
+
+            Pattern : "%{+field_name}, %{+field_name}"
+            Text : "foo, bar"  
+  
+            Output : {"field_name" : "foobar"}
+
+    We can also define the order the concatenation with the help of suffix `/<digits>` .
+
+    * **Usage**:
+
+            Pattern : "%{+field_name/2}, %{+field_name/1}"
+            Text : "foo, bar"
+        
+            Output : {"field_name" : "barfoo"}
+
+    If the order is not mentioned, the append operation will take place in the order of fields specified in the dissect pattern.<br><br>
+
+* **Indirect Field** : While defining a pattern, prefix the field with a `&` to assign the value found with this to the value of another field found.
+    * **Usage**:
+
+            Pattern : "%{?field_name}, %{&field_name}"
+            Text: "foo, bar"  
+    
+            Output : {“foo” : “bar”}
+
+  Here we can see that `foo` which was captured from the skip field `%{?field_name}` is made the key to value captured form the field `%{&field_name}`
+    * **Usage**:
+  
+            Pattern : %{field_name}, %{&field_name}
+            Text: "foo, bar"
+    
+            Output : {“field_name”:“foo”, “foo”:“bar”}
+
+    We can also indirectly assign the value to an appended field, along with `normal` field and `skip` field.
+
+### Padding
+
+* `->` operator can be used as a suffix to a field to indicate that white spaces after this field can be ignored.
+    * **Usage**:
+
+            Pattern : %{field1→} %{field2}
+            Text : “firstname               lastname”
+  
+            Output : {“field1” : “firstname”, “field2” : “lastname”}
+
+* This operator should be used as the right most suffix.
+    * **Usage**:
+
+          Pattern : %{fieldname/1->} %{fieldname/2}
+
+    If we use `->` before `/<digit>`, the `->` operator will also be considered part of the field name.
+
+
+## Developer Guide
+This plugin is compatible with Java 14. See
+- [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md)
+- [monitoring](https://github.com/opensearch-project/data-prepper/blob/main/docs/monitoring.md)

--- a/data-prepper-plugins/dissect-processor/build.gradle
+++ b/data-prepper-plugins/dissect-processor/build.gradle
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+    id 'java'
+}
+
+
+dependencies {
+    implementation project(':data-prepper-api')
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.0'
+    implementation 'io.micrometer:micrometer-core'
+    implementation project(path: ':data-prepper-api')
+    implementation project(path: ':data-prepper-plugins:mutate-event-processors')
+    testImplementation project(':data-prepper-plugins:log-generator-source')
+    testImplementation project(':data-prepper-test-common')
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Delimiter.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Delimiter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.dissect;
+
+public class Delimiter {
+    private final String delimiterString;
+    private int start = -1;
+    private int end = -1;
+    private Delimiter next = null;
+
+    private Delimiter prev = null;
+
+    public Delimiter(String delimiterString) {
+        this.delimiterString = delimiterString;
+    }
+
+    public int getStart() {
+        return start;
+    }
+
+    public void setStart(int ind) {
+        start = ind;
+    }
+
+    public int getEnd() {
+        return end;
+    }
+
+    public void setEnd(int ind) {
+        end = ind;
+    }
+
+    public Delimiter getNext() {
+        return next;
+    }
+
+    public void setNext(Delimiter nextDelimiter) {
+        next = nextDelimiter;
+    }
+
+    public Delimiter getPrev() {
+        return prev;
+    }
+
+    public void setPrev(Delimiter prevDelimiter) {
+        prev = prevDelimiter;
+    }
+
+    @Override
+    public String toString() {
+        return delimiterString;
+    }
+}

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessor.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessor.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.dissect;
+
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.processor.AbstractProcessor;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.processor.dissect.Fields.Field;
+import org.opensearch.dataprepper.plugins.processor.mutateevent.TargetType;
+import org.opensearch.dataprepper.typeconverter.TypeConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
+
+
+@DataPrepperPlugin(name = "dissect", pluginType = Processor.class, pluginConfigurationType = DissectProcessorConfig.class)
+public class DissectProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
+    private static final Logger LOG = LoggerFactory.getLogger(DissectProcessor.class);
+    private final DissectProcessorConfig dissectConfig;
+    private final Map<String, Dissector> dissectorMap = new HashMap<>();;
+    private final Map<String, TargetType> targetTypeMap;
+    private final ExpressionEvaluator expressionEvaluator;
+
+    @DataPrepperPluginConstructor
+    public DissectProcessor(PluginMetrics pluginMetrics, final DissectProcessorConfig dissectConfig, final ExpressionEvaluator expressionEvaluator) {
+        super(pluginMetrics);
+        this.dissectConfig = dissectConfig;
+        this.expressionEvaluator = expressionEvaluator;
+        this.targetTypeMap = dissectConfig.getTargetTypes();
+
+        Map<String, String> patternsMap = dissectConfig.getMap();
+        for (String key : patternsMap.keySet()) {
+            Dissector dissector = new Dissector(patternsMap.get(key));
+            dissectorMap.put(key,
+                             dissector);
+        }
+
+    }
+
+    @Override
+    public Collection<Record<Event>> doExecute(Collection<Record<Event>> records) {
+        for (final Record<Event> record : records) {
+            Event event = record.getData();
+            String dissectWhen = dissectConfig.getDissectWhen();
+            if (Objects.nonNull(dissectWhen) && !expressionEvaluator.evaluateConditional(dissectWhen, event)) {
+                continue;
+            }
+            try{
+                for(String field: dissectorMap.keySet()){
+                    if(event.containsKey(field)){
+                        dissectField(event, field);
+                    }
+                }
+            }
+            catch (Exception ex){
+                LOG.error(EVENT, "Error dissecting the event [{}] ", record.getData(), ex);
+            }
+        }
+        return records;
+    }
+
+    private void dissectField(Event event, String field){
+        Dissector dissector = dissectorMap.get(field);
+        String text = event.get(field, String.class);
+        if(dissector.dissectText(text)) {
+            List<Field> dissectedFields = dissector.getDissectedFields();
+            for(Field disectedField: dissectedFields) {
+                String dissectFieldName = disectedField.getKey();
+                Object dissectFieldValue = convertTargetType(dissectFieldName,disectedField.getValue());
+                event.put(disectedField.getKey(), dissectFieldValue);
+            }
+        }
+    }
+
+    private Object convertTargetType(String fieldKey, String fieldValue){
+        if(targetTypeMap == null){
+            return fieldValue;
+        }
+        try{
+            if(targetTypeMap.containsKey(fieldKey)){
+                TypeConverter converter = targetTypeMap.get(fieldKey).getTargetConverter();
+                return converter.convert(fieldValue);
+            } else {
+                return fieldValue;
+            }
+        } catch (NumberFormatException ex){
+            LOG.error("Unable to convert [{}] to the target type mentioned", fieldKey);
+            return fieldValue;
+        }
+    }
+
+
+
+    @Override
+    public void prepareForShutdown() {
+
+    }
+
+    @Override
+    public boolean isReadyForShutdown() {
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+}

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessor.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessor.java
@@ -32,7 +32,7 @@ import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
 public class DissectProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
     private static final Logger LOG = LoggerFactory.getLogger(DissectProcessor.class);
     private final DissectProcessorConfig dissectConfig;
-    private final Map<String, Dissector> dissectorMap = new HashMap<>();;
+    private final Map<String, Dissector> dissectorMap = new HashMap<>();
     private final Map<String, TargetType> targetTypeMap;
     private final ExpressionEvaluator expressionEvaluator;
 

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfig.java
@@ -1,0 +1,28 @@
+package org.opensearch.dataprepper.plugins.processor.dissect;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.plugins.processor.mutateevent.TargetType;
+
+import java.util.Map;
+
+public class DissectProcessorConfig {
+    @NotNull
+    @JsonProperty("map")
+    private Map<String, String> map;
+    @JsonProperty("target_types")
+    private Map<String, TargetType> targetTypes;
+    @JsonProperty("dissect_when")
+    private String dissectWhen;
+
+    public String getDissectWhen(){
+        return dissectWhen;
+    }
+
+    public Map<String, String> getMap() {
+        return map;
+    }
+
+    public Map<String, TargetType> getTargetTypes() { return targetTypes; }
+
+}

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Dissector.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Dissector.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.dissect;
+
+import org.opensearch.dataprepper.plugins.processor.dissect.Fields.AppendField;
+import org.opensearch.dataprepper.plugins.processor.dissect.Fields.Field;
+import org.opensearch.dataprepper.plugins.processor.dissect.Fields.FieldHelper;
+import org.opensearch.dataprepper.plugins.processor.dissect.Fields.IndirectField;
+import org.opensearch.dataprepper.plugins.processor.dissect.Fields.NormalField;
+import org.opensearch.dataprepper.plugins.processor.dissect.Fields.SkipField;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class Dissector {
+    private Map<String, SkipField> skipFieldMap;
+    private Map<String, NormalField> normalFieldMap;
+    private Map<String, IndirectField> indirectFieldMap;
+    private Map<String, List<AppendField>> unAppendedFieldsMap;
+    private final FieldHelper fieldHelper = new FieldHelper();
+    private final LinkedList<Field> fieldsList = new LinkedList<>();
+    private final LinkedList<Delimiter> delimiterList = new LinkedList<>();
+    private static final Pattern DISSECT_PATTERN = Pattern.compile("%\\{([^}]*)}");
+
+    public Dissector(String dissectPatternString){
+        int maxLength = dissectPatternString.length()/3;
+        String[] delimiterArray = new String[maxLength];
+        String[] fieldsArray = new String[maxLength];
+
+        int lastIndex = 0;
+        int fieldIndex = 0;
+        int delimIndex = 0;
+
+        Matcher matcher = DISSECT_PATTERN.matcher(dissectPatternString);
+        while (matcher.find()) {
+            int matchStart = matcher.start();
+            int matchEnd = matcher.end();
+
+            delimiterArray[delimIndex] = dissectPatternString.substring(lastIndex, matchStart);
+            fieldsArray[fieldIndex] = matcher.group(1);
+
+            delimIndex++;
+            fieldIndex++;
+            lastIndex = matchEnd;
+        }
+
+        if (lastIndex < dissectPatternString.length()) {
+            delimiterArray[delimIndex] = dissectPatternString.substring(lastIndex);
+        }
+        parseFields(fieldsArray);
+        parseDelimiters(delimiterArray);
+        setFieldsMaps();
+    }
+
+    public boolean dissectText(String text){
+        if(!setDelimiterIndexes(text)){
+            return false;
+        }
+        Field head = fieldsList.getFirst();
+        for (final Delimiter delimiter: delimiterList){
+            int fieldStart = 0;
+            int fieldEnd = delimiter.getStart();
+            if(delimiter.getPrev() == null && delimiter.getStart()==0){
+                continue;
+            }
+            if (delimiter.getPrev() != null || delimiter.getStart() == 0) {
+                fieldStart = delimiter.getPrev().getEnd() + 1;
+            }
+            head.setValue(text.substring(fieldStart, fieldEnd));
+            head = head.getNext();
+        }
+        if (delimiterList.getLast().getEnd() != text.length() - 1) {
+            int fieldStart = delimiterList.getLast().getEnd() + 1;
+            int fieldEnd = text.length();
+            head.setValue(text.substring(fieldStart, fieldEnd));
+        }
+        return true;
+    }
+
+    public List<Field> getDissectedFields(){
+        final List<Field> dissectedFields = new ArrayList<>();
+        Map<String, AppendField> appendFieldMap = getAppendedFields(unAppendedFieldsMap);
+
+        dissectedFields.addAll(normalFieldMap.values());
+        dissectedFields.addAll(appendFieldMap.values());
+
+        for(final Field indirectField : indirectFieldMap.values()){
+            if(normalFieldMap.containsKey(indirectField.getKey())){
+                indirectField.setKey(normalFieldMap.get(indirectField.getKey()).getValue());
+            }
+            if(skipFieldMap.containsKey(indirectField.getKey())){
+                indirectField.setKey(skipFieldMap.get(indirectField.getKey()).getValue());
+            }
+            if(appendFieldMap.containsKey(indirectField.getKey())){
+                indirectField.setKey(appendFieldMap
+                                             .get(indirectField.getKey()).getValue());
+            }
+            dissectedFields.add(indirectField);
+        }
+
+        return dissectedFields;
+    }
+
+    private void setFieldsMaps(){
+        this.normalFieldMap = fieldHelper.getNormalFieldMap();
+        this.skipFieldMap = fieldHelper.getSkipFieldMap();
+        this.indirectFieldMap = fieldHelper.getIndirectFieldMap();
+        this.unAppendedFieldsMap = fieldHelper.getAppendFieldMap();
+    }
+
+    private void parseFields(String[] fieldsArray){
+        for(final String fieldString : fieldsArray){
+            if(fieldString==null) {
+                return;
+            }
+            Field field = fieldHelper.getField(fieldString);
+            if(fieldsList.size()==0) {
+                fieldsList.addLast(field);
+            }
+            else{
+                fieldsList.getLast().setNext(field);
+                fieldsList.addLast(field);
+            }
+        }
+    }
+
+    private void parseDelimiters(String[] delimiterArray) {
+        for (final String delimiterString : delimiterArray) {
+            if (delimiterString == null) {
+                return;
+            }
+            if (delimiterString.length() == 0) {
+                continue;
+            }
+            Delimiter delimiter = new Delimiter(delimiterString);
+            if (delimiterList.size() == 0) {
+                delimiterList.addLast(delimiter);
+            } else {
+                delimiterList.getLast().setNext(delimiter);
+                delimiter.setPrev(delimiterList.getLast());
+                delimiterList.addLast(delimiter);
+            }
+        }
+    }
+
+    private boolean setDelimiterIndexes(String text){
+        for (Delimiter delimiter : delimiterList) {
+            int prevEnd = 0;
+            if (delimiter.getPrev() != null) {
+                prevEnd = delimiter.getPrev().getEnd() + 1;
+            }
+            String delimiterString = delimiter.toString();
+            int start = text.indexOf(delimiterString, prevEnd);
+            if (delimiterString.trim().isEmpty()) {
+                start = start + findLastWhitespaceIndex(text.substring(start), delimiterString.length());
+            }
+            int end = start + delimiterString.length() -1;
+            if (start < 0 || end > text.length()) {
+                return false;
+            }
+            delimiter.setStart(start);
+            delimiter.setEnd(end);
+        }
+        return true;
+    }
+
+    private Map<String, AppendField> getAppendedFields(Map<String, List<AppendField>> unAppendedFieldsMap){
+        final Map<String, AppendField> appendFieldMap = new HashMap<>();
+        for(final String key : unAppendedFieldsMap.keySet()){
+            List<AppendField> appendFields = unAppendedFieldsMap.get(key);
+            Collections.sort(appendFields);
+            String value = appendFields.stream().map(AppendField::getValue).collect(Collectors.joining());
+            AppendField sortedField = new AppendField(key);
+            sortedField.setValue(value);
+            appendFieldMap.put(sortedField.getKey(), sortedField);
+        }
+        return appendFieldMap;
+    }
+
+    private int findLastWhitespaceIndex(String s, int w) {
+
+        final String[] leadingSpaces = s.split("\\S", 2);
+
+        if (leadingSpaces.length > 0 && leadingSpaces[0].length() >= w) {
+            return leadingSpaces[0].length() - w;
+        }
+
+        return 0;
+    }
+}

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/AppendField.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/AppendField.java
@@ -1,0 +1,22 @@
+package org.opensearch.dataprepper.plugins.processor.dissect.Fields;
+
+public class AppendField extends Field implements Comparable<AppendField> {
+    private int index;
+    public AppendField(String key) {
+        this.setKey(key);
+    }
+
+    public void setIndex(int index){
+        this.index = index;
+    }
+
+    public int getIndex(){
+        return index;
+    }
+
+
+    @Override
+    public int compareTo(AppendField appendField) {
+        return this.index - appendField.getIndex();
+    }
+}

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/Field.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/Field.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.dissect.Fields;
+
+public abstract class Field {
+    boolean stripTrailing = false;
+    private String key;
+    private String value;
+    private Field next;
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public Field getNext() {
+        return next;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public void setNext(Field next) {
+        this.next = next;
+    }
+
+    public void setValue(String value) {
+        this.value = stripTrailing ? value.stripTrailing() : value;
+    }
+
+}

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/FieldHelper.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/FieldHelper.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.dissect.Fields;
+
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class FieldHelper {
+    private final Pattern appendPattern = Pattern.compile("^(.*?)->");
+    private final Pattern prefixPattern = Pattern.compile("([+&?])(.+)");
+    private final Pattern indexPattern = Pattern.compile("/(\\d+)$");
+    private final Map<String, SkipField> skipFieldMap = new HashMap<>();
+    private final Map<String, NormalField> normalFieldMap = new HashMap<>();
+    private final Map<String, IndirectField> indirectFieldMap = new HashMap<>();
+    private final Map<String, List<AppendField>> appendFieldMap = new HashMap<>();
+
+    public Map<String, SkipField> getSkipFieldMap(){
+        return skipFieldMap;
+    }
+    public Map<String, NormalField> getNormalFieldMap(){
+        return normalFieldMap;
+    }
+    public Map<String, IndirectField> getIndirectFieldMap(){
+        return indirectFieldMap;
+    }
+    public Map<String, List<AppendField>> getAppendFieldMap(){
+        return appendFieldMap;
+    }
+
+    public Field getField(String fieldString) {
+        if (fieldString == null) {
+            return null;
+        }
+        if(fieldString.trim().isEmpty()){
+            return new AppendField("");
+        }
+
+        Field field = null;
+
+        Matcher matcher = prefixPattern.matcher(fieldString);
+        if (matcher.matches()) {
+            final String notation = matcher.group(1);
+            final String key = matcher.group(2);
+            if (Objects.equals(notation, "+")) {
+                field = new AppendField(key);
+                setAppendIndex((AppendField) field);
+                setStripTrailing(field);
+                putInAppendMap((AppendField) field);
+            } else if (Objects.equals(notation, "?")) {
+                field = new SkipField(key);
+                setStripTrailing(field);
+                skipFieldMap.put(field.getKey(), (SkipField) field);
+            } else if (Objects.equals(notation, "&")) {
+                field = new IndirectField(key);
+                setStripTrailing(field);
+                indirectFieldMap.put(field.getKey(), (IndirectField) field);
+            }
+        } else {
+            field = new NormalField(fieldString);
+            setStripTrailing(field);
+            normalFieldMap.put(field.getKey(), (NormalField) field);
+        }
+        return field;
+    }
+
+    private void setAppendIndex(AppendField field) {
+        String fieldString = field.getKey();
+        Matcher matcher = indexPattern.matcher(fieldString);
+
+        if (matcher.find()) {
+            String key = fieldString.substring(0, matcher.start());
+            int index = Integer.parseInt(matcher.group(1));
+            field.setKey(key);
+            field.setIndex(index);
+        }
+    }
+
+    private void setStripTrailing(Field field) {
+        if (field == null) {
+            return;
+        }
+
+        String fieldString = field.getKey();
+
+        Matcher matcher = appendPattern.matcher(fieldString);
+        if (matcher.find()) {
+            field.setKey(matcher.group(1));
+            field.stripTrailing = true;
+        }
+    }
+
+    private void putInAppendMap(AppendField field) {
+        String key = field.getKey();
+        if (appendFieldMap.containsKey(key)) {
+            appendFieldMap.get(key).add(field);
+        } else {
+            List<AppendField> appendFields = new ArrayList<>();
+            appendFields.add(field);
+            appendFieldMap.put(key, appendFields);
+        }
+    }
+
+}

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/IndirectField.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/IndirectField.java
@@ -1,0 +1,10 @@
+package org.opensearch.dataprepper.plugins.processor.dissect.Fields;
+
+public class IndirectField extends Field {
+
+
+    public IndirectField(String key) {
+        this.setKey(key);
+    }
+
+}

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/NormalField.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/NormalField.java
@@ -1,0 +1,9 @@
+package org.opensearch.dataprepper.plugins.processor.dissect.Fields;
+
+public class NormalField extends Field {
+
+    public NormalField(String key) {
+        this.setKey(key);
+    }
+
+}

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/SkipField.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/Fields/SkipField.java
@@ -1,0 +1,9 @@
+package org.opensearch.dataprepper.plugins.processor.dissect.Fields;
+
+public class SkipField extends Field {
+
+    public SkipField(String key) {
+        this.setKey(key);
+    }
+
+}

--- a/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfigTest.java
+++ b/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorConfigTest.java
@@ -1,0 +1,46 @@
+package org.opensearch.dataprepper.plugins.processor.dissect;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.plugins.processor.mutateevent.TargetType;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
+
+class DissectProcessorConfigTest {
+    private DissectProcessorConfig dissectProcessorConfig;
+    private DissectProcessorConfig createObjectUnderTest() {
+        return new DissectProcessorConfig();
+    }
+
+    @BeforeEach
+    void setup(){
+        dissectProcessorConfig = createObjectUnderTest();
+    }
+
+    @Test
+    void test_get_map() throws NoSuchFieldException, IllegalAccessException {
+        Map<String, String> dissectMap = Map.of("key1", "%{field1}");
+        setField(DissectProcessorConfig.class, dissectProcessorConfig, "map", dissectMap);
+        assertThat(dissectProcessorConfig.getMap(), is(dissectMap));
+    }
+
+    @Test
+    void test_get_dissect_when() throws NoSuchFieldException, IllegalAccessException {
+        String dissectWhen = "/test!=null";
+        setField(DissectProcessorConfig.class, dissectProcessorConfig, "dissectWhen", dissectWhen);
+        assertThat(dissectProcessorConfig.getDissectWhen(), is(dissectWhen));
+    }
+
+    @Test
+    void test_get_targets_types() throws NoSuchFieldException, IllegalAccessException {
+        Map<String, TargetType> targetTypeMap = Map.of("field1", TargetType.INTEGER);
+        setField(DissectProcessorConfig.class, dissectProcessorConfig, "targetTypes", targetTypeMap);
+        assertThat(dissectProcessorConfig.getTargetTypes(), is(targetTypeMap));
+    }
+
+}

--- a/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorTest.java
+++ b/data-prepper-plugins/dissect-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessorTest.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.dissect;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.processor.mutateevent.TargetType;
+import org.opensearch.dataprepper.typeconverter.TypeConverter;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DissectProcessorTest {
+    @Mock
+    private PluginMetrics pluginMetrics;
+    @Mock
+    private ExpressionEvaluator expressionEvaluator;
+    @Mock
+    private DissectProcessorConfig dissectConfig;
+
+
+    @Test
+    void test_normal_field_trailing_spaces(){
+        Map<String, String> dissectMap = Map.of("test", " %{field1} %{field2} ");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent(" foo bar ");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field2"));
+
+        assertThat(dissectedRecords.get(0).getData().get("field1", String.class), is("foo"));
+        assertThat(dissectedRecords.get(0).getData().get("field2", String.class), is("bar"));
+
+    }
+
+    @Test
+    void test_normal_field_without_trailing_spaces(){
+        Map<String, String> dissectMap = Map.of("test", "dm1 %{field1} %{field2} dm2");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("dm1 foo bar dm2");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field2"));
+
+        assertThat(dissectedRecords.get(0).getData().get("field1", String.class), is("foo"));
+        assertThat(dissectedRecords.get(0).getData().get("field2", String.class), is("bar"));
+
+    }
+
+    @Test
+    void test_normal_field_failure_without_delimiters(){
+        Map<String, String> dissectMap = Map.of("test", "dm1 %{field1} %{field2} dm2");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("dm1 foo bar");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertFalse(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertFalse(dissectedRecords.get(0).getData().containsKey("field2"));
+    }
+
+    @Test
+    void test_normal_field_failure_with_extra_whitespaces(){
+        Map<String, String> dissectMap = Map.of("test", "dm1 %{field1} %{field2} dm2");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent(" dm1 foo bar dm2");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertFalse(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertFalse(dissectedRecords.get(0).getData().containsKey("field2"));
+    }
+
+    @Test
+    void test_named_skip_field(){
+        Map<String, String> dissectMap = Map.of("test", "dm1 %{?field1} %{field2} dm2");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("dm1 foo bar dm2");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertFalse(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field2"));
+
+        assertThat(dissectedRecords.get(0).getData().get("field2", String.class), is("bar"));
+    }
+
+    @Test
+    void test_unnamed_skip_field(){
+        Map<String, String> dissectMap = Map.of("test", "dm1 %{} %{field2} dm2");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("dm1 foo bar dm2");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertFalse(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field2"));
+
+        assertThat(dissectedRecords.get(0).getData().get("field2", String.class), is("bar"));
+    }
+
+    @Test
+    void test_indirect_field_with_skip_field(){
+        Map<String, String> dissectMap = Map.of("test", "dm1 %{?field1} %{&field1} dm2");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("dm1 foo bar dm2");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertFalse(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertTrue(dissectedRecords.get(0).getData().containsKey("foo"));
+
+        assertThat(dissectedRecords.get(0).getData().get("foo", String.class), is("bar"));
+    }
+
+    @Test
+    void test_indirect_field_with_normal_field(){
+        Map<String, String> dissectMap = Map.of("test", "dm1 %{field1} %{&field1} dm2");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("dm1 foo bar dm2");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertTrue(dissectedRecords.get(0).getData().containsKey("foo"));
+        assertThat(dissectedRecords.get(0).getData().get("field1", String.class), is("foo"));
+        assertThat(dissectedRecords.get(0).getData().get("foo", String.class), is("bar"));
+    }
+
+
+    @Test
+    void test_append_field_without_index(){
+        Map<String, String> dissectMap = Map.of("test", "dm1 %{+field1} %{+field1} dm2");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("dm1 foo bar dm2");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertThat(dissectedRecords.get(0).getData().get("field1", String.class), is("foobar"));
+    }
+
+    @Test
+    void test_append_field_with_index(){
+        Map<String, String> dissectMap = Map.of("test", "dm1 %{+field1/2} %{+field1/1} dm2");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("dm1 foo bar dm2");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertThat(dissectedRecords.get(0).getData().get("field1", String.class), is("barfoo"));
+    }
+
+    @Test
+    void test_append_whitespace_normal_field(){
+        Map<String, String> dissectMap = Map.of("test", "dm1 %{field1->} %{field2} dm2");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("dm1 foo      bar dm2");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertThat(dissectedRecords.get(0).getData().get("field1", String.class), is("foo"));
+    }
+
+    @Test
+    void test_append_whitespace_append_field(){
+        Map<String, String> dissectMap = Map.of("test", "dm1 %{+field1->} %{+field1} dm2");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("dm1 foo      bar dm2");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertThat(dissectedRecords.get(0).getData().get("field1", String.class), is("foobar"));
+    }
+
+    @Test
+    void test_append_whitespace_indirect_field(){
+        Map<String, String> dissectMap = Map.of("test", "dm1 %{?field1->} %{&field1} dm2");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("dm1 foo      bar dm2");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("foo"));
+        assertThat(dissectedRecords.get(0).getData().get("foo", String.class), is("bar"));
+    }
+
+    @Test
+    void test_skip_fields(){
+        Map<String, String> dissectMap = Map.of("test", "dm1 %{?field1->} %{?field3} %{field2} dm2");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("dm1 foo     skip   bar dm2");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field2"));
+        assertThat(dissectedRecords.get(0).getData().get("field2", String.class), is("bar"));
+    }
+
+    @Test
+    void test_normal_fields(){
+        Map<String, String> dissectMap = Map.of("test", "%{id->} %{function} %{server}");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("00000043     ViewReceive machine-321");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("function"));
+        assertThat(dissectedRecords.get(0).getData().get("function", String.class), is("ViewReceive"));
+    }
+
+    @Test
+    void test_indirect_field_with_append(){
+        Map<String, String> dissectMap = Map.of("test", "%{+field1->} %{+field1} %{&field1->}");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("foo     bar result     ");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("foobar"));
+        assertThat(dissectedRecords.get(0).getData().get("foobar", String.class), is("result"));
+    }
+
+    @Test
+    void test_target_type_int(){
+        Map<String, String> dissectMap = Map.of("test", "%{field1} %{field2}");
+        Map<String, TargetType> targetsMap = Map.of("field1", TargetType.INTEGER);
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        when(dissectConfig.getTargetTypes()).thenReturn(targetsMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("20 30");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertThat(dissectedRecords.get(0).getData().get("field1", Object.class), is(20));
+    }
+
+    @Test
+    void test_target_type_default(){
+        Map<String, String> dissectMap = Map.of("test", "%{field1} %{field2}");
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("20 30");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertTrue(dissectedRecords.get(0).getData().get("field1", Object.class) instanceof String);
+        assertThat(dissectedRecords.get(0).getData().get("field1", Object.class), is("20"));
+    }
+
+    @Test
+    void test_target_type_bool(){
+        Map<String, String> dissectMap = Map.of("test", "%{field1} %{field2}");
+        Map<String, TargetType> targetsMap = Map.of("field1", TargetType.BOOLEAN);
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        when(dissectConfig.getTargetTypes()).thenReturn(targetsMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("true 30");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertTrue(dissectedRecords.get(0).getData().get("field1", Object.class) instanceof Boolean);
+        assertThat(dissectedRecords.get(0).getData().get("field1", Object.class), is(true));
+    }
+
+    @Test
+    void test_target_type_double(){
+        Map<String, String> dissectMap = Map.of("test", "%{field1} %{field2}");
+        Map<String, TargetType> targetsMap = Map.of("field1", TargetType.DOUBLE);
+        when(dissectConfig.getMap()).thenReturn(dissectMap);
+        when(dissectConfig.getTargetTypes()).thenReturn(targetsMap);
+        final DissectProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("20.5 30");
+        final List<Record<Event>> dissectedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertTrue(dissectedRecords.get(0).getData().containsKey("field1"));
+        assertTrue(dissectedRecords.get(0).getData().get("field1", Object.class) instanceof Double);
+        assertThat(dissectedRecords.get(0).getData().get("field1", Object.class), is(20.5));
+    }
+
+
+
+
+    private DissectProcessor createObjectUnderTest() {
+        return new DissectProcessor(pluginMetrics, dissectConfig, expressionEvaluator);
+    }
+
+    private Record<Event> getEvent(String dissectText) {
+        final Map<String, Object> testData = new HashMap<>();
+        testData.put("test", dissectText);
+        return buildRecordWithEvent(testData);
+    }
+
+    private static Record<Event> buildRecordWithEvent(final Map<String, Object> data) {
+        return new Record<>(JacksonEvent
+                                    .builder()
+                                    .withData(data)
+                                    .withEventType("event")
+                                    .build());
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -128,3 +128,5 @@ include 'data-prepper-plugins:buffer-common'
 include 'data-prepper-plugins:sqs-source'
 include 'data-prepper-plugins:cloudwatch-logs'
 include 'data-prepper-plugins:http-sink'
+include 'data-prepper-plugins:dissect-processor'
+


### PR DESCRIPTION
### Description
Implemented Dissect processor functionality. 

#### Design overview:
For each pattern in `map` - 
1) Breakdown the pattern into 2 groups:
     - List of fields
     - List of delimiters
2) Assign the properties of prefix and suffix notations.

(Used regex for above 2 steps. These are executed only once to process the dissect pattern, before processing the logs)

3) For an incoming log, check if the `dissect_when` expression satisfies

For each mapped field's value if present -

4) Split the string with the help of delimiters and assign the the text beween the delimiters to the fields. 
5) Perform the operations on the fields, with the help of the suffix and prefix properties.
6) Convert the field types based on the `target_types`  map provided in the config.
7) Populate the output Json with the fields and their assigned values

 
### Issues Resolved
 [None]

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
