### PR TITLE
Fix consumer synchronization. Fix consumer to use user-specified groupId

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
@@ -83,6 +83,7 @@ public class KafkaSourceJsonTypeIT {
     private String bootstrapServers;
     private String testKey;
     private String testTopic;
+    private String testGroup;
 
     public KafkaSource createObjectUnderTest() {
         return new KafkaSource(sourceConfig, pluginMetrics, acknowledgementSetManager, pipelineDescription);
@@ -112,7 +113,7 @@ public class KafkaSourceJsonTypeIT {
         } catch (Exception e){}
 
         testKey = RandomStringUtils.randomAlphabetic(5);
-        final String testGroup = "TestGroup_"+RandomStringUtils.randomAlphabetic(6);
+        testGroup = "TestGroup_"+RandomStringUtils.randomAlphabetic(6);
         testTopic = "TestJsonTopic_"+RandomStringUtils.randomAlphabetic(5);
         jsonTopic = mock(TopicConfig.class);
         when(jsonTopic.getName()).thenReturn(testTopic);
@@ -337,6 +338,7 @@ public class KafkaSourceJsonTypeIT {
             Thread.sleep(1000);
         }
         kafkaSource.start(buffer);
+        assertThat(kafkaSource.getConsumer().groupMetadata().groupId(), equalTo(testGroup));
         produceJsonRecords(bootstrapServers, topicName, numRecords);
         int numRetries = 0;
         while (numRetries++ < 10 && (receivedRecords.size() != numRecords)) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfig.java
@@ -18,23 +18,24 @@ import java.time.Duration;
  * pipelines.yaml
  */
 public class TopicConfig {
-    private static final String AUTO_COMMIT = "false";
-    private static final Duration DEFAULT_COMMIT_INTERVAL = Duration.ofSeconds(5);
-    private static final Duration DEFAULT_SESSION_TIMEOUT = Duration.ofSeconds(45);
-    private static final int MAX_RETRY_ATTEMPT = Integer.MAX_VALUE;
+    static final boolean DEFAULT_AUTO_COMMIT = false;
+    static final Duration DEFAULT_COMMIT_INTERVAL = Duration.ofSeconds(5);
+    static final Duration DEFAULT_SESSION_TIMEOUT = Duration.ofSeconds(45);
+    static final int DEFAULT_MAX_RETRY_ATTEMPT = Integer.MAX_VALUE;
     static final String DEFAULT_AUTO_OFFSET_RESET = "latest";
-    static final Duration THREAD_WAITING_TIME = Duration.ofSeconds(5);
-    private static final Duration MAX_RECORD_FETCH_TIME = Duration.ofSeconds(4);
-    private static final Duration BUFFER_DEFAULT_TIMEOUT = Duration.ofSeconds(5);
-    private static final Duration MAX_RETRY_DELAY = Duration.ofSeconds(1);
-    private static final Integer FETCH_MAX_BYTES = 52428800;
-    private static final Integer FETCH_MAX_WAIT = 500;
-    private static final Integer FETCH_MIN_BYTES = 1;
-    private static final Duration RETRY_BACKOFF = Duration.ofSeconds(100);
-    private static final Duration MAX_POLL_INTERVAL = Duration.ofSeconds(300000);
-    private static final Integer CONSUMER_MAX_POLL_RECORDS = 500;
+    static final Duration DEFAULT_THREAD_WAITING_TIME = Duration.ofSeconds(5);
+    static final Duration DEFAULT_MAX_RECORD_FETCH_TIME = Duration.ofSeconds(4);
+    static final Duration DEFAULT_BUFFER_TIMEOUT = Duration.ofSeconds(5);
+    static final Duration DEFAULT_MAX_RETRY_DELAY = Duration.ofSeconds(1);
+    static final Integer DEFAULT_FETCH_MAX_BYTES = 52428800;
+    static final Integer DEFAULT_FETCH_MAX_WAIT = 500;
+    static final Integer DEFAULT_FETCH_MIN_BYTES = 1;
+    static final Duration DEFAULT_RETRY_BACKOFF = Duration.ofSeconds(10);
+    static final Duration DEFAULT_RECONNECT_BACKOFF = Duration.ofSeconds(10);
+    static final Duration DEFAULT_MAX_POLL_INTERVAL = Duration.ofSeconds(300000);
+    static final Integer DEFAULT_CONSUMER_MAX_POLL_RECORDS = 500;
     static final Integer DEFAULT_NUM_OF_WORKERS = 2;
-    static final Duration HEART_BEAT_INTERVAL_DURATION = Duration.ofSeconds(5);
+    static final Duration DEFAULT_HEART_BEAT_INTERVAL_DURATION = Duration.ofSeconds(5);
 
     @JsonProperty("name")
     @NotNull
@@ -54,18 +55,18 @@ public class TopicConfig {
     @JsonProperty("max_retry_attempts")
     @Valid
     @Size(min = 1, max = Integer.MAX_VALUE, message = " Max retry attempts should lies between 1 and Integer.MAX_VALUE")
-    private Integer maxRetryAttempts = MAX_RETRY_ATTEMPT;
+    private Integer maxRetryAttempts = DEFAULT_MAX_RETRY_ATTEMPT;
 
     @JsonProperty("max_retry_delay")
     @Valid
     @Size(min = 1)
-    private Duration maxRetryDelay = MAX_RETRY_DELAY;
+    private Duration maxRetryDelay = DEFAULT_MAX_RETRY_DELAY;
 
     @JsonProperty("serde_format")
     private MessageFormat serdeFormat= MessageFormat.PLAINTEXT;
 
     @JsonProperty("auto_commit")
-    private Boolean autoCommit = false;
+    private Boolean autoCommit = DEFAULT_AUTO_COMMIT;
 
     @JsonProperty("commit_interval")
     @Valid
@@ -86,47 +87,50 @@ public class TopicConfig {
     private String groupName;
 
     @JsonProperty("thread_waiting_time")
-    private Duration threadWaitingTime = THREAD_WAITING_TIME;
+    private Duration threadWaitingTime = DEFAULT_THREAD_WAITING_TIME;
 
     @JsonProperty("max_record_fetch_time")
-    private Duration maxRecordFetchTime = MAX_RECORD_FETCH_TIME;
+    private Duration maxRecordFetchTime = DEFAULT_MAX_RECORD_FETCH_TIME;
 
     @JsonProperty("buffer_default_timeout")
     @Valid
     @Size(min = 1)
-    private Duration bufferDefaultTimeout = BUFFER_DEFAULT_TIMEOUT;
+    private Duration bufferDefaultTimeout = DEFAULT_BUFFER_TIMEOUT;
 
     @JsonProperty("fetch_max_bytes")
     @Valid
     @Size(min = 1, max = 52428800)
-    private Integer fetchMaxBytes = FETCH_MAX_BYTES;
+    private Integer fetchMaxBytes = DEFAULT_FETCH_MAX_BYTES;
 
     @JsonProperty("fetch_max_wait")
     @Valid
     @Size(min = 1)
-    private Integer fetchMaxWait = FETCH_MAX_WAIT;
+    private Integer fetchMaxWait = DEFAULT_FETCH_MAX_WAIT;
 
     @JsonProperty("fetch_min_bytes")
     @Size(min = 1)
     @Valid
-    private Integer fetchMinBytes = FETCH_MIN_BYTES;
+    private Integer fetchMinBytes = DEFAULT_FETCH_MIN_BYTES;
 
     @JsonProperty("key_mode")
     private KafkaKeyMode kafkaKeyMode = KafkaKeyMode.INCLUDE_AS_FIELD;
 
     @JsonProperty("retry_backoff")
-    private Duration retryBackoff = RETRY_BACKOFF;
+    private Duration retryBackoff = DEFAULT_RETRY_BACKOFF;
+
+    @JsonProperty("reconnect_backoff")
+    private Duration reconnectBackoff = DEFAULT_RECONNECT_BACKOFF;
 
     @JsonProperty("max_poll_interval")
-    private Duration maxPollInterval = MAX_POLL_INTERVAL;
+    private Duration maxPollInterval = DEFAULT_MAX_POLL_INTERVAL;
 
     @JsonProperty("consumer_max_poll_records")
-    private Integer consumerMaxPollRecords = CONSUMER_MAX_POLL_RECORDS;
+    private Integer consumerMaxPollRecords = DEFAULT_CONSUMER_MAX_POLL_RECORDS;
 
     @JsonProperty("heart_beat_interval")
     @Valid
     @Size(min = 1)
-    private Duration heartBeatInterval= HEART_BEAT_INTERVAL_DURATION;
+    private Duration heartBeatInterval= DEFAULT_HEART_BEAT_INTERVAL_DURATION;
 
     public String getGroupId() {
         return groupId;
@@ -218,6 +222,10 @@ public class TopicConfig {
 
     public Duration getRetryBackoff() {
         return retryBackoff;
+    }
+
+    public Duration getReconnectBackoff() {
+        return reconnectBackoff;
     }
 
     public void setRetryBackoff(Duration retryBackoff) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSourceSecurityConfigurer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSourceSecurityConfigurer.java
@@ -17,9 +17,7 @@ import software.amazon.awssdk.services.kafka.KafkaClient;
 import software.amazon.awssdk.services.kafka.model.GetBootstrapBrokersRequest;
 import software.amazon.awssdk.services.kafka.model.GetBootstrapBrokersResponse;
 import software.amazon.awssdk.services.kafka.model.InternalServerErrorException;
-import software.amazon.awssdk.services.kafka.model.ConflictException;
-import software.amazon.awssdk.services.kafka.model.ForbiddenException;
-import software.amazon.awssdk.services.kafka.model.UnauthorizedException;
+import software.amazon.awssdk.services.kafka.model.KafkaException;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.StsException;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
@@ -214,17 +212,15 @@ public class KafkaSourceSecurityConfigurer {
             retryable = false;
             try {
                 result = kafkaClient.getBootstrapBrokers(request);
-            } catch (InternalServerErrorException | ConflictException | ForbiddenException | UnauthorizedException | StsException e) {
+            } catch (KafkaException | StsException e) {
                 LOG.debug("Failed to get bootstrap server information from MSK. Retrying...", e);
-
-                retryable = true;
                 try {
                     Thread.sleep(10000);
                 } catch (InterruptedException exp) {}
             } catch (Exception e) {
                 throw new RuntimeException("Failed to get bootstrap server information from MSK.", e);
             }
-        } while (retryable && numRetries++ < MAX_KAFKA_CLIENT_RETRIES);
+        } while (numRetries++ < MAX_KAFKA_CLIENT_RETRIES);
         if (Objects.isNull(result)) {
             throw new RuntimeException("Failed to get bootstrap server information from MSK after trying multiple times with retryable exceptions.");
         }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfigTest.java
@@ -67,21 +67,23 @@ class TopicConfigTest {
     @Tag(YAML_FILE_WITH_MISSING_CONSUMER_CONFIG)
     void testConfigValues_default() {
         assertEquals("my-topic-2", topicConfig.getName());
-        assertEquals(false, topicConfig.getAutoCommit());
-        assertEquals(Duration.ofSeconds(5), topicConfig.getCommitInterval());
-        assertEquals(45000, topicConfig.getSessionTimeOut().toMillis());
+        assertEquals("my-test-group", topicConfig.getGroupId());
+        assertEquals(TopicConfig.DEFAULT_AUTO_COMMIT, topicConfig.getAutoCommit());
+        assertEquals(TopicConfig.DEFAULT_COMMIT_INTERVAL, topicConfig.getCommitInterval());
+        assertEquals(TopicConfig.DEFAULT_SESSION_TIMEOUT, topicConfig.getSessionTimeOut());
         assertEquals(TopicConfig.DEFAULT_AUTO_OFFSET_RESET, topicConfig.getAutoOffsetReset());
-        assertEquals(TopicConfig.THREAD_WAITING_TIME, topicConfig.getThreadWaitingTime());
-        assertEquals(Duration.ofSeconds(4), topicConfig.getMaxRecordFetchTime());
-        assertEquals(Duration.ofSeconds(5), topicConfig.getBufferDefaultTimeout());
-        assertEquals(52428800L, topicConfig.getFetchMaxBytes().longValue());
-        assertEquals(500L, topicConfig.getFetchMaxWait().longValue());
-        assertEquals(1L, topicConfig.getFetchMinBytes().longValue());
-        assertEquals(Duration.ofSeconds(100), topicConfig.getRetryBackoff());
-        assertEquals(Duration.ofSeconds(300000), topicConfig.getMaxPollInterval());
-        assertEquals(500L, topicConfig.getConsumerMaxPollRecords().longValue());
-        assertEquals(TopicConfig.DEFAULT_NUM_OF_WORKERS, topicConfig.getWorkers().intValue());
-        assertEquals(TopicConfig.HEART_BEAT_INTERVAL_DURATION, topicConfig.getHeartBeatInterval());
+        assertEquals(TopicConfig.DEFAULT_THREAD_WAITING_TIME, topicConfig.getThreadWaitingTime());
+        assertEquals(TopicConfig.DEFAULT_MAX_RECORD_FETCH_TIME, topicConfig.getMaxRecordFetchTime());
+        assertEquals(TopicConfig.DEFAULT_BUFFER_TIMEOUT, topicConfig.getBufferDefaultTimeout());
+        assertEquals(TopicConfig.DEFAULT_FETCH_MAX_BYTES, topicConfig.getFetchMaxBytes());
+        assertEquals(TopicConfig.DEFAULT_FETCH_MAX_WAIT, topicConfig.getFetchMaxWait());
+        assertEquals(TopicConfig.DEFAULT_FETCH_MIN_BYTES, topicConfig.getFetchMinBytes());
+        assertEquals(TopicConfig.DEFAULT_RETRY_BACKOFF, topicConfig.getRetryBackoff());
+        assertEquals(TopicConfig.DEFAULT_RECONNECT_BACKOFF, topicConfig.getReconnectBackoff());
+        assertEquals(TopicConfig.DEFAULT_MAX_POLL_INTERVAL, topicConfig.getMaxPollInterval());
+        assertEquals(TopicConfig.DEFAULT_CONSUMER_MAX_POLL_RECORDS, topicConfig.getConsumerMaxPollRecords());
+        assertEquals(TopicConfig.DEFAULT_NUM_OF_WORKERS, topicConfig.getWorkers());
+        assertEquals(TopicConfig.DEFAULT_HEART_BEAT_INTERVAL_DURATION, topicConfig.getHeartBeatInterval());
     }
 
     @Test

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines-1.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines-1.yaml
@@ -6,9 +6,9 @@ log-pipeline:
       topics:
         - name: my-topic-2
           group_name: kafka-consumer-group-2
-          group_id: DPKafkaProj-2
+          group_id: my-test-group
         - name: my-topic-1
-          group_id: DPKafkaProj-1
+          group_id: my-test-group
       schema:
         registry_url: http://localhost:8081/
         version: 1

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines.yaml
@@ -7,6 +7,7 @@ log-pipeline:
       encryption: plaintext
       topics:
         - name: my-topic-1
+          group_id: my-test-group
           workers: 5
           auto_commit: false
           commit_interval: PT5S


### PR DESCRIPTION
### Description
This PR contains the following fixes
1. Addresses comments from PR #3082 
  -- Fixes consumer synchronization issue by avoid synchronization 
  -- Fixes LOG messages to use {}
2. MSK getBrokers API exception handles KafkaException
3. Fixes consumer to use user-configured groupID
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
