### PR TITLE
Updated GitHub Actions to use "Data Prepper" in the job titles

### DIFF
--- a/.github/workflows/data-prepper-log-analytics-basic-grok-e2e-tests.yml
+++ b/.github/workflows/data-prepper-log-analytics-basic-grok-e2e-tests.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Checkout Data-Prepper
+      - name: Checkout Data Prepper
         uses: actions/checkout@v2
       - name: Run basic grok end-to-end tests with Gradle
         run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:log:${{ matrix.test }}

--- a/.github/workflows/data-prepper-peer-forwarder-local-node-e2e-tests.yml
+++ b/.github/workflows/data-prepper-peer-forwarder-local-node-e2e-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Checkout Data-Prepper
+      - name: Checkout Data Prepper
         uses: actions/checkout@v2
       - name: Run raw-span latest release compatibility end-to-end tests with Gradle
         run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:peerforwarder:localAggregateEndToEndTest

--- a/.github/workflows/data-prepper-peer-forwarder-static-e2e-tests.yml
+++ b/.github/workflows/data-prepper-peer-forwarder-static-e2e-tests.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Checkout Data-Prepper
+      - name: Checkout Data Prepper
         uses: actions/checkout@v2
       - name: Run raw-span latest release compatibility end-to-end tests with Gradle
         run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:peerforwarder:${{ matrix.test }}

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-compatibility-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-compatibility-e2e-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Checkout Data-Prepper
+      - name: Checkout Data Prepper
         uses: actions/checkout@v2
       - name: Run raw-span latest release compatibility end-to-end tests with Gradle
         run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:trace:rawSpanLatestReleaseCompatibilityEndToEndTest

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Checkout Data-Prepper
+      - name: Checkout Data Prepper
         uses: actions/checkout@v2
       - name: Run raw-span end-to-end tests with Gradle
         run: ./gradlew -PopenTelemetryVersion=${{ matrix.otelVersion }} -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:trace:rawSpanEndToEndTest

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-peer-forwarder-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-peer-forwarder-e2e-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Checkout Data-Prepper
+      - name: Checkout Data Prepper
         uses: actions/checkout@v2
       - name: Run raw-span latest release compatibility end-to-end tests with Gradle
         run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:trace:rawSpanPeerForwarderEndToEndTest

--- a/.github/workflows/data-prepper-trace-analytics-service-map-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-service-map-e2e-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Checkout Data-Prepper
+      - name: Checkout Data Prepper
         uses: actions/checkout@v2
       - name: Run service-map end-to-end tests with Gradle
         run: ./gradlew -PendToEndJavaVersion=${{ matrix.java }} :e2e-test:trace:serviceMapPeerForwarderEndToEndTest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
-    - name: Checkout Data-Prepper
+    - name: Checkout Data Prepper
       uses: actions/checkout@v2
     - name: Build with Gradle
       run: ./gradlew build

--- a/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - name: Checkout Data-Prepper
+      - name: Checkout Data Prepper
         uses: actions/checkout@v2
       - name: Run Open Distro docker
         run: |

--- a/.github/workflows/opensearch-sink-opensearch-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opensearch-integration-tests.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - name: Checkout Data-Prepper
+      - name: Checkout Data Prepper
         uses: actions/checkout@v2
       - name: Run OpenSearch docker
         run: |

--- a/.github/workflows/performance-test-compile.yml
+++ b/.github/workflows/performance-test-compile.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - name: Checkout Data-Prepper
+      - name: Checkout Data Prepper
         uses: actions/checkout@v2
       - name: Build performance tests with Gradle
         run: ./gradlew :performance-test:compileGatlingJava

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Checkout Data-Prepper
+    - name: Checkout Data Prepper
       uses: actions/checkout@v2
     - name: Get Version
       run:  grep '^version=' gradle.properties >> $GITHUB_ENV
@@ -62,7 +62,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Checkout Data-Prepper
+      - name: Checkout Data Prepper
         uses: actions/checkout@v2
       - name: Get Version
         run:  grep '^version=' gradle.properties >> $GITHUB_ENV
@@ -88,7 +88,7 @@ jobs:
     timeout-minutes: 8
 
     steps:
-      - name: Checkout Data-Prepper
+      - name: Checkout Data Prepper
         uses: actions/checkout@v2
       - name: Get Version
         run:  grep '^version=' gradle.properties >> $GITHUB_ENV

--- a/.github/workflows/staging-resources-cdk-check.yml
+++ b/.github/workflows/staging-resources-cdk-check.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         node-version: '16'
 
-    - name: Checkout Data-Prepper
+    - name: Checkout Data Prepper
       uses: actions/checkout@v2
 
     - name: Install NPM Dependencies

--- a/.github/workflows/third-party-generate.yml
+++ b/.github/workflows/third-party-generate.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Checkout Data-Prepper
+    - name: Checkout Data Prepper
       uses: actions/checkout@v2
 
     - name: Generate Third Party Report


### PR DESCRIPTION
### Description

Since this project is "Data Prepper" this renames the titles in our GitHub Action jobs to use "Data Prepper" instead of "Data-Prepper."

 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
