### PR TITLE
Improved Avro error reporting related to schemas

### DIFF
--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodec.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodec.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 @DataPrepperPlugin(name = "avro", pluginType = OutputCodec.class, pluginConfigurationType = AvroOutputCodecConfig.class)
 public class AvroOutputCodec implements OutputCodec {
 
-    private static final List<String> NON_COMPLEX_TYPES = Arrays.asList("int", "long", "string", "float", "double", "bytes");
+    private static final List<String> PRIMITIVE_TYPES = Arrays.asList("int", "long", "string", "float", "double", "bytes");
     private static final Logger LOG = LoggerFactory.getLogger(AvroOutputCodec.class);
     private static final String AVRO = "avro";
     private static final String BASE_SCHEMA_STRING = "{\"type\":\"record\",\"name\":\"AvroRecords\",\"fields\":[";
@@ -189,7 +189,7 @@ public class AvroOutputCodec implements OutputCodec {
     private Object schemaMapper(final Schema.Field field, final Object rawValue) {
         Object finalValue = null;
         final String fieldType = field.schema().getType().name().toLowerCase();
-        if (NON_COMPLEX_TYPES.contains(fieldType)) {
+        if (PRIMITIVE_TYPES.contains(fieldType)) {
             switch (fieldType) {
                 case "string":
                     finalValue = rawValue.toString();

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodec.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodec.java
@@ -4,7 +4,6 @@
  */
 package org.opensearch.dataprepper.plugins.codec.avro;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
@@ -34,9 +33,8 @@ import java.util.Objects;
 @DataPrepperPlugin(name = "avro", pluginType = OutputCodec.class, pluginConfigurationType = AvroOutputCodecConfig.class)
 public class AvroOutputCodec implements OutputCodec {
 
-    private static final List<String> nonComplexTypes = Arrays.asList("int", "long", "string", "float", "double", "bytes");
+    private static final List<String> NON_COMPLEX_TYPES = Arrays.asList("int", "long", "string", "float", "double", "bytes");
     private static final Logger LOG = LoggerFactory.getLogger(AvroOutputCodec.class);
-    private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final String AVRO = "avro";
     private static final String BASE_SCHEMA_STRING = "{\"type\":\"record\",\"name\":\"AvroRecords\",\"fields\":[";
     private static final String END_SCHEMA_STRING = "]}";
@@ -52,13 +50,7 @@ public class AvroOutputCodec implements OutputCodec {
     public AvroOutputCodec(final AvroOutputCodecConfig config) {
         Objects.requireNonNull(config);
         this.config = config;
-    }
 
-    @Override
-    public void start(final OutputStream outputStream, final Event event, final OutputCodecContext codecContext) throws IOException {
-        Objects.requireNonNull(outputStream);
-        Objects.requireNonNull(codecContext);
-        this.codecContext = codecContext;
         if (config.getSchema() != null) {
             schema = parseSchema(config.getSchema());
         } else if (config.getFileLocation() != null) {
@@ -67,10 +59,18 @@ public class AvroOutputCodec implements OutputCodec {
             schema = parseSchema(AvroSchemaParserFromSchemaRegistry.getSchemaType(config.getSchemaRegistryUrl()));
         } else if (checkS3SchemaValidity()) {
             schema = AvroSchemaParserFromS3.parseSchema(config);
-        } else {
+        }
+    }
+
+    @Override
+    public void start(final OutputStream outputStream, final Event event, final OutputCodecContext codecContext) throws IOException {
+        Objects.requireNonNull(outputStream);
+        Objects.requireNonNull(codecContext);
+        this.codecContext = codecContext;
+        if (schema == null) {
             schema = buildInlineSchemaFromEvent(event);
         }
-        final DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<GenericRecord>(schema);
+        final DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(schema);
         dataFileWriter = new DataFileWriter<>(datumWriter);
         dataFileWriter.create(schema, outputStream);
     }
@@ -159,13 +159,13 @@ public class AvroOutputCodec implements OutputCodec {
         return AVRO;
     }
 
-    Schema parseSchema(final String schemaString) throws IOException {
+    Schema parseSchema(final String schemaString) {
         try {
             Objects.requireNonNull(schemaString);
             return new Schema.Parser().parse(schemaString);
         } catch (Exception e) {
-            LOG.error("Unable to parse Schema from Schema String provided.");
-            throw new IOException("Can't proceed without schema.");
+            LOG.error("Unable to parse Schema from Schema String provided.", e);
+            throw new RuntimeException("There is an error in the schema: " + e.getMessage());
         }
     }
 
@@ -177,6 +177,9 @@ public class AvroOutputCodec implements OutputCodec {
                 continue;
             }
             final Schema.Field field = schema.getField(key);
+            if (field == null) {
+                throw new RuntimeException("The event has a key ('" + key + "') which is not included in the schema.");
+            }
             final Object value = schemaMapper(field, eventData.get(key));
             avroRecord.put(key, value);
         }
@@ -186,7 +189,7 @@ public class AvroOutputCodec implements OutputCodec {
     private Object schemaMapper(final Schema.Field field, final Object rawValue) {
         Object finalValue = null;
         final String fieldType = field.schema().getType().name().toLowerCase();
-        if (nonComplexTypes.contains(fieldType)) {
+        if (NON_COMPLEX_TYPES.contains(fieldType)) {
             switch (fieldType) {
                 case "string":
                     finalValue = rawValue.toString();
@@ -225,7 +228,7 @@ public class AvroOutputCodec implements OutputCodec {
         return finalValue;
     }
 
-    private boolean checkS3SchemaValidity() throws IOException {
+    private boolean checkS3SchemaValidity() {
         return config.getBucketName() != null && config.getFileKey() != null && config.getRegion() != null;
     }
 }

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroSchemaParser.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroSchemaParser.java
@@ -6,36 +6,35 @@ package org.opensearch.dataprepper.plugins.codec.avro;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.avro.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class AvroSchemaParser {
     private static final ObjectMapper mapper = new ObjectMapper();
     private static final Logger LOG = LoggerFactory.getLogger(AvroOutputCodec.class);
 
-    public static Schema parseSchemaFromJsonFile(final String location) throws IOException {
+    public static Schema parseSchemaFromJsonFile(final String location) {
         final Map<?, ?> jsonMap;
         try {
             jsonMap = mapper.readValue(Paths.get(location).toFile(), Map.class);
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             LOG.error("Schema file not found, Error: {}", e.getMessage());
-            throw new IOException("Can't proceed without schema.");
+            throw new RuntimeException("Can't proceed without schema.");
         }
-        final Map<Object,Object> schemaMap = new HashMap<Object,Object>();
+        final Map<Object, Object> schemaMap = new HashMap<Object, Object>();
         for (Map.Entry<?, ?> entry : jsonMap.entrySet()) {
             schemaMap.put(entry.getKey(), entry.getValue());
         }
-        try{
+        try {
             return new Schema.Parser().parse(mapper.writeValueAsString(schemaMap));
-        }catch(Exception e) {
+        } catch (Exception e) {
             LOG.error("Unable to parse schema from the provided schema file, Error: {}", e.getMessage());
-            throw new IOException("Can't proceed without schema.");
+            throw new RuntimeException("Can't proceed without schema.");
         }
     }
 }

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroSchemaParserFromS3.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroSchemaParserFromS3.java
@@ -28,12 +28,12 @@ public class AvroSchemaParserFromS3 {
     private static final ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
     private static final Logger LOG = LoggerFactory.getLogger(AvroSchemaParserFromS3.class);
 
-    public static Schema parseSchema(AvroOutputCodecConfig config) throws IOException {
-        try{
+    public static Schema parseSchema(AvroOutputCodecConfig config) {
+        try {
             return new Schema.Parser().parse(getS3SchemaObject(config));
-        }catch (Exception e){
-            LOG.error("Unable to retrieve schema from S3. Error: "+e.getMessage());
-            throw new IOException("Can't proceed without schema.");
+        } catch (Exception e) {
+            LOG.error("Unable to retrieve schema from S3.", e);
+            throw new RuntimeException("There is an error in the schema: " + e.getMessage());
         }
     }
 
@@ -44,7 +44,8 @@ public class AvroSchemaParserFromS3 {
                 .key(config.getFileKey())
                 .build();
         ResponseInputStream<GetObjectResponse> s3Object = s3Client.getObject(getObjectRequest);
-        final Map<String, Object> stringObjectMap = objectMapper.readValue(s3Object, new TypeReference<>() {});
+        final Map<String, Object> stringObjectMap = objectMapper.readValue(s3Object, new TypeReference<>() {
+        });
         return objectMapper.writeValueAsString(stringObjectMap);
     }
 


### PR DESCRIPTION
### Description

This PR has two major updates:
* When starting Data Prepper, validate the provided schema. Prior to this PR it was happening only when an event is received.
* When a field does not exist in the Avro schema return an explicit exception. Prior to this PR, it was some vague message that was not possible to track down.
 
Additionally, this PR includes some code clean-up.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
