### PR TITLE
Updates Avro documentation with improved YAML and VPC Flow Log example

### DIFF
--- a/data-prepper-plugins/avro-codecs/README.md
+++ b/data-prepper-plugins/avro-codecs/README.md
@@ -1,6 +1,6 @@
 # Avro Sink/Output Codec
 
-This is an implementation of Avro Sink Codec that parses the Dataprepper Events into avro records and writes them into the underlying OutputStream.
+This is an implementation of Avro Sink Codec that parses the Data Prepper Events into Avro records and writes them into the underlying OutputStream.
 
 ## Usages
 
@@ -20,20 +20,35 @@ pipeline:
         max_retries: 5
         bucket: bucket_name
         object_key:
-          path_prefix: my-elb/%{yyyy}/%{MM}/%{dd}/
+          path_prefix: vpc-flow-logs/%{yyyy}/%{MM}/%{dd}/
         threshold:
           event_count: 2000
           maximum_size: 50mb
           event_collect_timeout: 15s
         codec:
           avro:
-            schema: "{\"namespace\": \"org.example.test\"," +
-                " \"type\": \"record\"," +
-                " \"name\": \"TestMessage\"," +
-                " \"fields\": [" +
-                "     {\"name\": \"name\", \"type\": \"string\"}," +
-                "     {\"name\": \"age\", \"type\": \"int\"}]" +
-                "}";
+            schema: >
+              {
+                "type" : "record",
+                "namespace" : "org.opensearch.dataprepper.examples",
+                "name" : "VpcFlowLog",
+                "fields" : [
+                  { "name" : "version", "type" : ["null", "string"]},
+                  { "name" : "srcport", "type": ["null", "int"]},
+                  { "name" : "dstport", "type": ["null", "int"]},
+                  { "name" : "accountId", "type" : ["null", "string"]},
+                  { "name" : "interfaceId", "type" : ["null", "string"]},
+                  { "name" : "srcaddr", "type" : ["null", "string"]},
+                  { "name" : "dstaddr", "type" : ["null", "string"]},
+                  { "name" : "start", "type": ["null", "int"]},
+                  { "name" : "end", "type": ["null", "int"]},
+                  { "name" : "protocol", "type": ["null", "int"]},
+                  { "name" : "packets", "type": ["null", "int"]},
+                  { "name" : "bytes", "type": ["null", "int"]},
+                  { "name" : "action", "type": ["null", "string"]},
+                  { "name" : "logStatus", "type" : ["null", "string"]}
+                ]
+              }
             exclude_keys:
               - s3
         buffer_type: in_memory


### PR DESCRIPTION
### Description

This PR shows a cleaner way to set the Avro schema using YAML. It also shows a working example for AWS VPC Flow Logs.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
