### PR TITLE
Fixed issue with CloudWatchLogMetrics not updating counters when no event handles are present.

### DIFF
--- a/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcher.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/main/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/CloudWatchLogsDispatcher.java
@@ -86,6 +86,7 @@ public class CloudWatchLogsDispatcher {
                 .cloudWatchLogsMetrics(cloudWatchLogsMetrics)
                 .putLogEventsRequest(putLogEventsRequest)
                 .eventHandles(eventHandles)
+                .totalEventCount(inputLogEvents.size())
                 .backOffTimeBase(backOffTimeBase)
                 .retryCount(retryCount)
                 .build());
@@ -97,6 +98,7 @@ public class CloudWatchLogsDispatcher {
         private final CloudWatchLogsMetrics cloudWatchLogsMetrics;
         private final PutLogEventsRequest putLogEventsRequest;
         private final Collection<EventHandle> eventHandles;
+        private final int totalEventCount;
         private final int retryCount;
         private final long backOffTimeBase;
 
@@ -132,10 +134,10 @@ public class CloudWatchLogsDispatcher {
 
 
             if (failedToTransmit) {
-                cloudWatchLogsMetrics.increaseLogEventFailCounter(eventHandles.size());
+                cloudWatchLogsMetrics.increaseLogEventFailCounter(totalEventCount);
                 releaseEventHandles(false, eventHandles);
             } else {
-                cloudWatchLogsMetrics.increaseLogEventSuccessCounter(eventHandles.size());
+                cloudWatchLogsMetrics.increaseLogEventSuccessCounter(totalEventCount);
                 releaseEventHandles(true, eventHandles);
             }
         }

--- a/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/UploaderTest.java
+++ b/data-prepper-plugins/cloudwatch-logs/src/test/java/org/opensearch/dataprepper/plugins/sink/cloudwatch_logs/client/UploaderTest.java
@@ -49,6 +49,7 @@ class UploaderTest {
                 .cloudWatchLogsMetrics(mockCloudWatchLogsMetrics)
                 .putLogEventsRequest(getMockPutLogEventsRequest())
                 .eventHandles(getTestEventHandles())
+                .totalEventCount(ThresholdConfig.DEFAULT_BATCH_SIZE)
                 .retryCount(ThresholdConfig.DEFAULT_RETRY_COUNT)
                 .backOffTimeBase(ThresholdConfig.DEFAULT_BACKOFF_TIME)
                 .build();


### PR DESCRIPTION
### Description
This change aims to fix the problem with updating metric counters in the CloudWatch Logs Sink when no event handles are present. It removes the dependency on the counters to increment by the number of events passed in instead of event handles passed in.
 
### Issues Resolved
This will resolve the issue found in [BUG] CloudWatch Logs Sink not generating LogEventSuccessMetrics #3113
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
