### PR TITLE
Make max partition fetch bytes configurable

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfig.java
@@ -32,6 +32,7 @@ public class TopicConfig {
     static final Integer DEFAULT_FETCH_MIN_BYTES = 1;
     static final Duration DEFAULT_RETRY_BACKOFF = Duration.ofSeconds(10);
     static final Duration DEFAULT_RECONNECT_BACKOFF = Duration.ofSeconds(10);
+    static final Integer DEFAULT_MAX_PARTITION_FETCH_BYTES = 1048576;
     static final Duration DEFAULT_MAX_POLL_INTERVAL = Duration.ofSeconds(300000);
     static final Integer DEFAULT_CONSUMER_MAX_POLL_RECORDS = 500;
     static final Integer DEFAULT_NUM_OF_WORKERS = 2;
@@ -91,6 +92,9 @@ public class TopicConfig {
 
     @JsonProperty("max_record_fetch_time")
     private Duration maxRecordFetchTime = DEFAULT_MAX_RECORD_FETCH_TIME;
+
+    @JsonProperty("max_partition_fetch_bytes")
+    private Integer maxPartitionFetchBytes = DEFAULT_MAX_PARTITION_FETCH_BYTES;
 
     @JsonProperty("buffer_default_timeout")
     @Valid
@@ -190,6 +194,10 @@ public class TopicConfig {
 
     public Duration getMaxRecordFetchTime() {
         return maxRecordFetchTime;
+    }
+
+    public Integer getMaxPartitionFetchBytes() {
+        return maxPartitionFetchBytes;
     }
 
     public void setMaxRecordFetchTime(Duration maxRecordFetchTime) {

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfigTest.java
@@ -84,6 +84,7 @@ class TopicConfigTest {
         assertEquals(TopicConfig.DEFAULT_CONSUMER_MAX_POLL_RECORDS, topicConfig.getConsumerMaxPollRecords());
         assertEquals(TopicConfig.DEFAULT_NUM_OF_WORKERS, topicConfig.getWorkers());
         assertEquals(TopicConfig.DEFAULT_HEART_BEAT_INTERVAL_DURATION, topicConfig.getHeartBeatInterval());
+        assertEquals(TopicConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES, topicConfig.getMaxPartitionFetchBytes());
     }
 
     @Test
@@ -105,6 +106,7 @@ class TopicConfigTest {
         assertEquals(500L, topicConfig.getConsumerMaxPollRecords().longValue());
         assertEquals(5, topicConfig.getWorkers().intValue());
         assertEquals(Duration.ofSeconds(3), topicConfig.getHeartBeatInterval());
+        assertEquals(10*TopicConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES, topicConfig.getMaxPartitionFetchBytes());
     }
 
     @Test

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines.yaml
@@ -23,6 +23,7 @@ log-pipeline:
           fetch_min_bytes: 1
           retry_backoff: PT100S
           consumer_max_poll_records: 500
+          max_partition_fetch_bytes: 10485760
       schema:
         registry_url: http://localhost:8081/
         version: 1


### PR DESCRIPTION
### Description
Make max partition fetch bytes configurable. Added config option to set max partition fetch bytes.
Also fixed the code to honor configured values for fetch bytes min and max poll interval.
Also fixed code to get authentication config only once and not for every topic.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
