### PR TITLE
Translate Processor : Fixed Bug: Target value datatype doesn't match the type option provided

### DIFF
--- a/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessor.java
+++ b/data-prepper-plugins/translate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/translate/TranslateProcessor.java
@@ -129,7 +129,7 @@ public class TranslateProcessor extends AbstractProcessor<Record<Event>, Record<
     }
 
     private Object getTargetValue(Object sourceObject, List<Object> targetValues, TargetsParameterConfig targetConfig) {
-        TypeConverter converter = targetConfig.getConverter();
+        TypeConverter converter = targetConfig.getTargetType().getTargetConverter();
         if(sourceObject instanceof String) {
             return converter.convert(targetValues.get(0));
         }


### PR DESCRIPTION
### Description
The data type of the target value is not matching the data type provided in the type option.
The issue is fixed for data types "integer", "double". 

**Not fixed:**

**However for boolean, internally converter from `TargetType.java` class is being used and in that converter for boolean values, we are doing `Boolean.parseBoolean(val)`. This returns true if  "true" is provided else will return false for any string**

So while checking the values in the map option, while parsing the config, the pipeline will not fail for `type: boolean`.
Need to fix this issue.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
