### PR TITLE
Add metrics to Kafka Source

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
@@ -119,6 +119,7 @@ public class KafkaSourceJsonTypeIT {
         when(jsonTopic.getName()).thenReturn(testTopic);
         when(jsonTopic.getGroupId()).thenReturn(testGroup);
         when(jsonTopic.getWorkers()).thenReturn(1);
+        when(jsonTopic.getMaxPollInterval()).thenReturn(Duration.ofSeconds(5));
         when(jsonTopic.getSessionTimeOut()).thenReturn(Duration.ofSeconds(15));
         when(jsonTopic.getHeartBeatInterval()).thenReturn(Duration.ofSeconds(3));
         when(jsonTopic.getAutoCommit()).thenReturn(false);

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceMultipleAuthTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceMultipleAuthTypeIT.java
@@ -130,6 +130,7 @@ public class KafkaSourceMultipleAuthTypeIT {
         when(plainTextTopic.getName()).thenReturn(testTopic);
         when(plainTextTopic.getGroupId()).thenReturn(testGroup);
         when(plainTextTopic.getWorkers()).thenReturn(1);
+        when(plainTextTopic.getMaxPollInterval()).thenReturn(Duration.ofSeconds(5));
         when(plainTextTopic.getSessionTimeOut()).thenReturn(Duration.ofSeconds(15));
         when(plainTextTopic.getHeartBeatInterval()).thenReturn(Duration.ofSeconds(3));
         when(plainTextTopic.getAutoCommit()).thenReturn(false);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSourceConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSourceConfig.java
@@ -68,9 +68,6 @@ public class KafkaSourceConfig {
     @JsonProperty("acknowledgments_timeout")
     private Duration acknowledgementsTimeout = DEFAULT_ACKNOWLEDGEMENTS_TIMEOUT;
 
-    @JsonProperty("metrics_update_interval")
-    private Duration metricsUpdateInterval = DEFAULT_METRICS_UPDATE_INTERVAL;
-
     @JsonProperty("client_dns_lookup")
     private String clientDnsLookup;
 
@@ -84,10 +81,6 @@ public class KafkaSourceConfig {
 
     public Duration getAcknowledgementsTimeout() {
         return acknowledgementsTimeout;
-    }
-
-    public Duration getMetricsUpdateInterval() {
-        return metricsUpdateInterval;
     }
 
     public List<TopicConfig> getTopics() {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSourceConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSourceConfig.java
@@ -37,7 +37,6 @@ public class KafkaSourceConfig {
     }
 
     public static final Duration DEFAULT_ACKNOWLEDGEMENTS_TIMEOUT = Duration.ofSeconds(30);
-    public static final Duration DEFAULT_METRICS_UPDATE_INTERVAL = Duration.ofSeconds(60);
 
     @JsonProperty("bootstrap_servers")
     private List<String> bootStrapServers;

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSourceConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSourceConfig.java
@@ -37,6 +37,7 @@ public class KafkaSourceConfig {
     }
 
     public static final Duration DEFAULT_ACKNOWLEDGEMENTS_TIMEOUT = Duration.ofSeconds(30);
+    public static final Duration DEFAULT_METRICS_UPDATE_INTERVAL = Duration.ofSeconds(60);
 
     @JsonProperty("bootstrap_servers")
     private List<String> bootStrapServers;
@@ -67,6 +68,9 @@ public class KafkaSourceConfig {
     @JsonProperty("acknowledgments_timeout")
     private Duration acknowledgementsTimeout = DEFAULT_ACKNOWLEDGEMENTS_TIMEOUT;
 
+    @JsonProperty("metrics_update_interval")
+    private Duration metricsUpdateInterval = DEFAULT_METRICS_UPDATE_INTERVAL;
+
     @JsonProperty("client_dns_lookup")
     private String clientDnsLookup;
 
@@ -80,6 +84,10 @@ public class KafkaSourceConfig {
 
     public Duration getAcknowledgementsTimeout() {
         return acknowledgementsTimeout;
+    }
+
+    public Duration getMetricsUpdateInterval() {
+        return metricsUpdateInterval;
     }
 
     public List<TopicConfig> getTopics() {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/TopicPartitionCommitTracker.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/TopicPartitionCommitTracker.java
@@ -21,7 +21,7 @@ public class TopicPartitionCommitTracker {
 
     public TopicPartitionCommitTracker(final TopicPartition topicPartition, Long committedOffset) {
         this.topicPartition = topicPartition;
-        this.committedOffset = Objects.nonNull(committedOffset) ? committedOffset : -1L;
+        this.committedOffset = Objects.nonNull(committedOffset) ? committedOffset-1 : -1L;
         this.offsetMaxMap = new HashMap<>();
         this.offsetMinMap = new HashMap<>();
         this.offsetMaxMap.put(this.committedOffset, Range.between(this.committedOffset, this.committedOffset));

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -119,7 +119,7 @@ public class KafkaSource implements Source<Record<Event>> {
         KafkaSourceSecurityConfigurer.setAuthProperties(authProperties, sourceConfig, LOG);
         sourceConfig.getTopics().forEach(topic -> {
             consumerGroupID = topic.getGroupId();
-            KafkaTopicMetrics topicMetrics = new KafkaTopicMetrics(topic.getName(), pluginMetrics);
+            KafkaTopicMetrics topicMetrics = new KafkaTopicMetrics(topic.getName(), pluginMetrics, sourceConfig.getMetricsUpdateInterval().getSeconds());
             Properties consumerProperties = getConsumerProperties(topic, authProperties);
             MessageFormat schema = MessageFormat.getByMessageFormatByName(schemaType);
             try {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -119,13 +119,13 @@ public class KafkaSource implements Source<Record<Event>> {
         KafkaSourceSecurityConfigurer.setAuthProperties(authProperties, sourceConfig, LOG);
         sourceConfig.getTopics().forEach(topic -> {
             consumerGroupID = topic.getGroupId();
-            KafkaTopicMetrics topicMetrics = new KafkaTopicMetrics(topic.getName(), pluginMetrics, sourceConfig.getMetricsUpdateInterval().getSeconds());
+            KafkaTopicMetrics topicMetrics = new KafkaTopicMetrics(topic.getName(), pluginMetrics);
             Properties consumerProperties = getConsumerProperties(topic, authProperties);
             MessageFormat schema = MessageFormat.getByMessageFormatByName(schemaType);
             try {
                 int numWorkers = topic.getWorkers();
                 executorService = Executors.newFixedThreadPool(numWorkers);
-                IntStream.range(0, numWorkers + 1).forEach(index -> {
+                IntStream.range(0, numWorkers).forEach(index -> {
                     switch (schema) {
                         case JSON:
                             kafkaConsumer = new KafkaConsumer<String, JsonNode>(consumerProperties);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -45,6 +45,7 @@ import org.opensearch.dataprepper.plugins.kafka.util.ClientDNSLookupType;
 import org.opensearch.dataprepper.plugins.kafka.util.KafkaSourceJsonDeserializer;
 import org.opensearch.dataprepper.plugins.kafka.util.KafkaSourceSecurityConfigurer;
 import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
+import org.opensearch.dataprepper.plugins.kafka.util.KafkaTopicMetrics;
 
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryKafkaDeserializer;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
@@ -118,6 +119,7 @@ public class KafkaSource implements Source<Record<Event>> {
         KafkaSourceSecurityConfigurer.setAuthProperties(authProperties, sourceConfig, LOG);
         sourceConfig.getTopics().forEach(topic -> {
             consumerGroupID = topic.getGroupId();
+            KafkaTopicMetrics topicMetrics = new KafkaTopicMetrics(topic.getName(), pluginMetrics);
             Properties consumerProperties = getConsumerProperties(topic, authProperties);
             MessageFormat schema = MessageFormat.getByMessageFormatByName(schemaType);
             try {
@@ -136,7 +138,7 @@ public class KafkaSource implements Source<Record<Event>> {
                             kafkaConsumer = new KafkaConsumer<String, String>(consumerProperties);
                             break;
                     }
-                    consumer = new KafkaSourceCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType, acknowledgementSetManager, pluginMetrics);
+                    consumer = new KafkaSourceCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType, acknowledgementSetManager, topicMetrics);
                     executorService.submit(consumer);
                 });
             } catch (Exception e) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSourceSecurityConfigurer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaSourceSecurityConfigurer.java
@@ -212,7 +212,7 @@ public class KafkaSourceSecurityConfigurer {
             try {
                 result = kafkaClient.getBootstrapBrokers(request);
             } catch (KafkaException | StsException e) {
-                LOG.debug("Failed to get bootstrap server information from MSK. Retrying...", e);
+                LOG.info("Failed to get bootstrap server information from MSK. Will try every 10 seconds for {} seconds", 10*MAX_KAFKA_CLIENT_RETRIES, e);
                 try {
                     Thread.sleep(10000);
                 } catch (InterruptedException exp) {}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicMetrics.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicMetrics.java
@@ -37,6 +37,7 @@ public class KafkaTopicMetrics {
         camelCaseMap.put("records-lag-max", "recordsLagMax");
         camelCaseMap.put("records-lead-min", "recordsLeadMin");
         camelCaseMap.put("commit-rate", "commitRate");
+        camelCaseMap.put("commit-total", "commitTotal");
         camelCaseMap.put("join-rate", "joinRate");
         camelCaseMap.put("incoming-byte-rate", "incomingByteRate");
         camelCaseMap.put("outgoing-byte-rate", "outgoingByteRate");
@@ -81,7 +82,7 @@ public class KafkaTopicMetrics {
             if ((metricName.contains("consumed")) ||
                 ((!metric.tags().containsKey("partition")) &&
                      (metricName.equals("records-lag-max") || metricName.equals("records-lead-min"))) ||
-                (metricName.equals("commit-rate") || metricName.equals("join-rate")) ||
+                (metricName.equals("commit-rate") || metricName.equals("join-rate") || metricName.equals("commit-total")) ||
                 (metricName.equals("incoming-byte-rate") || metricName.equals("outgoing-byte-rate"))) {
                     cmetrics.put(metricName, value.metricValue());
             }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicMetrics.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicMetrics.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.kafka.util;
 
+import io.micrometer.core.instrument.Counter;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
@@ -16,99 +17,166 @@ import java.util.Map;
 import java.util.HashMap;
 
 public class KafkaTopicMetrics {
-    private long metricUpdateInterval;
+    static final String NUMBER_OF_POSITIVE_ACKNOWLEDGEMENTS = "numberOfPositiveAcknowledgements";
+    static final String NUMBER_OF_NEGATIVE_ACKNOWLEDGEMENTS = "numberOfNegativeAcknowledgements";
+    static final String NUMBER_OF_RECORDS_FAILED_TO_PARSE = "numberOfRecordsFailedToParse";
+    static final String NUMBER_OF_DESERIALIZATION_ERRORS = "numberOfDeserializationErrors";
+    static final String NUMBER_OF_BUFFER_SIZE_OVERFLOWS = "numberOfBufferSizeOverflows";
+    static final String NUMBER_OF_POLL_AUTH_ERRORS = "numberOfPollAuthErrors";
+    static final String NUMBER_OF_NON_CONSUMERS = "numberOfNonConsumers";
+    static final String NUMBER_OF_RECORDS_COMMITTED = "numberOfRecordsCommitted";
+    static final String NUMBER_OF_RECORDS_CONSUMED = "numberOfRecordsConsumed";
+    static final String NUMBER_OF_BYTES_CONSUMED = "numberOfBytesConsumed";
+
     private final String topicName;
     private long updateTime;
-    private Map<KafkaConsumer, Map<String, Object>> consumerMetricsMap;
-    private Map<String, String> camelCaseMap;
+    private Map<String, String> metricsNameMap;
+    private Map<KafkaConsumer, Map<String, Double>> metricValues;
     private final PluginMetrics pluginMetrics;
-    
-    public KafkaTopicMetrics(final String topicName, final PluginMetrics pluginMetrics, final long metricUpdateInterval) {
+    private final Counter numberOfPositiveAcknowledgements;
+    private final Counter numberOfNegativeAcknowledgements;
+    private final Counter numberOfRecordsFailedToParse;
+    private final Counter numberOfDeserializationErrors;
+    private final Counter numberOfBufferSizeOverflows;
+    private final Counter numberOfPollAuthErrors;
+    private final Counter numberOfRecordsCommitted;
+    private final Counter numberOfNonConsumers;
+
+    public KafkaTopicMetrics(final String topicName, final PluginMetrics pluginMetrics) {
         this.pluginMetrics = pluginMetrics;
         this.topicName = topicName;
-        this.consumerMetricsMap = new HashMap<>();
         this.updateTime = Instant.now().getEpochSecond();
-        this.metricUpdateInterval = metricUpdateInterval;
-        this.camelCaseMap = new HashMap<>();
-        camelCaseMap.put("bytes-consumed-total", "bytesConsumedTotal");
-        camelCaseMap.put("records-consumed-total", "recordsConsumedTotal");
-        camelCaseMap.put("bytes-consumed-rate", "bytesConsumedRate");
-        camelCaseMap.put("records-consumed-rate", "recordsConsumedRate");
-        camelCaseMap.put("records-lag-max", "recordsLagMax");
-        camelCaseMap.put("records-lead-min", "recordsLeadMin");
-        camelCaseMap.put("commit-rate", "commitRate");
-        camelCaseMap.put("join-rate", "joinRate");
-        camelCaseMap.put("incoming-byte-rate", "incomingByteRate");
-        camelCaseMap.put("outgoing-byte-rate", "outgoingByteRate");
-        camelCaseMap.put("assigned-partitions", "outgoingByteRate");
+        this.metricValues = new HashMap<>();
+        initializeMetricNamesMap();
+        this.numberOfRecordsCommitted = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_RECORDS_COMMITTED));
+        this.numberOfRecordsFailedToParse = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_RECORDS_FAILED_TO_PARSE));
+        this.numberOfDeserializationErrors = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_DESERIALIZATION_ERRORS));
+        this.numberOfBufferSizeOverflows = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_BUFFER_SIZE_OVERFLOWS));
+        this.numberOfPollAuthErrors = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_POLL_AUTH_ERRORS));
+        this.numberOfNonConsumers = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_NON_CONSUMERS));
+        this.numberOfPositiveAcknowledgements = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_POSITIVE_ACKNOWLEDGEMENTS));
+        this.numberOfNegativeAcknowledgements = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_NEGATIVE_ACKNOWLEDGEMENTS));
     }
 
-    public void register(KafkaConsumer consumer) {
-        this.consumerMetricsMap.put(consumer, new HashMap<>());
+    private void initializeMetricNamesMap() {
+        this.metricsNameMap = new HashMap<>();
+        metricsNameMap.put("bytes-consumed-total", "bytesConsumedTotal");
+        metricsNameMap.put("records-consumed-total", "recordsConsumedTotal");
+        metricsNameMap.put("bytes-consumed-rate", "bytesConsumedRate");
+        metricsNameMap.put("records-consumed-rate", "recordsConsumedRate");
+        metricsNameMap.put("records-lag-max", "recordsLagMax");
+        metricsNameMap.put("records-lead-min", "recordsLeadMin");
+        metricsNameMap.put("commit-rate", "commitRate");
+        metricsNameMap.put("join-rate", "joinRate");
+        metricsNameMap.put("incoming-byte-rate", "incomingByteRate");
+        metricsNameMap.put("outgoing-byte-rate", "outgoingByteRate");
+        metricsNameMap.forEach((metricName, camelCaseName) -> {
+            pluginMetrics.gauge(getTopicMetricName(camelCaseName), metricValues, metricValues -> {
+                synchronized(metricValues) {
+                    if (metricName.equals("records-lag-max")) {
+                        double max = 0.0;
+                        for (Map.Entry<KafkaConsumer, Map<String, Double>> entry : metricValues.entrySet()) {
+                            if (entry.getValue().get(metricName) > max) {
+                                max = entry.getValue().get(metricName);
+                            }
+                        }
+                        return max;
+                    } else if (metricName.equals("records-lead-min")) {
+                        double min = Double.MAX_VALUE;
+                        for (Map.Entry<KafkaConsumer, Map<String, Double>> entry : metricValues.entrySet()) {
+                            if (entry.getValue().get(metricName) < min) {
+                                min = entry.getValue().get(metricName);
+                            }
+                        }
+                        return min;
+                    } else {
+                        double sum = 0;
+                        for (Map.Entry<KafkaConsumer, Map<String, Double>> entry : metricValues.entrySet()) {
+                            sum += entry.getValue().get(metricName);
+                        }
+                        return sum;
+                    }
+                }
+            });
+        });
+    }
+
+    public void register(final KafkaConsumer consumer) {
+        metricValues.put(consumer, new HashMap<>());
+        final Map<String, Double> consumerMetrics = metricValues.get(consumer);
+        metricsNameMap.forEach((k, name) -> {
+            consumerMetrics.put(k, 0.0);
+        });
+    }
+
+    public Counter getNumberOfRecordsCommitted() {
+        return numberOfRecordsCommitted;
+    }
+
+    public Counter getNumberOfNonConsumers() {
+        return numberOfNonConsumers;
+    }
+
+    public Counter getNumberOfPollAuthErrors() {
+        return numberOfPollAuthErrors;
+    }
+
+    public Counter getNumberOfBufferSizeOverflows() {
+        return numberOfBufferSizeOverflows;
+    }
+
+    public Counter getNumberOfDeserializationErrors() {
+        return numberOfDeserializationErrors;
+    }
+
+    public Counter getNumberOfRecordsFailedToParse() {
+        return numberOfRecordsFailedToParse;
+    }
+
+    public Counter getNumberOfNegativeAcknowledgements() {
+        return numberOfNegativeAcknowledgements;
+    }
+
+    public Counter getNumberOfPositiveAcknowledgements() {
+        return numberOfPositiveAcknowledgements;
+    }
+
+    public String getTopicMetricName(final String metricName) {
+        return "topic."+topicName+"."+metricName;
     }
 
     private String getCamelCaseName(final String name) {
-        String camelCaseName = camelCaseMap.get(name);
+        String camelCaseName = metricsNameMap.get(name);
         if (Objects.isNull(camelCaseName)) {
             return name;
         }
         return camelCaseName;
     }
 
-    public void setMetric(final KafkaConsumer consumer, final String metricName, Number metricValue) {
-        synchronized(consumerMetricsMap) {
-            Map<String, Object> cmetrics = consumerMetricsMap.get(consumer);
-            if (cmetrics != null) {
-                cmetrics.put(metricName, metricValue.doubleValue());
-            }
-        }
-    }
-
-    private void aggregateMetrics() {
-        synchronized (consumerMetricsMap) {
-            final Map<String, Double> aggregatedMetrics = new HashMap<>();
-            consumerMetricsMap.forEach((c, metricsMap) -> {
-                Double value = 0.0;
-                metricsMap.forEach((metricName, metricValue) -> {
-                    if (metricValue instanceof Double) {
-                        aggregatedMetrics.put(metricName, ((Double)metricValue) + aggregatedMetrics.getOrDefault(metricName, 0.0));
-                    }
-                });
-            });
-            aggregatedMetrics.forEach((name, value) -> {
-                pluginMetrics.gauge("topic."+topicName+"."+getCamelCaseName(name), value);
-            });
-        }
-    }
-
     public void update(final KafkaConsumer consumer) {
-        Map<String, Object> cmetrics = null;
-        synchronized(consumerMetricsMap) {
-            cmetrics = consumerMetricsMap.get(consumer);
-        }
-        // This should not happen...
-        if (Objects.isNull(cmetrics)) {
-            return;
-        }
         Map<MetricName, ? extends Metric> metrics = consumer.metrics();
-        for (Map.Entry<MetricName, ? extends Metric> entry : metrics.entrySet()) {
-            MetricName metric = entry.getKey();
-            Metric value = entry.getValue();
-            String metricName = metric.name();
-            String metricGroup = metric.group();
-            if (Objects.nonNull(camelCaseMap.get(metricName))) {
-                if (metric.tags().containsKey("partition") &&
-                   (metricName.equals("records-lag-max") || metricName.equals("records-lead-min"))) {
-                   continue;
-                }
-                cmetrics.put(metricName, value.metricValue());
-            }
-        }
 
-        long curTime = Instant.now().getEpochSecond();
-        if (curTime - updateTime > metricUpdateInterval) {
-            aggregateMetrics();
-            updateTime = curTime;
+        synchronized(metricValues) {
+            Map<String, Double> consumerMetrics = metricValues.get(consumer);
+            for (Map.Entry<MetricName, ? extends Metric> entry : metrics.entrySet()) {
+                MetricName metric = entry.getKey();
+                Metric value = entry.getValue();
+                String metricName = metric.name();
+                if (Objects.nonNull(metricsNameMap.get(metricName))) {
+                    if (metric.tags().containsKey("partition") &&
+                       (metricName.equals("records-lag-max") || metricName.equals("records-lead-min"))) {
+                       continue;
+                    }
+
+                    if (metricName.contains("consumed-total") && !metric.tags().containsKey("topic")) {
+                        continue;
+                    }
+                    if (metricName.contains("byte-rate") && metric.tags().containsKey("node-id")) {
+                        continue;
+                    }
+                    consumerMetrics.put(metricName, (Double)value.metricValue());
+                }
+            }
         }
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicMetrics.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicMetrics.java
@@ -37,7 +37,6 @@ public class KafkaTopicMetrics {
         camelCaseMap.put("records-lag-max", "recordsLagMax");
         camelCaseMap.put("records-lead-min", "recordsLeadMin");
         camelCaseMap.put("commit-rate", "commitRate");
-        camelCaseMap.put("commit-total", "commitTotal");
         camelCaseMap.put("join-rate", "joinRate");
         camelCaseMap.put("incoming-byte-rate", "incomingByteRate");
         camelCaseMap.put("outgoing-byte-rate", "outgoingByteRate");
@@ -56,11 +55,11 @@ public class KafkaTopicMetrics {
         return camelCaseName;
     }
 
-    public void setMetric(final KafkaConsumer consumer, final String metricName, Integer metricValue) {
+    public void setMetric(final KafkaConsumer consumer, final String metricName, Number metricValue) {
         synchronized(consumerMetricsMap) {
             Map<String, Object> cmetrics = consumerMetricsMap.get(consumer);
             if (cmetrics != null) {
-                cmetrics.put(metricName, (double)metricValue);
+                cmetrics.put(metricName, metricValue.doubleValue());
             }
         }
     }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicMetrics.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicMetrics.java
@@ -99,7 +99,6 @@ public class KafkaTopicMetrics {
                     });
                 });
                 aggregatedMetrics.forEach((name, value) -> {
-                    System.out.println("__METRIC__topic."+topicName+"."+getCamelCaseName(name)+"___VALUE__"+value);
                     pluginMetrics.gauge("topic."+topicName+"."+getCamelCaseName(name), value);
                 });
                 updateTime = curTime;

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicMetrics.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicMetrics.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.util;
+
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Map;
+import java.util.HashMap;
+
+public class KafkaTopicMetrics {
+    private int metricUpdateInterval;
+    private final String topicName;
+    private long updateTime;
+    private Map<KafkaConsumer, Map<String, Object>> consumerMetricsMap;
+    private Map<String, String> camelCaseMap;
+    private final PluginMetrics pluginMetrics;
+    
+    public KafkaTopicMetrics(final String topicName, final PluginMetrics pluginMetrics) {
+        this.pluginMetrics = pluginMetrics;
+        this.topicName = topicName;
+        this.consumerMetricsMap = new HashMap<>();
+        this.updateTime = Instant.now().getEpochSecond();
+        this.metricUpdateInterval = 60; //seconds
+        this.camelCaseMap = new HashMap<>();
+        camelCaseMap.put("bytes-consumed-total", "bytesConsumedTotal");
+        camelCaseMap.put("records-consumed-total", "recordsConsumedTotal");
+        camelCaseMap.put("bytes-consumed-rate", "bytesConsumedRate");
+        camelCaseMap.put("records-consumed-rate", "recordsConsumedRate");
+        camelCaseMap.put("records-lag-max", "recordsLagMax");
+        camelCaseMap.put("records-lead-min", "recordsLeadMin");
+        camelCaseMap.put("commit-rate", "commitRate");
+        camelCaseMap.put("join-rate", "joinRate");
+        camelCaseMap.put("incoming-byte-rate", "incomingByteRate");
+        camelCaseMap.put("outgoing-byte-rate", "outgoingByteRate");
+        camelCaseMap.put("assigned-partitions", "outgoingByteRate");
+    }
+
+    public void register(KafkaConsumer consumer) {
+        this.consumerMetricsMap.put(consumer, new HashMap<>());
+    }
+
+    private String getCamelCaseName(final String name) {
+        String camelCaseName = camelCaseMap.get(name);
+        if (Objects.isNull(camelCaseName)) {
+            return name;
+        }
+        return camelCaseName;
+    }
+
+    public void update(final KafkaConsumer consumer, final String metricName, Integer metricValue) {
+        synchronized(consumerMetricsMap) {
+            Map<String, Object> cmetrics = consumerMetricsMap.get(consumer);
+            if (cmetrics != null) {
+                cmetrics.put(metricName, (double)metricValue);
+            }
+        }
+    }
+
+    public void update(final KafkaConsumer consumer) {
+        Map<String, Object> cmetrics = null;
+        synchronized(consumerMetricsMap) {
+            cmetrics = consumerMetricsMap.get(consumer);
+        }
+        if (cmetrics == null) {
+            return;
+        }
+        Map<MetricName, ? extends Metric> metrics = consumer.metrics();
+        for (Map.Entry<MetricName, ? extends Metric> entry : metrics.entrySet()) {
+            MetricName metric = entry.getKey();
+            Metric value = entry.getValue();
+            String metricName = metric.name();
+            String metricGroup = metric.group();
+            if ((metricName.contains("consumed")) ||
+                ((!metric.tags().containsKey("partition")) &&
+                     (metricName.equals("records-lag-max") || metricName.equals("records-lead-min"))) ||
+                (metricName.equals("commit-rate") || metricName.equals("join-rate")) ||
+                (metricName.equals("incoming-byte-rate") || metricName.equals("outgoing-byte-rate"))) {
+                    cmetrics.put(metricName, value.metricValue());
+            }
+        }
+        synchronized (consumerMetricsMap) {
+            long curTime = Instant.now().getEpochSecond();
+            if (curTime - updateTime > metricUpdateInterval) {
+                final Map<String, Double> aggregatedMetrics = new HashMap<>();
+                consumerMetricsMap.forEach((c, metricsMap) -> {
+                    Double value = 0.0;
+                    metricsMap.forEach((metricName, metricValue) -> {
+                        if (metricValue instanceof Double) {
+                            aggregatedMetrics.put(metricName, ((Double)metricValue) + aggregatedMetrics.getOrDefault(metricName, 0.0));
+                        }
+                    });
+                });
+                aggregatedMetrics.forEach((name, value) -> {
+                    System.out.println("__METRIC__topic."+topicName+"."+getCamelCaseName(name)+"___VALUE__"+value);
+                    pluginMetrics.gauge("topic."+topicName+"."+getCamelCaseName(name), value);
+                });
+                updateTime = curTime;
+            }
+        }
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaSourceCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaSourceCustomConsumerTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -202,6 +201,7 @@ public class KafkaSourceCustomConsumerTest {
             Thread.sleep(10000);
         } catch (Exception e){}
 
+        consumer.processAcknowledgedOffsets();
         offsetsToCommit = consumer.getOffsetsToCommit();
         Assertions.assertEquals(offsetsToCommit.size(), 1);
         offsetsToCommit.forEach((topicPartition, offsetAndMetadata) -> {

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaSourceCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaSourceCustomConsumerTest.java
@@ -102,6 +102,10 @@ public class KafkaSourceCustomConsumerTest {
         topicMetrics = mock(KafkaTopicMetrics.class);
         counter = mock(Counter.class);
         topicConfig = mock(TopicConfig.class);
+        when(topicMetrics.getNumberOfPositiveAcknowledgements()).thenReturn(counter);
+        when(topicMetrics.getNumberOfNegativeAcknowledgements()).thenReturn(counter);
+        when(topicMetrics.getNumberOfNegativeAcknowledgements()).thenReturn(counter);
+        when(topicMetrics.getNumberOfRecordsCommitted()).thenReturn(counter);
         when(topicConfig.getThreadWaitingTime()).thenReturn(Duration.ofSeconds(1));
         when(topicConfig.getSerdeFormat()).thenReturn(MessageFormat.PLAINTEXT);
         when(topicConfig.getAutoCommit()).thenReturn(false);
@@ -245,6 +249,7 @@ public class KafkaSourceCustomConsumerTest {
             Thread.sleep(10000);
         } catch (Exception e){}
 
+        consumer.processAcknowledgedOffsets();
         offsetsToCommit = consumer.getOffsetsToCommit();
         Assertions.assertEquals(offsetsToCommit.size(), 0);
     }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/TopicPartitionCommitTrackerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/TopicPartitionCommitTrackerTest.java
@@ -37,7 +37,7 @@ class TopicPartitionCommitTrackerTest {
     @ParameterizedTest
     @MethodSource("getInputOrder")
     public void test(List<Integer> order) {
-        topicPartitionCommitTracker = createObjectUnderTest(testTopic, testPartition, -1L);
+        topicPartitionCommitTracker = createObjectUnderTest(testTopic, testPartition, 0L);
         List<Range<Long>> ranges = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             ranges.add(Range.between(i*10L, i*10L+9L));

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicMetricsTests.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicMetricsTests.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doAnswer;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import io.micrometer.core.instrument.Counter;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Random;
+import java.util.function.ToDoubleFunction; 
+
+@ExtendWith(MockitoExtension.class)
+public class KafkaTopicMetricsTests {
+    public final class KafkaTestMetric implements Metric {
+        private final Double value;
+        private final MetricName name;
+
+        public KafkaTestMetric(final double value, final MetricName name) {
+            this.value = value;
+            this.name = name;
+        }
+
+        @Override
+        public MetricName metricName() {
+            return name;
+        }
+
+        @Override
+        public Object metricValue() {
+            return value;
+        }
+    }
+
+    private String topicName;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    private Map<String, ToDoubleFunction> pluginMetricsMap;
+
+    private Random random;
+
+    private KafkaTopicMetrics topicMetrics;
+
+    private double bytesConsumed;
+    private double recordsConsumed;
+    private double bytesConsumedRate;
+    private double recordsConsumedRate;
+    private double recordsLagMax;
+    private double recordsLeadMin;
+    private double commitRate;
+    private double joinRate;
+    private double incomingByteRate;
+    private double outgoingByteRate;
+
+    @Mock
+    private Counter bytesConsumedCounter;
+
+    @Mock
+    private Counter recordsConsumedCounter;
+    private double bytesConsumedCount;
+    private double recordsConsumedCount;
+
+    @BeforeEach
+    void setUp() {
+        topicName = RandomStringUtils.randomAlphabetic(8);
+        bytesConsumed = 0.0;
+        recordsConsumed = 0.0;
+        bytesConsumedRate = 0.0;
+        recordsConsumedRate = 0.0;
+        recordsLagMax = 0.0;
+        recordsLeadMin = Double.MAX_VALUE;
+        commitRate = 0.0;
+        joinRate = 0.0;
+        incomingByteRate = 0.0;
+        outgoingByteRate = 0.0;
+
+        bytesConsumedCount = 0.0;
+        recordsConsumedCount = 0.0;
+
+        random = new Random();
+        pluginMetrics = mock(PluginMetrics.class);
+        pluginMetricsMap = new HashMap<>();
+        doAnswer((i) -> {
+            ToDoubleFunction f = (ToDoubleFunction)i.getArgument(2);
+            Object arg = (Object)i.getArgument(1);
+            String name = (String)i.getArgument(0);
+            pluginMetricsMap.put(name, f);
+            return f.applyAsDouble(arg);
+        }).when(pluginMetrics).gauge(any(String.class), any(Object.class), any());
+        bytesConsumedCounter = mock(Counter.class);
+        recordsConsumedCounter = mock(Counter.class);
+
+        doAnswer((i) -> {
+            String arg = (String)i.getArgument(0);
+            if (arg.contains("Bytes")) {
+                return bytesConsumedCounter;
+            } else {
+                return recordsConsumedCounter;
+            }
+        }).when(pluginMetrics).counter(any(String.class));
+        doAnswer((i) -> {
+            bytesConsumedCount += (double)i.getArgument(0);
+            return null;
+        }).when(bytesConsumedCounter).increment(any(Double.class));
+        doAnswer((i) -> {
+            recordsConsumedCount += (double)i.getArgument(0);
+            return null;
+        }).when(recordsConsumedCounter).increment(any(Double.class));
+    }
+
+    public KafkaTopicMetrics createObjectUnderTest() {
+        return new KafkaTopicMetrics(topicName, pluginMetrics);
+    }
+
+    private KafkaTestMetric getMetric(final String name, final double value, Map<String, String> tags) {
+        MetricName metricName = new MetricName(name, "group", "metric", tags);
+        return new KafkaTestMetric(value, metricName);
+    }
+        
+
+    private void populateKafkaMetrics(Map<MetricName, KafkaTestMetric> metrics, double numAssignedPartitions) {
+        Integer tmpBytesConsumed = random.nextInt() % 100 + 1;
+        if (tmpBytesConsumed < 0) {
+            tmpBytesConsumed = -tmpBytesConsumed;
+        }
+        bytesConsumed += tmpBytesConsumed;
+        Integer tmpRecordsConsumed = random.nextInt() % 10 + 1;
+        if (tmpRecordsConsumed < 0) {
+            tmpRecordsConsumed = -tmpRecordsConsumed;
+        }
+        recordsConsumed += tmpRecordsConsumed;
+
+        double tmpBytesConsumedRate = random.nextDouble()*100;
+        bytesConsumedRate += tmpBytesConsumedRate;
+
+        double tmpRecordsConsumedRate = random.nextDouble()*10;
+        recordsConsumedRate += tmpRecordsConsumedRate;
+
+        double tmpRecordsLagMax = random.nextDouble()*2;
+        recordsLagMax = Math.max(recordsLagMax, tmpRecordsLagMax);
+
+        double tmpRecordsLeadMin = random.nextDouble()*3;
+        recordsLeadMin = Math.min(recordsLeadMin, tmpRecordsLeadMin);
+
+        double tmpCommitRate = random.nextDouble();
+        commitRate += tmpCommitRate;
+
+        double tmpJoinRate = random.nextDouble();
+        joinRate += tmpJoinRate;
+
+        double tmpIncomingByteRate = random.nextDouble();
+        incomingByteRate += tmpIncomingByteRate;
+
+        double tmpOutgoingByteRate = random.nextDouble();
+        outgoingByteRate += tmpOutgoingByteRate;
+
+        Map<String, Double> metricsMap = new HashMap<>();
+        metricsMap.put("bytes-consumed-total", (double)tmpBytesConsumed);
+        metricsMap.put("records-consumed-total", (double)tmpRecordsConsumed);
+        metricsMap.put("bytes-consumed-rate", tmpBytesConsumedRate);
+        metricsMap.put("records-consumed-rate", tmpRecordsConsumedRate);
+        metricsMap.put("records-lag-max", tmpRecordsLagMax);
+        metricsMap.put("records-lead-min", tmpRecordsLeadMin);
+        metricsMap.put("commit-rate", tmpCommitRate);
+        metricsMap.put("join-rate", tmpJoinRate);
+        metricsMap.put("incoming-byte-rate", tmpIncomingByteRate);
+        metricsMap.put("outgoing-byte-rate", tmpOutgoingByteRate);
+        metricsMap.put("assigned-partitions", numAssignedPartitions);
+
+        metricsMap.forEach((name, value) -> {
+            Map<String, String> tags = new HashMap<>();
+            if (name.contains("-total")) {
+                tags.put("topic", topicName);
+            }
+            KafkaTestMetric metric = getMetric(name, value, tags);
+            metrics.put(metric.metricName(), metric);
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 5, 10})
+    //@ValueSource(ints = {2})
+    public void KafkaTopicMetricTest_checkMetricUpdates(int numConsumers) {
+        topicMetrics = createObjectUnderTest();
+        for (int i = 0; i < numConsumers; i++) {
+            KafkaConsumer kafkaConsumer = mock(KafkaConsumer.class);   
+            topicMetrics.register(kafkaConsumer);
+            Map<MetricName, KafkaTestMetric> metrics = new HashMap<>();
+            when(kafkaConsumer.metrics()).thenReturn(metrics);
+            populateKafkaMetrics(metrics, (i %2 == 1) ? 0.0 : 1.0);
+            topicMetrics.update(kafkaConsumer);
+        }
+        when(recordsConsumedCounter.count()).thenReturn(recordsConsumedCount);
+        when(bytesConsumedCounter.count()).thenReturn(bytesConsumedCount);
+        assertThat(topicMetrics.getNumberOfRecordsConsumed().count(), equalTo(recordsConsumed));
+        assertThat(topicMetrics.getNumberOfBytesConsumed().count(), equalTo(bytesConsumed));
+        pluginMetricsMap.forEach((k, v) -> {
+            double result = v.applyAsDouble(topicMetrics.getMetricValues());
+            if (k.contains("bytesConsumedRate")) {
+                assertEquals(result, bytesConsumedRate, 0.01d);
+            } else if (k.contains("recordsConsumedRate")) {
+                assertEquals(result, recordsConsumedRate, 0.01d);
+            } else if (k.contains("recordsLagMax")) {
+                assertEquals(result, recordsLagMax, 0.01d);
+            } else if (k.contains("recordsLeadMin")) {
+                assertEquals(result, recordsLeadMin, 0.01d);
+            } else if (k.contains("commitRate")) {
+                assertEquals(result, commitRate, 0.01d);
+            } else if (k.contains("joinRate")) {
+                assertEquals(result, joinRate, 0.01d);
+            } else if (k.contains("incomingByteRate")) {
+                assertEquals(result, incomingByteRate, 0.01d);
+            } else if (k.contains("outgoingByteRate")) {
+                assertEquals(result, outgoingByteRate, 0.01d);
+            } else if (k.contains("numberOfNonConsumers")) {
+                int expectedValue = numConsumers/2;
+                assertThat(result, equalTo((double)expectedValue));
+            } else {
+                assertThat(result, equalTo(k+": Unknown Metric"));
+            }
+        });
+        
+    }
+
+}


### PR DESCRIPTION
### Description
Add metrics to Kafka.
1. Each thread maintains a local copy of counters which are put in a topic level common data structure every 60 seconds.
2. These metrics are aggregated across different threads of a topic, every 60 seconds and are exported to PluginMetrics
 
Resolves #3112 
### Issues Resolved
#3112 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
