### PR TITLE
Adds Apache commons-lang3 to Gradle version catalog

### DIFF
--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.15.2'
     implementation 'org.apache.parquet:parquet-common:1.12.3'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation "org.apache.commons:commons-lang3:3.12.0"
+    implementation libs.commons.lang3
     testImplementation testLibs.junit.vintage
     testImplementation project(':data-prepper-test-common')
     testImplementation 'org.skyscreamer:jsonassert:1.5.1'

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     testImplementation testLibs.spring.test
     implementation libs.armeria.core
     implementation libs.armeria.grpc
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation libs.commons.lang3
     implementation 'software.amazon.awssdk:acm'
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:apache-client'
@@ -52,7 +52,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     testImplementation testLibs.junit.vintage
     testImplementation testLibs.mockito.inline
-    testImplementation 'org.apache.commons:commons-lang3:3.12.0'
+    testImplementation libs.commons.lang3
     testImplementation project(':data-prepper-api').sourceSets.test.output
 }
 

--- a/data-prepper-expression/build.gradle
+++ b/data-prepper-expression/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-slf4j2-impl'
     implementation 'com.github.seancfoley:ipaddress:5.4.0'
     testImplementation testLibs.spring.test
-    testImplementation "org.apache.commons:commons-lang3:3.12.0"
+    testImplementation libs.commons.lang3
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 

--- a/data-prepper-logstash-configuration/build.gradle
+++ b/data-prepper-logstash-configuration/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation project(':data-prepper-plugins:date-processor')
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation "org.apache.commons:commons-lang3:3.12.0"
+    implementation libs.commons.lang3
     testImplementation testLibs.slf4j.simple
     testImplementation testLibs.mockito.inline
 }

--- a/data-prepper-plugins/aggregate-processor/build.gradle
+++ b/data-prepper-plugins/aggregate-processor/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation project(':data-prepper-plugins:otel-proto-common')
     implementation project(':data-prepper-plugins:otel-metrics-raw-processor')
     implementation libs.guava.core
-    implementation "org.apache.commons:commons-lang3:3.12.0"
+    implementation libs.commons.lang3
     implementation libs.opentelemetry.proto
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'

--- a/data-prepper-plugins/anomaly-detector-processor/build.gradle
+++ b/data-prepper-plugins/anomaly-detector-processor/build.gradle
@@ -17,5 +17,5 @@ dependencies {
     implementation 'software.amazon.randomcutforest:randomcutforest-examples:3.7.0'
     implementation 'software.amazon.randomcutforest:randomcutforest-parkservices:3.7.0'
     implementation 'software.amazon.randomcutforest:randomcutforest-serialization-json:1.0'
-    testImplementation 'org.apache.commons:commons-lang3:3.12.0'
+    testImplementation libs.commons.lang3
 }

--- a/data-prepper-plugins/cloudwatch-logs/build.gradle
+++ b/data-prepper-plugins/cloudwatch-logs/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'software.amazon.awssdk:cloudwatch'
     implementation 'software.amazon.awssdk:cloudwatchlogs'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation libs.commons.lang3
     implementation 'org.projectlombok:lombok:1.18.26'
     implementation 'org.hibernate.validator:hibernate-validator:8.0.0.Final'
     testImplementation project(path: ':data-prepper-test-common')

--- a/data-prepper-plugins/common/build.gradle
+++ b/data-prepper-plugins/common/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:acm'
     implementation 'org.apache.commons:commons-compress:1.23.0'
-    implementation "org.apache.commons:commons-lang3:3.12.0"
+    implementation libs.commons.lang3
     implementation "org.bouncycastle:bcprov-jdk15on:1.70"
     implementation "org.bouncycastle:bcpkix-jdk15on:1.70"
     implementation 'org.reflections:reflections:0.10.2'

--- a/data-prepper-plugins/date-processor/build.gradle
+++ b/data-prepper-plugins/date-processor/build.gradle
@@ -12,5 +12,5 @@ dependencies {
     implementation project(':data-prepper-test-common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'
-    testImplementation 'org.apache.commons:commons-lang3:3.12.0'
+    testImplementation libs.commons.lang3
 }

--- a/data-prepper-plugins/failures-common/build.gradle
+++ b/data-prepper-plugins/failures-common/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     implementation 'io.micrometer:micrometer-core'
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:sts'
-    testImplementation 'org.apache.commons:commons-lang3:3.12.0'
+    testImplementation libs.commons.lang3
 }

--- a/data-prepper-plugins/geoip-processor/build.gradle
+++ b/data-prepper-plugins/geoip-processor/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation 'com.maxmind.geoip2:geoip2:4.0.1'
     implementation 'com.maxmind.db:maxmind-db:3.0.0'
 
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation libs.commons.lang3
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation project(':data-prepper-test-common')

--- a/data-prepper-plugins/http-sink/build.gradle
+++ b/data-prepper-plugins/http-sink/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation 'software.amazon.awssdk:sts'
     implementation 'software.amazon.awssdk:acm'
     implementation 'software.amazon.awssdk:auth'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation libs.commons.lang3
     implementation project(':data-prepper-plugins:failures-common')
     implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.2'
     testImplementation project(':data-prepper-test-common')

--- a/data-prepper-plugins/kafka-plugins/build.gradle
+++ b/data-prepper-plugins/kafka-plugins/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation 'org.apache.avro:avro:1.11.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.micrometer:micrometer-core'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation libs.commons.lang3
     implementation 'io.confluent:kafka-avro-serializer:7.3.3'
     implementation 'io.confluent:kafka-schema-registry-client:7.3.3'
     implementation 'io.confluent:kafka-avro-serializer:7.3.3'

--- a/data-prepper-plugins/log-generator-source/build.gradle
+++ b/data-prepper-plugins/log-generator-source/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:blocking-buffer')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    testImplementation 'org.apache.commons:commons-lang3:3.12.0'
+    testImplementation libs.commons.lang3
 }
 
 test {

--- a/data-prepper-plugins/opensearch-source/build.gradle
+++ b/data-prepper-plugins/opensearch-source/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'org.opensearch.client:opensearch-java:2.5.0'
     implementation 'org.opensearch.client:opensearch-rest-client:2.7.0'
     implementation 'co.elastic.clients:elasticsearch-java:7.17.0'
-    implementation "org.apache.commons:commons-lang3:3.12.0"
+    implementation libs.commons.lang3
     implementation('org.apache.maven:maven-artifact:3.0.3') {
         exclude group: 'org.codehaus.plexus'
     }

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'software.amazon.awssdk:arns'
     implementation 'io.micrometer:micrometer-core'
     implementation 'software.amazon.awssdk:s3'
-    implementation "org.apache.commons:commons-lang3:3.12.0"
+    implementation libs.commons.lang3
     implementation 'software.amazon.awssdk:apache-client'
     testImplementation testLibs.junit.vintage
     testImplementation 'commons-io:commons-io:2.12.0'

--- a/data-prepper-plugins/otel-logs-source/build.gradle
+++ b/data-prepper-plugins/otel-logs-source/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation 'com.linecorp.armeria:armeria-grpc:1.15.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation "org.apache.commons:commons-lang3:3.12.0"
+    implementation libs.commons.lang3
     implementation "org.bouncycastle:bcprov-jdk15on:1.69"
     implementation "org.bouncycastle:bcpkix-jdk15on:1.69"
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/data-prepper-plugins/otel-metrics-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-metrics-raw-processor/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(':data-prepper-plugins:common')
     implementation project(':data-prepper-plugins:otel-proto-common')
     implementation 'commons-codec:commons-codec:1.15'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation libs.commons.lang3
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation libs.opentelemetry.proto
     implementation libs.protobuf.util

--- a/data-prepper-plugins/otel-metrics-source/build.gradle
+++ b/data-prepper-plugins/otel-metrics-source/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation libs.armeria.grpc
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation "org.apache.commons:commons-lang3:3.12.0"
+    implementation libs.commons.lang3
     implementation "org.bouncycastle:bcprov-jdk15on:1.70"
     implementation "org.bouncycastle:bcpkix-jdk15on:1.70"
     testImplementation testLibs.junit.vintage

--- a/data-prepper-plugins/otel-proto-common/build.gradle
+++ b/data-prepper-plugins/otel-proto-common/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation libs.protobuf.util
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation "org.apache.commons:commons-lang3:3.12.0"
+    implementation libs.commons.lang3
     implementation 'commons-codec:commons-codec:1.15'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation libs.armeria.grpc
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation "org.apache.commons:commons-lang3:3.12.0"
+    implementation libs.commons.lang3
     implementation "org.bouncycastle:bcprov-jdk15on:1.70"
     implementation "org.bouncycastle:bcpkix-jdk15on:1.70"
     testImplementation testLibs.junit.vintage

--- a/data-prepper-plugins/prometheus-sink/build.gradle
+++ b/data-prepper-plugins/prometheus-sink/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'org.hibernate.validator:hibernate-validator:7.0.5.Final'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'software.amazon.awssdk:auth'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation libs.commons.lang3
     implementation project(':data-prepper-plugins:failures-common')
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.2'
     testImplementation project(':data-prepper-test-common')

--- a/data-prepper-plugins/rss-source/build.gradle
+++ b/data-prepper-plugins/rss-source/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.apptasticsoftware:rssreader:3.2.5'
-    testImplementation 'org.apache.commons:commons-lang3:3.12.0'
+    testImplementation libs.commons.lang3
     testImplementation project(':data-prepper-test-common')
 }
 

--- a/data-prepper-plugins/s3-sink/build.gradle
+++ b/data-prepper-plugins/s3-sink/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation 'org.apache.hadoop:hadoop-common:3.3.6'
     implementation 'org.apache.parquet:parquet-avro:1.13.1'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation libs.commons.lang3
     testImplementation project(':data-prepper-test-common')
 	implementation project(':data-prepper-plugins:parquet-codecs')
     implementation project(':data-prepper-plugins:parse-json-processor')

--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation 'org.apache.parquet:parquet-common:1.12.3'
     implementation 'dev.failsafe:failsafe:3.3.2'
     implementation 'org.apache.httpcomponents:httpcore:4.4.15'
-    testImplementation 'org.apache.commons:commons-lang3:3.12.0'
+    testImplementation libs.commons.lang3
     testImplementation 'com.github.tomakehurst:wiremock:3.0.0-beta-8'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation testLibs.junit.vintage

--- a/data-prepper-plugins/sns-sink/build.gradle
+++ b/data-prepper-plugins/sns-sink/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'software.amazon.awssdk:sqs'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.21'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation libs.commons.lang3
     implementation project(':data-prepper-plugins:failures-common')
     testImplementation project(':data-prepper-test-common')
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'

--- a/data-prepper-plugins/translate-processor/build.gradle
+++ b/data-prepper-plugins/translate-processor/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation project(path: ':data-prepper-plugins:mutate-event-processors')
     testImplementation project(':data-prepper-plugins:log-generator-source')
     testImplementation project(':data-prepper-test-common')
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation libs.commons.lang3
 }
 
 test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -36,6 +36,7 @@ dependencyResolutionManagement {
             library('spring-context', 'org.springframework', 'spring-context').versionRef('spring')
             version('guava', '32.0.1-jre')
             library('guava-core', 'com.google.guava', 'guava').versionRef('guava')
+            library('commons-lang3', 'org.apache.commons', 'commons-lang3').version('3.13.0')
         }
         testLibs {
             version('junit', '5.8.2')


### PR DESCRIPTION
### Description

We have a number of dependabot PRs to update commons-lang3. This PR should help reduce that to using only one version.

* Adds Apache `commons-lang3` to the Gradle version catalog
* Updates `commons-lang3` to use 3.13.0
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
