### PR TITLE
Add ttl to all dynamo source coordination store items on creation, not just when they are COMPLETED

### DIFF
--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStore.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStore.java
@@ -118,6 +118,10 @@ public class DynamoDbSourceCoordinationStore implements SourceCoordinationStore 
             dynamoDbSourcePartitionItem.setPartitionPriority(updateItem.getPartitionOwnershipTimeout().toString());
         }
 
+        if (Objects.nonNull(dynamoStoreSettings.getTtl())) {
+            dynamoDbSourcePartitionItem.setExpirationTime(Instant.now().plus(dynamoStoreSettings.getTtl()).getEpochSecond());
+        }
+
         dynamoDbClientWrapper.tryUpdatePartitionItem(dynamoDbSourcePartitionItem);
     }
 

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStore.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStore.java
@@ -65,6 +65,10 @@ public class DynamoDbSourceCoordinationStore implements SourceCoordinationStore 
                                           final Long closedCount,
                                           final String partitionProgressState) {
         final DynamoDbSourcePartitionItem newPartitionItem = new DynamoDbSourcePartitionItem();
+
+        if (Objects.nonNull(dynamoStoreSettings.getTtl())) {
+            newPartitionItem.setExpirationTime(Instant.now().plus(dynamoStoreSettings.getTtl()).getEpochSecond());
+        }
         newPartitionItem.setSourceIdentifier(sourceIdentifier);
         newPartitionItem.setSourceStatusCombinationKey(String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, sourcePartitionStatus));
         newPartitionItem.setPartitionPriority(Instant.now().toString());
@@ -112,10 +116,6 @@ public class DynamoDbSourceCoordinationStore implements SourceCoordinationStore 
 
         if (SourcePartitionStatus.ASSIGNED.equals(updateItem.getSourcePartitionStatus())) {
             dynamoDbSourcePartitionItem.setPartitionPriority(updateItem.getPartitionOwnershipTimeout().toString());
-        }
-
-        if (SourcePartitionStatus.COMPLETED.equals(updateItem.getSourcePartitionStatus()) && Objects.nonNull(dynamoStoreSettings.getTtl())) {
-            dynamoDbSourcePartitionItem.setExpirationTime(Instant.now().plus(dynamoStoreSettings.getTtl()).getEpochSecond());
         }
 
         dynamoDbClientWrapper.tryUpdatePartitionItem(dynamoDbSourcePartitionItem);


### PR DESCRIPTION
### Description
Previously, if TTL was enabled on the dynamo db store for source coordination, only COMPLETED partitions would get a TTL and expire after the duration specified in the config.

This change makes it so that the TTL is set on every item in the store on item creation and extended when the item is updated, not just the COMPLETED partitions.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
