### PR TITLE
Add include_keys and exclude_keys to S3 sink

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkModel.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/SinkModel.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -122,6 +123,13 @@ public class SinkModel extends PluginModel {
             this.includeKeys = includeKeys != null ? preprocessingKeys(includeKeys) : Collections.emptyList();
             this.excludeKeys = excludeKeys != null ? preprocessingKeys(excludeKeys) : Collections.emptyList();
             this.tagsTargetKey = tagsTargetKey;
+            validateConfiguration();
+        }
+
+        void validateConfiguration() {
+            if (!includeKeys.isEmpty() && !excludeKeys.isEmpty()) {
+                throw new InvalidPluginConfigurationException("include_keys and exclude_keys cannot both exist in the configuration at the same time.");
+            }
         }
 
 

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -209,6 +209,64 @@ With the `document_root_key` set to `status`. The document structure would be `{
     duration: "15 ms"
 }
 ```
+- `include_keys`: A list of keys to be included (retained). The key in the list can be a valid JSON path, such as 'request/status'. This option can work together with `document_root_key`.
+
+For example, If we have the following sample event:
+```
+{
+    status: 200,
+    message: null,
+    metadata: {
+        sourceIp: "123.212.49.58",
+        destinationIp: "79.54.67.231",
+        bytes: 3545,
+        duration: "15 ms"
+    }
+}
+```
+if `include_keys` is set to ["status", "metadata/sourceIp"], the document written to OpenSearch would be:
+```
+{
+    status: 200,
+    metadata: {
+        sourceIp: "123.212.49.58"
+    }
+}
+```
+if you have also set `document_root_key` as "metadata", and the include_keys as ["sourceIp, "bytes"], the document written to OpenSearch would be:
+```
+{
+   sourceIp: "123.212.49.58",
+   bytes: 3545
+}
+```
+
+- `exclude_keys`: Similar to include_keys except any keys in the list will be excluded. Note that you should not have both include_keys and exclude_keys in the configuration at the same time.
+
+For example, If we have the following sample event:
+```
+{
+    status: 200,
+    message: null,
+    metadata: {
+        sourceIp: "123.212.49.58",
+        destinationIp: "79.54.67.231",
+        bytes: 3545,
+        duration: "15 ms"
+    }
+}
+```
+if `exclude_keys` is set to ["status", "metadata/sourceIp"], the document written to OpenSearch would be:
+```
+{
+    message: null,
+    metadata: {
+        destinationIp: "79.54.67.231",
+        bytes: 3545,
+        duration: "15 ms"
+    }
+}
+```
 - `distribution_version`: A String indicating whether the sink backend version is Elasticsearch 6 or above (i.e. Elasticsearch 7.x or OpenSearch). `es6` represents Elasticsearch 6; `default` represents latest compatible backend version (Elasticsearch 7.x, OpenSearch 1.x, OpenSearch 2.x). Default to `default`.
 
 ### <a name="aws_configuration">AWS Configuration</a>


### PR DESCRIPTION
### Description
Add include_keys and exclude_keys to S3 sink
 
### Issues Resolved
#3080 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
