### PR TITLE
Fix otel log format issue #3123

### DIFF
--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodecTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodecTest.java
@@ -89,6 +89,7 @@ public class OTelProtoCodecTest {
 
     private static final String TEST_REQUEST_LOGS_IS_JSON_FILE = "test-request-log-is.json";
 
+    private static final String TEST_REQUEST_COMPLEX_LOGS_JSON_FILE = "test-request-complex-log.json";
 
     private static final Long TIME = TimeUnit.MILLISECONDS.toNanos(ZonedDateTime.of(
             LocalDateTime.of(2020, 5, 24, 14, 1, 0),
@@ -425,6 +426,15 @@ public class OTelProtoCodecTest {
 
             assertThat(logs.size() , is(equalTo(1)));
             validateLog(logs.get(0));
+        }
+
+        @Test
+        public void testParseExportComplexLogsServiceRequest_ScopedLogs() throws IOException {
+            final ExportLogsServiceRequest exportLogsServiceRequest = buildExportLogsServiceRequestFromJsonFile(TEST_REQUEST_COMPLEX_LOGS_JSON_FILE);
+            List<OpenTelemetryLog> logs = decoderUnderTest.parseExportLogsServiceRequest(exportLogsServiceRequest);
+
+            assertThat(logs.size() , is(equalTo(1)));
+            assertThat(logs.get(0).getBody(), is("{\"key1\":\"value1\",\"key2\":\"value2\",\"key3\":{\"nestedKey1\":\"nestedValue1\"}}"));
         }
 
         @Test

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-complex-log.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-complex-log.json
@@ -1,0 +1,57 @@
+{
+  "resourceLogs": [{
+    "resource": {
+      "attributes": [{
+        "key": "service.name",
+        "value": {
+          "stringValue": "service"
+        }
+      }]
+    },
+    "scopeLogs": [{
+      "logRecords": [{
+        "timeUnixNano": "1590328800000000000",
+        "severityNumber": "SEVERITY_NUMBER_DEBUG",
+        "body": {
+          "kvlistValue": {
+            "values": [{
+              "key": "key1",
+              "value": {
+                "stringValue": "value1"
+              }
+            }, {
+              "key": "key2",
+              "value": {
+                "stringValue": "value2"
+              }
+            }, {
+              "key": "key3",
+              "value": {
+                "kvlistValue": {
+                  "values": [{
+                    "key": "nestedKey1",
+                    "value": {
+                      "stringValue": "nestedValue1"
+                    }
+                  }]
+                }
+              }
+            }]
+          }
+        },
+        "attributes": [{
+          "key": "statement.params",
+          "value": {
+            "stringValue": "us-east-1"
+          }
+        }],
+        "droppedAttributesCount": 3,
+        "flags": 1,
+        "traceId": "uhocI7QJO2M=",
+        "spanId": "LMg6yQ68Rpw=",
+        "observedTimeUnixNano": "1590328802000000000"
+      }]
+    }],
+    "schemaUrl": "schemaurl"
+  }]
+}


### PR DESCRIPTION
Covert KVList into a regular json string format.
This issue is fixed on branch 2.3.
Once merged, it can port to the main branch.

Or please tell me if the data-prepper project wants this fix on the main only.
### Description
Fix the otel KVList 
### Issues Resolved
#3123 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
