### PR TITLE
MAINT: add integ test coverage for ODFE 0.10.0

### DIFF
--- a/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opendistro-integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         java: [11]
-        opendistro: [1.3.0, 1.6.0, 1.8.0, 1.9.0, 1.11.0, 1.12.0, 1.13.3]
+        opendistro: [0.10.0, 1.3.0, 1.6.0, 1.8.0, 1.9.0, 1.11.0, 1.12.0, 1.13.3]
       fail-fast: false
 
     runs-on: ubuntu-latest

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/DeclaredOpenSearchVersion.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/DeclaredOpenSearchVersion.java
@@ -14,6 +14,7 @@ import org.opensearch.Version;
 class DeclaredOpenSearchVersion implements Comparable<DeclaredOpenSearchVersion> {
     private static final DeclaredOpenSearchVersion DEFAULT = new DeclaredOpenSearchVersion(Distribution.OPENSEARCH, "1.0.0");
     public static final DeclaredOpenSearchVersion OPENDISTRO_1_9 = new DeclaredOpenSearchVersion(Distribution.OPENDISTRO, "1.9.0");
+    public static final DeclaredOpenSearchVersion OPENDISTRO_0_10 = new DeclaredOpenSearchVersion(Distribution.OPENDISTRO, "0.10.0");
 
     enum Distribution {
         OPENDISTRO,

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/DeclaredOpenSearchVersionTest.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/DeclaredOpenSearchVersionTest.java
@@ -44,12 +44,13 @@ class DeclaredOpenSearchVersionTest {
     @CsvSource({
             "opensearch:1.2.4,opensearch:1.2.4,0",
             "opendistro:1.13.3,opendistro:1.13.3,0",
+            "opendistro:0.10.0,opendistro:1.0.0,-1",
             "opensearch:1.2.4,opensearch:1.2.3,1",
             "opensearch:1.2.3,opensearch:1.2.4,-1",
             "opensearch:2.6.0,opensearch:1.2.3,1",
             "opensearch:1.2.3,opensearch:2.6.0,-1",
             "opensearch:1.3.9,opendistro:1.13.3,1",
-            "opendistro:1.13.3,opensearch:1.3.9,-1"
+            "opendistro:1.13.3,opensearch:1.3.9,-1",
     })
     void compareTo_returns_correct_value(final String versionStringToTest, final String otherVersionString, final int expectedCompareTo) {
         final DeclaredOpenSearchVersion objectUnderTest = DeclaredOpenSearchVersion.parse(versionStringToTest);

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -110,6 +110,7 @@ public class OpenSearchSinkIT {
     private static final String DEFAULT_RAW_SPAN_FILE_1 = "raw-span-1.json";
     private static final String DEFAULT_RAW_SPAN_FILE_2 = "raw-span-2.json";
     private static final String DEFAULT_SERVICE_MAP_FILE = "service-map-1.json";
+    private static final String INCLUDE_TYPE_NAME_FALSE_URI = "?include_type_name=false";
     private static final String TRACE_INGESTION_TEST_DISABLED_REASON = "Trace ingestion is not supported for ES 6";
 
     private RestClient client;
@@ -430,7 +431,7 @@ public class OpenSearchSinkIT {
         final PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFile);
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         final String extraURI = DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(
-                OpenSearchIntegrationHelper.getVersion()) >= 0 ? "?include_type_name=false" : "";
+                OpenSearchIntegrationHelper.getVersion()) >= 0 ? INCLUDE_TYPE_NAME_FALSE_URI : "";
         final Request request = new Request(HttpMethod.HEAD, testIndexAlias + extraURI);
         final Response response = client.performRequest(request);
         MatcherAssert.assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
@@ -452,7 +453,7 @@ public class OpenSearchSinkIT {
         final PluginSetting pluginSetting = generatePluginSettingByMetadata(metadata);
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         final String extraURI = DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(
-                OpenSearchIntegrationHelper.getVersion()) >= 0 ? "?include_type_name=false" : "";
+                OpenSearchIntegrationHelper.getVersion()) >= 0 ? INCLUDE_TYPE_NAME_FALSE_URI : "";
         Request request = new Request(HttpMethod.HEAD, indexAlias + extraURI);
         Response response = client.performRequest(request);
         MatcherAssert.assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
@@ -510,7 +511,7 @@ public class OpenSearchSinkIT {
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
 
         final String extraURI = DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(
-                OpenSearchIntegrationHelper.getVersion()) >= 0 ? "?include_type_name=false" : "";
+                OpenSearchIntegrationHelper.getVersion()) >= 0 ? INCLUDE_TYPE_NAME_FALSE_URI : "";
         Request getTemplateRequest = new Request(HttpMethod.GET,
                 "/" + templatePath + "/" + expectedIndexTemplateName + extraURI);
         Response getTemplateResponse = client.performRequest(getTemplateRequest);
@@ -1047,7 +1048,7 @@ public class OpenSearchSinkIT {
 
     private Map<String, Object> getIndexMappings(final String index) throws IOException {
         final String extraURI = DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(
-                OpenSearchIntegrationHelper.getVersion()) >= 0 ? "?include_type_name=false" : "";
+                OpenSearchIntegrationHelper.getVersion()) >= 0 ? INCLUDE_TYPE_NAME_FALSE_URI : "";
         final Request request = new Request(HttpMethod.GET, index + "/_mappings" + extraURI);
         final Response response = client.performRequest(request);
         final String responseBody = EntityUtils.toString(response.getEntity());

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -109,6 +110,7 @@ public class OpenSearchSinkIT {
     private static final String DEFAULT_RAW_SPAN_FILE_1 = "raw-span-1.json";
     private static final String DEFAULT_RAW_SPAN_FILE_2 = "raw-span-2.json";
     private static final String DEFAULT_SERVICE_MAP_FILE = "service-map-1.json";
+    private static final String TRACE_INGESTION_TEST_DISABLED_REASON = "Trace ingestion is not supported for ES 6";
 
     private RestClient client;
     private EventHandle eventHandle;
@@ -169,6 +171,7 @@ public class OpenSearchSinkIT {
     }
 
     @Test
+    @DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
     public void testInstantiateSinkRawSpanDefault() throws IOException {
         final PluginSetting pluginSetting = generatePluginSetting(IndexType.TRACE_ANALYTICS_RAW.getValue(), null, null);
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
@@ -212,6 +215,7 @@ public class OpenSearchSinkIT {
     }
 
     @Test
+    @DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
     public void testInstantiateSinkRawSpanReservedAliasAlreadyUsedAsIndex() throws IOException {
         final String reservedIndexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexType.TRACE_ANALYTICS_RAW);
         final Request request = new Request(HttpMethod.PUT, reservedIndexAlias);
@@ -222,6 +226,7 @@ public class OpenSearchSinkIT {
                 RuntimeException.class, () -> sink.doInitialize());
     }
 
+    @DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
     @ParameterizedTest
     @CsvSource({"true,true", "true,false", "false,true", "false,false"})
     public void testOutputRawSpanDefault(final boolean estimateBulkSizeUsingCompression,
@@ -290,6 +295,7 @@ public class OpenSearchSinkIT {
         MatcherAssert.assertThat(bulkRequestSizeBytesMetrics.get(2).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
     }
 
+    @DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
     @ParameterizedTest
     @CsvSource({"true,true", "true,false", "false,true", "false,false"})
     public void testOutputRawSpanWithDLQ(final boolean estimateBulkSizeUsingCompression,
@@ -352,6 +358,7 @@ public class OpenSearchSinkIT {
     }
 
     @Test
+    @DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
     public void testInstantiateSinkServiceMapDefault() throws IOException {
         final PluginSetting pluginSetting = generatePluginSetting(IndexType.TRACE_ANALYTICS_SERVICE_MAP.getValue(), null, null);
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
@@ -422,7 +429,9 @@ public class OpenSearchSinkIT {
                 getClass().getClassLoader().getResource(TEST_TEMPLATE_V1_FILE)).getFile();
         final PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFile);
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
-        final Request request = new Request(HttpMethod.HEAD, testIndexAlias);
+        final String extraURI = DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(
+                OpenSearchIntegrationHelper.getVersion()) >= 0 ? "?include_type_name=false" : "";
+        final Request request = new Request(HttpMethod.HEAD, testIndexAlias + extraURI);
         final Response response = client.performRequest(request);
         MatcherAssert.assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
         sink.shutdown();
@@ -433,6 +442,7 @@ public class OpenSearchSinkIT {
     }
 
     @Test
+    @DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
     public void testInstantiateSinkCustomIndex_WithIsmPolicy() throws IOException {
         final String indexAlias = "sink-custom-index-ism-test-alias";
         final String testTemplateFile = Objects.requireNonNull(
@@ -441,7 +451,9 @@ public class OpenSearchSinkIT {
         metadata.put(IndexConfiguration.ISM_POLICY_FILE, TEST_CUSTOM_INDEX_POLICY_FILE);
         final PluginSetting pluginSetting = generatePluginSettingByMetadata(metadata);
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
-        Request request = new Request(HttpMethod.HEAD, indexAlias);
+        final String extraURI = DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(
+                OpenSearchIntegrationHelper.getVersion()) >= 0 ? "?include_type_name=false" : "";
+        Request request = new Request(HttpMethod.HEAD, indexAlias + extraURI);
         Response response = client.performRequest(request);
         MatcherAssert.assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
         final String index = String.format("%s-000001", indexAlias);
@@ -497,7 +509,10 @@ public class OpenSearchSinkIT {
         PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, templateType, testTemplateFileV1);
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
 
-        Request getTemplateRequest = new Request(HttpMethod.GET, "/" + templatePath + "/" + expectedIndexTemplateName);
+        final String extraURI = DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(
+                OpenSearchIntegrationHelper.getVersion()) >= 0 ? "?include_type_name=false" : "";
+        Request getTemplateRequest = new Request(HttpMethod.GET,
+                "/" + templatePath + "/" + expectedIndexTemplateName + extraURI);
         Response getTemplateResponse = client.performRequest(getTemplateRequest);
         MatcherAssert.assertThat(getTemplateResponse.getStatusLine().getStatusCode(), equalTo(SC_OK));
 
@@ -513,7 +528,8 @@ public class OpenSearchSinkIT {
         pluginSetting = generatePluginSetting(null, testIndexAlias, templateType, testTemplateFileV2);
         sink = createObjectUnderTest(pluginSetting, true);
 
-        getTemplateRequest = new Request(HttpMethod.GET, "/" + templatePath + "/" + expectedIndexTemplateName);
+        getTemplateRequest = new Request(HttpMethod.GET,
+                "/" + templatePath + "/" + expectedIndexTemplateName + extraURI);
         getTemplateResponse = client.performRequest(getTemplateRequest);
         MatcherAssert.assertThat(getTemplateResponse.getStatusLine().getStatusCode(), equalTo(SC_OK));
 
@@ -529,7 +545,8 @@ public class OpenSearchSinkIT {
         pluginSetting = generatePluginSetting(null, testIndexAlias, templateType, testTemplateFileV1);
         sink = createObjectUnderTest(pluginSetting, true);
 
-        getTemplateRequest = new Request(HttpMethod.GET, "/" + templatePath + "/" + expectedIndexTemplateName);
+        getTemplateRequest = new Request(HttpMethod.GET,
+                "/" + templatePath + "/" + expectedIndexTemplateName + extraURI);
         getTemplateResponse = client.performRequest(getTemplateRequest);
         MatcherAssert.assertThat(getTemplateResponse.getStatusLine().getStatusCode(), equalTo(SC_OK));
 
@@ -623,6 +640,7 @@ public class OpenSearchSinkIT {
     }
 
     @Test
+    @DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
     public void testEventOutputWithTags() throws IOException, InterruptedException {
         final Event testEvent = JacksonEvent.builder()
                 .withData("{\"log\": \"foobar\"}")
@@ -651,6 +669,7 @@ public class OpenSearchSinkIT {
     }
 
     @Test
+    @DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
     public void testEventOutput() throws IOException, InterruptedException {
 
         final Event testEvent = JacksonEvent.builder()
@@ -838,6 +857,8 @@ public class OpenSearchSinkIT {
 
     @Test
     @Timeout(value = 1, unit = TimeUnit.MINUTES)
+    @DisabledIf(value = "isES6",
+            disabledReason = "PUT _opendistro/_security/api/roles/<role-id> request could not be parsed in ES 6.")
     public void testOutputManagementDisabled() throws IOException, InterruptedException {
         final String testIndexAlias = "test-" + UUID.randomUUID();
         final String roleName = UUID.randomUUID().toString();
@@ -894,6 +915,10 @@ public class OpenSearchSinkIT {
             metadata.put(ConnectionConfiguration.USERNAME, user);
             metadata.put(ConnectionConfiguration.PASSWORD, password);
         }
+        final String distributionVersion = DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(
+                OpenSearchIntegrationHelper.getVersion()) >= 0 ?
+                DistributionVersion.ES6.getVersion() : DistributionVersion.DEFAULT.getVersion();
+        metadata.put(IndexConfiguration.DISTRIBUTION_VERSION, distributionVersion);
         return metadata;
     }
 
@@ -1021,7 +1046,9 @@ public class OpenSearchSinkIT {
     }
 
     private Map<String, Object> getIndexMappings(final String index) throws IOException {
-        final Request request = new Request(HttpMethod.GET, index + "/_mappings");
+        final String extraURI = DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(
+                OpenSearchIntegrationHelper.getVersion()) >= 0 ? "?include_type_name=false" : "";
+        final Request request = new Request(HttpMethod.GET, index + "/_mappings" + extraURI);
         final Response response = client.performRequest(request);
         final String responseBody = EntityUtils.toString(response.getEntity());
 
@@ -1045,7 +1072,10 @@ public class OpenSearchSinkIT {
 
     @SuppressWarnings("unchecked")
     private void wipeAllOpenSearchIndices() throws IOException {
-        final Response response = client.performRequest(new Request("GET", "/*?expand_wildcards=all"));
+        final String getIndicesEndpoint = DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(
+                OpenSearchIntegrationHelper.getVersion()) >= 0 ?
+                "/*?expand_wildcards=all&include_type_name=false" : "/*?expand_wildcards=all";
+        final Response response = client.performRequest(new Request("GET", getIndicesEndpoint));
 
         final String responseBody = EntityUtils.toString(response.getEntity());
         final Map<String, Object> indexContent = createContentParser(XContentType.JSON.xContent(), responseBody).map();
@@ -1097,5 +1127,9 @@ public class OpenSearchSinkIT {
         final String createTemplateJson = objectMapper.writeValueAsString(templateJson);
         request.setJsonEntity(createTemplateJson);
         final Response response = client.performRequest(request);
+    }
+
+    private static boolean isES6() {
+        return DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(OpenSearchIntegrationHelper.getVersion()) >= 0;
     }
 }


### PR DESCRIPTION
### Description
This PR 

* adds integ test coverage on opensearch sink for ODFE 0.10.0 backend (ES 6.8 engine)
* properly disable test cases that does not apply under ES 6
 
### Issues Resolved
Resolves #3126 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
