### PR TITLE
Correct the behavior of the JSON output codec to write a JSON object …

### DIFF
--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodec.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodec.java
@@ -42,12 +42,15 @@ public class JsonOutputCodec implements OutputCodec {
         Objects.requireNonNull(codecContext);
         this.codecContext = codecContext;
         generator = factory.createGenerator(outputStream, JsonEncoding.UTF8);
+        generator.writeStartObject();
+        generator.writeFieldName(config.getKeyName());
         generator.writeStartArray();
     }
 
     @Override
     public void complete(final OutputStream outputStream) throws IOException {
         generator.writeEndArray();
+        generator.writeEndObject();
         generator.close();
         outputStream.flush();
         outputStream.close();
@@ -78,7 +81,6 @@ public class JsonOutputCodec implements OutputCodec {
     public String getExtension() {
         return JSON;
     }
-
 }
 
 

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodecConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodecConfig.java
@@ -4,6 +4,17 @@
  */
 package org.opensearch.dataprepper.plugins.codec.json;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
+
 public class JsonOutputCodecConfig {
-    
+    static final String DEFAULT_KEY_NAME = "events";
+
+    @JsonProperty("key_name")
+    @Size(min = 1, max = 2048)
+    private String keyName = DEFAULT_KEY_NAME;
+
+    public String getKeyName() {
+        return keyName;
+    }
 }

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonCodecsIT.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonCodecsIT.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.codec.json;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,6 +31,7 @@ import java.util.UUID;
 import java.util.function.Consumer;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -83,6 +85,13 @@ public class JsonCodecsIT {
         int index = 0;
         ObjectMapper mapper = new ObjectMapper();
         JsonNode jsonNode = mapper.readTree(outputStream.toByteArray());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.OBJECT));
+        Map.Entry<String, JsonNode> nextField = jsonNode.fields().next();
+        assertThat(nextField, notNullValue());
+        assertThat(nextField.getKey(), equalTo(JsonOutputCodecConfig.DEFAULT_KEY_NAME));
+        jsonNode = nextField.getValue();
+        assertThat(jsonNode, notNullValue());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.ARRAY));
         for (JsonNode element : jsonNode) {
             Set<String> keys = initialRecords.get(index).keySet();
             Map<String, Object> actualMap = new HashMap<>();

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodecTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodecTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.codec.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class JsonOutputCodecTest {
@@ -75,6 +77,13 @@ class JsonOutputCodecTest {
         int index = 0;
         ObjectMapper mapper = new ObjectMapper();
         JsonNode jsonNode = mapper.readTree(outputStream.toByteArray());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.OBJECT));
+        Map.Entry<String, JsonNode> nextField = jsonNode.fields().next();
+        assertThat(nextField, notNullValue());
+        assertThat(nextField.getKey(), equalTo(JsonOutputCodecConfig.DEFAULT_KEY_NAME));
+        jsonNode = nextField.getValue();
+        assertThat(jsonNode, notNullValue());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.ARRAY));
         for (JsonNode element : jsonNode) {
             Set<String> keys = expectedRecords.get(index).keySet();
             Map<String, Object> actualMap = new HashMap<>();


### PR DESCRIPTION
…first. Adds a configurable keyName for the array.

### Description

The new `json` codec writes a JSON array:

```
[{...},{...}]
```

This is not always valid JSON which is supposed to start with an object. This approach is also more flexible as you can add new fields.

This PR updates the behavior to write into a JSON object. It uses the key name `events` by default so that users do not need to configure anything.

```
{"events":[{...},{...}]}
```

I also added configuration so that it can be configured if desired.

e.g.

```
    - s3:
        codec:
          json:
            key_name: flowLogs
```

Produces:

```
{"flowLogs":[{...},{...}]}
```

 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
