### PR TITLE
Updates the Data Prepper tar.gz artifact to include JDK 17.0.8+7

### DIFF
--- a/release/build-resources.gradle
+++ b/release/build-resources.gradle
@@ -9,7 +9,7 @@ ext {
             linux: ['x64']
     ]
     jdkSources = [
-            linux_x64: 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.4.1_1.tar.gz',
+            linux_x64: 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.8_7.tar.gz',
             linux_arm64: 'https://hg.openjdk.java.net/aarch64-port/jdk8/archive/tip.tar.gz'
     ]
     awsResources = [


### PR DESCRIPTION
### Description

This PR updates to the latest current version of JDK 17 - `17.0.8+7`.

https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.8%2B7
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
