### PR TITLE
Add support for scheduled scan to s3 scan

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplier.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplier.java
@@ -7,10 +7,14 @@ package org.opensearch.dataprepper.plugins.source;
 
 import org.opensearch.dataprepper.model.source.coordinator.PartitionIdentifier;
 import org.opensearch.dataprepper.plugins.source.configuration.S3ScanKeyPathOption;
+import org.opensearch.dataprepper.plugins.source.configuration.S3ScanSchedulingOptions;
 import org.opensearch.dataprepper.plugins.source.ownership.BucketOwnerProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.utils.Pair;
 
 import java.time.Instant;
@@ -18,6 +22,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -26,22 +31,37 @@ import java.util.stream.Collectors;
 
 public class S3ScanPartitionCreationSupplier implements Function<Map<String, Object>, List<PartitionIdentifier>> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(S3ScanPartitionCreationSupplier.class);
+
     private static final String BUCKET_OBJECT_PARTITION_KEY_FORMAT = "%s|%s";
+    static final String SCAN_COUNT = "SCAN_COUNT";
+    static final String LAST_SCAN_TIME = "LAST_SCAN_TIME";
 
     private final S3Client s3Client;
     private final BucketOwnerProvider bucketOwnerProvider;
     private final List<ScanOptions> scanOptionsList;
+    private final S3ScanSchedulingOptions schedulingOptions;
     public S3ScanPartitionCreationSupplier(final S3Client s3Client,
                                            final BucketOwnerProvider bucketOwnerProvider,
-                                           final List<ScanOptions> scanOptionsList) {
+                                           final List<ScanOptions> scanOptionsList,
+                                           final S3ScanSchedulingOptions schedulingOptions) {
 
         this.s3Client = s3Client;
         this.bucketOwnerProvider = bucketOwnerProvider;
         this.scanOptionsList = scanOptionsList;
+        this.schedulingOptions = schedulingOptions;
     }
 
     @Override
     public List<PartitionIdentifier> apply(final Map<String, Object> globalStateMap) {
+
+        if (globalStateMap.isEmpty()) {
+          initializeGlobalStateMap(globalStateMap);
+        }
+
+        if (shouldScanBeSkipped(globalStateMap)) {
+            return Collections.emptyList();
+        }
 
         final List<PartitionIdentifier> objectsToProcess = new ArrayList<>();
 
@@ -60,27 +80,33 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
                 s3ScanKeyPathOption.getS3scanIncludePrefixOptions().forEach(includePath -> {
                     listObjectsV2Request.prefix(includePath);
                     objectsToProcess.addAll(listFilteredS3ObjectsForBucket(excludeItems, listObjectsV2Request,
-                            scanOptions.getBucketOption().getName(), scanOptions.getUseStartDateTime(), scanOptions.getUseEndDateTime()));
+                            scanOptions.getBucketOption().getName(), scanOptions.getUseStartDateTime(), scanOptions.getUseEndDateTime(), globalStateMap));
                 });
             else
                 objectsToProcess.addAll(listFilteredS3ObjectsForBucket(excludeItems, listObjectsV2Request,
-                        scanOptions.getBucketOption().getName(), scanOptions.getUseStartDateTime(), scanOptions.getUseEndDateTime()));
+                        scanOptions.getBucketOption().getName(), scanOptions.getUseStartDateTime(), scanOptions.getUseEndDateTime(), globalStateMap));
         }
+
+        globalStateMap.put(SCAN_COUNT, (Integer) globalStateMap.get(SCAN_COUNT) + 1);
+        globalStateMap.put(LAST_SCAN_TIME, Instant.now().toEpochMilli());
 
         return objectsToProcess;
     }
 
     private List<PartitionIdentifier> listFilteredS3ObjectsForBucket(final List<String> excludeKeyPaths,
-                                                    final ListObjectsV2Request.Builder listObjectsV2Request,
-                                                    final String bucket,
-                                                    final LocalDateTime startDateTime,
-                                                    final LocalDateTime endDateTime) {
+                                                                     final ListObjectsV2Request.Builder listObjectsV2Request,
+                                                                     final String bucket,
+                                                                     final LocalDateTime startDateTime,
+                                                                     final LocalDateTime endDateTime,
+                                                                     final Map<String, Object> globalStateMap) {
 
+        Instant mostRecentLastModifiedTimestamp = globalStateMap.containsKey(bucket) ? Instant.parse((String) globalStateMap.get(bucket)) : null;
         final List<PartitionIdentifier> allPartitionIdentifiers = new ArrayList<>();
         ListObjectsV2Response listObjectsV2Response = null;
         do {
             listObjectsV2Response = s3Client.listObjectsV2(listObjectsV2Request.fetchOwner(true).continuationToken(Objects.nonNull(listObjectsV2Response) ? listObjectsV2Response.nextContinuationToken() : null).build());
             allPartitionIdentifiers.addAll(listObjectsV2Response.contents().stream()
+                    .filter(s3Object -> isLastModifiedTimeAfterMostRecentScanForBucket(bucket, s3Object, globalStateMap))
                     .map(s3Object -> Pair.of(s3Object.key(), instantToLocalDateTime(s3Object.lastModified())))
                     .filter(keyTimestampPair -> !keyTimestampPair.left().endsWith("/"))
                     .filter(keyTimestampPair -> excludeKeyPaths.stream()
@@ -89,8 +115,11 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
                     .map(Pair::left)
                     .map(objectKey -> PartitionIdentifier.builder().withPartitionKey(String.format(BUCKET_OBJECT_PARTITION_KEY_FORMAT, bucket, objectKey)).build())
                     .collect(Collectors.toList()));
+
+            mostRecentLastModifiedTimestamp = getMostRecentLastModifiedTimestamp(listObjectsV2Response, mostRecentLastModifiedTimestamp);
         } while (listObjectsV2Response.isTruncated());
 
+        globalStateMap.put(bucket, Objects.nonNull(mostRecentLastModifiedTimestamp) ? mostRecentLastModifiedTimestamp.toString() : null);
         return allPartitionIdentifiers;
     }
 
@@ -106,9 +135,78 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
     private boolean isKeyMatchedBetweenTimeRange(final LocalDateTime lastModifiedTime,
                                                  final LocalDateTime startDateTime,
                                                  final LocalDateTime endDateTime){
-        if (Objects.isNull(startDateTime) || Objects.isNull(endDateTime)) {
+        if (Objects.isNull(startDateTime) || Objects.isNull(endDateTime) || Objects.nonNull(schedulingOptions)) {
             return true;
         }
         return lastModifiedTime.isAfter(startDateTime) && lastModifiedTime.isBefore(endDateTime);
+    }
+
+    private void initializeGlobalStateMap(final Map<String, Object> globalStateMap) {
+        globalStateMap.put(SCAN_COUNT, 0);
+    }
+
+    private boolean isLastModifiedTimeAfterMostRecentScanForBucket(final String bucketName,
+                                                                   final S3Object s3Object,
+                                                                   final Map<String, Object> globalStateMap) {
+        if (!globalStateMap.containsKey(bucketName) || Objects.isNull(globalStateMap.get(bucketName))) {
+            return true;
+        }
+
+        final Instant lastProcessedObjectTimestamp = Instant.parse((String) globalStateMap.get(bucketName));
+
+        return s3Object.lastModified().compareTo(lastProcessedObjectTimestamp) > 0;
+    }
+
+    private Instant getMostRecentLastModifiedTimestamp(final ListObjectsV2Response listObjectsV2Response,
+                                                       Instant mostRecentLastModifiedTimestamp) {
+
+        if (Objects.isNull(schedulingOptions)) {
+            return null;
+        }
+
+        for (final S3Object s3Object : listObjectsV2Response.contents()) {
+            if (Objects.isNull(mostRecentLastModifiedTimestamp) || s3Object.lastModified().isAfter(mostRecentLastModifiedTimestamp)) {
+                mostRecentLastModifiedTimestamp = s3Object.lastModified();
+            }
+        }
+
+        return mostRecentLastModifiedTimestamp;
+    }
+
+    private boolean shouldScanBeSkipped(final Map<String, Object> globalStateMap) {
+        if (Objects.isNull(schedulingOptions) && hasAlreadyBeenScanned(globalStateMap)) {
+            LOG.info("Skipping scan because the buckets have already been scanned once");
+            return true;
+        }
+
+        if (Objects.nonNull(schedulingOptions) &&
+                (hasReachedMaxScanCount(globalStateMap) || !hasReachedScheduledScanTime(globalStateMap))) {
+
+            if (hasReachedMaxScanCount(globalStateMap)) {
+                LOG.info("Skipping scan as the max scan count {} has been reached", schedulingOptions.getCount());
+            } else {
+                LOG.info("Skipping scan as the interval of {} seconds has not been reached yet", schedulingOptions.getInterval().toSeconds());
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean hasAlreadyBeenScanned(final Map<String, Object> globalStateMap) {
+        return (Integer) globalStateMap.get(SCAN_COUNT) > 0;
+    }
+
+    private boolean hasReachedMaxScanCount(final Map<String, Object> globalStateMap) {
+        return (Integer) globalStateMap.get(SCAN_COUNT) >= schedulingOptions.getCount();
+    }
+
+    private boolean hasReachedScheduledScanTime(final Map<String, Object> globalStateMap) {
+        if (!globalStateMap.containsKey(LAST_SCAN_TIME)) {
+            return true;
+        }
+
+        return Instant.now().minus(schedulingOptions.getInterval()).isAfter(Instant.ofEpochMilli((Long) globalStateMap.get(LAST_SCAN_TIME)));
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/ScanObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/ScanObjectWorker.java
@@ -93,7 +93,7 @@ public class ScanObjectWorker implements Runnable{
         acknowledgementSetCallbackCounter = pluginMetrics.counter(ACKNOWLEDGEMENT_SET_CALLBACK_METRIC_NAME);
         this.sourceCoordinator.initialize();
 
-        this.partitionCreationSupplier = new S3ScanPartitionCreationSupplier(s3Client, bucketOwnerProvider, scanOptionsBuilderList);
+        this.partitionCreationSupplier = new S3ScanPartitionCreationSupplier(s3Client, bucketOwnerProvider, scanOptionsBuilderList, s3ScanSchedulingOptions);
     }
 
     @Override

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOption.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOption.java
@@ -6,7 +6,6 @@ package org.opensearch.dataprepper.plugins.source.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.DurationDeserializer;
 import jakarta.validation.constraints.AssertTrue;
 import org.opensearch.dataprepper.plugins.source.CustomLocalDateTimeDeserializer;
 
@@ -30,7 +29,6 @@ public class S3ScanBucketOption {
     @JsonProperty("end_time")
     private LocalDateTime endTime;
 
-    @JsonDeserialize(using = DurationDeserializer.class)
     @JsonProperty("range")
     private Duration range;
 

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanScanOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanScanOptions.java
@@ -6,7 +6,7 @@ package org.opensearch.dataprepper.plugins.source.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.DurationDeserializer;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import org.opensearch.dataprepper.plugins.source.CustomLocalDateTimeDeserializer;
 
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
  * Class consists the scan options list bucket configuration properties.
  */
 public class S3ScanScanOptions {
-    @JsonDeserialize(using = DurationDeserializer.class)
+
     @JsonProperty("range")
     private Duration range;
 
@@ -33,14 +33,21 @@ public class S3ScanScanOptions {
     private LocalDateTime endTime;
 
     @JsonProperty("buckets")
+    @Valid
     private List<S3ScanBucketOptions> buckets;
 
     @JsonProperty("scheduling")
-    private S3ScanSchedulingOptions schedulingOptions = new S3ScanSchedulingOptions();
+    @Valid
+    private S3ScanSchedulingOptions schedulingOptions;
 
     @AssertTrue(message = "At most two options from start_time, end_time and range can be specified at the same time")
     public boolean hasValidTimeOptions() {
         return Stream.of(startTime, endTime, range).filter(Objects::nonNull).count() < 3;
+    }
+
+    @AssertTrue(message = "start_time, end_time, and range are not valid options when using scheduling with s3 scan")
+    public boolean hasValidTimeOptionsWithScheduling() {
+        return !Objects.nonNull(schedulingOptions) || Stream.of(startTime, endTime, range).noneMatch(Objects::nonNull);
     }
 
     public Duration getRange() {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanSchedulingOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanSchedulingOptions.java
@@ -7,16 +7,23 @@ package org.opensearch.dataprepper.plugins.source.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.time.DurationMax;
+import org.hibernate.validator.constraints.time.DurationMin;
 
 import java.time.Duration;
 
 public class S3ScanSchedulingOptions {
-    @JsonProperty("interval")
-    private Duration interval = Duration.ofHours(8);
 
-    @Min(1)
+    @JsonProperty("interval")
+    @NotNull
+    @DurationMin(seconds = 30L, message = "S3 scan interval must be at least 30 seconds")
+    @DurationMax(days = 365L, message = "S3 scan interval must be less than or equal to 365 days")
+    private Duration interval;
+
+    @Min(2)
     @JsonProperty("count")
-    private int count = 1;
+    private int count = Integer.MAX_VALUE;
 
     public Duration getInterval() {
         return interval;

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplierTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplierTest.java
@@ -158,7 +158,7 @@ public class S3ScanPartitionCreationSupplierTest {
     @Test
     void getNextPartition_supplier_with_scheduling_options_returns_expected_PartitionIdentifiers() {
         schedulingOptions = mock(S3ScanSchedulingOptions.class);
-        given(schedulingOptions.getInterval()).willReturn(Duration.ofMillis(10));
+        given(schedulingOptions.getInterval()).willReturn(Duration.ofMillis(0));
         given(schedulingOptions.getCount()).willReturn(2);
 
         final String firstBucket = "bucket-one";
@@ -171,8 +171,8 @@ public class S3ScanPartitionCreationSupplierTest {
         given(firstBucketScanOptions.getUseStartDateTime()).willReturn(null);
         given(firstBucketScanOptions.getUseEndDateTime()).willReturn(null);
         final S3ScanKeyPathOption firstBucketScanKeyPath = mock(S3ScanKeyPathOption.class);
-        given(firstBucketScanBucketOption.getkeyPrefix()).willReturn(firstBucketScanKeyPath);
-        given(firstBucketScanKeyPath.getS3scanIncludeOptions()).willReturn(List.of(UUID.randomUUID().toString()));
+        given(firstBucketScanBucketOption.getS3ScanFilter()).willReturn(firstBucketScanKeyPath);
+        given(firstBucketScanKeyPath.getS3scanIncludePrefixOptions()).willReturn(List.of(UUID.randomUUID().toString()));
         given(firstBucketScanKeyPath.getS3ScanExcludeSuffixOptions()).willReturn(List.of(".invalid"));
         scanOptionsList.add(firstBucketScanOptions);
 
@@ -183,8 +183,8 @@ public class S3ScanPartitionCreationSupplierTest {
         given(secondBucketScanOptions.getUseStartDateTime()).willReturn(null);
         given(secondBucketScanOptions.getUseEndDateTime()).willReturn(null);
         final S3ScanKeyPathOption secondBucketScanKeyPath = mock(S3ScanKeyPathOption.class);
-        given(secondBucketScanBucketOption.getkeyPrefix()).willReturn(secondBucketScanKeyPath);
-        given(secondBucketScanKeyPath.getS3scanIncludeOptions()).willReturn(null);
+        given(secondBucketScanBucketOption.getS3ScanFilter()).willReturn(secondBucketScanKeyPath);
+        given(secondBucketScanKeyPath.getS3scanIncludePrefixOptions()).willReturn(null);
         given(secondBucketScanKeyPath.getS3ScanExcludeSuffixOptions()).willReturn(null);
         scanOptionsList.add(secondBucketScanOptions);
 

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplierTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplierTest.java
@@ -15,17 +15,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.source.coordinator.PartitionIdentifier;
 import org.opensearch.dataprepper.plugins.source.configuration.S3ScanBucketOption;
 import org.opensearch.dataprepper.plugins.source.configuration.S3ScanKeyPathOption;
+import org.opensearch.dataprepper.plugins.source.configuration.S3ScanSchedulingOptions;
 import org.opensearch.dataprepper.plugins.source.ownership.BucketOwnerProvider;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +42,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.opensearch.dataprepper.plugins.source.S3ScanPartitionCreationSupplier.LAST_SCAN_TIME;
+import static org.opensearch.dataprepper.plugins.source.S3ScanPartitionCreationSupplier.SCAN_COUNT;
 
 @ExtendWith(MockitoExtension.class)
 public class S3ScanPartitionCreationSupplierTest {
@@ -51,6 +58,8 @@ public class S3ScanPartitionCreationSupplierTest {
 
     private List<ScanOptions> scanOptionsList;
 
+    private S3ScanSchedulingOptions schedulingOptions;
+
     @BeforeEach
     void setup() {
         scanOptionsList = new ArrayList<>();
@@ -58,11 +67,12 @@ public class S3ScanPartitionCreationSupplierTest {
 
 
     private Function<Map<String, Object>, List<PartitionIdentifier>> createObjectUnderTest() {
-        return new S3ScanPartitionCreationSupplier(s3Client, bucketOwnerProvider, scanOptionsList);
+        return new S3ScanPartitionCreationSupplier(s3Client, bucketOwnerProvider, scanOptionsList, schedulingOptions);
     }
 
     @Test
-    void getNextPartition_supplier_returns_expected_PartitionIdentifiers() {
+    void getNextPartition_supplier_without_scheduling_options_returns_expected_PartitionIdentifiers() {
+        schedulingOptions = null;
 
         final String firstBucket = UUID.randomUUID().toString();
         final String secondBucket = UUID.randomUUID().toString();
@@ -130,11 +140,137 @@ public class S3ScanPartitionCreationSupplierTest {
         final ArgumentCaptor<ListObjectsV2Request> listObjectsV2RequestArgumentCaptor = ArgumentCaptor.forClass(ListObjectsV2Request.class);
         given(s3Client.listObjectsV2(listObjectsV2RequestArgumentCaptor.capture())).willReturn(listObjectsResponse);
 
-        final List<PartitionIdentifier> resultingPartitions = partitionCreationSupplier.apply(new HashMap<>());
+        final Map<String, Object> globalStateMap = new HashMap<>();
+        final List<PartitionIdentifier> resultingPartitions = partitionCreationSupplier.apply(globalStateMap);
+
+        assertThat(globalStateMap, notNullValue());
+        assertThat(globalStateMap.containsKey(SCAN_COUNT), equalTo(true));
+        assertThat(globalStateMap.get(SCAN_COUNT), equalTo(1));
+
+        assertThat(partitionCreationSupplier.apply(globalStateMap), equalTo(Collections.emptyList()));
 
         assertThat(resultingPartitions, notNullValue());
         assertThat(resultingPartitions.size(), equalTo(expectedPartitionIdentifiers.size()));
         assertThat(resultingPartitions.stream().map(PartitionIdentifier::getPartitionKey).collect(Collectors.toList()),
                 containsInAnyOrder(expectedPartitionIdentifiers.stream().map(PartitionIdentifier::getPartitionKey).map(Matchers::equalTo).collect(Collectors.toList())));
+    }
+
+    @Test
+    void getNextPartition_supplier_with_scheduling_options_returns_expected_PartitionIdentifiers() {
+        schedulingOptions = mock(S3ScanSchedulingOptions.class);
+        given(schedulingOptions.getInterval()).willReturn(Duration.ofMillis(10));
+        given(schedulingOptions.getCount()).willReturn(2);
+
+        final String firstBucket = "bucket-one";
+        final String secondBucket = "bucket-two";
+
+        final ScanOptions firstBucketScanOptions = mock(ScanOptions.class);
+        final S3ScanBucketOption firstBucketScanBucketOption = mock(S3ScanBucketOption.class);
+        given(firstBucketScanOptions.getBucketOption()).willReturn(firstBucketScanBucketOption);
+        given(firstBucketScanBucketOption.getName()).willReturn(firstBucket);
+        given(firstBucketScanOptions.getUseStartDateTime()).willReturn(null);
+        given(firstBucketScanOptions.getUseEndDateTime()).willReturn(null);
+        final S3ScanKeyPathOption firstBucketScanKeyPath = mock(S3ScanKeyPathOption.class);
+        given(firstBucketScanBucketOption.getkeyPrefix()).willReturn(firstBucketScanKeyPath);
+        given(firstBucketScanKeyPath.getS3scanIncludeOptions()).willReturn(List.of(UUID.randomUUID().toString()));
+        given(firstBucketScanKeyPath.getS3ScanExcludeSuffixOptions()).willReturn(List.of(".invalid"));
+        scanOptionsList.add(firstBucketScanOptions);
+
+        final ScanOptions secondBucketScanOptions = mock(ScanOptions.class);
+        final S3ScanBucketOption secondBucketScanBucketOption = mock(S3ScanBucketOption.class);
+        given(secondBucketScanOptions.getBucketOption()).willReturn(secondBucketScanBucketOption);
+        given(secondBucketScanBucketOption.getName()).willReturn(secondBucket);
+        given(secondBucketScanOptions.getUseStartDateTime()).willReturn(null);
+        given(secondBucketScanOptions.getUseEndDateTime()).willReturn(null);
+        final S3ScanKeyPathOption secondBucketScanKeyPath = mock(S3ScanKeyPathOption.class);
+        given(secondBucketScanBucketOption.getkeyPrefix()).willReturn(secondBucketScanKeyPath);
+        given(secondBucketScanKeyPath.getS3scanIncludeOptions()).willReturn(null);
+        given(secondBucketScanKeyPath.getS3ScanExcludeSuffixOptions()).willReturn(null);
+        scanOptionsList.add(secondBucketScanOptions);
+
+        final Function<Map<String, Object>, List<PartitionIdentifier>> partitionCreationSupplier = createObjectUnderTest();
+
+        final List<PartitionIdentifier> expectedPartitionIdentifiers = new ArrayList<>();
+
+        final ListObjectsV2Response listObjectsResponse = mock(ListObjectsV2Response.class);
+        final List<S3Object> s3ObjectsList = new ArrayList<>();
+
+        final S3Object invalidFolderObject = mock(S3Object.class);
+        given(invalidFolderObject.key()).willReturn("folder-key/");
+        given(invalidFolderObject.lastModified()).willReturn(Instant.now());
+        s3ObjectsList.add(invalidFolderObject);
+
+        final S3Object invalidForFirstBucketSuffixObject = mock(S3Object.class);
+        given(invalidForFirstBucketSuffixObject.key()).willReturn("test.invalid");
+        given(invalidForFirstBucketSuffixObject.lastModified()).willReturn(Instant.now());
+        s3ObjectsList.add(invalidForFirstBucketSuffixObject);
+        expectedPartitionIdentifiers.add(PartitionIdentifier.builder().withPartitionKey(secondBucket + "|" + invalidForFirstBucketSuffixObject.key()).build());
+
+        final Instant mostRecentFirstScan = Instant.now().plusSeconds(1);
+        final S3Object validObject = mock(S3Object.class);
+        given(validObject.key()).willReturn("valid");
+        given(validObject.lastModified()).willReturn(mostRecentFirstScan);
+        s3ObjectsList.add(validObject);
+        expectedPartitionIdentifiers.add(PartitionIdentifier.builder().withPartitionKey(firstBucket + "|" + validObject.key()).build());
+        expectedPartitionIdentifiers.add(PartitionIdentifier.builder().withPartitionKey(secondBucket + "|" + validObject.key()).build());
+
+        final S3Object secondScanObject = mock(S3Object.class);
+        final Instant mostRecentSecondScan = Instant.now().plusSeconds(10);
+        given(secondScanObject.key()).willReturn("second-scan");
+        given(secondScanObject.lastModified()).willReturn(mostRecentSecondScan);
+
+        final List<PartitionIdentifier> expectedPartitionIdentifiersSecondScan = new ArrayList<>();
+        expectedPartitionIdentifiersSecondScan.add(PartitionIdentifier.builder().withPartitionKey(firstBucket + "|" + secondScanObject.key()).build());
+        expectedPartitionIdentifiersSecondScan.add(PartitionIdentifier.builder().withPartitionKey(secondBucket + "|" + secondScanObject.key()).build());
+
+        final List<S3Object> secondScanObjects = new ArrayList<>(s3ObjectsList);
+        secondScanObjects.add(secondScanObject);
+        given(listObjectsResponse.contents())
+                .willReturn(s3ObjectsList)
+                .willReturn(s3ObjectsList)
+                .willReturn(s3ObjectsList)
+                .willReturn(s3ObjectsList)
+                .willReturn(secondScanObjects)
+                .willReturn(secondScanObjects)
+                .willReturn(secondScanObjects)
+                .willReturn(secondScanObjects);
+
+        final ArgumentCaptor<ListObjectsV2Request> listObjectsV2RequestArgumentCaptor = ArgumentCaptor.forClass(ListObjectsV2Request.class);
+        given(s3Client.listObjectsV2(listObjectsV2RequestArgumentCaptor.capture())).willReturn(listObjectsResponse);
+
+        final Map<String, Object> globalStateMap = new HashMap<>();
+        final List<PartitionIdentifier> resultingPartitions = partitionCreationSupplier.apply(globalStateMap);
+
+        assertThat(resultingPartitions, notNullValue());
+        assertThat(resultingPartitions.size(), equalTo(expectedPartitionIdentifiers.size()));
+        assertThat(resultingPartitions.stream().map(PartitionIdentifier::getPartitionKey).collect(Collectors.toList()),
+                containsInAnyOrder(expectedPartitionIdentifiers.stream().map(PartitionIdentifier::getPartitionKey)
+                        .map(Matchers::equalTo).collect(Collectors.toList())));
+
+        assertThat(globalStateMap, notNullValue());
+        assertThat(globalStateMap.containsKey(SCAN_COUNT), equalTo(true));
+        assertThat(globalStateMap.get(SCAN_COUNT), equalTo(1));
+        assertThat(globalStateMap.containsKey(firstBucket), equalTo(true));
+        assertThat(globalStateMap.get(firstBucket), equalTo(mostRecentFirstScan.toString()));
+        assertThat(globalStateMap.containsKey(secondBucket), equalTo(true));
+        assertThat(globalStateMap.get(secondBucket), equalTo(mostRecentFirstScan.toString()));
+
+        final List<PartitionIdentifier> secondScanPartitions = partitionCreationSupplier.apply(globalStateMap);
+        assertThat(secondScanPartitions.size(), equalTo(expectedPartitionIdentifiersSecondScan.size()));
+        assertThat(secondScanPartitions.stream().map(PartitionIdentifier::getPartitionKey).collect(Collectors.toList()),
+                containsInAnyOrder(expectedPartitionIdentifiersSecondScan.stream().map(PartitionIdentifier::getPartitionKey).map(Matchers::equalTo).collect(Collectors.toList())));
+
+        assertThat(globalStateMap, notNullValue());
+        assertThat(globalStateMap.containsKey(SCAN_COUNT), equalTo(true));
+        assertThat(globalStateMap.get(SCAN_COUNT), equalTo(2));
+        assertThat(globalStateMap.containsKey(firstBucket), equalTo(true));
+        assertThat(globalStateMap.get(firstBucket), equalTo(mostRecentSecondScan.toString()));
+        assertThat(globalStateMap.containsKey(secondBucket), equalTo(true));
+        assertThat(globalStateMap.get(secondBucket), equalTo(mostRecentSecondScan.toString()));
+        assertThat(Instant.ofEpochMilli((Long) globalStateMap.get(LAST_SCAN_TIME)).isBefore(Instant.now()), equalTo(true));
+
+        assertThat(partitionCreationSupplier.apply(globalStateMap), equalTo(Collections.emptyList()));
+
+        verify(listObjectsResponse, times(8)).contents();
     }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanScanOptionsTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanScanOptionsTest.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import org.junit.Test;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -25,7 +24,6 @@ public class S3ScanScanOptionsTest {
     @Test
     public void s3scan_options_test_with_scan_yaml_configuration_test() throws JsonProcessingException {
         final String scanYaml = "        start_time: 2023-01-21T18:00:00\n" +
-                "        range: P90DT3H4M\n" +
                 "        end_time: 2023-04-21T18:00:00\n" +
                 "        buckets:\n" +
                 "          - bucket:\n" +
@@ -38,7 +36,6 @@ public class S3ScanScanOptionsTest {
         final S3ScanScanOptions s3ScanScanOptions = objectMapper.readValue(scanYaml, S3ScanScanOptions.class);
         assertThat(s3ScanScanOptions.getStartTime(),equalTo(LocalDateTime.parse("2023-01-21T18:00:00")));
         assertThat(s3ScanScanOptions.getEndTime(),equalTo(LocalDateTime.parse("2023-04-21T18:00:00")));
-        assertThat(s3ScanScanOptions.getRange(),equalTo(Duration.parse("P90DT3H4M")));
         assertThat(s3ScanScanOptions.getBuckets(),instanceOf(List.class));
         assertThat(s3ScanScanOptions.getBuckets().get(0).getS3ScanBucketOption().getName(),equalTo("test-s3-source-test-output"));
         assertThat(s3ScanScanOptions.getBuckets().get(0).getS3ScanBucketOption().getS3ScanFilter().getS3ScanExcludeSuffixOptions(),instanceOf(List.class));


### PR DESCRIPTION
### Description
This change adds scheduled scan support to s3 scan.

The default behavior, with no scheduling configured, is to scan the buckets one time, and then to stop scanning after that

When `scheduling` is configured, the buckets will be scanned continuously at a minimum rate specified by `interval`, up to the `count` number of times.  To handle deduplication for multiple scans without utilizing source coordination entirely, the lastModifiedAt timestamp of the most recent object that was scanned in a previous scan will be stored in the global state to filter out objects with lastModifiedAt times before this time.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
