### PR TITLE
Glue registry fixes. Fixed a bug in getMSKBootstrapServers

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfig.java
@@ -22,7 +22,7 @@ public class TopicConfig {
     static final Duration DEFAULT_COMMIT_INTERVAL = Duration.ofSeconds(5);
     static final Duration DEFAULT_SESSION_TIMEOUT = Duration.ofSeconds(45);
     static final int DEFAULT_MAX_RETRY_ATTEMPT = Integer.MAX_VALUE;
-    static final String DEFAULT_AUTO_OFFSET_RESET = "latest";
+    static final String DEFAULT_AUTO_OFFSET_RESET = "earliest";
     static final Duration DEFAULT_THREAD_WAITING_TIME = Duration.ofSeconds(5);
     static final Duration DEFAULT_MAX_RECORD_FETCH_TIME = Duration.ofSeconds(4);
     static final Duration DEFAULT_BUFFER_TIMEOUT = Duration.ofSeconds(5);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaSourceCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaSourceCustomConsumer.java
@@ -162,7 +162,7 @@ public class KafkaSourceCustomConsumer implements Runnable, ConsumerRebalanceLis
             Thread.sleep(10000);
         } catch (RecordDeserializationException e) {
             LOG.warn("Deserialization error - topic {} partition {} offset {}, seeking past the error record",
-                     e.topicPartition().topic(), e.topicPartition().partition(), e.offset());
+                     e.topicPartition().topic(), e.topicPartition().partition(), e.offset(), e);
             topicMetrics.getNumberOfDeserializationErrors().increment();
             consumer.seek(e.topicPartition(), e.offset()+1);
         }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -48,8 +48,6 @@ import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 import org.opensearch.dataprepper.plugins.kafka.util.KafkaTopicMetrics;
 
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryKafkaDeserializer;
-import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
-import com.amazonaws.services.schemaregistry.utils.AvroRecordType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,6 +98,8 @@ public class KafkaSource implements Source<Record<Event>> {
     private static final String SCHEMA_TYPE = "schemaType";
     private final AcknowledgementSetManager acknowledgementSetManager;
     private static CachedSchemaRegistryClient schemaRegistryClient;
+    private GlueSchemaRegistryKafkaDeserializer glueDeserializer;
+    private StringDeserializer stringDeserializer;
 
     @DataPrepperPluginConstructor
     public KafkaSource(final KafkaSourceConfig sourceConfig,
@@ -110,13 +110,14 @@ public class KafkaSource implements Source<Record<Event>> {
         this.pluginMetrics = pluginMetrics;
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.pipelineName = pipelineDescription.getPipelineName();
+        this.stringDeserializer = new StringDeserializer();
         shutdownInProgress = new AtomicBoolean(false);
     }
 
     @Override
     public void start(Buffer<Record<Event>> buffer) {
         Properties authProperties = new Properties();
-        KafkaSourceSecurityConfigurer.setAuthProperties(authProperties, sourceConfig, LOG);
+        glueDeserializer =  KafkaSourceSecurityConfigurer.setAuthProperties(authProperties, sourceConfig, LOG);
         sourceConfig.getTopics().forEach(topic -> {
             consumerGroupID = topic.getGroupId();
             KafkaTopicMetrics topicMetrics = new KafkaTopicMetrics(topic.getName(), pluginMetrics);
@@ -135,7 +136,11 @@ public class KafkaSource implements Source<Record<Event>> {
                             break;
                         case PLAINTEXT:
                         default:
-                            kafkaConsumer = new KafkaConsumer<String, String>(consumerProperties);
+                            if (sourceConfig.getSchemaConfig().getType() == SchemaRegistryType.AWS_GLUE) {
+                                kafkaConsumer = new KafkaConsumer(consumerProperties, stringDeserializer, glueDeserializer);
+                            } else {
+                                kafkaConsumer = new KafkaConsumer<String, String>(consumerProperties);
+                            }
                             break;
                     }
                     consumer = new KafkaSourceCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType, acknowledgementSetManager, topicMetrics);
@@ -296,7 +301,6 @@ public class KafkaSource implements Source<Record<Event>> {
         }
 
         if (schemaConfig.getType() == SchemaRegistryType.AWS_GLUE) {
-            setPropertiesForGlueSchemaRegistry(properties);
             return;
         }
 
@@ -307,13 +311,6 @@ public class KafkaSource implements Source<Record<Event>> {
         } else {
             throw new RuntimeException("RegistryURL must be specified for confluent schema registry");
         }
-    }
-
-    private void setPropertiesForGlueSchemaRegistry(Properties properties) {
-        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, GlueSchemaRegistryKafkaDeserializer.class.getName());
-        properties.put(AWSSchemaRegistryConstants.AWS_REGION, sourceConfig.getAwsConfig().getRegion());
-        properties.put(AWSSchemaRegistryConstants.AVRO_RECORD_TYPE, AvroRecordType.GENERIC_RECORD.getName());
     }
 
     private void setPropertiesForPlaintextAndJsonWithoutSchemaRegistry(Properties properties, final TopicConfig topicConfig) {


### PR DESCRIPTION
### Description
This change contains
1. Glue registry fixes to create Deserializer with credentials so that service account can access user account's GLUE registries
2. Fixed a bug in `getBootStrapServersForMsk()` which is looping when there is no error.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
