### PR TITLE
Add default value to cardinality keys

### DIFF
--- a/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessorConfig.java
+++ b/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessorConfig.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.Collections;
 import java.util.List;
 
 public class AnomalyDetectorProcessorConfig {
@@ -22,7 +23,7 @@ public class AnomalyDetectorProcessorConfig {
     private List<String> keys;
 
     @JsonProperty("identification_keys")
-    private List<String> identificationKeys;
+    private List<String> identificationKeys = Collections.emptyList();
 
     @JsonProperty("verbose")
     private Boolean verbose = false;


### PR DESCRIPTION
### Description
I made the mistake of not testing previous changes without omitting the `identification_keys` value from config. When I tried that I got a NPE since there no default is set. This causes a breaking change to anyone currently using the plugin.

This change adds that default value.
 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
