### PR TITLE
Fix flakey test caused by RCF variance. Update metric for RCF Instances

### DIFF
--- a/data-prepper-plugins/anomaly-detector-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessorTests.java
+++ b/data-prepper-plugins/anomaly-detector-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessorTests.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -48,7 +49,7 @@ public class AnomalyDetectorProcessorTests {
     @Mock
     private PluginMetrics pluginMetrics;
     @Mock
-    private Counter numberRCFInstances;
+    private AtomicInteger numberRCFInstances;
     @Mock
     private Counter recordsIn;
 
@@ -81,7 +82,7 @@ public class AnomalyDetectorProcessorTests {
         when(pluginFactory.loadPlugin(eq(AnomalyDetectorMode.class), any(PluginSetting.class)))
             .thenAnswer(invocation -> new RandomCutForestMode(randomCutForestModeConfig));
 
-        when(pluginMetrics.counter(AnomalyDetectorProcessor.NUMBER_RCF_INSTANCES)).thenReturn(numberRCFInstances);
+        when(pluginMetrics.gauge(eq(AnomalyDetectorProcessor.NUMBER_RCF_INSTANCES), any())).thenReturn(numberRCFInstances);
         when(pluginMetrics.counter(MetricNames.RECORDS_IN)).thenReturn(recordsIn);
         when(pluginMetrics.counter(MetricNames.RECORDS_OUT)).thenReturn(recordsOut);
         when(pluginMetrics.timer(MetricNames.TIME_ELAPSED)).thenReturn(timeElapsed);

--- a/data-prepper-plugins/anomaly-detector-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/modes/RandomCutForestModeTests.java
+++ b/data-prepper-plugins/anomaly-detector-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/modes/RandomCutForestModeTests.java
@@ -29,7 +29,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.Mockito.mock;
 import org.mockito.Mock;
 import static org.mockito.Mockito.when;
@@ -208,6 +209,6 @@ public class RandomCutForestModeTests {
 
         final List<Record<Event>> anomalyRecords = randomCutForestMode.handleEvents(recordsWithAnomaly).stream().collect(toList());;
         // Due to inherent variance in the RCF algorithm, 1-3 anomalies will be detected after the level shift.
-        assertThat(anomalyRecords.size(), both(greaterThan(0)).and(lessThan(4)));
+        assertThat(anomalyRecords.size(), both(greaterThanOrEqualTo(1)).and(lessThanOrEqualTo(3)));
     }
 }

--- a/data-prepper-plugins/anomaly-detector-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/modes/RandomCutForestModeTests.java
+++ b/data-prepper-plugins/anomaly-detector-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/modes/RandomCutForestModeTests.java
@@ -21,6 +21,7 @@ import static java.util.stream.Collectors.toList;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.greaterThan;
 
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.hamcrest.Matchers.lessThan;
 import static org.mockito.Mockito.mock;
 import org.mockito.Mock;
 import static org.mockito.Mockito.when;
@@ -205,6 +207,7 @@ public class RandomCutForestModeTests {
         }
 
         final List<Record<Event>> anomalyRecords = randomCutForestMode.handleEvents(recordsWithAnomaly).stream().collect(toList());;
-        assertThat(anomalyRecords.size(), equalTo(1));
+        // Due to inherent variance in the RCF algorithm, 1-3 anomalies will be detected after the level shift.
+        assertThat(anomalyRecords.size(), both(greaterThan(0)).and(lessThan(4)));
     }
 }


### PR DESCRIPTION
### Description
Inherent variability in the RCF algorithm was causing intermittent failures in a test that expected exactly one anomaly. That has been changed to an expected range of 1-3, which all values fell between over 100+ runs of the unit test.

RCFInstances metric changed from counter to gauge, to better monitor current cardinality. Name simplified.
  
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
