### PR TITLE
Support other scan time configs= combinations

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplier.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplier.java
@@ -138,9 +138,15 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
      */
     private boolean isKeyMatchedBetweenTimeRange(final LocalDateTime lastModifiedTime,
                                                  final LocalDateTime startDateTime,
-                                                 final LocalDateTime endDateTime){
-        if (Objects.isNull(startDateTime) || Objects.isNull(endDateTime) || Objects.nonNull(schedulingOptions)) {
+                                                 final LocalDateTime endDateTime) {
+        if (Objects.nonNull(schedulingOptions)) {
             return true;
+        } else if (Objects.isNull(startDateTime) && Objects.isNull(endDateTime)) {
+            return true;
+        } else if (Objects.isNull(startDateTime)) {
+            return lastModifiedTime.isBefore(endDateTime);
+        } else if (Objects.isNull(endDateTime)) {
+            return lastModifiedTime.isAfter(startDateTime);
         }
         return lastModifiedTime.isAfter(startDateTime) && lastModifiedTime.isBefore(endDateTime);
     }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/ScanOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/ScanOptions.java
@@ -5,6 +5,8 @@
 package org.opensearch.dataprepper.plugins.source;
 
 import org.opensearch.dataprepper.plugins.source.configuration.S3ScanBucketOption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -15,7 +17,7 @@ import java.util.stream.Stream;
  * Class consists the scan related properties.
  */
 public class ScanOptions {
-
+    private static final Logger LOG = LoggerFactory.getLogger(ScanOptions.class);
     private LocalDateTime startDateTime;
 
     private Duration range;
@@ -102,21 +104,22 @@ public class ScanOptions {
                     .filter(Objects::nonNull)
                     .count();
 
-            if (nonNullCount == 0 || nonNullCount == 2) {
-                setDateTimeToUse(bucketStartDateTime, bucketEndDateTime, bucketRange);
-            } else if (nonNullCount == 3) {
-                long originalBucketLevelNonNullCount = Stream.of(
-                        bucketOption.getStartTime(), bucketOption.getEndTime(), bucketOption.getRange())
-                        .filter(Objects::nonNull)
-                        .count();
+            long originalBucketLevelNonNullCount = Stream.of(
+                            bucketOption.getStartTime(), bucketOption.getEndTime(), bucketOption.getRange())
+                    .filter(Objects::nonNull)
+                    .count();
 
-                if (originalBucketLevelNonNullCount == 2) {
-                    setDateTimeToUse(bucketOption.getStartTime(), bucketOption.getEndTime(), bucketOption.getRange());
-                } else {
+            if (nonNullCount == 3) {
+                if (originalBucketLevelNonNullCount == 3) {
                     scanRangeDateValidationError();
+                } else if (originalBucketLevelNonNullCount == 2) {
+                    setDateTimeToUse(bucketOption.getStartTime(), bucketOption.getEndTime(), bucketOption.getRange());
+                } else if (originalBucketLevelNonNullCount == 1) {
+                    // Use start_time, end_time, range from global level options, because we are unable to build it from single option configured at bucket level
+                    setDateTimeToUse(startDateTime, endDateTime, range);
                 }
             } else {
-                scanRangeDateValidationError();
+                setDateTimeToUse(bucketStartDateTime, bucketEndDateTime, bucketRange);
             }
             return new ScanOptions(this);
         }
@@ -132,10 +135,17 @@ public class ScanOptions {
             } else if (Objects.nonNull(bucketEndDateTime) && Objects.nonNull(bucketRange)) {
                 this.useStartDateTime = bucketEndDateTime.minus(bucketRange);
                 this.useEndDateTime = bucketEndDateTime;
+            } else if (Objects.nonNull(bucketStartDateTime)) {
+                this.useStartDateTime = bucketStartDateTime;
+            } else if (Objects.nonNull(bucketEndDateTime)) {
+                this.useEndDateTime = bucketEndDateTime;
+            } else if (Objects.nonNull(bucketRange)) {
+                LOG.info("Scan is configured with just range for the bucket with name {}, unable to establish a time period with range alone. " +
+                        "Configure start_time or end_time, else all the objects in the bucket will be included", bucketOption.getName());
             }
         }
 
-        private void scanRangeDateValidationError(){
+        private void scanRangeDateValidationError() {
             String message = "To set a time range for the bucket with name " + bucketOption.getName() +
                     ", specify any two configurations from start_time, end_time and range";
             throw new IllegalArgumentException(message);

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/ScanOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/ScanOptions.java
@@ -115,8 +115,14 @@ public class ScanOptions {
                 } else if (originalBucketLevelNonNullCount == 2) {
                     setDateTimeToUse(bucketOption.getStartTime(), bucketOption.getEndTime(), bucketOption.getRange());
                 } else if (originalBucketLevelNonNullCount == 1) {
-                    // Use start_time, end_time, range from global level options, because we are unable to build it from single option configured at bucket level
-                    setDateTimeToUse(startDateTime, endDateTime, range);
+                    if (Objects.nonNull(bucketOption.getStartTime()) || Objects.nonNull(bucketOption.getEndTime())) {
+                        setDateTimeToUse(bucketOption.getStartTime(), bucketOption.getEndTime(), bucketOption.getRange());
+                    } else {
+                        LOG.warn("Scan is configured with start_time and end_time at global level and range at bucket level for the bucket with name {}. " +
+                                "Unable to establish a time period with range alone at bucket level. " +
+                                "Using start_time and end_time configured at global level and ignoring range.", bucketOption.getName());
+                        setDateTimeToUse(startDateTime, endDateTime, range);
+                    }
                 }
             } else {
                 setDateTimeToUse(bucketStartDateTime, bucketEndDateTime, bucketRange);
@@ -140,7 +146,7 @@ public class ScanOptions {
             } else if (Objects.nonNull(bucketEndDateTime)) {
                 this.useEndDateTime = bucketEndDateTime;
             } else if (Objects.nonNull(bucketRange)) {
-                LOG.info("Scan is configured with just range for the bucket with name {}, unable to establish a time period with range alone. " +
+                LOG.warn("Scan is configured with just range for the bucket with name {}. Unable to establish a time period with range alone. " +
                         "Configure start_time or end_time, else all the objects in the bucket will be included", bucketOption.getName());
             }
         }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOptions.java
@@ -5,11 +5,14 @@
 package org.opensearch.dataprepper.plugins.source.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+
 /**
  * Class consists the bucket properties.
  */
 public class S3ScanBucketOptions {
     @JsonProperty("bucket")
+    @Valid
     private S3ScanBucketOption scanBucketOption;
 
     public S3ScanBucketOption getS3ScanBucketOption() {

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ScanOptionsTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ScanOptionsTest.java
@@ -142,6 +142,8 @@ class ScanOptionsTest {
                         LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
                 Arguments.of(null, LocalDateTime.parse("2023-01-24T18:00:00"), Duration.parse("P3D"),
                         LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
+                Arguments.of(LocalDateTime.parse("2023-01-21T18:00:00"), null, null, LocalDateTime.parse("2023-01-21T18:00:00"), null),
+                Arguments.of(null, LocalDateTime.parse("2023-01-21T18:00:00"), null, null, LocalDateTime.parse("2023-01-21T18:00:00")),
                 Arguments.of(null, null, null, null, null)
         );
     }
@@ -149,10 +151,7 @@ class ScanOptionsTest {
     private static Stream<Arguments> invalidTimeRangeOptions() {
         return Stream.of(
                 Arguments.of(LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-04-21T18:00:00"),
-                        Duration.parse("P90DT3H4M")),
-                Arguments.of(LocalDateTime.parse("2023-01-21T18:00:00"), null, null),
-                Arguments.of(null, LocalDateTime.parse("2023-04-21T18:00:00"), null),
-                Arguments.of(null, null, Duration.parse("P90DT3H4M"))
+                        Duration.parse("P90DT3H4M"))
         );
     }
 
@@ -164,6 +163,8 @@ class ScanOptionsTest {
                         LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
                 Arguments.of(null, LocalDateTime.parse("2023-01-24T18:00:00"), Duration.ofDays(3L),
                         LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
+                Arguments.of(LocalDateTime.parse("2023-01-21T18:00:00"), null, null, LocalDateTime.parse("2023-01-21T18:00:00"), null),
+                Arguments.of(null, LocalDateTime.parse("2023-01-21T18:00:00"), null, null, LocalDateTime.parse("2023-01-21T18:00:00")),
                 Arguments.of(null, null, null, null, null)
         );
     }
@@ -189,30 +190,20 @@ class ScanOptionsTest {
                 Arguments.of(
                         LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00"), null,
                         LocalDateTime.parse("2023-05-21T18:00:00"), null, Duration.ofDays(3L),
-                        LocalDateTime.parse("2023-05-21T18:00:00"), LocalDateTime.parse("2023-05-24T18:00:00"))
+                        LocalDateTime.parse("2023-05-21T18:00:00"), LocalDateTime.parse("2023-05-24T18:00:00")),
+                Arguments.of(
+                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00"), null,
+                        null, null, Duration.ofDays(3L),
+                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00")),
+                Arguments.of(
+                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-12-24T18:00:00"), null,
+                        LocalDateTime.parse("2023-05-21T18:00:00"), null, null,
+                        LocalDateTime.parse("2023-05-21T18:00:00"), LocalDateTime.parse("2023-12-24T18:00:00"))
         );
     }
 
     private static Stream<Arguments> invalidCombinedTimeRangeOptions() {
         return Stream.of(
-                Arguments.of(
-                        LocalDateTime.parse("2023-05-21T18:00:00"), null, null,
-                        LocalDateTime.parse("2023-05-24T18:00:00"), null, null),
-                Arguments.of(
-                        null, LocalDateTime.parse("2023-05-24T18:00:00"), null,
-                        null, LocalDateTime.parse("2023-05-21T18:00:00"), null),
-                Arguments.of(
-                        null, null, Duration.ofDays(3L),
-                        null, null, Duration.ofDays(3L)),
-                Arguments.of(
-                        LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00"), null,
-                        null, null, Duration.ofDays(3L)),
-                Arguments.of(
-                        LocalDateTime.parse("2023-01-21T18:00:00"), null, Duration.ofDays(3L),
-                        null, LocalDateTime.parse("2023-05-24T18:00:00"), null),
-                Arguments.of(
-                        null, LocalDateTime.parse("2023-01-24T18:00:00"), Duration.ofDays(3L),
-                        LocalDateTime.parse("2023-05-21T18:00:00"), null, null),
                 Arguments.of(
                         LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-01-24T18:00:00"), Duration.ofDays(3L),
                         LocalDateTime.parse("2023-05-21T18:00:00"), LocalDateTime.parse("2023-05-24T18:00:00"), Duration.ofDays(3L))

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ScanOptionsTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ScanOptionsTest.java
@@ -198,7 +198,15 @@ class ScanOptionsTest {
                 Arguments.of(
                         LocalDateTime.parse("2023-01-21T18:00:00"), LocalDateTime.parse("2023-12-24T18:00:00"), null,
                         LocalDateTime.parse("2023-05-21T18:00:00"), null, null,
-                        LocalDateTime.parse("2023-05-21T18:00:00"), LocalDateTime.parse("2023-12-24T18:00:00"))
+                        LocalDateTime.parse("2023-05-21T18:00:00"), LocalDateTime.parse("2023-12-24T18:00:00")),
+                Arguments.of(
+                        LocalDateTime.parse("2023-01-21T18:00:00"), null, Duration.ofDays(3L),
+                        null, LocalDateTime.parse("2023-05-21T18:00:00"), null,
+                        null, LocalDateTime.parse("2023-05-21T18:00:00")),
+                Arguments.of(
+                        null, LocalDateTime.parse("2023-01-21T18:00:00"), Duration.ofDays(3L),
+                        LocalDateTime.parse("2023-05-21T18:00:00"), null, null,
+                        LocalDateTime.parse("2023-05-21T18:00:00"), null)
         );
     }
 

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ScanOptionsTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ScanOptionsTest.java
@@ -40,21 +40,6 @@ class ScanOptionsTest {
     }
 
     @ParameterizedTest
-    @MethodSource("invalidTimeRangeOptions")
-    public void s3scan_options_with_invalid_global_time_range_throws_exception_when_build(
-            LocalDateTime startDateTime, LocalDateTime endDateTime, Duration range) throws NoSuchFieldException, IllegalAccessException {
-        S3ScanBucketOption bucketOption = new S3ScanBucketOption();
-        setField(S3ScanBucketOption.class, bucketOption, "name", "bucket_name");
-
-        assertThrows(IllegalArgumentException.class, () -> ScanOptions.builder()
-                .setStartDateTime(startDateTime)
-                .setEndDateTime(endDateTime)
-                .setRange(range)
-                .setBucketOption(bucketOption)
-                .build());
-    }
-
-    @ParameterizedTest
     @MethodSource("validBucketTimeRangeOptions")
     public void s3scan_options_with_valid_bucket_time_range_build_success(
             LocalDateTime bucketStartDateTime, LocalDateTime bucketEndDateTime, Duration bucketRange,


### PR DESCRIPTION
### Description
- All objects will be included if none of the `start_time`, `end_time` and `range` are configured
- all objects after `start_time` are included if only `start_time` is configured
- all objects before `end_time` are included if only `end_time` is configured
- all objects are included i only `range` is included, as it's not possible to build a time range without start or end time. 

If any of the following combinations is configured
1. `start_time`, `range` at global level and `end_time` at bucket level, only end_time is considered and all objects before end_time will be included in scan
2. `end_time`, `range` at global level and `start_time` at bucket level, only `start_time` is considered and all objects after `start_time` will be included in scan
3. `start_time`, `end_time` at global level and `range` at bucket level, `start_time` and `end_time` configured at bucket level is used as it's not possible to define a period just from range at bucket level.
 
### Issues Resolved
NA
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
