### PR TITLE
Fix flaky integration test in conditional routing integration tests

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySinkAccessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySinkAccessor.java
@@ -34,7 +34,7 @@ public class InMemorySinkAccessor {
     public List<Record<Event>> get(final String testingKey) {
         lock.lock();
         try {
-            return recordsMap.getOrDefault(testingKey, Collections.emptyList());
+            return new ArrayList<>(recordsMap.getOrDefault(testingKey, Collections.emptyList()));
         } finally {
             lock.unlock();
         }
@@ -49,7 +49,7 @@ public class InMemorySinkAccessor {
     public List<Record<Event>> getAndClear(final String testingKey) {
         lock.lock();
         try {
-            final List<Record<Event>> records = recordsMap.getOrDefault(testingKey, Collections.emptyList());
+            final List<Record<Event>> records = get(testingKey);
 
             recordsMap.remove(testingKey);
 


### PR DESCRIPTION
### Description

The integration tests were sometimes throwing a ConcurrentModificationException on the list provided by `InMemorySinkAccessor`. Wrap that in a new list so that it won't be modified when checking it.
 
### Issues Resolved
Resolves #3139
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
