### PR TITLE
Support s3:// prefix

### DIFF
--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfig.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfig.java
@@ -6,7 +6,7 @@
 package org.opensearch.dataprepper.plugins.dlq.s3;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import software.amazon.awssdk.arns.Arn;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -33,8 +33,10 @@ public class S3DlqWriterConfig {
     private static final String DEFAULT_AWS_REGION = "us-east-1";
     private static final String AWS_IAM_ROLE = "role";
     private static final String AWS_IAM = "iam";
+    private static final String S3_PREFIX = "s3://";
+
     @JsonProperty("bucket")
-    @NotNull
+    @NotEmpty
     @Size(min = 3, max = 63, message = "bucket lengthy should be between 3 and 63 characters")
     private String bucket;
 
@@ -55,6 +57,9 @@ public class S3DlqWriterConfig {
     private String stsExternalId;
 
     public String getBucket() {
+        if (bucket.startsWith(S3_PREFIX)) {
+            return bucket.substring(S3_PREFIX.length());
+        }
         return bucket;
     }
 

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfig.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfig.java
@@ -37,7 +37,6 @@ public class S3DlqWriterConfig {
 
     @JsonProperty("bucket")
     @NotEmpty
-    @Size(min = 3, max = 63, message = "bucket lengthy should be between 3 and 63 characters")
     private String bucket;
 
     @JsonProperty("key_path_prefix")

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfig.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfig.java
@@ -37,6 +37,7 @@ public class S3DlqWriterConfig {
 
     @JsonProperty("bucket")
     @NotEmpty
+    @Size(min = 3, max = 500, message = "bucket length should be at least 3 characters")
     private String bucket;
 
     @JsonProperty("key_path_prefix")

--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfigTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfigTest.java
@@ -45,7 +45,7 @@ public class S3DlqWriterConfigTest {
 
     @ParameterizedTest
     @CsvSource({"bucket-name, bucket-name", "s3://bucket-name, bucket-name"})
-    public void getS3ClientWithInvalidStsRoleArnThrowException_(final String bucketName, final String expectedBucketName) throws NoSuchFieldException, IllegalAccessException {
+    public void getS3BucketNameShouldReturnCorrectBucketName(final String bucketName, final String expectedBucketName) throws NoSuchFieldException, IllegalAccessException {
         final S3DlqWriterConfig config = new S3DlqWriterConfig();
         reflectivelySetField(config, "bucket", bucketName);
         assertThat(config.getBucket(), is(equalTo(expectedBucketName)));

--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfigTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfigTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.dlq.s3;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import software.amazon.awssdk.regions.Region;
@@ -40,6 +41,14 @@ public class S3DlqWriterConfigTest {
         final S3DlqWriterConfig config = new S3DlqWriterConfig();
         reflectivelySetField(config, "stsRoleArn", stsRoleArn);
         assertThrows(IllegalArgumentException.class, config::getS3Client);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"bucket-name, bucket-name", "s3://bucket-name, bucket-name"})
+    public void getS3ClientWithInvalidStsRoleArnThrowException_(final String bucketName, final String expectedBucketName) throws NoSuchFieldException, IllegalAccessException {
+        final S3DlqWriterConfig config = new S3DlqWriterConfig();
+        reflectivelySetField(config, "bucket", bucketName);
+        assertThat(config.getBucket(), is(equalTo(expectedBucketName)));
     }
 
     @ParameterizedTest

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkConfig.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkConfig.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferTypeOptions;
 import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionOption;
@@ -20,6 +21,7 @@ import org.opensearch.dataprepper.plugins.sink.s3.configuration.ThresholdOptions
  * s3 sink configuration class contains properties, used to read yaml configuration.
  */
 public class S3SinkConfig {
+    static final String S3_PREFIX = "s3://";
 
     private static final int DEFAULT_CONNECTION_RETRIES = 5;
     private static final int DEFAULT_UPLOAD_RETRIES = 5;
@@ -30,8 +32,8 @@ public class S3SinkConfig {
     private AwsAuthenticationOptions awsAuthenticationOptions;
 
     @JsonProperty("bucket")
-    @NotNull
     @NotEmpty
+    @Size(min = 3, max = 63, message = "bucket lengthy should be between 3 and 63 characters")
     private String bucketName;
 
     @JsonProperty("object_key")
@@ -77,6 +79,9 @@ public class S3SinkConfig {
      * @return bucket name.
      */
     public String getBucketName() {
+        if (bucketName.startsWith(S3_PREFIX)) {
+            return bucketName.substring(S3_PREFIX.length());
+        }
         return bucketName;
     }
 

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkConfig.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkConfig.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferTypeOptions;
 import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionOption;
@@ -32,6 +33,7 @@ public class S3SinkConfig {
 
     @JsonProperty("bucket")
     @NotEmpty
+    @Size(min = 3, max = 500, message = "bucket length should be at least 3 characters")
     private String bucketName;
 
     @JsonProperty("object_key")

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkConfig.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkConfig.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferTypeOptions;
 import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionOption;
@@ -33,7 +32,6 @@ public class S3SinkConfig {
 
     @JsonProperty("bucket")
     @NotEmpty
-    @Size(min = 3, max = 63, message = "bucket lengthy should be between 3 and 63 characters")
     private String bucketName;
 
     @JsonProperty("object_key")

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkConfigTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkConfigTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.opensearch.dataprepper.plugins.sink.s3.S3SinkConfig.S3_PREFIX;
 
 class S3SinkConfigTest {
 
@@ -42,6 +43,15 @@ class S3SinkConfigTest {
         final String bucketName = UUID.randomUUID().toString();
         final S3SinkConfig objectUnderTest = new S3SinkConfig();
         ReflectivelySetField.setField(S3SinkConfig.class, objectUnderTest, "bucketName", bucketName);
+        assertThat(objectUnderTest.getBucketName(), equalTo(bucketName));
+    }
+
+    @Test
+    void get_bucket_name_with_s3_prefix_test() throws NoSuchFieldException, IllegalAccessException {
+        final String bucketName = UUID.randomUUID().toString();
+        final String bucketNameWithPrefix = S3_PREFIX + bucketName;
+        final S3SinkConfig objectUnderTest = new S3SinkConfig();
+        ReflectivelySetField.setField(S3SinkConfig.class, objectUnderTest, "bucketName", bucketNameWithPrefix);
         assertThat(objectUnderTest.getBucketName(), equalTo(bucketName));
     }
 

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOption.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOption.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import org.opensearch.dataprepper.plugins.source.CustomLocalDateTimeDeserializer;
 
 import java.time.Duration;
@@ -23,6 +24,7 @@ public class S3ScanBucketOption {
 
     @JsonProperty("name")
     @NotEmpty
+    @Size(min = 3, max = 500, message = "bucket length should be at least 3 characters")
     private String name;
 
     @JsonDeserialize(using = CustomLocalDateTimeDeserializer.class)

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOption.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOption.java
@@ -7,6 +7,8 @@ package org.opensearch.dataprepper.plugins.source.configuration;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import org.opensearch.dataprepper.plugins.source.CustomLocalDateTimeDeserializer;
 
 import java.time.Duration;
@@ -18,7 +20,11 @@ import java.util.stream.Stream;
  * Class consists the bucket related configuration properties.
  */
 public class S3ScanBucketOption {
+    private static final String S3_PREFIX = "s3://";
+
     @JsonProperty("name")
+    @NotEmpty
+    @Size(min = 3, max = 63, message = "bucket lengthy should be between 3 and 63 characters")
     private String name;
 
     @JsonDeserialize(using = CustomLocalDateTimeDeserializer.class)
@@ -41,6 +47,9 @@ public class S3ScanBucketOption {
     }
 
     public String getName() {
+        if (name.startsWith(S3_PREFIX)) {
+            return name.substring(S3_PREFIX.length());
+        }
         return name;
     }
 

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOption.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOption.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Size;
 import org.opensearch.dataprepper.plugins.source.CustomLocalDateTimeDeserializer;
 
 import java.time.Duration;
@@ -24,7 +23,6 @@ public class S3ScanBucketOption {
 
     @JsonProperty("name")
     @NotEmpty
-    @Size(min = 3, max = 63, message = "bucket lengthy should be between 3 and 63 characters")
     private String name;
 
     @JsonDeserialize(using = CustomLocalDateTimeDeserializer.class)

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ScanOptionsTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/ScanOptionsTest.java
@@ -42,12 +42,15 @@ class ScanOptionsTest {
     @ParameterizedTest
     @MethodSource("invalidTimeRangeOptions")
     public void s3scan_options_with_invalid_global_time_range_throws_exception_when_build(
-            LocalDateTime startDateTime, LocalDateTime endDateTime, Duration range) {
+            LocalDateTime startDateTime, LocalDateTime endDateTime, Duration range) throws NoSuchFieldException, IllegalAccessException {
+        S3ScanBucketOption bucketOption = new S3ScanBucketOption();
+        setField(S3ScanBucketOption.class, bucketOption, "name", "bucket_name");
+
         assertThrows(IllegalArgumentException.class, () -> ScanOptions.builder()
                 .setStartDateTime(startDateTime)
                 .setEndDateTime(endDateTime)
                 .setRange(range)
-                .setBucketOption(new S3ScanBucketOption())
+                .setBucketOption(bucketOption)
                 .build());
     }
 

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOptionTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOptionTest.java
@@ -41,4 +41,11 @@ public class S3ScanBucketOptionTest {
         assertThat(s3ScanBucketOption.getS3ScanFilter().getS3ScanExcludeSuffixOptions(),instanceOf(List.class));
         assertThat(s3ScanBucketOption.getS3ScanFilter().getS3ScanExcludeSuffixOptions().get(1),equalTo(".png"));
     }
+
+    @Test
+    public void s3scan_bucket_options_with_s3_prefix_test() throws JsonProcessingException {
+        final String bucketOptionsYaml = "              name: s3://test-s3-source-test-output";
+        final S3ScanBucketOption s3ScanBucketOption = objectMapper.readValue(bucketOptionsYaml, S3ScanBucketOption.class);
+        assertThat(s3ScanBucketOption.getName(), equalTo("test-s3-source-test-output"));
+    }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOptionTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/configuration/S3ScanBucketOptionTest.java
@@ -44,7 +44,7 @@ public class S3ScanBucketOptionTest {
 
     @Test
     public void s3scan_bucket_options_with_s3_prefix_test() throws JsonProcessingException {
-        final String bucketOptionsYaml = "              name: s3://test-s3-source-test-output";
+        final String bucketOptionsYaml = "---\nname: s3://test-s3-source-test-output";
         final S3ScanBucketOption s3ScanBucketOption = objectMapper.readValue(bucketOptionsYaml, S3ScanBucketOption.class);
         assertThat(s3ScanBucketOption.getName(), equalTo("test-s3-source-test-output"));
     }


### PR DESCRIPTION
### Description
Support `s3://` prefix in s3 bucket name
 
### Issues Resolved
resolves #2143
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
