### PR TITLE
Only log that the scan is complete one time for s3 scan

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplier.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ScanPartitionCreationSupplier.java
@@ -36,6 +36,7 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
     private static final String BUCKET_OBJECT_PARTITION_KEY_FORMAT = "%s|%s";
     static final String SCAN_COUNT = "SCAN_COUNT";
     static final String LAST_SCAN_TIME = "LAST_SCAN_TIME";
+    static final String SINGLE_SCAN_COMPLETE = "SINGLE_SCAN_COMPLETE";
 
     private final S3Client s3Client;
     private final BucketOwnerProvider bucketOwnerProvider;
@@ -143,6 +144,7 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
 
     private void initializeGlobalStateMap(final Map<String, Object> globalStateMap) {
         globalStateMap.put(SCAN_COUNT, 0);
+        globalStateMap.put(SINGLE_SCAN_COMPLETE, false);
     }
 
     private boolean isLastModifiedTimeAfterMostRecentScanForBucket(final String bucketName,
@@ -174,13 +176,21 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
     }
 
     private boolean shouldScanBeSkipped(final Map<String, Object> globalStateMap) {
+
         if (Objects.isNull(schedulingOptions) && hasAlreadyBeenScanned(globalStateMap)) {
-            LOG.info("Skipping scan because the buckets have already been scanned once");
+
+            if (!(Boolean) globalStateMap.get(SINGLE_SCAN_COMPLETE)) {
+                LOG.info("Single S3 scan has already been completed");
+                globalStateMap.put(SINGLE_SCAN_COMPLETE, true);
+            }
+
             return true;
         }
 
         if (Objects.nonNull(schedulingOptions) &&
                 (hasReachedMaxScanCount(globalStateMap) || !hasReachedScheduledScanTime(globalStateMap))) {
+
+
 
             if (hasReachedMaxScanCount(globalStateMap)) {
                 LOG.info("Skipping scan as the max scan count {} has been reached", schedulingOptions.getCount());


### PR DESCRIPTION
### Description
Track when single scan is complete to only log once when the scan has already been completed
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
