### PR TITLE
Fix S3 sink writing to closed stream exception

### DIFF
--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
@@ -138,6 +138,7 @@ public class S3SinkService {
                         releaseEventHandles(false);
                     }
                     currentBuffer = bufferFactory.getBuffer();
+                    outputStream = currentBuffer.getOutputStream();
                 }
             }
         } catch (IOException | InterruptedException e) {


### PR DESCRIPTION
### Description
Fixes a bug where the S3 sink tries to write to a closed stream if data is flushed mid batch.
 
### Issues Resolved
Resolves #3160 
 
### Check List
- [x] New functionality includes testing.
- [N/A] New functionality has a documentation issue. Please link to it in this PR.
  - [N/A] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
