### PR TITLE
Fix timestamp to use 24 hour instead of 12 hour

### DIFF
--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/configuration/ObjectKeyOptions.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/configuration/ObjectKeyOptions.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * An implementation class of path prefix and file pattern configuration Options
  */
 public class ObjectKeyOptions {
-    private static final String DEFAULT_OBJECT_NAME_PATTERN = "events-%{yyyy-MM-dd'T'hh-mm-ss}";
+    private static final String DEFAULT_OBJECT_NAME_PATTERN = "events-%{yyyy-MM-dd'T'HH-mm-ss'Z'}";
 
     @JsonProperty("path_prefix")
     private String pathPrefix;

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/configuration/ObjectKeyOptionsTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/configuration/ObjectKeyOptionsTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 class ObjectKeyOptionsTest {
 
-    private static final String DEFAULT_FILE_PATTERN = "events-%{yyyy-MM-dd'T'hh-mm-ss}";
+    private static final String DEFAULT_FILE_PATTERN = "events-%{yyyy-MM-dd'T'HH-mm-ss'Z'}";
 
     @Test
     void default_file_pattern_test() {


### PR DESCRIPTION
### Description
Use `HH` instead of `hh` in the default format to get the 24 hour rather than 12 hour timestamp. Also add `Z` to denote UTC
 
### Issues Resolved
Partially #3158 
 
### Check List
- [x] New functionality includes testing.
- [N/A] New functionality has a documentation issue. Please link to it in this PR.
  - [N/A] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
