### PR TITLE
Add limit to cardinality key, and metric for cardinality overflow

### DIFF
--- a/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessor.java
+++ b/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessor.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.processor.anomalydetector;
 
 
+import io.micrometer.core.instrument.Counter;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -17,6 +18,8 @@ import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.plugins.hasher.IdentificationKeysHasher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -30,14 +33,19 @@ public class AnomalyDetectorProcessor extends AbstractProcessor<Record<Event>, R
     public static final String DEVIATION_KEY = "deviation_from_expected";
     public static final String GRADE_KEY = "grade";
     static final String NUMBER_RCF_INSTANCES = "RCFInstances";
+    static final String CARDINALITY_OVERFLOW = "cardinalityOverflow";
 
     private final Boolean verbose;
+    private final int cardinalityLimit;
     private final IdentificationKeysHasher identificationKeysHasher;
     private final List<String> keys;
     private final PluginFactory pluginFactory;
     private final HashMap<Integer, AnomalyDetectorMode> forestMap;
     private final AtomicInteger cardinality;
     private final AnomalyDetectorProcessorConfig anomalyDetectorProcessorConfig;
+    private static final Logger LOG = LoggerFactory.getLogger(AnomalyDetectorProcessor.class);
+    private final Counter cardinalityOverflowCounter;
+    private boolean overflowWarned = false;
 
     @DataPrepperPluginConstructor
     public AnomalyDetectorProcessor(final AnomalyDetectorProcessorConfig anomalyDetectorProcessorConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory) {
@@ -48,6 +56,8 @@ public class AnomalyDetectorProcessor extends AbstractProcessor<Record<Event>, R
         this.keys = anomalyDetectorProcessorConfig.getKeys();
         this.verbose = anomalyDetectorProcessorConfig.getVerbose();
         this.cardinality = pluginMetrics.gauge(NUMBER_RCF_INSTANCES, new AtomicInteger());
+        this.cardinalityLimit = anomalyDetectorProcessorConfig.getCardinalityLimit();
+        this.cardinalityOverflowCounter = pluginMetrics.counter(CARDINALITY_OVERFLOW);
         forestMap = new HashMap<>();
     }
 
@@ -68,12 +78,20 @@ public class AnomalyDetectorProcessor extends AbstractProcessor<Record<Event>, R
             final IdentificationKeysHasher.IdentificationKeysMap identificationKeysMap = identificationKeysHasher.createIdentificationKeysMapFromEvent(event);
             AnomalyDetectorMode forest = forestMap.get(identificationKeysMap.hashCode());
 
-            if (Objects.isNull(forest)) {
+            if (Objects.nonNull(forest)) {
+                recordsOut.addAll(forest.handleEvents(List.of(record)));
+            } else if (forestMap.size() < cardinalityLimit) {
                 forest = loadAnomalyDetectorMode(pluginFactory);
                 forest.initialize(keys, verbose);
                 forestMap.put(identificationKeysMap.hashCode(), forest);
+                recordsOut.addAll(forest.handleEvents(List.of(record)));
+            } else {
+                if (!overflowWarned) {
+                    LOG.warn("Cardinality limit reached, see cardinalityOverflow metric for count of skipped records");
+                    overflowWarned = true;
+                }
+                cardinalityOverflowCounter.increment();
             }
-            recordsOut.addAll(forestMap.get(identificationKeysMap.hashCode()).handleEvents(List.of(record)));
         }
         cardinality.set(forestMap.size());
         return recordsOut;

--- a/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessorConfig.java
+++ b/data-prepper-plugins/anomaly-detector-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/anomalydetector/AnomalyDetectorProcessorConfig.java
@@ -28,6 +28,9 @@ public class AnomalyDetectorProcessorConfig {
     @JsonProperty("verbose")
     private Boolean verbose = false;
 
+    @JsonProperty("cardinality_limit")
+    private int cardinalityLimit = 5000;
+
     public PluginModel getDetectorMode() { 
         return detectorMode;
     }
@@ -46,6 +49,9 @@ public class AnomalyDetectorProcessorConfig {
     }
     public boolean getVerbose() {
         return verbose;
+    }
+    public int getCardinalityLimit() {
+        return cardinalityLimit;
     }
 
 


### PR DESCRIPTION
### Description
Added a configurable `cardinality_limit` to set the max number of RCF instances a node can produce. Created a metric to track overflow, or number of RCF instances that could not be created due to this limit.


 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
