### PR TITLE
Reword circuit breaker configuration log message

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/breaker/HeapCircuitBreaker.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/breaker/HeapCircuitBreaker.java
@@ -66,7 +66,7 @@ class HeapCircuitBreaker implements InnerCircuitBreaker, AutoCloseable {
         scheduledExecutorService
                         .scheduleAtFixedRate(this::checkMemory, 0L, checkInterval.toMillis(), TimeUnit.MILLISECONDS);
 
-        LOG.info("Heap circuit breaker with usage of {} bytes.", usageBytes);
+        LOG.info("Circuit breaker heap limit is set to {} bytes.", usageBytes);
     }
 
     @Override


### PR DESCRIPTION
### Description
Rewords the log message to be more clear that the circuit breaker has not been tripped, but is configured with a certain heap limit
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
