### PR TITLE
Update Kafka source/sink to use ByteCount

### DIFF
--- a/data-prepper-plugins/kafka-plugins/README.md
+++ b/data-prepper-plugins/kafka-plugins/README.md
@@ -1,144 +1,11 @@
 # Kafka source
 
-This is the Data Prepper Kafka source plugin that reads records from Kafka topic. It uses the consumer API provided by Kafka to read messages from the kafka broker.
+This source allows Data Prepper to use Kafka as source. This source reads records from one or more Kafka topics. It uses the consumer API provided by Kafka to read messages from the kafka broker to create DataPrepper events for further processing by the Data Prepper pipeline.
 
+## Basic Usage and Configuration
 
-## Usages
+For usage and configuration, please refer to the documentation [here] (https://opensearch.org/docs/2.9/data-prepper/pipelines/configuration/sources/sources/kafka-source).
 
-The Kafka source should be configured as part of Data Prepper pipeline yaml file.
-
-## Configuration Options
-
-```
-log-pipeline:
-  source:
-    kafka:
-      bootstrap_servers:
-        - 127.0.0.1:9093
-      topics:
-        - name: my-topic-1
-          workers: 10
-          autocommit: false
-          autocommit_interval: 5s
-          session_timeout: 45s
-          max_retry_delay: 1s
-          auto_offset_reset: earliest
-          thread_waiting_time: 1s
-          max_record_fetch_time: 4s
-          heart_beat_interval: 3s
-          buffer_default_timeout: 5s
-          fetch_max_bytes: 52428800
-          fetch_max_wait: 500
-          fetch_min_bytes: 1
-          retry_backoff: 100s
-          max_poll_interval: 300000s
-          consumer_max_poll_records: 500
-        - name: my-topic-2
-          workers: 10
-      schema:
-        registry_url: http://localhost:8081/
-        version: 1
-      authentication:
-        sasl_plaintext:
-          username: admin
-          password: admin-secret
-        sasl_oauth:
-          oauth_client_id: 0oa9wc21447Pc5vsV5d8
-          oauth_client_secret: aGmOfHqIEvBJGDxXAOOcatiE9PvsPgoEePx8IPPb
-          oauth_login_server: https://dev-1365.okta.com
-          oauth_login_endpoint: /oauth2/default/v1/token
-          oauth_login_grant_type: refresh_token
-          oauth_login_scope: kafka
-          oauth_introspect_server: https://dev-1365.okta.com
-          oauth_introspect_endpoint: /oauth2/default/v1/introspect
-          oauth_sasl_mechanism: OAUTHBEARER
-          oauth_security_protocol: SASL_PLAINTEXT
-          oauth_sasl_login_callback_handler_class: org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler
-          oauth_jwks_endpoint_url: https://dev-1365.okta.com/oauth2/default/v1/keys
-  sink:
-    - stdout:
-
-```
-
-## Configuration
-
-- `bootstrap_servers` (Required) : It is a host/port to use for establishing the initial connection to the Kafka cluster. Multiple brokers can be configured.
-
-- `topics` (Required) : The topic in which kafka source plugin associated with to read the messages.The maximum number of topics should be 10.
-
-- `name` (Required) : This denotes the name of the topic, and it is a mandatory one. Multiple list can be configured and the maximum number of topic should be 10.
-
-- `workers` (Optional) : Number of multithreaded consumers associated with each topic. Defaults to `10` and its maximum value should be 200.
-
-- `autocommit` (Optional) : If false, the consumer's offset will not be periodically committed in the background. Defaults to `false`.
-
-- `autocommit_interval` (Optional) : The frequency in seconds that the consumer offsets are auto-committed to Kafka. Defaults to `1s`.
-
-- `session_timeout` (Optional) : The timeout used to detect client failures when using Kafka's group management. It is used for the rebalance.
-
-- `max_retry_delay` (Optional) : By default the Kafka source will retry for every 1 second when there is a buffer write error. Defaults to `1s`.
-
-- `auto_offset_reset` (Optional) : automatically reset the offset to the earliest or latest offset. Defaults to `earliest`.
-
-- `thread_waiting_time` (Optional) : It is the time for thread to wait until other thread completes the task and signal it.
-
-- `max_record_fetch_time` (Optional) : maximum time to fetch the record from the topic.
-Defaults to `4s`.
-
-- `heart_beat_interval` (Optional) : The expected time between heartbeats to the consumer coordinator when using Kafka's group management facilities. Defaults to `1s`.
-
-- `buffer_default_timeout` (Optional) :  The maximum time to write data to the buffer. Defaults to `1s`.
-
-- `fetch_max_bytes` (Optional) : The maximum record batch size accepted by the broker.
-Defaults to `52428800`.
-
-- `fetch_max_wait` (Optional) : The maximum amount of time the server will block before answering the fetch request if there isn't sufficient data to immediately satisfy the requirement. Defaults to `500`.
-
-- `fetch_min_bytes` (Optional) : The minimum amount of data the server should return for a fetch request. Defaults to `1`.
-
-- `retry_backoff` (Optional) : The amount of time to wait before attempting to retry a failed request to a given topic partition.  Defaults to `5s`.
-
-- `max_poll_interval` (Optional) : The maximum delay between invocations of poll() when using consumer group management. Defaults to `1s`.
-
-- `consumer_max_poll_records` (Optional) : The maximum number of records returned in a single call to poll(). Defaults to `1s`.
-
-### <a name="schema_configuration">Schema Configuration</a>
-
-- `registry_url` (Optional) : Deserialize a record value from a bytearray into a String. Defaults to `org.apache.kafka.common.serialization.StringDeserializer`.
-
-- `version` (Optional) : Deserialize a record key from a bytearray into a String. Defaults to `org.apache.kafka.common.serialization.StringDeserializer`.
-
-### <a name="auth_configuration">Auth Configuration for SASL PLAINTEXT</a>
-
-- `username` (Optional) : The username for the Plaintext authentication.
-
-- `password` (Optional) : The password for the Plaintext authentication.
-
-### <a name="auth_configuration">OAuth Configuration for SASLOAUTH</a>
-
-- `oauth_client_id`: It is the client id is the public identifier of your authorization server.
-
-- `oauth_client_secret` : It is a secret known only to the application and the authorization server.
-
-- `oauth_login_server` : The URL of the OAuth server.(Eg: https://dev.okta.com)
-
-- `oauth_login_endpoint`: The End point URL of the OAuth server.(Eg: /oauth2/default/v1/token)
-
-- `oauth_login_grant_type` (Optional) : This grant type refers to the way an application gets an access token.
-
-- `oauth_login_scope` (Optional) : This scope limit an application's access to a user's account.
-
-- `oauth_introspect_server` (Optional) : The URL of the introspect server. Most of the cases it should be similar to the oauth_login_server URL (Eg:https://dev.okta.com)
-
-- `oauth_introspect_endpoint` (Optional) : The end point of the introspect server URL.(Eg: /oauth2/default/v1/introspect)
-
-- `oauth_sasl_mechanism` (Optional) : It describes the authentication mechanism.
-
-- `oauth_security_protocol` (Optional) : It is the SASL security protocol like PLAINTEXT or SSL.
-
-- `oauth_sasl_login_callback_handler_class` (Optional) : It is the user defined or built in Kafka class to handle login and its callbeck.
-
-- `oauth_jwks_endpoint_url` (Optional) : The absolute URL for the oauth token refresh.
 
 ## Integration Tests
 
@@ -161,18 +28,33 @@ ssl.keystore.password=<password of keystore>
 ```
 The truststore must have "localhost" certificates in them.
 
-Command to start kafka server
+3. Create a file with name `kafka_server_jaas.conf` and with the following contents:
+```
+KafkaClient {
+    org.apache.kafka.common.security.plain.PlainLoginModule required
+    username="admin"
+    password="admin"
+    user_admin="admin";
+};
+```
+
+4. Export `KAFKA_OPTS` environment variable
+```
+export KAFKA_OPTS=-Djava.security.auth.login.config=kafka_server_jaas.conf
+```
+
+5. start kafka server
 ```
 bin/kafka-server-start.sh config/server.properties
 ```
 
-3. Command to run multi auth type integration tests
+6. Command to run multi auth type integration tests
 
 ```
-./gradlew    data-prepper-plugins:kafka-plugins:integrationTest -Dtests.kafka.bootstrap_servers=<bootstrap-servers> -Dtests.kafka.trust_store_location=</path/to/client.truststore.jks> -Dtests.kafka.trust_store_password=<password> -Dtests.kafka.saslssl_bootstrap_servers=<sasl-bootstrap-server> -Dtests.kafka.ssl_bootstrap_servers=<ssl-bootstrap-servers> -Dtests.kafka.saslplain_bootstrap_servers=<plain-bootstrap-servers> -Dtests.kafka.username=<username> -Dtests.kafka.password=<password> --tests "*KafkaSourceMultipleAuthTypeIT*"
+./gradlew    data-prepper-plugins:kafka-plugins:integrationTest -Dtests.kafka.bootstrap_servers=localhost:9092 -Dtests.kafka.saslssl_bootstrap_servers=localhost:9093 -Dtests.kafka.ssl_bootstrap_servers=localhost:9094 -Dtests.kafka.saslplain_bootstrap_servers=localhost:9095 -Dtests.kafka.username=admin -Dtests.kafka.password=admin --tests "*KafkaSourceMultipleAuthTypeIT*"
 ```
 
-4. Command to run msk glue integration tests
+7. Command to run msk glue integration tests
 
 ```
 ./gradlew     data-prepper-plugins:kafka-plugins:integrationTest -Dtests.kafka.bootstrap_servers=<msk-bootstrap-servers> -Dtests.kafka.glue_registry_name=<glue-registry-name> -Dtests.kafka.glue_avro_schema_name=<glue-registry-avro-schema-name> -Dtests.kafka.glue_json_schema_name=<glue-registry-json-schema-name> -Dtests.msk.region=<msk-region> -Dtests.msk.arn=<msk-arn>  --tests "*TestAvroRecordConsumer*" 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfig.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.opensearch.dataprepper.model.types.ByteCount;
 
 import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 
@@ -24,12 +25,12 @@ public class TopicConfig {
     static final String DEFAULT_AUTO_OFFSET_RESET = "earliest";
     static final Duration DEFAULT_THREAD_WAITING_TIME = Duration.ofSeconds(5);
     static final Duration DEFAULT_MAX_RECORD_FETCH_TIME = Duration.ofSeconds(4);
-    static final Integer DEFAULT_FETCH_MAX_BYTES = 52428800;
+    static final String DEFAULT_FETCH_MAX_BYTES = "50mb";
     static final Integer DEFAULT_FETCH_MAX_WAIT = 500;
-    static final Integer DEFAULT_FETCH_MIN_BYTES = 1;
+    static final String DEFAULT_FETCH_MIN_BYTES = "1b";
     static final Duration DEFAULT_RETRY_BACKOFF = Duration.ofSeconds(10);
     static final Duration DEFAULT_RECONNECT_BACKOFF = Duration.ofSeconds(10);
-    static final Integer DEFAULT_MAX_PARTITION_FETCH_BYTES = 1048576;
+    static final String DEFAULT_MAX_PARTITION_FETCH_BYTES = "1mb";
     static final Duration DEFAULT_MAX_POLL_INTERVAL = Duration.ofSeconds(300);
     static final Integer DEFAULT_CONSUMER_MAX_POLL_RECORDS = 500;
     static final Integer DEFAULT_NUM_OF_WORKERS = 2;
@@ -73,12 +74,10 @@ public class TopicConfig {
     private Duration threadWaitingTime = DEFAULT_THREAD_WAITING_TIME;
 
     @JsonProperty("max_partition_fetch_bytes")
-    private Integer maxPartitionFetchBytes = DEFAULT_MAX_PARTITION_FETCH_BYTES;
+    private String maxPartitionFetchBytes = DEFAULT_MAX_PARTITION_FETCH_BYTES;
 
     @JsonProperty("fetch_max_bytes")
-    @Valid
-    @Size(min = 1, max = 52428800)
-    private Integer fetchMaxBytes = DEFAULT_FETCH_MAX_BYTES;
+    private String fetchMaxBytes = DEFAULT_FETCH_MAX_BYTES;
 
     @JsonProperty("fetch_max_wait")
     @Valid
@@ -86,9 +85,7 @@ public class TopicConfig {
     private Integer fetchMaxWait = DEFAULT_FETCH_MAX_WAIT;
 
     @JsonProperty("fetch_min_bytes")
-    @Size(min = 1)
-    @Valid
-    private Integer fetchMinBytes = DEFAULT_FETCH_MIN_BYTES;
+    private String fetchMinBytes = DEFAULT_FETCH_MIN_BYTES;
 
     @JsonProperty("key_mode")
     private KafkaKeyMode kafkaKeyMode = KafkaKeyMode.INCLUDE_AS_FIELD;
@@ -154,12 +151,16 @@ public class TopicConfig {
         this.threadWaitingTime = threadWaitingTime;
     }
 
-    public Integer getMaxPartitionFetchBytes() {
-        return maxPartitionFetchBytes;
+    public long getMaxPartitionFetchBytes() {
+        return ByteCount.parse(maxPartitionFetchBytes).getBytes();
     }
 
-    public Integer getFetchMaxBytes() {
-        return fetchMaxBytes;
+    public long getFetchMaxBytes() {
+        long value = ByteCount.parse(fetchMaxBytes).getBytes();
+        if (value < 1 || value > 50*1024*1024) {
+            throw new RuntimeException("Invalid Fetch Max Bytes");
+        }
+        return value;
     }
 
     public void setAutoCommit(Boolean autoCommit) {
@@ -170,8 +171,12 @@ public class TopicConfig {
         return fetchMaxWait;
     }
 
-    public Integer getFetchMinBytes() {
-        return fetchMinBytes;
+    public long getFetchMinBytes() {
+        long value = ByteCount.parse(fetchMinBytes).getBytes();
+        if (value < 1) {
+            throw new RuntimeException("Invalid Fetch Min Bytes");
+        }
+        return value;
     }
 
     public Duration getRetryBackoff() {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -358,7 +358,7 @@ public class KafkaSource implements Source<Record<Event>> {
 
     private void setConsumerTopicProperties(Properties properties, TopicConfig topicConfig) {
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroupID);
-        properties.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, topicConfig.getMaxPartitionFetchBytes());
+        properties.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, (int)topicConfig.getMaxPartitionFetchBytes());
         properties.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, ((Long)topicConfig.getRetryBackoff().toMillis()).intValue());
         properties.put(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG, ((Long)topicConfig.getReconnectBackoff().toMillis()).intValue());
         properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
@@ -373,9 +373,9 @@ public class KafkaSource implements Source<Record<Event>> {
                 ((Long)topicConfig.getMaxPollInterval().toMillis()).intValue());
         properties.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, ((Long)topicConfig.getSessionTimeOut().toMillis()).intValue());
         properties.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, ((Long)topicConfig.getHeartBeatInterval().toMillis()).intValue());
-        properties.put(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, topicConfig.getFetchMaxBytes().intValue());
+        properties.put(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, (int)topicConfig.getFetchMaxBytes());
         properties.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, topicConfig.getFetchMaxWait());
-        properties.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, topicConfig.getFetchMinBytes());
+        properties.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, (int)topicConfig.getFetchMinBytes());
     }
 
     private void setPropertiesForSchemaRegistryConnectivity(Properties properties) {

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfigTest.java
@@ -25,6 +25,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.opensearch.dataprepper.model.types.ByteCount;
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
 class TopicConfigTest {
 
@@ -73,16 +77,16 @@ class TopicConfigTest {
         assertEquals(TopicConfig.DEFAULT_SESSION_TIMEOUT, topicConfig.getSessionTimeOut());
         assertEquals(TopicConfig.DEFAULT_AUTO_OFFSET_RESET, topicConfig.getAutoOffsetReset());
         assertEquals(TopicConfig.DEFAULT_THREAD_WAITING_TIME, topicConfig.getThreadWaitingTime());
-        assertEquals(TopicConfig.DEFAULT_FETCH_MAX_BYTES, topicConfig.getFetchMaxBytes());
+        assertEquals(ByteCount.parse(TopicConfig.DEFAULT_FETCH_MAX_BYTES).getBytes(), topicConfig.getFetchMaxBytes());
         assertEquals(TopicConfig.DEFAULT_FETCH_MAX_WAIT, topicConfig.getFetchMaxWait());
-        assertEquals(TopicConfig.DEFAULT_FETCH_MIN_BYTES, topicConfig.getFetchMinBytes());
+        assertEquals(ByteCount.parse(TopicConfig.DEFAULT_FETCH_MIN_BYTES).getBytes(), topicConfig.getFetchMinBytes());
         assertEquals(TopicConfig.DEFAULT_RETRY_BACKOFF, topicConfig.getRetryBackoff());
         assertEquals(TopicConfig.DEFAULT_RECONNECT_BACKOFF, topicConfig.getReconnectBackoff());
         assertEquals(TopicConfig.DEFAULT_MAX_POLL_INTERVAL, topicConfig.getMaxPollInterval());
         assertEquals(TopicConfig.DEFAULT_CONSUMER_MAX_POLL_RECORDS, topicConfig.getConsumerMaxPollRecords());
         assertEquals(TopicConfig.DEFAULT_NUM_OF_WORKERS, topicConfig.getWorkers());
         assertEquals(TopicConfig.DEFAULT_HEART_BEAT_INTERVAL_DURATION, topicConfig.getHeartBeatInterval());
-        assertEquals(TopicConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES, topicConfig.getMaxPartitionFetchBytes());
+        assertEquals(ByteCount.parse(TopicConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES).getBytes(), topicConfig.getMaxPartitionFetchBytes());
     }
 
     @Test
@@ -94,15 +98,15 @@ class TopicConfigTest {
         assertEquals(45000, topicConfig.getSessionTimeOut().toMillis());
         assertEquals("earliest", topicConfig.getAutoOffsetReset());
         assertEquals(Duration.ofSeconds(1), topicConfig.getThreadWaitingTime());
-        assertEquals(52428800, topicConfig.getFetchMaxBytes().longValue());
+        assertEquals(52428800L, topicConfig.getFetchMaxBytes());
         assertEquals(500L, topicConfig.getFetchMaxWait().longValue());
-        assertEquals(1L, topicConfig.getFetchMinBytes().longValue());
+        assertEquals(1L, topicConfig.getFetchMinBytes());
         assertEquals(Duration.ofSeconds(100), topicConfig.getRetryBackoff());
         assertEquals(Duration.ofSeconds(300), topicConfig.getMaxPollInterval());
         assertEquals(500L, topicConfig.getConsumerMaxPollRecords().longValue());
         assertEquals(5, topicConfig.getWorkers().intValue());
         assertEquals(Duration.ofSeconds(3), topicConfig.getHeartBeatInterval());
-        assertEquals(10*TopicConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES, topicConfig.getMaxPartitionFetchBytes());
+        assertEquals(10*ByteCount.parse(TopicConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES).getBytes(), topicConfig.getMaxPartitionFetchBytes());
     }
 
     @Test
@@ -122,6 +126,17 @@ class TopicConfigTest {
         assertNotNull(topicConfig.getConsumerMaxPollRecords());
         assertNotNull(topicConfig.getWorkers());
         assertNotNull(topicConfig.getHeartBeatInterval());
+    }
+
+    @Test
+    @Tag(YAML_FILE_WITH_CONSUMER_CONFIG)
+    void TestInvalidConfigValues() throws NoSuchFieldException, IllegalAccessException {
+        setField(TopicConfig.class, topicConfig, "fetchMaxBytes", "60mb");
+        assertThrows(RuntimeException.class, () -> topicConfig.getFetchMaxBytes());
+        setField(TopicConfig.class, topicConfig, "fetchMaxBytes", "0b");
+        assertThrows(RuntimeException.class, () -> topicConfig.getFetchMaxBytes());
+        setField(TopicConfig.class, topicConfig, "fetchMinBytes", "0b");
+        assertThrows(RuntimeException.class, () -> topicConfig.getFetchMinBytes());
     }
 
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines.yaml
@@ -15,12 +15,12 @@ log-pipeline:
           auto_offset_reset: earliest
           thread_waiting_time: PT1S
           heart_beat_interval: PT3S
-          fetch_max_bytes: 52428800
+          fetch_max_bytes: "50mb"
           fetch_max_wait: 500
-          fetch_min_bytes: 1
+          fetch_min_bytes: "1b"
           retry_backoff: PT100S
           consumer_max_poll_records: 500
-          max_partition_fetch_bytes: 10485760
+          max_partition_fetch_bytes: "10mb"
       schema:
         registry_url: http://localhost:8081/
         version: 1


### PR DESCRIPTION
### Description
Update Kafka source/sink to use ByteCount

Modified Kafka Topic Configuration to use ByteCount for bytes related configuration.
 Resolves #3116 
### Issues Resolved
Resolves #3116 
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
