### PR TITLE
Continue calling S3SinkService::output even if records is empty to flush stale batches

### DIFF
--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
@@ -106,9 +106,6 @@ public class S3Sink extends AbstractSink<Record<Event>> {
      */
     @Override
     public void doOutput(final Collection<Record<Event>> records) {
-        if (records.isEmpty()) {
-            return;
-        }
         s3SinkService.output(records);
     }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
@@ -23,7 +23,6 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.concurrent.locks.Lock;

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
@@ -144,7 +144,7 @@ public class S3SinkService {
         if (ThresholdCheck.checkThresholdExceed(currentBuffer, maxEvents, maxBytes, maxCollectionDuration)) {
             try {
                 codec.complete(currentBuffer.getOutputStream());
-                final String s3Key = generateKey(codec);
+                String s3Key = currentBuffer.getKey();
                 LOG.info("Writing {} to S3 with {} events and size of {} bytes.",
                         s3Key, currentBuffer.getEventCount(), currentBuffer.getSize());
                 final boolean isFlushToS3 = retryFlushToS3(currentBuffer, s3Key);
@@ -160,7 +160,7 @@ public class S3SinkService {
                     objectsFailedCounter.increment();
                     releaseEventHandles(false);
                 }
-                currentBuffer = bufferFactory.getBuffer();
+                currentBuffer = bufferFactory.getBuffer(s3Client, () -> bucket, keyGenerator::generateKey);
             } catch (final IOException e) {
                 LOG.error("Exception while completing codec", e);
             }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
@@ -184,7 +184,7 @@ public class S3SinkService {
             } catch (AwsServiceException | SdkClientException e) {
                 LOG.error("Exception occurred while uploading records to s3 bucket. Retry countdown  : {} | exception:",
                         retryCount, e);
-                LOG.info("Error Massage {}", e.getMessage());
+                LOG.info("Error Message {}", e.getMessage());
                 --retryCount;
                 if (retryCount == 0) {
                     return isUploadedToS3;

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceTest.java
@@ -291,7 +291,7 @@ class S3SinkServiceTest {
 
         bufferFactory = mock(BufferFactory.class);
         Buffer buffer = mock(Buffer.class);
-        when(bufferFactory.getBuffer()).thenReturn(buffer);
+        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
         when(buffer.getEventCount()).thenReturn(10);
 
         final OutputStream outputStream = mock(OutputStream.class);
@@ -301,7 +301,7 @@ class S3SinkServiceTest {
         s3SinkService.output(Collections.emptyList());
 
         verify(snapshotSuccessCounter, times(1)).increment();
-        verify(buffer, times(1)).flushToS3(any(), anyString(), anyString());
+        verify(buffer, times(1)).flushToS3();
     }
 
     @Test
@@ -309,7 +309,7 @@ class S3SinkServiceTest {
 
         bufferFactory = mock(BufferFactory.class);
         Buffer buffer = mock(Buffer.class);
-        when(bufferFactory.getBuffer()).thenReturn(buffer);
+        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
         when(buffer.getEventCount()).thenReturn(0);
         final long objectSize = random.nextInt(1_000_000) + 10_000;
         when(buffer.getSize()).thenReturn(objectSize);
@@ -321,7 +321,7 @@ class S3SinkServiceTest {
         s3SinkService.output(Collections.emptyList());
 
         verify(snapshotSuccessCounter, times(0)).increment();
-        verify(buffer, times(0)).flushToS3(any(), anyString(), anyString());
+        verify(buffer, times(0)).flushToS3();
     }
 
     @Test

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceTest.java
@@ -158,7 +158,7 @@ class S3SinkServiceTest {
         S3SinkService s3SinkService = createObjectUnderTest();
         assertNotNull(s3SinkService);
         s3SinkService.output(generateRandomStringEventRecord());
-        verify(snapshotSuccessCounter, times(50)).increment();
+        verify(snapshotSuccessCounter, times(51)).increment();
     }
 
 
@@ -181,7 +181,7 @@ class S3SinkServiceTest {
         S3SinkService s3SinkService = createObjectUnderTest();
         assertNotNull(s3SinkService);
         s3SinkService.output(generateRandomStringEventRecord());
-        verify(snapshotSuccessCounter, times(50)).increment();
+        verify(snapshotSuccessCounter, times(51)).increment();
     }
 
     @Test
@@ -200,7 +200,7 @@ class S3SinkServiceTest {
         assertNotNull(s3SinkService);
         assertThat(s3SinkService, instanceOf(S3SinkService.class));
         s3SinkService.output(generateRandomStringEventRecord());
-        verify(snapshotSuccessCounter, times(50)).increment();
+        verify(snapshotSuccessCounter, times(51)).increment();
     }
 
     @Test
@@ -219,7 +219,7 @@ class S3SinkServiceTest {
         final S3SinkService s3SinkService = createObjectUnderTest();
         s3SinkService.output(generateRandomStringEventRecord());
 
-        verify(s3ObjectSizeSummary, times(50)).record(objectSize);
+        verify(s3ObjectSizeSummary, times(51)).record(objectSize);
     }
 
     @Test
@@ -245,7 +245,7 @@ class S3SinkServiceTest {
 
         s3SinkService.output(generateEventRecords(2));
 
-        verify(snapshotSuccessCounter, times(2)).increment();
+        verify(snapshotSuccessCounter, times(3)).increment();
         verify(codec).writeEvent(any(), eq(outputStream1));
         verify(codec).writeEvent(any(), eq(outputStream2));
     }
@@ -283,7 +283,7 @@ class S3SinkServiceTest {
         s3SinkService.output(Collections.singletonList(new Record<>(event)));
 
         verify(s3ObjectSizeSummary, never()).record(anyLong());
-        verify(buffer, times(3)).flushToS3();
+        verify(buffer, times(6)).flushToS3();
     }
 
     @Test


### PR DESCRIPTION
### Description
Any data left in the S3 sink buffer after traffic stops won't be flushed to S3 sink the threshold check is never reached again. This PR changes the behavior to continue calling `S3SinkService::output` even if the current processing batch is empty to check if the previously buffered data should now be flushed.
 
### Check List
- [x] New functionality includes testing.
- [N/a] New functionality has a documentation issue. Please link to it in this PR.
  - [N/a] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
