### PR TITLE
Fix uncaught exception causing pipeline shutdown 

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonOtelLog.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonOtelLog.java
@@ -109,7 +109,12 @@ public class JacksonOtelLog extends JacksonEvent implements OpenTelemetryLog {
 
     @Override
     public String toJsonString() {
-        final ObjectNode attributesNode = (ObjectNode) getJsonNode().get("attributes");
+        ObjectNode attributesNode;
+        try {
+            attributesNode = (ObjectNode) getJsonNode().get("attributes");
+        } catch (final ClassCastException e) {
+            attributesNode = null;
+        }
         final ObjectNode flattenedJsonNode = getJsonNode().deepCopy();
         if (attributesNode != null) {
             flattenedJsonNode.remove("attributes");

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonOtelLog.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonOtelLog.java
@@ -109,24 +109,21 @@ public class JacksonOtelLog extends JacksonEvent implements OpenTelemetryLog {
 
     @Override
     public String toJsonString() {
-        ObjectNode attributesNode;
-        try {
-            attributesNode = (ObjectNode) getJsonNode().get("attributes");
-        } catch (final ClassCastException e) {
-            attributesNode = null;
-        }
-        final ObjectNode flattenedJsonNode = getJsonNode().deepCopy();
-        if (attributesNode != null) {
+        Object anyAttributes = getJsonNode().get("attributes");
+        if(anyAttributes instanceof ObjectNode) {
+            final ObjectNode flattenedJsonNode = getJsonNode().deepCopy();
             flattenedJsonNode.remove("attributes");
-            for (Iterator<Map.Entry<String, JsonNode>> it = attributesNode.fields(); it.hasNext(); ) {
+
+            for (Iterator<Map.Entry<String, JsonNode>> it = ((ObjectNode) anyAttributes).fields(); it.hasNext(); ) {
                 Map.Entry<String, JsonNode> entry = it.next();
                 String field = entry.getKey();
                 if (!flattenedJsonNode.has(field)) {
                     flattenedJsonNode.set(field, entry.getValue());
                 }
             }
+            return flattenedJsonNode.toString();
         }
-        return flattenedJsonNode.toString();
+        return super.toJsonString();
     }
     /**
      * Builder for creating {@link JacksonLog}.

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonOtelLogTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonOtelLogTest.java
@@ -151,7 +151,7 @@ public class JacksonOtelLogTest {
     }
 
     @Test
-    public void testDeformedAttributesToJsonStringNotThrow() {
+    public void test_non_object_attributes_toJsonString_serializes_as_is() {
         JacksonOtelLog testLog = JacksonOtelLog.builder()
                 .withAttributes(Map.of("key", "value"))
                 .build();

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonOtelLogTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonOtelLogTest.java
@@ -149,5 +149,16 @@ public class JacksonOtelLogTest {
         String expected = String.format(file, TEST_TIME_KEY1, TEST_KEY2);
         JSONAssert.assertEquals(expected, actual, false);
     }
+
+    @Test
+    public void testDeformedAttributesToJsonStringNotThrow() {
+        JacksonOtelLog testLog = JacksonOtelLog.builder()
+                .withAttributes(Map.of("key", "value"))
+                .build();
+        assertThat(testLog.toJsonString(), equalTo("{\"key\":\"value\"}"));
+
+        testLog.put("attributes", "a string");
+        assertThat(testLog.toJsonString(), equalTo("{\"attributes\":\"a string\"}"));
+    }
 }
 

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessor.java
@@ -40,7 +40,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
     private final String pointer;
     private final String parseWhen;
     private final List<String> tagsOnFailure;
-    private final boolean overwriteIfKeyExists;
+    private final boolean overwriteIfDestinationExists;
 
     private final ExpressionEvaluator expressionEvaluator;
 
@@ -55,7 +55,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
         pointer = parseJsonProcessorConfig.getPointer();
         parseWhen = parseJsonProcessorConfig.getParseWhen();
         tagsOnFailure = parseJsonProcessorConfig.getTagsOnFailure();
-        overwriteIfKeyExists = parseJsonProcessorConfig.getOverwriteIfKeyExists();
+        overwriteIfDestinationExists = parseJsonProcessorConfig.getOverwriteIfDestinationExists();
         this.expressionEvaluator = expressionEvaluator;
     }
 
@@ -87,7 +87,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
 
                     if (doWriteToRoot) {
                         writeToRoot(event, parsedJson);
-                    } else if (overwriteIfKeyExists || !event.containsKey(destination)) {
+                    } else if (overwriteIfDestinationExists || !event.containsKey(destination)) {
                         event.put(destination, parsedJson);
                     }
                 } catch (final JsonProcessingException jsonException) {
@@ -171,7 +171,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
 
     private void writeToRoot(final Event event, final Map<String, Object> parsedJson) {
         for (Map.Entry<String, Object> entry : parsedJson.entrySet()) {
-            if (overwriteIfKeyExists || !event.containsKey(entry.getKey())) {
+            if (overwriteIfDestinationExists || !event.containsKey(entry.getKey())) {
                 event.put(entry.getKey(), entry.getValue());
             }
         }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessor.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessor.java
@@ -40,6 +40,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
     private final String pointer;
     private final String parseWhen;
     private final List<String> tagsOnFailure;
+    private final boolean overwriteIfKeyExists;
 
     private final ExpressionEvaluator expressionEvaluator;
 
@@ -54,6 +55,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
         pointer = parseJsonProcessorConfig.getPointer();
         parseWhen = parseJsonProcessorConfig.getParseWhen();
         tagsOnFailure = parseJsonProcessorConfig.getTagsOnFailure();
+        overwriteIfKeyExists = parseJsonProcessorConfig.getOverwriteIfKeyExists();
         this.expressionEvaluator = expressionEvaluator;
     }
 
@@ -85,7 +87,7 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
 
                     if (doWriteToRoot) {
                         writeToRoot(event, parsedJson);
-                    } else {
+                    } else if (overwriteIfKeyExists || !event.containsKey(destination)) {
                         event.put(destination, parsedJson);
                     }
                 } catch (final JsonProcessingException jsonException) {
@@ -169,7 +171,9 @@ public class ParseJsonProcessor extends AbstractProcessor<Record<Event>, Record<
 
     private void writeToRoot(final Event event, final Map<String, Object> parsedJson) {
         for (Map.Entry<String, Object> entry : parsedJson.entrySet()) {
-            event.put(entry.getKey(), entry.getValue());
+            if (overwriteIfKeyExists || !event.containsKey(entry.getKey())) {
+                event.put(entry.getKey(), entry.getValue());
+            }
         }
     }
 }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfig.java
@@ -32,7 +32,7 @@ public class ParseJsonProcessorConfig {
     private List<String> tagsOnFailure;
 
     @JsonProperty("overwrite_if_key_exists")
-    private boolean overwriteIfKeyExists = true;
+    private boolean overwriteIfDestinationExists = true;
 
     /**
      * The field of the Event that contains the JSON data.
@@ -71,8 +71,8 @@ public class ParseJsonProcessorConfig {
 
     public String getParseWhen() { return parseWhen; }
 
-    public boolean getOverwriteIfKeyExists() {
-        return overwriteIfKeyExists;
+    public boolean getOverwriteIfDestinationExists() {
+        return overwriteIfDestinationExists;
     }
 
     @AssertTrue(message = "destination cannot be empty, whitespace, or a front slash (/)")

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfig.java
@@ -31,7 +31,7 @@ public class ParseJsonProcessorConfig {
     @JsonProperty("tags_on_failure")
     private List<String> tagsOnFailure;
 
-    @JsonProperty("overwrite_if_key_exists")
+    @JsonProperty("overwrite_if_destination_exists")
     private boolean overwriteIfDestinationExists = true;
 
     /**

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfig.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfig.java
@@ -31,6 +31,9 @@ public class ParseJsonProcessorConfig {
     @JsonProperty("tags_on_failure")
     private List<String> tagsOnFailure;
 
+    @JsonProperty("overwrite_if_key_exists")
+    private boolean overwriteIfKeyExists = true;
+
     /**
      * The field of the Event that contains the JSON data.
      *
@@ -67,6 +70,10 @@ public class ParseJsonProcessorConfig {
     }
 
     public String getParseWhen() { return parseWhen; }
+
+    public boolean getOverwriteIfKeyExists() {
+        return overwriteIfKeyExists;
+    }
 
     @AssertTrue(message = "destination cannot be empty, whitespace, or a front slash (/)")
     boolean isValidDestination() {

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfigTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfigTest.java
@@ -29,7 +29,7 @@ public class ParseJsonProcessorConfigTest {
         assertThat(objectUnderTest.getDestination(), equalTo(null));
         assertThat(objectUnderTest.getPointer(), equalTo(null));
         assertThat(objectUnderTest.getTagsOnFailure(), equalTo(null));
-        assertThat(objectUnderTest.getOverwriteIfKeyExists(), equalTo(true));
+        assertThat(objectUnderTest.getOverwriteIfDestinationExists(), equalTo(true));
     }
 
     @Nested

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfigTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorConfigTest.java
@@ -29,6 +29,7 @@ public class ParseJsonProcessorConfigTest {
         assertThat(objectUnderTest.getDestination(), equalTo(null));
         assertThat(objectUnderTest.getPointer(), equalTo(null));
         assertThat(objectUnderTest.getTagsOnFailure(), equalTo(null));
+        assertThat(objectUnderTest.getOverwriteIfKeyExists(), equalTo(true));
     }
 
     @Nested

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorTest.java
@@ -52,7 +52,7 @@ class ParseJsonProcessorTest {
         when(processorConfig.getDestination()).thenReturn(defaultConfig.getDestination());
         when(processorConfig.getPointer()).thenReturn(defaultConfig.getPointer());
         when(processorConfig.getParseWhen()).thenReturn(null);
-        when(processorConfig.getOverwriteIfKeyExists()).thenReturn(true);
+        when(processorConfig.getOverwriteIfDestinationExists()).thenReturn(true);
     }
 
     private ParseJsonProcessor createObjectUnderTest() {
@@ -99,7 +99,7 @@ class ParseJsonProcessorTest {
     void test_when_dataFieldEqualToRootField_then_notOverwritesOriginalFields() {
         final String source = "root_source";
         when(processorConfig.getSource()).thenReturn(source);
-        when(processorConfig.getOverwriteIfKeyExists()).thenReturn(false);
+        when(processorConfig.getOverwriteIfDestinationExists()).thenReturn(false);
         parseJsonProcessor = createObjectUnderTest(); // need to recreate so that new config options are used
 
         final Map<String, Object> data = Map.ofEntries(
@@ -119,7 +119,7 @@ class ParseJsonProcessorTest {
         final String source = "root_source";
         when(processorConfig.getSource()).thenReturn(source);
         when(processorConfig.getDestination()).thenReturn(source);  // write back to source
-        when(processorConfig.getOverwriteIfKeyExists()).thenReturn(false);
+        when(processorConfig.getOverwriteIfDestinationExists()).thenReturn(false);
         parseJsonProcessor = createObjectUnderTest(); // need to recreate so that new config options are used
 
         final Map<String, Object> data = Map.of("key","value");

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorTest.java
@@ -52,6 +52,7 @@ class ParseJsonProcessorTest {
         when(processorConfig.getDestination()).thenReturn(defaultConfig.getDestination());
         when(processorConfig.getPointer()).thenReturn(defaultConfig.getPointer());
         when(processorConfig.getParseWhen()).thenReturn(null);
+        when(processorConfig.getOverwriteIfKeyExists()).thenReturn(true);
     }
 
     private ParseJsonProcessor createObjectUnderTest() {
@@ -92,6 +93,42 @@ class ParseJsonProcessorTest {
 
         assertThatKeyEquals(parsedEvent, source, "value_that_will_overwrite_source");
         assertThatKeyEquals(parsedEvent, "key", "value");
+    }
+
+    @Test
+    void test_when_dataFieldEqualToRootField_then_notOverwritesOriginalFields() {
+        final String source = "root_source";
+        when(processorConfig.getSource()).thenReturn(source);
+        when(processorConfig.getOverwriteIfKeyExists()).thenReturn(false);
+        parseJsonProcessor = createObjectUnderTest(); // need to recreate so that new config options are used
+
+        final Map<String, Object> data = Map.ofEntries(
+                entry(source,"value_that_will_overwrite_source"),
+                entry("key","value")
+        );
+
+        final String serializedMessage = convertMapToJSONString(data);
+        final Event parsedEvent = createAndParseMessageEvent(serializedMessage);
+
+        assertThatKeyEquals(parsedEvent, source, "{\"root_source\":\"value_that_will_overwrite_source\", \"key\":\"value\"}");
+        assertThatKeyEquals(parsedEvent, "key", "value");
+    }
+
+    @Test
+    void test_when_dataFieldEqualToDestinationField_then_notOverwritesOriginalFields() {
+        final String source = "root_source";
+        when(processorConfig.getSource()).thenReturn(source);
+        when(processorConfig.getDestination()).thenReturn(source);  // write back to source
+        when(processorConfig.getOverwriteIfKeyExists()).thenReturn(false);
+        parseJsonProcessor = createObjectUnderTest(); // need to recreate so that new config options are used
+
+        final Map<String, Object> data = Map.of("key","value");
+
+        final String serializedMessage = convertMapToJSONString(data);
+        final Event parsedEvent = createAndParseMessageEvent(serializedMessage);
+
+        assertThatKeyEquals(parsedEvent, source, "{\"key\":\"value\"}");
+        assertThat(parsedEvent.containsKey("key"), equalTo(false));
     }
 
     @Test

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/parsejson/ParseJsonProcessorTest.java
@@ -102,16 +102,12 @@ class ParseJsonProcessorTest {
         when(processorConfig.getOverwriteIfDestinationExists()).thenReturn(false);
         parseJsonProcessor = createObjectUnderTest(); // need to recreate so that new config options are used
 
-        final Map<String, Object> data = Map.ofEntries(
-                entry(source,"value_that_will_overwrite_source"),
-                entry("key","value")
-        );
+        final Map<String, Object> data = Map.of(source,"value_that_will_not_be_overwritten");
 
         final String serializedMessage = convertMapToJSONString(data);
         final Event parsedEvent = createAndParseMessageEvent(serializedMessage);
 
-        assertThatKeyEquals(parsedEvent, source, "{\"root_source\":\"value_that_will_overwrite_source\", \"key\":\"value\"}");
-        assertThatKeyEquals(parsedEvent, "key", "value");
+        assertThatKeyEquals(parsedEvent, source, "{\"root_source\":\"value_that_will_not_be_overwritten\"}");
     }
 
     @Test


### PR DESCRIPTION
### Description
Fixes #3184 by:
- Catch ClassCastException in JacksonOtelLog.toJsonString()
- Add `overwrite_if_exists` option to parse-json processor. It defaults to true to avoid breaking change. Set it to false will prevent fields from being overwritten by the processor.
 
### Issues Resolved
Resolves #3184
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
