### PR TITLE
Nullable values/schemas in Avro and Parquet output codecs

### DIFF
--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/AvroAutoSchemaGenerator.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/AvroAutoSchemaGenerator.java
@@ -1,0 +1,91 @@
+package org.opensearch.dataprepper.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generates an Avro schema from Event data.
+ */
+public class AvroAutoSchemaGenerator {
+    public Schema autoDetermineSchema(final Map<String, Object> data,
+                                      final OutputCodecContext outputCodecContext) {
+        return autoGenerateRecordSchema(data, outputCodecContext, "Event");
+    }
+
+    private Schema autoGenerateRecordSchema(final Map<String, Object> eventData, OutputCodecContext codecContext, String typeName) {
+        SchemaBuilder.FieldAssembler<Schema> fieldsAssembler = SchemaBuilder.record(typeName).fields();
+        for (final String key : eventData.keySet()) {
+            if (codecContext != null && codecContext.getExcludeKeys().contains(key)) {
+                continue;
+            }
+            Schema schemaForValue = createSchemaForValue(key, eventData.get(key), codecContext);
+            fieldsAssembler = fieldsAssembler.name(key).type().unionOf()
+                    .nullType()
+                    .and()
+                    .type(schemaForValue)
+                    .endUnion()
+                    .nullDefault();
+        }
+        return fieldsAssembler.endRecord();
+    }
+
+
+    private Schema createSchemaForValue(String key, final Object value, OutputCodecContext codecContext) {
+        if(value == null)
+            throw new SchemaGenerationException("Unable to auto-generate a schema because a provided value is null. key='" + key + "'.");
+        if (value instanceof String) {
+            return SchemaBuilder.builder().stringType();
+        } else if (value instanceof Long) {
+            return SchemaBuilder.builder().longType();
+        } else if (value instanceof Integer) {
+            return SchemaBuilder.builder().intType();
+        } else if (value instanceof Float) {
+            return SchemaBuilder.builder().floatType();
+        } else if (value instanceof Double) {
+            return SchemaBuilder.builder().doubleType();
+        } else if (value instanceof Boolean) {
+            return SchemaBuilder.builder().booleanType();
+        } else if (value instanceof Byte[] || value instanceof byte[]) {
+            return SchemaBuilder.builder().bytesType();
+        } else if (value instanceof Map) {
+            return autoGenerateRecordSchema((Map<String, Object>) value, codecContext, convertFieldNameToTypeName(key));
+        } else if (value instanceof List) {
+            List<?> listProvided = (List<?>) value;
+            if(listProvided.isEmpty()) {
+                throw new SchemaGenerationException("Cannot determine the element type for the Avro array because a provided list is empty and has no type information. key='" + key + "'.");
+            }
+            Object sampleElement = listProvided.get(0);
+            return SchemaBuilder.builder()
+                    .array()
+                    .items(nullableType(createSchemaForValue(null, sampleElement, codecContext)));
+        }
+        throw new SchemaGenerationException("Unable to auto-generate a schema for field '" +
+                key +
+                "' because the the type '" + value.getClass() + "' is not a recognized type for auto-generation.");
+    }
+
+    private Schema nullableType(Schema schema) {
+        return SchemaBuilder.unionOf()
+                .nullType()
+                .and()
+                .type(schema)
+                .endUnion();
+    }
+
+    private String convertFieldNameToTypeName(String fieldName) {
+        char startCharacter = fieldName.charAt(0);
+        if(Character.isAlphabetic(startCharacter)) {
+            startCharacter = Character.toUpperCase(startCharacter);
+        }
+
+        char[] typeChars = new char[fieldName.length()];
+        typeChars[0] = startCharacter;
+        fieldName.getChars(1, fieldName.length(), typeChars, 1);
+        return new String(typeChars);
+    }
+
+}

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/AvroEventConverter.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/AvroEventConverter.java
@@ -1,0 +1,58 @@
+package org.opensearch.dataprepper.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Converts an Event into an Avro record.
+ * <p>
+ * It might be a good idea to consolidate similar logic for input.
+ */
+public class AvroEventConverter {
+
+    private final SchemaChooser schemaChooser;
+
+    public AvroEventConverter() {
+        schemaChooser = new SchemaChooser();
+    }
+
+    public GenericRecord convertEventDataToAvro(final Schema schema,
+                                                final Map<String, Object> eventData,
+                                                OutputCodecContext codecContext) {
+        final GenericRecord avroRecord = new GenericData.Record(schema);
+        final boolean isExcludeKeyAvailable = !codecContext.getExcludeKeys().isEmpty();
+        for (final String key : eventData.keySet()) {
+            if (isExcludeKeyAvailable && codecContext.getExcludeKeys().contains(key)) {
+                continue;
+            }
+            final Schema.Field field = schema.getField(key);
+            if (field == null) {
+                throw new RuntimeException("The event has a key ('" + key + "') which is not included in the schema.");
+            }
+            final Object value = schemaMapper(field, eventData.get(key), codecContext);
+            avroRecord.put(key, value);
+        }
+        return avroRecord;
+    }
+
+    private Object schemaMapper(final Schema.Field field, final Object rawValue, OutputCodecContext codecContext) {
+        Schema providedSchema = schemaChooser.chooseSchema(field.schema());
+
+        if (providedSchema.getType() == Schema.Type.RECORD && rawValue instanceof Map) {
+            return convertEventDataToAvro(providedSchema, (Map<String, Object>) rawValue, codecContext);
+        } else if (providedSchema.getType() == Schema.Type.ARRAY && rawValue instanceof List) {
+            GenericData.Array<String> avroArray =
+                    new GenericData.Array<>(((List<String>) rawValue).size(), providedSchema);
+            for (String element : ((List<String>) rawValue)) {
+                avroArray.add(element);
+            }
+            return avroArray;
+        }
+        return rawValue;
+    }
+}

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/SchemaChooser.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/SchemaChooser.java
@@ -1,0 +1,21 @@
+package org.opensearch.dataprepper.avro;
+
+import org.apache.avro.Schema;
+
+class SchemaChooser {
+    Schema chooseSchema(Schema providedSchema) {
+        if(providedSchema.isNullable()) {
+            return getFirstNonNullable(providedSchema);
+        }
+
+        return providedSchema;
+    }
+
+    private Schema getFirstNonNullable(Schema providedSchema) {
+        return providedSchema.getTypes()
+                .stream()
+                .filter(s -> s.getType() != Schema.Type.NULL)
+                .findFirst()
+                .orElse(providedSchema);
+    }
+}

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/SchemaGenerationException.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/SchemaGenerationException.java
@@ -1,0 +1,7 @@
+package org.opensearch.dataprepper.avro;
+
+public class SchemaGenerationException extends RuntimeException {
+    SchemaGenerationException(String message) {
+        super(message);
+    }
+}

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodec.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodec.java
@@ -6,10 +6,11 @@ package org.opensearch.dataprepper.plugins.codec.avro;
 
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileWriter;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
+import org.opensearch.dataprepper.avro.AvroAutoSchemaGenerator;
+import org.opensearch.dataprepper.avro.AvroEventConverter;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
@@ -20,9 +21,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -32,14 +30,12 @@ import java.util.Objects;
  */
 @DataPrepperPlugin(name = "avro", pluginType = OutputCodec.class, pluginConfigurationType = AvroOutputCodecConfig.class)
 public class AvroOutputCodec implements OutputCodec {
-
-    private static final List<String> PRIMITIVE_TYPES = Arrays.asList("int", "long", "string", "float", "double", "bytes");
     private static final Logger LOG = LoggerFactory.getLogger(AvroOutputCodec.class);
     private static final String AVRO = "avro";
-    private static final String BASE_SCHEMA_STRING = "{\"type\":\"record\",\"name\":\"AvroRecords\",\"fields\":[";
-    private static final String END_SCHEMA_STRING = "]}";
 
     private final AvroOutputCodecConfig config;
+    private final AvroEventConverter avroEventConverter;
+    private final AvroAutoSchemaGenerator avroAutoSchemaGenerator;
     private DataFileWriter<GenericRecord> dataFileWriter;
 
     private Schema schema;
@@ -50,6 +46,9 @@ public class AvroOutputCodec implements OutputCodec {
     public AvroOutputCodec(final AvroOutputCodecConfig config) {
         Objects.requireNonNull(config);
         this.config = config;
+
+        avroEventConverter = new AvroEventConverter();
+        avroAutoSchemaGenerator = new AvroAutoSchemaGenerator();
 
         if (config.getSchema() != null) {
             schema = parseSchema(config.getSchema());
@@ -76,64 +75,14 @@ public class AvroOutputCodec implements OutputCodec {
     }
 
     public Schema buildInlineSchemaFromEvent(final Event event) throws IOException {
+        final Map<String, Object> data;
         if (codecContext != null && codecContext.getTagsTargetKey() != null) {
-            return parseSchema(buildSchemaStringFromEventMap(addTagsToEvent(event, codecContext.getTagsTargetKey()).toMap(), false));
+            data = addTagsToEvent(event, codecContext.getTagsTargetKey()).toMap();
         } else {
-            return parseSchema(buildSchemaStringFromEventMap(event.toMap(), false));
+            data = event.toMap();
         }
-    }
 
-    private String buildSchemaStringFromEventMap(final Map<String, Object> eventData, boolean nestedRecordFlag) {
-        final StringBuilder builder = new StringBuilder();
-        int nestedRecordIndex = 1;
-        if (!nestedRecordFlag) {
-            builder.append(BASE_SCHEMA_STRING);
-        } else {
-            builder.append("{\"type\":\"record\",\"name\":\"" + "NestedRecord" + nestedRecordIndex + "\",\"fields\":[");
-            nestedRecordIndex++;
-        }
-        String fields;
-        int index = 0;
-        for (final String key : eventData.keySet()) {
-            if (codecContext != null && codecContext.getExcludeKeys().contains(key)) {
-                continue;
-            }
-            if (index == 0) {
-                if (!(eventData.get(key) instanceof Map)) {
-                    fields = "{\"name\":\"" + key + "\",\"type\":\"" + typeMapper(eventData.get(key)) + "\"}";
-                } else {
-                    fields = "{\"name\":\"" + key + "\",\"type\":" + typeMapper(eventData.get(key)) + "}";
-                }
-            } else {
-                if (!(eventData.get(key) instanceof Map)) {
-                    fields = "," + "{\"name\":\"" + key + "\",\"type\":\"" + typeMapper(eventData.get(key)) + "\"}";
-                } else {
-                    fields = "," + "{\"name\":\"" + key + "\",\"type\":" + typeMapper(eventData.get(key)) + "}";
-                }
-            }
-            builder.append(fields);
-            index++;
-        }
-        builder.append(END_SCHEMA_STRING);
-        return builder.toString();
-    }
-
-    private String typeMapper(final Object value) {
-        if (value instanceof Integer || value.getClass().equals(int.class)) {
-            return "int";
-        } else if (value instanceof Float || value.getClass().equals(float.class)) {
-            return "float";
-        } else if (value instanceof Double || value.getClass().equals(double.class)) {
-            return "double";
-        } else if (value instanceof Long || value.getClass().equals(long.class)) {
-            return "long";
-        } else if (value instanceof Byte[]) {
-            return "bytes";
-        } else if (value instanceof Map) {
-            return buildSchemaStringFromEventMap((Map<String, Object>) value, true);
-        } else {
-            return "string";
-        }
+        return avroAutoSchemaGenerator.autoDetermineSchema(data, codecContext);
     }
 
     @Override
@@ -145,13 +94,14 @@ public class AvroOutputCodec implements OutputCodec {
     @Override
     public void writeEvent(final Event event, final OutputStream outputStream) throws IOException {
         Objects.requireNonNull(event);
+        final Map<String, Object> data;
         if (codecContext.getTagsTargetKey() != null) {
-            final GenericRecord avroRecord = buildAvroRecord(schema, addTagsToEvent(event, codecContext.getTagsTargetKey()).toMap());
-            dataFileWriter.append(avroRecord);
+            data = addTagsToEvent(event, codecContext.getTagsTargetKey()).toMap();
         } else {
-            final GenericRecord avroRecord = buildAvroRecord(schema, event.toMap());
-            dataFileWriter.append(avroRecord);
+            data = event.toMap();
         }
+        final GenericRecord avroRecord = avroEventConverter.convertEventDataToAvro(schema, data, codecContext);
+        dataFileWriter.append(avroRecord);
     }
 
     @Override
@@ -167,65 +117,6 @@ public class AvroOutputCodec implements OutputCodec {
             LOG.error("Unable to parse Schema from Schema String provided.", e);
             throw new RuntimeException("There is an error in the schema: " + e.getMessage());
         }
-    }
-
-    private GenericRecord buildAvroRecord(final Schema schema, final Map<String, Object> eventData) {
-        final GenericRecord avroRecord = new GenericData.Record(schema);
-        final boolean isExcludeKeyAvailable = !codecContext.getExcludeKeys().isEmpty();
-        for (final String key : eventData.keySet()) {
-            if (isExcludeKeyAvailable && codecContext.getExcludeKeys().contains(key)) {
-                continue;
-            }
-            final Schema.Field field = schema.getField(key);
-            if (field == null) {
-                throw new RuntimeException("The event has a key ('" + key + "') which is not included in the schema.");
-            }
-            final Object value = schemaMapper(field, eventData.get(key));
-            avroRecord.put(key, value);
-        }
-        return avroRecord;
-    }
-
-    private Object schemaMapper(final Schema.Field field, final Object rawValue) {
-        Object finalValue = null;
-        final String fieldType = field.schema().getType().name().toLowerCase();
-        if (PRIMITIVE_TYPES.contains(fieldType)) {
-            switch (fieldType) {
-                case "string":
-                    finalValue = rawValue.toString();
-                    break;
-                case "int":
-                    finalValue = Integer.parseInt(rawValue.toString());
-                    break;
-                case "float":
-                    finalValue = Float.parseFloat(rawValue.toString());
-                    break;
-                case "double":
-                    finalValue = Double.parseDouble(rawValue.toString());
-                    break;
-                case "long":
-                    finalValue = Long.parseLong(rawValue.toString());
-                    break;
-                case "bytes":
-                    finalValue = rawValue.toString().getBytes(StandardCharsets.UTF_8);
-                    break;
-                default:
-                    LOG.error("Unrecognised Field name : '{}' & type : '{}'", field.name(), fieldType);
-                    break;
-            }
-        } else {
-            if (fieldType.equals("record") && rawValue instanceof Map) {
-                finalValue = buildAvroRecord(field.schema(), (Map<String, Object>) rawValue);
-            } else if (fieldType.equals("array") && rawValue instanceof List) {
-                GenericData.Array<String> avroArray =
-                        new GenericData.Array<>(((List<String>) rawValue).size(), field.schema());
-                for (String element : ((List<String>) rawValue)) {
-                    avroArray.add(element);
-                }
-                finalValue = avroArray;
-            }
-        }
-        return finalValue;
     }
 
     private boolean checkS3SchemaValidity() {

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/AvroAutoSchemaGeneratorTest.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/AvroAutoSchemaGeneratorTest.java
@@ -1,0 +1,201 @@
+package org.opensearch.dataprepper.avro;
+
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.Mock;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+
+class AvroAutoSchemaGeneratorTest {
+    @Mock
+    private OutputCodecContext outputCodecContext;
+
+    private AvroAutoSchemaGenerator createObjectUnderTest() {
+        return new AvroAutoSchemaGenerator();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+    void autoDetermineSchema_with_primitive_type_returns_nullable_of_that_type(Object value, Schema.Type expectedType) {
+        String key = randomAvroName();
+
+        Schema schema = createObjectUnderTest().autoDetermineSchema(Map.of(key, value), outputCodecContext);
+
+        assertThat(schema, notNullValue());
+        assertThat(schema.getName(), equalTo("Event"));
+        assertThat(schema.getFields(), notNullValue());
+        assertThat(schema.getFields().size(), equalTo(1));
+        Schema.Field field = schema.getField(key);
+        assertThat(field, notNullValue());
+        assertThat(field.defaultVal(), equalTo(Schema.NULL_VALUE));
+        assertThat(field.schema(), notNullValue());
+        assertThat(field.schema().isNullable(), equalTo(true));
+        assertThat(field.schema().isUnion(), equalTo(true));
+        assertThat(field.schema().getTypes(), notNullValue());
+        assertThat(field.schema().getTypes().size(), equalTo(2));
+        assertThat(field.schema().getTypes().get(0), notNullValue());
+        assertThat(field.schema().getTypes().get(0).getType(), equalTo(Schema.Type.NULL));
+        assertThat(field.schema().getTypes().get(1), notNullValue());
+        assertThat(field.schema().getTypes().get(1).getType(), equalTo(expectedType));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+    void autoDetermineSchema_with_map_returns_nullable_record_with_nullable_primitives(Object primitiveType, Schema.Type expectedType) {
+        String recordKey = randomAvroName();
+        String innerKey = randomAvroName();
+
+        Map<String, Object> inputMap = Map.of(recordKey, Map.of(innerKey, primitiveType));
+        Schema actualEventSchema = createObjectUnderTest().autoDetermineSchema(inputMap, outputCodecContext);
+
+        assertThat(actualEventSchema, notNullValue());
+        assertThat(actualEventSchema.getName(), equalTo("Event"));
+        assertThat(actualEventSchema.getFields(), notNullValue());
+        assertThat(actualEventSchema.getFields().size(), equalTo(1));
+        Schema.Field field = actualEventSchema.getField(recordKey);
+        assertThat(field, notNullValue());
+        assertThat(field.defaultVal(), equalTo(Schema.NULL_VALUE));
+        assertThat(field.schema(), notNullValue());
+        assertThat(field.schema().isNullable(), equalTo(true));
+        assertThat(field.schema().isUnion(), equalTo(true));
+        assertThat(field.schema().getTypes(), notNullValue());
+        assertThat(field.schema().getTypes().size(), equalTo(2));
+        assertThat(field.schema().getTypes().get(0), notNullValue());
+        assertThat(field.schema().getTypes().get(0).getType(), equalTo(Schema.Type.NULL));
+        Schema actualRecordSchema = field.schema().getTypes().get(1);
+        assertThat(actualRecordSchema, notNullValue());
+        assertThat(actualRecordSchema.getType(), equalTo(Schema.Type.RECORD));
+
+        assertThat(actualRecordSchema, notNullValue());
+        assertThat(actualRecordSchema.getName(), equalTo(recordKey.replaceFirst("a", "A")));
+        assertThat(actualRecordSchema.getFields(), notNullValue());
+        assertThat(actualRecordSchema.getFields().size(), equalTo(1));
+        Schema.Field actualInnerField = actualRecordSchema.getField(innerKey);
+        assertThat(actualInnerField, notNullValue());
+        assertThat(actualInnerField.defaultVal(), equalTo(Schema.NULL_VALUE));
+        assertThat(actualInnerField.schema(), notNullValue());
+        assertThat(actualInnerField.schema().isNullable(), equalTo(true));
+        assertThat(actualInnerField.schema().isUnion(), equalTo(true));
+        assertThat(actualInnerField.schema().getTypes(), notNullValue());
+        assertThat(actualInnerField.schema().getTypes().size(), equalTo(2));
+        assertThat(actualInnerField.schema().getTypes().get(0), notNullValue());
+        assertThat(actualInnerField.schema().getTypes().get(0).getType(), equalTo(Schema.Type.NULL));
+        assertThat(actualInnerField.schema().getTypes().get(1), notNullValue());
+        assertThat(actualInnerField.schema().getTypes().get(1).getType(), equalTo(expectedType));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+    void autoDetermineSchema_with_list_returns_nullable_array_with_nullable_primitives(Object primitiveType, Schema.Type expectedType) {
+        String arrayKey = randomAvroName();
+
+        Map<String, Object> inputMap = Map.of(arrayKey, List.of(primitiveType));
+        Schema actualEventSchema = createObjectUnderTest().autoDetermineSchema(inputMap, outputCodecContext);
+
+        assertThat(actualEventSchema, notNullValue());
+        assertThat(actualEventSchema.getName(), equalTo("Event"));
+        assertThat(actualEventSchema.getFields(), notNullValue());
+        assertThat(actualEventSchema.getFields().size(), equalTo(1));
+        Schema.Field field = actualEventSchema.getField(arrayKey);
+        assertThat(field, notNullValue());
+        assertThat(field.defaultVal(), equalTo(Schema.NULL_VALUE));
+        assertThat(field.schema(), notNullValue());
+        assertThat(field.schema().isNullable(), equalTo(true));
+        assertThat(field.schema().isUnion(), equalTo(true));
+        assertThat(field.schema().getTypes(), notNullValue());
+        assertThat(field.schema().getTypes().size(), equalTo(2));
+        assertThat(field.schema().getTypes().get(0), notNullValue());
+        assertThat(field.schema().getTypes().get(0).getType(), equalTo(Schema.Type.NULL));
+        Schema actualArraySchema = field.schema().getTypes().get(1);
+        assertThat(actualArraySchema, notNullValue());
+        assertThat(actualArraySchema.getType(), equalTo(Schema.Type.ARRAY));
+
+        assertThat(actualArraySchema, notNullValue());
+        Schema actualElementType = actualArraySchema.getElementType();
+        assertThat(actualElementType, notNullValue());
+        assertThat(actualElementType.isNullable(), equalTo(true));
+        assertThat(actualElementType.isUnion(), equalTo(true));
+        assertThat(actualElementType.getTypes(), notNullValue());
+        assertThat(actualElementType.getTypes().size(), equalTo(2));
+        assertThat(actualElementType.getTypes().get(0), notNullValue());
+        assertThat(actualElementType.getTypes().get(0).getType(), equalTo(Schema.Type.NULL));
+        assertThat(actualElementType.getTypes().get(1), notNullValue());
+        assertThat(actualElementType.getTypes().get(1).getType(), equalTo(expectedType));
+    }
+
+    @Test
+    void autoDetermineSchema_with_empty_list_throws() {
+        String arrayKey = randomAvroName();
+
+        Map<String, Object> inputMap = Map.of(arrayKey, List.of());
+        AvroAutoSchemaGenerator objectUnderTest = createObjectUnderTest();
+        SchemaGenerationException actualException = assertThrows(SchemaGenerationException.class, () -> objectUnderTest.autoDetermineSchema(inputMap, outputCodecContext));
+
+        assertThat(actualException.getMessage(), notNullValue());
+        assertThat(actualException.getMessage(), containsString(arrayKey));
+    }
+
+    @Test
+    void autoDetermineSchema_with_null_value_throws() {
+        String fieldKey = randomAvroName();
+
+        Map<String, Object> inputMap = Collections.singletonMap(fieldKey, null);
+        AvroAutoSchemaGenerator objectUnderTest = createObjectUnderTest();
+        SchemaGenerationException actualException = assertThrows(SchemaGenerationException.class, () -> objectUnderTest.autoDetermineSchema(inputMap, outputCodecContext));
+
+        assertThat(actualException.getMessage(), notNullValue());
+        assertThat(actualException.getMessage(), containsString(fieldKey));
+        assertThat(actualException.getMessage(), containsString("null"));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SomeUnknownTypesArgumentsProvider.class)
+    void autoDetermineSchema_with_unknown_type_throws(Class<?> unknownType) {
+        Object value = mock(unknownType);
+        String fieldKey = randomAvroName();
+
+        AvroAutoSchemaGenerator objectUnderTest = createObjectUnderTest();
+        Map<String, Object> inputMap = Map.of(fieldKey, value);
+        SchemaGenerationException actualException = assertThrows(SchemaGenerationException.class, () -> objectUnderTest.autoDetermineSchema(inputMap, outputCodecContext));
+
+        assertThat(actualException.getMessage(), notNullValue());
+        assertThat(actualException.getMessage(), containsString(fieldKey));
+        assertThat(actualException.getMessage(), containsString(value.getClass().toString()));
+    }
+
+    static class SomeUnknownTypesArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    arguments(Random.class),
+                    arguments(InputStream.class),
+                    arguments(File.class)
+            );
+        }
+    }
+
+    private static String randomAvroName() {
+        return "a" + UUID.randomUUID().toString().replaceAll("-", "");
+    }
+}

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/AvroEventConverterTest.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/AvroEventConverterTest.java
@@ -1,0 +1,53 @@
+package org.opensearch.dataprepper.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AvroEventConverterTest {
+    @Mock
+    private Schema schema;
+
+    @Mock
+    private OutputCodecContext codecContext;
+
+    @BeforeEach
+    void setUp() {
+        when(schema.getType()).thenReturn(Schema.Type.RECORD);
+    }
+
+    private AvroEventConverter createObjectUnderTest() {
+        return new AvroEventConverter();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+    void convertEventDataToAvro_does_not_need_to_getField_on_empty_map() {
+        Map<String, Object> data = Collections.emptyMap();
+        GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+        assertThat(actualRecord, notNullValue());
+        assertThat(actualRecord.getSchema(), equalTo(schema));
+
+        verify(schema, never()).getField(anyString());
+    }
+
+}

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/PrimitiveClassesToTypesArgumentsProvider.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/PrimitiveClassesToTypesArgumentsProvider.java
@@ -1,0 +1,31 @@
+package org.opensearch.dataprepper.avro;
+
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class PrimitiveClassesToTypesArgumentsProvider implements ArgumentsProvider {
+    private static final Random RANDOM = new Random();
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        byte[] bytes = new byte[10];
+        RANDOM.nextBytes(bytes);
+        return Stream.of(
+                arguments(UUID.randomUUID().toString(), Schema.Type.STRING),
+                arguments(RANDOM.nextInt(10_000), Schema.Type.INT),
+                arguments(RANDOM.nextLong(), Schema.Type.LONG),
+                arguments(RANDOM.nextFloat(), Schema.Type.FLOAT),
+                arguments(RANDOM.nextDouble(), Schema.Type.DOUBLE),
+                arguments(RANDOM.nextBoolean(), Schema.Type.BOOLEAN),
+                arguments(bytes, Schema.Type.BYTES)
+        );
+    }
+}

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/SchemaChooserTest.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/SchemaChooserTest.java
@@ -1,0 +1,130 @@
+package org.opensearch.dataprepper.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@ExtendWith(MockitoExtension.class)
+class SchemaChooserTest {
+    private SchemaChooser createObjectUnderTest() {
+        return new SchemaChooser();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PrimitiveTypesArgumentsProvider.class)
+    void chooseSchema_should_return_non_nullable_when_nullable_with_primitives(Schema.Type primitiveType) {
+        Schema innerSchema = SchemaBuilder.builder().type(primitiveType.getName());
+        Schema schema = SchemaBuilder
+                .nullable()
+                .type(innerSchema);
+
+        Schema actualSchema = createObjectUnderTest().chooseSchema(schema);
+        assertThat(actualSchema, notNullValue());
+        assertThat(actualSchema.getType(), equalTo(primitiveType));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PrimitiveTypesArgumentsProvider.class)
+    void chooseSchema_should_return_non_nullable_when_nullable_with_record(Schema.Type fieldType) {
+        Schema innerSchema = SchemaBuilder.builder().record(randomAvroName())
+                .fields()
+                .name(randomAvroName()).type(fieldType.getName()).noDefault()
+                .endRecord();
+        Schema schema = SchemaBuilder
+                .nullable()
+                .type(innerSchema);
+
+        Schema actualSchema = createObjectUnderTest().chooseSchema(schema);
+        assertThat(actualSchema, notNullValue());
+        assertThat(actualSchema.getType(), equalTo(Schema.Type.RECORD));
+        assertThat(actualSchema.getName(), equalTo(innerSchema.getName()));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PrimitiveTypesArgumentsProvider.class)
+    void chooseSchema_should_return_non_nullable_when_nullable_with_array(Schema.Type itemType) {
+        Schema innerSchema = SchemaBuilder.builder()
+                .array()
+                .items(SchemaBuilder.builder().type(itemType.getName()));
+
+        Schema schema = SchemaBuilder
+                .nullable()
+                .type(innerSchema);
+
+        Schema actualSchema = createObjectUnderTest().chooseSchema(schema);
+        assertThat(actualSchema, notNullValue());
+        assertThat(actualSchema.getType(), equalTo(Schema.Type.ARRAY));
+        assertThat(actualSchema.getElementType(), notNullValue());
+        assertThat(actualSchema.getElementType().getType(), equalTo(itemType));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PrimitiveTypesArgumentsProvider.class)
+    void chooseSchema_with_non_nullable_returns_input_with_non_nullable_primitive_types(Schema.Type primitiveType) {
+        Schema inputSchema = SchemaBuilder.builder().type(primitiveType.getName());
+
+        Schema actualSchema = createObjectUnderTest().chooseSchema(inputSchema);
+        assertThat(actualSchema, notNullValue());
+        assertThat(actualSchema.getType(), equalTo(primitiveType));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PrimitiveTypesArgumentsProvider.class)
+    void chooseSchema_with_non_nullable_returns_input_with_non_nullable_record(Schema.Type fieldType) {
+        Schema schema = SchemaBuilder.builder().record(randomAvroName())
+                .fields()
+                .name(randomAvroName()).type(fieldType.getName()).noDefault()
+                .endRecord();
+
+        Schema actualSchema = createObjectUnderTest().chooseSchema(schema);
+        assertThat(actualSchema, equalTo(schema));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PrimitiveTypesArgumentsProvider.class)
+    void chooseSchema_with_non_nullable_returns_input_with_non_nullable_array(Schema.Type itemType) {
+        Schema schema = SchemaBuilder.builder()
+                .array()
+                .items(SchemaBuilder.builder().type(itemType.getName()));
+
+
+        Schema actualSchema = createObjectUnderTest().chooseSchema(schema);
+        assertThat(actualSchema, notNullValue());
+        assertThat(actualSchema.getType(), equalTo(Schema.Type.ARRAY));
+        assertThat(actualSchema.getElementType(), notNullValue());
+        assertThat(actualSchema.getElementType().getType(), equalTo(itemType));
+    }
+
+    private static String randomAvroName() {
+        return "a" + UUID.randomUUID().toString().replaceAll("-", "");
+    }
+
+    static class PrimitiveTypesArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    arguments(Schema.Type.STRING),
+                    arguments(Schema.Type.INT),
+                    arguments(Schema.Type.LONG),
+                    arguments(Schema.Type.FLOAT),
+                    arguments(Schema.Type.DOUBLE),
+                    arguments(Schema.Type.BOOLEAN),
+                    arguments(Schema.Type.BYTES)
+            );
+        }
+    }
+}

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodecTest.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodecTest.java
@@ -7,23 +7,21 @@ package org.opensearch.dataprepper.plugins.codec.avro;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileStream;
+import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.log.JacksonLog;
-import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,29 +29,35 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class AvroOutputCodecTest {
-    private static final String EXPECTED_SCHEMA_STRING = "{\"type\":\"record\",\"name\":\"AvroRecords\",\"fields\":[{\"name\"" +
-            ":\"name\",\"type\":\"string\"},{\"name\":\"nestedRecord\",\"type\":{\"type\":\"record\",\"name\":" +
-            "\"NestedRecord1\",\"fields\":[{\"name\":\"secondFieldInNestedRecord\",\"type\":\"int\"},{\"name\":\"" +
-            "firstFieldInNestedRecord\",\"type\":\"string\"}]}},{\"name\":\"age\",\"type\":\"int\"}]}";
+    private static final String EXPECTED_SCHEMA_STRING = "{\"type\":\"record\",\"name\":\"Event\",\"fields\":" +
+            "[{\"name\":\"myDouble\",\"type\":[\"null\",\"double\"],\"default\":null},{\"name\":\"myLong\",\"type\":[\"null\",\"long\"],\"default\":null}," +
+            "{\"name\":\"myArray\",\"type\":[\"null\",{\"type\":\"array\",\"items\":[\"null\",\"string\"]}],\"default\":null}," +
+            "{\"name\":\"name\",\"type\":[\"null\",\"string\"],\"default\":null}," +
+            "{\"name\":\"nestedRecord\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"NestedRecord\",\"fields\":[{\"name\":\"secondFieldInNestedRecord\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"firstFieldInNestedRecord\",\"type\":[\"null\",\"string\"],\"default\":null}]}],\"default\":null}," +
+            "{\"name\":\"age\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"myFloat\",\"type\":[\"null\",\"float\"],\"default\":null}]}";
+    public static final int TOTAL_TOP_LEVEL_FIELDS = 7;
     private AvroOutputCodecConfig config;
 
     private ByteArrayOutputStream outputStream;
 
-    private static int numberOfRecords;
-
     @BeforeEach
     void setUp() {
         config = new AvroOutputCodecConfig();
-        config.setSchema(parseSchema().toString());
+        config.setSchema(createStandardSchema().toString());
     }
 
     private AvroOutputCodec createObjectUnderTest() {
@@ -62,7 +66,7 @@ public class AvroOutputCodecTest {
 
     @Test
     void constructor_throws_if_schema_is_invalid() {
-        String invalidSchema = parseSchema().toString().replaceAll(",", ";");
+        String invalidSchema = createStandardSchema().toString().replaceAll(",", ";");
         config.setSchema(invalidSchema);
 
         RuntimeException actualException = assertThrows(RuntimeException.class, this::createObjectUnderTest);
@@ -75,37 +79,130 @@ public class AvroOutputCodecTest {
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 10, 100})
     void test_happy_case(final int numberOfRecords) throws Exception {
-        AvroOutputCodecTest.numberOfRecords = numberOfRecords;
         AvroOutputCodec avroOutputCodec = createObjectUnderTest();
         outputStream = new ByteArrayOutputStream();
         OutputCodecContext codecContext = new OutputCodecContext();
         avroOutputCodec.start(outputStream, null, codecContext);
-        for (int index = 0; index < numberOfRecords; index++) {
-            final Event event = getRecord(index).getData();
+        List<Map<String, Object>> inputMaps = generateRecords(numberOfRecords);
+        for (Map<String, Object> inputMap : inputMaps) {
+            final Event event = createEventRecord(inputMap);
             avroOutputCodec.writeEvent(event, outputStream);
         }
         avroOutputCodec.complete(outputStream);
-        List<GenericRecord> actualRecords = createAvroRecordsList(outputStream);
+
+        final List<GenericRecord> actualAvroRecords = createAvroRecordsList(outputStream);
+        assertThat(actualAvroRecords.size(), equalTo(numberOfRecords));
+
         int index = 0;
-        for (final GenericRecord actualRecord : actualRecords) {
+        for (final GenericRecord actualRecord : actualAvroRecords) {
 
             assertThat(actualRecord, notNullValue());
             assertThat(actualRecord.getSchema(), notNullValue());
 
-            Map expectedMap = generateRecords(numberOfRecords).get(index);
-            Map actualMap = new HashMap();
+            final Map<String, Object> expectedMap = inputMaps.get(index);
+            final Map<String, Object> actualMap = new HashMap<>();
+
             for (Schema.Field field : actualRecord.getSchema().getFields()) {
                 if (actualRecord.get(field.name()) instanceof GenericRecord) {
                     GenericRecord nestedRecord = (GenericRecord) actualRecord.get(field.name());
                     actualMap.put(field.name(), convertRecordToMap(nestedRecord));
+                } else if(actualRecord.get(field.name()) instanceof GenericArray) {
+                    GenericArray genericArray = (GenericArray) actualRecord.get(field.name());
+                    actualMap.put(field.name(), genericArray.stream().map(AvroOutputCodecTest::decodeOutputIfEncoded).collect(Collectors.toList()));
+                }
+                else {
+                    Object decodedActualOutput = decodeOutputIfEncoded(actualRecord.get(field.name()));
+                    actualMap.put(field.name(), decodedActualOutput);
+                }
+            }
+            assertThat(actualMap, equalTo(expectedMap));
+            index++;
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 100})
+    void test_happy_case_nullable_records(final int numberOfRecords) throws Exception {
+        config.setSchema(createStandardSchemaNullable().toString());
+        AvroOutputCodec avroOutputCodec = createObjectUnderTest();
+        outputStream = new ByteArrayOutputStream();
+        OutputCodecContext codecContext = new OutputCodecContext();
+        avroOutputCodec.start(outputStream, null, codecContext);
+        List<Map<String, Object>> inputMaps = generateRecords(numberOfRecords);
+        for (Map<String, Object> inputMap : inputMaps) {
+            final Event event = createEventRecord(inputMap);
+            avroOutputCodec.writeEvent(event, outputStream);
+        }
+        avroOutputCodec.complete(outputStream);
+
+        final List<GenericRecord> actualAvroRecords = createAvroRecordsList(outputStream);
+        assertThat(actualAvroRecords.size(), equalTo(numberOfRecords));
+
+
+        int index = 0;
+        for (final GenericRecord actualRecord : actualAvroRecords) {
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), notNullValue());
+
+            final Map<String, Object> expectedMap = inputMaps.get(index);
+            final Map<String, Object> actualMap = new HashMap<>();
+
+            for (Schema.Field field : actualRecord.getSchema().getFields()) {
+                if (field.name().equals("nestedRecord")) {
+                    GenericRecord nestedRecord = (GenericRecord) actualRecord.get(field.name());
+                    actualMap.put(field.name(), convertRecordToMap(nestedRecord));
+                } else if(field.name().equals("myArray")) {
+                    GenericArray<?> genericArray = (GenericArray<?>) actualRecord.get(field.name());
+                    List<?> items = genericArray.stream()
+                            .map(AvroOutputCodecTest::decodeOutputIfEncoded)
+                            .collect(Collectors.toList());
+                    actualMap.put(field.name(), items);
                 } else {
                     Object decodedActualOutput = decodeOutputIfEncoded(actualRecord.get(field.name()));
                     actualMap.put(field.name(), decodedActualOutput);
                 }
             }
-            assertThat(expectedMap, Matchers.equalTo(actualMap));
+            assertThat(actualMap, equalTo(expectedMap));
             index++;
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 100})
+    void test_happy_case_nullable_records_with_empty_maps(final int numberOfRecords) throws Exception {
+        config.setSchema(createStandardSchemaNullable().toString());
+        AvroOutputCodec objectUnderTest = createObjectUnderTest();
+        outputStream = new ByteArrayOutputStream();
+        OutputCodecContext codecContext = new OutputCodecContext();
+        objectUnderTest.start(outputStream, null, codecContext);
+        List<Map<String, Object>> inputMaps = generateEmptyRecords(numberOfRecords);
+        for (Map<String, Object> inputMap : inputMaps) {
+            final Event event = createEventRecord(inputMap);
+            objectUnderTest.writeEvent(event, outputStream);
+        }
+        objectUnderTest.complete(outputStream);
+
+        final List<GenericRecord> actualAvroRecords = createAvroRecordsList(outputStream);
+        assertThat(actualAvroRecords.size(), equalTo(numberOfRecords));
+
+
+        int count = 0;
+        for (final GenericRecord actualRecord : actualAvroRecords) {
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), notNullValue());
+
+            List<Schema.Field> fields = actualRecord.getSchema().getFields();
+            assertThat(fields.size(), equalTo(TOTAL_TOP_LEVEL_FIELDS));
+            for (Schema.Field field : fields) {
+                Object actualValue = actualRecord.get(field.name());
+                assertThat(actualValue, nullValue());
+            }
+            count++;
+        }
+
+        assertThat(count, equalTo(inputMaps.size()));
     }
 
     @Test
@@ -128,64 +225,89 @@ public class AvroOutputCodecTest {
     public void testInlineSchemaBuilder() throws IOException {
         Schema expectedSchema = new Schema.Parser().parse(EXPECTED_SCHEMA_STRING);
         AvroOutputCodec avroOutputCodec = createObjectUnderTest();
-        numberOfRecords = 1;
-        Event event = getRecord(0).getData();
+        Event event = createEventRecord(generateRecords(1).get(0));
         Schema actualSchema = avroOutputCodec.buildInlineSchemaFromEvent(event);
-        assertThat(actualSchema, Matchers.equalTo(expectedSchema));
+        assertThat(actualSchema, equalTo(expectedSchema));
     }
 
 
-    private static Record<Event> getRecord(int index) {
-        List<HashMap> recordList = generateRecords(numberOfRecords);
-        final Event event = JacksonLog.builder().withData(recordList.get(index)).build();
-        return new Record<>(event);
+    private static Event createEventRecord(final Map<String, Object> eventData) {
+        return JacksonLog.builder().withData(eventData).build();
     }
 
-    private static List<HashMap> generateRecords(int numberOfRecords) {
-
-        List<HashMap> recordList = new ArrayList<>();
+    private static List<Map<String, Object>> generateRecords(final int numberOfRecords) {
+        final List<Map<String, Object>> recordList = new ArrayList<>();
 
         for (int rows = 0; rows < numberOfRecords; rows++) {
 
-            HashMap<String, Object> eventData = new HashMap<>();
+            final Map<String, Object> eventData = new HashMap<>();
 
             eventData.put("name", "Person" + rows);
             eventData.put("age", rows);
-            HashMap<String, Object> nestedRecord = new HashMap<>();
+            eventData.put("myLong", (long) rows + (long) Integer.MAX_VALUE);
+            eventData.put("myFloat", rows * 1.5f);
+            eventData.put("myDouble", rows * 1.89d);
+            eventData.put("myArray", List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+            final Map<String, Object> nestedRecord = new HashMap<>();
             nestedRecord.put("firstFieldInNestedRecord", "testString" + rows);
             nestedRecord.put("secondFieldInNestedRecord", rows);
             eventData.put("nestedRecord", nestedRecord);
-            recordList.add((eventData));
-
+            recordList.add(eventData);
         }
         return recordList;
     }
 
-    private static Schema parseSchema() {
-        Schema innerSchema = parseInnerSchemaForNestedRecord();
-        return SchemaBuilder.record("Person")
-                .fields()
-                .name("name").type().stringType().noDefault()
-                .name("age").type().intType().noDefault()
-                .name("nestedRecord").type(innerSchema).noDefault()
-                .endRecord();
-
+    private static List<Map<String, Object>> generateEmptyRecords(final int numberOfRecords) {
+        return IntStream.range(0, numberOfRecords)
+                .mapToObj(i -> Collections.<String, Object>emptyMap())
+                .collect(Collectors.toList());
     }
 
-    private static Schema parseInnerSchemaForNestedRecord() {
-        return SchemaBuilder
-                .record("nestedRecord")
-                .fields()
-                .name("firstFieldInNestedRecord")
-                .type(Schema.create(Schema.Type.STRING))
-                .noDefault()
-                .name("secondFieldInNestedRecord")
-                .type(Schema.create(Schema.Type.INT))
-                .noDefault()
-                .endRecord();
+    private static Schema createStandardSchema() {
+        return createStandardSchema(false);
     }
 
-    private static Object decodeOutputIfEncoded(Object encodedActualOutput) throws UnsupportedEncodingException {
+    private static Schema createStandardSchemaNullable() {
+        return createStandardSchema(true);
+    }
+
+    private static Schema createStandardSchema(
+            final boolean useNullable) {
+        final Function<SchemaBuilder.FieldTypeBuilder<Schema>, SchemaBuilder.BaseFieldTypeBuilder<Schema>> typeModifier;
+        if(useNullable) {
+            typeModifier = SchemaBuilder.FieldTypeBuilder::nullable;
+        } else {
+            typeModifier = schemaFieldTypeBuilder -> schemaFieldTypeBuilder;
+        }
+        SchemaBuilder.FieldAssembler<Schema> assembler = SchemaBuilder.record("Person")
+                .fields();
+        assembler = typeModifier.apply(assembler.name("name").type()).stringType().noDefault();
+        assembler = typeModifier.apply(assembler.name("age").type()).intType().noDefault();
+        assembler = typeModifier.apply(assembler.name("myLong").type()).longType().noDefault();
+        assembler = typeModifier.apply(assembler.name("myFloat").type()).floatType().noDefault();
+        assembler = typeModifier.apply(assembler.name("myDouble").type()).doubleType().noDefault();
+        assembler = typeModifier.apply(assembler.name("myArray").type()).array().items().stringType().noDefault();
+        final Schema innerSchema = createStandardInnerSchemaForNestedRecord(useNullable, typeModifier);
+        assembler = assembler.name("nestedRecord").type(innerSchema).noDefault();
+
+        return assembler.endRecord();
+    }
+
+    private static Schema createStandardInnerSchemaForNestedRecord(
+            boolean useNullable, final Function<SchemaBuilder.FieldTypeBuilder<Schema>, SchemaBuilder.BaseFieldTypeBuilder<Schema>> typeModifier) {
+        SchemaBuilder.RecordBuilder<Schema> nestedRecord;
+        if(useNullable) {
+            nestedRecord = SchemaBuilder.nullable().record("nestedRecord");
+        } else {
+            nestedRecord = SchemaBuilder.record("nestedRecord");
+        }
+        SchemaBuilder.FieldAssembler<Schema> assembler = nestedRecord.fields();
+        assembler = typeModifier.apply(assembler.name("firstFieldInNestedRecord").type()).stringType().noDefault();
+        assembler = typeModifier.apply(assembler.name("secondFieldInNestedRecord").type()).intType().noDefault();
+        return assembler.endRecord();
+    }
+
+    private static Object decodeOutputIfEncoded(Object encodedActualOutput) {
         if (encodedActualOutput instanceof Utf8) {
             byte[] utf8Bytes = encodedActualOutput.toString().getBytes(StandardCharsets.UTF_8);
             return new String(utf8Bytes, StandardCharsets.UTF_8);
@@ -197,7 +319,7 @@ public class AvroOutputCodecTest {
     private static List<GenericRecord> createAvroRecordsList(ByteArrayOutputStream outputStream) throws IOException {
         final byte[] avroData = outputStream.toByteArray();
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(avroData);
-        DataFileStream<GenericRecord> stream = new DataFileStream<GenericRecord>(byteArrayInputStream, new GenericDatumReader<GenericRecord>());
+        DataFileStream<GenericRecord> stream = new DataFileStream<GenericRecord>(byteArrayInputStream, new GenericDatumReader<>());
         List<GenericRecord> actualRecords = new ArrayList<>();
 
         while (stream.hasNext()) {

--- a/data-prepper-plugins/s3-sink/build.gradle
+++ b/data-prepper-plugins/s3-sink/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:sts'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.21'
+    implementation project(':data-prepper-plugins:avro-codecs')
     implementation 'org.apache.avro:avro:1.11.1'
     implementation 'org.apache.hadoop:hadoop-common:3.3.6'
     implementation 'org.apache.parquet:parquet-avro:1.13.1'
@@ -27,7 +28,6 @@ dependencies {
     testImplementation project(':data-prepper-plugins:parquet-codecs')
     testImplementation project(':data-prepper-plugins:parse-json-processor')
     testImplementation project(':data-prepper-plugins:csv-processor')
-    testImplementation project(':data-prepper-plugins:avro-codecs')
     testImplementation testLibs.slf4j.simple
     testImplementation 'software.amazon.awssdk:s3-transfer-manager'
     testImplementation 'software.amazon.awssdk.crt:aws-crt:0.25.0'

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodec.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodec.java
@@ -5,43 +5,36 @@
 package org.opensearch.dataprepper.plugins.codec.parquet;
 
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.OutputFile;
 import org.apache.parquet.io.PositionOutputStream;
+import org.opensearch.dataprepper.avro.AvroAutoSchemaGenerator;
+import org.opensearch.dataprepper.avro.AvroEventConverter;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 import org.opensearch.dataprepper.plugins.fs.LocalInputFile;
-import org.opensearch.dataprepper.plugins.fs.LocalOutputFile;
 import org.opensearch.dataprepper.plugins.s3keyindex.S3ObjectIndexUtility;
 import org.opensearch.dataprepper.plugins.sink.s3.S3OutputCodecContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
 @DataPrepperPlugin(name = "parquet", pluginType = OutputCodec.class, pluginConfigurationType = ParquetOutputCodecConfig.class)
 public class ParquetOutputCodec implements OutputCodec {
-    private static final Logger LOG = LoggerFactory.getLogger(ParquetOutputCodec.class);
-
     private final ParquetOutputCodecConfig config;
-    private static final String BASE_SCHEMA_STRING = "{\"type\":\"record\",\"name\":\"ParquetRecords\",\"fields\":[";
-    private static final String END_SCHEMA_STRING = "]}";
     private static Schema schema;
+    private final AvroEventConverter avroEventConverter;
+    private final AvroAutoSchemaGenerator avroAutoSchemaGenerator;
     private ParquetWriter<GenericRecord> writer;
     private OutputCodecContext codecContext;
     private static final String PARQUET = "parquet";
@@ -49,13 +42,15 @@ public class ParquetOutputCodec implements OutputCodec {
     private static final String TIME_PATTERN_REGULAR_EXPRESSION = "\\%\\{.*?\\}";
     private static final Pattern SIMPLE_DURATION_PATTERN = Pattern.compile(TIME_PATTERN_REGULAR_EXPRESSION);
     private String key;
-    private static final List<String> primitiveTypes = Arrays.asList("int", "long", "string", "float", "double", "bytes");
 
 
     @DataPrepperPluginConstructor
     public ParquetOutputCodec(final ParquetOutputCodecConfig config) {
         Objects.requireNonNull(config);
         this.config = config;
+
+        avroEventConverter = new AvroEventConverter();
+        avroAutoSchemaGenerator = new AvroAutoSchemaGenerator();
     }
 
     @Override
@@ -68,10 +63,10 @@ public class ParquetOutputCodec implements OutputCodec {
         if(!(codecContext instanceof S3OutputCodecContext)) {
             throw new RuntimeException("The Parquet output codec only works with S3 presently");
         }
-        S3OutputStream s3OutputStream = (S3OutputStream) outputStream;
+        PositionOutputStream s3OutputStream = (PositionOutputStream) outputStream;
         CompressionCodecName compressionCodecName = CompressionConverter.convertCodec(((S3OutputCodecContext) codecContext).getCompressionOption());
         this.codecContext = codecContext;
-        buildSchemaAndKey(event, codecContext.getTagsTargetKey());
+        buildSchemaAndKey(event);
         final S3OutputFile s3OutputFile = new S3OutputFile(s3OutputStream);
         buildWriter(s3OutputFile, compressionCodecName);
     }
@@ -81,15 +76,7 @@ public class ParquetOutputCodec implements OutputCodec {
         return true;
     }
 
-    public synchronized void start(File file, final OutputCodecContext codecContext) throws IOException {
-        Objects.requireNonNull(codecContext);
-        this.codecContext = codecContext;
-        LocalOutputFile localOutputFile = new LocalOutputFile(file);
-        buildSchemaAndKey(null, null);
-        buildWriter(localOutputFile, CompressionCodecName.UNCOMPRESSED);
-    }
-
-    void buildSchemaAndKey(final Event event, final String tagsTargetKey) throws IOException {
+    void buildSchemaAndKey(final Event event) throws IOException {
         if (config.getSchema() != null) {
             schema = parseSchema(config.getSchema());
         } else if (config.getFileLocation() != null) {
@@ -99,70 +86,20 @@ public class ParquetOutputCodec implements OutputCodec {
         } else if (checkS3SchemaValidity()) {
             schema = ParquetSchemaParserFromS3.parseSchema(config);
         } else {
-            schema = buildInlineSchemaFromEvent(event, tagsTargetKey);
+            schema = buildInlineSchemaFromEvent(event);
         }
         key = generateKey();
     }
 
-    public Schema buildInlineSchemaFromEvent(final Event event, final String tagsTargetKey) throws IOException {
-        if (tagsTargetKey != null) {
-            return parseSchema(buildSchemaStringFromEventMap(addTagsToEvent(event, tagsTargetKey).toMap(), false));
+    public Schema buildInlineSchemaFromEvent(final Event event) throws IOException {
+        final Map<String, Object> data;
+        if (codecContext != null && codecContext.getTagsTargetKey() != null) {
+            data = addTagsToEvent(event, codecContext.getTagsTargetKey()).toMap();
         } else {
-            return parseSchema(buildSchemaStringFromEventMap(event.toMap(), false));
+            data = event.toMap();
         }
-    }
 
-    private String buildSchemaStringFromEventMap(final Map<String, Object> eventData, boolean nestedRecordFlag) {
-        final StringBuilder builder = new StringBuilder();
-        int nestedRecordIndex = 1;
-        if (!nestedRecordFlag) {
-            builder.append(BASE_SCHEMA_STRING);
-        } else {
-            builder.append("{\"type\":\"record\",\"name\":\"" + "NestedRecord" + nestedRecordIndex + "\",\"fields\":[");
-            nestedRecordIndex++;
-        }
-        String fields;
-        int index = 0;
-        for (final String key : eventData.keySet()) {
-            if (codecContext.getExcludeKeys().contains(key)) {
-                continue;
-            }
-            if (index == 0) {
-                if (!(eventData.get(key) instanceof Map)) {
-                    fields = "{\"name\":\"" + key + "\",\"type\":\"" + typeMapper(eventData.get(key)) + "\"}";
-                } else {
-                    fields = "{\"name\":\"" + key + "\",\"type\":" + typeMapper(eventData.get(key)) + "}";
-                }
-            } else {
-                if (!(eventData.get(key) instanceof Map)) {
-                    fields = "," + "{\"name\":\"" + key + "\",\"type\":\"" + typeMapper(eventData.get(key)) + "\"}";
-                } else {
-                    fields = "," + "{\"name\":\"" + key + "\",\"type\":" + typeMapper(eventData.get(key)) + "}";
-                }
-            }
-            builder.append(fields);
-            index++;
-        }
-        builder.append(END_SCHEMA_STRING);
-        return builder.toString();
-    }
-
-    private String typeMapper(final Object value) {
-        if (value instanceof Integer || value.getClass().equals(int.class)) {
-            return "int";
-        } else if (value instanceof Float || value.getClass().equals(float.class)) {
-            return "float";
-        } else if (value instanceof Double || value.getClass().equals(double.class)) {
-            return "double";
-        } else if (value instanceof Long || value.getClass().equals(long.class)) {
-            return "long";
-        } else if (value instanceof Byte[]) {
-            return "bytes";
-        } else if (value instanceof Map) {
-            return buildSchemaStringFromEventMap((Map<String, Object>) value, true);
-        } else {
-            return "string";
-        }
+        return avroAutoSchemaGenerator.autoDetermineSchema(data, codecContext);
     }
 
     private void buildWriter(OutputFile outputFile, CompressionCodecName compressionCodecName) throws IOException {
@@ -174,21 +111,13 @@ public class ParquetOutputCodec implements OutputCodec {
 
     @Override
     public void writeEvent(final Event event, final OutputStream outputStream) throws IOException {
-        final GenericData.Record parquetRecord = new GenericData.Record(schema);
         final Event modifiedEvent;
         if (codecContext.getTagsTargetKey() != null) {
             modifiedEvent = addTagsToEvent(event, codecContext.getTagsTargetKey());
         } else {
             modifiedEvent = event;
         }
-        for (final String key : modifiedEvent.toMap().keySet()) {
-            if (codecContext.getExcludeKeys().contains(key)) {
-                continue;
-            }
-            final Schema.Field field = schema.getField(key);
-            final Object value = schemaMapper(field, modifiedEvent.toMap().get(key));
-            parquetRecord.put(key, value);
-        }
+        GenericRecord parquetRecord = avroEventConverter.convertEventDataToAvro(schema, modifiedEvent.toMap(), codecContext);
         writer.write(parquetRecord);
     }
 
@@ -241,59 +170,6 @@ public class ParquetOutputCodec implements OutputCodec {
 
     private String buildObjectFileName(final String configNamePattern) {
         return S3ObjectIndexUtility.getObjectNameWithDateTimeId(configNamePattern) + "." + getExtension();
-    }
-
-    private static Object schemaMapper(final Schema.Field field, final Object rawValue) {
-        Object finalValue = null;
-        final String fieldType = field.schema().getType().name().toLowerCase();
-        if (field.schema().getLogicalType() == null && primitiveTypes.contains(fieldType)) {
-            switch (fieldType) {
-                case "string":
-                    finalValue = rawValue.toString();
-                    break;
-                case "int":
-                    finalValue = Integer.parseInt(rawValue.toString());
-                    break;
-                case "float":
-                    finalValue = Float.parseFloat(rawValue.toString());
-                    break;
-                case "double":
-                    finalValue = Double.parseDouble(rawValue.toString());
-                    break;
-                case "long":
-                    finalValue = Long.parseLong(rawValue.toString());
-                    break;
-                case "bytes":
-                    finalValue = rawValue.toString().getBytes(StandardCharsets.UTF_8);
-                    break;
-                default:
-                    LOG.error("Unrecognised Field name : '{}' & type : '{}'", field.name(), fieldType);
-                    break;
-            }
-        } else {
-            final String logicalTypeName = field.schema().getLogicalType().getName();
-            switch (logicalTypeName) {
-                case "date":
-                    finalValue = Integer.parseInt(rawValue.toString());
-                    break;
-                case "time-millis":
-                case "timestamp-millis":
-                case "time-micros":
-                case "timestamp-micros":
-                    finalValue = Long.parseLong(rawValue.toString());
-                    break;
-                case "decimal":
-                    Double.parseDouble(rawValue.toString());
-                    break;
-                case "uuid":
-                    finalValue = rawValue.toString().getBytes(StandardCharsets.UTF_8);
-                    break;
-                default:
-                    LOG.error("Unrecognised Logical Datatype for field : '{}' & type : '{}'", field.name(), logicalTypeName);
-                    break;
-            }
-        }
-        return finalValue;
     }
 
     boolean checkS3SchemaValidity() {

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/S3OutputFile.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/S3OutputFile.java
@@ -11,9 +11,9 @@ import java.io.IOException;
 
 
 class S3OutputFile implements OutputFile {
-    private final S3OutputStream outputStream;
+    private final PositionOutputStream outputStream;
 
-    public S3OutputFile(S3OutputStream outputStream) {
+    public S3OutputFile(PositionOutputStream outputStream) {
         this.outputStream = outputStream;
     }
 


### PR DESCRIPTION
### Description

This adds two conceptual changes:

* Both Avro and Parquet can provide `null` values when the schema is defined to allow nullable values. This is supported for primitive types, records, and arrays.
* When auto-generating an Avro schema, generate it to include nullable unions. This is true for primitive types, records, and arrays.

Internally, it refactors both the Avro and Parquet OutputCodecs to use a common set of classes for Avro schema generation and Avro record conversion. This is part of the `avro-codecs` project. Thus, the S3 sink depends on this project now. It also prefers using the Avro SDK for schema models instead of raw strings.
 
### Issues Resolved
Resolves part of #3158.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
