### PR TITLE
Corrects the JSON output codec - type support and include/exclude keys

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/OutputCodecContext.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/OutputCodecContext.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.model.sink;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Data Prepper Output Codec Context class.
@@ -18,6 +19,7 @@ public class OutputCodecContext {
 
     private final List<String> includeKeys;
     private final List<String> excludeKeys;
+    private final Predicate<String> inclusionPredicate;
 
     public OutputCodecContext() {
         this(null, Collections.emptyList(), Collections.emptyList());
@@ -28,6 +30,14 @@ public class OutputCodecContext {
         this.tagsTargetKey = tagsTargetKey;
         this.includeKeys = includeKeys;
         this.excludeKeys = excludeKeys;
+
+        if (includeKeys != null && !includeKeys.isEmpty()) {
+            inclusionPredicate = k -> includeKeys.contains(k);
+        } else if (excludeKeys != null && !excludeKeys.isEmpty()) {
+            inclusionPredicate = k -> !excludeKeys.contains(k);
+        } else {
+            inclusionPredicate = k -> true;
+        }
     }
 
 
@@ -48,5 +58,9 @@ public class OutputCodecContext {
 
     public List<String> getExcludeKeys() {
         return excludeKeys;
+    }
+
+    public boolean shouldIncludeKey(String key) {
+        return inclusionPredicate.test(key);
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/OutputCodecContextTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/OutputCodecContextTest.java
@@ -10,14 +10,13 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class OutputCodecContextTest {
-
-
     @Test
     public void testOutputCodecContextBasic() {
         final String testTagsTargetKey = RandomStringUtils.randomAlphabetic(6);
@@ -32,8 +31,6 @@ public class OutputCodecContextTest {
         assertNull(emptyContext.getTagsTargetKey());
         assertThat(emptyContext.getIncludeKeys(), equalTo(testIncludeKeys));
         assertThat(emptyContext.getExcludeKeys(), equalTo(testExcludeKeys));
-
-
     }
 
     @Test
@@ -53,7 +50,43 @@ public class OutputCodecContextTest {
         assertNull(emptyContext.getTagsTargetKey());
         assertThat(emptyContext.getIncludeKeys(), equalTo(testIncludeKeys));
         assertThat(emptyContext.getExcludeKeys(), equalTo(testExcludeKeys));
+    }
 
+    @Test
+    void shouldIncludeKey_returns_expected_when_no_include_exclude() {
+        OutputCodecContext objectUnderTest = new OutputCodecContext(null, null, null);
+        assertThat(objectUnderTest.shouldIncludeKey(UUID.randomUUID().toString()), equalTo(true));
+    }
 
+    @Test
+    void shouldIncludeKey_returns_expected_when_empty_lists_for_include_exclude() {
+        OutputCodecContext objectUnderTest = new OutputCodecContext(null, Collections.emptyList(), Collections.emptyList());
+        assertThat(objectUnderTest.shouldIncludeKey(UUID.randomUUID().toString()), equalTo(true));
+    }
+
+    @Test
+    void shouldIncludeKey_returns_expected_when_includeKey() {
+        String includeKey1 = UUID.randomUUID().toString();
+        String includeKey2 = UUID.randomUUID().toString();
+        final List<String> includeKeys = List.of(includeKey1, includeKey2);
+
+        OutputCodecContext objectUnderTest = new OutputCodecContext(null, includeKeys, null);
+
+        assertThat(objectUnderTest.shouldIncludeKey(includeKey1), equalTo(true));
+        assertThat(objectUnderTest.shouldIncludeKey(includeKey2), equalTo(true));
+        assertThat(objectUnderTest.shouldIncludeKey(UUID.randomUUID().toString()), equalTo(false));
+    }
+
+    @Test
+    void shouldIncludeKey_returns_expected_when_excludeKey() {
+        String excludeKey1 = UUID.randomUUID().toString();
+        String excludeKey2 = UUID.randomUUID().toString();
+        final List<String> excludeKeys = List.of(excludeKey1, excludeKey2);
+
+        OutputCodecContext objectUnderTest = new OutputCodecContext(null, null, excludeKeys);
+
+        assertThat(objectUnderTest.shouldIncludeKey(excludeKey1), equalTo(false));
+        assertThat(objectUnderTest.shouldIncludeKey(excludeKey2), equalTo(false));
+        assertThat(objectUnderTest.shouldIncludeKey(UUID.randomUUID().toString()), equalTo(true));
     }
 }

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodec.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodec.java
@@ -7,6 +7,8 @@ package org.opensearch.dataprepper.plugins.codec.json;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
@@ -15,7 +17,10 @@ import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * An implementation of {@link OutputCodec} which deserializes Data-Prepper events
@@ -23,10 +28,10 @@ import java.util.Objects;
  */
 @DataPrepperPlugin(name = "json", pluginType = OutputCodec.class, pluginConfigurationType = JsonOutputCodecConfig.class)
 public class JsonOutputCodec implements OutputCodec {
-
+    private final ObjectMapper objectMapper = new ObjectMapper();
     private static final String JSON = "json";
     private static final JsonFactory factory = new JsonFactory();
-    JsonOutputCodecConfig config;
+    private final JsonOutputCodecConfig config;
     private JsonGenerator generator;
     private OutputCodecContext codecContext;
 
@@ -34,6 +39,11 @@ public class JsonOutputCodec implements OutputCodec {
     public JsonOutputCodec(final JsonOutputCodecConfig config) {
         Objects.requireNonNull(config);
         this.config = config;
+    }
+
+    @Override
+    public String getExtension() {
+        return JSON;
     }
 
     @Override
@@ -59,27 +69,30 @@ public class JsonOutputCodec implements OutputCodec {
     @Override
     public synchronized void writeEvent(final Event event, final OutputStream outputStream) throws IOException {
         Objects.requireNonNull(event);
+        Map<String, Object> dataMap = getDataMapToSerialize(event);
+        objectMapper.writeValue(generator, dataMap);
+        generator.flush();
+    }
+
+    private Map<String, Object> getDataMapToSerialize(Event event) throws JsonProcessingException {
         final Event modifiedEvent;
         if (codecContext.getTagsTargetKey() != null) {
             modifiedEvent = addTagsToEvent(event, codecContext.getTagsTargetKey());
         } else {
             modifiedEvent = event;
         }
-        generator.writeStartObject();
-        final boolean isExcludeKeyAvailable = !codecContext.getExcludeKeys().isEmpty();
-        for (final String key : modifiedEvent.toMap().keySet()) {
-            if (isExcludeKeyAvailable && codecContext.getExcludeKeys().contains(key)) {
-                continue;
-            }
-            generator.writeStringField(key, modifiedEvent.toMap().get(key).toString());
-        }
-        generator.writeEndObject();
-        generator.flush();
-    }
+        Map<String, Object> dataMap = modifiedEvent.toMap();
 
-    @Override
-    public String getExtension() {
-        return JSON;
+        if ((codecContext.getIncludeKeys() != null && !codecContext.getIncludeKeys().isEmpty()) ||
+                (codecContext.getExcludeKeys() != null && !codecContext.getExcludeKeys().isEmpty())) {
+
+            Map<String, Object> finalDataMap = dataMap;
+            dataMap = dataMap.keySet()
+                    .stream()
+                    .filter(codecContext::shouldIncludeKey)
+                    .collect(Collectors.toMap(Function.identity(), finalDataMap::get));
+        }
+        return dataMap;
     }
 }
 

--- a/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodecTest.java
+++ b/data-prepper-plugins/parse-json-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/json/JsonOutputCodecTest.java
@@ -8,13 +8,11 @@ package org.opensearch.dataprepper.plugins.codec.json;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.log.JacksonLog;
-import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 
 import java.io.ByteArrayOutputStream;
@@ -30,31 +28,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class JsonOutputCodecTest {
-
-    private static int numberOfRecords;
     private ByteArrayOutputStream outputStream;
-
-    private static Record getRecord(int index) {
-        List<HashMap> recordList = generateRecords(numberOfRecords);
-        final Event event = JacksonLog.builder().withData(recordList.get(index)).build();
-        return new Record<>(event);
-    }
-
-    private static List<HashMap> generateRecords(int numberOfRecords) {
-
-        List<HashMap> recordList = new ArrayList<>();
-
-        for (int rows = 0; rows < numberOfRecords; rows++) {
-
-            HashMap<String, String> eventData = new HashMap<>();
-
-            eventData.put("name", "Person" + rows);
-            eventData.put("age", Integer.toString(rows));
-            recordList.add((eventData));
-
-        }
-        return recordList;
-    }
 
     private JsonOutputCodec createObjectUnderTest() {
         return new JsonOutputCodec(new JsonOutputCodecConfig());
@@ -63,17 +37,18 @@ class JsonOutputCodecTest {
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 10, 100})
     void test_happy_case(final int numberOfRecords) throws IOException {
-        JsonOutputCodecTest.numberOfRecords = numberOfRecords;
         JsonOutputCodec jsonOutputCodec = createObjectUnderTest();
         outputStream = new ByteArrayOutputStream();
         OutputCodecContext codecContext = new OutputCodecContext();
         jsonOutputCodec.start(outputStream, null, codecContext);
+
+        final List<Map<String, Object>> expectedData = generateRecords(numberOfRecords);
         for (int index = 0; index < numberOfRecords; index++) {
-            final Event event = (Event) getRecord(index).getData();
+            final Event event = convertToEvent(expectedData.get(index));
             jsonOutputCodec.writeEvent(event, outputStream);
         }
         jsonOutputCodec.complete(outputStream);
-        List<HashMap> expectedRecords = generateRecords(numberOfRecords);
+
         int index = 0;
         ObjectMapper mapper = new ObjectMapper();
         JsonNode jsonNode = mapper.readTree(outputStream.toByteArray());
@@ -84,16 +59,92 @@ class JsonOutputCodecTest {
         jsonNode = nextField.getValue();
         assertThat(jsonNode, notNullValue());
         assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.ARRAY));
-        for (JsonNode element : jsonNode) {
-            Set<String> keys = expectedRecords.get(index).keySet();
+        for (JsonNode actualElement : jsonNode) {
+            Map<String, Object> expectedMap = expectedData.get(index);
+            Set<String> keys = expectedMap.keySet();
             Map<String, Object> actualMap = new HashMap<>();
             for (String key : keys) {
-                actualMap.put(key, element.get(key).asText());
+                actualMap.put(key, getValue(actualElement.get(key)));
             }
-            assertThat(expectedRecords.get(index), Matchers.equalTo(actualMap));
+            assertThat(actualMap, equalTo(expectedMap));
             index++;
-
         }
+
+        assertThat(index, equalTo(numberOfRecords));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 100})
+    void writeEvent_with_include_keys(final int numberOfRecords) throws IOException {
+        JsonOutputCodec jsonOutputCodec = createObjectUnderTest();
+        outputStream = new ByteArrayOutputStream();
+        OutputCodecContext codecContext = new OutputCodecContext(null, List.of("name"), null);
+        jsonOutputCodec.start(outputStream, null, codecContext);
+
+        final List<Map<String, Object>> expectedData = generateRecords(numberOfRecords);
+        for (int index = 0; index < numberOfRecords; index++) {
+            final Event event = convertToEvent(expectedData.get(index));
+            jsonOutputCodec.writeEvent(event, outputStream);
+        }
+        jsonOutputCodec.complete(outputStream);
+
+        int index = 0;
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(outputStream.toByteArray());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.OBJECT));
+        Map.Entry<String, JsonNode> nextField = jsonNode.fields().next();
+        assertThat(nextField, notNullValue());
+        assertThat(nextField.getKey(), equalTo(JsonOutputCodecConfig.DEFAULT_KEY_NAME));
+        jsonNode = nextField.getValue();
+        assertThat(jsonNode, notNullValue());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.ARRAY));
+        for (JsonNode actualElement : jsonNode) {
+            Map<String, Object> expectedMap = expectedData.get(index);
+            assertThat(actualElement.has("age"), equalTo(false));
+            assertThat(actualElement.has("name"), equalTo(true));
+            assertThat(actualElement.get("name").getNodeType(), equalTo(JsonNodeType.STRING));
+            assertThat(actualElement.get("name").asText(), equalTo(expectedMap.get("name")));
+            index++;
+        }
+
+        assertThat(index, equalTo(numberOfRecords));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 100})
+    void writeEvent_with_exclude_keys(final int numberOfRecords) throws IOException {
+        JsonOutputCodec jsonOutputCodec = createObjectUnderTest();
+        outputStream = new ByteArrayOutputStream();
+        OutputCodecContext codecContext = new OutputCodecContext(null, null, List.of("age"));
+        jsonOutputCodec.start(outputStream, null, codecContext);
+
+        final List<Map<String, Object>> expectedData = generateRecords(numberOfRecords);
+        for (int index = 0; index < numberOfRecords; index++) {
+            final Event event = convertToEvent(expectedData.get(index));
+            jsonOutputCodec.writeEvent(event, outputStream);
+        }
+        jsonOutputCodec.complete(outputStream);
+
+        int index = 0;
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(outputStream.toByteArray());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.OBJECT));
+        Map.Entry<String, JsonNode> nextField = jsonNode.fields().next();
+        assertThat(nextField, notNullValue());
+        assertThat(nextField.getKey(), equalTo(JsonOutputCodecConfig.DEFAULT_KEY_NAME));
+        jsonNode = nextField.getValue();
+        assertThat(jsonNode, notNullValue());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.ARRAY));
+        for (JsonNode actualElement : jsonNode) {
+            Map<String, Object> expectedMap = expectedData.get(index);
+            assertThat(actualElement.has("age"), equalTo(false));
+            assertThat(actualElement.has("name"), equalTo(true));
+            assertThat(actualElement.get("name").getNodeType(), equalTo(JsonNodeType.STRING));
+            assertThat(actualElement.get("name").asText(), equalTo(expectedMap.get("name")));
+            index++;
+        }
+
+        assertThat(index, equalTo(numberOfRecords));
     }
 
     @Test
@@ -101,5 +152,37 @@ class JsonOutputCodecTest {
         JsonOutputCodec jsonOutputCodec = createObjectUnderTest();
 
         assertThat("json", equalTo(jsonOutputCodec.getExtension()));
+    }
+
+    private static Event convertToEvent(Map<String, Object> data) {
+        return JacksonLog.builder().withData(data).build();
+    }
+
+    private static List<Map<String, Object>> generateRecords(int numberOfRecords) {
+
+        List<Map<String, Object>> recordList = new ArrayList<>();
+
+        for (int rows = 0; rows < numberOfRecords; rows++) {
+
+            Map<String, Object> eventData = new HashMap<>();
+
+            eventData.put("name", "Person" + rows);
+            eventData.put("age", rows);
+            recordList.add(eventData);
+
+        }
+
+        return recordList;
+    }
+
+
+    private Object getValue(JsonNode jsonNode) {
+        if(jsonNode.isTextual())
+            return jsonNode.asText();
+
+        if(jsonNode.isInt())
+            return jsonNode.asInt();
+
+        throw new RuntimeException("Test not setup correctly.");
     }
 }


### PR DESCRIPTION
### Description

This fixes two problems with the `json` OutputCodec:

1. Serialize data correctly. Previously, it was serializing everything as text.
2. Support include/exclude keys correctly. Previously, only exclude was working

Additionally, this adds logic in OutputCodecContext to determine if a key can be used. This will be used in other codecs as well.
 
### Issues Resolved
Resolves #3146
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
