### PR TITLE
Correctly add compression extensions to the generated S3 sink keys

### DIFF
--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceIT.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceIT.java
@@ -173,7 +173,7 @@ class S3SinkServiceIT {
 
     void configureNewLineCodec() {
         codec = new NdjsonOutputCodec(ndjsonOutputConfig);
-        keyGenerator = new KeyGenerator(s3SinkConfig, codec);
+        keyGenerator = new KeyGenerator(s3SinkConfig, StandardExtensionProvider.create(codec, CompressionOption.NONE));
     }
 
     @Test
@@ -356,7 +356,7 @@ class S3SinkServiceIT {
         parquetOutputCodecConfig.setSchema(parseSchema().toString());
         parquetOutputCodecConfig.setPathPrefix(PATH_PREFIX);
         codec = new ParquetOutputCodec(parquetOutputCodecConfig);
-        keyGenerator = new KeyGenerator(s3SinkConfig, codec);
+        keyGenerator = new KeyGenerator(s3SinkConfig, StandardExtensionProvider.create(codec, CompressionOption.NONE));
     }
 
     private Collection<Record<Event>> getRecordList() {

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ExtensionProvider.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ExtensionProvider.java
@@ -1,0 +1,5 @@
+package org.opensearch.dataprepper.plugins.sink.s3;
+
+public interface ExtensionProvider {
+    String getExtension();
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/KeyGenerator.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/KeyGenerator.java
@@ -5,16 +5,15 @@
 
 package org.opensearch.dataprepper.plugins.sink.s3;
 
-import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.ObjectKey;
 
 public class KeyGenerator {
     private final S3SinkConfig s3SinkConfig;
-    private final OutputCodec outputCodec;
+    private final ExtensionProvider extensionProvider;
 
-    public KeyGenerator(S3SinkConfig s3SinkConfig, OutputCodec outputCodec) {
+    public KeyGenerator(S3SinkConfig s3SinkConfig, ExtensionProvider extensionProvider) {
         this.s3SinkConfig = s3SinkConfig;
-        this.outputCodec = outputCodec;
+        this.extensionProvider = extensionProvider;
     }
 
     /**
@@ -24,7 +23,7 @@ public class KeyGenerator {
      */
     String generateKey() {
         final String pathPrefix = ObjectKey.buildingPathPrefix(s3SinkConfig);
-        final String namePattern = ObjectKey.objectFileName(s3SinkConfig, outputCodec.getExtension());
+        final String namePattern = ObjectKey.objectFileName(s3SinkConfig, extensionProvider.getExtension());
         return (!pathPrefix.isEmpty()) ? pathPrefix + namePattern : namePattern;
     }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/StandardExtensionProvider.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/StandardExtensionProvider.java
@@ -1,0 +1,33 @@
+package org.opensearch.dataprepper.plugins.sink.s3;
+
+import org.opensearch.dataprepper.model.codec.OutputCodec;
+import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionOption;
+
+class StandardExtensionProvider implements ExtensionProvider {
+    private final String extension;
+
+    static ExtensionProvider create(OutputCodec outputCodec, CompressionOption compressionOption) {
+
+        String codecExtension = outputCodec.getExtension();
+
+        if(outputCodec.isCompressionInternal()) {
+            return new StandardExtensionProvider(codecExtension);
+        }
+
+        String extension = compressionOption.getExtension()
+                .map(compressionExtension -> codecExtension + "." + compressionExtension)
+                .orElse(codecExtension);
+
+
+        return new StandardExtensionProvider(extension);
+    }
+
+    private StandardExtensionProvider(String extension) {
+        this.extension = extension;
+    }
+
+    @Override
+    public String getExtension() {
+        return extension;
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/compression/CompressionOption.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/compression/CompressionOption.java
@@ -9,13 +9,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public enum CompressionOption {
-    NONE("none", NoneCompressionEngine::new),
-    GZIP("gzip", GZipCompressionEngine::new),
-    SNAPPY("snappy", SnappyCompressionEngine::new);
+    NONE("none", null, NoneCompressionEngine::new),
+    GZIP("gzip", "gz", GZipCompressionEngine::new),
+    SNAPPY("snappy", "snappy", SnappyCompressionEngine::new);
 
     private static final Map<String, CompressionOption> OPTIONS_MAP = Arrays.stream(CompressionOption.values())
             .collect(Collectors.toMap(
@@ -25,9 +26,11 @@ public enum CompressionOption {
 
     private final String option;
 
+    private final String extension;
     private final Supplier<CompressionEngine> compressionEngineSupplier;
-    CompressionOption(final String option, final Supplier<CompressionEngine> compressionEngineSupplier) {
+    CompressionOption(final String option, String extension, final Supplier<CompressionEngine> compressionEngineSupplier) {
         this.option = option.toLowerCase();
+        this.extension = extension;
         this.compressionEngineSupplier = compressionEngineSupplier;
     }
 
@@ -37,6 +40,10 @@ public enum CompressionOption {
 
     public String getOption() {
         return option;
+    }
+
+    public Optional<String> getExtension() {
+        return Optional.ofNullable(extension);
     }
 
     @JsonCreator

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/StandardExtensionProviderTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/StandardExtensionProviderTest.java
@@ -1,0 +1,72 @@
+package org.opensearch.dataprepper.plugins.sink.s3;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.codec.OutputCodec;
+import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionOption;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StandardExtensionProviderTest {
+
+    @Mock
+    private OutputCodec outputCodec;
+
+    @Mock
+    private CompressionOption compressionOption;
+
+    private String codecExtension;
+
+    @BeforeEach
+    void setUp() {
+        codecExtension = UUID.randomUUID().toString();
+    }
+
+    @Test
+    void getExtension_returns_extension_of_codec_when_compression_internal() {
+        when(outputCodec.getExtension()).thenReturn(codecExtension);
+        when(outputCodec.isCompressionInternal()).thenReturn(true);
+
+        ExtensionProvider extensionProvider = StandardExtensionProvider.create(outputCodec, compressionOption);
+        assertThat(extensionProvider, notNullValue());
+        assertThat(extensionProvider.getExtension(), equalTo(codecExtension));
+
+        verify(compressionOption, never()).getExtension();
+    }
+
+    @Test
+    void getExtension_returns_extension_of_codec_compression_has_no_extension() {
+        when(outputCodec.getExtension()).thenReturn(codecExtension);
+        when(compressionOption.getExtension()).thenReturn(Optional.empty());
+
+        ExtensionProvider extensionProvider = StandardExtensionProvider.create(outputCodec, compressionOption);
+        assertThat(extensionProvider, notNullValue());
+        assertThat(extensionProvider.getExtension(), equalTo(codecExtension));
+
+        verify(compressionOption).getExtension();
+    }
+
+    @Test
+    void getExtension_returns_extension_of_codec_compression_has_extension() {
+        String compressionExtension = UUID.randomUUID().toString();
+        when(outputCodec.getExtension()).thenReturn(codecExtension);
+        when(compressionOption.getExtension()).thenReturn(Optional.of(compressionExtension));
+
+        ExtensionProvider extensionProvider = StandardExtensionProvider.create(outputCodec, compressionOption);
+        assertThat(extensionProvider, notNullValue());
+        assertThat(extensionProvider.getExtension(), equalTo(codecExtension + "." + compressionExtension));
+    }
+
+}

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/compression/CompressionOptionTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/compression/CompressionOptionTest.java
@@ -12,10 +12,12 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -38,6 +40,29 @@ class CompressionOptionTest {
         assertThat(option.getCompressionEngine(), instanceOf(expectedEngineType));
     }
 
+    @ParameterizedTest
+    @EnumSource(CompressionOption.class)
+    void getExtension_returns_non_null_Optional(final CompressionOption option) {
+        assertThat(option.getExtension(), notNullValue());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(OptionToExpectedExtension.class)
+    void getExtension_returns_expected_extension(final CompressionOption option, final String expectedExtension) {
+        Optional<String> extension = option.getExtension();
+        assertThat(extension, notNullValue());
+        assertThat(extension.isEmpty(), equalTo(false));
+        assertThat(extension.get(), equalTo(expectedExtension));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = CompressionOption.class, names = {"NONE"})
+    void getExtension_returns_empty_Optional_when_no_extension(final CompressionOption option) {
+        Optional<String> extension = option.getExtension();
+        assertThat(extension, notNullValue());
+        assertThat(extension.isEmpty(), equalTo(true));
+    }
+
     static class OptionToExpectedEngine implements ArgumentsProvider {
         @Override
         public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
@@ -45,6 +70,16 @@ class CompressionOptionTest {
                     arguments(CompressionOption.NONE, NoneCompressionEngine.class),
                     arguments(CompressionOption.GZIP, GZipCompressionEngine.class),
                     arguments(CompressionOption.SNAPPY, SnappyCompressionEngine.class)
+            );
+        }
+    }
+
+    static class OptionToExpectedExtension implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
+            return Stream.of(
+                    arguments(CompressionOption.GZIP, "gz"),
+                    arguments(CompressionOption.SNAPPY, "snappy")
             );
         }
     }


### PR DESCRIPTION
### Description

Supports adding the compression extension for keys generated for the S3 sink. This also avoids adding the extension when the codec supports internal compression.
 
### Issues Resolved
Resolves #3158
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
