### PR TITLE
Corrects the output codecs for Avro/Parquet to use the include/exclude keys

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/OutputCodecContext.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/OutputCodecContext.java
@@ -60,7 +60,27 @@ public class OutputCodecContext {
         return excludeKeys;
     }
 
+    /**
+     * Returns true if the key should be included according to the values of
+     * {@link #getExcludeKeys()} and {@link #getIncludeKeys()}.
+     *
+     * @param key The key to include or exclude.
+     * @return True if included; false if excluded.
+     */
     public boolean shouldIncludeKey(String key) {
         return inclusionPredicate.test(key);
+    }
+
+    /**
+     * Returns true if the key should not be included according to the values of
+     * {@link #getExcludeKeys()} and {@link #getIncludeKeys()}.
+     * <p>
+     * This version may be helpful for unit testing since mocks of it would return false by default.
+     *
+     * @param key The key to include or exclude.
+     * @return True if excluded; false if included.
+     */
+    public boolean shouldNotIncludeKey(String key) {
+        return !inclusionPredicate.test(key);
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/OutputCodecContextTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/OutputCodecContextTest.java
@@ -6,6 +6,8 @@
 package org.opensearch.dataprepper.model.sink;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -52,41 +54,113 @@ public class OutputCodecContextTest {
         assertThat(emptyContext.getExcludeKeys(), equalTo(testExcludeKeys));
     }
 
-    @Test
-    void shouldIncludeKey_returns_expected_when_no_include_exclude() {
-        OutputCodecContext objectUnderTest = new OutputCodecContext(null, null, null);
-        assertThat(objectUnderTest.shouldIncludeKey(UUID.randomUUID().toString()), equalTo(true));
+    @Nested
+    class WithNullIncludeExclude {
+        private OutputCodecContext createObjectUnderTest() {
+            return new OutputCodecContext(null, null, null);
+        }
+
+        @Test
+        void shouldIncludeKey_returns_true_when_no_include_exclude() {
+            assertThat(createObjectUnderTest().shouldIncludeKey(UUID.randomUUID().toString()), equalTo(true));
+        }
+
+        @Test
+        void shouldNotIncludeKey_returns_false_when_no_include_exclude() {
+            assertThat(createObjectUnderTest().shouldNotIncludeKey(UUID.randomUUID().toString()), equalTo(false));
+        }
     }
 
-    @Test
-    void shouldIncludeKey_returns_expected_when_empty_lists_for_include_exclude() {
-        OutputCodecContext objectUnderTest = new OutputCodecContext(null, Collections.emptyList(), Collections.emptyList());
-        assertThat(objectUnderTest.shouldIncludeKey(UUID.randomUUID().toString()), equalTo(true));
+    @Nested
+    class WithEmptyIncludeExclude {
+        private OutputCodecContext createObjectUnderTest() {
+            return new OutputCodecContext(null, Collections.emptyList(), Collections.emptyList());
+        }
+
+        @Test
+        void shouldIncludeKey_returns_true_when_empty_lists_for_include_exclude() {
+            assertThat(createObjectUnderTest().shouldIncludeKey(UUID.randomUUID().toString()), equalTo(true));
+        }
+
+        @Test
+        void shouldNotIncludeKey_returns_false_when_empty_lists_for_include_exclude() {
+            assertThat(createObjectUnderTest().shouldNotIncludeKey(UUID.randomUUID().toString()), equalTo(false));
+        }
     }
 
-    @Test
-    void shouldIncludeKey_returns_expected_when_includeKey() {
-        String includeKey1 = UUID.randomUUID().toString();
-        String includeKey2 = UUID.randomUUID().toString();
-        final List<String> includeKeys = List.of(includeKey1, includeKey2);
+    @Nested
+    class WithIncludeKey {
 
-        OutputCodecContext objectUnderTest = new OutputCodecContext(null, includeKeys, null);
+        private String includeKey1;
+        private String includeKey2;
+        private List<String> includeKeys;
 
-        assertThat(objectUnderTest.shouldIncludeKey(includeKey1), equalTo(true));
-        assertThat(objectUnderTest.shouldIncludeKey(includeKey2), equalTo(true));
-        assertThat(objectUnderTest.shouldIncludeKey(UUID.randomUUID().toString()), equalTo(false));
+        @BeforeEach
+        void setUp() {
+            includeKey1 = UUID.randomUUID().toString();
+            includeKey2 = UUID.randomUUID().toString();
+            includeKeys = List.of(includeKey1, includeKey2);
+
+        }
+
+        private OutputCodecContext createObjectUnderTest() {
+            return new OutputCodecContext(null, includeKeys, null);
+        }
+
+        @Test
+        void shouldIncludeKey_returns_expected_when_includeKey() {
+            OutputCodecContext objectUnderTest = createObjectUnderTest();
+
+            assertThat(objectUnderTest.shouldIncludeKey(includeKey1), equalTo(true));
+            assertThat(objectUnderTest.shouldIncludeKey(includeKey2), equalTo(true));
+            assertThat(objectUnderTest.shouldIncludeKey(UUID.randomUUID().toString()), equalTo(false));
+        }
+
+        @Test
+        void shouldNotIncludeKey_returns_expected_when_includeKey() {
+
+            OutputCodecContext objectUnderTest = createObjectUnderTest();
+
+            assertThat(objectUnderTest.shouldNotIncludeKey(includeKey1), equalTo(false));
+            assertThat(objectUnderTest.shouldNotIncludeKey(includeKey2), equalTo(false));
+            assertThat(objectUnderTest.shouldNotIncludeKey(UUID.randomUUID().toString()), equalTo(true));
+        }
     }
 
-    @Test
-    void shouldIncludeKey_returns_expected_when_excludeKey() {
-        String excludeKey1 = UUID.randomUUID().toString();
-        String excludeKey2 = UUID.randomUUID().toString();
-        final List<String> excludeKeys = List.of(excludeKey1, excludeKey2);
+    @Nested
+    class WithExcludeKey {
 
-        OutputCodecContext objectUnderTest = new OutputCodecContext(null, null, excludeKeys);
+        private String excludeKey1;
+        private String excludeKey2;
+        private List<String> excludeKeys;
 
-        assertThat(objectUnderTest.shouldIncludeKey(excludeKey1), equalTo(false));
-        assertThat(objectUnderTest.shouldIncludeKey(excludeKey2), equalTo(false));
-        assertThat(objectUnderTest.shouldIncludeKey(UUID.randomUUID().toString()), equalTo(true));
+        @BeforeEach
+        void setUp() {
+            excludeKey1 = UUID.randomUUID().toString();
+            excludeKey2 = UUID.randomUUID().toString();
+            excludeKeys = List.of(excludeKey1, excludeKey2);
+        }
+
+        private OutputCodecContext createObjectUnderTest() {
+            return new OutputCodecContext(null, null, excludeKeys);
+        }
+
+        @Test
+        void shouldIncludeKey_returns_expected_when_excludeKey() {
+            OutputCodecContext objectUnderTest = createObjectUnderTest();
+
+            assertThat(objectUnderTest.shouldIncludeKey(excludeKey1), equalTo(false));
+            assertThat(objectUnderTest.shouldIncludeKey(excludeKey2), equalTo(false));
+            assertThat(objectUnderTest.shouldIncludeKey(UUID.randomUUID().toString()), equalTo(true));
+        }
+
+        @Test
+        void shouldNotIncludeKey_returns_expected_when_excludeKey() {
+            OutputCodecContext objectUnderTest = createObjectUnderTest();
+
+            assertThat(objectUnderTest.shouldNotIncludeKey(excludeKey1), equalTo(true));
+            assertThat(objectUnderTest.shouldNotIncludeKey(excludeKey2), equalTo(true));
+            assertThat(objectUnderTest.shouldNotIncludeKey(UUID.randomUUID().toString()), equalTo(false));
+        }
     }
 }

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/AvroAutoSchemaGenerator.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/AvroAutoSchemaGenerator.java
@@ -19,7 +19,7 @@ public class AvroAutoSchemaGenerator {
     private Schema autoGenerateRecordSchema(final Map<String, Object> eventData, OutputCodecContext codecContext, String typeName) {
         SchemaBuilder.FieldAssembler<Schema> fieldsAssembler = SchemaBuilder.record(typeName).fields();
         for (final String key : eventData.keySet()) {
-            if (codecContext != null && codecContext.getExcludeKeys().contains(key)) {
+            if (codecContext != null && codecContext.shouldNotIncludeKey(key)) {
                 continue;
             }
             Schema schemaForValue = createSchemaForValue(key, eventData.get(key), codecContext);

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/AvroEventConverter.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/AvroEventConverter.java
@@ -14,20 +14,22 @@ import java.util.Map;
  * It might be a good idea to consolidate similar logic for input.
  */
 public class AvroEventConverter {
-
     private final SchemaChooser schemaChooser;
 
     public AvroEventConverter() {
-        schemaChooser = new SchemaChooser();
+        this(new SchemaChooser());
+    }
+
+    AvroEventConverter(final SchemaChooser schemaChooser) {
+        this.schemaChooser = schemaChooser;
     }
 
     public GenericRecord convertEventDataToAvro(final Schema schema,
                                                 final Map<String, Object> eventData,
                                                 OutputCodecContext codecContext) {
         final GenericRecord avroRecord = new GenericData.Record(schema);
-        final boolean isExcludeKeyAvailable = !codecContext.getExcludeKeys().isEmpty();
         for (final String key : eventData.keySet()) {
-            if (isExcludeKeyAvailable && codecContext.getExcludeKeys().contains(key)) {
+            if (codecContext != null && codecContext.shouldNotIncludeKey(key)) {
                 continue;
             }
             final Schema.Field field = schema.getField(key);

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/AvroEventConverterTest.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/AvroEventConverterTest.java
@@ -3,6 +3,7 @@ package org.opensearch.dataprepper.avro;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -12,10 +13,13 @@ import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -24,6 +28,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class AvroEventConverterTest {
     @Mock
+    private SchemaChooser schemaChooser;
+    @Mock(lenient = true)
     private Schema schema;
 
     @Mock
@@ -34,8 +40,9 @@ class AvroEventConverterTest {
         when(schema.getType()).thenReturn(Schema.Type.RECORD);
     }
 
+
     private AvroEventConverter createObjectUnderTest() {
-        return new AvroEventConverter();
+        return new AvroEventConverter(schemaChooser);
     }
 
     @ParameterizedTest
@@ -50,4 +57,54 @@ class AvroEventConverterTest {
         verify(schema, never()).getField(anyString());
     }
 
+    @Nested
+    class WithField {
+
+        private String fieldName;
+        @Mock(lenient = true)
+        private Schema.Field field;
+        @Mock
+        private Schema fieldSchema;
+
+        @BeforeEach
+        void setUp() {
+            fieldName = UUID.randomUUID().toString();
+            when(schema.getField(fieldName)).thenReturn(field);
+            when(schema.getFields()).thenReturn(Collections.singletonList(field));
+            when(field.schema()).thenReturn(fieldSchema);
+            when(field.pos()).thenReturn(0);
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_adds_fields(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(fieldName, value);
+            when(fieldSchema.getType()).thenReturn(expectedType);
+
+            when(schemaChooser.chooseSchema(fieldSchema)).thenReturn(fieldSchema);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(fieldName), notNullValue());
+            assertThat(actualRecord.get(fieldName), instanceOf(value.getClass()));
+            assertThat(actualRecord.get(fieldName), equalTo(value));
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_files_if_should_not_include(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(fieldName, value);
+            when(codecContext.shouldNotIncludeKey(fieldName)).thenReturn(true);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(fieldName), nullValue());
+        }
+    }
 }


### PR DESCRIPTION
### Description

Corrects include/exclude key behavior for Avro/Parquet codecs. This also adds a new method `shouldNotIncludeKey` to `OutputCodecContext`. This is helpful for unit testing because it requires less mocking.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
