### PR TITLE
Improve the S3 sink integration tests combinations

### DIFF
--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/InMemoryBufferScenario.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/InMemoryBufferScenario.java
@@ -7,8 +7,6 @@ package org.opensearch.dataprepper.plugins.sink.s3;
 
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferTypeOptions;
 
-import static org.opensearch.dataprepper.plugins.sink.s3.S3SinkIT.MEDIUM_OBJECT_SIZE;
-
 public class InMemoryBufferScenario implements BufferScenario {
     @Override
     public BufferTypeOptions getBufferType() {
@@ -17,6 +15,6 @@ public class InMemoryBufferScenario implements BufferScenario {
 
     @Override
     public int getMaximumNumberOfEvents() {
-        return MEDIUM_OBJECT_SIZE;
+        return SizeCombination.MEDIUM_LARGER.getTotalSize();
     }
 }

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/LocalFileBufferScenario.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/LocalFileBufferScenario.java
@@ -7,8 +7,6 @@ package org.opensearch.dataprepper.plugins.sink.s3;
 
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferTypeOptions;
 
-import static org.opensearch.dataprepper.plugins.sink.s3.S3SinkIT.LARGE_OBJECT_SIZE;
-
 public class LocalFileBufferScenario implements BufferScenario {
     @Override
     public BufferTypeOptions getBufferType() {
@@ -17,6 +15,6 @@ public class LocalFileBufferScenario implements BufferScenario {
 
     @Override
     public int getMaximumNumberOfEvents() {
-        return LARGE_OBJECT_SIZE;
+        return SizeCombination.LARGE.getTotalSize();
     }
 }

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/MultiPartBufferScenario.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/MultiPartBufferScenario.java
@@ -7,8 +7,6 @@ package org.opensearch.dataprepper.plugins.sink.s3;
 
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferTypeOptions;
 
-import static org.opensearch.dataprepper.plugins.sink.s3.S3SinkIT.LARGE_OBJECT_SIZE;
-
 public class MultiPartBufferScenario implements BufferScenario {
     @Override
     public BufferTypeOptions getBufferType() {
@@ -17,6 +15,6 @@ public class MultiPartBufferScenario implements BufferScenario {
 
     @Override
     public int getMaximumNumberOfEvents() {
-        return LARGE_OBJECT_SIZE;
+        return SizeCombination.LARGE.getTotalSize();
     }
 }

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/SizeCombination.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/SizeCombination.java
@@ -1,0 +1,32 @@
+package org.opensearch.dataprepper.plugins.sink.s3;
+
+/**
+ * Represents common size combinations.
+ */
+final class SizeCombination {
+    static final SizeCombination EXACTLY_ONE = new SizeCombination(1, 1);
+    static final SizeCombination MEDIUM_SMALLER = new SizeCombination(100, 10);
+    static final SizeCombination MEDIUM_LARGER = new SizeCombination(500, 50);
+    static final SizeCombination LARGE = new SizeCombination(500, 500);
+
+    private final int batchSize;
+
+    private final int numberOfBatches;
+
+    private SizeCombination(int batchSize, int numberOfBatches) {
+        this.batchSize = batchSize;
+        this.numberOfBatches = numberOfBatches;
+    }
+
+    int getTotalSize() {
+        return batchSize * numberOfBatches;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public int getNumberOfBatches() {
+        return numberOfBatches;
+    }
+}


### PR DESCRIPTION
### Description

This PR makes improvements to the S3 sink tests. It reduces sample size, removes some tests which would often cause the JVM to run out of memory, and removes redundant tests. It also sets up a combination for codecs which will not cause the scenarios to grow out of hand.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
