### PR TITLE
Updates to the S3 sink to speed up the unit test/build time

### DIFF
--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceIT.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceIT.java
@@ -242,7 +242,7 @@ class S3SinkServiceIT {
 
     private S3SinkService createObjectUnderTest() {
         OutputCodecContext codecContext = new OutputCodecContext("Tag", Collections.emptyList(), Collections.emptyList());
-        return new S3SinkService(s3SinkConfig, bufferFactory, codec, codecContext, s3Client, keyGenerator, pluginMetrics);
+        return new S3SinkService(s3SinkConfig, bufferFactory, codec, codecContext, s3Client, keyGenerator, Duration.ofSeconds(5), pluginMetrics);
     }
 
     private int gets3ObjectCount() {

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.time.Duration;
 import java.util.Collection;
 
 /**
@@ -75,7 +76,7 @@ public class S3Sink extends AbstractSink<Record<Event>> {
 
         S3OutputCodecContext s3OutputCodecContext = new S3OutputCodecContext(OutputCodecContext.fromSinkContext(sinkContext), compressionOption);
 
-        s3SinkService = new S3SinkService(s3SinkConfig, bufferFactory, codec, s3OutputCodecContext, s3Client, keyGenerator, pluginMetrics);
+        s3SinkService = new S3SinkService(s3SinkConfig, bufferFactory, codec, s3OutputCodecContext, s3Client, keyGenerator, Duration.ofSeconds(5), pluginMetrics);
     }
 
     @Override

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.concurrent.locks.Lock;
@@ -49,7 +50,7 @@ public class S3SinkService {
     private Buffer currentBuffer;
     private final int maxEvents;
     private final ByteCount maxBytes;
-    private final long maxCollectionDuration;
+    private final Duration maxCollectionDuration;
     private final String bucket;
     private final int maxRetries;
     private final Counter objectsSucceededCounter;
@@ -59,6 +60,7 @@ public class S3SinkService {
     private final DistributionSummary s3ObjectSizeSummary;
     private final OutputCodecContext codecContext;
     private final KeyGenerator keyGenerator;
+    private final Duration retrySleepTime;
 
     /**
      * @param s3SinkConfig  s3 sink related configuration.
@@ -68,20 +70,22 @@ public class S3SinkService {
      * @param pluginMetrics metrics.
      */
     public S3SinkService(final S3SinkConfig s3SinkConfig, final BufferFactory bufferFactory,
-                         final OutputCodec codec, final OutputCodecContext codecContext, final S3Client s3Client, final KeyGenerator keyGenerator, final PluginMetrics pluginMetrics) {
+                         final OutputCodec codec, final OutputCodecContext codecContext, final S3Client s3Client, final KeyGenerator keyGenerator,
+                         final Duration retrySleepTime, final PluginMetrics pluginMetrics) {
         this.s3SinkConfig = s3SinkConfig;
         this.bufferFactory = bufferFactory;
         this.codec = codec;
         this.s3Client = s3Client;
         this.codecContext = codecContext;
         this.keyGenerator = keyGenerator;
+        this.retrySleepTime = retrySleepTime;
         reentrantLock = new ReentrantLock();
 
         bufferedEventHandles = new LinkedList<>();
 
         maxEvents = s3SinkConfig.getThresholdOptions().getEventCount();
         maxBytes = s3SinkConfig.getThresholdOptions().getMaximumSize();
-        maxCollectionDuration = s3SinkConfig.getThresholdOptions().getEventCollectTimeOut().getSeconds();
+        maxCollectionDuration = s3SinkConfig.getThresholdOptions().getEventCollectTimeOut();
 
         bucket = s3SinkConfig.getBucketName();
         maxRetries = s3SinkConfig.getMaxUploadRetries();
@@ -191,7 +195,7 @@ public class S3SinkService {
                 }
 
                 try {
-                    Thread.sleep(5000);
+                    Thread.sleep(retrySleepTime.toMillis());
                 } catch (final InterruptedException ex) {
                     LOG.warn("Interrupted while backing off before retrying S3 upload", ex);
                 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ThresholdCheck.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ThresholdCheck.java
@@ -8,6 +8,8 @@ package org.opensearch.dataprepper.plugins.sink.s3;
 import org.opensearch.dataprepper.model.types.ByteCount;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.Buffer;
 
+import java.time.Duration;
+
 /**
  * Check threshold limits.
  */
@@ -24,13 +26,13 @@ public class ThresholdCheck {
      * @param maxCollectionDuration maximum event collection duration provided by user as threshold.
      * @return boolean value whether the threshold are met.
      */
-    public static boolean checkThresholdExceed(final Buffer currentBuffer, final int maxEvents, final ByteCount maxBytes, final long maxCollectionDuration) {
+    public static boolean checkThresholdExceed(final Buffer currentBuffer, final int maxEvents, final ByteCount maxBytes, final Duration maxCollectionDuration) {
         if (maxEvents > 0) {
             return currentBuffer.getEventCount() + 1 > maxEvents ||
-                    currentBuffer.getDuration() > maxCollectionDuration ||
+                    currentBuffer.getDuration().compareTo(maxCollectionDuration) > 0 ||
                     currentBuffer.getSize() > maxBytes.getBytes();
         } else {
-            return currentBuffer.getDuration() > maxCollectionDuration ||
+            return currentBuffer.getDuration().compareTo(maxCollectionDuration) > 0 ||
                     currentBuffer.getSize() > maxBytes.getBytes();
         }
     }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/Buffer.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/Buffer.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.sink.s3.accumulator;
 
 import java.io.OutputStream;
+import java.time.Duration;
 
 /**
  * A buffer can hold data before flushing it to S3.
@@ -18,7 +19,7 @@ public interface Buffer {
     long getSize();
     int getEventCount();
 
-    long getDuration();
+    Duration getDuration();
 
     void flushToS3();
 

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CompressionBuffer.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CompressionBuffer.java
@@ -9,6 +9,7 @@ import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionEngine;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.time.Duration;
 import java.util.Objects;
 
 class CompressionBuffer implements Buffer {
@@ -32,7 +33,7 @@ class CompressionBuffer implements Buffer {
     }
 
     @Override
-    public long getDuration() {
+    public Duration getDuration() {
         return innerBuffer.getDuration();
     }
 

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/InMemoryBuffer.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/InMemoryBuffer.java
@@ -11,6 +11,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -50,8 +51,8 @@ public class InMemoryBuffer implements Buffer {
         return eventCount;
     }
 
-    public long getDuration() {
-        return watch.getTime(TimeUnit.SECONDS);
+    public Duration getDuration() {
+        return Duration.ofMillis(watch.getTime(TimeUnit.MILLISECONDS));
     }
 
     /**

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/LocalFileBuffer.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/LocalFileBuffer.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -68,8 +69,8 @@ public class LocalFileBuffer implements Buffer {
     }
 
     @Override
-    public long getDuration(){
-        return watch.getTime(TimeUnit.SECONDS);
+    public Duration getDuration(){
+        return Duration.ofMillis(watch.getTime(TimeUnit.MILLISECONDS));
     }
 
     /**

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/MultipartBuffer.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/MultipartBuffer.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.time.StopWatch;
 import org.opensearch.dataprepper.plugins.codec.parquet.S3OutputStream;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 public class MultipartBuffer implements Buffer {
@@ -40,8 +41,8 @@ public class MultipartBuffer implements Buffer {
         return eventCount;
     }
 
-    public long getDuration() {
-        return watch.getTime(TimeUnit.SECONDS);
+    public Duration getDuration() {
+        return Duration.ofMillis(watch.getTime(TimeUnit.MILLISECONDS));
     }
 
     /**

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceTest.java
@@ -133,7 +133,7 @@ class S3SinkServiceTest {
     }
 
     private S3SinkService createObjectUnderTest() {
-        return new S3SinkService(s3SinkConfig, bufferFactory, codec, codecContext, s3Client, keyGenerator, pluginMetrics);
+        return new S3SinkService(s3SinkConfig, bufferFactory, codec, codecContext, s3Client, keyGenerator, Duration.ofMillis(100), pluginMetrics);
     }
 
     @Test

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/ThresholdCheckTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/ThresholdCheckTest.java
@@ -7,130 +7,104 @@ package org.opensearch.dataprepper.plugins.sink.s3;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.types.ByteCount;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.Buffer;
-import org.opensearch.dataprepper.plugins.sink.s3.accumulator.InMemoryBufferFactory;
 
-import java.io.IOException;
-import java.io.OutputStream;
+import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class ThresholdCheckTest {
 
-    private Buffer inMemoryBuffer;
+    @Mock(lenient = true)
+    private Buffer buffer;
+    private int maxEvents;
+    private ByteCount maxBytes;
+    private Duration maxCollectionDuration;
 
     @BeforeEach
-    void setUp() throws IOException {
-        inMemoryBuffer = new InMemoryBufferFactory().getBuffer(null, null, null);
-
-        while (inMemoryBuffer.getEventCount() < 100) {
-            OutputStream outputStream = inMemoryBuffer.getOutputStream();
-            outputStream.write(generateByteArray());
-            int eventCount = inMemoryBuffer.getEventCount() +1;
-            inMemoryBuffer.setEventCount(eventCount);
-        }
+    void setUp() {
+        maxEvents = 10_000;
+        maxBytes = ByteCount.parse("48mb");
+        maxCollectionDuration = Duration.ofMinutes(5);
     }
 
     @Test
-    void test_exceedThreshold_true_dueTo_maxEvents_is_less_than_buffered_event_count() {
-        final int maxEvents = 95;
-        final ByteCount maxBytes = ByteCount.parse("50kb");
-        final long maxCollectionDuration = 15;
-        boolean isThresholdExceed = ThresholdCheck.checkThresholdExceed(inMemoryBuffer, maxEvents,
+    void test_exceedThreshold_true_dueTo_maxEvents_is_greater_than_buffered_event_count() {
+        when(buffer.getSize()).thenReturn(maxBytes.getBytes() - 1000);
+        when(buffer.getEventCount()).thenReturn(maxEvents + 1);
+        when(buffer.getDuration()).thenReturn(maxCollectionDuration.minusSeconds(1));
+
+        boolean isThresholdExceed = ThresholdCheck.checkThresholdExceed(buffer, maxEvents,
                 maxBytes, maxCollectionDuration);
+
         assertTrue(isThresholdExceed, "Threshold not exceeded");
     }
 
     @Test
-    void test_exceedThreshold_false_dueTo_maxEvents_is_greater_than_buffered_event_count() {
-        final int maxEvents = 105;
-        final ByteCount maxBytes = ByteCount.parse("50mb");
-        final long maxCollectionDuration = 50;
-        boolean isThresholdExceed = ThresholdCheck.checkThresholdExceed(inMemoryBuffer, maxEvents, maxBytes,
-                maxCollectionDuration);
-        assertFalse(isThresholdExceed, "Threshold exceeded");
-    }
+    void test_exceedThreshold_false_dueTo_maxEvents_is_less_than_buffered_event_count() {
+        when(buffer.getSize()).thenReturn(maxBytes.getBytes() - 1000);
+        when(buffer.getEventCount()).thenReturn(maxEvents - 1);
+        when(buffer.getDuration()).thenReturn(this.maxCollectionDuration.minusSeconds(1));
 
-    @Test
-    void test_exceedThreshold_ture_dueTo_maxBytes_is_less_than_buffered_byte_count() {
-        final int maxEvents = 500;
-        final ByteCount maxBytes = ByteCount.parse("1b");
-        final long maxCollectionDuration = 15;
-        boolean isThresholdExceed = ThresholdCheck.checkThresholdExceed(inMemoryBuffer, maxEvents, maxBytes,
-                maxCollectionDuration);
-        assertTrue(isThresholdExceed, "Threshold not exceeded");
-    }
-
-    @Test
-    void test_exceedThreshold_false_dueTo_maxBytes_is_greater_than_buffered_byte_count() {
-        final int maxEvents = 500;
-        final ByteCount maxBytes = ByteCount.parse("8mb");
-        final long maxCollectionDuration = 15;
-        boolean isThresholdExceed = ThresholdCheck.checkThresholdExceed(inMemoryBuffer, maxEvents,
+        boolean isThresholdExceed = ThresholdCheck.checkThresholdExceed(buffer, maxEvents,
                 maxBytes, maxCollectionDuration);
+
         assertFalse(isThresholdExceed, "Threshold exceeded");
     }
 
     @Test
-    void test_exceedThreshold_ture_dueTo_maxCollectionDuration_is_less_than_buffered_event_collection_duration()
-            throws IOException, InterruptedException {
-        final int maxEvents = 500;
-        final ByteCount maxBytes = ByteCount.parse("500mb");
-        final long maxCollectionDuration = 10;
+    void test_exceedThreshold_true_dueTo_maxBytes_is_greater_than_buffered_byte_count() {
+        when(buffer.getSize()).thenReturn(maxBytes.getBytes() + 1000);
+        when(buffer.getEventCount()).thenReturn(maxEvents - 1);
+        when(buffer.getDuration()).thenReturn(maxCollectionDuration.minusSeconds(1));
 
-        inMemoryBuffer = new InMemoryBufferFactory().getBuffer(null, null, null);
-        boolean isThresholdExceed = Boolean.FALSE;
-        synchronized (this) {
-            while (inMemoryBuffer.getEventCount() < 100) {
-                OutputStream outputStream = inMemoryBuffer.getOutputStream();
-                outputStream.write(generateByteArray());
-                int eventCount = inMemoryBuffer.getEventCount() +1;
-                inMemoryBuffer.setEventCount(eventCount);
-                isThresholdExceed = ThresholdCheck.checkThresholdExceed(inMemoryBuffer, maxEvents,
-                        maxBytes, maxCollectionDuration);
-                if (isThresholdExceed) {
-                    break;
-                }
-                wait(5000);
-            }
-        }
+        boolean isThresholdExceed = ThresholdCheck.checkThresholdExceed(buffer, maxEvents,
+                maxBytes, maxCollectionDuration);
+
         assertTrue(isThresholdExceed, "Threshold not exceeded");
     }
 
     @Test
-    void test_exceedThreshold_ture_dueTo_maxCollectionDuration_is_greater_than_buffered_event_collection_duration()
-            throws IOException, InterruptedException {
-        final int maxEvents = 500;
-        final ByteCount maxBytes = ByteCount.parse("500mb");
-        final long maxCollectionDuration = 240;
+    void test_exceedThreshold_false_dueTo_maxBytes_is_less_than_buffered_byte_count() {
+        when(buffer.getSize()).thenReturn(maxBytes.getBytes() - 1000);
+        when(buffer.getEventCount()).thenReturn(maxEvents - 1);
+        when(buffer.getDuration()).thenReturn(maxCollectionDuration.minusSeconds(1));
 
-        inMemoryBuffer = new InMemoryBufferFactory().getBuffer(null,null, null);
+        boolean isThresholdExceed = ThresholdCheck.checkThresholdExceed(buffer, maxEvents,
+                maxBytes, maxCollectionDuration);
 
-        boolean isThresholdExceed = Boolean.FALSE;
-        synchronized (this) {
-            while (inMemoryBuffer.getEventCount() < 100) {
-                OutputStream outputStream = inMemoryBuffer.getOutputStream();
-                outputStream.write(generateByteArray());
-                int eventCount = inMemoryBuffer.getEventCount() +1;
-                inMemoryBuffer.setEventCount(eventCount);
-                isThresholdExceed = ThresholdCheck.checkThresholdExceed(inMemoryBuffer,
-                        maxEvents, maxBytes, maxCollectionDuration);
-                if (isThresholdExceed) {
-                    break;
-                }
-                wait(50);
-            }
-        }
         assertFalse(isThresholdExceed, "Threshold exceeded");
     }
 
-    private byte[] generateByteArray() {
-        byte[] bytes = new byte[10000];
-        for (int i = 0; i < 10000; i++) {
-            bytes[i] = (byte) i;
-        }
-        return bytes;
+    @Test
+    void test_exceedThreshold_true_dueTo_maxCollectionDuration_is_greater_than_buffered_event_collection_duration() {
+        when(buffer.getSize()).thenReturn(maxBytes.getBytes() - 1000);
+        when(buffer.getEventCount()).thenReturn(maxEvents - 1);
+        when(buffer.getDuration()).thenReturn(maxCollectionDuration.plusSeconds(1));
+
+        boolean isThresholdExceed = ThresholdCheck.checkThresholdExceed(buffer, maxEvents,
+                maxBytes, maxCollectionDuration);
+
+        assertTrue(isThresholdExceed, "Threshold not exceeded");
+    }
+
+    @Test
+    void test_exceedThreshold_false_dueTo_maxCollectionDuration_is_less_than_buffered_event_collection_duration() {
+        when(buffer.getSize()).thenReturn(maxBytes.getBytes() - 1000);
+        when(buffer.getEventCount()).thenReturn(maxEvents - 1);
+        when(buffer.getDuration()).thenReturn(maxCollectionDuration.minusSeconds(1));
+
+        boolean isThresholdExceed = ThresholdCheck.checkThresholdExceed(buffer, maxEvents,
+                maxBytes, maxCollectionDuration);
+
+
+        assertFalse(isThresholdExceed, "Threshold exceeded");
     }
 }

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CompressionBufferTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CompressionBufferTest.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.time.Duration;
 import java.util.Random;
 import java.util.UUID;
 
@@ -81,7 +82,7 @@ class CompressionBufferTest {
 
     @Test
     void getDuration_returns_inner_getDuration() {
-        final long duration = random.nextInt(10_000) + 1_000;
+        final Duration duration = Duration.ofMillis(random.nextInt(10_000) + 1_000);
 
         final CompressionBuffer objectUnderTest = createObjectUnderTest();
         when(innerBuffer.getDuration()).thenReturn(duration);

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/LocalFileBufferTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/LocalFileBufferTest.java
@@ -11,9 +11,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -61,7 +63,8 @@ class LocalFileBufferTest {
         }
         assertThat(localFileBuffer.getSize(), greaterThan(1l));
         assertThat(localFileBuffer.getEventCount(), equalTo(55));
-        assertThat(localFileBuffer.getDuration(), equalTo(0L));
+        assertThat(localFileBuffer.getDuration(), notNullValue());
+        assertThat(localFileBuffer.getDuration(), greaterThanOrEqualTo(Duration.ZERO));
         localFileBuffer.flushAndCloseStream();
         localFileBuffer.removeTemporaryFile();
         assertFalse(tempFile.exists(), "The temp file has not been deleted.");
@@ -71,7 +74,8 @@ class LocalFileBufferTest {
     void test_without_write_events_into_buffer() {
         assertThat(localFileBuffer.getSize(), equalTo(0L));
         assertThat(localFileBuffer.getEventCount(), equalTo(0));
-        assertThat(localFileBuffer.getDuration(), equalTo(0L));
+        assertThat(localFileBuffer.getDuration(), notNullValue());
+        assertThat(localFileBuffer.getDuration(), greaterThanOrEqualTo(Duration.ZERO));
         localFileBuffer.flushAndCloseStream();
         localFileBuffer.removeTemporaryFile();
         assertFalse(tempFile.exists(), "The temp file has not been deleted.");
@@ -87,7 +91,8 @@ class LocalFileBufferTest {
         }
         assertThat(localFileBuffer.getSize(), greaterThan(1l));
         assertThat(localFileBuffer.getEventCount(), equalTo(55));
-        assertThat(localFileBuffer.getDuration(), greaterThanOrEqualTo(0L));
+        assertThat(localFileBuffer.getDuration(), notNullValue());
+        assertThat(localFileBuffer.getDuration(), greaterThanOrEqualTo(Duration.ZERO));
 
         when(keySupplier.get()).thenReturn(KEY);
         when(bucketSupplier.get()).thenReturn(BUCKET_NAME);


### PR DESCRIPTION
### Description

This PR includes changes which reduce the total time to build the `s3-sink` project from over 2minutes to about 15 seconds on my machine.

* Use the Duration class instead of a nebulous long to send duration times around. This can allow for millisecond resolution.
* Inject the retry sleep time into `S3SinkService` so that unit test can take much less time.
* Using mocking in `ThresholdCheckTest` to avoid unnecessary sleeps.

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
