### PR TITLE
Adds an auto_schema flag to Avro/Parquet codecs

### DIFF
--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodecConfig.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodecConfig.java
@@ -5,6 +5,7 @@
 package org.opensearch.dataprepper.plugins.codec.avro;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.AssertTrue;
 
 /**
  * Configuration class for {@link AvroOutputCodec}.
@@ -13,11 +14,27 @@ public class AvroOutputCodecConfig {
     @JsonProperty("schema")
     private String schema;
 
+    @JsonProperty("auto_schema")
+    private boolean autoSchema;
+
+    @AssertTrue(message = "The Avro codec requires either defining a schema or setting auto_schema to true to automatically generate a schema.")
+    boolean isSchemaOrAutoSchemaDefined() {
+        return schema != null ^ autoSchema;
+    }
+
     public String getSchema() {
         return schema;
     }
 
-    public void setSchema(String schema) {
+    void setSchema(final String schema) {
         this.schema = schema;
+    }
+
+    public boolean isAutoSchema() {
+        return autoSchema;
+    }
+
+    void setAutoSchema(final boolean autoSchema) {
+        this.autoSchema = autoSchema;
     }
 }

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodecConfigTest.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodecConfigTest.java
@@ -1,0 +1,47 @@
+package org.opensearch.dataprepper.plugins.codec.avro;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class AvroOutputCodecConfigTest {
+
+    private AvroOutputCodecConfig createObjectUnderTest() {
+        return new AvroOutputCodecConfig();
+    }
+
+    @Test
+    void isSchemaOrAutoSchemaDefined_returns_true_if_schema_defined() {
+        AvroOutputCodecConfig objectUnderTest = createObjectUnderTest();
+        objectUnderTest.setSchema(UUID.randomUUID().toString());
+
+        assertThat(objectUnderTest.isSchemaOrAutoSchemaDefined(), equalTo(true));
+    }
+
+    @Test
+    void isSchemaOrAutoSchemaDefined_returns_true_if_schema_null_and_autoSchema_true() {
+        AvroOutputCodecConfig objectUnderTest = createObjectUnderTest();
+        objectUnderTest.setAutoSchema(true);
+
+        assertThat(objectUnderTest.isSchemaOrAutoSchemaDefined(), equalTo(true));
+    }
+
+    @Test
+    void isSchemaOrAutoSchemaDefined_returns_false_if_schema_null() {
+        AvroOutputCodecConfig objectUnderTest = createObjectUnderTest();
+
+        assertThat(objectUnderTest.isSchemaOrAutoSchemaDefined(), equalTo(false));
+    }
+
+    @Test
+    void isSchemaOrAutoSchemaDefined_returns_false_if_schema_and_autoSchema() {
+        AvroOutputCodecConfig objectUnderTest = createObjectUnderTest();
+        objectUnderTest.setSchema(UUID.randomUUID().toString());
+        objectUnderTest.setAutoSchema(true);
+
+        assertThat(objectUnderTest.isSchemaOrAutoSchemaDefined(), equalTo(false));
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodecConfig.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodecConfig.java
@@ -5,17 +5,34 @@
 package org.opensearch.dataprepper.plugins.codec.parquet;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.AssertTrue;
 
 public class ParquetOutputCodecConfig {
     @JsonProperty("schema")
     private String schema;
 
+    @JsonProperty("auto_schema")
+    private boolean autoSchema;
+
+    @AssertTrue(message = "The Parquet codec requires either defining a schema or setting auto_schema to true to automatically generate a schema.")
+    boolean isSchemaOrAutoSchemaDefined() {
+        return schema != null ^ autoSchema;
+    }
+
     public String getSchema() {
         return schema;
     }
 
-    public void setSchema(String schema) {
+    public void setSchema(final String schema) {
         this.schema = schema;
+    }
+
+    public boolean isAutoSchema() {
+        return autoSchema;
+    }
+
+    void setAutoSchema(final boolean autoSchema) {
+        this.autoSchema = autoSchema;
     }
 }
 

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodecConfigTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodecConfigTest.java
@@ -1,0 +1,48 @@
+package org.opensearch.dataprepper.plugins.codec.parquet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class ParquetOutputCodecConfigTest {
+
+    private ParquetOutputCodecConfig createObjectUnderTest() {
+        return new ParquetOutputCodecConfig();
+    }
+
+    @Test
+    void isSchemaOrAutoSchemaDefined_returns_true_if_schema_defined() {
+        ParquetOutputCodecConfig objectUnderTest = createObjectUnderTest();
+        objectUnderTest.setSchema(UUID.randomUUID().toString());
+
+        assertThat(objectUnderTest.isSchemaOrAutoSchemaDefined(), equalTo(true));
+    }
+
+    @Test
+    void isSchemaOrAutoSchemaDefined_returns_true_if_schema_null_and_autoSchema_true() {
+        ParquetOutputCodecConfig objectUnderTest = createObjectUnderTest();
+        objectUnderTest.setAutoSchema(true);
+
+        assertThat(objectUnderTest.isSchemaOrAutoSchemaDefined(), equalTo(true));
+    }
+
+    @Test
+    void isSchemaOrAutoSchemaDefined_returns_false_if_schema_null() {
+        ParquetOutputCodecConfig objectUnderTest = createObjectUnderTest();
+
+        assertThat(objectUnderTest.isSchemaOrAutoSchemaDefined(), equalTo(false));
+    }
+
+    @Test
+    void isSchemaOrAutoSchemaDefined_returns_false_if_schema_and_autoSchema() {
+        ParquetOutputCodecConfig objectUnderTest = createObjectUnderTest();
+        objectUnderTest.setSchema(UUID.randomUUID().toString());
+        objectUnderTest.setAutoSchema(true);
+
+        assertThat(objectUnderTest.isSchemaOrAutoSchemaDefined(), equalTo(false));
+    }
+
+}


### PR DESCRIPTION
### Description

The current design of the auto-schema generation for the Avro/Parquet codecs will make the default behavior automatically generate a schema. Users may not be aware that this is happening.

This PR adds a new field `auto_schema` to enable the feature.

Thus, the user can configure a codec as such:

```
s3:
  codec:
    parquet:
      auto_schema: true
```
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
