### PR TITLE
Kafka source fixes: commit offsets, consumer group mutations, consume…

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
@@ -5,52 +5,50 @@
 
 package org.opensearch.dataprepper.plugins.kafka.source;
 
-import org.apache.kafka.clients.producer.KafkaProducer;
+import io.micrometer.core.instrument.Counter;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.opensearch.dataprepper.acknowledgements.DefaultAcknowledgementSetManager;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
-import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventMetadata;
-import org.opensearch.dataprepper.acknowledgements.DefaultAcknowledgementSetManager;
-import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSourceConfig;
-import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaKeyMode;
+import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.kafka.configuration.EncryptionType;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaKeyMode;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSourceConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.TopicConfig;
-import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
-import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 
-import static org.mockito.Mockito.when;
-import org.mockito.Mock;
-import static org.mockito.Mockito.mock;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.equalTo;
-import org.apache.commons.lang3.RandomStringUtils;
-
-import io.micrometer.core.instrument.Counter;
-import java.util.List;
-import java.util.Map;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import java.time.Duration;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class KafkaSourceJsonTypeIT {
     private static final int TEST_ID = 123456;
@@ -104,7 +102,6 @@ public class KafkaSourceJsonTypeIT {
         acknowledgementSetManager = new DefaultAcknowledgementSetManager(executor);
         pipelineDescription = mock(PipelineDescription.class);
         when(sourceConfig.getAcknowledgementsEnabled()).thenReturn(false);
-        when(sourceConfig.getAcknowledgementsTimeout()).thenReturn(KafkaSourceConfig.DEFAULT_ACKNOWLEDGEMENTS_TIMEOUT);
         when(sourceConfig.getSchemaConfig()).thenReturn(null);
         when(pluginMetrics.counter(anyString())).thenReturn(counter);
         when(pipelineDescription.getPipelineName()).thenReturn("testPipeline");

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceMultipleAuthTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceMultipleAuthTypeIT.java
@@ -5,48 +5,46 @@
 
 package org.opensearch.dataprepper.plugins.kafka.source;
 
-import org.apache.kafka.clients.producer.KafkaProducer;
+import io.micrometer.core.instrument.Counter;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
-import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSourceConfig;
-import org.opensearch.dataprepper.plugins.kafka.configuration.PlainTextAuthConfig;
+import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.EncryptionType;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSourceConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.PlainTextAuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.TopicConfig;
-import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
-import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 
-import static org.mockito.Mockito.when;
-import org.mockito.Mock;
-import static org.mockito.Mockito.mock;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.equalTo;
-import org.apache.commons.lang3.RandomStringUtils;
-
-import io.micrometer.core.instrument.Counter;
-import java.util.List;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import java.time.Duration;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class KafkaSourceMultipleAuthTypeIT {
     @Mock
@@ -112,7 +110,6 @@ public class KafkaSourceMultipleAuthTypeIT {
         acknowledgementSetManager = mock(AcknowledgementSetManager.class);
         pipelineDescription = mock(PipelineDescription.class);
         when(sourceConfig.getAcknowledgementsEnabled()).thenReturn(false);
-        when(sourceConfig.getAcknowledgementsTimeout()).thenReturn(KafkaSourceConfig.DEFAULT_ACKNOWLEDGEMENTS_TIMEOUT);
         when(sourceConfig.getSchemaConfig()).thenReturn(null);
         when(pluginMetrics.counter(anyString())).thenReturn(counter);
         when(pipelineDescription.getPipelineName()).thenReturn("testPipeline");

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSourceConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSourceConfig.java
@@ -12,7 +12,6 @@ import jakarta.validation.constraints.Size;
 
 import java.util.List;
 import java.util.Objects;
-import java.time.Duration;
 
 /**
  * * A helper class that helps to read user configuration values from
@@ -35,8 +34,6 @@ public class KafkaSourceConfig {
             return insecure;
         }
     }
-
-    public static final Duration DEFAULT_ACKNOWLEDGEMENTS_TIMEOUT = Duration.ofSeconds(30);
 
     @JsonProperty("bootstrap_servers")
     private List<String> bootStrapServers;
@@ -64,9 +61,6 @@ public class KafkaSourceConfig {
     @JsonProperty("acknowledgments")
     private Boolean acknowledgementsEnabled = false;
 
-    @JsonProperty("acknowledgments_timeout")
-    private Duration acknowledgementsTimeout = DEFAULT_ACKNOWLEDGEMENTS_TIMEOUT;
-
     @JsonProperty("client_dns_lookup")
     private String clientDnsLookup;
 
@@ -76,10 +70,6 @@ public class KafkaSourceConfig {
 
     public Boolean getAcknowledgementsEnabled() {
         return acknowledgementsEnabled;
-    }
-
-    public Duration getAcknowledgementsTimeout() {
-        return acknowledgementsTimeout;
     }
 
     public List<TopicConfig> getTopics() {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/CommitOffsetRange.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/CommitOffsetRange.java
@@ -1,0 +1,21 @@
+package org.opensearch.dataprepper.plugins.kafka.consumer;
+
+import org.apache.commons.lang3.Range;
+
+public class CommitOffsetRange {
+    private final long epoch;
+    private final Range<Long> offsets;
+
+    public CommitOffsetRange(final Range<Long> offsets, final long epoch) {
+        this.offsets = offsets;
+        this.epoch = epoch;
+    }
+
+    public long getEpoch() {
+        return epoch;
+    }
+
+    public Range<Long> getOffsets() {
+        return offsets;
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -5,34 +5,34 @@
 
 package org.opensearch.dataprepper.plugins.kafka.source;
 
+import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryKafkaDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import io.confluent.kafka.serializers.KafkaJsonDeserializer;
 import kafka.common.BrokerEndPointNotAvailableException;
 import org.apache.avro.generic.GenericRecord;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.errors.BrokerNotAvailableException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
-import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
-import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
-
 import org.opensearch.dataprepper.plugins.kafka.configuration.AuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSourceConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.OAuthConfig;
@@ -44,11 +44,8 @@ import org.opensearch.dataprepper.plugins.kafka.consumer.KafkaSourceCustomConsum
 import org.opensearch.dataprepper.plugins.kafka.util.ClientDNSLookupType;
 import org.opensearch.dataprepper.plugins.kafka.util.KafkaSourceJsonDeserializer;
 import org.opensearch.dataprepper.plugins.kafka.util.KafkaSourceSecurityConfigurer;
-import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 import org.opensearch.dataprepper.plugins.kafka.util.KafkaTopicMetrics;
-
-import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryKafkaDeserializer;
-
+import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,25 +54,26 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.InetAddress;
-import java.net.Socket;
-import java.util.Map;
-import java.util.List;
-import java.util.Objects;
-import java.util.Comparator;
-import java.util.Properties;
-import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.concurrent.Executors;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.IntStream;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
 
 /**
  * The starting point of the Kafka-source plugin and the Kafka consumer
@@ -100,6 +98,8 @@ public class KafkaSource implements Source<Record<Event>> {
     private static CachedSchemaRegistryClient schemaRegistryClient;
     private GlueSchemaRegistryKafkaDeserializer glueDeserializer;
     private StringDeserializer stringDeserializer;
+    private final Map<TopicConfig, ExecutorService> topicExecutorService;
+    private final Map<TopicConfig, KafkaSourceCustomConsumer> topicConsumer;
 
     @DataPrepperPluginConstructor
     public KafkaSource(final KafkaSourceConfig sourceConfig,
@@ -112,6 +112,8 @@ public class KafkaSource implements Source<Record<Event>> {
         this.pipelineName = pipelineDescription.getPipelineName();
         this.stringDeserializer = new StringDeserializer();
         shutdownInProgress = new AtomicBoolean(false);
+        topicExecutorService = new HashMap<>();
+        topicConsumer = new HashMap<>();
     }
 
     @Override
@@ -146,6 +148,9 @@ public class KafkaSource implements Source<Record<Event>> {
                     }
                     consumer = new KafkaSourceCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType, acknowledgementSetManager, topicMetrics);
                     executorService.submit(consumer);
+
+                    topicExecutorService.put(topic, executorService);
+                    topicConsumer.put(topic, consumer);
                 });
             } catch (Exception e) {
                 if (e instanceof BrokerNotAvailableException ||
@@ -162,8 +167,15 @@ public class KafkaSource implements Source<Record<Event>> {
 
     @Override
     public void stop() {
-        LOG.info("Shutting down Consumers...");
         shutdownInProgress.set(true);
+        LOG.info("Shutting down Consumers...");
+        sourceConfig.getTopics().forEach(topic -> {
+            stopConsumer(topicExecutorService.get(topic), topicConsumer.get(topic));
+        });
+        LOG.info("Consumer shutdown successfully...");
+    }
+
+    public void stopConsumer(final ExecutorService executorService, final KafkaSourceCustomConsumer consumer) {
         executorService.shutdown();
         try {
             if (!executorService.awaitTermination(
@@ -178,7 +190,7 @@ public class KafkaSource implements Source<Record<Event>> {
                 Thread.currentThread().interrupt();
             }
         }
-        LOG.info("Consumer shutdown successfully...");
+        consumer.closeConsumer();
     }
 
     private long calculateLongestThreadWaitingTime() {
@@ -270,7 +282,6 @@ public class KafkaSource implements Source<Record<Event>> {
                 // the schemaType to PLAINTEXT
                 LOG.error("GET request failed while fetching the schema registry. Defaulting to schema type PLAINTEXT");
                 return MessageFormat.PLAINTEXT.toString();
-
             }
         } catch (IOException e) {
             LOG.error("An error while fetching the schema registry details : ", e);

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSourceConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaSourceConfigTest.java
@@ -11,12 +11,11 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.List;
-import java.util.Collections;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
-import java.time.Duration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
@@ -66,7 +65,6 @@ class KafkaSourceConfigTest {
 	@Test
 	void test_topics_not_null(){
 		assertEquals(false, kafkaSourceConfig.getAcknowledgementsEnabled());
-		assertEquals(KafkaSourceConfig.DEFAULT_ACKNOWLEDGEMENTS_TIMEOUT, kafkaSourceConfig.getAcknowledgementsTimeout());
 		assertThat(kafkaSourceConfig.getTopics(), notNullValue());
 	}
 
@@ -81,10 +79,7 @@ class KafkaSourceConfigTest {
 		assertEquals("127.0.0.1:9092", kafkaSourceConfig.getBootStrapServers());
 		assertEquals(Collections.singletonList(topicConfig), kafkaSourceConfig.getTopics());
         setField(KafkaSourceConfig.class, kafkaSourceConfig, "acknowledgementsEnabled", true);
-        Duration testTimeout = Duration.ofSeconds(10);
-        setField(KafkaSourceConfig.class, kafkaSourceConfig, "acknowledgementsTimeout", testTimeout);
 		assertEquals(true, kafkaSourceConfig.getAcknowledgementsEnabled());
-		assertEquals(testTimeout, kafkaSourceConfig.getAcknowledgementsTimeout());
 		assertEquals(EncryptionType.SSL, kafkaSourceConfig.getEncryptionConfig().getType());
         setField(KafkaSourceConfig.EncryptionConfig.class, encryptionConfig, "type", EncryptionType.NONE);
 		assertEquals(EncryptionType.NONE, encryptionConfig.getType());


### PR DESCRIPTION
…r shutdown

### Description
This PR includes changes from following PR from kkondaka and adds few more additional fixes.
https://github.com/opensearch-project/data-prepper/pull/3200

> Register handlers for partition add/revoke callbacks. 
> Fixed commitOffsets to include acknowledged records.
> Fixed kafka consumers shutdown.


 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
