### PR TITLE
Fix bug where enum for s3 select was using NotBlank annotation

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3SelectOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/configuration/S3SelectOptions.java
@@ -5,8 +5,8 @@
 package org.opensearch.dataprepper.plugins.source.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * Class consists the s3 select options.
@@ -24,7 +24,7 @@ public class S3SelectOptions {
 	private String expressionType = DEFAULT_EXPRESSION_TYPE;
 
 	@JsonProperty("input_serialization")
-	@NotBlank(message = "input serialization format cannot be null or empty")
+	@NotNull
 	private S3SelectSerializationFormatOption s3SelectSerializationFormatOption;
 
 	@JsonProperty("compression_type")


### PR DESCRIPTION
### Description
Using the s3 select input_serialization field results in an exception 

```
ERROR org.opensearch.dataprepper.parser.PipelineParser - Construction of pipeline components failed, skipping building of pipeline [s3-scan-pipeline] and its connected pipelines
jakarta.validation.UnexpectedTypeException: HV000030: No validator could be found for constraint 'jakarta.validation.constraints.NotBlank' validating type 'org.opensearch.dataprepper.plugins.source.configuration.S3SelectSerializationFormatOption'. Check configuration for 's3SelectOptions.s3SelectSerializationFormatOption'
	at org.hibernate.validator.internal.engine.constraintvalidation.ConstraintTree.getExceptionForNullValidator(ConstraintTree.java:116) ~[hibernate-validator-8.0.0.Final.jar:8.0.0.Final]
```

Fixed by switching annotation from @NotBlank to @NonNull
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
