### PR TITLE
Catch exceptions when writing to the output codec and drop the event.

### DIFF
--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
@@ -121,13 +121,17 @@ public class S3SinkService {
                     codec.writeEvent(event, currentBuffer.getOutputStream());
                     int count = currentBuffer.getEventCount() + 1;
                     currentBuffer.setEventCount(count);
+
+                    if (event.getEventHandle() != null) {
+                        bufferedEventHandles.add(event.getEventHandle());
+                    }
                 } catch (Exception ex) {
+                    if (event.getEventHandle() != null) {
+                        event.getEventHandle().release(false);
+                    }
                     LOG.error("Unable to add event to buffer. Dropping this event.");
                 }
 
-                if (event.getEventHandle() != null) {
-                    bufferedEventHandles.add(event.getEventHandle());
-                }
                 flushToS3IfNeeded();
             }
             flushToS3IfNeeded();

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceTest.java
@@ -10,6 +10,7 @@ import io.micrometer.core.instrument.DistributionSummary;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
@@ -54,6 +55,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -469,6 +471,34 @@ class S3SinkServiceTest {
         for (EventHandle eventHandle : eventHandles2) {
             verify(eventHandle).release(true);
         }
+    }
+
+    @Test
+    void output_will_skip_and_drop_failed_records() throws IOException {
+        bufferFactory = mock(BufferFactory.class);
+        final Buffer buffer = mock(Buffer.class);
+        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
+
+        final long objectSize = random.nextInt(1_000_000) + 10_000;
+        when(buffer.getSize()).thenReturn(objectSize);
+
+        final OutputStream outputStream = mock(OutputStream.class);
+        when(buffer.getOutputStream()).thenReturn(outputStream);
+
+        final S3SinkService s3SinkService = createObjectUnderTest();
+
+        List<Record<Event>> records = generateEventRecords(2);
+        Event event1 = records.get(0).getData();
+        Event event2 = records.get(1).getData();
+
+        doThrow(RuntimeException.class).when(codec).writeEvent(event1, outputStream);
+
+        s3SinkService.output(records);
+
+        InOrder inOrder = inOrder(codec);
+        inOrder.verify(codec).start(eq(outputStream), eq(event1), any());
+        inOrder.verify(codec).writeEvent(event1, outputStream);
+        inOrder.verify(codec).writeEvent(event2, outputStream);
     }
 
     @Test


### PR DESCRIPTION
### Description

Currently, failures in the S3 sink may cause the entire pipeline to crash. This PR resolves that by catching exceptions for each event and dropping that event only.
 
### Issues Resolved

Resolves #3202
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
