### PR TITLE
Improvements in the release GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,23 +4,24 @@ on:
   workflow_dispatch:
     inputs:
       release-major-tag:
-        description: 'Whether to create major tag of docker image or not. This will create a tag such as 2.3 which points to this version.'
+        description: 'Whether to create major tag of docker image or not. This will create a tag such as 2 which points to this version.'
         required: true
         type: boolean
       release-latest-tag:
         description: >
-          'Whether to create latest tag of docker image or not. This will update the latest tag to point to this version. You should set this when releasing the latest version, but not patches to old versions.'
+          Whether to create latest tag of docker image or not. This will update the latest tag to point to this version. You should set this when releasing the latest version, but not patches to old versions.
         required: true
         type: boolean
 
 permissions:
   id-token: write
   contents: write
+  issues: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 50
 
     steps:
     - name: Set up JDK
@@ -109,7 +110,7 @@ jobs:
 
   promote:
     runs-on: ubuntu-latest
-    if: success() || failure()
+    if: ${{ (success() || failure()) && needs.build.result == 'success' }}
     needs: [build, validate-docker, validate-archive]
     permissions:
       contents: write


### PR DESCRIPTION
### Description

* The conditional for the promotion job now fails if the build job fails.
* Increased the build timeout to 50 minutes since our builds take so long.
* Added permission to write GitHub issues.
* Documentation correction.
 
### Issues Resolved

N/A - working toward release
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
