### PR TITLE
Removes @cmanning09 from the CODEOWNERS file to allow release builds

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @chenqi0805 @engechas @graytaylor0 @dinujoh @kkondaka @cmanning09 @asifsmohammed @dlvenable @oeyh
+*   @chenqi0805 @engechas @graytaylor0 @dinujoh @kkondaka @asifsmohammed @dlvenable @oeyh


### PR DESCRIPTION
### Description

The release build does not work because the user @cmanning09 doesn't have write access to the repository. This PR removes him from the CODEOWNERS to allow the release build to proceed.
 
Failure:

https://github.com/opensearch-project/data-prepper/actions/runs/5956094674/job/16156990189

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
