### PR TITLE
Fix for kafka source not committing offsets issue #3231

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaSourceCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaSourceCustomConsumerTest.java
@@ -156,6 +156,8 @@ public class KafkaSourceCustomConsumerTest {
             Assertions.assertEquals(topicPartition.topic(), topic);
             Assertions.assertEquals(offsetAndMetadata.offset(), 2L);
         });
+        Assertions.assertEquals(consumer.getNumRecordsCommitted(), 2L);
+
 
         for (Record<Event> record: bufferedRecords) {
             Event event = record.getData();
@@ -214,6 +216,8 @@ public class KafkaSourceCustomConsumerTest {
             Assertions.assertEquals(topicPartition.topic(), topic);
             Assertions.assertEquals(offsetAndMetadata.offset(), 2L);
         });
+        // This counter should not be incremented with acknowledgements
+        Assertions.assertEquals(consumer.getNumRecordsCommitted(), 0L);
     }
 
     @Test
@@ -276,6 +280,7 @@ public class KafkaSourceCustomConsumerTest {
             Assertions.assertEquals(topicPartition.topic(), topic);
             Assertions.assertEquals(offsetAndMetadata.offset(), 102L);
         });
+        Assertions.assertEquals(consumer.getNumRecordsCommitted(), 2L);
 
         for (Record<Event> record: bufferedRecords) {
             Event event = record.getData();
@@ -309,3 +314,4 @@ public class KafkaSourceCustomConsumerTest {
     }
 
 }
+

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/TopicPartitionCommitTrackerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/TopicPartitionCommitTrackerTest.java
@@ -7,17 +7,12 @@ package org.opensearch.dataprepper.plugins.kafka.consumer;
 
 import org.apache.commons.lang3.Range;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,10 +20,16 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 @ExtendWith(MockitoExtension.class)
 class TopicPartitionCommitTrackerTest {
     private final String testTopic = "test_topic";
     private final int testPartition = 1;
+
     private TopicPartitionCommitTracker topicPartitionCommitTracker;
     public TopicPartitionCommitTracker createObjectUnderTest(String topic, int partition, Long offset) {
         return new TopicPartitionCommitTracker(topic, partition, offset);
@@ -53,6 +54,51 @@ class TopicPartitionCommitTrackerTest {
         }
         assertTrue(Objects.nonNull(result));
         assertThat(result.offset(), equalTo(100L));
+        assertThat(topicPartitionCommitTracker.getCommittedRecordCount(), equalTo(100L));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getInputOrder")
+    public void testNonZeroOffsets(List<Integer> order) {
+        long beginOffset = 874;
+        long endOffset = beginOffset + 10;
+        topicPartitionCommitTracker = createObjectUnderTest(testTopic, testPartition, beginOffset);
+        List<Range<Long>> ranges = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            ranges.add(Range.between(beginOffset + i*10L, beginOffset + i*10L+9L));
+        }
+        OffsetAndMetadata result = null;
+        Long expectedOffset = (long)endOffset;
+        for (Integer i: order) {
+            result = topicPartitionCommitTracker.addCompletedOffsets(ranges.get(i));
+            if (ranges.get(i).getMaximum() == (expectedOffset - 1)) {
+                assertThat(result.offset(), greaterThanOrEqualTo(expectedOffset));
+                expectedOffset = result.offset() + 10L;
+            }
+        }
+        assertTrue(Objects.nonNull(result));
+        assertThat(result.offset(), equalTo(beginOffset + 100L));
+        assertThat(topicPartitionCommitTracker.getCommittedRecordCount(), equalTo(100L));
+    }
+
+    @Test
+    public void testCommittedCount() {
+        topicPartitionCommitTracker = createObjectUnderTest(testTopic, testPartition, 0L);
+        topicPartitionCommitTracker.addCompletedOffsets(Range.between(5L, 7L));
+        assertThat(topicPartitionCommitTracker.getCommittedRecordCount(), equalTo(0L));
+        topicPartitionCommitTracker.addCompletedOffsets(Range.between(8L, 9L));
+        assertThat(topicPartitionCommitTracker.getCommittedRecordCount(), equalTo(0L));
+        topicPartitionCommitTracker.addCompletedOffsets(Range.between(0L, 4L));
+        assertThat(topicPartitionCommitTracker.getCommittedRecordCount(), equalTo(10L));
+
+        topicPartitionCommitTracker = createObjectUnderTest(testTopic, testPartition, 436L);
+        topicPartitionCommitTracker.addCompletedOffsets(Range.between(441L, 445L));
+        assertThat(topicPartitionCommitTracker.getCommittedRecordCount(), equalTo(0L));
+        topicPartitionCommitTracker.addCompletedOffsets(Range.between(436L, 439L));
+        assertThat(topicPartitionCommitTracker.getCommittedRecordCount(), equalTo(4L));
+        topicPartitionCommitTracker.addCompletedOffsets(Range.between(440L, 440L));
+        assertThat(topicPartitionCommitTracker.getCommittedRecordCount(), equalTo(6L));
+
     }
 
     private static Stream<Arguments> getInputOrder() {
@@ -65,6 +111,7 @@ class TopicPartitionCommitTrackerTest {
             Collections.shuffle(order);
             orderList.add(order);
         }
+
         return Stream.of(
             Arguments.of(List.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)),
             Arguments.of(List.of(9, 8, 7, 6, 5, 4, 3, 2, 1, 0)),
@@ -80,5 +127,5 @@ class TopicPartitionCommitTrackerTest {
             Arguments.of(orderList.get(9))
         );
     }
-
 }
+


### PR DESCRIPTION
### Description
This PR fixes following issues:
- Commit offsets when a kafka partition's beginning offset is non-zero.
- Fix numRecordsCommitted metric.
- Fix shutdown sequence for all topics+workers.

Following tests were conducted with these changes:
> Ingest 10M records from a kafka topic + group membership mutations.
> Ingest 12 M records from 2 kafka topics in single pipeline.
> Ingest 10M records from 2 different topics in 2 different pipelines.
> 2 pipelines part of same consumer group ingesting 10 M records.
> Shutdown pipeline in the middle of ingestion and resume and make sure all data is ingested.
> Ingest data without acknowledgments enabled.
> Ingest data with auto_offset_reset=earliest/latest.

 
### Issues Resolved
Resolves #3231 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
