### PR TITLE
Behavioral change to Avro codecs and schema handling

### DIFF
--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/AbstractAvroEventConverterTemplate.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/AbstractAvroEventConverterTemplate.java
@@ -1,0 +1,70 @@
+package org.opensearch.dataprepper.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+
+import java.util.List;
+import java.util.Map;
+
+abstract class AbstractAvroEventConverterTemplate implements AvroEventConverter {
+    private final SchemaChooser schemaChooser;
+
+    protected AbstractAvroEventConverterTemplate(final SchemaChooser schemaChooser) {
+        this.schemaChooser = schemaChooser;
+    }
+
+    @Override
+    public GenericRecord convertEventDataToAvro(final Schema schema,
+                                                final Map<String, Object> eventData,
+                                                final OutputCodecContext codecContext) {
+        return convertEventDataToAvro(schema, eventData, codecContext, true);
+    }
+
+    private GenericRecord convertEventDataToAvro(final Schema schema,
+                                                 final Map<String, Object> eventData,
+                                                 final OutputCodecContext codecContext,
+                                                 boolean rootOfData) {
+        final GenericRecord avroRecord = new GenericData.Record(schema);
+
+        for (String key : getKeyNames(schema, eventData, codecContext, rootOfData)) {
+            final Schema.Field field = schema.getField(key);
+            if (field == null) {
+                throw new RuntimeException("The event has a key ('" + key + "') which is not included in the schema.");
+            }
+            final Object value = schemaMapper(field, eventData.get(key), codecContext);
+            avroRecord.put(key, value);
+        }
+
+        return avroRecord;
+    }
+
+
+    private Object schemaMapper(final Schema.Field field, final Object rawValue, OutputCodecContext codecContext) {
+        Schema providedSchema = schemaChooser.chooseSchema(field.schema());
+
+        if (providedSchema.getType() == Schema.Type.RECORD && rawValue instanceof Map) {
+            return convertEventDataToAvro(providedSchema, (Map<String, Object>) rawValue, codecContext, false);
+        } else if (providedSchema.getType() == Schema.Type.ARRAY && rawValue instanceof List) {
+            GenericData.Array<Object> avroArray =
+                    new GenericData.Array<>(((List<?>) rawValue).size(), providedSchema);
+            for (Object element : ((List<?>) rawValue)) {
+                avroArray.add(element);
+            }
+            return avroArray;
+        }
+        return rawValue;
+    }
+
+    /**
+     * Template method to get key names for a given object.
+     *
+     * @param schema The Avro schema
+     * @param eventData Current event data
+     * @param codecContext The {@link OutputCodecContext}
+     * @param rootOfData True, if this is the root of the data. False when this is nested.
+     * @return An {@Iterable} of key names.
+     */
+    abstract Iterable<String> getKeyNames(Schema schema, Map<String, Object> eventData, OutputCodecContext codecContext, boolean rootOfData);
+}

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/AvroEventConverter.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/AvroEventConverter.java
@@ -1,10 +1,9 @@
 package org.opensearch.dataprepper.avro;
 
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -12,43 +11,16 @@ import java.util.Map;
  * <p>
  * It might be a good idea to consolidate similar logic for input.
  */
-public class AvroEventConverter {
-    private final SchemaChooser schemaChooser;
-
-    public AvroEventConverter() {
-        this(new SchemaChooser());
-    }
-
-    AvroEventConverter(final SchemaChooser schemaChooser) {
-        this.schemaChooser = schemaChooser;
-    }
-
-    public GenericRecord convertEventDataToAvro(final Schema schema,
-                                                final Map<String, Object> eventData) {
-        final GenericRecord avroRecord = new GenericData.Record(schema);
-
-        for (Schema.Field field : schema.getFields()) {
-            String key = field.name();
-            final Object value = schemaMapper(field, eventData.get(key));
-            avroRecord.put(key, value);
-        }
-
-        return avroRecord;
-    }
-
-    private Object schemaMapper(final Schema.Field field, final Object rawValue) {
-        Schema providedSchema = schemaChooser.chooseSchema(field.schema());
-
-        if (providedSchema.getType() == Schema.Type.RECORD && rawValue instanceof Map) {
-            return convertEventDataToAvro(providedSchema, (Map<String, Object>) rawValue);
-        } else if (providedSchema.getType() == Schema.Type.ARRAY && rawValue instanceof List) {
-            GenericData.Array<Object> avroArray =
-                    new GenericData.Array<>(((List<?>) rawValue).size(), providedSchema);
-            for (Object element : ((List<?>) rawValue)) {
-                avroArray.add(element);
-            }
-            return avroArray;
-        }
-        return rawValue;
-    }
+public interface AvroEventConverter {
+    /**
+     * Converts event data into an Avro record.
+     *
+     * @param schema The defined Avro schema
+     * @param eventData The event data; may include tags
+     * @param codecContext The output codec context which may define values included/excluded.
+     * @return The generated Avro {@link GenericRecord}.
+     */
+    GenericRecord convertEventDataToAvro(final Schema schema,
+                                         final Map<String, Object> eventData,
+                                         final OutputCodecContext codecContext);
 }

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/EventDefinedAvroEventConverter.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/EventDefinedAvroEventConverter.java
@@ -1,0 +1,39 @@
+package org.opensearch.dataprepper.avro;
+
+import org.apache.avro.Schema;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Converts an Event into an Avro record.
+ * <p>
+ * This implementation utilizes the Event data first to populate the Avro record. Thus,
+ * it will fail if the Event has any fields not in the schema.
+ */
+public class EventDefinedAvroEventConverter extends AbstractAvroEventConverterTemplate {
+    public EventDefinedAvroEventConverter() {
+        this(new SchemaChooser());
+    }
+
+    EventDefinedAvroEventConverter(final SchemaChooser schemaChooser) {
+        super(schemaChooser);
+    }
+
+    @Override
+    Iterable<String> getKeyNames(Schema schema, Map<String, Object> eventData, OutputCodecContext codecContext, boolean rootOfData) {
+        Set<String> keySet = eventData.keySet();
+
+        if(codecContext == null || !rootOfData) {
+            return keySet;
+        }
+        else {
+            return keySet.stream()
+                    .filter(Predicate.not(codecContext::shouldNotIncludeKey))
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/SchemaDefinedAvroEventConverter.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/avro/SchemaDefinedAvroEventConverter.java
@@ -1,0 +1,31 @@
+package org.opensearch.dataprepper.avro;
+
+import org.apache.avro.Schema;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Converts an Event into an Avro record.
+ * <p>
+ * This implementation relies on the defined schema. Thus, any fields in the Event which
+ * are not in the schema will be ignored.
+ */
+public class SchemaDefinedAvroEventConverter extends AbstractAvroEventConverterTemplate {
+    public SchemaDefinedAvroEventConverter() {
+        this(new SchemaChooser());
+    }
+
+    SchemaDefinedAvroEventConverter(final SchemaChooser schemaChooser) {
+        super(schemaChooser);
+    }
+
+    @Override
+    Iterable<String> getKeyNames(Schema schema, Map<String, Object> eventData, OutputCodecContext codecContext, boolean rootOfData) {
+        return schema.getFields()
+                .stream()
+                .map(Schema.Field::name)
+                .collect(Collectors.toList());
+    }
+}

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodec.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodec.java
@@ -11,6 +11,8 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.opensearch.dataprepper.avro.AvroAutoSchemaGenerator;
 import org.opensearch.dataprepper.avro.AvroEventConverter;
+import org.opensearch.dataprepper.avro.EventDefinedAvroEventConverter;
+import org.opensearch.dataprepper.avro.SchemaDefinedAvroEventConverter;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
@@ -47,11 +49,13 @@ public class AvroOutputCodec implements OutputCodec {
         Objects.requireNonNull(config);
         this.config = config;
 
-        avroEventConverter = new AvroEventConverter();
         avroAutoSchemaGenerator = new AvroAutoSchemaGenerator();
 
         if (config.getSchema() != null) {
             schema = parseSchema(config.getSchema());
+            avroEventConverter = new SchemaDefinedAvroEventConverter();
+        } else {
+            avroEventConverter = new EventDefinedAvroEventConverter();
         }
     }
 
@@ -94,7 +98,7 @@ public class AvroOutputCodec implements OutputCodec {
         } else {
             data = event.toMap();
         }
-        final GenericRecord avroRecord = avroEventConverter.convertEventDataToAvro(schema, data);
+        final GenericRecord avroRecord = avroEventConverter.convertEventDataToAvro(schema, data, codecContext);
         dataFileWriter.append(avroRecord);
     }
 

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodec.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodec.java
@@ -94,7 +94,7 @@ public class AvroOutputCodec implements OutputCodec {
         } else {
             data = event.toMap();
         }
-        final GenericRecord avroRecord = avroEventConverter.convertEventDataToAvro(schema, data, codecContext);
+        final GenericRecord avroRecord = avroEventConverter.convertEventDataToAvro(schema, data);
         dataFileWriter.append(avroRecord);
     }
 

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/AvroEventConverterTest.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/AvroEventConverterTest.java
@@ -1,6 +1,7 @@
 package org.opensearch.dataprepper.avro;
 
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -9,9 +10,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -21,6 +22,8 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,9 +34,6 @@ class AvroEventConverterTest {
     private SchemaChooser schemaChooser;
     @Mock(lenient = true)
     private Schema schema;
-
-    @Mock
-    private OutputCodecContext codecContext;
 
     @BeforeEach
     void setUp() {
@@ -49,7 +49,7 @@ class AvroEventConverterTest {
     @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
     void convertEventDataToAvro_does_not_need_to_getField_on_empty_map() {
         Map<String, Object> data = Collections.emptyMap();
-        GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+        GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
 
         assertThat(actualRecord, notNullValue());
         assertThat(actualRecord.getSchema(), equalTo(schema));
@@ -58,7 +58,7 @@ class AvroEventConverterTest {
     }
 
     @Nested
-    class WithField {
+    class WithPrimitiveField {
 
         private String fieldName;
         @Mock(lenient = true)
@@ -71,6 +71,7 @@ class AvroEventConverterTest {
             fieldName = UUID.randomUUID().toString();
             when(schema.getField(fieldName)).thenReturn(field);
             when(schema.getFields()).thenReturn(Collections.singletonList(field));
+            when(field.name()).thenReturn(fieldName);
             when(field.schema()).thenReturn(fieldSchema);
             when(field.pos()).thenReturn(0);
         }
@@ -83,7 +84,7 @@ class AvroEventConverterTest {
 
             when(schemaChooser.chooseSchema(fieldSchema)).thenReturn(fieldSchema);
 
-            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
 
             assertThat(actualRecord, notNullValue());
             assertThat(actualRecord.getSchema(), equalTo(schema));
@@ -95,16 +96,351 @@ class AvroEventConverterTest {
 
         @ParameterizedTest
         @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
-        void convertEventDataToAvro_skips_files_if_should_not_include(Object value, Schema.Type expectedType) {
-            Map<String, Object> data = Map.of(fieldName, value);
-            when(codecContext.shouldNotIncludeKey(fieldName)).thenReturn(true);
+        void convertEventDataToAvro_skips_non_present_fields(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Collections.emptyMap();
+            when(fieldSchema.getType()).thenReturn(expectedType);
 
-            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+            when(schemaChooser.chooseSchema(fieldSchema)).thenReturn(fieldSchema);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
 
             assertThat(actualRecord, notNullValue());
             assertThat(actualRecord.getSchema(), equalTo(schema));
 
             assertThat(actualRecord.get(fieldName), nullValue());
         }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_null_values(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Collections.singletonMap(fieldName, null);
+            when(fieldSchema.getType()).thenReturn(expectedType);
+
+            when(schemaChooser.chooseSchema(fieldSchema)).thenReturn(fieldSchema);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(fieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_only_includes_fields_which_are_defined_in_the_schema(Object value, Schema.Type expectedType) {
+            when(fieldSchema.getType()).thenReturn(expectedType);
+            when(schemaChooser.chooseSchema(fieldSchema)).thenReturn(fieldSchema);
+
+            String nonFieldKey = randomAvroName();
+            Map<String, Object> data = Map.of(
+                    fieldName, value,
+                    nonFieldKey, UUID.randomUUID().toString()
+                    );
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(fieldName), notNullValue());
+            assertThat(actualRecord.get(fieldName), instanceOf(value.getClass()));
+            assertThat(actualRecord.get(fieldName), equalTo(value));
+
+            assertThat(actualRecord.hasField(nonFieldKey), equalTo(false));
+        }
+    }
+
+    @Nested
+    class WithRecordField {
+        private String recordFieldName;
+        private String nestedFieldName;
+        @Mock(lenient = true)
+        private Schema.Field nestedField;
+        @Mock
+        private Schema nestedFieldSchema;
+        @Mock
+        private Schema recordFieldSchema;
+
+        @BeforeEach
+        void setUp() {
+            recordFieldName = randomAvroName();
+            nestedFieldName = randomAvroName();
+
+            when(nestedField.name()).thenReturn(nestedFieldName);
+            when(nestedField.schema()).thenReturn(nestedFieldSchema);
+            when(nestedField.pos()).thenReturn(0);
+
+            when(recordFieldSchema.getType()).thenReturn(Schema.Type.RECORD);
+            lenient().when(recordFieldSchema.getField(nestedFieldName)).thenReturn(nestedField);
+            lenient().when(recordFieldSchema.getFields()).thenReturn(Collections.singletonList(nestedField));
+
+            Schema.Field recordField = mock(Schema.Field.class);
+            when(schema.getField(recordFieldName)).thenReturn(recordField);
+            when(schema.getFields()).thenReturn(Collections.singletonList(recordField));
+
+            when(recordField.name()).thenReturn(recordFieldName);
+            when(recordField.schema()).thenReturn(recordFieldSchema);
+            when(recordField.pos()).thenReturn(0);
+
+            when(schemaChooser.chooseSchema(recordFieldSchema)).thenReturn(recordFieldSchema);
+            lenient().when(schemaChooser.chooseSchema(nestedFieldSchema)).thenReturn(nestedFieldSchema);
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_adds_nested_fields(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(recordFieldName, Map.of(nestedFieldName, value));
+            when(nestedFieldSchema.getType()).thenReturn(expectedType);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(recordFieldName), notNullValue());
+            assertThat(actualRecord.get(recordFieldName), instanceOf(GenericData.Record.class));
+            GenericData.Record actualSubRecord = (GenericData.Record) actualRecord.get(recordFieldName);
+
+            assertThat(actualSubRecord.getSchema(), notNullValue());
+            assertThat(actualSubRecord.getSchema(), equalTo(recordFieldSchema));
+            assertThat(actualSubRecord.getSchema().getType(), equalTo(Schema.Type.RECORD));
+            assertThat(actualSubRecord.get(nestedFieldName), notNullValue());
+            assertThat(actualSubRecord.get(nestedFieldName), instanceOf(value.getClass()));
+            assertThat(actualSubRecord.get(nestedFieldName), equalTo(value));
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_non_present_records(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Collections.emptyMap();
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(recordFieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_null_record(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Collections.singletonMap(recordFieldName, null);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(recordFieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_non_present_nested_fields(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(recordFieldName, Collections.emptyMap());
+            when(nestedFieldSchema.getType()).thenReturn(expectedType);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(recordFieldName), notNullValue());
+            assertThat(actualRecord.get(recordFieldName), instanceOf(GenericData.Record.class));
+            GenericData.Record actualSubRecord = (GenericData.Record) actualRecord.get(recordFieldName);
+
+            assertThat(actualSubRecord.getSchema(), notNullValue());
+            assertThat(actualSubRecord.getSchema(), equalTo(recordFieldSchema));
+            assertThat(actualSubRecord.getSchema().getType(), equalTo(Schema.Type.RECORD));
+            assertThat(actualSubRecord.get(nestedFieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_null_nested_fields(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(recordFieldName, Collections.singletonMap(nestedFieldName, null));
+            when(nestedFieldSchema.getType()).thenReturn(expectedType);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(recordFieldName), notNullValue());
+            assertThat(actualRecord.get(recordFieldName), instanceOf(GenericData.Record.class));
+            GenericData.Record actualSubRecord = (GenericData.Record) actualRecord.get(recordFieldName);
+
+            assertThat(actualSubRecord.getSchema(), notNullValue());
+            assertThat(actualSubRecord.getSchema(), equalTo(recordFieldSchema));
+            assertThat(actualSubRecord.getSchema().getType(), equalTo(Schema.Type.RECORD));
+            assertThat(actualSubRecord.get(nestedFieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_only_includes_fields_which_are_defined_in_the_schema(Object value, Schema.Type expectedType) {
+            when(nestedFieldSchema.getType()).thenReturn(expectedType);
+
+            String nonFieldKey = UUID.randomUUID().toString();
+            String nonFieldValue = UUID.randomUUID().toString();
+            Map<String, Object> data = Map.of(
+                    recordFieldName,
+                    Map.of(
+                            nestedFieldName, value,
+                            nonFieldKey, nonFieldValue
+                    ));
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(recordFieldName), notNullValue());
+            assertThat(actualRecord.get(recordFieldName), instanceOf(GenericData.Record.class));
+            GenericData.Record actualSubRecord = (GenericData.Record) actualRecord.get(recordFieldName);
+
+            assertThat(actualSubRecord.getSchema(), notNullValue());
+            assertThat(actualSubRecord.getSchema(), equalTo(recordFieldSchema));
+            assertThat(actualSubRecord.getSchema().getType(), equalTo(Schema.Type.RECORD));
+            assertThat(actualSubRecord.get(nestedFieldName), notNullValue());
+            assertThat(actualSubRecord.get(nestedFieldName), instanceOf(value.getClass()));
+            assertThat(actualSubRecord.get(nestedFieldName), equalTo(value));
+
+            assertThat(actualRecord.hasField(nonFieldKey), equalTo(false));
+        }
+    }
+
+    @Nested
+    class WithArrayField {
+        private String arrayFieldName;
+        private String nestedFieldName;
+        @Mock(lenient = true)
+        private Schema.Field nestedField;
+        @Mock
+        private Schema nestedFieldSchema;
+        @Mock
+        private Schema arrayFieldSchema;
+
+        @BeforeEach
+        void setUp() {
+            arrayFieldName = randomAvroName();
+            nestedFieldName = randomAvroName();
+
+            when(nestedField.name()).thenReturn(nestedFieldName);
+            when(nestedField.schema()).thenReturn(nestedFieldSchema);
+            when(nestedField.pos()).thenReturn(0);
+
+            when(arrayFieldSchema.getType()).thenReturn(Schema.Type.ARRAY);
+            //when(arrayFieldSchema.getElementType()).thenReturn(nestedFieldSchema);
+            //lenient().when(arrayFieldSchema.getField(nestedFieldName)).thenReturn(nestedField);
+            //lenient().when(arrayFieldSchema.getFields()).thenReturn(Collections.singletonList(nestedField));
+
+            Schema.Field recordField = mock(Schema.Field.class);
+            when(schema.getField(arrayFieldName)).thenReturn(recordField);
+            when(schema.getFields()).thenReturn(Collections.singletonList(recordField));
+
+            when(recordField.name()).thenReturn(arrayFieldName);
+            when(recordField.schema()).thenReturn(arrayFieldSchema);
+            when(recordField.pos()).thenReturn(0);
+
+            when(schemaChooser.chooseSchema(arrayFieldSchema)).thenReturn(arrayFieldSchema);
+            lenient().when(schemaChooser.chooseSchema(nestedFieldSchema)).thenReturn(nestedFieldSchema);
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_adds_array_values(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(arrayFieldName, List.of(value));
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(arrayFieldName), notNullValue());
+            assertThat(actualRecord.get(arrayFieldName), instanceOf(GenericData.Array.class));
+            GenericData.Array actualArray = (GenericData.Array) actualRecord.get(arrayFieldName);
+
+            assertThat(actualArray.getSchema(), notNullValue());
+            assertThat(actualArray.getSchema(), equalTo(arrayFieldSchema));
+            assertThat(actualArray.getSchema().getType(), equalTo(Schema.Type.ARRAY));
+            assertThat(actualArray.size(), equalTo(1));
+            assertThat(actualArray.get(0), notNullValue());
+            assertThat(actualArray.get(0), equalTo(value));
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_non_present_arrays(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Collections.emptyMap();
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(arrayFieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_null_array(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Collections.singletonMap(arrayFieldName, null);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(arrayFieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_includes_empty_arrays(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(arrayFieldName, Collections.emptyList());
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(arrayFieldName), notNullValue());
+            assertThat(actualRecord.get(arrayFieldName), instanceOf(GenericData.Array.class));
+            GenericData.Array actualArray = (GenericData.Array) actualRecord.get(arrayFieldName);
+
+            assertThat(actualArray.getSchema(), notNullValue());
+            assertThat(actualArray.getSchema(), equalTo(arrayFieldSchema));
+            assertThat(actualArray.getSchema().getType(), equalTo(Schema.Type.ARRAY));
+            assertThat(actualArray.size(), equalTo(0));
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_includes_null_array_elements(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(arrayFieldName, Collections.singletonList(null));
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(arrayFieldName), notNullValue());
+            assertThat(actualRecord.get(arrayFieldName), instanceOf(GenericData.Array.class));
+            GenericData.Array actualArray = (GenericData.Array) actualRecord.get(arrayFieldName);
+
+            assertThat(actualArray.getSchema(), notNullValue());
+            assertThat(actualArray.getSchema(), equalTo(arrayFieldSchema));
+            assertThat(actualArray.getSchema().getType(), equalTo(Schema.Type.ARRAY));
+            assertThat(actualArray.size(), equalTo(1));
+            assertThat(actualArray.get(0), nullValue());
+        }
+    }
+
+
+    private static String randomAvroName() {
+        return "a" + UUID.randomUUID().toString().replaceAll("-", "");
     }
 }

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/EventDefinedAvroEventConverterTest.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/avro/EventDefinedAvroEventConverterTest.java
@@ -1,0 +1,491 @@
+package org.opensearch.dataprepper.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventDefinedAvroEventConverterTest {
+    @Mock
+    private SchemaChooser schemaChooser;
+    @Mock(lenient = true)
+    private Schema schema;
+    private OutputCodecContext codecContext = null;
+
+    @BeforeEach
+    void setUp() {
+        when(schema.getType()).thenReturn(Schema.Type.RECORD);
+    }
+
+    private EventDefinedAvroEventConverter createObjectUnderTest() {
+        return new EventDefinedAvroEventConverter(schemaChooser);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+    void convertEventDataToAvro_does_not_need_to_getField_on_empty_map() {
+        Map<String, Object> data = Collections.emptyMap();
+        GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+        assertThat(actualRecord, notNullValue());
+        assertThat(actualRecord.getSchema(), equalTo(schema));
+
+        verify(schema, never()).getField(anyString());
+    }
+
+    @Nested
+    class WithPrimitiveField {
+
+        private String fieldName;
+        @Mock(lenient = true)
+        private Schema.Field field;
+        @Mock
+        private Schema fieldSchema;
+
+        @BeforeEach
+        void setUp() {
+            fieldName = UUID.randomUUID().toString();
+            when(schema.getField(fieldName)).thenReturn(field);
+            when(schema.getFields()).thenReturn(Collections.singletonList(field));
+            when(field.name()).thenReturn(fieldName);
+            when(field.schema()).thenReturn(fieldSchema);
+            when(field.pos()).thenReturn(0);
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_adds_fields(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(fieldName, value);
+            when(fieldSchema.getType()).thenReturn(expectedType);
+
+            when(schemaChooser.chooseSchema(fieldSchema)).thenReturn(fieldSchema);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(fieldName), notNullValue());
+            assertThat(actualRecord.get(fieldName), instanceOf(value.getClass()));
+            assertThat(actualRecord.get(fieldName), equalTo(value));
+        }
+
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_non_present_fields(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Collections.emptyMap();
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(fieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_null_values(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Collections.singletonMap(fieldName, null);
+            when(fieldSchema.getType()).thenReturn(expectedType);
+
+            when(schemaChooser.chooseSchema(fieldSchema)).thenReturn(fieldSchema);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(fieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_fields_if_should_not_include_when_not_in_schema(Object value, Schema.Type expectedType) {
+            when(schemaChooser.chooseSchema(fieldSchema)).thenReturn(fieldSchema);
+
+            String nonFieldKey = randomAvroName();
+            Map<String, Object> data = Map.of(
+                    fieldName, value,
+                    nonFieldKey, value
+            );
+
+            codecContext = mock(OutputCodecContext.class);
+            when(codecContext.shouldNotIncludeKey(fieldName)).thenReturn(false);
+            when(codecContext.shouldNotIncludeKey(nonFieldKey)).thenReturn(true);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(fieldName), notNullValue());
+            assertThat(actualRecord.get(fieldName), instanceOf(value.getClass()));
+            assertThat(actualRecord.get(fieldName), equalTo(value));
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_fields_if_should_not_include_when_in_schema(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(fieldName, value);
+
+            codecContext = mock(OutputCodecContext.class);
+            when(codecContext.shouldNotIncludeKey(fieldName)).thenReturn(true);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(fieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_throws_on_fields_which_are_not_defined_in_the_schema(Object value, Schema.Type expectedType) {
+            lenient().when(schemaChooser.chooseSchema(fieldSchema)).thenReturn(fieldSchema);
+
+            String nonFieldKey = randomAvroName();
+            Map<String, Object> data = Map.of(
+                    fieldName, value,
+                    nonFieldKey, value
+                    );
+
+            codecContext = mock(OutputCodecContext.class);
+
+            EventDefinedAvroEventConverter objectUnderTest = createObjectUnderTest();
+            RuntimeException actualException = assertThrows(RuntimeException.class, () -> objectUnderTest.convertEventDataToAvro(schema, data, codecContext));
+
+            assertThat(actualException.getMessage(), notNullValue());
+            assertThat(actualException.getMessage(), containsString(nonFieldKey));
+        }
+    }
+
+    @Nested
+    class WithRecordField {
+        private String recordFieldName;
+        private String nestedFieldName;
+        @Mock(lenient = true)
+        private Schema.Field nestedField;
+        @Mock
+        private Schema nestedFieldSchema;
+        @Mock
+        private Schema recordFieldSchema;
+
+        @BeforeEach
+        void setUp() {
+            recordFieldName = randomAvroName();
+            nestedFieldName = randomAvroName();
+
+            when(nestedField.name()).thenReturn(nestedFieldName);
+            when(nestedField.schema()).thenReturn(nestedFieldSchema);
+            when(nestedField.pos()).thenReturn(0);
+
+            lenient().when(recordFieldSchema.getType()).thenReturn(Schema.Type.RECORD);
+            lenient().when(recordFieldSchema.getField(nestedFieldName)).thenReturn(nestedField);
+            lenient().when(recordFieldSchema.getFields()).thenReturn(Collections.singletonList(nestedField));
+
+            Schema.Field recordField = mock(Schema.Field.class);
+            when(schema.getField(recordFieldName)).thenReturn(recordField);
+            when(schema.getFields()).thenReturn(Collections.singletonList(recordField));
+
+            lenient().when(recordField.schema()).thenReturn(recordFieldSchema);
+            lenient().when(recordField.pos()).thenReturn(0);
+
+            lenient().when(schemaChooser.chooseSchema(recordFieldSchema)).thenReturn(recordFieldSchema);
+            lenient().when(schemaChooser.chooseSchema(nestedFieldSchema)).thenReturn(nestedFieldSchema);
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_adds_nested_fields(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(recordFieldName, Map.of(nestedFieldName, value));
+            when(nestedFieldSchema.getType()).thenReturn(expectedType);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(recordFieldName), notNullValue());
+            assertThat(actualRecord.get(recordFieldName), instanceOf(GenericData.Record.class));
+            GenericData.Record actualSubRecord = (GenericData.Record) actualRecord.get(recordFieldName);
+
+            assertThat(actualSubRecord.getSchema(), notNullValue());
+            assertThat(actualSubRecord.getSchema(), equalTo(recordFieldSchema));
+            assertThat(actualSubRecord.getSchema().getType(), equalTo(Schema.Type.RECORD));
+            assertThat(actualSubRecord.get(nestedFieldName), notNullValue());
+            assertThat(actualSubRecord.get(nestedFieldName), instanceOf(value.getClass()));
+            assertThat(actualSubRecord.get(nestedFieldName), equalTo(value));
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_non_present_records(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Collections.emptyMap();
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(recordFieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_null_record(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Collections.singletonMap(recordFieldName, null);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(recordFieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_non_present_nested_fields(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(recordFieldName, Collections.emptyMap());
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(recordFieldName), notNullValue());
+            assertThat(actualRecord.get(recordFieldName), instanceOf(GenericData.Record.class));
+            GenericData.Record actualSubRecord = (GenericData.Record) actualRecord.get(recordFieldName);
+
+            assertThat(actualSubRecord.getSchema(), notNullValue());
+            assertThat(actualSubRecord.getSchema(), equalTo(recordFieldSchema));
+            assertThat(actualSubRecord.getSchema().getType(), equalTo(Schema.Type.RECORD));
+            assertThat(actualSubRecord.get(nestedFieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_null_nested_fields(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(recordFieldName, Collections.singletonMap(nestedFieldName, null));
+            when(nestedFieldSchema.getType()).thenReturn(expectedType);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(recordFieldName), notNullValue());
+            assertThat(actualRecord.get(recordFieldName), instanceOf(GenericData.Record.class));
+            GenericData.Record actualSubRecord = (GenericData.Record) actualRecord.get(recordFieldName);
+
+            assertThat(actualSubRecord.getSchema(), notNullValue());
+            assertThat(actualSubRecord.getSchema(), equalTo(recordFieldSchema));
+            assertThat(actualSubRecord.getSchema().getType(), equalTo(Schema.Type.RECORD));
+            assertThat(actualSubRecord.get(nestedFieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_does_not_skip_nested_fields_because_include_keys_are_not_paths(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(recordFieldName, Map.of(nestedFieldName, value));
+            when(nestedFieldSchema.getType()).thenReturn(expectedType);
+
+            codecContext = mock(OutputCodecContext.class);
+            lenient().when(codecContext.shouldNotIncludeKey(nestedFieldName)).thenReturn(true);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(recordFieldName), notNullValue());
+            assertThat(actualRecord.get(recordFieldName), instanceOf(GenericData.Record.class));
+            GenericData.Record actualSubRecord = (GenericData.Record) actualRecord.get(recordFieldName);
+
+            assertThat(actualSubRecord.getSchema(), notNullValue());
+            assertThat(actualSubRecord.getSchema(), equalTo(recordFieldSchema));
+            assertThat(actualSubRecord.getSchema().getType(), equalTo(Schema.Type.RECORD));
+            assertThat(actualSubRecord.get(nestedFieldName), notNullValue());
+            assertThat(actualSubRecord.get(nestedFieldName), instanceOf(value.getClass()));
+            assertThat(actualSubRecord.get(nestedFieldName), equalTo(value));
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_throws_on_fields_which_are_not_defined_in_the_schema(Object value, Schema.Type expectedType) {
+            String nonFieldKey = UUID.randomUUID().toString();
+            Map<String, Object> data = Map.of(
+                    recordFieldName,
+                    Map.of(
+                            nestedFieldName, value,
+                            nonFieldKey, value
+                    ));
+
+            codecContext = mock(OutputCodecContext.class);
+            when(codecContext.shouldNotIncludeKey(nonFieldKey)).thenReturn(true);
+
+            EventDefinedAvroEventConverter objectUnderTest = createObjectUnderTest();
+            RuntimeException actualException = assertThrows(RuntimeException.class, () -> objectUnderTest.convertEventDataToAvro(schema, data, codecContext));
+
+            assertThat(actualException.getMessage(), notNullValue());
+            assertThat(actualException.getMessage(), containsString(nonFieldKey));
+        }
+    }
+
+    @Nested
+    class WithArrayField {
+        private String arrayFieldName;
+        private String nestedFieldName;
+        @Mock(lenient = true)
+        private Schema.Field nestedField;
+        @Mock
+        private Schema nestedFieldSchema;
+        @Mock
+        private Schema arrayFieldSchema;
+
+        @BeforeEach
+        void setUp() {
+            arrayFieldName = randomAvroName();
+            nestedFieldName = randomAvroName();
+
+            when(nestedField.name()).thenReturn(nestedFieldName);
+            when(nestedField.schema()).thenReturn(nestedFieldSchema);
+            when(nestedField.pos()).thenReturn(0);
+
+            lenient().when(arrayFieldSchema.getType()).thenReturn(Schema.Type.ARRAY);
+
+            Schema.Field recordField = mock(Schema.Field.class);
+            when(schema.getField(arrayFieldName)).thenReturn(recordField);
+            when(schema.getFields()).thenReturn(Collections.singletonList(recordField));
+
+            lenient().when(recordField.schema()).thenReturn(arrayFieldSchema);
+            when(recordField.pos()).thenReturn(0);
+
+            lenient().when(schemaChooser.chooseSchema(arrayFieldSchema)).thenReturn(arrayFieldSchema);
+            lenient().when(schemaChooser.chooseSchema(nestedFieldSchema)).thenReturn(nestedFieldSchema);
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_adds_array_values(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(arrayFieldName, List.of(value));
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(arrayFieldName), notNullValue());
+            assertThat(actualRecord.get(arrayFieldName), instanceOf(GenericData.Array.class));
+            GenericData.Array actualArray = (GenericData.Array) actualRecord.get(arrayFieldName);
+
+            assertThat(actualArray.getSchema(), notNullValue());
+            assertThat(actualArray.getSchema(), equalTo(arrayFieldSchema));
+            assertThat(actualArray.getSchema().getType(), equalTo(Schema.Type.ARRAY));
+            assertThat(actualArray.size(), equalTo(1));
+            assertThat(actualArray.get(0), notNullValue());
+            assertThat(actualArray.get(0), equalTo(value));
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_non_present_arrays(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Collections.emptyMap();
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(arrayFieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_skips_null_array(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Collections.singletonMap(arrayFieldName, null);
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(arrayFieldName), nullValue());
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_includes_empty_arrays(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(arrayFieldName, Collections.emptyList());
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(arrayFieldName), notNullValue());
+            assertThat(actualRecord.get(arrayFieldName), instanceOf(GenericData.Array.class));
+            GenericData.Array actualArray = (GenericData.Array) actualRecord.get(arrayFieldName);
+
+            assertThat(actualArray.getSchema(), notNullValue());
+            assertThat(actualArray.getSchema(), equalTo(arrayFieldSchema));
+            assertThat(actualArray.getSchema().getType(), equalTo(Schema.Type.ARRAY));
+            assertThat(actualArray.size(), equalTo(0));
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(PrimitiveClassesToTypesArgumentsProvider.class)
+        void convertEventDataToAvro_includes_null_array_elements(Object value, Schema.Type expectedType) {
+            Map<String, Object> data = Map.of(arrayFieldName, Collections.singletonList(null));
+
+            GenericRecord actualRecord = createObjectUnderTest().convertEventDataToAvro(schema, data, codecContext);
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), equalTo(schema));
+
+            assertThat(actualRecord.get(arrayFieldName), notNullValue());
+            assertThat(actualRecord.get(arrayFieldName), instanceOf(GenericData.Array.class));
+            GenericData.Array actualArray = (GenericData.Array) actualRecord.get(arrayFieldName);
+
+            assertThat(actualArray.getSchema(), notNullValue());
+            assertThat(actualArray.getSchema(), equalTo(arrayFieldSchema));
+            assertThat(actualArray.getSchema().getType(), equalTo(Schema.Type.ARRAY));
+            assertThat(actualArray.size(), equalTo(1));
+            assertThat(actualArray.get(0), nullValue());
+        }
+    }
+
+    private static String randomAvroName() {
+        return "a" + UUID.randomUUID().toString().replaceAll("-", "");
+    }
+}

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodecTest.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodecTest.java
@@ -207,18 +207,41 @@ public class AvroOutputCodecTest {
 
     @Test
     void writeEvent_throws_exception_when_field_does_not_exist() throws IOException {
-        final Event eventWithInvalidField = mock(Event.class);
         final String invalidFieldName = UUID.randomUUID().toString();
-        when(eventWithInvalidField.toMap()).thenReturn(Collections.singletonMap(invalidFieldName, UUID.randomUUID().toString()));
+
+        Map<String, Object> mapWithInvalid = generateRecords(1).get(0);
+        mapWithInvalid.put(invalidFieldName, UUID.randomUUID().toString());
+        final Event eventWithInvalidField = mock(Event.class);
+        when(eventWithInvalidField.toMap()).thenReturn(mapWithInvalid);
+
         final AvroOutputCodec objectUnderTest = createObjectUnderTest();
 
         outputStream = new ByteArrayOutputStream();
         objectUnderTest.start(outputStream, null, new OutputCodecContext());
 
-        final RuntimeException actualException = assertThrows(RuntimeException.class, () -> objectUnderTest.writeEvent(eventWithInvalidField, outputStream));
+        objectUnderTest.writeEvent(eventWithInvalidField, outputStream);
+        objectUnderTest.complete(outputStream);
 
-        assertThat(actualException.getMessage(), notNullValue());
-        assertThat(actualException.getMessage(), containsString(invalidFieldName));
+        final List<GenericRecord> actualAvroRecords = createAvroRecordsList(outputStream);
+        assertThat(actualAvroRecords.size(), equalTo(1));
+
+        int count = 0;
+        for (final GenericRecord actualRecord : actualAvroRecords) {
+
+            assertThat(actualRecord, notNullValue());
+            assertThat(actualRecord.getSchema(), notNullValue());
+
+            List<Schema.Field> fields = actualRecord.getSchema().getFields();
+            assertThat(fields.size(), equalTo(TOTAL_TOP_LEVEL_FIELDS));
+            for (Schema.Field field : fields) {
+                Object actualValue = actualRecord.get(field.name());
+                assertThat(actualValue, notNullValue());
+            }
+            count++;
+        }
+
+        assertThat(count, equalTo(1));
+
     }
 
     @Test

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodec.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodec.java
@@ -104,7 +104,7 @@ public class ParquetOutputCodec implements OutputCodec {
         } else {
             modifiedEvent = event;
         }
-        GenericRecord parquetRecord = avroEventConverter.convertEventDataToAvro(schema, modifiedEvent.toMap(), codecContext);
+        GenericRecord parquetRecord = avroEventConverter.convertEventDataToAvro(schema, modifiedEvent.toMap());
         writer.write(parquetRecord);
     }
 


### PR DESCRIPTION
### Description

This PR makes a fundamental change to how the Avro-based codecs (Avro and Parquet) handle mapping Events to Avro records.

There are now two cases which are handled differently:

1. If the pipeline author defines a schema, this takes precedence over the incoming data. Thus, extra fields will be ignored.
2. If the schema is auto-generated, then future events must match the schema. Thus, extra fields will drop the events.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
