### PR TITLE
Fixes a bug with the S3 parquet output codec size calculation

### DIFF
--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/InMemoryBufferScenario.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/InMemoryBufferScenario.java
@@ -15,6 +15,6 @@ public class InMemoryBufferScenario implements BufferScenario {
 
     @Override
     public int getMaximumNumberOfEvents() {
-        return SizeCombination.MEDIUM_LARGER.getTotalSize();
+        return SizeCombination.LARGE.getTotalSize();
     }
 }

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/ParquetOutputScenario.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/ParquetOutputScenario.java
@@ -49,7 +49,7 @@ public class ParquetOutputScenario implements OutputScenario {
 
     @Override
     public Set<BufferTypeOptions> getIncompatibleBufferTypes() {
-        return Set.of(BufferTypeOptions.LOCALFILE, BufferTypeOptions.INMEMORY);
+        return Set.of(BufferTypeOptions.LOCALFILE, BufferTypeOptions.MULTI_PART);
     }
 
     @Override

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/SizeCombination.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/SizeCombination.java
@@ -29,4 +29,9 @@ final class SizeCombination {
     public int getNumberOfBatches() {
         return numberOfBatches;
     }
+
+    @Override
+    public String toString() {
+        return "batchSize=" + batchSize +",batches=" + numberOfBatches;
+    }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
@@ -19,8 +19,12 @@ import org.opensearch.dataprepper.model.sink.AbstractSink;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 import org.opensearch.dataprepper.model.sink.Sink;
 import org.opensearch.dataprepper.model.sink.SinkContext;
+import org.opensearch.dataprepper.plugins.codec.parquet.ParquetOutputCodec;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferFactory;
+import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferTypeOptions;
+import org.opensearch.dataprepper.plugins.sink.s3.accumulator.CodecBufferFactory;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.CompressionBufferFactory;
+import org.opensearch.dataprepper.plugins.sink.s3.codec.BufferedCodec;
 import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionEngine;
 import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionOption;
 import org.slf4j.Logger;
@@ -66,7 +70,13 @@ public class S3Sink extends AbstractSink<Record<Event>> {
         sinkInitialized = Boolean.FALSE;
 
         final S3Client s3Client = ClientFactory.createS3Client(s3SinkConfig, awsCredentialsSupplier);
-        final BufferFactory innerBufferFactory = s3SinkConfig.getBufferType().getBufferFactory();
+        BufferFactory innerBufferFactory = s3SinkConfig.getBufferType().getBufferFactory();
+        if(codec instanceof ParquetOutputCodec && s3SinkConfig.getBufferType() != BufferTypeOptions.INMEMORY) {
+            throw new InvalidPluginConfigurationException("The Parquet sink codec is an in_memory buffer only.");
+        }
+        if(codec instanceof BufferedCodec) {
+            innerBufferFactory = new CodecBufferFactory(innerBufferFactory, (BufferedCodec) codec);
+        }
         CompressionOption compressionOption = s3SinkConfig.getCompression();
         final CompressionEngine compressionEngine = compressionOption.getCompressionEngine();
         bufferFactory = new CompressionBufferFactory(innerBufferFactory, compressionEngine, codec);

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
@@ -164,6 +164,8 @@ public class S3SinkService {
     }
 
     private void flushToS3IfNeeded() {
+        LOG.trace("Flush to S3 check: currentBuffer.size={}, currentBuffer.events={}, currentBuffer.duration={}",
+                currentBuffer.getSize(), currentBuffer.getEventCount(), currentBuffer.getDuration());
         if (ThresholdCheck.checkThresholdExceed(currentBuffer, maxEvents, maxBytes, maxCollectionDuration)) {
             try {
                 codec.complete(currentBuffer.getOutputStream());

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ByteArrayPositionOutputStream.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ByteArrayPositionOutputStream.java
@@ -1,0 +1,20 @@
+package org.opensearch.dataprepper.plugins.sink.s3.accumulator;
+
+import org.apache.parquet.io.DelegatingPositionOutputStream;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class ByteArrayPositionOutputStream extends DelegatingPositionOutputStream {
+    private final ByteArrayOutputStream innerOutputStream;
+
+    public ByteArrayPositionOutputStream(ByteArrayOutputStream innerOutputStream) {
+        super(innerOutputStream);
+        this.innerOutputStream = innerOutputStream;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        return innerOutputStream.size();
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CodecBuffer.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CodecBuffer.java
@@ -1,0 +1,52 @@
+package org.opensearch.dataprepper.plugins.sink.s3.accumulator;
+
+import org.opensearch.dataprepper.plugins.sink.s3.codec.BufferedCodec;
+
+import java.io.OutputStream;
+import java.time.Duration;
+
+public class CodecBuffer implements Buffer {
+    private final Buffer innerBuffer;
+    private final BufferedCodec bufferedCodec;
+
+    public CodecBuffer(Buffer innerBuffer, BufferedCodec bufferedCodec) {
+        this.innerBuffer = innerBuffer;
+        this.bufferedCodec = bufferedCodec;
+    }
+
+    @Override
+    public long getSize() {
+        return bufferedCodec.getSize()
+                .orElseGet(innerBuffer::getSize);
+    }
+
+    @Override
+    public int getEventCount() {
+        return innerBuffer.getEventCount();
+    }
+
+    @Override
+    public Duration getDuration() {
+        return innerBuffer.getDuration();
+    }
+
+    @Override
+    public void flushToS3() {
+        innerBuffer.flushToS3();
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        return innerBuffer.getOutputStream();
+    }
+
+    @Override
+    public void setEventCount(int eventCount) {
+        innerBuffer.setEventCount(eventCount);
+    }
+
+    @Override
+    public String getKey() {
+        return innerBuffer.getKey();
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CodecBufferFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CodecBufferFactory.java
@@ -1,0 +1,22 @@
+package org.opensearch.dataprepper.plugins.sink.s3.accumulator;
+
+import org.opensearch.dataprepper.plugins.sink.s3.codec.BufferedCodec;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.util.function.Supplier;
+
+public class CodecBufferFactory implements BufferFactory {
+    private final BufferFactory innerBufferFactory;
+    private final BufferedCodec bufferedCodec;
+
+    public CodecBufferFactory(BufferFactory innerBufferFactory, BufferedCodec codec) {
+        this.innerBufferFactory = innerBufferFactory;
+        this.bufferedCodec = codec;
+    }
+
+    @Override
+    public Buffer getBuffer(S3Client s3Client, Supplier<String> bucketSupplier, Supplier<String> keySupplier) {
+        Buffer innerBuffer = innerBufferFactory.getBuffer(s3Client, bucketSupplier, keySupplier);
+        return new CodecBuffer(innerBuffer, bufferedCodec);
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/InMemoryBuffer.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/InMemoryBuffer.java
@@ -21,6 +21,7 @@ import java.util.function.Supplier;
 public class InMemoryBuffer implements Buffer {
 
     private static final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    private static final ByteArrayPositionOutputStream byteArrayPositionOutputStream = new ByteArrayPositionOutputStream(byteArrayOutputStream);
     private final S3Client s3Client;
     private final Supplier<String> bucketSupplier;
     private final Supplier<String> keySupplier;
@@ -86,6 +87,6 @@ public class InMemoryBuffer implements Buffer {
 
     @Override
     public OutputStream getOutputStream() {
-        return byteArrayOutputStream;
+        return byteArrayPositionOutputStream;
     }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/codec/BufferedCodec.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/codec/BufferedCodec.java
@@ -1,0 +1,12 @@
+package org.opensearch.dataprepper.plugins.sink.s3.codec;
+
+import org.opensearch.dataprepper.model.codec.OutputCodec;
+
+import java.util.Optional;
+
+/**
+ * Represents a {@link OutputCodec} which supplies its own buffer.
+ */
+public interface BufferedCodec extends OutputCodec {
+    Optional<Long> getSize();
+}

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ByteArrayPositionOutputStreamTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ByteArrayPositionOutputStreamTest.java
@@ -1,0 +1,41 @@
+package org.opensearch.dataprepper.plugins.sink.s3.accumulator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ByteArrayPositionOutputStreamTest {
+    @Mock
+    private ByteArrayOutputStream innerOutputStream;
+
+    private Random random;
+
+    @BeforeEach
+    void setUp() {
+        random = new Random();
+    }
+
+
+    private ByteArrayPositionOutputStream createObjectUnderTest() {
+        return new ByteArrayPositionOutputStream(innerOutputStream);
+    }
+
+    @Test
+    void getPos_returns_size() throws IOException {
+        int innerSize = random.nextInt(100_000) + 1_000;
+        when(innerOutputStream.size()).thenReturn(innerSize);
+
+        assertThat(createObjectUnderTest().getPos(), equalTo((long) innerSize));
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CodecBufferTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CodecBufferTest.java
@@ -1,0 +1,107 @@
+package org.opensearch.dataprepper.plugins.sink.s3.accumulator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.sink.s3.codec.BufferedCodec;
+
+import java.io.OutputStream;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CodecBufferTest {
+    @Mock
+    private Buffer innerBuffer;
+
+    @Mock
+    private BufferedCodec bufferedCodec;
+    private Random random;
+
+    @BeforeEach
+    void setUp() {
+        random = new Random();
+    }
+
+    private CodecBuffer createObjectUnderTest() {
+        return new CodecBuffer(innerBuffer, bufferedCodec);
+    }
+
+    @Test
+    void getSize_returns_BufferedCodec_getSize_if_present() {
+        long bufferedCodecSize = Integer.MAX_VALUE + random.nextInt(100_000) + 1000;
+        when(bufferedCodec.getSize()).thenReturn(Optional.of(bufferedCodecSize));
+
+        assertThat(createObjectUnderTest().getSize(), equalTo(bufferedCodecSize));
+
+        verify(innerBuffer, never()).getSize();
+    }
+
+    @Test
+    void getSize_returns_innerBuffer_getSize_if_BufferedCodec_getSize_not_present() {
+        long innerSize = Integer.MAX_VALUE + random.nextInt(100_000) + 1000;
+        when(innerBuffer.getSize()).thenReturn(innerSize);
+
+        assertThat(createObjectUnderTest().getSize(), equalTo(innerSize));
+    }
+
+    @Test
+    void getEventCount_returns_inner_getEventCount() {
+        int innerEventCount = random.nextInt(100_000) + 1000;
+        when(innerBuffer.getEventCount()).thenReturn(innerEventCount);
+
+        assertThat(createObjectUnderTest().getEventCount(), equalTo(innerEventCount));
+    }
+
+    @Test
+    void getDuration_returns_inner_getDuration() {
+        Duration innerDuration = Duration.ofSeconds(random.nextInt(10_000) + 100);
+        when(innerBuffer.getDuration()).thenReturn(innerDuration);
+
+        assertThat(createObjectUnderTest().getDuration(), equalTo(innerDuration));
+
+    }
+
+    @Test
+    void getOutputStream_returns_inner_getOutputStream() {
+        OutputStream innerOutputStream = mock(OutputStream.class);
+        when(innerBuffer.getOutputStream()).thenReturn(innerOutputStream);
+
+        assertThat(createObjectUnderTest().getOutputStream(), equalTo(innerOutputStream));
+    }
+
+    @Test
+    void getKey_returns_inner_getKey() {
+        String innerKey = UUID.randomUUID().toString();
+        when(innerBuffer.getKey()).thenReturn(innerKey);
+
+        assertThat(createObjectUnderTest().getKey(), equalTo(innerKey));
+    }
+
+    @Test
+    void setEventCount_calls_inner_setEventCount() {
+        int newEventCount = random.nextInt(100_000) + 1000;
+
+        createObjectUnderTest().setEventCount(newEventCount);
+
+        verify(innerBuffer).setEventCount(newEventCount);
+    }
+
+    @Test
+    void flushToS3_calls_inner_flushToS3() {
+        createObjectUnderTest().flushToS3();
+
+        verify(innerBuffer).flushToS3();
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/test/resources/simplelogger.properties
+++ b/data-prepper-plugins/s3-sink/src/test/resources/simplelogger.properties
@@ -5,3 +5,5 @@
 
 org.slf4j.simpleLogger.showDateTime=true
 org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd' 'HH:mm:ss.SSS
+org.slf4j.simpleLogger.log.org.opensearch.dataprepper.plugins.sink.s3=debug
+org.slf4j.simpleLogger.log.org.opensearch.dataprepper.plugins.codec.parquet=debug


### PR DESCRIPTION
### Description

Fixes the `parquet` output codec's size determination. Previously, it was not providing the correct size calculation and thus the `threshold.maximum_size` was not working.

This codec is actually writing data into an in-memory buffer managed by the `ParquetWriter`. Only at the end does the `ParquetWriter` write data to the `OutputStream`. So relying on the size of the `OutputStream` was incorrect.

I solved this by adding a new interface `BufferedCodec` which indicates that the codec itself has a buffer. The new `CodecBuffer` class will use that buffer size instead.

Additionally, I found that since the `parquet` codec is writing in-memory and then flushing, it isn't really using the `multipart` buffer as expected. Thus, I changed the validations such that this codec can only be used with the `in-memory` buffer. This also required making the `InMemoryBuffer` provide `PositionOutputStream` as required by Parquet.

This PR includes a few other changes that I found helpful such as:
* Adds `toString` on `SizeCombination` to have more helpful output in JUnit reports.
* Additional debug logging
* Enable debug particularly relevant debug logging for the `s3` sink integration tests.


### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
