### PR TITLE
Add exception handling and retry to uncaught exceptions, catch IndexN…

### DIFF
--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchIndexProgressState.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchIndexProgressState.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.opensearch;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.Instant;
@@ -14,9 +15,16 @@ import java.util.Objects;
 
 public class OpenSearchIndexProgressState {
 
+    @JsonInclude(JsonInclude.Include. NON_NULL)
     private String pitId;
+
+    @JsonInclude(JsonInclude.Include. NON_NULL)
     private Long pitCreationTime;
+
+    @JsonInclude(JsonInclude.Include. NON_NULL)
     private Long keepAlive;
+
+    @JsonInclude(JsonInclude.Include. NON_NULL)
     private List<String> searchAfter;
 
     public OpenSearchIndexProgressState() {

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchIndexProgressState.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchIndexProgressState.java
@@ -15,16 +15,16 @@ import java.util.Objects;
 
 public class OpenSearchIndexProgressState {
 
-    @JsonInclude(JsonInclude.Include. NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String pitId;
 
-    @JsonInclude(JsonInclude.Include. NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long pitCreationTime;
 
-    @JsonInclude(JsonInclude.Include. NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long keepAlive;
 
-    @JsonInclude(JsonInclude.Include. NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<String> searchAfter;
 
     public OpenSearchIndexProgressState() {

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/OpenSearchIndexPartitionCreationSupplier.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/OpenSearchIndexPartitionCreationSupplier.java
@@ -110,7 +110,7 @@ public class OpenSearchIndexPartitionCreationSupplier implements Function<Map<St
         final List<OpenSearchIndex> includedIndices = indexParametersConfiguration.getIncludedIndices();
         final List<OpenSearchIndex> excludedIndices = indexParametersConfiguration.getExcludedIndices();
 
-        final boolean matchesIncludedPattern = includedIndices.isEmpty() || doesIndexMatchPattern(includedIndices, indexName);
+        final boolean matchesIncludedPattern = (Objects.isNull(includedIndices) || includedIndices.isEmpty()) || doesIndexMatchPattern(includedIndices, indexName);
         final boolean matchesExcludePattern = doesIndexMatchPattern(excludedIndices, indexName);
 
 

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/exceptions/IndexNotFoundException.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/exceptions/IndexNotFoundException.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions;
+
+public class IndexNotFoundException extends RuntimeException {
+    public IndexNotFoundException(final String message) { super (message); }
+}

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessorTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/ElasticsearchAccessorTest.java
@@ -159,7 +159,9 @@ public class ElasticsearchAccessorTest {
 
         when(elasticSearchClient.openPointInTime(any(OpenPointInTimeRequest.class))).thenThrow(elasticsearchException);
 
-        assertThrows(SearchContextLimitException.class, () -> createObjectUnderTest().createPit(createPointInTimeRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(SearchContextLimitException.class, () -> objectUnderTest.createPit(createPointInTimeRequest));
     }
 
     @Test
@@ -180,7 +182,9 @@ public class ElasticsearchAccessorTest {
 
         when(elasticSearchClient.openPointInTime(any(OpenPointInTimeRequest.class))).thenThrow(exception);
 
-        assertThrows(IndexNotFoundException.class, () -> createObjectUnderTest().createPit(createPointInTimeRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(IndexNotFoundException.class, () -> objectUnderTest.createPit(createPointInTimeRequest));
     }
 
     @Test
@@ -199,7 +203,9 @@ public class ElasticsearchAccessorTest {
 
         when(elasticSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
 
-        assertThrows(SearchContextLimitException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(SearchContextLimitException.class, () -> objectUnderTest.createScroll(createScrollRequest));
     }
 
     @Test
@@ -222,7 +228,9 @@ public class ElasticsearchAccessorTest {
 
         when(elasticSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
 
-        assertThrows(IndexNotFoundException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(IndexNotFoundException.class, () -> objectUnderTest.createScroll(createScrollRequest));
     }
 
     @Test
@@ -243,7 +251,9 @@ public class ElasticsearchAccessorTest {
 
         when(elasticSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
 
-        assertThrows(IndexNotFoundException.class, () -> createObjectUnderTest().searchWithoutSearchContext(noSearchContextSearchRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(IndexNotFoundException.class, () -> objectUnderTest.searchWithoutSearchContext(noSearchContextSearchRequest));
     }
 
     @Test
@@ -262,7 +272,9 @@ public class ElasticsearchAccessorTest {
 
         when(elasticSearchClient.openPointInTime(any(OpenPointInTimeRequest.class))).thenThrow(openSearchException);
 
-        assertThrows(ElasticsearchException.class, () -> createObjectUnderTest().createPit(createPointInTimeRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(ElasticsearchException.class, () -> objectUnderTest.createPit(createPointInTimeRequest));
     }
 
     @Test
@@ -280,7 +292,8 @@ public class ElasticsearchAccessorTest {
 
         when(elasticSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
 
-        assertThrows(ElasticsearchException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+        assertThrows(ElasticsearchException.class, () -> objectUnderTest.createScroll(createScrollRequest));
     }
 
     @Test
@@ -294,7 +307,9 @@ public class ElasticsearchAccessorTest {
 
         when(elasticSearchClient.openPointInTime(any(OpenPointInTimeRequest.class))).thenThrow(IOException.class);
 
-        assertThrows(RuntimeException.class, () -> createObjectUnderTest().createPit(createPointInTimeRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(RuntimeException.class, () -> objectUnderTest.createPit(createPointInTimeRequest));
     }
 
     @Test
@@ -313,7 +328,9 @@ public class ElasticsearchAccessorTest {
 
         when(elasticSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
 
-        final RuntimeException exceptionThrown = assertThrows(RuntimeException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        final RuntimeException exceptionThrown = assertThrows(RuntimeException.class, () -> objectUnderTest.createScroll(createScrollRequest));
         assertThat(exceptionThrown instanceof SearchContextLimitException, equalTo(false));
     }
 

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
@@ -160,7 +160,9 @@ public class OpenSearchAccessorTest {
 
         when(openSearchClient.createPit(any(CreatePitRequest.class))).thenThrow(openSearchException);
 
-        assertThrows(SearchContextLimitException.class, () -> createObjectUnderTest().createPit(createPointInTimeRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(SearchContextLimitException.class, () -> objectUnderTest.createPit(createPointInTimeRequest));
     }
 
     @Test
@@ -181,7 +183,9 @@ public class OpenSearchAccessorTest {
 
         when(openSearchClient.createPit(any(CreatePitRequest.class))).thenThrow(openSearchException);
 
-        assertThrows(IndexNotFoundException.class, () -> createObjectUnderTest().createPit(createPointInTimeRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(IndexNotFoundException.class, () -> objectUnderTest.createPit(createPointInTimeRequest));
     }
 
     @Test
@@ -200,7 +204,9 @@ public class OpenSearchAccessorTest {
 
         when(openSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
 
-        assertThrows(SearchContextLimitException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(SearchContextLimitException.class, () -> objectUnderTest.createScroll(createScrollRequest));
     }
 
     @Test
@@ -223,7 +229,9 @@ public class OpenSearchAccessorTest {
 
         when(openSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(openSearchException);
 
-        assertThrows(IndexNotFoundException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(IndexNotFoundException.class, () -> objectUnderTest.createScroll(createScrollRequest));
     }
 
     @Test
@@ -244,7 +252,9 @@ public class OpenSearchAccessorTest {
 
         when(openSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(openSearchException);
 
-        assertThrows(IndexNotFoundException.class, () -> createObjectUnderTest().searchWithoutSearchContext(noSearchContextSearchRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(IndexNotFoundException.class, () -> objectUnderTest.searchWithoutSearchContext(noSearchContextSearchRequest));
     }
 
     @Test
@@ -263,7 +273,9 @@ public class OpenSearchAccessorTest {
 
         when(openSearchClient.createPit(any(CreatePitRequest.class))).thenThrow(openSearchException);
 
-        assertThrows(OpenSearchException.class, () -> createObjectUnderTest().createPit(createPointInTimeRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(OpenSearchException.class, () -> objectUnderTest.createPit(createPointInTimeRequest));
     }
 
     @Test
@@ -281,7 +293,9 @@ public class OpenSearchAccessorTest {
 
         when(openSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
 
-        assertThrows(OpenSearchException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(OpenSearchException.class, () -> objectUnderTest.createScroll(createScrollRequest));
     }
 
     @Test
@@ -295,7 +309,9 @@ public class OpenSearchAccessorTest {
 
         when(openSearchClient.createPit(any(CreatePitRequest.class))).thenThrow(IOException.class);
 
-        assertThrows(RuntimeException.class, () -> createObjectUnderTest().createPit(createPointInTimeRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        assertThrows(RuntimeException.class, () -> objectUnderTest.createPit(createPointInTimeRequest));
     }
 
     @Test
@@ -314,7 +330,9 @@ public class OpenSearchAccessorTest {
 
         when(openSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
 
-        final RuntimeException exceptionThrown = assertThrows(RuntimeException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+        final SearchAccessor objectUnderTest = createObjectUnderTest();
+
+        final RuntimeException exceptionThrown = assertThrows(RuntimeException.class, () -> objectUnderTest.createScroll(createScrollRequest));
         assertThat(exceptionThrown instanceof SearchContextLimitException, equalTo(false));
     }
 

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.ErrorCause;
+import org.opensearch.client.opensearch._types.ErrorResponse;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch.core.ClearScrollRequest;
 import org.opensearch.client.opensearch.core.ClearScrollResponse;
@@ -29,6 +30,7 @@ import org.opensearch.client.opensearch.core.pit.DeletePitRequest;
 import org.opensearch.client.opensearch.core.pit.DeletePitResponse;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.IndexNotFoundException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchContextLimitException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreatePointInTimeResponse;
@@ -36,6 +38,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.CreateScrollResponse;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeletePointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DeleteScrollRequest;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.NoSearchContextSearchRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchContextType;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchPointInTimeRequest;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchScrollRequest;
@@ -57,6 +60,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor.INDEX_NOT_FOUND_EXCEPTION;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor.PIT_RESOURCE_LIMIT_ERROR_TYPE;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchAccessor.SCROLL_RESOURCE_LIMIT_EXCEPTION_MESSAGE;
 
@@ -160,6 +164,27 @@ public class OpenSearchAccessorTest {
     }
 
     @Test
+    void create_pit_with_exception_for_index_not_found_throws_IndexNotFoundException() throws IOException {
+        final String indexName = UUID.randomUUID().toString();
+        final String keepAlive = UUID.randomUUID().toString();
+
+        final CreatePointInTimeRequest createPointInTimeRequest = mock(CreatePointInTimeRequest.class);
+        when(createPointInTimeRequest.getIndex()).thenReturn(indexName);
+        when(createPointInTimeRequest.getKeepAlive()).thenReturn(keepAlive);
+
+        final OpenSearchException openSearchException = mock(OpenSearchException.class);
+        final ErrorResponse errorResponse = mock(ErrorResponse.class);
+        final ErrorCause errorCause = mock(ErrorCause.class);
+        when(errorCause.type()).thenReturn(INDEX_NOT_FOUND_EXCEPTION);
+        when(errorResponse.error()).thenReturn(errorCause);
+        when(openSearchException.response()).thenReturn(errorResponse);
+
+        when(openSearchClient.createPit(any(CreatePitRequest.class))).thenThrow(openSearchException);
+
+        assertThrows(IndexNotFoundException.class, () -> createObjectUnderTest().createPit(createPointInTimeRequest));
+    }
+
+    @Test
     void create_scroll_with_exception_for_scroll_limit_throws_SearchContextLimitException() throws IOException {
         final String indexName = UUID.randomUUID().toString();
         final String scrollTime = UUID.randomUUID().toString();
@@ -176,6 +201,50 @@ public class OpenSearchAccessorTest {
         when(openSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(exception);
 
         assertThrows(SearchContextLimitException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+    }
+
+    @Test
+    void create_scroll_with_exception_for_index_not_found_throws_IndexNotFoundException() throws IOException {
+        final String indexName = UUID.randomUUID().toString();
+        final String scrollTime = UUID.randomUUID().toString();
+        final Integer size = new Random().nextInt(10);
+
+        final CreateScrollRequest createScrollRequest = mock(CreateScrollRequest.class);
+        when(createScrollRequest.getIndex()).thenReturn(indexName);
+        when(createScrollRequest.getScrollTime()).thenReturn(scrollTime);
+        when(createScrollRequest.getSize()).thenReturn(size);
+
+        final OpenSearchException openSearchException = mock(OpenSearchException.class);
+        final ErrorResponse errorResponse = mock(ErrorResponse.class);
+        final ErrorCause errorCause = mock(ErrorCause.class);
+        when(errorCause.type()).thenReturn(INDEX_NOT_FOUND_EXCEPTION);
+        when(errorResponse.error()).thenReturn(errorCause);
+        when(openSearchException.response()).thenReturn(errorResponse);
+
+        when(openSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(openSearchException);
+
+        assertThrows(IndexNotFoundException.class, () -> createObjectUnderTest().createScroll(createScrollRequest));
+    }
+
+    @Test
+    void searchWithoutSearchContext_with_exception_for_index_not_found_throws_IndexNotFoundException() throws IOException {
+        final Integer paginationSize = new Random().nextInt();
+        final String index = UUID.randomUUID().toString();
+
+        final NoSearchContextSearchRequest noSearchContextSearchRequest = mock(NoSearchContextSearchRequest.class);
+        when(noSearchContextSearchRequest.getPaginationSize()).thenReturn(paginationSize);
+        when(noSearchContextSearchRequest.getIndex()).thenReturn(index);
+
+        final OpenSearchException openSearchException = mock(OpenSearchException.class);
+        final ErrorResponse errorResponse = mock(ErrorResponse.class);
+        final ErrorCause errorCause = mock(ErrorCause.class);
+        when(errorCause.type()).thenReturn(INDEX_NOT_FOUND_EXCEPTION);
+        when(errorResponse.error()).thenReturn(errorCause);
+        when(openSearchException.response()).thenReturn(errorResponse);
+
+        when(openSearchClient.search(any(SearchRequest.class), eq(ObjectNode.class))).thenThrow(openSearchException);
+
+        assertThrows(IndexNotFoundException.class, () -> createObjectUnderTest().searchWithoutSearchContext(noSearchContextSearchRequest));
     }
 
     @Test


### PR DESCRIPTION
…otFoundException for os source

### Description
* Instead of the worker threads stopping when an exception is thrown when calling `getNextPartition`, they will now log the error, back off and retry
* Catches IndexNotFoundException and marks that partition as completed before continuing processing
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
