### PR TITLE
Disallow the combination of a user-defined schema and include/exclude keys

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/OutputCodec.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/OutputCodec.java
@@ -74,6 +74,8 @@ public interface OutputCodec {
         return false;
     }
 
+    default void validateAgainstCodecContext(OutputCodecContext outputCodecContext) { }
+
     default Event addTagsToEvent(Event event, String tagsTargetKey) throws JsonProcessingException {
         String eventJsonString = event.jsonBuilder().includeTags(tagsTargetKey).toJsonString();
         Map<String, Object> eventData = objectMapper.readValue(eventJsonString, new TypeReference<>() {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/OutputCodecTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/OutputCodecTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 public class OutputCodecTest {
     @Test
@@ -30,6 +31,17 @@ public class OutputCodecTest {
         OutputCodec objectUnderTest = mock(OutputCodec.class, InvocationOnMock::callRealMethod);
 
         assertThat(objectUnderTest.isCompressionInternal(), equalTo(false));
+    }
+
+    @Test
+    void validateAgainstCodecContext_does_not_throw_or_interact_with_outputCodecContext() {
+        OutputCodec objectUnderTest = mock(OutputCodec.class, InvocationOnMock::callRealMethod);
+
+        OutputCodecContext outputCodecContext = mock(OutputCodecContext.class);
+
+        objectUnderTest.validateAgainstCodecContext(outputCodecContext);
+
+        verifyNoInteractions(outputCodecContext);
     }
 
     @Test

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodec.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodec.java
@@ -17,6 +17,7 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,6 +106,17 @@ public class AvroOutputCodec implements OutputCodec {
     @Override
     public String getExtension() {
         return AVRO;
+    }
+
+    @Override
+    public void validateAgainstCodecContext(OutputCodecContext outputCodecContext) {
+        if (config.isAutoSchema())
+            return;
+
+        if ((outputCodecContext.getIncludeKeys() != null && !outputCodecContext.getIncludeKeys().isEmpty()) ||
+                (outputCodecContext.getExcludeKeys() != null && !outputCodecContext.getExcludeKeys().isEmpty())) {
+            throw new InvalidPluginConfigurationException("Providing a user-defined schema and using sink include or exclude keys is not an allowed configuration.");
+        }
     }
 
     Schema parseSchema(final String schemaString) {

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodecTest.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodecTest.java
@@ -12,11 +12,13 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.log.JacksonLog;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 
 import java.io.ByteArrayInputStream;
@@ -41,6 +43,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 public class AvroOutputCodecTest {
     private static final String EXPECTED_SCHEMA_STRING = "{\"type\":\"record\",\"name\":\"Event\",\"fields\":" +
@@ -274,6 +277,117 @@ public class AvroOutputCodecTest {
         assertThat(actualSchema, equalTo(expectedSchema));
     }
 
+    @Nested
+    class ValidateWithSchema {
+        private OutputCodecContext codecContext;
+        private List<String> keys;
+
+        @BeforeEach
+        void setUp() {
+            config.setSchema(createStandardSchemaNullable().toString());
+            codecContext = mock(OutputCodecContext.class);
+            keys = List.of(UUID.randomUUID().toString());
+        }
+
+        @Test
+        void validateAgainstCodecContext_throws_when_user_defined_schema_and_includeKeys_non_empty() {
+            when(codecContext.getIncludeKeys()).thenReturn(keys);
+
+            AvroOutputCodec objectUnderTest = createObjectUnderTest();
+            assertThrows(InvalidPluginConfigurationException.class, () -> objectUnderTest.validateAgainstCodecContext(codecContext));
+        }
+
+        @Test
+        void validateAgainstCodecContext_throws_when_user_defined_schema_and_excludeKeys_non_empty() {
+            when(codecContext.getExcludeKeys()).thenReturn(keys);
+
+            AvroOutputCodec objectUnderTest = createObjectUnderTest();
+            assertThrows(InvalidPluginConfigurationException.class, () -> objectUnderTest.validateAgainstCodecContext(codecContext));
+        }
+
+        @Test
+        void validateAgainstCodecContext_is_ok_when_user_defined_schema_and_includeKeys_isNull() {
+            when(codecContext.getIncludeKeys()).thenReturn(null);
+
+            createObjectUnderTest().validateAgainstCodecContext(codecContext);
+        }
+
+        @Test
+        void validateAgainstCodecContext_is_ok_when_user_defined_schema_and_includeKeys_isEmpty() {
+            when(codecContext.getIncludeKeys()).thenReturn(Collections.emptyList());
+
+            createObjectUnderTest().validateAgainstCodecContext(codecContext);
+        }
+
+        @Test
+        void validateAgainstCodecContext_is_ok_when_user_defined_schema_and_excludeKeys_isNull() {
+            when(codecContext.getExcludeKeys()).thenReturn(null);
+
+            createObjectUnderTest().validateAgainstCodecContext(codecContext);
+        }
+
+        @Test
+        void validateAgainstCodecContext_is_ok_when_user_defined_schema_and_excludeKeys_isEmpty() {
+            when(codecContext.getExcludeKeys()).thenReturn(Collections.emptyList());
+
+            createObjectUnderTest().validateAgainstCodecContext(codecContext);
+        }
+    }
+
+    @Nested
+    class ValidateWithAutoSchema {
+        private OutputCodecContext codecContext;
+        private List<String> keys;
+
+        @BeforeEach
+        void setUp() {
+            config.setAutoSchema(true);
+            codecContext = mock(OutputCodecContext.class, withSettings().lenient());
+            keys = List.of(UUID.randomUUID().toString());
+        }
+
+        @Test
+        void validateAgainstCodecContext_is_ok_when_auto_schema_and_includeKeys_non_empty() {
+            when(codecContext.getIncludeKeys()).thenReturn(keys);
+
+            createObjectUnderTest().validateAgainstCodecContext(codecContext);
+        }
+
+        @Test
+        void validateAgainstCodecContext_is_ok_when_auto_schema_and_excludeKeys_non_empty() {
+            when(codecContext.getExcludeKeys()).thenReturn(keys);
+
+            createObjectUnderTest().validateAgainstCodecContext(codecContext);
+        }
+
+        @Test
+        void validateAgainstCodecContext_is_ok_when_auto_schema_and_includeKeys_isNull() {
+            when(codecContext.getIncludeKeys()).thenReturn(null);
+
+            createObjectUnderTest().validateAgainstCodecContext(codecContext);
+        }
+
+        @Test
+        void validateAgainstCodecContext_is_ok_when_auto_schema_and_includeKeys_isEmpty() {
+            when(codecContext.getIncludeKeys()).thenReturn(Collections.emptyList());
+
+            createObjectUnderTest().validateAgainstCodecContext(codecContext);
+        }
+
+        @Test
+        void validateAgainstCodecContext_is_ok_when_auto_schema_and_excludeKeys_isNull() {
+            when(codecContext.getExcludeKeys()).thenReturn(null);
+
+            createObjectUnderTest().validateAgainstCodecContext(codecContext);
+        }
+
+        @Test
+        void validateAgainstCodecContext_is_ok_when_auto_schema_and_excludeKeys_isEmpty() {
+            when(codecContext.getExcludeKeys()).thenReturn(Collections.emptyList());
+
+            createObjectUnderTest().validateAgainstCodecContext(codecContext);
+        }
+    }
 
     private static Event createEventRecord(final Map<String, Object> eventData) {
         return JacksonLog.builder().withData(eventData).build();

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodec.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodec.java
@@ -19,6 +19,7 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 import org.opensearch.dataprepper.plugins.sink.s3.S3OutputCodecContext;
 import org.opensearch.dataprepper.plugins.sink.s3.codec.BufferedCodec;
@@ -121,6 +122,17 @@ public class ParquetOutputCodec implements OutputCodec, BufferedCodec {
     @Override
     public String getExtension() {
         return PARQUET;
+    }
+
+    @Override
+    public void validateAgainstCodecContext(OutputCodecContext outputCodecContext) {
+        if (config.isAutoSchema())
+            return;
+
+        if ((outputCodecContext.getIncludeKeys() != null && !outputCodecContext.getIncludeKeys().isEmpty()) ||
+                (outputCodecContext.getExcludeKeys() != null && !outputCodecContext.getExcludeKeys().isEmpty())) {
+            throw new InvalidPluginConfigurationException("Providing a user-defined schema and using sink include or exclude keys is not an allowed configuration.");
+        }
     }
 
     static Schema parseSchema(final String schemaString) {

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
@@ -86,6 +86,8 @@ public class S3Sink extends AbstractSink<Record<Event>> {
 
         S3OutputCodecContext s3OutputCodecContext = new S3OutputCodecContext(OutputCodecContext.fromSinkContext(sinkContext), compressionOption);
 
+        codec.validateAgainstCodecContext(s3OutputCodecContext);
+
         s3SinkService = new S3SinkService(s3SinkConfig, bufferFactory, codec, s3OutputCodecContext, s3Client, keyGenerator, Duration.ofSeconds(5), pluginMetrics);
     }
 


### PR DESCRIPTION
### Description

Disallows adding an S3 sink with an Avro or Parquet codec which uses both a user-defined schema and include/exclude keys. Auto-schema may still use include/exclude keys.
 
### Issues Resolved

Resolves #3253.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
