### PR TITLE
Tag failure (dependent on PR Recursive#3198)

### DIFF
--- a/data-prepper-plugins/key-value-processor/README.md
+++ b/data-prepper-plugins/key-value-processor/README.md
@@ -90,6 +90,9 @@ When run, the processor will parse the message into the following output:
   * Example: `remove_brackets` is `false`. `{"key1=(value1)"}` will parse into `{"key1": "(value1)"}`
   * In the case of a key-value pair with a brackets and a split character, the splitting will take priority over `remove_brackets=true`. `{key1=(value1&value2)}` will parse into `{"key1":"value1","value2)":null}`
 
+* `tag_on_failure` - When a kv operation causes a runtime exception to be thrown within the processor, the operation is safely aborted without crashing the processor, and the event is tagged with the provided value.
+  * Default: `["keyvalueprocessor_failure"]`
+
 ## Developer Guide
 This plugin is compatible with Java 14. See
 - [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md)

--- a/data-prepper-plugins/key-value-processor/README.md
+++ b/data-prepper-plugins/key-value-processor/README.md
@@ -92,6 +92,7 @@ When run, the processor will parse the message into the following output:
 
 * `tag_on_failure` - When a kv operation causes a runtime exception to be thrown within the processor, the operation is safely aborted without crashing the processor, and the event is tagged with the provided value.
   * Default: `["keyvalueprocessor_failure"]`
+  * Example: in the case of a runtime exception, the output will be `{"message": "some input message", "tags": ["keyvalueprocessor_failure"]}`
 
 ## Developer Guide
 This plugin is compatible with Java 14. See

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -46,11 +46,14 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
     private final String whitespaceStrict = "strict";
     private final String whitespaceLenient = "lenient";
     private final Set<String> validWhitespaceSet = Set.of(whitespaceLenient, whitespaceStrict);
+    private final List<String> tagOnFailure;
 
     @DataPrepperPluginConstructor
     public KeyValueProcessor(final PluginMetrics pluginMetrics, final KeyValueProcessorConfig keyValueProcessorConfig) {
         super(pluginMetrics);
         this.keyValueProcessorConfig = keyValueProcessorConfig;
+
+        tagOnFailure = keyValueProcessorConfig.getTagOnFailure();
 
         if(keyValueProcessorConfig.getFieldDelimiterRegex() != null
                 && !keyValueProcessorConfig.getFieldDelimiterRegex().isEmpty()) {

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -29,6 +29,7 @@ public class KeyValueProcessorConfig {
     static final String DEFAULT_WHITESPACE = "lenient";
     static final boolean DEFAULT_SKIP_DUPLICATE_VALUES = false;
     static final boolean DEFAULT_REMOVE_BRACKETS = false;
+    static final List<String> DEFAULT_TAG_ON_FAILURE = new ArrayList<>(Arrays.asList("keyvalueprocessor_failure"));
 
     @NotEmpty
     private String source = DEFAULT_SOURCE;
@@ -90,6 +91,9 @@ public class KeyValueProcessorConfig {
     @JsonProperty("remove_brackets")
     @NotNull
     private boolean removeBrackets = DEFAULT_REMOVE_BRACKETS;
+
+    @JsonProperty("tag_on_failure")
+    private List<String> tagOnFailure = DEFAULT_TAG_ON_FAILURE;
 
     public String getSource() {
         return source;
@@ -157,5 +161,9 @@ public class KeyValueProcessorConfig {
 
     public boolean getRemoveBrackets() {
         return removeBrackets;
+    }
+
+    public List<String> getTagOnFailure() {
+        return tagOnFailure;
     }
 }

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 


### PR DESCRIPTION
### Description
When a kv operation causes a runtime exception to be thrown within the processor, the operation is safely aborted without crashing the processor, and the event is tagged with the provided value.

Since this PR is dependent on the restructuring of code done in #3198 , the implementation of this feature is not fully complete. Once the other PR is approved and merged into main, something similar to the two lines of code below can be added into the recursive try/catch block.

```
LOG.error("Recursive parsing ran into an unexpected error");
recordEvent.getMetadata().addTags(tagOnFailure);
```
 
### Issues Resolved
Resolves #886 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
