### PR TITLE
Fix jenkins maven publishing stage and disable other stages for now

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -82,145 +82,145 @@ pipeline {
                 }
             }
         }
-        stage('Promote Archives') {
-            agent {
-                docker {
-                    label 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
-                    image 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3'
-                    args '-e JAVA_HOME=/opt/java/openjdk-11'
-                    registryUrl 'https://public.ecr.aws/'
-                    alwaysPull true
-                }
-            }
-            stages {
-                stage('Download Archives') {
-                    steps {
-                        script {
-                            archivePath = "${DATA_PREPPER_ARTIFACT_STAGING_SITE}/${VERSION}/${DATA_PREPPER_BUILD_NUMBER}/archive"
+        // stage('Promote Archives') {
+        //     agent {
+        //         docker {
+        //             label 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
+        //             image 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3'
+        //             args '-e JAVA_HOME=/opt/java/openjdk-11'
+        //             registryUrl 'https://public.ecr.aws/'
+        //             alwaysPull true
+        //         }
+        //     }
+        //     stages {
+        //         stage('Download Archives') {
+        //             steps {
+        //                 script {
+        //                     archivePath = "${DATA_PREPPER_ARTIFACT_STAGING_SITE}/${VERSION}/${DATA_PREPPER_BUILD_NUMBER}/archive"
 
-                            dir('archive') {
-                                sh "curl -sSL ${archivePath}/opensearch-data-prepper-${VERSION}-linux-x64.tar.gz -o opensearch-data-prepper-${VERSION}-linux-x64.tar.gz"
-                                sh "curl -sSL ${archivePath}/opensearch-data-prepper-jdk-${VERSION}-linux-x64.tar.gz -o opensearch-data-prepper-jdk-${VERSION}-linux-x64.tar.gz"
-                            }
-                        }
-                    }
-                }
-                stage('Sign and Release Archives') {
-                    steps {
-                        script {
-                            publishToArtifactsProdBucket(
-                                assumedRoleName: 'data-prepper-artifacts-upload-role',
-                                source: "${env.WORKSPACE}/archive",
-                                destination: "data-prepper/${VERSION}/",
-                                signingPlatform: 'linux',
-                                sigType: '.sig',
-                                sigOverwrite: true
-                            )
-                        }
-                    }
-                }
-            }
-            post() {
-                always {
-                    script {
-                        postCleanup()
-                    }
-                }
-            }
-        }
-        stage('Promote Docker') {
-            agent {
-                docker {
-                    label 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
-                    image 'docker/library/alpine:3'
-                    registryUrl 'https://public.ecr.aws/'
-                    alwaysPull true
-                }
-            }
-            stages {
-                stage('Copy Docker Image to DockerHub') {
-                    steps {
-                        script {
-                            def dockerCopyHub =
-                                build job: 'docker-copy',
-                                parameters: [
-                                    string(name: 'SOURCE_IMAGE_REGISTRY', value: "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}"),
-                                    string(name: 'SOURCE_IMAGE', value: "data-prepper:${VERSION}-${DATA_PREPPER_BUILD_NUMBER}"),
-                                    string(name: 'DESTINATION_IMAGE_REGISTRY', value: 'opensearchproject'),
-                                    string(name: 'DESTINATION_IMAGE', value: "data-prepper:${VERSION}")
-                                ]
+        //                     dir('archive') {
+        //                         sh "curl -sSL ${archivePath}/opensearch-data-prepper-${VERSION}-linux-x64.tar.gz -o opensearch-data-prepper-${VERSION}-linux-x64.tar.gz"
+        //                         sh "curl -sSL ${archivePath}/opensearch-data-prepper-jdk-${VERSION}-linux-x64.tar.gz -o opensearch-data-prepper-jdk-${VERSION}-linux-x64.tar.gz"
+        //                     }
+        //                 }
+        //             }
+        //         }
+        //         stage('Sign and Release Archives') {
+        //             steps {
+        //                 script {
+        //                     publishToArtifactsProdBucket(
+        //                         assumedRoleName: 'data-prepper-artifacts-upload-role',
+        //                         source: "${env.WORKSPACE}/archive",
+        //                         destination: "data-prepper/${VERSION}/",
+        //                         signingPlatform: 'linux',
+        //                         sigType: '.sig',
+        //                         sigOverwrite: true
+        //                     )
+        //                 }
+        //             }
+        //         }
+        //     }
+        //     post() {
+        //         always {
+        //             script {
+        //                 postCleanup()
+        //             }
+        //         }
+        //     }
+        // }
+        // stage('Promote Docker') {
+        //     agent {
+        //         docker {
+        //             label 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
+        //             image 'docker/library/alpine:3'
+        //             registryUrl 'https://public.ecr.aws/'
+        //             alwaysPull true
+        //         }
+        //     }
+        //     stages {
+        //         stage('Copy Docker Image to DockerHub') {
+        //             steps {
+        //                 script {
+        //                     def dockerCopyHub =
+        //                         build job: 'docker-copy',
+        //                         parameters: [
+        //                             string(name: 'SOURCE_IMAGE_REGISTRY', value: "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}"),
+        //                             string(name: 'SOURCE_IMAGE', value: "data-prepper:${VERSION}-${DATA_PREPPER_BUILD_NUMBER}"),
+        //                             string(name: 'DESTINATION_IMAGE_REGISTRY', value: 'opensearchproject'),
+        //                             string(name: 'DESTINATION_IMAGE', value: "data-prepper:${VERSION}")
+        //                         ]
 
-                            if (RELEASE_MAJOR_TAG) {
-                                def majorVersion = VERSION.tokenize('.')[0].trim()
-                                def dockerCopyHubMajor =
-                                    build job: 'docker-copy',
-                                    parameters: [
-                                        string(name: 'SOURCE_IMAGE_REGISTRY', value: "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}"),
-                                        string(name: 'SOURCE_IMAGE', value: "data-prepper:${VERSION}-${DATA_PREPPER_BUILD_NUMBER}"),
-                                        string(name: 'DESTINATION_IMAGE_REGISTRY', value: 'opensearchproject'),
-                                        string(name: 'DESTINATION_IMAGE', value: "data-prepper:${majorVersion}")
-                                    ]
-                            }
+        //                     if (RELEASE_MAJOR_TAG) {
+        //                         def majorVersion = VERSION.tokenize('.')[0].trim()
+        //                         def dockerCopyHubMajor =
+        //                             build job: 'docker-copy',
+        //                             parameters: [
+        //                                 string(name: 'SOURCE_IMAGE_REGISTRY', value: "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}"),
+        //                                 string(name: 'SOURCE_IMAGE', value: "data-prepper:${VERSION}-${DATA_PREPPER_BUILD_NUMBER}"),
+        //                                 string(name: 'DESTINATION_IMAGE_REGISTRY', value: 'opensearchproject'),
+        //                                 string(name: 'DESTINATION_IMAGE', value: "data-prepper:${majorVersion}")
+        //                             ]
+        //                     }
 
-                            if (RELEASE_LATEST_TAG) {
-                                def dockerCopyHubLatest =
-                                    build job: 'docker-copy',
-                                    parameters: [
-                                        string(name: 'SOURCE_IMAGE_REGISTRY', value: "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}"),
-                                        string(name: 'SOURCE_IMAGE', value: "data-prepper:${VERSION}-${DATA_PREPPER_BUILD_NUMBER}"),
-                                        string(name: 'DESTINATION_IMAGE_REGISTRY', value: 'opensearchproject'),
-                                        string(name: 'DESTINATION_IMAGE', value: 'data-prepper:latest')
-                                    ]
-                            }
-                        }
-                    }
-                }
-                stage('Copy Docker Image to ECR') {
-                    steps {
-                        script {
-                            def dockerCopyECR =
-                                build job: 'docker-copy',
-                                parameters: [
-                                    string(name: 'SOURCE_IMAGE_REGISTRY', value: "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}"),
-                                    string(name: 'SOURCE_IMAGE', value: "data-prepper:${VERSION}-${DATA_PREPPER_BUILD_NUMBER}"),
-                                    string(name: 'DESTINATION_IMAGE_REGISTRY', value: 'public.ecr.aws/opensearchproject'),
-                                    string(name: 'DESTINATION_IMAGE', value: "data-prepper:${VERSION}")
-                                ]
+        //                     if (RELEASE_LATEST_TAG) {
+        //                         def dockerCopyHubLatest =
+        //                             build job: 'docker-copy',
+        //                             parameters: [
+        //                                 string(name: 'SOURCE_IMAGE_REGISTRY', value: "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}"),
+        //                                 string(name: 'SOURCE_IMAGE', value: "data-prepper:${VERSION}-${DATA_PREPPER_BUILD_NUMBER}"),
+        //                                 string(name: 'DESTINATION_IMAGE_REGISTRY', value: 'opensearchproject'),
+        //                                 string(name: 'DESTINATION_IMAGE', value: 'data-prepper:latest')
+        //                             ]
+        //                     }
+        //                 }
+        //             }
+        //         }
+        //         stage('Copy Docker Image to ECR') {
+        //             steps {
+        //                 script {
+        //                     def dockerCopyECR =
+        //                         build job: 'docker-copy',
+        //                         parameters: [
+        //                             string(name: 'SOURCE_IMAGE_REGISTRY', value: "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}"),
+        //                             string(name: 'SOURCE_IMAGE', value: "data-prepper:${VERSION}-${DATA_PREPPER_BUILD_NUMBER}"),
+        //                             string(name: 'DESTINATION_IMAGE_REGISTRY', value: 'public.ecr.aws/opensearchproject'),
+        //                             string(name: 'DESTINATION_IMAGE', value: "data-prepper:${VERSION}")
+        //                         ]
 
-                            if (RELEASE_MAJOR_TAG) {
-                                def majorVersion = VERSION.tokenize('.')[0].trim()
-                                def dockerCopyECRMajor =
-                                    build job: 'docker-copy',
-                                    parameters: [
-                                        string(name: 'SOURCE_IMAGE_REGISTRY', value: "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}"),
-                                        string(name: 'SOURCE_IMAGE', value: "data-prepper:${VERSION}-${DATA_PREPPER_BUILD_NUMBER}"),
-                                        string(name: 'DESTINATION_IMAGE_REGISTRY', value: 'public.ecr.aws/opensearchproject'),
-                                        string(name: 'DESTINATION_IMAGE', value: "data-prepper:${majorVersion}")
-                                    ]
-                            }
+        //                     if (RELEASE_MAJOR_TAG) {
+        //                         def majorVersion = VERSION.tokenize('.')[0].trim()
+        //                         def dockerCopyECRMajor =
+        //                             build job: 'docker-copy',
+        //                             parameters: [
+        //                                 string(name: 'SOURCE_IMAGE_REGISTRY', value: "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}"),
+        //                                 string(name: 'SOURCE_IMAGE', value: "data-prepper:${VERSION}-${DATA_PREPPER_BUILD_NUMBER}"),
+        //                                 string(name: 'DESTINATION_IMAGE_REGISTRY', value: 'public.ecr.aws/opensearchproject'),
+        //                                 string(name: 'DESTINATION_IMAGE', value: "data-prepper:${majorVersion}")
+        //                             ]
+        //                     }
 
-                            if (RELEASE_LATEST_TAG) {
-                                def dockerCopyECRLatest =
-                                    build job: 'docker-copy',
-                                    parameters: [
-                                        string(name: 'SOURCE_IMAGE_REGISTRY', value: "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}"),
-                                        string(name: 'SOURCE_IMAGE', value: "data-prepper:${VERSION}-${DATA_PREPPER_BUILD_NUMBER}"),
-                                        string(name: 'DESTINATION_IMAGE_REGISTRY', value: 'public.ecr.aws/opensearchproject'),
-                                        string(name: 'DESTINATION_IMAGE', value: 'data-prepper:latest')
-                                    ]
-                            }
-                        }
-                    }
-                }
-            }
-            post() {
-                always {
-                    script {
-                        postCleanup()
-                    }
-                }
-            }
-        }
+        //                     if (RELEASE_LATEST_TAG) {
+        //                         def dockerCopyECRLatest =
+        //                             build job: 'docker-copy',
+        //                             parameters: [
+        //                                 string(name: 'SOURCE_IMAGE_REGISTRY', value: "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}"),
+        //                                 string(name: 'SOURCE_IMAGE', value: "data-prepper:${VERSION}-${DATA_PREPPER_BUILD_NUMBER}"),
+        //                                 string(name: 'DESTINATION_IMAGE_REGISTRY', value: 'public.ecr.aws/opensearchproject'),
+        //                                 string(name: 'DESTINATION_IMAGE', value: 'data-prepper:latest')
+        //                             ]
+        //                     }
+        //                 }
+        //             }
+        //         }
+        //     }
+        //     post() {
+        //         always {
+        //             script {
+        //                 postCleanup()
+        //             }
+        //         }
+        //     }
+        // }
         stage('Promote Maven') {
             agent {
                 docker {
@@ -241,7 +241,7 @@ pipeline {
                             fileTypes = ['-javadoc.jar', '.jar', '.pom', '-sources.jar', '.module']
                             checksums = ['', '.md5', '.sha1', '.sha256', '.sha512']
 
-                            downloadArtifacts()
+                            downloadArtifacts("$VERSION")
                         }
                     }
                 }
@@ -281,13 +281,13 @@ pipeline {
     }
 }
 
-def downloadArtifacts() {
+def downloadArtifacts(version) {
     dir('maven') {
         for (artifact in artifacts) {
-            sh "mkdir -p ${group}/${artifact}/${VERSION}"
+            sh "mkdir -p ${group}/${artifact}/${version}"
             for (fileType in fileTypes) {
                 for (checksum in checksums) {
-                    sh "curl -sSL ${mavenPath}/${group}/${artifact}/${VERSION}/${artifact}-${VERSION}${fileType}${checksum} -o ${group}/${artifact}/${VERSION}/${artifact}-${VERSION}${fileType}${checksum}"
+                    sh "curl -sSL ${mavenPath}/${group}/${artifact}/${version}/${artifact}-${version}${fileType}${checksum} -o ${group}/${artifact}/${version}/${artifact}-${version}${fileType}${checksum}"
                 }
             }
         }


### PR DESCRIPTION
### Description
The new and recent run for data-prepper release failed https://build.ci.opensearch.org/job/release-data-prepper/3/ in maven stage. This was due to downloadArtifacts method unable to find the VERSION variable. This change fixes it. Also since we already released on other platforms disabling those stages to avoid re-release. 
I'll be creating another PR after release to enable these stages back.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
