### PR TITLE
Removes some unnecessary dependencies in the S3 sink and Parquet codecs

### DIFF
--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.15.2'
-    implementation 'org.apache.parquet:parquet-common:1.12.3'
+    implementation 'org.apache.parquet:parquet-common:1.13.1'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation libs.commons.lang3
     testImplementation testLibs.junit.vintage

--- a/data-prepper-plugins/avro-codecs/build.gradle
+++ b/data-prepper-plugins/avro-codecs/build.gradle
@@ -6,7 +6,7 @@
 dependencies {
     implementation project(path: ':data-prepper-api')
     implementation 'org.apache.avro:avro:1.11.1'
-    implementation 'org.apache.parquet:parquet-common:1.12.3'
+    implementation 'org.apache.parquet:parquet-common:1.13.1'
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:apache-client'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'

--- a/data-prepper-plugins/common/build.gradle
+++ b/data-prepper-plugins/common/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation 'org.reflections:reflections:0.10.2'
     implementation 'io.micrometer:micrometer-core'
     testImplementation testLibs.junit.vintage
-    implementation 'org.apache.parquet:parquet-common:1.12.3'
+    implementation 'org.apache.parquet:parquet-common:1.13.1'
     implementation 'org.xerial.snappy:snappy-java:1.1.10.3'
     testImplementation project(':data-prepper-plugins:blocking-buffer')
     testImplementation 'commons-io:commons-io:2.12.0'

--- a/data-prepper-plugins/csv-processor/build.gradle
+++ b/data-prepper-plugins/csv-processor/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'io.micrometer:micrometer-core'
-    implementation 'org.apache.parquet:parquet-common:1.12.3'
+    implementation 'org.apache.parquet:parquet-common:1.13.1'
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:apache-client'
     testImplementation project(':data-prepper-plugins:log-generator-source')

--- a/data-prepper-plugins/newline-codecs/build.gradle
+++ b/data-prepper-plugins/newline-codecs/build.gradle
@@ -9,11 +9,8 @@ repositories {
 
 dependencies {
     implementation project(':data-prepper-api')
-    implementation 'com.fasterxml.jackson.core:jackson-core'
-    implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation 'org.apache.parquet:parquet-common:1.12.3'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    implementation 'com.fasterxml.jackson.core:jackson-annotation'
+    implementation 'org.apache.parquet:parquet-common:1.13.1'
     testImplementation project(':data-prepper-plugins:common')
 }
 

--- a/data-prepper-plugins/newline-codecs/build.gradle
+++ b/data-prepper-plugins/newline-codecs/build.gradle
@@ -9,7 +9,7 @@ repositories {
 
 dependencies {
     implementation project(':data-prepper-api')
-    implementation 'com.fasterxml.jackson.core:jackson-annotation'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'org.apache.parquet:parquet-common:1.13.1'
     testImplementation project(':data-prepper-plugins:common')
 }

--- a/data-prepper-plugins/parquet-codecs/build.gradle
+++ b/data-prepper-plugins/parquet-codecs/build.gradle
@@ -8,11 +8,11 @@ dependencies {
     implementation project(':data-prepper-plugins:common')
     implementation 'org.apache.avro:avro:1.11.0'
     implementation 'org.apache.hadoop:hadoop-common:3.3.5'
-    implementation 'org.apache.hadoop:hadoop-mapreduce-client-core:3.3.5'
-    implementation 'org.apache.parquet:parquet-avro:1.12.3'
-    implementation 'org.apache.parquet:parquet-column:1.12.3'
-    implementation 'org.apache.parquet:parquet-common:1.12.3'
-    implementation 'org.apache.parquet:parquet-hadoop:1.12.3'
+    //implementation 'org.apache.hadoop:hadoop-mapreduce-client-core:3.3.5'
+    implementation 'org.apache.parquet:parquet-avro:1.13.1'
+    implementation 'org.apache.parquet:parquet-column:1.13.1'
+    implementation 'org.apache.parquet:parquet-common:1.13.1'
+    implementation 'org.apache.parquet:parquet-hadoop:1.13.1'
     testImplementation project(':data-prepper-test-common')
 }
 

--- a/data-prepper-plugins/parquet-codecs/build.gradle
+++ b/data-prepper-plugins/parquet-codecs/build.gradle
@@ -8,7 +8,9 @@ dependencies {
     implementation project(':data-prepper-plugins:common')
     implementation 'org.apache.avro:avro:1.11.0'
     implementation 'org.apache.hadoop:hadoop-common:3.3.5'
-    //implementation 'org.apache.hadoop:hadoop-mapreduce-client-core:3.3.5'
+    implementation('org.apache.hadoop:hadoop-mapreduce-client-core:3.3.5') {
+        exclude group: 'org.apache.hadoop', module: 'hadoop-hdfs-client'
+    }
     implementation 'org.apache.parquet:parquet-avro:1.13.1'
     implementation 'org.apache.parquet:parquet-column:1.13.1'
     implementation 'org.apache.parquet:parquet-common:1.13.1'

--- a/data-prepper-plugins/parquet-codecs/build.gradle
+++ b/data-prepper-plugins/parquet-codecs/build.gradle
@@ -7,19 +7,12 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')
     implementation 'org.apache.avro:avro:1.11.0'
-    implementation 'software.amazon.awssdk:s3'
-    implementation 'software.amazon.awssdk:apache-client'
     implementation 'org.apache.hadoop:hadoop-common:3.3.5'
-    implementation 'org.apache.hadoop:hadoop-hdfs-client:3.3.5'
-    implementation 'org.apache.hadoop:hadoop-yarn-client:3.3.5'
-    implementation 'org.apache.hadoop:hadoop-yarn-common:3.3.5'
     implementation 'org.apache.hadoop:hadoop-mapreduce-client-core:3.3.5'
     implementation 'org.apache.parquet:parquet-avro:1.12.3'
     implementation 'org.apache.parquet:parquet-column:1.12.3'
     implementation 'org.apache.parquet:parquet-common:1.12.3'
     implementation 'org.apache.parquet:parquet-hadoop:1.12.3'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     testImplementation project(':data-prepper-test-common')
 }
 

--- a/data-prepper-plugins/parse-json-processor/build.gradle
+++ b/data-prepper-plugins/parse-json-processor/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation 'org.apache.parquet:parquet-common:1.12.3'
+    implementation 'org.apache.parquet:parquet-common:1.13.1'
     testImplementation project(':data-prepper-test-common')
 }
 

--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
     implementation 'org.xerial.snappy:snappy-java:1.1.10.1'
-    implementation 'org.apache.parquet:parquet-common:1.12.3'
+    implementation 'org.apache.parquet:parquet-common:1.13.1'
     implementation 'dev.failsafe:failsafe:3.3.2'
     implementation 'org.apache.httpcomponents:httpcore:4.4.15'
     testImplementation libs.commons.lang3
@@ -48,10 +48,10 @@ dependencies {
     testImplementation project(':data-prepper-plugins:parquet-codecs')
     testImplementation 'org.apache.avro:avro:1.11.0'
     testImplementation 'org.apache.hadoop:hadoop-common:3.3.5'
-    testImplementation 'org.apache.parquet:parquet-avro:1.12.3'
-    testImplementation 'org.apache.parquet:parquet-column:1.12.3'
-    testImplementation 'org.apache.parquet:parquet-common:1.12.3'
-    testImplementation 'org.apache.parquet:parquet-hadoop:1.12.3'
+    testImplementation 'org.apache.parquet:parquet-avro:1.13.1'
+    testImplementation 'org.apache.parquet:parquet-column:1.13.1'
+    testImplementation 'org.apache.parquet:parquet-common:1.13.1'
+    testImplementation 'org.apache.parquet:parquet-hadoop:1.13.1'
     constraints {
         testImplementation('org.eclipse.jetty:jetty-bom') {
             version {

--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -48,10 +48,6 @@ dependencies {
     testImplementation project(':data-prepper-plugins:parquet-codecs')
     testImplementation 'org.apache.avro:avro:1.11.0'
     testImplementation 'org.apache.hadoop:hadoop-common:3.3.5'
-    testImplementation 'org.apache.hadoop:hadoop-hdfs-client:3.3.5'
-    testImplementation 'org.apache.hadoop:hadoop-yarn-client:3.3.5'
-    testImplementation 'org.apache.hadoop:hadoop-yarn-common:3.3.5'
-    testImplementation 'org.apache.hadoop:hadoop-mapreduce-client-core:3.3.5'
     testImplementation 'org.apache.parquet:parquet-avro:1.12.3'
     testImplementation 'org.apache.parquet:parquet-column:1.12.3'
     testImplementation 'org.apache.parquet:parquet-common:1.12.3'


### PR DESCRIPTION
### Description

This PR removes Hadoop HDFS and YARN, neither of which are used. Map-reduce is needed when testing.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
