### PR TITLE
Checkstyle to to 10.12.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,10 @@ allprojects {
             endWithNewline()
         }
     }
+
+    checkstyle {
+        toolVersion = '10.12.3'
+    }
 }
 
 subprojects {


### PR DESCRIPTION
### Description

Updates the Checkstyle tool version to 10.12.3 which is the current latest.

This may help with a Guava vulnerability as it uses Guava 32.0.1.

Snippet from `./gradlew dependencies`:

```
\--- com.puppycrawl.tools:checkstyle:10.12.3
     +--- info.picocli:picocli:4.7.4
     +--- org.antlr:antlr4-runtime:4.11.1
     +--- commons-beanutils:commons-beanutils:1.9.4
     |    \--- commons-collections:commons-collections:3.2.2
     +--- com.google.guava:guava:32.0.1-jre
```

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
