### PR TITLE
Add Support for OTel Log SeverityText (#3280)

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonOtelLog.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonOtelLog.java
@@ -273,7 +273,7 @@ public class JacksonOtelLog extends JacksonEvent implements OpenTelemetryLog {
          *
          * @param severityText sets the severity text of this log event
          * @return the builder
-         * @since 2.4
+         * @since 2.5
          */
         public Builder withSeverityText(final String severityText) {
             data.put(SEVERITY_TEXT_KEY, severityText);

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonOtelLog.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonOtelLog.java
@@ -33,6 +33,7 @@ public class JacksonOtelLog extends JacksonEvent implements OpenTelemetryLog {
     protected static final String SPAN_ID_KEY = "spanId";
     protected static final String TRACE_ID_KEY = "traceId";
     protected static final String SEVERITY_NUMBER_KEY = "severityNumber";
+    protected static final String SEVERITY_TEXT_KEY = "severityText";
     protected static final String DROPPED_ATTRIBUTES_COUNT_KEY = "droppedAttributesCount";
 
 
@@ -85,6 +86,11 @@ public class JacksonOtelLog extends JacksonEvent implements OpenTelemetryLog {
     @Override
     public Integer getSeverityNumber() {
         return this.get(SEVERITY_NUMBER_KEY, Integer.class);
+    }
+
+    @Override
+    public String getSeverityText() {
+        return this.get(SEVERITY_TEXT_KEY, String.class);
     }
 
     @Override
@@ -259,6 +265,18 @@ public class JacksonOtelLog extends JacksonEvent implements OpenTelemetryLog {
          */
         public Builder withSeverityNumber(final Integer severityNumber) {
             data.put(SEVERITY_NUMBER_KEY, severityNumber);
+            return getThis();
+        }
+
+        /**
+         * Sets the severity text of this log event
+         *
+         * @param severityText sets the severity text of this log event
+         * @return the builder
+         * @since 2.4
+         */
+        public Builder withSeverityText(final String severityText) {
+            data.put(SEVERITY_TEXT_KEY, severityText);
             return getThis();
         }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/OpenTelemetryLog.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/OpenTelemetryLog.java
@@ -89,6 +89,15 @@ public interface OpenTelemetryLog extends Log {
     Integer getSeverityNumber();
 
     /**
+     * Gets the severity text of this log event.
+     *
+     * @return the severity number encoded as Integer
+     * @since 2.4
+     */
+    String getSeverityText();
+
+
+    /**
      * Gets the dropped attributes count of this log event.
      *
      * @return the dropped attributes count as Integer

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/OpenTelemetryLog.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/OpenTelemetryLog.java
@@ -92,7 +92,7 @@ public interface OpenTelemetryLog extends Log {
      * Gets the severity text of this log event.
      *
      * @return the severity number encoded as Integer
-     * @since 2.4
+     * @since 2.5
      */
     String getSeverityText();
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonOtelLogTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonOtelLogTest.java
@@ -39,6 +39,7 @@ public class JacksonOtelLogTest {
     private static final String TEST_TRACE_ID = "1234";
     private static final String TEST_SPAN_ID = "4321";
     private static final Integer TEST_SEVERITY_NUMBER = 2;
+    private static final String TEST_SEVERITY_TEXT = "severity";
     private static final Integer TEST_DROPPED_ATTRIBUTES_COUNT = 4;
     private static final Object TEST_BODY = Map.of("log", "message");
 
@@ -57,6 +58,7 @@ public class JacksonOtelLogTest {
                 .withTraceId(TEST_TRACE_ID)
                 .withSpanId(TEST_SPAN_ID)
                 .withSeverityNumber(TEST_SEVERITY_NUMBER)
+                .withSeverityText(TEST_SEVERITY_TEXT)
                 .withDroppedAttributesCount(TEST_DROPPED_ATTRIBUTES_COUNT)
                 .withBody(TEST_BODY);
 
@@ -103,6 +105,12 @@ public class JacksonOtelLogTest {
     public void testGetSpanId() {
         final String spanId = log.getSpanId();
         assertThat(spanId, is(equalTo(TEST_SPAN_ID)));
+    }
+
+    @Test
+    public void testGetServerityText() {
+        final String severityText = log.getSeverityText();
+        assertThat(severityText, is(equalTo(TEST_SEVERITY_TEXT)));
     }
 
     @Test

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodec.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodec.java
@@ -252,6 +252,7 @@ public class OTelProtoCodec {
                             .withTraceId(OTelProtoCodec.convertByteStringToString(log.getTraceId()))
                             .withSpanId(OTelProtoCodec.convertByteStringToString(log.getSpanId()))
                             .withSeverityNumber(log.getSeverityNumberValue())
+                            .withSeverityText(log.getSeverityText())
                             .withDroppedAttributesCount(log.getDroppedAttributesCount())
                             .withBody(OTelProtoCodec.convertAnyValue(log.getBody()))
                             .build())

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodecTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodecTest.java
@@ -444,6 +444,7 @@ public class OTelProtoCodecTest {
             assertThat(logRecord.getDroppedAttributesCount(), is(3));
             assertThat(logRecord.getSchemaUrl(), is("schemaurl"));
             assertThat(logRecord.getSeverityNumber(), is(5));
+            assertThat(logRecord.getSeverityText(), is("Severity value"));
             assertThat(logRecord.getTraceId(), is("ba1a1c23b4093b63"));
             assertThat(logRecord.getSpanId(), is("2cc83ac90ebc469c"));
             Map<String, Object> mergedAttributes = logRecord.getAttributes();

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-log-is.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-log-is.json
@@ -13,6 +13,7 @@
       "logRecords": [{
         "timeUnixNano": "1590328800000000000",
         "severityNumber": "SEVERITY_NUMBER_DEBUG",
+        "severityText": "Severity value",
         "body": {
           "stringValue": "Log value"
         },

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-log.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-request-log.json
@@ -12,6 +12,7 @@
       "logRecords": [{
         "timeUnixNano": "1590328800000000000",
         "severityNumber": "SEVERITY_NUMBER_DEBUG",
+        "severityText": "Severity value",
         "body": {
           "stringValue": "Log value"
         },


### PR DESCRIPTION
The OpenTelemetry Codec lacks support for the severity text. This oversight is corrected by extracting the field from the OTLP source data and copying it to a matching field in the JSON document. It tightly aligns with the already supported SeverityNumber field. This closes a gap in the OTLP logs data model mapping. Unit tests of codec and JSON mapping are adjusted for the added field.

### Description
The OpenTelemetry Codec lacks support for the severity text. This oversight is corrected by extracting the field from the OTLP source data and copying it to a matching field in the JSON document. It tightly aligns with the already supported `severityNumber` field. 

### Issues Resolved
Resolves #3280 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
