### PR TITLE
Add support for OpenSearch Serverless collections to the opensearch s…

### DIFF
--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/AwsAuthenticationConfiguration.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/AwsAuthenticationConfiguration.java
@@ -29,6 +29,9 @@ public class AwsAuthenticationConfiguration {
     @Size(max = 5, message = "sts_header_overrides supports a maximum of 5 headers to override")
     private Map<String, String> awsStsHeaderOverrides;
 
+    @JsonProperty("serverless")
+    private Boolean serverless = false;
+
     public String getAwsStsRoleArn() {
         return awsStsRoleArn;
     }
@@ -43,6 +46,10 @@ public class AwsAuthenticationConfiguration {
 
     public Map<String, String> getAwsStsHeaderOverrides() {
         return awsStsHeaderOverrides;
+    }
+
+    public Boolean isServerlessCollection() {
+        return serverless;
     }
 }
 

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SearchConfiguration.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SearchConfiguration.java
@@ -21,7 +21,6 @@ public class SearchConfiguration {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final Logger LOG = LoggerFactory.getLogger(SearchConfiguration.class);
 
-    // TODO: Should we default this to NONE and remove the version lookup to determine scroll or point-in-time as the default behavior?
     @JsonProperty("search_context_type")
     private SearchContextType searchContextType;
 

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchClientFactory.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchClientFactory.java
@@ -56,6 +56,7 @@ public class OpenSearchClientFactory {
     private static final Logger LOG = LoggerFactory.getLogger(OpenSearchClientFactory.class);
 
     private static final String AOS_SERVICE_NAME = "es";
+    private static final String AOSS_SERVICE_NAME = "aoss";
 
     private final AwsCredentialsSupplier awsCredentialsSupplier;
 
@@ -96,9 +97,13 @@ public class OpenSearchClientFactory {
                 .withStsHeaderOverrides(openSearchSourceConfiguration.getAwsAuthenticationOptions().getAwsStsHeaderOverrides())
                 .build());
 
+        final boolean isServerlessCollection = Objects.nonNull(openSearchSourceConfiguration.getAwsAuthenticationOptions()) &&
+                openSearchSourceConfiguration.getAwsAuthenticationOptions().isServerlessCollection();
+
         return new AwsSdk2Transport(createSdkHttpClient(openSearchSourceConfiguration),
                 HttpHost.create(openSearchSourceConfiguration.getHosts().get(0)).getHostName(),
-                AOS_SERVICE_NAME, openSearchSourceConfiguration.getAwsAuthenticationOptions().getAwsRegion(),
+                isServerlessCollection ? AOSS_SERVICE_NAME : AOS_SERVICE_NAME,
+                openSearchSourceConfiguration.getAwsAuthenticationOptions().getAwsRegion(),
                 AwsSdk2TransportOptions.builder()
                         .setCredentials(awsCredentialsProvider)
                         .setMapper(new JacksonJsonpMapper())


### PR DESCRIPTION
…ource

### Description
This change adds a `serverless` flag in the opensearch source to support Amazon OpenSearch Serverless collections

```
aws:
  serverless: true
```

Serverless collections do not support point in time APIs, but I tested with both `search_after` and `scroll` and they worked as intended (the scroll deletion still fails from the client but is likely related to this issue (https://github.com/opensearch-project/opensearch-java/issues/521)
 
### Issues Resolved
Related to #1985 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
