### PR TITLE
Add metrics for the opensearch source

### DIFF
--- a/data-prepper-plugins/opensearch-source/build.gradle
+++ b/data-prepper-plugins/opensearch-source/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation project(':data-prepper-plugins:buffer-common')
     implementation project(':data-prepper-plugins:aws-plugin-api')
     implementation 'software.amazon.awssdk:apache-client'
+    implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
     implementation 'software.amazon.awssdk:s3'

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSource.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSource.java
@@ -4,6 +4,7 @@
  */
 package org.opensearch.dataprepper.plugins.source.opensearch;
 
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
@@ -14,6 +15,7 @@ import org.opensearch.dataprepper.model.source.Source;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.UsesSourceCoordination;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.plugins.source.opensearch.metrics.OpenSearchSourcePluginMetrics;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.OpenSearchClientFactory;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessor;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessorStrategy;
@@ -24,6 +26,7 @@ public class OpenSearchSource implements Source<Record<Event>>, UsesSourceCoordi
     private final AwsCredentialsSupplier awsCredentialsSupplier;
     private final OpenSearchSourceConfiguration openSearchSourceConfiguration;
     private final AcknowledgementSetManager acknowledgementSetManager;
+    private final PluginMetrics pluginMetrics;
 
     private SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator;
     private OpenSearchService openSearchService;
@@ -31,10 +34,12 @@ public class OpenSearchSource implements Source<Record<Event>>, UsesSourceCoordi
     @DataPrepperPluginConstructor
     public OpenSearchSource(final OpenSearchSourceConfiguration openSearchSourceConfiguration,
                             final AwsCredentialsSupplier awsCredentialsSupplier,
-                            final AcknowledgementSetManager acknowledgementSetManager) {
+                            final AcknowledgementSetManager acknowledgementSetManager,
+                            final PluginMetrics pluginMetrics) {
         this.openSearchSourceConfiguration = openSearchSourceConfiguration;
         this.awsCredentialsSupplier = awsCredentialsSupplier;
         this.acknowledgementSetManager = acknowledgementSetManager;
+        this.pluginMetrics = pluginMetrics;
 
         openSearchSourceConfiguration.validateAwsConfigWithUsernameAndPassword();
     }
@@ -47,14 +52,16 @@ public class OpenSearchSource implements Source<Record<Event>>, UsesSourceCoordi
         startProcess(openSearchSourceConfiguration, buffer);
     }
 
-    private void startProcess(final OpenSearchSourceConfiguration openSearchSourceConfiguration, final Buffer<Record<Event>> buffer)  {
+    private void startProcess(final OpenSearchSourceConfiguration openSearchSourceConfiguration,
+                              final Buffer<Record<Event>> buffer)  {
 
         final OpenSearchClientFactory openSearchClientFactory = OpenSearchClientFactory.create(awsCredentialsSupplier);
+        final OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics = OpenSearchSourcePluginMetrics.create(pluginMetrics);
         final SearchAccessorStrategy searchAccessorStrategy = SearchAccessorStrategy.create(openSearchSourceConfiguration, openSearchClientFactory);
 
         final SearchAccessor searchAccessor = searchAccessorStrategy.getSearchAccessor();
 
-        openSearchService = OpenSearchService.createOpenSearchService(searchAccessor, sourceCoordinator, openSearchSourceConfiguration, buffer, acknowledgementSetManager);
+        openSearchService = OpenSearchService.createOpenSearchService(searchAccessor, sourceCoordinator, openSearchSourceConfiguration, buffer, acknowledgementSetManager, openSearchSourcePluginMetrics);
         openSearchService.start();
     }
 

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/metrics/OpenSearchSourcePluginMetrics.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/metrics/OpenSearchSourcePluginMetrics.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+
+public class OpenSearchSourcePluginMetrics {
+
+    static final String DOCUMENTS_PROCESSED = "documentsProcessed";
+    static final String INDICES_PROCESSED = "indicesProcessed";
+    static final String INDEX_PROCESSING_TIME_ELAPSED = "indexProcessingTime";
+    static final String PROCESSING_ERRORS = "processingErrors";
+
+    private final Counter documentsProcessedCounter;
+    private final Counter indicesProcessedCounter;
+    private final Counter processingErrorsCounter;
+    private final Timer indexProcessingTimeTimer;
+
+    public static OpenSearchSourcePluginMetrics create(final PluginMetrics pluginMetrics) {
+        return new OpenSearchSourcePluginMetrics(pluginMetrics);
+    }
+
+    private OpenSearchSourcePluginMetrics(final PluginMetrics pluginMetrics) {
+        documentsProcessedCounter = pluginMetrics.counter(DOCUMENTS_PROCESSED);
+        indicesProcessedCounter = pluginMetrics.counter(INDICES_PROCESSED);
+        processingErrorsCounter = pluginMetrics.counter(PROCESSING_ERRORS);
+        indexProcessingTimeTimer = pluginMetrics.timer(INDEX_PROCESSING_TIME_ELAPSED);
+    }
+
+    public Counter getDocumentsProcessedCounter() {
+        return documentsProcessedCounter;
+    }
+
+    public Counter getIndicesProcessedCounter() {
+        return indicesProcessedCounter;
+    }
+
+    public Counter getProcessingErrorsCounter() {
+        return processingErrorsCounter;
+    }
+
+    public Timer getIndexProcessingTimeTimer() {
+        return indexProcessingTimeTimer;
+    }
+}

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorker.java
@@ -92,10 +92,7 @@ public class NoSearchContextWorker implements SearchWorker, Runnable {
                             sourceCoordinator,
                             indexPartition.get());
 
-                    openSearchSourcePluginMetrics.getIndexProcessingTimeTimer().recordCallable(() -> {
-                        processIndex(indexPartition.get(), acknowledgementSet.getLeft());
-                        return null;
-                    });
+                    openSearchSourcePluginMetrics.getIndexProcessingTimeTimer().record(() -> processIndex(indexPartition.get(), acknowledgementSet.getLeft()));
 
                     completeIndexPartition(openSearchSourceConfiguration, acknowledgementSet.getLeft(), acknowledgementSet.getRight(),
                             indexPartition.get(), sourceCoordinator);

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorker.java
@@ -19,6 +19,7 @@ import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionU
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchIndexProgressState;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SearchConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.metrics.OpenSearchSourcePluginMetrics;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessor;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.IndexNotFoundException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.NoSearchContextSearchRequest;
@@ -48,19 +49,22 @@ public class NoSearchContextWorker implements SearchWorker, Runnable {
     private final BufferAccumulator<Record<Event>> bufferAccumulator;
     private final OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier;
     private final AcknowledgementSetManager acknowledgementSetManager;
+    private final OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics;
 
     public NoSearchContextWorker(final SearchAccessor searchAccessor,
                      final OpenSearchSourceConfiguration openSearchSourceConfiguration,
                      final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator,
                      final BufferAccumulator<Record<Event>> bufferAccumulator,
                      final OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier,
-                     final AcknowledgementSetManager acknowledgementSetManager) {
+                     final AcknowledgementSetManager acknowledgementSetManager,
+                     final OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics) {
         this.searchAccessor = searchAccessor;
         this.sourceCoordinator = sourceCoordinator;
         this.openSearchSourceConfiguration = openSearchSourceConfiguration;
         this.bufferAccumulator = bufferAccumulator;
         this.openSearchIndexPartitionCreationSupplier = openSearchIndexPartitionCreationSupplier;
         this.acknowledgementSetManager = acknowledgementSetManager;
+        this.openSearchSourcePluginMetrics = openSearchSourcePluginMetrics;
     }
 
     @Override
@@ -88,11 +92,15 @@ public class NoSearchContextWorker implements SearchWorker, Runnable {
                             sourceCoordinator,
                             indexPartition.get());
 
-                    processIndex(indexPartition.get(), acknowledgementSet.getLeft());
+                    openSearchSourcePluginMetrics.getIndexProcessingTimeTimer().recordCallable(() -> {
+                        processIndex(indexPartition.get(), acknowledgementSet.getLeft());
+                        return null;
+                    });
 
                     completeIndexPartition(openSearchSourceConfiguration, acknowledgementSet.getLeft(), acknowledgementSet.getRight(),
                             indexPartition.get(), sourceCoordinator);
 
+                    openSearchSourcePluginMetrics.getIndicesProcessedCounter().increment();
                 } catch (final PartitionUpdateException | PartitionNotFoundException | PartitionNotOwnedException e) {
                     LOG.warn("The search_after worker received an exception from the source coordinator. There is a potential for duplicate data for index {}, giving up partition and getting next partition: {}", indexPartition.get().getPartitionKey(), e.getMessage());
                     sourceCoordinator.giveUpPartitions();
@@ -102,8 +110,10 @@ public class NoSearchContextWorker implements SearchWorker, Runnable {
                 } catch (final Exception e) {
                     LOG.error("Unknown exception while processing index '{}', moving on to another index:", indexPartition.get().getPartitionKey(), e);
                     sourceCoordinator.giveUpPartitions();
+                    openSearchSourcePluginMetrics.getProcessingErrorsCounter().increment();
                 }
             } catch (final Exception e) {
+                openSearchSourcePluginMetrics.getProcessingErrorsCounter().increment();
                 LOG.error("Received an exception while trying to get index to process with search_after, backing off and retrying", e);
                 try {
                     Thread.sleep(STANDARD_BACKOFF_MILLIS);
@@ -143,7 +153,9 @@ public class NoSearchContextWorker implements SearchWorker, Runnable {
                         acknowledgementSet.add(record.getData());
                     }
                     bufferAccumulator.add(record);
+                    openSearchSourcePluginMetrics.getDocumentsProcessedCounter().increment();
                 } catch (Exception e) {
+                    openSearchSourcePluginMetrics.getProcessingErrorsCounter().increment();
                     LOG.error("Failed writing OpenSearch documents to buffer. The last document created has document id '{}' from index '{}' : {}",
                             record.getData().getMetadata().getAttribute(DOCUMENT_ID_METADATA_ATTRIBUTE_NAME),
                             record.getData().getMetadata().getAttribute(INDEX_METADATA_ATTRIBUTE_NAME), e.getMessage());
@@ -157,6 +169,7 @@ public class NoSearchContextWorker implements SearchWorker, Runnable {
         try {
             bufferAccumulator.flush();
         } catch (final Exception e) {
+            openSearchSourcePluginMetrics.getProcessingErrorsCounter().increment();
             LOG.error("Failed writing remaining OpenSearch documents to buffer due to: {}", e.getMessage());
         }
     }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
@@ -18,6 +18,7 @@ import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionU
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchIndexProgressState;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SearchConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.metrics.OpenSearchSourcePluginMetrics;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessor;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.IndexNotFoundException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.SearchContextLimitException;
@@ -63,19 +64,22 @@ public class PitWorker implements SearchWorker, Runnable {
     private final OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier;
 
     private final AcknowledgementSetManager acknowledgementSetManager;
+    private final OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics;
 
     public PitWorker(final SearchAccessor searchAccessor,
                      final OpenSearchSourceConfiguration openSearchSourceConfiguration,
                      final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator,
                      final BufferAccumulator<Record<Event>> bufferAccumulator,
                      final OpenSearchIndexPartitionCreationSupplier openSearchIndexPartitionCreationSupplier,
-                     final AcknowledgementSetManager acknowledgementSetManager) {
+                     final AcknowledgementSetManager acknowledgementSetManager,
+                     final OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics) {
         this.searchAccessor = searchAccessor;
         this.sourceCoordinator = sourceCoordinator;
         this.openSearchSourceConfiguration = openSearchSourceConfiguration;
         this.bufferAccumulator = bufferAccumulator;
         this.openSearchIndexPartitionCreationSupplier = openSearchIndexPartitionCreationSupplier;
         this.acknowledgementSetManager = acknowledgementSetManager;
+        this.openSearchSourcePluginMetrics = openSearchSourcePluginMetrics;
     }
 
     @Override
@@ -102,10 +106,15 @@ public class PitWorker implements SearchWorker, Runnable {
                             sourceCoordinator,
                             indexPartition.get());
 
-                    processIndex(indexPartition.get(), acknowledgementSet.getLeft());
+                    openSearchSourcePluginMetrics.getIndexProcessingTimeTimer().recordCallable(() -> {
+                        processIndex(indexPartition.get(), acknowledgementSet.getLeft());
+                        return null;
+                    });
 
                     completeIndexPartition(openSearchSourceConfiguration, acknowledgementSet.getLeft(), acknowledgementSet.getRight(),
                             indexPartition.get(), sourceCoordinator);
+
+                    openSearchSourcePluginMetrics.getIndicesProcessedCounter().increment();
                 } catch (final PartitionUpdateException | PartitionNotFoundException | PartitionNotOwnedException e) {
                     LOG.warn("PitWorker received an exception from the source coordinator. There is a potential for duplicate data for index {}, giving up partition and getting next partition: {}", indexPartition.get().getPartitionKey(), e.getMessage());
                     sourceCoordinator.giveUpPartitions();
@@ -113,6 +122,7 @@ public class PitWorker implements SearchWorker, Runnable {
                     LOG.warn("Received SearchContextLimitExceeded exception for index {}. Giving up index and waiting {} seconds before retrying: {}",
                             indexPartition.get().getPartitionKey(), BACKOFF_ON_PIT_LIMIT_REACHED.getSeconds(), e.getMessage());
                     sourceCoordinator.giveUpPartitions();
+                    openSearchSourcePluginMetrics.getProcessingErrorsCounter().increment();
                     try {
                         Thread.sleep(BACKOFF_ON_PIT_LIMIT_REACHED.toMillis());
                     } catch (final InterruptedException ex) {
@@ -124,9 +134,11 @@ public class PitWorker implements SearchWorker, Runnable {
                 } catch (final RuntimeException e) {
                     LOG.error("Unknown exception while processing index '{}':", indexPartition.get().getPartitionKey(), e);
                     sourceCoordinator.giveUpPartitions();
+                    openSearchSourcePluginMetrics.getProcessingErrorsCounter().increment();
                 }
             } catch (final Exception e) {
                 LOG.error("Received an exception while trying to get index to process with PIT, backing off and retrying", e);
+                openSearchSourcePluginMetrics.getProcessingErrorsCounter().increment();
                 try {
                     Thread.sleep(STANDARD_BACKOFF_MILLIS);
                 } catch (final InterruptedException ex) {
@@ -180,7 +192,9 @@ public class PitWorker implements SearchWorker, Runnable {
                         acknowledgementSet.add(record.getData());
                     }
                     bufferAccumulator.add(record);
+                    openSearchSourcePluginMetrics.getDocumentsProcessedCounter().increment();
                 } catch (Exception e) {
+                    openSearchSourcePluginMetrics.getProcessingErrorsCounter().increment();
                     LOG.error("Failed writing OpenSearch documents to buffer. The last document created has document id '{}' from index '{}' : {}",
                             record.getData().getMetadata().getAttribute(DOCUMENT_ID_METADATA_ATTRIBUTE_NAME),
                             record.getData().getMetadata().getAttribute(INDEX_METADATA_ATTRIBUTE_NAME), e.getMessage());
@@ -195,6 +209,7 @@ public class PitWorker implements SearchWorker, Runnable {
         try {
             bufferAccumulator.flush();
         } catch (final Exception e) {
+            openSearchSourcePluginMetrics.getProcessingErrorsCounter().increment();
             LOG.error("Failed flushing remaining OpenSearch documents to buffer due to: {}", e.getMessage());
         }
 

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
@@ -106,10 +106,7 @@ public class PitWorker implements SearchWorker, Runnable {
                             sourceCoordinator,
                             indexPartition.get());
 
-                    openSearchSourcePluginMetrics.getIndexProcessingTimeTimer().recordCallable(() -> {
-                        processIndex(indexPartition.get(), acknowledgementSet.getLeft());
-                        return null;
-                    });
+                    openSearchSourcePluginMetrics.getIndexProcessingTimeTimer().record(() -> processIndex(indexPartition.get(), acknowledgementSet.getLeft()));
 
                     completeIndexPartition(openSearchSourceConfiguration, acknowledgementSet.getLeft(), acknowledgementSet.getRight(),
                             indexPartition.get(), sourceCoordinator);

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
@@ -99,10 +99,7 @@ public class ScrollWorker implements SearchWorker {
                             sourceCoordinator,
                             indexPartition.get());
 
-                    openSearchSourcePluginMetrics.getIndexProcessingTimeTimer().recordCallable(() -> {
-                        processIndex(indexPartition.get(), acknowledgementSet.getLeft());
-                        return null;
-                    });
+                    openSearchSourcePluginMetrics.getIndexProcessingTimeTimer().record(() -> processIndex(indexPartition.get(), acknowledgementSet.getLeft()));
 
                     completeIndexPartition(openSearchSourceConfiguration, acknowledgementSet.getLeft(), acknowledgementSet.getRight(),
                             indexPartition.get(), sourceCoordinator);

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchServiceTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchServiceTest.java
@@ -22,6 +22,7 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SchedulingParameterConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SearchConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.metrics.OpenSearchSourcePluginMetrics;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.NoSearchContextWorker;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.OpenSearchIndexPartitionCreationSupplier;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.PitWorker;
@@ -66,6 +67,9 @@ public class OpenSearchServiceTest {
     private AcknowledgementSetManager acknowledgementSetManager;
 
     @Mock
+    private OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics;
+
+    @Mock
     private SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator;
 
     @Mock
@@ -93,7 +97,7 @@ public class OpenSearchServiceTest {
              })) {
             executorsMockedStatic.when(Executors::newSingleThreadScheduledExecutor).thenReturn(scheduledExecutorService);
             bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(buffer, openSearchSourceConfiguration.getSearchConfiguration().getBatchSize(), BUFFER_TIMEOUT)).thenReturn(bufferAccumulator);
-            return OpenSearchService.createOpenSearchService(openSearchAccessor, sourceCoordinator, openSearchSourceConfiguration, buffer, acknowledgementSetManager);
+            return OpenSearchService.createOpenSearchService(openSearchAccessor, sourceCoordinator, openSearchSourceConfiguration, buffer, acknowledgementSetManager, openSearchSourcePluginMetrics);
         }
     }
 

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorkerTest.java
@@ -5,12 +5,16 @@
 
 package org.opensearch.dataprepper.plugins.source.opensearch.worker;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -22,6 +26,7 @@ import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchIndexProgr
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SchedulingParameterConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SearchConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.metrics.OpenSearchSourcePluginMetrics;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.SearchAccessor;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.exceptions.IndexNotFoundException;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.NoSearchContextSearchRequest;
@@ -32,6 +37,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -53,6 +59,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.ACKNOWLEDGEMENT_SET_TIMEOUT_SECONDS;
 
@@ -77,16 +84,35 @@ public class NoSearchContextWorkerTest {
     @Mock
     private AcknowledgementSetManager acknowledgementSetManager;
 
+    @Mock
+    private OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics;
+
+    @Mock
+    private Counter documentsProcessedCounter;
+
+    @Mock
+    private Counter indicesProcessedCounter;
+
+    @Mock
+    private Counter processingErrorsCounter;
+
+    @Mock
+    private Timer indexProcessingTimeTimer;
+
     private ExecutorService executorService;
 
     @BeforeEach
     void setup() {
         executorService = Executors.newSingleThreadExecutor();
         lenient().when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(false);
+        lenient().when(openSearchSourcePluginMetrics.getDocumentsProcessedCounter()).thenReturn(documentsProcessedCounter);
+        lenient().when(openSearchSourcePluginMetrics.getIndicesProcessedCounter()).thenReturn(indicesProcessedCounter);
+        lenient().when(openSearchSourcePluginMetrics.getProcessingErrorsCounter()).thenReturn(processingErrorsCounter);
+        lenient().when(openSearchSourcePluginMetrics.getIndexProcessingTimeTimer()).thenReturn(indexProcessingTimeTimer);
     }
 
     private NoSearchContextWorker createObjectUnderTest() {
-        return new NoSearchContextWorker(searchAccessor, openSearchSourceConfiguration, sourceCoordinator, bufferAccumulator, openSearchIndexPartitionCreationSupplier, acknowledgementSetManager);
+        return new NoSearchContextWorker(searchAccessor, openSearchSourceConfiguration, sourceCoordinator, bufferAccumulator, openSearchIndexPartitionCreationSupplier, acknowledgementSetManager, openSearchSourcePluginMetrics);
     }
 
     @Test
@@ -104,7 +130,8 @@ public class NoSearchContextWorkerTest {
     }
 
     @Test
-    void run_when_search_without_search_context_throws_index_not_found_exception_completes_the_partition() throws InterruptedException {
+    void run_when_search_without_search_context_throws_index_not_found_exception_completes_the_partition() throws Exception {
+        mockTimerCallable();
 
         final SourcePartition<OpenSearchIndexProgressState> sourcePartition = mock(SourcePartition.class);
         final String partitionKey = UUID.randomUUID().toString();
@@ -131,10 +158,16 @@ public class NoSearchContextWorkerTest {
 
         verify(sourceCoordinator).completePartition(partitionKey);
         verify(sourceCoordinator, never()).closePartition(anyString(), any(Duration.class), anyInt());
+
+        verifyNoInteractions(documentsProcessedCounter);
+        verifyNoInteractions(indicesProcessedCounter);
+        verifyNoInteractions(processingErrorsCounter);
     }
 
     @Test
     void run_with_getNextPartition_with_non_empty_partition_processes_and_closes_that_partition() throws Exception {
+        mockTimerCallable();
+
         final SourcePartition<OpenSearchIndexProgressState> sourcePartition = mock(SourcePartition.class);
         final String partitionKey = UUID.randomUUID().toString();
         when(sourcePartition.getPartitionKey()).thenReturn(partitionKey);
@@ -188,10 +221,16 @@ public class NoSearchContextWorkerTest {
         assertThat(noSearchContextSearchRequests.get(1).getIndex(), equalTo(partitionKey));
         assertThat(noSearchContextSearchRequests.get(1).getPaginationSize(), equalTo(2));
         assertThat(noSearchContextSearchRequests.get(1).getSearchAfter(), equalTo(searchWithSearchAfterResults.getNextSearchAfter()));
+
+        verify(documentsProcessedCounter, times(3)).increment();
+        verify(indicesProcessedCounter).increment();
+        verifyNoInteractions(processingErrorsCounter);
     }
 
     @Test
     void run_with_getNextPartition_with_acknowledgments_processes_and_closes_that_partition() throws Exception {
+        mockTimerCallable();
+
         final AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
         AtomicReference<Integer> numEventsAdded = new AtomicReference<>(0);
         doAnswer(a -> {
@@ -261,5 +300,20 @@ public class NoSearchContextWorkerTest {
         assertThat(noSearchContextSearchRequests.get(1).getSearchAfter(), equalTo(searchWithSearchAfterResults.getNextSearchAfter()));
 
         verify(acknowledgementSet).complete();
+
+        verify(documentsProcessedCounter, times(3)).increment();
+        verify(indicesProcessedCounter).increment();
+        verifyNoInteractions(processingErrorsCounter);
+    }
+
+    private void mockTimerCallable() throws Exception {
+        when(indexProcessingTimeTimer.recordCallable(ArgumentMatchers.<Callable<Void>>any())).thenAnswer(
+                (Answer<Void>) invocation -> {
+                    final Object[] args = invocation.getArguments();
+                    @SuppressWarnings("unchecked")
+                    final Callable<Void> callable = (Callable<Void>) args[0];
+                    return callable.call();
+                }
+        );
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorkerTest.java
@@ -11,10 +11,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -37,7 +35,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -84,7 +81,7 @@ public class NoSearchContextWorkerTest {
     @Mock
     private AcknowledgementSetManager acknowledgementSetManager;
 
-    @Mock
+    @Mock(lenient = true)
     private OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics;
 
     @Mock
@@ -105,10 +102,10 @@ public class NoSearchContextWorkerTest {
     void setup() {
         executorService = Executors.newSingleThreadExecutor();
         lenient().when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(false);
-        lenient().when(openSearchSourcePluginMetrics.getDocumentsProcessedCounter()).thenReturn(documentsProcessedCounter);
-        lenient().when(openSearchSourcePluginMetrics.getIndicesProcessedCounter()).thenReturn(indicesProcessedCounter);
-        lenient().when(openSearchSourcePluginMetrics.getProcessingErrorsCounter()).thenReturn(processingErrorsCounter);
-        lenient().when(openSearchSourcePluginMetrics.getIndexProcessingTimeTimer()).thenReturn(indexProcessingTimeTimer);
+        when(openSearchSourcePluginMetrics.getDocumentsProcessedCounter()).thenReturn(documentsProcessedCounter);
+        when(openSearchSourcePluginMetrics.getIndicesProcessedCounter()).thenReturn(indicesProcessedCounter);
+        when(openSearchSourcePluginMetrics.getProcessingErrorsCounter()).thenReturn(processingErrorsCounter);
+        when(openSearchSourcePluginMetrics.getIndexProcessingTimeTimer()).thenReturn(indexProcessingTimeTimer);
     }
 
     private NoSearchContextWorker createObjectUnderTest() {
@@ -306,14 +303,10 @@ public class NoSearchContextWorkerTest {
         verifyNoInteractions(processingErrorsCounter);
     }
 
-    private void mockTimerCallable() throws Exception {
-        when(indexProcessingTimeTimer.recordCallable(ArgumentMatchers.<Callable<Void>>any())).thenAnswer(
-                (Answer<Void>) invocation -> {
-                    final Object[] args = invocation.getArguments();
-                    @SuppressWarnings("unchecked")
-                    final Callable<Void> callable = (Callable<Void>) args[0];
-                    return callable.call();
-                }
-        );
+    private void mockTimerCallable() {
+        doAnswer(a -> {
+            a.<Runnable>getArgument(0).run();
+            return null;
+        }).when(indexProcessingTimeTimer).record(any(Runnable.class));
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorkerTest.java
@@ -11,10 +11,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -40,7 +38,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -89,7 +86,7 @@ public class ScrollWorkerTest {
     @Mock
     private AcknowledgementSetManager acknowledgementSetManager;
 
-    @Mock
+    @Mock(lenient = true)
     private OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics;
 
     @Mock
@@ -110,10 +107,10 @@ public class ScrollWorkerTest {
     void setup() {
         executorService = Executors.newSingleThreadExecutor();
         lenient().when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(false);
-        lenient().when(openSearchSourcePluginMetrics.getDocumentsProcessedCounter()).thenReturn(documentsProcessedCounter);
-        lenient().when(openSearchSourcePluginMetrics.getIndicesProcessedCounter()).thenReturn(indicesProcessedCounter);
-        lenient().when(openSearchSourcePluginMetrics.getProcessingErrorsCounter()).thenReturn(processingErrorsCounter);
-        lenient().when(openSearchSourcePluginMetrics.getIndexProcessingTimeTimer()).thenReturn(indexProcessingTimeTimer);
+        when(openSearchSourcePluginMetrics.getDocumentsProcessedCounter()).thenReturn(documentsProcessedCounter);
+        when(openSearchSourcePluginMetrics.getIndicesProcessedCounter()).thenReturn(indicesProcessedCounter);
+        when(openSearchSourcePluginMetrics.getProcessingErrorsCounter()).thenReturn(processingErrorsCounter);
+        when(openSearchSourcePluginMetrics.getIndexProcessingTimeTimer()).thenReturn(indexProcessingTimeTimer);
     }
 
     private ScrollWorker createObjectUnderTest() {
@@ -382,15 +379,11 @@ public class ScrollWorkerTest {
         verifyNoInteractions(processingErrorsCounter);
     }
 
-    private void mockTimerCallable() throws Exception {
-        when(indexProcessingTimeTimer.recordCallable(ArgumentMatchers.<Callable<Void>>any())).thenAnswer(
-                (Answer<Void>) invocation -> {
-                    final Object[] args = invocation.getArguments();
-                    @SuppressWarnings("unchecked")
-                    final Callable<Void> callable = (Callable<Void>) args[0];
-                    return callable.call();
-                }
-        );
+    private void mockTimerCallable() {
+        doAnswer(a -> {
+            a.<Runnable>getArgument(0).run();
+            return null;
+        }).when(indexProcessingTimeTimer).record(any(Runnable.class));
     }
 
 }


### PR DESCRIPTION
### Description
Adds the following metrics for the opensearch source

Counters

* documentsProcessed
* indicesProcessed
* processingErrors

Timer

* indexProcessingTime
 
### Issues Resolved
Related to #1985 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
