### PR TITLE
Need two digits for dates in the common Apache log format in Gatling

### DIFF
--- a/performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/tools/Templates.java
+++ b/performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/tools/Templates.java
@@ -14,11 +14,11 @@ import java.util.List;
 import java.util.function.Function;
 
 public final class Templates {
-    public static final String APACHE_COMMON_LOG_DATETIME_PATTERN = "d/LLL/uuuu:HH:mm:ss";
-    public static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(APACHE_COMMON_LOG_DATETIME_PATTERN);
+    private static final String APACHE_COMMON_LOG_DATETIME_PATTERN = "dd/LLL/uuuu:HH:mm:ss";
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(APACHE_COMMON_LOG_DATETIME_PATTERN);
 
     public static String now() {
-        return formatter.format(LocalDateTime.now()) + " -0700";
+        return FORMATTER.format(LocalDateTime.now()) + " -0700";
     }
     
     public static Function<Session, String> apacheCommonLogTemplate(final int batchSize) {

--- a/performance-test/src/gatling/resources/bodies/singleLog.json
+++ b/performance-test/src/gatling/resources/bodies/singleLog.json
@@ -1,5 +1,5 @@
 [
   {
-    "log": "127.0.0.1 - frank [7/Dec/2021:10:00:00 -0700] \"GET /apache_pb.gif HTTP/1.0\" 200 2326"
+    "log": "127.0.0.1 - frank [17/Dec/2021:10:00:00 -0700] \"GET /apache_pb.gif HTTP/1.0\" 200 2326"
   }
 ]


### PR DESCRIPTION
### Description

The Gatling performance tests were sending a single digit for the day-of-month in the date format. This is incorrect and causing problems with typed Grok processing pipelines.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
