### PR TITLE
Gatling performance - round-robin hosts and documentation

### DIFF
--- a/performance-test/README.md
+++ b/performance-test/README.md
@@ -22,6 +22,28 @@ To run TargetRpsSimulation. Source code available at `./performance-test/src/gat
 ./gradlew :performance-test:gatlingRun-org.opensearch.dataprepper.test.performance.TargetRpsSimulation
 ```
 
+### Configurations
+
+You can configure the test in order to target different endpoints with different configurations.
+Supply the configurations as Java system variables on the command line.
+
+For example, you can configure the port and use HTTPS with a custom certificate with the following:
+
+```
+./gradlew -Dport=7099 -Dprotocol=https -Dpath=/simple-sample-pipeline/logs -Djavax.net.ssl.keyStore=examples/demo/test_keystore.p12 :performance-test:gatlingRun-org.opensearch.dataprepper.test.performance.SingleRequestSimulation
+```
+
+**Available configuration options:**
+
+* `host` - The host name or a comma-delimited list of host names. Defaults to `localhost`.
+* `port` - The destination port. The default value is `2021`.
+* `protocol` - The scheme to use in the URL. Can be `http` or `https`. Defaults to `http`.
+* `path` - The path of the HTTP endpoint. This uses the default `http` path of `/log/ingest`.
+* `authentication` - The authentication to use with the target. Currently supports `aws_sigv4`.
+* `aws_region` - The AWS region to use in signing. Required with `aws_sigv4` authentication.
+* `aws_service` - The AWS service name to use in signing. Required with `aws_sigv4` authentication.
+
+
 ### Verify Gatling scenarios compile
 ```shell
 ./gradlew :performance-test:compileGatlingJava

--- a/performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/tools/Protocol.java
+++ b/performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/tools/Protocol.java
@@ -8,6 +8,10 @@ package org.opensearch.dataprepper.test.performance.tools;
 import io.gatling.javaapi.http.HttpDsl;
 import io.gatling.javaapi.http.HttpProtocolBuilder;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public final class Protocol {
     private Protocol() {
     }
@@ -17,27 +21,37 @@ public final class Protocol {
 
     private static final String HTTP_PROTOCOL = System.getProperty("protocol", HTTP);
 
-    public static final String LOCALHOST = "localhost";
-    private static final String HOST = System.getProperty("host", LOCALHOST);
+    private static final String LOCALHOST = "localhost";
 
-    private static final Integer defaultPort = 2021;
-    private static final Integer port = Integer.getInteger("port", defaultPort);
+    private static final Integer DEFAULT_PORT = 2021;
+    private static final Integer PORT = Integer.getInteger("port", DEFAULT_PORT);
+
+    private static List<String> loadHosts() {
+        String host = System.getProperty("host", LOCALHOST);
+
+        return Arrays.asList(host.split(","));
+    }
 
     private static String asUrl(final String protocol, final String host, final Integer port) {
         return protocol + "://" + host + ":" + port;
     }
+    private static List<String> asUrls(final String protocol, final List<String> host, final Integer port) {
+        return host.stream()
+                .map(h -> asUrl(protocol, h, port))
+                .collect(Collectors.toList());
+    }
 
     public static HttpProtocolBuilder httpProtocol() {
-        return httpProtocol(HTTP_PROTOCOL, HOST, port);
+        return httpProtocol(HTTP_PROTOCOL, loadHosts(), PORT);
     }
 
     public static HttpProtocolBuilder httpsProtocol(final Integer port) {
-        return httpProtocol(HTTPS, HOST, port);
+        return httpProtocol(HTTPS, loadHosts(), port);
     }
 
-    private static HttpProtocolBuilder httpProtocol(final String protocol, final String host, final Integer port) {
+    private static HttpProtocolBuilder httpProtocol(final String protocol, final List<String> hosts, final Integer port) {
         return HttpDsl.http
-                .baseUrl(asUrl(protocol, host, port))
+                .baseUrls(asUrls(protocol, hosts, port))
                 .sign(SignerProvider.getSigner())
                 .acceptHeader("application/json")
                 .header("Content-Type", "application/json");


### PR DESCRIPTION
### Description

This has two changes related to the Gatling performance tests.

* Allows the `host` property to take a comma-delimited list of host names for round-robin testing.
* Documentation for the new configurations.
 
### Issues Resolved

N/A

### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
