### PR TITLE
Exponential backoff and jitter for opensearch source when no indices are available to process

### DIFF
--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorker.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.BACKOFF_ON_EXCEPTION;
-import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.calculateLinearBackoffAndJitter;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.calculateExponentialBackoffAndJitter;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.completeIndexPartition;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.createAcknowledgmentSet;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_ID_METADATA_ATTRIBUTE_NAME;
@@ -79,7 +79,7 @@ public class NoSearchContextWorker implements SearchWorker, Runnable {
 
                 if (indexPartition.isEmpty()) {
                     try {
-                        Thread.sleep(calculateLinearBackoffAndJitter(++noAvailableIndicesCount));
+                        Thread.sleep(calculateExponentialBackoffAndJitter(++noAvailableIndicesCount));
                         continue;
                     } catch (final InterruptedException e) {
                         LOG.info("The search_after worker was interrupted while sleeping after acquiring no indices to process, stopping processing");

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.BACKOFF_ON_EXCEPTION;
-import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.calculateLinearBackoffAndJitter;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.calculateExponentialBackoffAndJitter;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.completeIndexPartition;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.createAcknowledgmentSet;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_ID_METADATA_ATTRIBUTE_NAME;
@@ -91,7 +91,7 @@ public class PitWorker implements SearchWorker, Runnable {
 
                 if (indexPartition.isEmpty()) {
                     try {
-                        Thread.sleep(calculateLinearBackoffAndJitter(++noAvailableIndicesCount));
+                        Thread.sleep(calculateExponentialBackoffAndJitter(++noAvailableIndicesCount));
                         continue;
                     } catch (final InterruptedException e) {
                         LOG.info("The PitWorker was interrupted while sleeping after acquiring no indices to process, stopping processing");

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
@@ -36,6 +36,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.BACKOFF_ON_EXCEPTION;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.calculateLinearBackoffAndJitter;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.completeIndexPartition;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.createAcknowledgmentSet;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_ID_METADATA_ATTRIBUTE_NAME;
@@ -47,9 +49,6 @@ import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client
 public class PitWorker implements SearchWorker, Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(PitWorker.class);
-
-    private static final int STANDARD_BACKOFF_MILLIS = 30_000;
-    private static final Duration BACKOFF_ON_PIT_LIMIT_REACHED = Duration.ofSeconds(60);
 
     static final String STARTING_KEEP_ALIVE = "15m";
     private static final Duration STARTING_KEEP_ALIVE_DURATION = Duration.ofMinutes(15);
@@ -65,6 +64,8 @@ public class PitWorker implements SearchWorker, Runnable {
 
     private final AcknowledgementSetManager acknowledgementSetManager;
     private final OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics;
+
+    private int noAvailableIndicesCount = 0;
 
     public PitWorker(final SearchAccessor searchAccessor,
                      final OpenSearchSourceConfiguration openSearchSourceConfiguration,
@@ -90,13 +91,15 @@ public class PitWorker implements SearchWorker, Runnable {
 
                 if (indexPartition.isEmpty()) {
                     try {
-                        Thread.sleep(STANDARD_BACKOFF_MILLIS);
+                        Thread.sleep(calculateLinearBackoffAndJitter(++noAvailableIndicesCount));
                         continue;
                     } catch (final InterruptedException e) {
                         LOG.info("The PitWorker was interrupted while sleeping after acquiring no indices to process, stopping processing");
                         return;
                     }
                 }
+
+                noAvailableIndicesCount = 0;
 
                 try {
 
@@ -118,11 +121,11 @@ public class PitWorker implements SearchWorker, Runnable {
                     sourceCoordinator.giveUpPartitions();
                 } catch (final SearchContextLimitException e) {
                     LOG.warn("Received SearchContextLimitExceeded exception for index {}. Giving up index and waiting {} seconds before retrying: {}",
-                            indexPartition.get().getPartitionKey(), BACKOFF_ON_PIT_LIMIT_REACHED.getSeconds(), e.getMessage());
+                            indexPartition.get().getPartitionKey(), BACKOFF_ON_EXCEPTION.getSeconds(), e.getMessage());
                     sourceCoordinator.giveUpPartitions();
                     openSearchSourcePluginMetrics.getProcessingErrorsCounter().increment();
                     try {
-                        Thread.sleep(BACKOFF_ON_PIT_LIMIT_REACHED.toMillis());
+                        Thread.sleep(BACKOFF_ON_EXCEPTION.toMillis());
                     } catch (final InterruptedException ex) {
                         return;
                     }
@@ -138,7 +141,7 @@ public class PitWorker implements SearchWorker, Runnable {
                 LOG.error("Received an exception while trying to get index to process with PIT, backing off and retrying", e);
                 openSearchSourcePluginMetrics.getProcessingErrorsCounter().increment();
                 try {
-                    Thread.sleep(STANDARD_BACKOFF_MILLIS);
+                    Thread.sleep(BACKOFF_ON_EXCEPTION.toMillis());
                 } catch (final InterruptedException ex) {
                     LOG.info("The PitWorker was interrupted before backing off and retrying, stopping processing");
                     return;

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorker.java
@@ -36,7 +36,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.BACKOFF_ON_EXCEPTION;
-import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.calculateLinearBackoffAndJitter;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.calculateExponentialBackoffAndJitter;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.completeIndexPartition;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.createAcknowledgmentSet;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.MetadataKeyAttributes.DOCUMENT_ID_METADATA_ATTRIBUTE_NAME;
@@ -87,7 +87,7 @@ public class ScrollWorker implements SearchWorker {
 
                 if (indexPartition.isEmpty()) {
                     try {
-                        Thread.sleep(calculateLinearBackoffAndJitter(++noAvailableIndicesCount));
+                        Thread.sleep(calculateExponentialBackoffAndJitter(++noAvailableIndicesCount));
                         continue;
                     } catch (final InterruptedException e) {
                         LOG.info("The ScrollWorker was interrupted while sleeping after acquiring no indices to process, stopping processing");

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeoutException;
 
 import static com.google.common.math.LongMath.pow;
 import static com.google.common.primitives.Longs.min;
+import static java.lang.Math.max;
 
 public class WorkerCommonUtils {
     private static final Random RANDOM = new Random();
@@ -29,7 +30,7 @@ public class WorkerCommonUtils {
     static final Duration BACKOFF_ON_EXCEPTION = Duration.ofSeconds(60);
 
     static final int ACKNOWLEDGEMENT_SET_TIMEOUT_SECONDS = Integer.MAX_VALUE;
-    static final Duration STARTING_BACKOFF = Duration.ofMillis(2500);
+    static final Duration STARTING_BACKOFF = Duration.ofMillis(500);
     static final Duration MAX_BACKOFF = Duration.ofSeconds(60);
     static final int BACKOFF_RATE = 2;
     static final Duration MAX_JITTER = Duration.ofSeconds(2);
@@ -73,8 +74,8 @@ public class WorkerCommonUtils {
         }
     }
 
-    static long calculateLinearBackoffAndJitter(final int retryCount) {
+    static long calculateExponentialBackoffAndJitter(final int retryCount) {
         final long jitterMillis = MIN_JITTER.toMillis() + RANDOM.nextInt((int) (MAX_JITTER.toMillis() - MIN_JITTER.toMillis() + 1));
-        return min(STARTING_BACKOFF.toMillis() * pow(BACKOFF_RATE, retryCount - 1) + jitterMillis, MAX_BACKOFF.toMillis());
+        return max(1, min(STARTING_BACKOFF.toMillis() * pow(BACKOFF_RATE, retryCount - 1) + jitterMillis, MAX_BACKOFF.toMillis()));
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtilsTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtilsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.MAX_BACKOFF;
+
+public class WorkerCommonUtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("retryCountToExpectedBackoffRange")
+    void calculateLinearBackoffAndJitter_returns_expected_backoff_range_for_retryCount(
+            final int retryCount, final long minExpectedBackoff, final long maxExpectedBackoff) {
+
+        final long backOffForRetryCount = WorkerCommonUtils.calculateLinearBackoffAndJitter(retryCount);
+
+        assertThat(backOffForRetryCount, Matchers.greaterThanOrEqualTo(minExpectedBackoff));
+        assertThat(backOffForRetryCount, Matchers.lessThanOrEqualTo(maxExpectedBackoff));
+    }
+
+    private static Stream<Arguments> retryCountToExpectedBackoffRange() {
+        return Stream.of(
+                Arguments.of(1, 500, 4_500),
+                Arguments.of(2, 2_500, 7_500),
+                Arguments.of(3, 8_000, 12_000),
+                Arguments.of(4, 18_000, 22_000),
+                Arguments.of(5, 38_000, 42_000),
+                Arguments.of(6, MAX_BACKOFF.toMillis(), MAX_BACKOFF.toMillis())
+        );
+    }
+
+}

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtilsTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtilsTest.java
@@ -22,7 +22,7 @@ public class WorkerCommonUtilsTest {
     void calculateLinearBackoffAndJitter_returns_expected_backoff_range_for_retryCount(
             final int retryCount, final long minExpectedBackoff, final long maxExpectedBackoff) {
 
-        final long backOffForRetryCount = WorkerCommonUtils.calculateLinearBackoffAndJitter(retryCount);
+        final long backOffForRetryCount = WorkerCommonUtils.calculateExponentialBackoffAndJitter(retryCount);
 
         assertThat(backOffForRetryCount, Matchers.greaterThanOrEqualTo(minExpectedBackoff));
         assertThat(backOffForRetryCount, Matchers.lessThanOrEqualTo(maxExpectedBackoff));
@@ -30,12 +30,12 @@ public class WorkerCommonUtilsTest {
 
     private static Stream<Arguments> retryCountToExpectedBackoffRange() {
         return Stream.of(
-                Arguments.of(1, 500, 4_500),
-                Arguments.of(2, 2_500, 7_500),
-                Arguments.of(3, 8_000, 12_000),
-                Arguments.of(4, 18_000, 22_000),
-                Arguments.of(5, 38_000, 42_000),
-                Arguments.of(6, MAX_BACKOFF.toMillis(), MAX_BACKOFF.toMillis())
+                Arguments.of(1, 1, 2_500),
+                Arguments.of(2, 1, 3_000),
+                Arguments.of(3, 1, 4_000),
+                Arguments.of(4, 2_000, 6_000),
+                Arguments.of(7, 30_000, 34_000),
+                Arguments.of(8, MAX_BACKOFF.toMillis(), MAX_BACKOFF.toMillis())
         );
     }
 


### PR DESCRIPTION
### Description
Adds exponential backoff and jitter for the opensearch source instead of waiting a standard 30 seconds when there are no indices to process, starting with 2.5 seconds and a max of 60 seconds.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
