### PR TITLE
Run the Gradle builds in parallel to reduce the overall build time

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout Data Prepper
       uses: actions/checkout@v2
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew --parallel build
     - name: Upload Unit Test Results
       if: always()
       uses: actions/upload-artifact@v3
@@ -35,7 +35,7 @@ jobs:
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1
     - name: Generate Javadocs
-      run: ./gradlew javadoc
+      run: ./gradlew --parallel javadoc
 
   publish-test-results:
     name: "Publish Unit Tests Results"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Get Version
       run:  grep '^version=' gradle.properties >> $GITHUB_ENV
     - name: Build Jar Files
-      run: ./gradlew build
+      run: ./gradlew --parallel build
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -42,7 +42,7 @@ jobs:
         aws-region: us-east-1
 
     - name: Build Archives
-      run: ./gradlew :release:archives:buildArchives -Prelease
+      run: ./gradlew --parallel :release:archives:buildArchives -Prelease
 
     - name: Build Maven Artifacts
       run: ./gradlew publish


### PR DESCRIPTION
### Description

Runs the Gradle builds in parallel. This reduces the overall build time by about 5-8 minutes.

Running this on my machine the build only takes 3-4 minutes. However, it seems the GHA runners may not have have much extra CPU available to make better use of parallel testing.
 
### Issues Resolved

Contributes some toward #925.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
