### PR TITLE
Gradle task to generate an aggregate test report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -271,6 +271,11 @@ configure(coreProjects) {
     check.dependsOn jacocoTestCoverageVerification
 }
 
+task generateAggregateTestReport(type: TestReport) {
+    destinationDirectory = file("${layout.buildDirectory}/reports/tests")
+    reportOn subprojects*.test
+}
+
 licenseReport {
     excludeOwnGroup = true
     excludeBoms = true


### PR DESCRIPTION
### Description

This adds a new Gradle task to generate an aggregate test report.

```
./gradlew generateAggregateTestReport
```

This is not used by any automation. But, developers can use it to aggregate results locally.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
