### PR TITLE
Rename os source rate/job_count to interval/count, acquire UNASSIGNED partitions before CLOSED partitions

### DIFF
--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStore.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStore.java
@@ -91,17 +91,17 @@ public class DynamoDbSourceCoordinationStore implements SourceCoordinationStore 
             return acquiredAssignedItem;
         }
 
-        final Optional<SourcePartitionStoreItem> acquiredClosedItem = dynamoDbClientWrapper.getAvailablePartition(
-                ownerId, ownershipTimeout, SourcePartitionStatus.CLOSED,
-                String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.CLOSED), 1);
+        final Optional<SourcePartitionStoreItem> acquiredUnassignedItem = dynamoDbClientWrapper.getAvailablePartition(
+                ownerId, ownershipTimeout, SourcePartitionStatus.UNASSIGNED,
+                String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.UNASSIGNED), 5);
 
-        if (acquiredClosedItem.isPresent()) {
-            return acquiredClosedItem;
+        if (acquiredUnassignedItem.isPresent()) {
+            return acquiredUnassignedItem;
         }
 
         return dynamoDbClientWrapper.getAvailablePartition(
-                ownerId, ownershipTimeout, SourcePartitionStatus.UNASSIGNED,
-                String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.UNASSIGNED), 5);
+                ownerId, ownershipTimeout, SourcePartitionStatus.CLOSED,
+                String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.CLOSED), 1);
     }
 
     @Override

--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbSourceCoordinationStoreTest.java
@@ -252,6 +252,11 @@ public class DynamoDbSourceCoordinationStoreTest {
                 1))
                 .willReturn(Optional.empty());
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
+                SourcePartitionStatus.UNASSIGNED,
+                String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.UNASSIGNED),
+                5))
+                .willReturn(Optional.empty());
+        given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
                 SourcePartitionStatus.CLOSED,
                 String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.CLOSED),
                 1))
@@ -276,11 +281,6 @@ public class DynamoDbSourceCoordinationStoreTest {
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
                 SourcePartitionStatus.ASSIGNED,
                 String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.ASSIGNED),
-                1))
-                .willReturn(Optional.empty());
-        given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,
-                SourcePartitionStatus.CLOSED,
-                String.format(SOURCE_STATUS_COMBINATION_KEY_FORMAT, sourceIdentifier, SourcePartitionStatus.CLOSED),
                 1))
                 .willReturn(Optional.empty());
         given(dynamoDbClientWrapper.getAvailablePartition(ownerId, ownershipTimeout,

--- a/data-prepper-plugins/in-memory-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/inmemory/InMemoryPartitionAccessor.java
+++ b/data-prepper-plugins/in-memory-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/inmemory/InMemoryPartitionAccessor.java
@@ -85,21 +85,21 @@ public class InMemoryPartitionAccessor {
     }
 
     public Optional<SourcePartitionStoreItem> getNextItem() {
-        final QueuedPartitionsItem nextClosedPartitionItem = closedPartitions.peek();
-
-        if (Objects.nonNull(nextClosedPartitionItem)) {
-            if (nextClosedPartitionItem.sortedTimestamp.isBefore(Instant.now()) && partitionLookup.containsKey(nextClosedPartitionItem.sourceIdentifier)) {
-                closedPartitions.remove();
-                return Optional.ofNullable(partitionLookup.get(nextClosedPartitionItem.sourceIdentifier).get(nextClosedPartitionItem.partitionKey));
-            }
-        }
-
         final QueuedPartitionsItem nextUnassignedPartitionItem = unassignedPartitions.peek();
 
         if (Objects.nonNull(nextUnassignedPartitionItem)) {
             if (partitionLookup.containsKey(nextUnassignedPartitionItem.sourceIdentifier)) {
                 unassignedPartitions.remove();
                 return Optional.ofNullable(partitionLookup.get(nextUnassignedPartitionItem.sourceIdentifier).get(nextUnassignedPartitionItem.partitionKey));
+            }
+        }
+
+        final QueuedPartitionsItem nextClosedPartitionItem = closedPartitions.peek();
+
+        if (Objects.nonNull(nextClosedPartitionItem)) {
+            if (nextClosedPartitionItem.sortedTimestamp.isBefore(Instant.now()) && partitionLookup.containsKey(nextClosedPartitionItem.sourceIdentifier)) {
+                closedPartitions.remove();
+                return Optional.ofNullable(partitionLookup.get(nextClosedPartitionItem.sourceIdentifier).get(nextClosedPartitionItem.partitionKey));
             }
         }
 

--- a/data-prepper-plugins/in-memory-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/inmemory/InMemoryPartitionAccessorTest.java
+++ b/data-prepper-plugins/in-memory-source-coordination-store/src/test/java/org/opensearch/dataprepper/plugins/sourcecoordinator/inmemory/InMemoryPartitionAccessorTest.java
@@ -171,11 +171,11 @@ public class InMemoryPartitionAccessorTest {
 
         final Optional<SourcePartitionStoreItem> acquiredItem = objectUnderTest.getNextItem();
         assertThat(acquiredItem.isPresent(), equalTo(true));
-        assertThat(acquiredItem.get(), equalTo(item));
+        assertThat(acquiredItem.get(), equalTo(thirdItem));
 
         final Optional<SourcePartitionStoreItem> secondAcquiredItem = objectUnderTest.getNextItem();
         assertThat(secondAcquiredItem.isPresent(), equalTo(true));
-        assertThat(secondAcquiredItem.get(), equalTo(thirdItem));
+        assertThat(secondAcquiredItem.get(), equalTo(item));
     }
 
     @Test

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SchedulingParameterConfiguration.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SchedulingParameterConfiguration.java
@@ -19,8 +19,8 @@ public class SchedulingParameterConfiguration {
     private Duration interval = Duration.ofHours(8);
 
     @Min(1)
-    @JsonProperty("count")
-    private int count = 1;
+    @JsonProperty("index_read_count")
+    private int indexReadCount = 1;
 
     @JsonProperty("start_time")
     private String startTime = Instant.now().toString();
@@ -32,8 +32,8 @@ public class SchedulingParameterConfiguration {
         return interval;
     }
 
-    public int getCount() {
-        return count;
+    public int getIndexReadCount() {
+        return indexReadCount;
     }
 
     public Instant getStartTime() {

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SchedulingParameterConfiguration.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SchedulingParameterConfiguration.java
@@ -15,12 +15,12 @@ import java.time.Instant;
 
 public class SchedulingParameterConfiguration {
 
-    @JsonProperty("rate")
-    private Duration rate = Duration.ofHours(8);
+    @JsonProperty("interval")
+    private Duration interval = Duration.ofHours(8);
 
     @Min(1)
-    @JsonProperty("job_count")
-    private int jobCount = 1;
+    @JsonProperty("count")
+    private int count = 1;
 
     @JsonProperty("start_time")
     private String startTime = Instant.now().toString();
@@ -28,12 +28,12 @@ public class SchedulingParameterConfiguration {
     @JsonIgnore
     private Instant startTimeInstant;
 
-    public Duration getRate() {
-        return rate;
+    public Duration getInterval() {
+        return interval;
     }
 
-    public int getJobCount() {
-        return jobCount;
+    public int getCount() {
+        return count;
     }
 
     public Instant getStartTime() {

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SearchConfiguration.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SearchConfiguration.java
@@ -5,16 +5,11 @@
 
 package org.opensearch.dataprepper.plugins.source.opensearch.configuration;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.validation.constraints.AssertTrue;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchContextType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Map;
 
 public class SearchConfiguration {
 
@@ -27,32 +22,11 @@ public class SearchConfiguration {
     @JsonProperty("batch_size")
     private Integer batchSize = 1000;
 
-    @JsonProperty("query")
-    private String queryString = "{ \"query\": { \"match_all\": {} }}";
-
-    @JsonIgnore
-    private Map<String, Object> queryMap;
-
     public SearchContextType getSearchContextType() {
         return searchContextType;
     }
 
     public Integer getBatchSize() {
         return batchSize;
-    }
-
-    public Map<String, Object> getQuery() {
-        return queryMap;
-    }
-
-    @AssertTrue(message = "query is not a valid json string")
-    boolean isQueryValid() {
-        try {
-            queryMap = objectMapper.readValue(queryString, new TypeReference<>() {});
-            return true;
-        } catch (final Exception e) {
-            LOG.error("Invalid query json string: ", e);
-            return false;
-        }
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
@@ -48,8 +48,8 @@ public class WorkerCommonUtils {
                 if (result == true) {
                     sourceCoordinator.closePartition(
                             indexPartition.getPartitionKey(),
-                            openSearchSourceConfiguration.getSchedulingParameterConfiguration().getRate(),
-                            openSearchSourceConfiguration.getSchedulingParameterConfiguration().getJobCount());
+                            openSearchSourceConfiguration.getSchedulingParameterConfiguration().getInterval(),
+                            openSearchSourceConfiguration.getSchedulingParameterConfiguration().getCount());
                 }
                 completableFuture.complete(result);
             }, Duration.ofSeconds(ACKNOWLEDGEMENT_SET_TIMEOUT_SECONDS));
@@ -69,8 +69,8 @@ public class WorkerCommonUtils {
         } else {
             sourceCoordinator.closePartition(
                     indexPartition.getPartitionKey(),
-                    openSearchSourceConfiguration.getSchedulingParameterConfiguration().getRate(),
-                    openSearchSourceConfiguration.getSchedulingParameterConfiguration().getJobCount());
+                    openSearchSourceConfiguration.getSchedulingParameterConfiguration().getInterval(),
+                    openSearchSourceConfiguration.getSchedulingParameterConfiguration().getCount());
         }
     }
 

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
@@ -49,7 +49,7 @@ public class WorkerCommonUtils {
                     sourceCoordinator.closePartition(
                             indexPartition.getPartitionKey(),
                             openSearchSourceConfiguration.getSchedulingParameterConfiguration().getInterval(),
-                            openSearchSourceConfiguration.getSchedulingParameterConfiguration().getCount());
+                            openSearchSourceConfiguration.getSchedulingParameterConfiguration().getIndexReadCount());
                 }
                 completableFuture.complete(result);
             }, Duration.ofSeconds(ACKNOWLEDGEMENT_SET_TIMEOUT_SECONDS));
@@ -70,7 +70,7 @@ public class WorkerCommonUtils {
             sourceCoordinator.closePartition(
                     indexPartition.getPartitionKey(),
                     openSearchSourceConfiguration.getSchedulingParameterConfiguration().getInterval(),
-                    openSearchSourceConfiguration.getSchedulingParameterConfiguration().getCount());
+                    openSearchSourceConfiguration.getSchedulingParameterConfiguration().getIndexReadCount());
         }
     }
 

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfigurationTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfigurationTest.java
@@ -35,10 +35,9 @@ public class OpenSearchSourceConfigurationTest {
                 "    - index_name_regex: \"regex\"\n" +
                 "    - index_name_regex: \"regex-two\"\n" +
                 "scheduling:\n" +
-                "  job_count: 3\n" +
+                "  count: 3\n" +
                 "search_options:\n" +
-                "  batch_size: 1000\n" +
-                "  query: \"test\"\n";
+                "  batch_size: 1000\n";
         final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
 
         assertThat(sourceConfiguration.getSearchConfiguration(), notNullValue());
@@ -67,10 +66,9 @@ public class OpenSearchSourceConfigurationTest {
                         "    - index_name_regex: \"regex\"\n" +
                         "    - index_name_regex: \"regex-two\"\n" +
                         "scheduling:\n" +
-                        "  job_count: 3\n" +
+                        "  count: 3\n" +
                         "search_options:\n" +
-                        "  batch_size: 1000\n" +
-                        "  query: \"test\"\n";
+                        "  batch_size: 1000\n";
         final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
 
         assertThat(sourceConfiguration.getSearchConfiguration(), notNullValue());
@@ -100,10 +98,9 @@ public class OpenSearchSourceConfigurationTest {
                 "  region: \"us-east-1\"\n" +
                 "  sts_role_arn: \"arn:aws:iam::123456789012:role/aos-role\"\n" +
                 "scheduling:\n" +
-                "  job_count: 3\n" +
+                "  count: 3\n" +
                 "search_options:\n" +
-                "  batch_size: 1000\n" +
-                "  query: \"test\"\n";
+                "  batch_size: 1000\n";
 
         final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
 
@@ -131,10 +128,9 @@ public class OpenSearchSourceConfigurationTest {
             "  sts_role_arn: \"arn:aws:iam::123456789012:role/aos-role\"\n" +
             "  sts_external_id: \"some-random-id\"\n" +
             "scheduling:\n" +
-            "  job_count: 3\n" +
+            "  count: 3\n" +
             "search_options:\n" +
-            "  batch_size: 1000\n" +
-            "  query: \"test\"\n";
+            "  batch_size: 1000\n";
 
         final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
 
@@ -166,10 +162,9 @@ public class OpenSearchSourceConfigurationTest {
                 "  region: \"us-east-1\"\n" +
                 "  sts_role_arn: \"arn:aws:iam::123456789012:role/aos-role\"\n" +
                 "scheduling:\n" +
-                "  job_count: 3\n" +
+                "  count: 3\n" +
                 "search_options:\n" +
-                "  batch_size: 1000\n" +
-                "  query: \"test\"\n";
+                "  batch_size: 1000\n";
 
         final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
 
@@ -188,10 +183,9 @@ public class OpenSearchSourceConfigurationTest {
                         "    - index_name_regex: \"regex\"\n" +
                         "    - index_name_regex: \"regex-two\"\n" +
                         "scheduling:\n" +
-                        "  job_count: 3\n" +
+                        "  count: 3\n" +
                         "search_options:\n" +
-                        "  batch_size: 1000\n" +
-                        "  query: \"test\"\n";
+                        "  batch_size: 1000\n";
 
         final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
 

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfigurationTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfigurationTest.java
@@ -35,7 +35,7 @@ public class OpenSearchSourceConfigurationTest {
                 "    - index_name_regex: \"regex\"\n" +
                 "    - index_name_regex: \"regex-two\"\n" +
                 "scheduling:\n" +
-                "  count: 3\n" +
+                "  index_read_count: 3\n" +
                 "search_options:\n" +
                 "  batch_size: 1000\n";
         final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
@@ -66,7 +66,7 @@ public class OpenSearchSourceConfigurationTest {
                         "    - index_name_regex: \"regex\"\n" +
                         "    - index_name_regex: \"regex-two\"\n" +
                         "scheduling:\n" +
-                        "  count: 3\n" +
+                        "  index_read_count: 3\n" +
                         "search_options:\n" +
                         "  batch_size: 1000\n";
         final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
@@ -98,7 +98,7 @@ public class OpenSearchSourceConfigurationTest {
                 "  region: \"us-east-1\"\n" +
                 "  sts_role_arn: \"arn:aws:iam::123456789012:role/aos-role\"\n" +
                 "scheduling:\n" +
-                "  count: 3\n" +
+                "  index_read_count: 3\n" +
                 "search_options:\n" +
                 "  batch_size: 1000\n";
 
@@ -128,7 +128,7 @@ public class OpenSearchSourceConfigurationTest {
             "  sts_role_arn: \"arn:aws:iam::123456789012:role/aos-role\"\n" +
             "  sts_external_id: \"some-random-id\"\n" +
             "scheduling:\n" +
-            "  count: 3\n" +
+            "  index_read_count: 3\n" +
             "search_options:\n" +
             "  batch_size: 1000\n";
 
@@ -162,7 +162,7 @@ public class OpenSearchSourceConfigurationTest {
                 "  region: \"us-east-1\"\n" +
                 "  sts_role_arn: \"arn:aws:iam::123456789012:role/aos-role\"\n" +
                 "scheduling:\n" +
-                "  count: 3\n" +
+                "  index_read_count: 3\n" +
                 "search_options:\n" +
                 "  batch_size: 1000\n";
 
@@ -183,7 +183,7 @@ public class OpenSearchSourceConfigurationTest {
                         "    - index_name_regex: \"regex\"\n" +
                         "    - index_name_regex: \"regex-two\"\n" +
                         "scheduling:\n" +
-                        "  count: 3\n" +
+                        "  index_read_count: 3\n" +
                         "search_options:\n" +
                         "  batch_size: 1000\n";
 

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SchedulingParameterConfigurationTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SchedulingParameterConfigurationTest.java
@@ -23,21 +23,21 @@ public class SchedulingParameterConfigurationTest {
     @Test
     void default_scheduling_configuration() {
         final SchedulingParameterConfiguration schedulingParameterConfiguration = new SchedulingParameterConfiguration();
-        assertThat(schedulingParameterConfiguration.getJobCount(), equalTo(1));
+        assertThat(schedulingParameterConfiguration.getCount(), equalTo(1));
         assertThat(schedulingParameterConfiguration.isStartTimeValid(), equalTo(true));
         assertThat(schedulingParameterConfiguration.getStartTime().isBefore(Instant.now()), equalTo(true));
-        assertThat(schedulingParameterConfiguration.getRate(), equalTo(Duration.ofHours(8)));
+        assertThat(schedulingParameterConfiguration.getInterval(), equalTo(Duration.ofHours(8)));
     }
 
     @Test
     void non_default_scheduling_configuration() throws JsonProcessingException {
         final String schedulingConfigurationYaml =
-                "  job_count: 3\n" +
+                "  count: 3\n" +
                 "  start_time: \"2007-12-03T10:15:30.00Z\"\n";
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = objectMapper.readValue(schedulingConfigurationYaml, SchedulingParameterConfiguration.class);
 
-        assertThat(schedulingParameterConfiguration.getJobCount(), equalTo(3));
+        assertThat(schedulingParameterConfiguration.getCount(), equalTo(3));
         assertThat(schedulingParameterConfiguration.isStartTimeValid(), equalTo(true));
         assertThat(schedulingParameterConfiguration.getStartTime(), equalTo(Instant.parse("2007-12-03T10:15:30.00Z")));
     }
@@ -45,12 +45,12 @@ public class SchedulingParameterConfigurationTest {
     @Test
     void invalid_start_time_configuration_test() throws JsonProcessingException {
         final String schedulingConfigurationYaml =
-                "  job_count: 3\n" +
+                "  count: 3\n" +
                         "  start_time: \"2007-12-03T10:15:30\"\n";
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = objectMapper.readValue(schedulingConfigurationYaml, SchedulingParameterConfiguration.class);
 
-        assertThat(schedulingParameterConfiguration.getJobCount(), equalTo(3));
+        assertThat(schedulingParameterConfiguration.getCount(), equalTo(3));
         assertThat(schedulingParameterConfiguration.isStartTimeValid(), equalTo(false));
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SchedulingParameterConfigurationTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SchedulingParameterConfigurationTest.java
@@ -23,7 +23,7 @@ public class SchedulingParameterConfigurationTest {
     @Test
     void default_scheduling_configuration() {
         final SchedulingParameterConfiguration schedulingParameterConfiguration = new SchedulingParameterConfiguration();
-        assertThat(schedulingParameterConfiguration.getCount(), equalTo(1));
+        assertThat(schedulingParameterConfiguration.getIndexReadCount(), equalTo(1));
         assertThat(schedulingParameterConfiguration.isStartTimeValid(), equalTo(true));
         assertThat(schedulingParameterConfiguration.getStartTime().isBefore(Instant.now()), equalTo(true));
         assertThat(schedulingParameterConfiguration.getInterval(), equalTo(Duration.ofHours(8)));
@@ -32,12 +32,12 @@ public class SchedulingParameterConfigurationTest {
     @Test
     void non_default_scheduling_configuration() throws JsonProcessingException {
         final String schedulingConfigurationYaml =
-                "  count: 3\n" +
+                "  index_read_count: 3\n" +
                 "  start_time: \"2007-12-03T10:15:30.00Z\"\n";
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = objectMapper.readValue(schedulingConfigurationYaml, SchedulingParameterConfiguration.class);
 
-        assertThat(schedulingParameterConfiguration.getCount(), equalTo(3));
+        assertThat(schedulingParameterConfiguration.getIndexReadCount(), equalTo(3));
         assertThat(schedulingParameterConfiguration.isStartTimeValid(), equalTo(true));
         assertThat(schedulingParameterConfiguration.getStartTime(), equalTo(Instant.parse("2007-12-03T10:15:30.00Z")));
     }
@@ -45,12 +45,12 @@ public class SchedulingParameterConfigurationTest {
     @Test
     void invalid_start_time_configuration_test() throws JsonProcessingException {
         final String schedulingConfigurationYaml =
-                "  count: 3\n" +
+                "  index_read_count: 3\n" +
                         "  start_time: \"2007-12-03T10:15:30\"\n";
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = objectMapper.readValue(schedulingConfigurationYaml, SchedulingParameterConfiguration.class);
 
-        assertThat(schedulingParameterConfiguration.getCount(), equalTo(3));
+        assertThat(schedulingParameterConfiguration.getIndexReadCount(), equalTo(3));
         assertThat(schedulingParameterConfiguration.isStartTimeValid(), equalTo(false));
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SearchConfigurationTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/SearchConfigurationTest.java
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SearchConfigurationTest {
@@ -25,7 +24,6 @@ public class SearchConfigurationTest {
     void default_search_configuration() {
         final SearchConfiguration searchConfiguration = new SearchConfiguration();
 
-        assertThat(searchConfiguration.getQuery(), equalTo(null));
         assertThat(searchConfiguration.getBatchSize(), equalTo(1000));
     }
 
@@ -33,13 +31,9 @@ public class SearchConfigurationTest {
     void non_default_search_configuration() {
         final Map<String, Object> pluginSettings = new HashMap<>();
         pluginSettings.put("batch_size", 2000);
-        pluginSettings.put("query", "{\"query\": {\"match_all\": {} }}");
 
         final SearchConfiguration searchConfiguration = objectMapper.convertValue(pluginSettings, SearchConfiguration.class);
         assertThat(searchConfiguration.getBatchSize(),equalTo(2000));
-        assertThat(searchConfiguration.isQueryValid(), equalTo(true));
-        assertThat(searchConfiguration.getQuery(), notNullValue());
-        assertThat(searchConfiguration.getQuery().containsKey("query"), equalTo(true));
     }
 
     @Test
@@ -47,10 +41,8 @@ public class SearchConfigurationTest {
 
         final Map<String, Object> pluginSettings = new HashMap<>();
         pluginSettings.put("batch_size", 1000);
-        pluginSettings.put("query", "\\{query: \"my_query\"}");
 
         final SearchConfiguration searchConfiguration = objectMapper.convertValue(pluginSettings, SearchConfiguration.class);
         assertThat(searchConfiguration.getBatchSize(),equalTo(1000));
-        assertThat(searchConfiguration.isQueryValid(), equalTo(false));
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorkerTest.java
@@ -188,7 +188,7 @@ public class NoSearchContextWorkerTest {
         when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getIndexReadCount()).thenReturn(1);
         when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
@@ -265,7 +265,7 @@ public class NoSearchContextWorkerTest {
         when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getIndexReadCount()).thenReturn(1);
         when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorkerTest.java
@@ -188,8 +188,8 @@ public class NoSearchContextWorkerTest {
         when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getJobCount()).thenReturn(1);
-        when(schedulingParameterConfiguration.getRate()).thenReturn(Duration.ZERO);
+        when(schedulingParameterConfiguration.getCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
         doNothing().when(sourceCoordinator).closePartition(partitionKey,
@@ -265,8 +265,8 @@ public class NoSearchContextWorkerTest {
         when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getJobCount()).thenReturn(1);
-        when(schedulingParameterConfiguration.getRate()).thenReturn(Duration.ZERO);
+        when(schedulingParameterConfiguration.getCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
         doNothing().when(sourceCoordinator).closePartition(partitionKey,

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
@@ -168,8 +168,8 @@ public class PitWorkerTest {
         when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getJobCount()).thenReturn(1);
-        when(schedulingParameterConfiguration.getRate()).thenReturn(Duration.ZERO);
+        when(schedulingParameterConfiguration.getCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
         doNothing().when(sourceCoordinator).closePartition(partitionKey,
@@ -268,8 +268,8 @@ public class PitWorkerTest {
         when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getJobCount()).thenReturn(1);
-        when(schedulingParameterConfiguration.getRate()).thenReturn(Duration.ZERO);
+        when(schedulingParameterConfiguration.getCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
         doNothing().when(sourceCoordinator).closePartition(partitionKey,
@@ -354,8 +354,8 @@ public class PitWorkerTest {
         when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getJobCount()).thenReturn(1);
-        when(schedulingParameterConfiguration.getRate()).thenReturn(Duration.ZERO);
+        when(schedulingParameterConfiguration.getCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
         doNothing().when(sourceCoordinator).closePartition(partitionKey,

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
@@ -168,7 +168,7 @@ public class PitWorkerTest {
         when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getIndexReadCount()).thenReturn(1);
         when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
@@ -268,7 +268,7 @@ public class PitWorkerTest {
         when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getIndexReadCount()).thenReturn(1);
         when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
@@ -354,7 +354,7 @@ public class PitWorkerTest {
         when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getIndexReadCount()).thenReturn(1);
         when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorkerTest.java
@@ -167,8 +167,8 @@ public class ScrollWorkerTest {
         when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getJobCount()).thenReturn(1);
-        when(schedulingParameterConfiguration.getRate()).thenReturn(Duration.ZERO);
+        when(schedulingParameterConfiguration.getCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
         doNothing().when(sourceCoordinator).closePartition(partitionKey,
@@ -262,8 +262,8 @@ public class ScrollWorkerTest {
         when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getJobCount()).thenReturn(1);
-        when(schedulingParameterConfiguration.getRate()).thenReturn(Duration.ZERO);
+        when(schedulingParameterConfiguration.getCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
         doNothing().when(sourceCoordinator).closePartition(partitionKey,

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorkerTest.java
@@ -167,7 +167,7 @@ public class ScrollWorkerTest {
         when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getIndexReadCount()).thenReturn(1);
         when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
@@ -262,7 +262,7 @@ public class ScrollWorkerTest {
         when(sourceCoordinator.getNextPartition(openSearchIndexPartitionCreationSupplier)).thenReturn(Optional.of(sourcePartition)).thenReturn(Optional.empty());
 
         final SchedulingParameterConfiguration schedulingParameterConfiguration = mock(SchedulingParameterConfiguration.class);
-        when(schedulingParameterConfiguration.getCount()).thenReturn(1);
+        when(schedulingParameterConfiguration.getIndexReadCount()).thenReturn(1);
         when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 


### PR DESCRIPTION
### Description

* rename opensearch source scheduling `rate` and `job_count` to `interval` and `count`
* Change the order that source coordination stores acquire partitions to check for UNASSIGNED partitions before checking CLOSED. This has the following benefits 
    1. Pipelines that do not use the CLOSED functionality (like s3 scan) will not waste a query to the store whenever a partition is acquired
    2. CLOSED partitions will not starve UNASSIGNED partitions when the `reOpenAt` time is small, and instead will guarantee that all UNASSIGNED partitions are processed before CLOSED partitions
* Remove `query` from the OpenSearch source configuration, as it is unused in the code
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
