### PR TITLE
BUG: Stop S3 source on InterruptedException

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ScanService.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/S3ScanService.java
@@ -36,6 +36,7 @@ public class S3ScanService {
     private final AcknowledgementSetManager acknowledgementSetManager;
     private final S3ObjectDeleteWorker s3ObjectDeleteWorker;
     private final PluginMetrics pluginMetrics;
+    private ScanObjectWorker scanObjectWorker;
 
     public S3ScanService(final S3SourceConfig s3SourceConfig,
                          final S3ClientBuilderFactory s3ClientBuilderFactory,
@@ -60,13 +61,14 @@ public class S3ScanService {
     }
 
     public void start() {
-        scanObjectWorkerThread = new Thread(new ScanObjectWorker(s3ClientBuilderFactory.getS3Client(),
-                getScanOptions(),s3ObjectHandler,bucketOwnerProvider, sourceCoordinator, s3SourceConfig, acknowledgementSetManager, s3ObjectDeleteWorker, pluginMetrics));
+        scanObjectWorker = new ScanObjectWorker(s3ClientBuilderFactory.getS3Client(),
+                getScanOptions(),s3ObjectHandler,bucketOwnerProvider, sourceCoordinator, s3SourceConfig, acknowledgementSetManager, s3ObjectDeleteWorker, pluginMetrics);
+        scanObjectWorkerThread = new Thread(scanObjectWorker);
         scanObjectWorkerThread.start();
     }
 
     public void stop() {
-        scanObjectWorkerThread.interrupt();
+        scanObjectWorker.stop();
     }
 
     /**

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/ScanObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/ScanObjectWorker.java
@@ -66,7 +66,7 @@ public class ScanObjectWorker implements Runnable{
     private final AcknowledgementSetManager acknowledgementSetManager;
 
     // Should there be a duration or time that is configured in the source to stop processing? Otherwise will only stop when data prepper is stopped
-    private boolean shouldStopProcessing = false;
+    private volatile boolean isStopped = false;
     private final boolean deleteS3ObjectsOnRead;
     private final S3ObjectDeleteWorker s3ObjectDeleteWorker;
     private final PluginMetrics pluginMetrics;
@@ -100,8 +100,7 @@ public class ScanObjectWorker implements Runnable{
 
     @Override
     public void run() {
-        while (!shouldStopProcessing) {
-
+        while (!isStopped) {
             try {
                 startProcessingObject(STANDARD_BACKOFF_MILLIS);
             } catch (final Exception e) {
@@ -110,7 +109,7 @@ public class ScanObjectWorker implements Runnable{
                     Thread.sleep(RETRY_BACKOFF_ON_EXCEPTION_MILLIS);
                 } catch (final InterruptedException ex) {
                     LOG.error("S3 Scan worker thread interrupted while backing off.", ex);
-                    shouldStopProcessing = true;
+                    return;
                 }
             }
 
@@ -131,7 +130,7 @@ public class ScanObjectWorker implements Runnable{
             try {
                 Thread.sleep(waitTimeMillis);
             } catch (InterruptedException e) {
-                shouldStopProcessing = true;
+                LOG.error("S3 Scan worker thread interrupted while backing off.", e);
             }
             return;
         }
@@ -177,7 +176,7 @@ public class ScanObjectWorker implements Runnable{
         } catch (final ExecutionException | TimeoutException e) {
             LOG.error("Exception occurred while waiting for acknowledgement.", e);
         } catch (final InterruptedException e) {
-            shouldStopProcessing = true;
+            LOG.error("S3 Scan worker thread interrupted while processing S3 object.", e);
         }
     }
 
@@ -195,5 +194,10 @@ public class ScanObjectWorker implements Runnable{
             LOG.error("Error while process the parseS3Object. ",ex);
         }
         return Optional.empty();
+    }
+
+    void stop() {
+        isStopped = true;
+        Thread.currentThread().interrupt();
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsService.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsService.java
@@ -30,6 +30,7 @@ public class SqsService {
     private final AcknowledgementSetManager acknowledgementSetManager;
 
     private Thread sqsWorkerThread;
+    private SqsWorker sqsWorker;
 
     public SqsService(final AcknowledgementSetManager acknowledgementSetManager,
                       final S3SourceConfig s3SourceConfig,
@@ -46,7 +47,8 @@ public class SqsService {
     public void start() {
         final Backoff backoff = Backoff.exponential(INITIAL_DELAY, MAXIMUM_DELAY).withJitter(JITTER_RATE)
                 .withMaxAttempts(Integer.MAX_VALUE);
-        sqsWorkerThread = new Thread(new SqsWorker(acknowledgementSetManager, sqsClient, s3Accessor, s3SourceConfig, pluginMetrics, backoff));
+        sqsWorker = new SqsWorker(acknowledgementSetManager, sqsClient, s3Accessor, s3SourceConfig, pluginMetrics, backoff);
+        sqsWorkerThread = new Thread(sqsWorker);
         sqsWorkerThread.start();
     }
 
@@ -62,6 +64,6 @@ public class SqsService {
     }
 
     public void stop() {
-        sqsWorkerThread.interrupt();
+        sqsWorker.stop();
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/SqsWorker.java
@@ -71,7 +71,7 @@ public class SqsWorker implements Runnable {
     private final AcknowledgementSetManager acknowledgementSetManager;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private boolean isStopped;
+    private volatile boolean isStopped = false;
 
     public SqsWorker(final AcknowledgementSetManager acknowledgementSetManager,
                      final SqsClient sqsClient,
@@ -115,7 +115,6 @@ public class SqsWorker implements Runnable {
                     Thread.sleep(s3SourceConfig.getSqsOptions().getPollDelay().toMillis());
                 } catch (final InterruptedException e) {
                     LOG.error("Thread is interrupted while polling SQS.", e);
-                    isStopped = true;
                 }
             }
         }
@@ -166,7 +165,6 @@ public class SqsWorker implements Runnable {
             Thread.sleep(delayMillis);
         } catch (final InterruptedException e){
             LOG.error("Thread is interrupted while polling SQS with retry.", e);
-            isStopped = true;
         }
     }
 
@@ -338,4 +336,8 @@ public class SqsWorker implements Runnable {
                 .build();
     }
 
+    void stop() {
+        isStopped = true;
+        Thread.currentThread().interrupt();
+    }
 }


### PR DESCRIPTION
### Description
This changes fixes the issue where S3 source with SQS never stops polling when pipeline shutdown is called. This is because of `InterruptedException` which resets the interrupt status.
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
