### PR TITLE
Moves cmanning09 to the emeritus section.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,7 +11,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Taylor Gray          | [graytaylor0](https://github.com/graytaylor0)         | Amazon      |
 | Dinu John            | [dinujoh](https://github.com/dinujoh)                 | Amazon      |
 | Krishna Kondaka      | [kkondaka](https://github.com/kkondaka)               | Amazon      |
-| Christopher Manning  | [cmanning09](https://github.com/cmanning09)           | Amazon      |
 | Asif Sohail Mohammed | [asifsmohammed](https://github.com/asifsmohammed)     | Amazon      |
 | David Venable        | [dlvenable](https://github.com/dlvenable)             | Amazon      |
 | Hai Yan              | [oeyh](https://github.com/oeyh)                       | Amazon      |
@@ -22,6 +21,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Maintainer           | GitHub ID                                             | Affiliation |
 | -------------------- | ----------------------------------------------------- | ----------- |
 | Steven Bayer         | [sbayer55](https://github.com/sbayer55)               | Amazon      |
+| Christopher Manning  | [cmanning09](https://github.com/cmanning09)           | Amazon      |
 | David Powers         | [dapowers87](https://github.com/dapowers87)           | Amazon      |
 | Shivani Shukla       | [sshivanii](https://github.com/sshivanii)             | Amazon      |
 | Phill Treddenick     | [treddeni-amazon](https://github.com/treddeni-amazon) | Amazon      |


### PR DESCRIPTION
### Description

Moves a previous maintainer to the emeritus section. - cmanning09.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
