### PR TITLE
Use async client to delete scroll and pit for OpenSearch as workaroun…

### DIFF
--- a/data-prepper-plugins/opensearch-source/build.gradle
+++ b/data-prepper-plugins/opensearch-source/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation project(':data-prepper-plugins:buffer-common')
     implementation project(':data-prepper-plugins:aws-plugin-api')
     implementation 'software.amazon.awssdk:apache-client'
+    implementation 'software.amazon.awssdk:netty-nio-client'
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
@@ -63,11 +63,15 @@ public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory 
     static final String SCROLL_RESOURCE_LIMIT_EXCEPTION_MESSAGE = "Trying to create too many scroll contexts";
 
     private final OpenSearchClient openSearchClient;
+    private final OpenSearchClient openSearchAsyncClient;
     private final SearchContextType searchContextType;
 
-    public OpenSearchAccessor(final OpenSearchClient openSearchClient, final SearchContextType searchContextType) {
+    public OpenSearchAccessor(final OpenSearchClient openSearchClient,
+                              final OpenSearchClient asyncOpenSearchClient,
+                              final SearchContextType searchContextType) {
         this.openSearchClient = openSearchClient;
         this.searchContextType = searchContextType;
+        this.openSearchAsyncClient = asyncOpenSearchClient;
     }
 
     @Override
@@ -126,7 +130,7 @@ public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory 
     @Override
     public void deletePit(final DeletePointInTimeRequest deletePointInTimeRequest) {
         try {
-            final DeletePitResponse deletePitResponse = openSearchClient.deletePit(DeletePitRequest.of(builder -> builder.pitId(Collections.singletonList(deletePointInTimeRequest.getPitId()))));
+            final DeletePitResponse deletePitResponse = openSearchAsyncClient.deletePit(DeletePitRequest.of(builder -> builder.pitId(Collections.singletonList(deletePointInTimeRequest.getPitId()))));
             if (isPitDeletedSuccessfully(deletePitResponse)) {
                 LOG.debug("Successfully deleted point in time id {}", deletePointInTimeRequest.getPitId());
             } else {
@@ -193,7 +197,7 @@ public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory 
     @Override
     public void deleteScroll(final DeleteScrollRequest deleteScrollRequest) {
         try {
-            final ClearScrollResponse clearScrollResponse = openSearchClient.clearScroll(ClearScrollRequest.of(request -> request.scrollId(deleteScrollRequest.getScrollId())));
+            final ClearScrollResponse clearScrollResponse = openSearchAsyncClient.clearScroll(ClearScrollRequest.of(request -> request.scrollId(deleteScrollRequest.getScrollId())));
             if (clearScrollResponse.succeeded()) {
                 LOG.debug("Successfully deleted scroll context with id {}", deleteScrollRequest.getScrollId());
             } else {

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessor.java
@@ -63,15 +63,12 @@ public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory 
     static final String SCROLL_RESOURCE_LIMIT_EXCEPTION_MESSAGE = "Trying to create too many scroll contexts";
 
     private final OpenSearchClient openSearchClient;
-    private final OpenSearchClient openSearchAsyncClient;
     private final SearchContextType searchContextType;
 
     public OpenSearchAccessor(final OpenSearchClient openSearchClient,
-                              final OpenSearchClient asyncOpenSearchClient,
                               final SearchContextType searchContextType) {
         this.openSearchClient = openSearchClient;
         this.searchContextType = searchContextType;
-        this.openSearchAsyncClient = asyncOpenSearchClient;
     }
 
     @Override
@@ -130,7 +127,7 @@ public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory 
     @Override
     public void deletePit(final DeletePointInTimeRequest deletePointInTimeRequest) {
         try {
-            final DeletePitResponse deletePitResponse = openSearchAsyncClient.deletePit(DeletePitRequest.of(builder -> builder.pitId(Collections.singletonList(deletePointInTimeRequest.getPitId()))));
+            final DeletePitResponse deletePitResponse = openSearchClient.deletePit(DeletePitRequest.of(builder -> builder.pitId(Collections.singletonList(deletePointInTimeRequest.getPitId()))));
             if (isPitDeletedSuccessfully(deletePitResponse)) {
                 LOG.debug("Successfully deleted point in time id {}", deletePointInTimeRequest.getPitId());
             } else {
@@ -197,7 +194,7 @@ public class OpenSearchAccessor implements SearchAccessor, ClusterClientFactory 
     @Override
     public void deleteScroll(final DeleteScrollRequest deleteScrollRequest) {
         try {
-            final ClearScrollResponse clearScrollResponse = openSearchAsyncClient.clearScroll(ClearScrollRequest.of(request -> request.scrollId(deleteScrollRequest.getScrollId())));
+            final ClearScrollResponse clearScrollResponse = openSearchClient.clearScroll(ClearScrollRequest.of(request -> request.scrollId(deleteScrollRequest.getScrollId())));
             if (clearScrollResponse.succeeded()) {
                 LOG.debug("Successfully deleted scroll context with id {}", deleteScrollRequest.getScrollId());
             } else {

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessorStrategy.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessorStrategy.java
@@ -101,7 +101,9 @@ public class SearchAccessorStrategy {
         }
 
         if (Objects.isNull(elasticsearchClient)) {
-            return new OpenSearchAccessor(openSearchClient, searchContextType);
+            return new OpenSearchAccessor(openSearchClient,
+                    openSearchClientFactory.provideOpenSearchAsyncClient(openSearchSourceConfiguration),
+                    searchContextType);
         }
 
         return new ElasticsearchAccessor(elasticsearchClient, searchContextType);
@@ -110,14 +112,18 @@ public class SearchAccessorStrategy {
     private SearchAccessor createSearchAccessorForServerlessCollection(final OpenSearchClient openSearchClient) {
         if (Objects.isNull(openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType())) {
             LOG.info("Configured with AOS serverless flag as true, defaulting to search_context_type as 'none', which uses search_after");
-            return new OpenSearchAccessor(openSearchClient, SearchContextType.NONE);
+            return new OpenSearchAccessor(openSearchClient,
+                    openSearchClientFactory.provideOpenSearchAsyncClient(openSearchSourceConfiguration),
+                    SearchContextType.NONE);
         } else {
             if (SearchContextType.POINT_IN_TIME.equals(openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType())) {
                 throw new InvalidPluginConfigurationException("A search_context_type of point_in_time is not supported for serverless collections");
             }
 
             LOG.info("Using search_context_type set in the config: '{}'", openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType().toString().toLowerCase());
-            return new OpenSearchAccessor(openSearchClient, openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType());
+            return new OpenSearchAccessor(openSearchClient,
+                    openSearchClientFactory.provideOpenSearchAsyncClient(openSearchSourceConfiguration),
+                    openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType());
         }
     }
 

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessorStrategy.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessorStrategy.java
@@ -95,14 +95,13 @@ public class SearchAccessorStrategy {
             searchContextType = SearchContextType.POINT_IN_TIME;
         } else {
             LOG.info("{} distribution, version {} detected. Scroll contexts will be used to search documents. " +
-                    "Upgrade your cluster to at least version {} to use Point in Time APIs instead of scroll.", distribution, versionNumber,
-                    distribution.equals(ELASTICSEARCH_DISTRIBUTION) ? ELASTICSEARCH_POINT_IN_TIME_SUPPORT_VERSION_CUTOFF : OPENSEARCH_POINT_IN_TIME_SUPPORT_VERSION_CUTOFF);
+                    "Upgrade your cluster to at least OpenSearch {} to use Point in Time APIs instead of scroll.", distribution, versionNumber,
+                    OPENSEARCH_POINT_IN_TIME_SUPPORT_VERSION_CUTOFF);
             searchContextType = SearchContextType.SCROLL;
         }
 
         if (Objects.isNull(elasticsearchClient)) {
             return new OpenSearchAccessor(openSearchClient,
-                    openSearchClientFactory.provideOpenSearchAsyncClient(openSearchSourceConfiguration),
                     searchContextType);
         }
 
@@ -113,16 +112,15 @@ public class SearchAccessorStrategy {
         if (Objects.isNull(openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType())) {
             LOG.info("Configured with AOS serverless flag as true, defaulting to search_context_type as 'none', which uses search_after");
             return new OpenSearchAccessor(openSearchClient,
-                    openSearchClientFactory.provideOpenSearchAsyncClient(openSearchSourceConfiguration),
                     SearchContextType.NONE);
         } else {
-            if (SearchContextType.POINT_IN_TIME.equals(openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType())) {
-                throw new InvalidPluginConfigurationException("A search_context_type of point_in_time is not supported for serverless collections");
+            if (SearchContextType.POINT_IN_TIME.equals(openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType()) ||
+                SearchContextType.SCROLL.equals(openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType())) {
+                throw new InvalidPluginConfigurationException("A search_context_type of point_in_time or scroll is not supported for serverless collections");
             }
 
             LOG.info("Using search_context_type set in the config: '{}'", openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType().toString().toLowerCase());
             return new OpenSearchAccessor(openSearchClient,
-                    openSearchClientFactory.provideOpenSearchAsyncClient(openSearchSourceConfiguration),
                     openSearchSourceConfiguration.getSearchConfiguration().getSearchContextType());
         }
     }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
@@ -70,11 +70,8 @@ public class OpenSearchAccessorTest {
     @Mock
     private OpenSearchClient openSearchClient;
 
-    @Mock
-    private OpenSearchClient asyncOpenSearchClient;
-
     private SearchAccessor createObjectUnderTest() {
-        return new OpenSearchAccessor(openSearchClient, asyncOpenSearchClient, SearchContextType.POINT_IN_TIME);
+        return new OpenSearchAccessor(openSearchClient, SearchContextType.POINT_IN_TIME);
     }
 
     @Test
@@ -352,7 +349,7 @@ public class OpenSearchAccessorTest {
         when(deletePitRecord.successful()).thenReturn(successful);
         when(deletePitResponse.pits()).thenReturn(Collections.singletonList(deletePitRecord));
 
-        when(asyncOpenSearchClient.deletePit(any(DeletePitRequest.class))).thenReturn(deletePitResponse);
+        when(openSearchClient.deletePit(any(DeletePitRequest.class))).thenReturn(deletePitResponse);
 
         createObjectUnderTest().deletePit(deletePointInTimeRequest);
     }
@@ -369,7 +366,7 @@ public class OpenSearchAccessorTest {
         when(clearScrollResponse.succeeded()).thenReturn(successful);
 
 
-        when(asyncOpenSearchClient.clearScroll(any(ClearScrollRequest.class))).thenReturn(clearScrollResponse);
+        when(openSearchClient.clearScroll(any(ClearScrollRequest.class))).thenReturn(clearScrollResponse);
 
         createObjectUnderTest().deleteScroll(deleteScrollRequest);
     }
@@ -381,7 +378,7 @@ public class OpenSearchAccessorTest {
         final DeletePointInTimeRequest deletePointInTimeRequest = mock(DeletePointInTimeRequest.class);
         when(deletePointInTimeRequest.getPitId()).thenReturn(pitId);
 
-        when(asyncOpenSearchClient.deletePit(any(DeletePitRequest.class))).thenThrow(OpenSearchException.class);
+        when(openSearchClient.deletePit(any(DeletePitRequest.class))).thenThrow(OpenSearchException.class);
 
         createObjectUnderTest().deletePit(deletePointInTimeRequest);
     }
@@ -394,7 +391,7 @@ public class OpenSearchAccessorTest {
         when(deleteScrollRequest.getScrollId()).thenReturn(scrollId);
 
 
-        when(asyncOpenSearchClient.clearScroll(any(ClearScrollRequest.class))).thenThrow(OpenSearchException.class);
+        when(openSearchClient.clearScroll(any(ClearScrollRequest.class))).thenThrow(OpenSearchException.class);
 
         createObjectUnderTest().deleteScroll(deleteScrollRequest);
     }
@@ -406,7 +403,7 @@ public class OpenSearchAccessorTest {
         final DeletePointInTimeRequest deletePointInTimeRequest = mock(DeletePointInTimeRequest.class);
         when(deletePointInTimeRequest.getPitId()).thenReturn(pitId);
 
-        when(asyncOpenSearchClient.deletePit(any(DeletePitRequest.class))).thenThrow(IOException.class);
+        when(openSearchClient.deletePit(any(DeletePitRequest.class))).thenThrow(IOException.class);
 
         createObjectUnderTest().deletePit(deletePointInTimeRequest);
     }
@@ -419,7 +416,7 @@ public class OpenSearchAccessorTest {
         when(deleteScrollRequest.getScrollId()).thenReturn(scrollId);
 
 
-        when(asyncOpenSearchClient.clearScroll(any(ClearScrollRequest.class))).thenThrow(IOException.class);
+        when(openSearchClient.clearScroll(any(ClearScrollRequest.class))).thenThrow(IOException.class);
 
         createObjectUnderTest().deleteScroll(deleteScrollRequest);
     }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchAccessorTest.java
@@ -70,8 +70,11 @@ public class OpenSearchAccessorTest {
     @Mock
     private OpenSearchClient openSearchClient;
 
+    @Mock
+    private OpenSearchClient asyncOpenSearchClient;
+
     private SearchAccessor createObjectUnderTest() {
-        return new OpenSearchAccessor(openSearchClient, SearchContextType.POINT_IN_TIME);
+        return new OpenSearchAccessor(openSearchClient, asyncOpenSearchClient, SearchContextType.POINT_IN_TIME);
     }
 
     @Test
@@ -349,7 +352,7 @@ public class OpenSearchAccessorTest {
         when(deletePitRecord.successful()).thenReturn(successful);
         when(deletePitResponse.pits()).thenReturn(Collections.singletonList(deletePitRecord));
 
-        when(openSearchClient.deletePit(any(DeletePitRequest.class))).thenReturn(deletePitResponse);
+        when(asyncOpenSearchClient.deletePit(any(DeletePitRequest.class))).thenReturn(deletePitResponse);
 
         createObjectUnderTest().deletePit(deletePointInTimeRequest);
     }
@@ -366,7 +369,7 @@ public class OpenSearchAccessorTest {
         when(clearScrollResponse.succeeded()).thenReturn(successful);
 
 
-        when(openSearchClient.clearScroll(any(ClearScrollRequest.class))).thenReturn(clearScrollResponse);
+        when(asyncOpenSearchClient.clearScroll(any(ClearScrollRequest.class))).thenReturn(clearScrollResponse);
 
         createObjectUnderTest().deleteScroll(deleteScrollRequest);
     }
@@ -378,7 +381,7 @@ public class OpenSearchAccessorTest {
         final DeletePointInTimeRequest deletePointInTimeRequest = mock(DeletePointInTimeRequest.class);
         when(deletePointInTimeRequest.getPitId()).thenReturn(pitId);
 
-        when(openSearchClient.deletePit(any(DeletePitRequest.class))).thenThrow(OpenSearchException.class);
+        when(asyncOpenSearchClient.deletePit(any(DeletePitRequest.class))).thenThrow(OpenSearchException.class);
 
         createObjectUnderTest().deletePit(deletePointInTimeRequest);
     }
@@ -391,7 +394,7 @@ public class OpenSearchAccessorTest {
         when(deleteScrollRequest.getScrollId()).thenReturn(scrollId);
 
 
-        when(openSearchClient.clearScroll(any(ClearScrollRequest.class))).thenThrow(OpenSearchException.class);
+        when(asyncOpenSearchClient.clearScroll(any(ClearScrollRequest.class))).thenThrow(OpenSearchException.class);
 
         createObjectUnderTest().deleteScroll(deleteScrollRequest);
     }
@@ -403,7 +406,7 @@ public class OpenSearchAccessorTest {
         final DeletePointInTimeRequest deletePointInTimeRequest = mock(DeletePointInTimeRequest.class);
         when(deletePointInTimeRequest.getPitId()).thenReturn(pitId);
 
-        when(openSearchClient.deletePit(any(DeletePitRequest.class))).thenThrow(IOException.class);
+        when(asyncOpenSearchClient.deletePit(any(DeletePitRequest.class))).thenThrow(IOException.class);
 
         createObjectUnderTest().deletePit(deletePointInTimeRequest);
     }
@@ -416,7 +419,7 @@ public class OpenSearchAccessorTest {
         when(deleteScrollRequest.getScrollId()).thenReturn(scrollId);
 
 
-        when(openSearchClient.clearScroll(any(ClearScrollRequest.class))).thenThrow(IOException.class);
+        when(asyncOpenSearchClient.clearScroll(any(ClearScrollRequest.class))).thenThrow(IOException.class);
 
         createObjectUnderTest().deleteScroll(deleteScrollRequest);
     }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchClientFactoryTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchClientFactoryTest.java
@@ -78,27 +78,6 @@ public class OpenSearchClientFactoryTest {
     }
 
     @Test
-    void provideAsyncOpenSearchClient_with_username_and_password() {
-        final String username = UUID.randomUUID().toString();
-        final String password = UUID.randomUUID().toString();
-        when(openSearchSourceConfiguration.getUsername()).thenReturn(username);
-        when(openSearchSourceConfiguration.getPassword()).thenReturn(password);
-
-        when(connectionConfiguration.getCertPath()).thenReturn(null);
-        when(connectionConfiguration.getSocketTimeout()).thenReturn(null);
-        when(connectionConfiguration.getConnectTimeout()).thenReturn(null);
-        when(connectionConfiguration.isInsecure()).thenReturn(true);
-
-        when(openSearchSourceConfiguration.getAwsAuthenticationOptions()).thenReturn(null);
-
-        final OpenSearchClient openSearchClient = createObjectUnderTest().provideOpenSearchAsyncClient(openSearchSourceConfiguration);
-        assertThat(openSearchClient, notNullValue());
-
-        verifyNoInteractions(awsCredentialsSupplier);
-
-    }
-
-    @Test
     void provideElasticSearchClient_with_username_and_password() {
         final String username = UUID.randomUUID().toString();
         final String password = UUID.randomUUID().toString();
@@ -146,7 +125,6 @@ public class OpenSearchClientFactoryTest {
     @Test
     void provideOpenSearchClient_with_aws_auth() {
         when(connectionConfiguration.getCertPath()).thenReturn(null);
-        when(connectionConfiguration.getSocketTimeout()).thenReturn(null);
         when(connectionConfiguration.getConnectTimeout()).thenReturn(null);
 
         final AwsAuthenticationConfiguration awsAuthenticationConfiguration = mock(AwsAuthenticationConfiguration.class);
@@ -162,33 +140,6 @@ public class OpenSearchClientFactoryTest {
         when(awsCredentialsSupplier.getProvider(awsCredentialsOptionsArgumentCaptor.capture())).thenReturn(awsCredentialsProvider);
 
         final OpenSearchClient openSearchClient = createObjectUnderTest().provideOpenSearchClient(openSearchSourceConfiguration);
-        assertThat(openSearchClient, notNullValue());
-
-        final AwsCredentialsOptions awsCredentialsOptions = awsCredentialsOptionsArgumentCaptor.getValue();
-        assertThat(awsCredentialsOptions, notNullValue());
-        assertThat(awsCredentialsOptions.getRegion(), equalTo(Region.US_EAST_1));
-        assertThat(awsCredentialsOptions.getStsHeaderOverrides(), equalTo(Collections.emptyMap()));
-        assertThat(awsCredentialsOptions.getStsRoleArn(), equalTo(stsRoleArn));
-    }
-
-    @Test
-    void provideAsyncOpenSearchClient_with_aws_auth() {
-        when(connectionConfiguration.getCertPath()).thenReturn(null);
-        when(connectionConfiguration.getConnectTimeout()).thenReturn(null);
-
-        final AwsAuthenticationConfiguration awsAuthenticationConfiguration = mock(AwsAuthenticationConfiguration.class);
-        when(awsAuthenticationConfiguration.getAwsRegion()).thenReturn(Region.US_EAST_1);
-        final String stsRoleArn = "arn:aws:iam::123456789012:role/my-role";
-        when(awsAuthenticationConfiguration.getAwsStsRoleArn()).thenReturn(stsRoleArn);
-        when(awsAuthenticationConfiguration.getAwsStsHeaderOverrides()).thenReturn(Collections.emptyMap());
-        when(awsAuthenticationConfiguration.isServerlessCollection()).thenReturn(false);
-        when(openSearchSourceConfiguration.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationConfiguration);
-
-        final ArgumentCaptor<AwsCredentialsOptions> awsCredentialsOptionsArgumentCaptor = ArgumentCaptor.forClass(AwsCredentialsOptions.class);
-        final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
-        when(awsCredentialsSupplier.getProvider(awsCredentialsOptionsArgumentCaptor.capture())).thenReturn(awsCredentialsProvider);
-
-        final OpenSearchClient openSearchClient = createObjectUnderTest().provideOpenSearchAsyncClient(openSearchSourceConfiguration);
         assertThat(openSearchClient, notNullValue());
 
         final AwsCredentialsOptions awsCredentialsOptions = awsCredentialsOptionsArgumentCaptor.getValue();
@@ -235,7 +186,6 @@ public class OpenSearchClientFactoryTest {
     @Test
     void provideOpenSearchClient_with_aws_auth_and_serverless_flag_true() {
         when(connectionConfiguration.getCertPath()).thenReturn(null);
-        when(connectionConfiguration.getSocketTimeout()).thenReturn(null);
         when(connectionConfiguration.getConnectTimeout()).thenReturn(null);
 
         final AwsAuthenticationConfiguration awsAuthenticationConfiguration = mock(AwsAuthenticationConfiguration.class);

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessStrategyTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessStrategyTest.java
@@ -64,8 +64,6 @@ public class SearchAccessStrategyTest {
         final OpenSearchClient openSearchClient = mock(OpenSearchClient.class);
         when(openSearchClient.info()).thenReturn(infoResponse);
         when(openSearchClientFactory.provideOpenSearchClient(openSearchSourceConfiguration)).thenReturn(openSearchClient);
-        when(openSearchClientFactory.provideOpenSearchAsyncClient(openSearchSourceConfiguration)).thenReturn(mock(OpenSearchClient.class));
-
         final SearchAccessor searchAccessor = createObjectUnderTest().getSearchAccessor();
         assertThat(searchAccessor, notNullValue());
         assertThat(searchAccessor.getSearchContextType(), equalTo(SearchContextType.POINT_IN_TIME));
@@ -144,7 +142,6 @@ public class SearchAccessStrategyTest {
         final OpenSearchClient openSearchClient = mock(OpenSearchClient.class);
         when(openSearchClient.info()).thenReturn(infoResponse);
         when(openSearchClientFactory.provideOpenSearchClient(openSearchSourceConfiguration)).thenReturn(openSearchClient);
-        when(openSearchClientFactory.provideOpenSearchAsyncClient(openSearchSourceConfiguration)).thenReturn(mock(OpenSearchClient.class));
 
         final SearchAccessor searchAccessor = createObjectUnderTest().getSearchAccessor();
         assertThat(searchAccessor, notNullValue());
@@ -185,7 +182,6 @@ public class SearchAccessStrategyTest {
         final OpenSearchClient openSearchClient = mock(OpenSearchClient.class);
         when(openSearchClient.info()).thenReturn(infoResponse);
         when(openSearchClientFactory.provideOpenSearchClient(openSearchSourceConfiguration)).thenReturn(openSearchClient);
-        when(openSearchClientFactory.provideOpenSearchAsyncClient(openSearchSourceConfiguration)).thenReturn(mock(OpenSearchClient.class));
 
         final SearchConfiguration searchConfiguration = mock(SearchConfiguration.class);
         when(searchConfiguration.getSearchContextType()).thenReturn(SearchContextType.NONE);
@@ -212,15 +208,16 @@ public class SearchAccessStrategyTest {
         assertThat(searchAccessor.getSearchContextType(), equalTo(SearchContextType.NONE));
     }
 
-    @Test
-    void serverless_flag_true_throws_InvalidPluginConfiguration_if_search_context_type_is_point_in_time() {
+    @ParameterizedTest
+    @ValueSource(strings = {"POINT_IN_TIME", "SCROLL"})
+    void serverless_flag_true_throws_InvalidPluginConfiguration_if_search_context_type_is_point_in_time_or_scroll(final String searchContextType) {
 
         final AwsAuthenticationConfiguration awsAuthenticationConfiguration = mock(AwsAuthenticationConfiguration.class);
         when(awsAuthenticationConfiguration.isServerlessCollection()).thenReturn(true);
         when(openSearchSourceConfiguration.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationConfiguration);
 
         final SearchConfiguration searchConfiguration = mock(SearchConfiguration.class);
-        when(searchConfiguration.getSearchContextType()).thenReturn(SearchContextType.POINT_IN_TIME);
+        when(searchConfiguration.getSearchContextType()).thenReturn(SearchContextType.valueOf(searchContextType));
         when(openSearchSourceConfiguration.getSearchConfiguration()).thenReturn(searchConfiguration);
 
         final SearchAccessorStrategy objectUnderTest = createObjectUnderTest();
@@ -229,7 +226,7 @@ public class SearchAccessStrategyTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"NONE", "SCROLL"})
+    @ValueSource(strings = {"NONE"})
     void serverless_flag_true_uses_search_context_type_from_config(final String searchContextType) {
 
         final AwsAuthenticationConfiguration awsAuthenticationConfiguration = mock(AwsAuthenticationConfiguration.class);

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessStrategyTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessStrategyTest.java
@@ -64,6 +64,7 @@ public class SearchAccessStrategyTest {
         final OpenSearchClient openSearchClient = mock(OpenSearchClient.class);
         when(openSearchClient.info()).thenReturn(infoResponse);
         when(openSearchClientFactory.provideOpenSearchClient(openSearchSourceConfiguration)).thenReturn(openSearchClient);
+        when(openSearchClientFactory.provideOpenSearchAsyncClient(openSearchSourceConfiguration)).thenReturn(mock(OpenSearchClient.class));
 
         final SearchAccessor searchAccessor = createObjectUnderTest().getSearchAccessor();
         assertThat(searchAccessor, notNullValue());
@@ -143,6 +144,7 @@ public class SearchAccessStrategyTest {
         final OpenSearchClient openSearchClient = mock(OpenSearchClient.class);
         when(openSearchClient.info()).thenReturn(infoResponse);
         when(openSearchClientFactory.provideOpenSearchClient(openSearchSourceConfiguration)).thenReturn(openSearchClient);
+        when(openSearchClientFactory.provideOpenSearchAsyncClient(openSearchSourceConfiguration)).thenReturn(mock(OpenSearchClient.class));
 
         final SearchAccessor searchAccessor = createObjectUnderTest().getSearchAccessor();
         assertThat(searchAccessor, notNullValue());
@@ -183,6 +185,7 @@ public class SearchAccessStrategyTest {
         final OpenSearchClient openSearchClient = mock(OpenSearchClient.class);
         when(openSearchClient.info()).thenReturn(infoResponse);
         when(openSearchClientFactory.provideOpenSearchClient(openSearchSourceConfiguration)).thenReturn(openSearchClient);
+        when(openSearchClientFactory.provideOpenSearchAsyncClient(openSearchSourceConfiguration)).thenReturn(mock(OpenSearchClient.class));
 
         final SearchConfiguration searchConfiguration = mock(SearchConfiguration.class);
         when(searchConfiguration.getSearchContextType()).thenReturn(SearchContextType.NONE);


### PR DESCRIPTION
…d for bug in client

### Description
The OpenSearch Java Client has an issue where delete requests with sigv4 are not signed correctly (https://github.com/opensearch-project/opensearch-java/issues/521). 

As a workaround, this change constructs an async OpenSearch client to make only the delete calls for scroll and pit
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
