### PR TITLE
Armeria 1.25.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,6 +171,23 @@ subprojects {
             }
         }
     }
+
+    configurations.all {
+        resolutionStrategy.eachDependency { def details ->
+            if (details.requested.group == 'io.netty') {
+                if (details.requested.name == 'netty') {
+                    details.useTarget group: 'io.netty', name: 'netty-all', version: '4.1.96.Final'
+                    // replace with your desired version
+                } else if (!details.requested.name.startsWith('netty-tcnative')) {
+                    details.useVersion '4.1.96.Final'
+                    details.because 'Fixes CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
+                }
+            } else if (details.requested.group == 'log4j' && details.requested.name == 'log4j') {
+                details.useTarget group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.17.1'
+            }
+        }
+    }
+
     test {
         useJUnitPlatform()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -163,28 +163,16 @@ subprojects {
                 }
                 because 'CVE from transitive dependencies'
             }
+            implementation('org.xerial.snappy:snappy-java') {
+                version {
+                    require '1.1.10.1'
+                }
+                because 'Fixes CVE-2023-35165, CVE-2023-34455, CVE-2023-34453, CVE-2023-34454, CVE-2023-2976'
+            }
         }
     }
     test {
         useJUnitPlatform()
-    }
-
-    configurations.all {
-        resolutionStrategy.eachDependency { def details ->
-            if (details.requested.group == 'io.netty') {
-                if (details.requested.name == 'netty') {
-                    details.useTarget group: 'io.netty', name: 'netty-all', version: '4.1.86.Final'
-                    // replace with your desired version
-                } else if (!details.requested.name.startsWith('netty-tcnative')) {
-                    details.useVersion '4.1.86.Final'
-                    details.because 'Fixes CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
-                }
-            } else if (details.requested.group == 'log4j' && details.requested.name == 'log4j') {
-                details.useTarget group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.17.1'
-            } else if (details.requested.group == 'org.xerial.snappy' && details.requested.name == 'snappy-java') {
-                details.useTarget group: 'org.xerial.snappy', name: 'snappy-java', version: '1.1.10.1'
-            }
-        }
     }
 
     build.dependsOn test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwarder_ClientServerIT.java
@@ -11,6 +11,7 @@ import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.Server;
+import io.netty.handler.ssl.NotSslRecordException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -326,7 +327,7 @@ class PeerForwarder_ClientServerIT {
                     () -> client.serializeRecordsAndSendHttpRequest(outgoingRecords, LOCALHOST, pluginId, pipelineName).get());
 
             assertThat(actualException.getCause(), instanceOf(UnprocessedRequestException.class));
-            assertThat(actualException.getCause().getCause(), instanceOf(SSLHandshakeException.class));
+            assertThat(actualException.getCause().getCause(), instanceOf(NotSslRecordException.class));
 
             final Collection<Record<Event>> receivedRecords = getServerSideRecords(peerForwarderProvider);
             assertThat(receivedRecords, notNullValue());

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ dependencyResolutionManagement {
         libs {
             version('slf4j', '2.0.6')
             library('slf4j-api', 'org.slf4j', 'slf4j-api').versionRef('slf4j')
-            version('armeria', '1.22.1')
+            version('armeria', '1.25.2')
             library('armeria-core', 'com.linecorp.armeria', 'armeria').versionRef('armeria')
             library('armeria-grpc', 'com.linecorp.armeria', 'armeria-grpc').versionRef('armeria')
             library('armeria-junit', 'com.linecorp.armeria', 'armeria-junit5').versionRef('armeria')


### PR DESCRIPTION
### Description

Updates Armeria to 1.25.2. This also removes Gradle resolution strategies which fix some dependencies to specific versions. Instead, use dependency version requirements which allow for using newer versions.
 
### Issues Resolved

Resolves #3069.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
