### PR TITLE
Support a local ARM Docker image by using Ubuntu Jammy for the base image

### DIFF
--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk-alpine
+FROM eclipse-temurin:17-jre-jammy
 ARG PIPELINE_FILEPATH
 ARG CONFIG_FILEPATH
 ARG ARCHIVE_FILE
@@ -9,8 +9,8 @@ ENV ENV_CONFIG_FILEPATH=$CONFIG_FILEPATH
 ENV ENV_PIPELINE_FILEPATH=$PIPELINE_FILEPATH
 
 # Update all packages
-RUN apk update
-RUN apk add --no-cache bash bc
+RUN apt -y update
+RUN apt -y install bash bc
 
 RUN mkdir -p /var/log/data-prepper
 ADD $ARCHIVE_FILE /usr/share


### PR DESCRIPTION
### Description

Support a local ARM Docker image by using Ubuntu Jammy for the base image. Also use only the JRE to keep the image size smaller. 
 
### Issues Resolved

Resolves #3352
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
