### PR TITLE
Fix KafkaSourceCustomConsumerTest to use await() instead of Thread.sleep()

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaSourceCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaSourceCustomConsumer.java
@@ -121,6 +121,10 @@ public class KafkaSourceCustomConsumer implements Runnable, ConsumerRebalanceLis
         this.errLogRateLimiter = new LogRateLimiter(2, System.currentTimeMillis());
     }
 
+    KafkaTopicMetrics getTopicMetrics() {
+        return topicMetrics;
+    }
+
     private long getCurrentTimeNanos() {
         Instant now = Instant.now();
         return now.getEpochSecond()*1000000000+now.getNano();


### PR DESCRIPTION
### Description

Fix KafkaSourceCustomConsumerTest to wait for shorter time and bail out as soon as possible instead of waiting for a fixed time.

This change replaces Thread.sleep(10000) with await() so that the overall wait time is less.
 
Resolves #3263 
### Issues Resolved
Resolves #3263 
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
