### PR TITLE
Exclude system indices by default, add include_system_indices configu…

### DIFF
--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfiguration.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfiguration.java
@@ -41,7 +41,7 @@ public class OpenSearchSourceConfiguration {
 
     @JsonProperty("indices")
     @Valid
-    private IndexParametersConfiguration indexParametersConfiguration;
+    private IndexParametersConfiguration indexParametersConfiguration = new IndexParametersConfiguration();
 
     @JsonProperty("aws")
     @Valid

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/IndexParametersConfiguration.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/IndexParametersConfiguration.java
@@ -13,6 +13,9 @@ import java.util.List;
 
 public class IndexParametersConfiguration {
 
+    @JsonProperty("include_system_indices")
+    private Boolean includeSystemIndices = false;
+
     @JsonProperty("include")
     @Valid
     private List<OpenSearchIndex> include = Collections.emptyList();
@@ -27,6 +30,10 @@ public class IndexParametersConfiguration {
 
     public List<OpenSearchIndex> getExcludedIndices() {
         return exclude;
+    }
+
+    public Boolean isIncludeSystemIndices() {
+        return includeSystemIndices;
     }
 
 }

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/OpenSearchIndexPartitionCreationSupplier.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/OpenSearchIndexPartitionCreationSupplier.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 
 public class OpenSearchIndexPartitionCreationSupplier implements Function<Map<String, Object>, List<PartitionIdentifier>> {
 
+    private static final String SYSTEM_INDEX_PREFIX = ".";
     private static final Logger LOG = LoggerFactory.getLogger(OpenSearchIndexPartitionCreationSupplier.class);
 
     private final OpenSearchSourceConfiguration openSearchSourceConfiguration;
@@ -107,8 +108,8 @@ public class OpenSearchIndexPartitionCreationSupplier implements Function<Map<St
             return false;
         }
 
-        if (Objects.isNull(indexParametersConfiguration)) {
-            return true;
+        if (!indexParametersConfiguration.isIncludeSystemIndices() && isSystemIndex(indexName)) {
+            return false;
         }
 
         final List<OpenSearchIndex> includedIndices = indexParametersConfiguration.getIncludedIndices();
@@ -130,5 +131,9 @@ public class OpenSearchIndexPartitionCreationSupplier implements Function<Map<St
             }
         }
         return false;
+    }
+
+    private boolean isSystemIndex(final String indexName) {
+        return indexName.startsWith(SYSTEM_INDEX_PREFIX);
     }
 }

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchIndexPartitionCreationSupplierTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchIndexPartitionCreationSupplierTest.java
@@ -137,11 +137,18 @@ public class OpenSearchIndexPartitionCreationSupplierTest {
 
         final IndexParametersConfiguration indexParametersConfiguration = mock(IndexParametersConfiguration.class);
 
+        when(indexParametersConfiguration.isIncludeSystemIndices()).thenReturn(true);
+
         final List<OpenSearchIndex> includedIndices = new ArrayList<>();
         final OpenSearchIndex includeIndex = mock(OpenSearchIndex.class);
         final String includePattern = "my-pattern-[a-c].*";
         when(includeIndex.getIndexNamePattern()).thenReturn(Pattern.compile(includePattern));
         includedIndices.add(includeIndex);
+
+        final OpenSearchIndex includeSystemIndex = mock(OpenSearchIndex.class);
+        final String includePatternSystemIndex = "\\..*";
+        when(includeSystemIndex.getIndexNamePattern()).thenReturn(Pattern.compile(includePatternSystemIndex));
+        includedIndices.add(includeSystemIndex);
 
         final List<OpenSearchIndex> excludedIndices = new ArrayList<>();
         final OpenSearchIndex excludeIndex = mock(OpenSearchIndex.class);
@@ -161,6 +168,8 @@ public class OpenSearchIndexPartitionCreationSupplierTest {
         final List<IndicesRecord> indicesRecords = new ArrayList<>();
         final IndicesRecord includedIndex = mock(IndicesRecord.class);
         when(includedIndex.index()).thenReturn("my-pattern-a-include");
+        final IndicesRecord includedSystemIndex = mock(IndicesRecord.class);
+        when(includedSystemIndex.index()).thenReturn(".system_index");
         final IndicesRecord excludedIndex = mock(IndicesRecord.class);
         when(excludedIndex.index()).thenReturn("second-exclude-test");
         final IndicesRecord includedAndThenExcluded = mock(IndicesRecord.class);
@@ -169,6 +178,7 @@ public class OpenSearchIndexPartitionCreationSupplierTest {
         when(neitherIncludedOrExcluded.index()).thenReturn("random-index");
 
         indicesRecords.add(includedIndex);
+        indicesRecords.add(includedSystemIndex);
         indicesRecords.add(excludedIndex);
         indicesRecords.add(includedAndThenExcluded);
         indicesRecords.add(neitherIncludedOrExcluded);
@@ -181,6 +191,7 @@ public class OpenSearchIndexPartitionCreationSupplierTest {
         final List<PartitionIdentifier> partitionIdentifierList = createObjectUnderTest().apply(Collections.emptyMap());
 
         assertThat(partitionIdentifierList, notNullValue());
+        assertThat(partitionIdentifierList.size(), equalTo(2));
     }
 
     @Test
@@ -191,6 +202,7 @@ public class OpenSearchIndexPartitionCreationSupplierTest {
         final co.elastic.clients.elasticsearch.cat.IndicesResponse indicesResponse = mock(co.elastic.clients.elasticsearch.cat.IndicesResponse.class);
 
         final IndexParametersConfiguration indexParametersConfiguration = mock(IndexParametersConfiguration.class);
+        when(indexParametersConfiguration.isIncludeSystemIndices()).thenReturn(false);
 
         final List<OpenSearchIndex> includedIndices = new ArrayList<>();
         final OpenSearchIndex includeIndex = mock(OpenSearchIndex.class);
@@ -218,6 +230,8 @@ public class OpenSearchIndexPartitionCreationSupplierTest {
         when(includedIndex.index()).thenReturn("my-pattern-a-include");
         final co.elastic.clients.elasticsearch.cat.indices.IndicesRecord excludedIndex = mock(co.elastic.clients.elasticsearch.cat.indices.IndicesRecord.class);
         when(excludedIndex.index()).thenReturn("second-exclude-test");
+        final co.elastic.clients.elasticsearch.cat.indices.IndicesRecord excludedSystemIndex = mock(co.elastic.clients.elasticsearch.cat.indices.IndicesRecord.class);
+        when(excludedSystemIndex.index()).thenReturn(".system_index");
         final co.elastic.clients.elasticsearch.cat.indices.IndicesRecord includedAndThenExcluded = mock(co.elastic.clients.elasticsearch.cat.indices.IndicesRecord.class);
         when(includedAndThenExcluded.index()).thenReturn("my-pattern-a-exclude");
         final co.elastic.clients.elasticsearch.cat.indices.IndicesRecord neitherIncludedOrExcluded = mock(co.elastic.clients.elasticsearch.cat.indices.IndicesRecord.class);
@@ -225,6 +239,7 @@ public class OpenSearchIndexPartitionCreationSupplierTest {
 
         indicesRecords.add(includedIndex);
         indicesRecords.add(excludedIndex);
+        indicesRecords.add(excludedSystemIndex);
         indicesRecords.add(includedAndThenExcluded);
         indicesRecords.add(neitherIncludedOrExcluded);
 
@@ -236,6 +251,7 @@ public class OpenSearchIndexPartitionCreationSupplierTest {
         final List<PartitionIdentifier> partitionIdentifierList = createObjectUnderTest().apply(Collections.emptyMap());
 
         assertThat(partitionIdentifierList, notNullValue());
+        assertThat(partitionIdentifierList.size(), equalTo(1));
     }
 
     private static Stream<Arguments> opensearchCatIndicesExceptions() {


### PR DESCRIPTION
…ration option for os source

### Description
Adds a new parameter to the opensearch source, `include_system_indices`, that defaults to false

```
indices:
  include_system_indices: true
```
 
### Issues Resolved
Resolves #3360 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
