### PR TITLE
Fix exemplar list in Histogram and Count aggregations

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
@@ -53,7 +53,6 @@ public class CountAggregateAction implements AggregateAction {
         this.countKey = countAggregateActionConfig.getCountKey();
         this.startTimeKey = countAggregateActionConfig.getStartTimeKey();
         this.outputFormat = countAggregateActionConfig.getOutputFormat();
-        this.exemplarList = new ArrayList<>();
     }
 
     private long getTimeNanos(Instant time) {
@@ -87,6 +86,7 @@ public class CountAggregateAction implements AggregateAction {
             groupState.put(startTimeKey, Instant.now());
             groupState.putAll(aggregateActionInput.getIdentificationKeys());
             groupState.put(countKey, 1);
+            exemplarList = new ArrayList<>();
             exemplarList.add(createExemplar(event));
         } else {
             Integer v = (Integer)groupState.get(countKey) + 1;

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
@@ -57,7 +57,6 @@ public class HistogramAggregateAction implements AggregateAction {
     private final String key;
     private final String units;
     private final boolean recordMinMax;
-    private List<Exemplar> exemplarList;
     private Event minEvent;
     private Event maxEvent;
     private double minValue;
@@ -71,7 +70,6 @@ public class HistogramAggregateAction implements AggregateAction {
         this.key = histogramAggregateActionConfig.getKey();
         List<Number> bucketList = histogramAggregateActionConfig.getBuckets();
         this.buckets = new double[bucketList.size()+2];
-        this.exemplarList = new ArrayList<>();
         int bucketIdx = 0;
         this.buckets[bucketIdx++] = -Float.MAX_VALUE;
         for (int i = 0; i < bucketList.size(); i++) {
@@ -197,6 +195,7 @@ public class HistogramAggregateAction implements AggregateAction {
         long startTimeNanos = getTimeNanos(startTime);
         long endTimeNanos = getTimeNanos(endTime);
         String histogramKey = HISTOGRAM_METRIC_NAME + "_key";
+        List<Exemplar> exemplarList = new ArrayList<>();
         exemplarList.add(createExemplar("min", minEvent, minValue));
         exemplarList.add(createExemplar("max", maxEvent, maxValue));
         if (outputFormat.equals(OutputFormat.RAW.toString())) {


### PR DESCRIPTION
### Description
ExemplarList generated for Count and Histogram aggregate actions is accumulating the exemplars across different aggregation periods. It should be reset every time new aggregation window starts. This fix resets and includes only new exemplar list whenever a new metric event is generated at the end of aggregation duration.

 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
