### PR TITLE
Fixes CVE-2023-42503 by updating commons-compress

### DIFF
--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation testLibs.junit.vintage
     testImplementation project(':data-prepper-test-common')
     testImplementation 'org.skyscreamer:jsonassert:1.5.1'
-    testImplementation 'commons-io:commons-io:2.13.0'
+    testImplementation libs.commons.io
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/common/build.gradle
+++ b/data-prepper-plugins/common/build.gradle
@@ -10,10 +10,10 @@ dependencies {
     api project(':data-prepper-api')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation "commons-io:commons-io:2.12.0"
+    implementation libs.commons.io
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:acm'
-    implementation 'org.apache.commons:commons-compress:1.23.0'
+    implementation libs.commons.compress
     implementation libs.commons.lang3
     implementation libs.bouncycastle.bcprov
     implementation libs.bouncycastle.bcpkix
@@ -23,7 +23,7 @@ dependencies {
     implementation 'org.apache.parquet:parquet-common:1.13.1'
     implementation 'org.xerial.snappy:snappy-java:1.1.10.3'
     testImplementation project(':data-prepper-plugins:blocking-buffer')
-    testImplementation 'commons-io:commons-io:2.12.0'
+    testImplementation libs.commons.io
     testImplementation testLibs.mockito.inline
 }
 

--- a/data-prepper-plugins/geoip-processor/build.gradle
+++ b/data-prepper-plugins/geoip-processor/build.gradle
@@ -9,10 +9,9 @@ dependencies {
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation 'org.apache.commons:commons-compress:1.21'
-
+    implementation libs.commons.compress
     implementation 'org.mapdb:mapdb:3.0.8'
-    implementation 'commons-io:commons-io:2.12.0'
+    implementation libs.commons.io
     implementation 'software.amazon.awssdk:aws-sdk-java:2.20.67'
     implementation 'software.amazon.awssdk:s3-transfer-manager'
     implementation 'software.amazon.awssdk.crt:aws-crt:0.21.17'

--- a/data-prepper-plugins/http-sink/build.gradle
+++ b/data-prepper-plugins/http-sink/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation 'org.apache.commons:commons-compress:1.21'
+    implementation libs.commons.compress
     implementation 'joda-time:joda-time:2.11.1'
     implementation project(':data-prepper-plugins:common')
     implementation project(path: ':data-prepper-plugins:common')

--- a/data-prepper-plugins/http-source/build.gradle
+++ b/data-prepper-plugins/http-source/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(':data-prepper-plugins:common')
     implementation project(':data-prepper-plugins:armeria-common')
     implementation libs.armeria.core
-    implementation 'commons-io:commons-io:2.12.0'
+    implementation libs.commons.io
     implementation 'software.amazon.awssdk:acm'
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:apache-client'

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation libs.commons.lang3
     implementation 'software.amazon.awssdk:apache-client'
     testImplementation testLibs.junit.vintage
-    testImplementation 'commons-io:commons-io:2.12.0'
+    testImplementation libs.commons.io
     testImplementation 'net.bytebuddy:byte-buddy:1.14.7'
     testImplementation 'net.bytebuddy:byte-buddy-agent:1.14.7'
     testImplementation testLibs.slf4j.simple

--- a/data-prepper-plugins/otel-logs-source/build.gradle
+++ b/data-prepper-plugins/otel-logs-source/build.gradle
@@ -12,11 +12,11 @@ dependencies {
     implementation project(':data-prepper-plugins:common')
     implementation project(':data-prepper-plugins:blocking-buffer')
     implementation project(':data-prepper-plugins:otel-proto-common')
-    implementation 'commons-codec:commons-codec:1.15'
+    implementation libs.commons.codec
     implementation project(':data-prepper-plugins:armeria-common')
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation libs.opentelemetry.proto
-    implementation "commons-io:commons-io:2.11.0"
+    implementation libs.commons.io
     implementation 'software.amazon.awssdk:acm'
     implementation 'software.amazon.awssdk:auth'
     implementation 'software.amazon.awssdk:regions'
@@ -31,7 +31,7 @@ dependencies {
     implementation libs.bouncycastle.bcpkix
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation testLibs.mockito.inline
-    testImplementation("commons-io:commons-io:2.10.0")
+    testImplementation libs.commons.io
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/otel-metrics-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-metrics-raw-processor/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')
     implementation project(':data-prepper-plugins:otel-proto-common')
-    implementation 'commons-codec:commons-codec:1.15'
+    implementation libs.commons.codec
     implementation libs.commons.lang3
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation libs.opentelemetry.proto

--- a/data-prepper-plugins/otel-metrics-source/build.gradle
+++ b/data-prepper-plugins/otel-metrics-source/build.gradle
@@ -11,11 +11,11 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')
     implementation project(':data-prepper-plugins:blocking-buffer')
-    implementation 'commons-codec:commons-codec:1.15'
+    implementation libs.commons.codec
     implementation project(':data-prepper-plugins:armeria-common')
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation libs.opentelemetry.proto
-    implementation "commons-io:commons-io:2.12.0"
+    implementation libs.commons.io
     implementation 'software.amazon.awssdk:acm'
     implementation 'software.amazon.awssdk:auth'
     implementation 'software.amazon.awssdk:regions'
@@ -31,7 +31,7 @@ dependencies {
     testImplementation testLibs.junit.vintage
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation testLibs.mockito.inline
-    testImplementation("commons-io:commons-io:2.12.0")
+    testImplementation libs.commons.io
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/otel-proto-common/build.gradle
+++ b/data-prepper-plugins/otel-proto-common/build.gradle
@@ -14,6 +14,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation libs.commons.lang3
-    implementation 'commons-codec:commons-codec:1.15'
+    implementation libs.commons.codec
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/data-prepper-plugins/otel-trace-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-processor/build.gradle
@@ -10,7 +10,7 @@ plugins {
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')
-    implementation 'commons-codec:commons-codec:1.15'
+    implementation libs.commons.codec
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation libs.opentelemetry.proto
     implementation libs.protobuf.util

--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -13,10 +13,10 @@ dependencies {
     implementation project(':data-prepper-plugins:blocking-buffer')
     implementation project(':data-prepper-plugins:armeria-common')
     implementation project(':data-prepper-plugins:otel-proto-common')
-    implementation 'commons-codec:commons-codec:1.15'
+    implementation libs.commons.codec
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation libs.opentelemetry.proto
-    implementation "commons-io:commons-io:2.12.0"
+    implementation libs.commons.io
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:acm'
     implementation libs.protobuf.util
@@ -31,7 +31,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation testLibs.mockito.inline
     testImplementation testLibs.slf4j.simple
-    testImplementation("commons-io:commons-io:2.12.0")
+    testImplementation libs.commons.io
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/prometheus-sink/build.gradle
+++ b/data-prepper-plugins/prometheus-sink/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation 'org.apache.commons:commons-compress:1.21'
+    implementation libs.commons.compress
     implementation project(':data-prepper-plugins:common')
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'org.hibernate.validator:hibernate-validator:7.0.5.Final'

--- a/data-prepper-plugins/s3-sink/build.gradle
+++ b/data-prepper-plugins/s3-sink/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation 'org.apache.commons:commons-compress:1.21'
+    implementation libs.commons.compress
     implementation 'joda-time:joda-time:2.11.1'
     implementation 'org.hibernate.validator:hibernate-validator:7.0.5.Final'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'

--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -24,8 +24,8 @@ dependencies {
     implementation 'software.amazon.awssdk:netty-nio-client'
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation 'commons-io:commons-io:2.11.0'
-    implementation 'org.apache.commons:commons-compress:1.21'
+    implementation libs.commons.io
+    implementation libs.commons.compress
     implementation 'joda-time:joda-time:2.11.1'
     implementation 'org.hibernate.validator:hibernate-validator:7.0.5.Final'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation project(':data-prepper-plugins:common')
     implementation project(':data-prepper-plugins:mapdb-processor-state')
     testImplementation project(':data-prepper-api').sourceSets.test.output
-    implementation 'commons-codec:commons-codec:1.16.0'
+    implementation libs.commons.codec
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation(libs.opentelemetry.proto) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -40,6 +40,9 @@ dependencyResolutionManagement {
             version('guava', '32.0.1-jre')
             library('guava-core', 'com.google.guava', 'guava').versionRef('guava')
             library('commons-lang3', 'org.apache.commons', 'commons-lang3').version('3.13.0')
+            library('commons-io', 'commons-io', 'commons-io').version('2.13.0')
+            library('commons-codec', 'commons-codec', 'commons-codec').version('1.16.0')
+            library('commons-compress', 'org.apache.commons', 'commons-compress').version('1.24.0')
         }
         testLibs {
             version('junit', '5.8.2')


### PR DESCRIPTION
### Description

Updates commons-compress to 1.24.0 which fixes CVE-2023-42503. As part of this change, I updated the Apache commons projects to use the Gradle version catalog to keep versions in sync.
 
### Issues Resolved

Resolves #3347.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
