### PR TITLE
Support writing to root in KeyValue processor

### DIFF
--- a/data-prepper-plugins/key-value-processor/README.md
+++ b/data-prepper-plugins/key-value-processor/README.md
@@ -31,7 +31,7 @@ When run, the processor will parse the message into the following output:
 ## Configuration
 * `source` - The field in the message that will be parsed. 
   * Default: `message`
-* `destination` - The field the parsed source will be output to. This will overwrite any preexisting data for that key.
+* `destination` - The field the parsed source will be output to. This will overwrite any preexisting data for that key. If `destination` is set to `null`, the parsed fields will be written to the root of the event.
   * Default: `parsed_message`
 * `field_delimiter_regex` - A regex specifying the delimiter between key/value pairs. Special regex characters such as `[` and `]` must be escaped using `\\`.
   * There is no default.
@@ -98,6 +98,8 @@ When run, the processor will parse the message into the following output:
   * While `recursive` is `true`, `remove_brackets` cannot also be `true`.
   * While `recursive` is `true`, `skip_duplicate_values` will always be `true`.
   * While `recursive` is `true`, `whitespace` will always be `"strict"`.
+* `overwrite_if_destination_exists` - Specify whether to overwrite existing fields if there are key conflicts when writing parsed fields to the event. 
+  * Default: `true` 
 
 ## Developer Guide
 This plugin is compatible with Java 14. See

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -34,7 +34,6 @@ public class KeyValueProcessorConfig {
     @NotEmpty
     private String source = DEFAULT_SOURCE;
 
-    @NotEmpty
     private String destination = DEFAULT_DESTINATION;
 
     @JsonProperty("field_delimiter_regex")
@@ -95,6 +94,9 @@ public class KeyValueProcessorConfig {
     @JsonProperty("recursive")
     @NotNull
     private boolean recursive = DEFAULT_RECURSIVE;
+
+    @JsonProperty("overwrite_if_destination_exists")
+    private boolean overwriteIfDestinationExists = true;
 
     public String getSource() {
         return source;
@@ -166,5 +168,9 @@ public class KeyValueProcessorConfig {
 
     public boolean getRecursive() {
         return recursive;
+    }
+
+    public boolean getOverwriteIfDestinationExists() {
+        return overwriteIfDestinationExists;
     }
 }


### PR DESCRIPTION
### Description
Support writing to root in KeyValue processor; also adds a new option `overwrite_if_destination_exists` to allow users to control whether parsed fields will overwrite existing fields. 
 
### Issues Resolved
Resolves #3378 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
