### PR TITLE
Add support for fully async acknowledgments in source coordination

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
@@ -257,8 +257,7 @@ public class PluginSetting implements PipelineDescription {
         throw new IllegalArgumentException(String.format(UNEXPECTED_ATTRIBUTE_TYPE_MSG, object.getClass(), attribute));
     }
 
-    private <T> void checkObjectType(final String attribute, final Object object, final Class<T> type) {
-        if (object != null && !(type.isAssignableFrom(object.getClass()))){
+    private <T> void checkObjectType(final String attribute, final Object object, final Class<T> type) {if (object != null && !(type.isAssignableFrom(object.getClass()))){
             throw new IllegalArgumentException(String.format(UNEXPECTED_ATTRIBUTE_TYPE_MSG, object.getClass(), attribute));
         }
     }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
@@ -127,6 +127,7 @@ public interface Event extends Serializable {
      * Returns formatted parts of the input string replaced by their values in the event or the values from the result
      * of a Data Prepper expression
      * @param format input format
+     * @param expressionEvaluator - The expression evaluator that will support formatting from Data Prepper expressions
      * @return returns a string with no formatted parts, returns null if no value is found
      * @throws RuntimeException if the input string is not properly formatted
      * @since 2.1

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourceCoordinator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourceCoordinator.java
@@ -105,5 +105,5 @@ public interface SourceCoordinator<T> {
      * @param ackowledgmentTimeout - the amount of time that this partition can be completed by the acknowledgment callback before another instance of Data Prepper
      *                             can pick it up for processing
      */
-    void updatePartitionForAckWait(final String partitionKey, final Duration ackowledgmentTimeout);
+    void updatePartitionForAcknowledgmentWait(final String partitionKey, final Duration ackowledgmentTimeout);
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinator.java
@@ -40,6 +40,10 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     private static final Logger LOG = LoggerFactory.getLogger(LeaseBasedSourceCoordinator.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    private static final String COMPLETE_ACTION = "complete";
+    private static final String CLOSE_ACTION = "close";
+    private static final String SAVE_STATE_ACTION = "saveState";
+
     static final String PARTITION_CREATION_SUPPLIER_INVOCATION_COUNT = "partitionCreationSupplierInvocations";
     static final String NO_PARTITIONS_ACQUIRED_COUNT = "noPartitionsAcquired";
     static final String PARTITION_CREATED_COUNT = "partitionsCreatedCount";
@@ -121,9 +125,9 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
         this.partitionsGivenUpCounter = pluginMetrics.counter(PARTITION_OWNERSHIP_GIVEN_UP_COUNT);
         this.partitionNotFoundErrorCounter = pluginMetrics.counter(PARTITION_NOT_FOUND_ERROR_COUNT);
         this.partitionNotOwnedErrorCounter = pluginMetrics.counter(PARTITION_NOT_OWNED_ERROR_COUNT);
-        this.saveStatePartitionUpdateErrorCounter = pluginMetrics.counter(PARTITION_UPDATE_ERROR_COUNT, "saveState");
-        this.closePartitionUpdateErrorCounter = pluginMetrics.counter(PARTITION_UPDATE_ERROR_COUNT, "close");
-        this.completePartitionUpdateErrorCounter = pluginMetrics.counter(PARTITION_UPDATE_ERROR_COUNT, "complete");
+        this.saveStatePartitionUpdateErrorCounter = pluginMetrics.counter(PARTITION_UPDATE_ERROR_COUNT, SAVE_STATE_ACTION);
+        this.closePartitionUpdateErrorCounter = pluginMetrics.counter(PARTITION_UPDATE_ERROR_COUNT, CLOSE_ACTION);
+        this.completePartitionUpdateErrorCounter = pluginMetrics.counter(PARTITION_UPDATE_ERROR_COUNT, COMPLETE_ACTION);
     }
 
     @Override
@@ -205,7 +209,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     public void completePartition(final String partitionKey, final Boolean fromAcknowledgmentsCallback) {
         validateIsInitialized();
 
-        final SourcePartitionStoreItem itemToUpdate = fromAcknowledgmentsCallback ? getSourcePartitionStoreItem(partitionKey, "complete") : validateAndGetSourcePartitionStoreItem(partitionKey, "complete");
+        final SourcePartitionStoreItem itemToUpdate = getItemWithAction(partitionKey, COMPLETE_ACTION, fromAcknowledgmentsCallback);
         validatePartitionOwnership(itemToUpdate);
 
         itemToUpdate.setPartitionOwner(null);
@@ -232,7 +236,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     public void closePartition(final String partitionKey, final Duration reopenAfter, final int maxClosedCount, final Boolean fromAcknowledgmentsCallback) {
         validateIsInitialized();
 
-        final SourcePartitionStoreItem itemToUpdate = fromAcknowledgmentsCallback ? getSourcePartitionStoreItem(partitionKey, "close") : validateAndGetSourcePartitionStoreItem(partitionKey, "close");
+        final SourcePartitionStoreItem itemToUpdate = getItemWithAction(partitionKey, CLOSE_ACTION, fromAcknowledgmentsCallback);
         validatePartitionOwnership(itemToUpdate);
 
         itemToUpdate.setPartitionOwner(null);
@@ -275,7 +279,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     public <S extends T> void saveProgressStateForPartition(final String partitionKey, final S partitionProgressState) {
         validateIsInitialized();
 
-        final SourcePartitionStoreItem itemToUpdate = validateAndGetSourcePartitionStoreItem(partitionKey, "save state");
+        final SourcePartitionStoreItem itemToUpdate = validateAndGetSourcePartitionStoreItem(partitionKey, SAVE_STATE_ACTION);
         validatePartitionOwnership(itemToUpdate);
 
         itemToUpdate.setPartitionOwnershipTimeout(Instant.now().plus(DEFAULT_LEASE_TIMEOUT));
@@ -295,7 +299,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     }
 
     @Override
-    public void updatePartitionForAckWait(final String partitionKey, final Duration ackowledgmentTimeout) {
+    public void updatePartitionForAcknowledgmentWait(final String partitionKey, final Duration ackowledgmentTimeout) {
         validateIsInitialized();
 
         final SourcePartitionStoreItem itemToUpdate = validateAndGetSourcePartitionStoreItem(partitionKey, "update for ack wait");
@@ -462,5 +466,11 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
         } catch (final JsonProcessingException | PartitionUpdateException e) {
             LOG.warn("There was an error saving global state after creating partitions.", e);
         }
+    }
+
+    private SourcePartitionStoreItem getItemWithAction(final String partitionKey, final String action, final Boolean fromAcknowledgmentsCallback) {
+        // The validation against activePartition in partition manager needs to be skipped when called from acknowledgments callback
+        // because otherwise it will fail the validation since it is actively working on a different partition when ack is received
+        return fromAcknowledgmentsCallback ? getSourcePartitionStoreItem(partitionKey, action) : validateAndGetSourcePartitionStoreItem(partitionKey, action);
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinatorTest.java
@@ -925,7 +925,7 @@ public class LeaseBasedSourceCoordinatorTest {
         doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);
 
         final Duration ackTimeout = Duration.ofSeconds(10);
-        createObjectUnderTest().updatePartitionForAckWait(sourcePartition.getPartitionKey(), ackTimeout);
+        createObjectUnderTest().updatePartitionForAcknowledgmentWait(sourcePartition.getPartitionKey(), ackTimeout);
 
         final ArgumentCaptor<Instant> argumentCaptorForPartitionOwnershipTimeout = ArgumentCaptor.forClass(Instant.class);
         verify(sourcePartitionStoreItem).setPartitionOwnershipTimeout(argumentCaptorForPartitionOwnershipTimeout.capture());

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinatorTest.java
@@ -440,7 +440,7 @@ public class LeaseBasedSourceCoordinatorTest {
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
 
-        assertThrows(PartitionNotOwnedException.class, () -> createObjectUnderTest().completePartition(UUID.randomUUID().toString()));
+        assertThrows(PartitionNotOwnedException.class, () -> createObjectUnderTest().completePartition(UUID.randomUUID().toString(), false));
 
         verify(partitionNotOwnedErrorCounter).increment();
 
@@ -469,7 +469,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
         given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.empty());
 
-        assertThrows(PartitionNotFoundException.class, () -> createObjectUnderTest().completePartition(sourcePartition.getPartitionKey()));
+        assertThrows(PartitionNotFoundException.class, () -> createObjectUnderTest().completePartition(sourcePartition.getPartitionKey(), false));
 
         verify(partitionNotFoundErrorCounter).increment();
 
@@ -500,7 +500,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(sourcePartitionStoreItem.getSourcePartitionKey()).willReturn(sourcePartition.getPartitionKey());
         given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
-        assertThrows(PartitionNotOwnedException.class, () -> createObjectUnderTest().completePartition(sourcePartition.getPartitionKey()));
+        assertThrows(PartitionNotOwnedException.class, () -> createObjectUnderTest().completePartition(sourcePartition.getPartitionKey(), false));
 
         verify(partitionManager).removeActivePartition();
 
@@ -536,7 +536,7 @@ public class LeaseBasedSourceCoordinatorTest {
 
         if (updatedItemSuccessfully) {
             doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);
-            createObjectUnderTest().completePartition(sourcePartition.getPartitionKey());
+            createObjectUnderTest().completePartition(sourcePartition.getPartitionKey(), false);
 
             verify(sourcePartitionStoreItem).setSourcePartitionStatus(SourcePartitionStatus.COMPLETED);
             verify(sourcePartitionStoreItem).setReOpenAt(null);
@@ -549,7 +549,7 @@ public class LeaseBasedSourceCoordinatorTest {
             verifyNoInteractions(completePartitionUpdateErrorCounter);
         } else {
             doThrow(PartitionUpdateException.class).when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);
-            assertThrows(PartitionUpdateException.class, () -> createObjectUnderTest().completePartition(sourcePartition.getPartitionKey()));
+            assertThrows(PartitionUpdateException.class, () -> createObjectUnderTest().completePartition(sourcePartition.getPartitionKey(), false));
 
             verify(completePartitionUpdateErrorCounter).increment();
             verifyNoInteractions(partitionsCompletedCounter);
@@ -570,6 +570,27 @@ public class LeaseBasedSourceCoordinatorTest {
     }
 
     @Test
+    void completePartition_with_fromAcknowledgmentCallback_true_does_not_interact_with_partition_manager() throws UnknownHostException {
+        final SourcePartition<String> sourcePartition = SourcePartition.builder(String.class)
+                .withPartitionKey(UUID.randomUUID().toString())
+                .withPartitionState(null)
+                .build();
+
+        given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(sourceIdentifierWithPartitionPrefix + ":" + InetAddress.getLocalHost().getHostName());
+
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);
+        createObjectUnderTest().completePartition(sourcePartition.getPartitionKey(), true);
+
+        verify(sourcePartitionStoreItem).setSourcePartitionStatus(SourcePartitionStatus.COMPLETED);
+        verify(sourcePartitionStoreItem).setReOpenAt(null);
+        verify(sourcePartitionStoreItem).setPartitionOwnershipTimeout(null);
+        verify(sourcePartitionStoreItem).setPartitionOwner(null);
+
+        verifyNoInteractions(partitionManager);
+    }
+
+    @Test
     void closePartition_with_partitionKey_that_is_not_owned_throws_partition_not_owned_exception() {
         final SourcePartition<String> sourcePartition = SourcePartition.builder(String.class)
                 .withPartitionKey(UUID.randomUUID().toString())
@@ -578,7 +599,7 @@ public class LeaseBasedSourceCoordinatorTest {
 
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
 
-        assertThrows(PartitionNotOwnedException.class, () -> createObjectUnderTest().closePartition(UUID.randomUUID().toString(), Duration.ofMinutes(2), 1));
+        assertThrows(PartitionNotOwnedException.class, () -> createObjectUnderTest().closePartition(UUID.randomUUID().toString(), Duration.ofMinutes(2), 1, false));
 
         verify(partitionNotOwnedErrorCounter).increment();
 
@@ -607,7 +628,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
         given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.empty());
 
-        assertThrows(PartitionNotFoundException.class, () -> createObjectUnderTest().closePartition(sourcePartition.getPartitionKey(), Duration.ofMinutes(2), 1));
+        assertThrows(PartitionNotFoundException.class, () -> createObjectUnderTest().closePartition(sourcePartition.getPartitionKey(), Duration.ofMinutes(2), 1, false));
 
         verify(partitionNotFoundErrorCounter).increment();
 
@@ -638,7 +659,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(sourcePartitionStoreItem.getSourcePartitionKey()).willReturn(sourcePartition.getPartitionKey());
         given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
-        assertThrows(PartitionNotOwnedException.class, () -> createObjectUnderTest().closePartition(sourcePartition.getPartitionKey(), Duration.ofMinutes(2), 1));
+        assertThrows(PartitionNotOwnedException.class, () -> createObjectUnderTest().closePartition(sourcePartition.getPartitionKey(), Duration.ofMinutes(2), 1, false));
 
         verify(partitionManager).removeActivePartition();
 
@@ -683,7 +704,7 @@ public class LeaseBasedSourceCoordinatorTest {
 
         if (updatedItemSuccessfully) {
             doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);
-            createObjectUnderTest().closePartition(sourcePartition.getPartitionKey(), Duration.ofMinutes(2), maxClosedCount);
+            createObjectUnderTest().closePartition(sourcePartition.getPartitionKey(), Duration.ofMinutes(2), maxClosedCount, false);
 
             verify(sourcePartitionStoreItem).setPartitionOwnershipTimeout(null);
             verify(sourcePartitionStoreItem).setPartitionOwner(null);
@@ -703,7 +724,7 @@ public class LeaseBasedSourceCoordinatorTest {
             verify(partitionManager).removeActivePartition();
         } else {
             doThrow(PartitionUpdateException.class).when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);
-            assertThrows(PartitionUpdateException.class, () -> createObjectUnderTest().closePartition(sourcePartition.getPartitionKey(), Duration.ofMinutes(2), maxClosedCount));
+            assertThrows(PartitionUpdateException.class, () -> createObjectUnderTest().closePartition(sourcePartition.getPartitionKey(), Duration.ofMinutes(2), maxClosedCount, false));
             if (closedCount >= maxClosedCount) {
                 verify(completePartitionUpdateErrorCounter).increment();
                 verifyNoInteractions(closePartitionUpdateErrorCounter);
@@ -723,6 +744,30 @@ public class LeaseBasedSourceCoordinatorTest {
                 partitionsGivenUpCounter,
                 partitionNotFoundErrorCounter,
                 saveStatePartitionUpdateErrorCounter);
+    }
+
+    @Test
+    void closePartition_with_fromAcknowledgmentCallback_true_does_not_interact_with_partition_manager() throws UnknownHostException {
+        final SourcePartition<String> sourcePartition = SourcePartition.builder(String.class)
+                .withPartitionKey(UUID.randomUUID().toString())
+                .withPartitionState(null)
+                .build();
+
+        final long closedCount = 1;
+
+        given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(sourceIdentifierWithPartitionPrefix + ":" + InetAddress.getLocalHost().getHostName());
+        given(sourcePartitionStoreItem.getSourcePartitionStatus()).willReturn(SourcePartitionStatus.COMPLETED);
+        given(sourcePartitionStoreItem.getClosedCount()).willReturn(closedCount);
+
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);
+        createObjectUnderTest().closePartition(sourcePartition.getPartitionKey(),  Duration.ofMinutes(2), 1, true);
+
+        verify(sourcePartitionStoreItem).setSourcePartitionStatus(SourcePartitionStatus.COMPLETED);
+        verify(sourcePartitionStoreItem).setPartitionOwnershipTimeout(null);
+        verify(sourcePartitionStoreItem).setPartitionOwner(null);
+
+        verifyNoInteractions(partitionManager);
     }
 
     @Test
@@ -862,6 +907,32 @@ public class LeaseBasedSourceCoordinatorTest {
                 closePartitionUpdateErrorCounter,
                 partitionNotOwnedErrorCounter,
                 completePartitionUpdateErrorCounter);
+    }
+
+    @Test
+    void updatePartitionForAckWait_updates_partition_ownership_and_removes_active_partition_from_partition_manager() throws UnknownHostException {
+        final SourcePartition<String> sourcePartition = SourcePartition.builder(String.class)
+                .withPartitionKey(UUID.randomUUID().toString())
+                .withPartitionState(null)
+                .build();
+
+        final Instant beforeSave = Instant.now();
+
+        given(partitionManager.getActivePartition()).willReturn(Optional.of(sourcePartition));
+        given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(sourceIdentifierWithPartitionPrefix + ":" + InetAddress.getLocalHost().getHostName());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+
+        doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);
+
+        final Duration ackTimeout = Duration.ofSeconds(10);
+        createObjectUnderTest().updatePartitionForAckWait(sourcePartition.getPartitionKey(), ackTimeout);
+
+        final ArgumentCaptor<Instant> argumentCaptorForPartitionOwnershipTimeout = ArgumentCaptor.forClass(Instant.class);
+        verify(sourcePartitionStoreItem).setPartitionOwnershipTimeout(argumentCaptorForPartitionOwnershipTimeout.capture());
+        final Instant newPartitionOwnershipTimeout = argumentCaptorForPartitionOwnershipTimeout.getValue();
+        assertThat(newPartitionOwnershipTimeout.isAfter(beforeSave.plus(ackTimeout)), equalTo(true));
+
+        verify(partitionManager).removeActivePartition();
     }
 
     @Test

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorker.java
@@ -4,7 +4,6 @@
  */
 package org.opensearch.dataprepper.plugins.source.opensearch.worker;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -34,7 +33,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.BACKOFF_ON_EXCEPTION;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.calculateExponentialBackoffAndJitter;
@@ -103,19 +101,18 @@ public class PitWorker implements SearchWorker, Runnable {
 
                 try {
 
-                    final Pair<AcknowledgementSet, CompletableFuture<Boolean>> acknowledgementSet = createAcknowledgmentSet(
+                    final AcknowledgementSet acknowledgementSet = createAcknowledgmentSet(
                             acknowledgementSetManager,
                             openSearchSourceConfiguration,
                             sourceCoordinator,
                             indexPartition.get());
 
-                    openSearchSourcePluginMetrics.getIndexProcessingTimeTimer().record(() -> processIndex(indexPartition.get(), acknowledgementSet.getLeft()));
+                    openSearchSourcePluginMetrics.getIndexProcessingTimeTimer().record(() -> processIndex(indexPartition.get(), acknowledgementSet));
 
-                    completeIndexPartition(openSearchSourceConfiguration, acknowledgementSet.getLeft(), acknowledgementSet.getRight(),
+                    completeIndexPartition(openSearchSourceConfiguration, acknowledgementSet,
                             indexPartition.get(), sourceCoordinator);
 
                     openSearchSourcePluginMetrics.getIndicesProcessedCounter().increment();
-                    LOG.info("Completed processing for index: '{}'", indexPartition.get().getPartitionKey());
                 } catch (final PartitionUpdateException | PartitionNotFoundException | PartitionNotOwnedException e) {
                     LOG.warn("PitWorker received an exception from the source coordinator. There is a potential for duplicate data for index {}, giving up partition and getting next partition: {}", indexPartition.get().getPartitionKey(), e.getMessage());
                     sourceCoordinator.giveUpPartitions();
@@ -131,7 +128,7 @@ public class PitWorker implements SearchWorker, Runnable {
                     }
                 } catch (final IndexNotFoundException e){
                     LOG.warn("{}, marking index as complete and continuing processing", e.getMessage());
-                    sourceCoordinator.completePartition(indexPartition.get().getPartitionKey());
+                    sourceCoordinator.completePartition(indexPartition.get().getPartitionKey(), false);
                 } catch (final RuntimeException e) {
                     LOG.error("Unknown exception while processing index '{}':", indexPartition.get().getPartitionKey(), e);
                     sourceCoordinator.giveUpPartitions();

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
@@ -5,20 +5,17 @@
 
 package org.opensearch.dataprepper.plugins.source.opensearch.worker;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.source.coordinator.SourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartition;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchIndexProgressState;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Random;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static com.google.common.math.LongMath.pow;
 import static com.google.common.primitives.Longs.min;
@@ -26,51 +23,53 @@ import static java.lang.Math.max;
 
 public class WorkerCommonUtils {
     private static final Random RANDOM = new Random();
+    private static final Logger LOG = LoggerFactory.getLogger(WorkerCommonUtils.class);
 
     static final Duration BACKOFF_ON_EXCEPTION = Duration.ofSeconds(60);
 
-    static final int ACKNOWLEDGEMENT_SET_TIMEOUT_SECONDS = Integer.MAX_VALUE;
+    static final Duration ACKNOWLEDGEMENT_SET_TIMEOUT = Duration.ofHours(2);
     static final Duration STARTING_BACKOFF = Duration.ofMillis(500);
     static final Duration MAX_BACKOFF = Duration.ofSeconds(60);
     static final int BACKOFF_RATE = 2;
     static final Duration MAX_JITTER = Duration.ofSeconds(2);
     static final Duration MIN_JITTER = Duration.ofSeconds(-2);
 
-    static Pair<AcknowledgementSet, CompletableFuture<Boolean>> createAcknowledgmentSet(final AcknowledgementSetManager acknowledgementSetManager,
+    static AcknowledgementSet createAcknowledgmentSet(final AcknowledgementSetManager acknowledgementSetManager,
                                                                                                final OpenSearchSourceConfiguration openSearchSourceConfiguration,
                                                                                                final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator,
                                                                                                final SourcePartition<OpenSearchIndexProgressState> indexPartition) {
         AcknowledgementSet acknowledgementSet = null;
-        CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
-
         if (openSearchSourceConfiguration.isAcknowledgmentsEnabled()) {
             acknowledgementSet = acknowledgementSetManager.create((result) -> {
                 if (result == true) {
                     sourceCoordinator.closePartition(
                             indexPartition.getPartitionKey(),
                             openSearchSourceConfiguration.getSchedulingParameterConfiguration().getInterval(),
-                            openSearchSourceConfiguration.getSchedulingParameterConfiguration().getIndexReadCount());
+                            openSearchSourceConfiguration.getSchedulingParameterConfiguration().getIndexReadCount(),
+                            true);
+
+                    LOG.info("Received acknowledgment of completion from sink for index {}", indexPartition.getPartitionKey());
                 }
-                completableFuture.complete(result);
-            }, Duration.ofSeconds(ACKNOWLEDGEMENT_SET_TIMEOUT_SECONDS));
+            }, ACKNOWLEDGEMENT_SET_TIMEOUT);
         }
 
-        return Pair.of(acknowledgementSet, completableFuture);
+        return acknowledgementSet;
     }
 
     static void completeIndexPartition(final OpenSearchSourceConfiguration openSearchSourceConfiguration,
                                               final AcknowledgementSet acknowledgementSet,
-                                              final CompletableFuture<Boolean> completableFuture,
                                               final SourcePartition<OpenSearchIndexProgressState> indexPartition,
-                                              final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator) throws ExecutionException, InterruptedException, TimeoutException {
+                                              final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator) {
         if (openSearchSourceConfiguration.isAcknowledgmentsEnabled()) {
+            sourceCoordinator.updatePartitionForAckWait(indexPartition.getPartitionKey(), ACKNOWLEDGEMENT_SET_TIMEOUT);
             acknowledgementSet.complete();
-            completableFuture.get(ACKNOWLEDGEMENT_SET_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } else {
             sourceCoordinator.closePartition(
                     indexPartition.getPartitionKey(),
                     openSearchSourceConfiguration.getSchedulingParameterConfiguration().getInterval(),
-                    openSearchSourceConfiguration.getSchedulingParameterConfiguration().getIndexReadCount());
+                    openSearchSourceConfiguration.getSchedulingParameterConfiguration().getIndexReadCount(),
+                    false);
+            LOG.info("Completed processing of index {}", indexPartition.getPartitionKey());
         }
     }
 

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
@@ -61,7 +61,7 @@ public class WorkerCommonUtils {
                                               final SourcePartition<OpenSearchIndexProgressState> indexPartition,
                                               final SourceCoordinator<OpenSearchIndexProgressState> sourceCoordinator) {
         if (openSearchSourceConfiguration.isAcknowledgmentsEnabled()) {
-            sourceCoordinator.updatePartitionForAckWait(indexPartition.getPartitionKey(), ACKNOWLEDGEMENT_SET_TIMEOUT);
+            sourceCoordinator.updatePartitionForAcknowledgmentWait(indexPartition.getPartitionKey(), ACKNOWLEDGEMENT_SET_TIMEOUT);
             acknowledgementSet.complete();
         } else {
             sourceCoordinator.closePartition(

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
@@ -273,7 +273,7 @@ public class PitWorkerTest {
         when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
-        doNothing().when(sourceCoordinator).updatePartitionForAckWait(partitionKey, ACKNOWLEDGEMENT_SET_TIMEOUT);
+        doNothing().when(sourceCoordinator).updatePartitionForAcknowledgmentWait(partitionKey, ACKNOWLEDGEMENT_SET_TIMEOUT);
         doNothing().when(sourceCoordinator).closePartition(partitionKey,
                 Duration.ZERO, 1, true);
 
@@ -379,7 +379,7 @@ public class PitWorkerTest {
         verify(searchAccessor, never()).createPit(any(CreatePointInTimeRequest.class));
         verify(searchAccessor, times(2)).searchWithPit(any(SearchPointInTimeRequest.class));
         verify(sourceCoordinator, times(2)).saveProgressStateForPartition(eq(partitionKey), eq(openSearchIndexProgressState));
-        verify(sourceCoordinator, times(0)).updatePartitionForAckWait(anyString(), any(Duration.class));
+        verify(sourceCoordinator, times(0)).updatePartitionForAcknowledgmentWait(anyString(), any(Duration.class));
 
         verify(documentsProcessedCounter, times(3)).increment();
         verify(indicesProcessedCounter).increment();

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
@@ -50,6 +50,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -64,7 +65,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.PitWorker.EXTEND_KEEP_ALIVE_TIME;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.PitWorker.STARTING_KEEP_ALIVE;
-import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.ACKNOWLEDGEMENT_SET_TIMEOUT_SECONDS;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.ACKNOWLEDGEMENT_SET_TIMEOUT;
 
 @ExtendWith(MockitoExtension.class)
 public class PitWorkerTest {
@@ -173,7 +174,7 @@ public class PitWorkerTest {
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
         doNothing().when(sourceCoordinator).closePartition(partitionKey,
-                Duration.ZERO, 1);
+                Duration.ZERO, 1, false);
 
 
         final Future<?> future = executorService.submit(() -> createObjectUnderTest().run());
@@ -233,7 +234,7 @@ public class PitWorkerTest {
             Consumer<Boolean> consumer = invocation.getArgument(0);
             consumer.accept(true);
             return acknowledgementSet;
-        }).when(acknowledgementSetManager).create(any(Consumer.class), eq(Duration.ofSeconds(ACKNOWLEDGEMENT_SET_TIMEOUT_SECONDS)));
+        }).when(acknowledgementSetManager).create(any(Consumer.class), eq(ACKNOWLEDGEMENT_SET_TIMEOUT));
         when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(true);
 
         final SourcePartition<OpenSearchIndexProgressState> sourcePartition = mock(SourcePartition.class);
@@ -272,8 +273,9 @@ public class PitWorkerTest {
         when(schedulingParameterConfiguration.getInterval()).thenReturn(Duration.ZERO);
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
+        doNothing().when(sourceCoordinator).updatePartitionForAckWait(partitionKey, ACKNOWLEDGEMENT_SET_TIMEOUT);
         doNothing().when(sourceCoordinator).closePartition(partitionKey,
-                Duration.ZERO, 1);
+                Duration.ZERO, 1, true);
 
 
         final Future<?> future = executorService.submit(() -> createObjectUnderTest().run());
@@ -359,7 +361,7 @@ public class PitWorkerTest {
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
         doNothing().when(sourceCoordinator).closePartition(partitionKey,
-                Duration.ZERO, 1);
+                Duration.ZERO, 1, false);
 
 
         final Future<?> future = executorService.submit(() -> createObjectUnderTest().run());
@@ -377,6 +379,7 @@ public class PitWorkerTest {
         verify(searchAccessor, never()).createPit(any(CreatePointInTimeRequest.class));
         verify(searchAccessor, times(2)).searchWithPit(any(SearchPointInTimeRequest.class));
         verify(sourceCoordinator, times(2)).saveProgressStateForPartition(eq(partitionKey), eq(openSearchIndexProgressState));
+        verify(sourceCoordinator, times(0)).updatePartitionForAckWait(anyString(), any(Duration.class));
 
         verify(documentsProcessedCounter, times(3)).increment();
         verify(indicesProcessedCounter).increment();
@@ -407,7 +410,7 @@ public class PitWorkerTest {
 
         verify(searchAccessor, never()).deletePit(any(DeletePointInTimeRequest.class));
         verify(sourceCoordinator).giveUpPartitions();
-        verify(sourceCoordinator, never()).closePartition(anyString(), any(Duration.class), anyInt());
+        verify(sourceCoordinator, never()).closePartition(anyString(), any(Duration.class), anyInt(), anyBoolean());
 
         verifyNoInteractions(documentsProcessedCounter);
         verifyNoInteractions(indicesProcessedCounter);
@@ -438,8 +441,8 @@ public class PitWorkerTest {
         assertThat(executorService.awaitTermination(100, TimeUnit.MILLISECONDS), equalTo(true));
 
         verify(searchAccessor, never()).deletePit(any(DeletePointInTimeRequest.class));
-        verify(sourceCoordinator).completePartition(partitionKey);
-        verify(sourceCoordinator, never()).closePartition(anyString(), any(Duration.class), anyInt());
+        verify(sourceCoordinator).completePartition(partitionKey, false);
+        verify(sourceCoordinator, never()).closePartition(anyString(), any(Duration.class), anyInt(), anyBoolean());
 
         verifyNoInteractions(documentsProcessedCounter);
         verifyNoInteractions(indicesProcessedCounter);

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorkerTest.java
@@ -49,6 +49,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -63,7 +64,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.ScrollWorker.SCROLL_TIME_PER_BATCH;
-import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.ACKNOWLEDGEMENT_SET_TIMEOUT_SECONDS;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.ACKNOWLEDGEMENT_SET_TIMEOUT;
 
 @ExtendWith(MockitoExtension.class)
 public class ScrollWorkerTest {
@@ -172,7 +173,7 @@ public class ScrollWorkerTest {
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
         doNothing().when(sourceCoordinator).closePartition(partitionKey,
-                Duration.ZERO, 1);
+                Duration.ZERO, 1, false);
 
 
         final Future<?> future = executorService.submit(() -> createObjectUnderTest().run());
@@ -227,7 +228,7 @@ public class ScrollWorkerTest {
             Consumer<Boolean> consumer = invocation.getArgument(0);
             consumer.accept(true);
             return acknowledgementSet;
-        }).when(acknowledgementSetManager).create(any(Consumer.class), eq(Duration.ofSeconds(ACKNOWLEDGEMENT_SET_TIMEOUT_SECONDS)));
+        }).when(acknowledgementSetManager).create(any(Consumer.class), eq(ACKNOWLEDGEMENT_SET_TIMEOUT));
         when(openSearchSourceConfiguration.isAcknowledgmentsEnabled()).thenReturn(true);
 
         final SourcePartition<OpenSearchIndexProgressState> sourcePartition = mock(SourcePartition.class);
@@ -267,7 +268,7 @@ public class ScrollWorkerTest {
         when(openSearchSourceConfiguration.getSchedulingParameterConfiguration()).thenReturn(schedulingParameterConfiguration);
 
         doNothing().when(sourceCoordinator).closePartition(partitionKey,
-                Duration.ZERO, 1);
+                Duration.ZERO, 1, true);
 
 
         final Future<?> future = executorService.submit(() -> createObjectUnderTest().run());
@@ -336,7 +337,7 @@ public class ScrollWorkerTest {
 
         verifyNoMoreInteractions(searchAccessor);
         verify(sourceCoordinator).giveUpPartitions();
-        verify(sourceCoordinator, never()).closePartition(anyString(), any(Duration.class), anyInt());
+        verify(sourceCoordinator, never()).closePartition(anyString(), any(Duration.class), anyInt(), eq(false));
 
         verifyNoInteractions(documentsProcessedCounter);
         verifyNoInteractions(indicesProcessedCounter);
@@ -371,8 +372,8 @@ public class ScrollWorkerTest {
         assertThat(executorService.awaitTermination(100, TimeUnit.MILLISECONDS), equalTo(true));
 
         verifyNoMoreInteractions(searchAccessor);
-        verify(sourceCoordinator).completePartition(partitionKey);
-        verify(sourceCoordinator, never()).closePartition(anyString(), any(Duration.class), anyInt());
+        verify(sourceCoordinator).completePartition(partitionKey, false);
+        verify(sourceCoordinator, never()).closePartition(anyString(), any(Duration.class), anyInt(), anyBoolean());
 
         verifyNoInteractions(documentsProcessedCounter);
         verifyNoInteractions(indicesProcessedCounter);

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ScanObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ScanObjectWorker.java
@@ -155,7 +155,7 @@ public class ScanObjectWorker implements Runnable{
 
             if (endToEndAcknowledgementsEnabled) {
                 deleteObjectRequest.ifPresent(waitingForAcknowledgements::add);
-                sourceCoordinator.updatePartitionForAckWait(objectToProcess.get().getPartitionKey(), ACKNOWLEDGEMENT_SET_TIMEOUT);
+                sourceCoordinator.updatePartitionForAcknowledgmentWait(objectToProcess.get().getPartitionKey(), ACKNOWLEDGEMENT_SET_TIMEOUT);
                 acknowledgementSet.complete();
             } else {
                 sourceCoordinator.completePartition(objectToProcess.get().getPartitionKey(), false);

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ScanObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ScanObjectWorker.java
@@ -28,10 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 /**
@@ -45,7 +41,7 @@ public class ScanObjectWorker implements Runnable{
     private static final int STANDARD_BACKOFF_MILLIS = 30_000;
     private static final int RETRY_BACKOFF_ON_EXCEPTION_MILLIS = 5_000;
 
-    static final int ACKNOWLEDGEMENT_SET_TIMEOUT_SECONDS = Integer.MAX_VALUE;
+    static final Duration ACKNOWLEDGEMENT_SET_TIMEOUT = Duration.ofHours(2);
     static final String ACKNOWLEDGEMENT_SET_CALLBACK_METRIC_NAME = "acknowledgementSetCallbackCounter";
 
     private final S3Client s3Client;
@@ -141,18 +137,16 @@ public class ScanObjectWorker implements Runnable{
         try {
             List<DeleteObjectRequest> waitingForAcknowledgements = new ArrayList<>();
             AcknowledgementSet acknowledgementSet = null;
-            CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
 
             if (endToEndAcknowledgementsEnabled) {
                 acknowledgementSet = acknowledgementSetManager.create((result) -> {
                     acknowledgementSetCallbackCounter.increment();
                     // Delete only if this is positive acknowledgement
                     if (result == true) {
-                        sourceCoordinator.completePartition(objectToProcess.get().getPartitionKey());
+                        sourceCoordinator.completePartition(objectToProcess.get().getPartitionKey(), true);
                         waitingForAcknowledgements.forEach(s3ObjectDeleteWorker::deleteS3Object);
                     }
-                    completableFuture.complete(result);
-                }, Duration.ofSeconds(ACKNOWLEDGEMENT_SET_TIMEOUT_SECONDS));
+                }, ACKNOWLEDGEMENT_SET_TIMEOUT);
             }
 
 
@@ -161,22 +155,18 @@ public class ScanObjectWorker implements Runnable{
 
             if (endToEndAcknowledgementsEnabled) {
                 deleteObjectRequest.ifPresent(waitingForAcknowledgements::add);
+                sourceCoordinator.updatePartitionForAckWait(objectToProcess.get().getPartitionKey(), ACKNOWLEDGEMENT_SET_TIMEOUT);
                 acknowledgementSet.complete();
-                completableFuture.get(ACKNOWLEDGEMENT_SET_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             } else {
-                sourceCoordinator.completePartition(objectToProcess.get().getPartitionKey());
+                sourceCoordinator.completePartition(objectToProcess.get().getPartitionKey(), false);
                 deleteObjectRequest.ifPresent(s3ObjectDeleteWorker::deleteS3Object);
             }
         } catch (final NoSuchKeyException e) {
             LOG.warn("Object {} from bucket {} could not be found, marking this object as complete and continuing processing", objectKey, bucket);
-            sourceCoordinator.completePartition(objectToProcess.get().getPartitionKey());
+            sourceCoordinator.completePartition(objectToProcess.get().getPartitionKey(), false);
         } catch (final PartitionNotOwnedException | PartitionNotFoundException | PartitionUpdateException e) {
             LOG.warn("S3 scan object worker received an exception from the source coordinator. There is a potential for duplicate data from {}, giving up partition and getting next partition: {}", objectKey, e.getMessage());
             sourceCoordinator.giveUpPartitions();
-        } catch (final ExecutionException | TimeoutException e) {
-            LOG.error("Exception occurred while waiting for acknowledgement.", e);
-        } catch (final InterruptedException e) {
-            LOG.error("S3 Scan worker thread interrupted while processing S3 object.", e);
         }
     }
 

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanObjectWorkerTest.java
@@ -193,7 +193,7 @@ class S3ScanObjectWorkerTest {
 
         scanObjectWorker.runWithoutInfiniteLoop();
 
-        verify(sourceCoordinator).updatePartitionForAckWait(partitionKey, ACKNOWLEDGEMENT_SET_TIMEOUT);
+        verify(sourceCoordinator).updatePartitionForAcknowledgmentWait(partitionKey, ACKNOWLEDGEMENT_SET_TIMEOUT);
         verify(sourceCoordinator).completePartition(partitionKey, true);
         verify(s3ObjectDeleteWorker).buildDeleteObjectRequest(bucket, objectKey);
         verify(acknowledgementSet).complete();
@@ -230,7 +230,7 @@ class S3ScanObjectWorkerTest {
         scanObjectWorker.runWithoutInfiniteLoop();
 
         verify(sourceCoordinator).completePartition(partitionKey, false);
-        verify(sourceCoordinator, times(0)).updatePartitionForAckWait(anyString(), any(Duration.class));
+        verify(sourceCoordinator, times(0)).updatePartitionForAcknowledgmentWait(anyString(), any(Duration.class));
         verifyNoInteractions(s3ObjectDeleteWorker);
         verifyNoInteractions(acknowledgementSetManager);
 

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanObjectWorkerTest.java
@@ -48,11 +48,13 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.s3.ScanObjectWorker.ACKNOWLEDGEMENT_SET_CALLBACK_METRIC_NAME;
+import static org.opensearch.dataprepper.plugins.source.s3.ScanObjectWorker.ACKNOWLEDGEMENT_SET_TIMEOUT;
 
 @ExtendWith(MockitoExtension.class)
 class S3ScanObjectWorkerTest {
@@ -150,7 +152,7 @@ class S3ScanObjectWorkerTest {
 
         final ArgumentCaptor<S3ObjectReference> objectReferenceArgumentCaptor = ArgumentCaptor.forClass(S3ObjectReference.class);
         doNothing().when(s3ObjectHandler).parseS3Object(objectReferenceArgumentCaptor.capture(), eq(null), eq(sourceCoordinator), eq(partitionKey));
-        doNothing().when(sourceCoordinator).completePartition(anyString());
+        doNothing().when(sourceCoordinator).completePartition(anyString(), eq(false));
 
         createObjectUnderTest().runWithoutInfiniteLoop();
 
@@ -179,7 +181,7 @@ class S3ScanObjectWorkerTest {
 
         final ArgumentCaptor<S3ObjectReference> objectReferenceArgumentCaptor = ArgumentCaptor.forClass(S3ObjectReference.class);
         doNothing().when(s3ObjectHandler).parseS3Object(objectReferenceArgumentCaptor.capture(), eq(acknowledgementSet), eq(sourceCoordinator), eq(partitionKey));
-        doNothing().when(sourceCoordinator).completePartition(anyString());
+        doNothing().when(sourceCoordinator).completePartition(anyString(), eq(true));
 
         final ScanObjectWorker scanObjectWorker = createObjectUnderTest();
 
@@ -191,7 +193,8 @@ class S3ScanObjectWorkerTest {
 
         scanObjectWorker.runWithoutInfiniteLoop();
 
-        verify(sourceCoordinator).completePartition(partitionKey);
+        verify(sourceCoordinator).updatePartitionForAckWait(partitionKey, ACKNOWLEDGEMENT_SET_TIMEOUT);
+        verify(sourceCoordinator).completePartition(partitionKey, true);
         verify(s3ObjectDeleteWorker).buildDeleteObjectRequest(bucket, objectKey);
         verify(acknowledgementSet).complete();
         verify(counter).increment();
@@ -220,13 +223,14 @@ class S3ScanObjectWorkerTest {
 
         final ArgumentCaptor<S3ObjectReference> objectReferenceArgumentCaptor = ArgumentCaptor.forClass(S3ObjectReference.class);
         doNothing().when(s3ObjectHandler).parseS3Object(objectReferenceArgumentCaptor.capture(), eq(null), eq(sourceCoordinator), eq(partitionKey));
-        doNothing().when(sourceCoordinator).completePartition(anyString());
+        doNothing().when(sourceCoordinator).completePartition(anyString(), eq(false));
 
         final ScanObjectWorker scanObjectWorker = createObjectUnderTest();
 
         scanObjectWorker.runWithoutInfiniteLoop();
 
-        verify(sourceCoordinator).completePartition(partitionKey);
+        verify(sourceCoordinator).completePartition(partitionKey, false);
+        verify(sourceCoordinator, times(0)).updatePartitionForAckWait(anyString(), any(Duration.class));
         verifyNoInteractions(s3ObjectDeleteWorker);
         verifyNoInteractions(acknowledgementSetManager);
 
@@ -254,14 +258,14 @@ class S3ScanObjectWorkerTest {
 
         final ArgumentCaptor<S3ObjectReference> objectReferenceArgumentCaptor = ArgumentCaptor.forClass(S3ObjectReference.class);
         doNothing().when(s3ObjectHandler).parseS3Object(objectReferenceArgumentCaptor.capture(), eq(null), eq(sourceCoordinator), eq(partitionKey));
-        doNothing().when(sourceCoordinator).completePartition(anyString());
+        doNothing().when(sourceCoordinator).completePartition(anyString(), eq(false));
 
         final ScanObjectWorker scanObjectWorker = createObjectUnderTest();
 
         scanObjectWorker.runWithoutInfiniteLoop();
 
         verifyNoInteractions(acknowledgementSetManager);
-        verify(sourceCoordinator).completePartition(partitionKey);
+        verify(sourceCoordinator).completePartition(partitionKey, false);
         verifyNoInteractions(s3ObjectDeleteWorker);
 
         final S3ObjectReference processedObject = objectReferenceArgumentCaptor.getValue();
@@ -289,7 +293,7 @@ class S3ScanObjectWorkerTest {
 
         final ArgumentCaptor<S3ObjectReference> objectReferenceArgumentCaptor = ArgumentCaptor.forClass(S3ObjectReference.class);
         doThrow(NoSuchKeyException.class).when(s3ObjectHandler).parseS3Object(objectReferenceArgumentCaptor.capture(), eq(null), eq(sourceCoordinator), eq(partitionKey));
-        doNothing().when(sourceCoordinator).completePartition(partitionKey);
+        doNothing().when(sourceCoordinator).completePartition(partitionKey, false);
 
         createObjectUnderTest().runWithoutInfiniteLoop();
 


### PR DESCRIPTION
### Description
This changes adds a new function to the source coordinator interface

```
updatePartitionForAckWait(final String partitionKey, final Duration acknowledgmentTimeout)
```

This method will give ownership of `acknowledgmentTimeout` amount for the acknowledgment to be received. If the acknowledgment for the partition is not received in time, then another instance of Data Prepper will attempt to process it from the beginning. Calling the `updatePartitionForAckWait` is also necessary to allow the current node to pick up a new partition to process immediately. 

Also added a paramter `fromAcknowledgmentCallback` to `close/completePartition`. Only the callback functions should set this to true when the partition is closed or completed by the callback. 

* Implemented the use of this change in both s3 scan and the opensearch source to have acknowledgment timeout of 2 hours (we could consider making this configurable in the future, but given that we have infinite timeout in Kafka, I was hoping we would consolidate on the user experience for acknowledgments timeout first) Instead of waiting to receive the acknowledgments from the sink, it will now be done completely asynchronously, meaning the source will continuously pick up the next partition and write it to the buffer. 

### Issues Resolved
Resolves #3381 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
