### PR TITLE
Add retry to Kafka Consumer Create in source

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.BrokerNotAvailableException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -82,6 +83,8 @@ import java.util.stream.IntStream;
 @SuppressWarnings("deprecation")
 @DataPrepperPlugin(name = "kafka", pluginType = Source.class, pluginConfigurationType = KafkaSourceConfig.class)
 public class KafkaSource implements Source<Record<Event>> {
+    private static final String NO_RESOLVABLE_URLS_ERROR_MESSAGE = "No resolvable bootstrap urls given in bootstrap.servers";
+    private static final long RETRY_SLEEP_INTERVAL = 30000;
     private static final Logger LOG = LoggerFactory.getLogger(KafkaSource.class);
     private final KafkaSourceConfig sourceConfig;
     private AtomicBoolean shutdownInProgress;
@@ -130,22 +133,25 @@ public class KafkaSource implements Source<Record<Event>> {
                 allTopicExecutorServices.add(executorService);
 
                 IntStream.range(0, numWorkers).forEach(index -> {
-                    switch (schema) {
-                        case JSON:
-                            kafkaConsumer = new KafkaConsumer<String, JsonNode>(consumerProperties);
+                    while (true) {
+                        try {
+                            kafkaConsumer = createKafkaConsumer(schema, consumerProperties);
                             break;
-                        case AVRO:
-                            kafkaConsumer = new KafkaConsumer<String, GenericRecord>(consumerProperties);
-                            break;
-                        case PLAINTEXT:
-                        default:
-                            glueDeserializer = KafkaSourceSecurityConfigurer.getGlueSerializer(sourceConfig);
-                            if (Objects.nonNull(glueDeserializer)) {
-                                kafkaConsumer = new KafkaConsumer(consumerProperties, stringDeserializer, glueDeserializer);
+                        } catch (ConfigException ce) {
+                            if (ce.getMessage().contains(NO_RESOLVABLE_URLS_ERROR_MESSAGE)) {
+                                LOG.warn("Exception while creating Kafka consumer: ", ce);
+                                LOG.warn("Bootstrap URL could not be resolved. Retrying in {} ms...", RETRY_SLEEP_INTERVAL);
+                                try {
+                                    sleep(RETRY_SLEEP_INTERVAL);
+                                } catch (InterruptedException ie) {
+                                    Thread.currentThread().interrupt();
+                                    throw new RuntimeException(ie);
+                                }
                             } else {
-                                kafkaConsumer = new KafkaConsumer<String, String>(consumerProperties);
+                                throw ce;
                             }
-                            break;
+                        }
+
                     }
                     consumer = new KafkaSourceCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType, acknowledgementSetManager, topicMetrics);
                     allTopicConsumers.add(consumer);
@@ -163,6 +169,23 @@ public class KafkaSource implements Source<Record<Event>> {
             }
             LOG.info("Started Kafka source for topic " + topic.getName());
         });
+    }
+
+    public KafkaConsumer<?, ?> createKafkaConsumer(final MessageFormat schema, final Properties consumerProperties) {
+        switch (schema) {
+            case JSON:
+                return new KafkaConsumer<String, JsonNode>(consumerProperties);
+            case AVRO:
+                 return new KafkaConsumer<String, GenericRecord>(consumerProperties);
+            case PLAINTEXT:
+            default:
+                glueDeserializer = KafkaSourceSecurityConfigurer.getGlueSerializer(sourceConfig);
+                if (Objects.nonNull(glueDeserializer)) {
+                    return new KafkaConsumer(consumerProperties, stringDeserializer, glueDeserializer);
+                } else {
+                    return new KafkaConsumer<String, String>(consumerProperties);
+                }
+        }
     }
 
     @Override
@@ -484,5 +507,9 @@ public class KafkaSource implements Source<Record<Event>> {
             maskedString.append('*');
         }
         return maskedString.append(serverIP.substring(maskedLength)).toString();
+    }
+
+    protected void sleep(final long millis) throws InterruptedException {
+        Thread.sleep(millis);
     }
 }


### PR DESCRIPTION
### Description
Certain error was seen when Kafka Source was constructed using new MSK instance:

```
Caused by: org.apache.kafka.common.config.ConfigException: No resolvable bootstrap urls given in bootstrap.servers
    at org.apache.kafka.clients.ClientUtils.parseAndValidateAddresses(ClientUtils.java:89) ~[kafka-clients-7.4.0-ccs.jar:?]
    at org.apache.kafka.clients.ClientUtils.parseAndValidateAddresses(ClientUtils.java:48) ~[kafka-clients-7.4.0-ccs.jar:?]
    at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:731) ~[kafka-clients-7.4.0-ccs.jar:?]
    at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:665) ~[kafka-clients-7.4.0-ccs.jar:?]
    at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:646) ~[kafka-clients-7.4.0-ccs.jar:?]
    at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:626) ~[kafka-clients-7.4.0-ccs.jar:?]
    at org.opensearch.dataprepper.plugins.kafka.source.KafkaSource.lambda$start$0(KafkaSource.java:146) ~[kafka-plugins-2.4.0.jar:?]
    at java.util.stream.Streams$RangeIntSpliterator.forEachRemaining(Streams.java:104) ~[?:?]
    at java.util.stream.IntPipeline$Head.forEach(IntPipeline.java:593) ~[?:?]
    at org.opensearch.dataprepper.plugins.kafka.source.KafkaSource.lambda$start$1(KafkaSource.java:132) ~[kafka-plugins-2.4.0.jar:?]
    at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
    at org.opensearch.dataprepper.plugins.kafka.source.KafkaSource.start(KafkaSource.java:122) ~[kafka-plugins-2.4.0.jar:?]
    at org.opensearch.dataprepper.pipeline.Pipeline.startSourceAndProcessors(Pipeline.java:210) ~[data-prepper-core-2.4.0.jar:?]
    at org.opensearch.dataprepper.pipeline.Pipeline.lambda$execute$2(Pipeline.java:251) ~[data-prepper-core-2.4.0.jar:?]
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
    at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
    ... 2 more
```
Adding 3 retries of 30 seconds each to the Kafka consumer construction to account for Route53 propagation delays.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
