### PR TITLE
Add support for Update/Upsert/Delete operations in OpenSearch Sink

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
@@ -157,6 +157,23 @@ public class PluginSetting implements PipelineDescription {
         return (List<T>) object;
     }
 
+    public <K, V> List<Map<K, V>> getTypedListOfMaps(final String attribute, final Class<K> keyType, final Class<V> valueType) {
+        Object object = getAttributeOrDefault(attribute, null);
+        if (object == null) {
+            return null;
+        }
+
+        checkObjectType(attribute, object, List.class);
+
+        for (final Map<K, V> listItem: (List<Map<K, V>>) object) {
+            ((Map<?, ?>) listItem).forEach((key, value) -> {
+                checkObjectType(attribute, key, keyType);
+                checkObjectType(attribute, value, valueType);
+            });
+        }
+        return (List<Map<K, V>>) object;
+    }
+
     /**
      * Returns the value of the specified {@literal Map<String, String> object}, or {@code defaultValue} if this settings contains no value for
      * the attribute.

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
@@ -157,6 +157,17 @@ public class PluginSetting implements PipelineDescription {
         return (List<T>) object;
     }
 
+    /**
+     * Returns the value of the specified {@literal List<Map<String, String>>}, or {@code defaultValue} if this settings contains no value for
+     * the attribute.
+     *
+     * @param keyType      key type of the Map
+     * @param valueType    value type stored in the Map
+     * @param <K> The key type
+     * @param <V> The value type
+     * @return the value of the specified attribute, or {@code defaultValue} if this settings contains no value for
+     * the attribute
+     */
     public <K, V> List<Map<K, V>> getTypedListOfMaps(final String attribute, final Class<K> keyType, final Class<V> valueType) {
         Object object = getAttributeOrDefault(attribute, null);
         if (object == null) {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
@@ -74,7 +74,10 @@ public interface Event extends Serializable {
     String toJsonString();
 
     /**
+     * Returns the JsonNode containing the internal representation of the event
      *
+     * @return JsonNode
+     * @since 2.5
      */
     JsonNode getJsonNode();
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.model.event;
 
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.io.Serializable;
 import java.util.List;
@@ -71,6 +72,11 @@ public interface Event extends Serializable {
      * @since 1.2
      */
     String toJsonString();
+
+    /**
+     *
+     */
+    JsonNode getJsonNode();
 
     /**
      * Gets a serialized Json string of the specific key in the Event

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -119,7 +119,8 @@ public class JacksonEvent implements Event {
         return mapper.valueToTree(data);
     }
 
-    protected JsonNode getJsonNode() {
+    @Override
+    public JsonNode getJsonNode() {
         return jsonNode;
     }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -320,6 +320,28 @@ public class JacksonEvent implements Event {
         return formatStringInternal(format, expressionEvaluator);
     }
 
+    public static boolean isValidFormatExpressions(final String format, final ExpressionEvaluator expressionEvaluator) {
+        if (Objects.isNull(expressionEvaluator)) {
+            return false;
+        }
+        int fromIndex = 0;
+        int position = 0;
+        while ((position = format.indexOf("${", fromIndex)) != -1) {
+            int endPosition = format.indexOf("}", position + 1);
+            if (endPosition == -1) {
+                return false;
+            }
+            String name = format.substring(position + 2, endPosition);
+
+            Object val;
+            if (!expressionEvaluator.isValidExpressionStatement(name)) {
+                return false;
+            }
+            fromIndex = endPosition + 1;
+        }
+        return true;
+    }
+
     private String formatStringInternal(final String format, final ExpressionEvaluator expressionEvaluator) {
         int fromIndex = 0;
         String result = "";

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PluginSettingsTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PluginSettingsTests.java
@@ -46,6 +46,7 @@ public class PluginSettingsTests {
     private static final String TEST_INT_ATTRIBUTE = "int-attribute";
     private static final String TEST_STRING_ATTRIBUTE = "string-attribute";
     private static final String TEST_STRINGLIST_ATTRIBUTE = "list-attribute";
+    private static final String TEST_LIST_OF_MAPS_ATTRIBUTE = "map-list-attribute";
     private static final String TEST_STRINGMAP_ATTRIBUTE = "map-attribute";
     private static final String TEST_STRINGLISTMAP_ATTRIBUTE = "list-map-attribute";
     private static final String TEST_BOOL_ATTRIBUTE = "bool-attribute";
@@ -146,6 +147,16 @@ public class PluginSettingsTests {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
 
         assertThat(pluginSetting.getTypedMap(TEST_STRINGMAP_ATTRIBUTE, String.class, String.class), is(equalTo(TEST_STRINGMAP_VALUE)));
+    }
+
+    @Test
+    public void testGetTypedListOfMaps() {
+        final Map<String, String> TEST_SETTINGS_MAP = ImmutableMap.of(TEST_STRING_ATTRIBUTE, TEST_STRING_VALUE);
+        final List<Map<String, String>> TEST_SETTINGS_LIST = List.of(TEST_SETTINGS_MAP);
+        final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_LIST_OF_MAPS_ATTRIBUTE, TEST_SETTINGS_LIST);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
+
+        assertThat(pluginSetting.getTypedListOfMaps(TEST_LIST_OF_MAPS_ATTRIBUTE, String.class, String.class), is(equalTo(List.of(TEST_SETTINGS_MAP))));
     }
 
     @Test
@@ -268,6 +279,20 @@ public class PluginSettingsTests {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_AS_NULL);
 
         assertThat(pluginSetting.getTypedListMap(TEST_STRINGLISTMAP_NULL_ATTRIBUTE, String.class, String.class), nullValue());
+    }
+
+    /**
+     * Request attributes are present with null values, expect nulls to be returned
+     */
+    @Test
+    public void testGetTypedListOfMaps_AsNull() {
+        final String TEST_STRINGLISTOFMAPS_NULL_ATTRIBUTE = "typedlistofmaps-null-attribute";
+        final Map<String, Object> TEST_SETTINGS_AS_NULL = new HashMap<>();
+
+        TEST_SETTINGS_AS_NULL.put(TEST_STRINGLISTOFMAPS_NULL_ATTRIBUTE, null);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_AS_NULL);
+
+        assertThat(pluginSetting.getTypedListOfMaps(TEST_STRINGLISTOFMAPS_NULL_ATTRIBUTE, String.class, String.class), nullValue());
     }
 
     /**

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -530,6 +530,25 @@ public class JacksonEventTest {
         assertThat(event.formatString(formattedString), is(equalTo(finalString)));
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "abc-${/foo, false",
+            "abc-${/foo}, true",
+            "abc-${getMetadata(\"key\")}, true",
+            "abc-${getXYZ(\"key\")}, false"
+    })
+    public void testBuild_withIsValidFormatExpressions(final String format, final Boolean expectedResult) {
+        final ExpressionEvaluator expressionEvaluator = mock(ExpressionEvaluator.class);
+        when(expressionEvaluator.isValidExpressionStatement("/foo")).thenReturn(true);
+        when(expressionEvaluator.isValidExpressionStatement("getMetadata(\"key\")")).thenReturn(true);
+        assertThat(JacksonEvent.isValidFormatExpressions(format, expressionEvaluator), equalTo(expectedResult));
+    }
+
+    @Test
+    public void testBuild_withIsValidFormatExpressionsWithNullEvaluator() {
+        assertThat(JacksonEvent.isValidFormatExpressions("${}", null), equalTo(false));
+    }
+
     @Test
     public void testBuild_withFormatStringWithExpressionEvaluator() {
 

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -146,6 +146,28 @@ e.g. [otel-v1-apm-span-index-template.json](https://github.com/opensearch-projec
 - `dlq_file`(optional): A String of absolute file path for DLQ failed output records. Defaults to null.
 If not provided, failed records will be written into the default data-prepper log file (`logs/Data-Prepper.log`). If the `dlq` option is present along with this, an error is thrown.
 
+- `action`(optional): A string indicating the type of action to be performed. Supported values are "create", "update", "upsert", "delete" and "index". Default value is "index". It also be an expression which evaluates to one of the supported values mentioned earlier.
+
+- `actions`(optional): This is an alternative to `action`. `actions` can have multiple actions, each with a condition. The first action for which the condition evaluates to true is picked as the action for an event. The action must be one of the supported values mentioned under `action` field above. Just like in case of `action`, the `type` mentioned in `actions` can be an expression which evaluates to one of the supported values. For example, the following configuration shows different action types for different conditions.
+
+```
+  sink:
+    - opensearch
+        actions:
+          - type: "create"
+             when: "/some_key == CREATE"
+          - type: "index"
+             when: "/some_key == INDEX"
+          - type: "upsert"
+             when: "/some_key == UPSERT"
+          - type: "update"
+             when: "/some_key == UPDATE"
+          - type: "delete"
+             when: "/some_key == DELETE"
+         # default case
+          - type: "index"
+```
+
 - `dlq` (optional): DLQ configurations. See [DLQ](https://github.com/opensearch-project/data-prepper/tree/main/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/README.md) for details. If the `dlq_file` option is present along with this, an error is thrown.
 
 - `max_retries`(optional): A number indicating the maximum number of times OpenSearch Sink should try to push the data to the OpenSearch server before considering it as failure. Defaults to `Integer.MAX_VALUE`.

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -104,6 +104,7 @@ public class OpenSearchSinkIT {
     private static final String PIPELINE_NAME = "integTestPipeline";
     private static final String TEST_CUSTOM_INDEX_POLICY_FILE = "test-custom-index-policy-file.json";
     private static final String TEST_TEMPLATE_V1_FILE = "test-index-template.json";
+    private static final String TEST_TEMPLATE_BULK_FILE = "test-bulk-template.json";
     private static final String TEST_TEMPLATE_V2_FILE = "test-index-template-v2.json";
     private static final String TEST_INDEX_TEMPLATE_V1_FILE = "test-composable-index-template.json";
     private static final String TEST_INDEX_TEMPLATE_V2_FILE = "test-composable-index-template-v2.json";
@@ -641,6 +642,213 @@ public class OpenSearchSinkIT {
     }
 
     @Test
+    public void testBulkActionCreateWithExpression() throws IOException, InterruptedException {
+        final String testIndexAlias = "test-alias";
+        final String testTemplateFile = Objects.requireNonNull(
+                getClass().getClassLoader().getResource(TEST_TEMPLATE_V1_FILE)).getFile();
+        final String testIdField = "someId";
+        final String testId = "foo";
+        final List<Record<Event>> testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson(testIdField, testId)));
+        final PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFile);
+        pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
+        Event event = (Event)testRecords.get(0).getData();
+        event.getMetadata().setAttribute("action", "create");
+        when(expressionEvaluator.isValidExpressionStatement("getMetadata(\"action\")")).thenReturn(true);
+        when(expressionEvaluator.evaluate("getMetadata(\"action\")", event)).thenReturn(event.getMetadata().getAttribute("action"));
+        pluginSetting.getSettings().put(IndexConfiguration.ACTION, "${getMetadata(\"action\")}");
+        final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
+        sink.output(testRecords);
+        final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
+        MatcherAssert.assertThat(retSources.size(), equalTo(1));
+        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        sink.shutdown();
+
+        // verify metrics
+        final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(OpenSearchSink.BULKREQUEST_LATENCY).toString());
+        MatcherAssert.assertThat(bulkRequestLatencies.size(), equalTo(3));
+        // COUNT
+        Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
+    }
+
+    @Test
+    public void testBulkActionCreateWithInvalidExpression() throws IOException, InterruptedException {
+        final String testIndexAlias = "test-alias";
+        final String testTemplateFile = Objects.requireNonNull(
+                getClass().getClassLoader().getResource(TEST_TEMPLATE_V1_FILE)).getFile();
+        final String testIdField = "someId";
+        final String testId = "foo";
+        final List<Record<Event>> testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson(testIdField, testId)));
+        final PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFile);
+        pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
+        Event event = (Event)testRecords.get(0).getData();
+        event.getMetadata().setAttribute("action", "unknown");
+        when(expressionEvaluator.isValidExpressionStatement("getMetadata(\"action\")")).thenReturn(true);
+        when(expressionEvaluator.evaluate("getMetadata(\"action\")", event)).thenReturn(event.getMetadata().getAttribute("action"));
+        pluginSetting.getSettings().put(IndexConfiguration.ACTION, "${getMetadata(\"action\")}");
+        final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
+        sink.output(testRecords);
+        final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
+        MatcherAssert.assertThat(retSources.size(), equalTo(0));
+        MatcherAssert.assertThat(sink.getInvalidActionErrorsCount(), equalTo(1.0));
+        sink.shutdown();
+    }
+
+    @Test
+    public void testBulkActionCreateWithActions() throws IOException, InterruptedException {
+        final String testIndexAlias = "test-alias";
+        final String testTemplateFile = Objects.requireNonNull(
+                getClass().getClassLoader().getResource(TEST_TEMPLATE_V1_FILE)).getFile();
+        final String testIdField = "someId";
+        final String testId = "foo";
+        final List<Record<Event>> testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson(testIdField, testId)));
+
+        final PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFile);
+        pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
+        List<Map<String, Object>> aList = new ArrayList<>();
+        Map<String, Object> aMap = new HashMap<>();
+        aMap.put("type", BulkAction.CREATE.toString());
+        aList.add(aMap);
+        pluginSetting.getSettings().put(IndexConfiguration.ACTIONS, aList);
+        final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
+        sink.output(testRecords);
+        final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
+        MatcherAssert.assertThat(retSources.size(), equalTo(1));
+        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        sink.shutdown();
+
+        // verify metrics
+        final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(OpenSearchSink.BULKREQUEST_LATENCY).toString());
+        MatcherAssert.assertThat(bulkRequestLatencies.size(), equalTo(3));
+        // COUNT
+        Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
+    }
+
+    @Test
+    public void testBulkActionUpdateWithActions() throws IOException, InterruptedException {
+        final String testIndexAlias = "test-alias-upd1";
+        final String testTemplateFile = Objects.requireNonNull(
+                getClass().getClassLoader().getResource(TEST_TEMPLATE_BULK_FILE)).getFile();
+
+        final String testIdField = "someId";
+        final String testId = "foo";
+        List<Record<Event>> testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson2(testIdField, testId, "name", "value1")));
+
+        final PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFile);
+        pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
+        List<Map<String, Object>> aList = new ArrayList<>();
+        Map<String, Object> aMap = new HashMap<>();
+        aMap.put("type", BulkAction.CREATE.toString());
+        aList.add(aMap);
+        pluginSetting.getSettings().put(IndexConfiguration.ACTIONS, aList);
+        OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
+        sink.output(testRecords);
+        List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
+        MatcherAssert.assertThat(retSources.size(), equalTo(1));
+        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        sink.shutdown();
+
+        // verify metrics
+        final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(OpenSearchSink.BULKREQUEST_LATENCY).toString());
+        MatcherAssert.assertThat(bulkRequestLatencies.size(), equalTo(3));
+        // COUNT
+        Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
+        testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson2(testIdField, testId, "name", "value2")));
+        aList = new ArrayList<>();
+        aMap = new HashMap<>();
+        aMap.put("type", BulkAction.UPDATE.toString());
+        aList.add(aMap);
+        pluginSetting.getSettings().put(IndexConfiguration.ACTIONS, aList);
+        sink = createObjectUnderTest(pluginSetting, true);
+        sink.output(testRecords);
+        retSources = getSearchResponseDocSources(testIndexAlias);
+
+        MatcherAssert.assertThat(retSources.size(), equalTo(1));
+        Map<String, Object> source = retSources.get(0);
+        MatcherAssert.assertThat((String)source.get("name"), equalTo("value2"));
+        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        sink.shutdown();
+    }
+
+    @Test
+    public void testBulkActionUpsertWithActions() throws IOException, InterruptedException {
+        final String testIndexAlias = "test-alias-upd2";
+        final String testTemplateFile = Objects.requireNonNull(
+                getClass().getClassLoader().getResource(TEST_TEMPLATE_BULK_FILE)).getFile();
+
+        final String testIdField = "someId";
+        final String testId = "foo";
+        List<Record<Event>> testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson2(testIdField, testId, "name", "value1")));
+
+        final PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFile);
+        pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
+        List<Map<String, Object>> aList = new ArrayList<>();
+        Map<String, Object> aMap = new HashMap<>();
+        aMap.put("type", BulkAction.CREATE.toString());
+        aList.add(aMap);
+        pluginSetting.getSettings().put(IndexConfiguration.ACTIONS, aList);
+        OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
+        sink.output(testRecords);
+        List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
+        MatcherAssert.assertThat(retSources.size(), equalTo(1));
+        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        sink.shutdown();
+
+        // verify metrics
+        final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(OpenSearchSink.BULKREQUEST_LATENCY).toString());
+        MatcherAssert.assertThat(bulkRequestLatencies.size(), equalTo(3));
+        // COUNT
+        Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
+        testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson3(testIdField, testId, "name", "value3", "newKey", "newValue")));
+        aList = new ArrayList<>();
+        aMap = new HashMap<>();
+        aMap.put("type", BulkAction.UPSERT.toString());
+        aList.add(aMap);
+        pluginSetting.getSettings().put(IndexConfiguration.ACTIONS, aList);
+        sink = createObjectUnderTest(pluginSetting, true);
+        sink.output(testRecords);
+        retSources = getSearchResponseDocSources(testIndexAlias);
+
+        MatcherAssert.assertThat(retSources.size(), equalTo(1));
+        Map<String, Object> source = retSources.get(0);
+        MatcherAssert.assertThat((String)source.get("name"), equalTo("value3"));
+        MatcherAssert.assertThat((String)source.get("newKey"), equalTo("newValue"));
+        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        sink.shutdown();
+    }
+
+    @Test
+    public void testBulkActionDeleteWithActions() throws IOException, InterruptedException {
+        final String testIndexAlias = "test-alias-upd1";
+        final String testTemplateFile = Objects.requireNonNull(
+                getClass().getClassLoader().getResource(TEST_TEMPLATE_BULK_FILE)).getFile();
+
+        final String testIdField = "someId";
+        final String testId = "foo";
+        List<Record<Event>> testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson(testIdField, testId)));
+
+        final PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFile);
+        pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
+        List<Map<String, Object>> aList = new ArrayList<>();
+        Map<String, Object> aMap = new HashMap<>();
+        aMap.put("type", BulkAction.DELETE.toString());
+        aList.add(aMap);
+        pluginSetting.getSettings().put(IndexConfiguration.ACTIONS, aList);
+        OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
+        sink.output(testRecords);
+        List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
+        MatcherAssert.assertThat(retSources.size(), equalTo(0));
+        sink.shutdown();
+    }
+
+    @Test
     @DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
     public void testEventOutputWithTags() throws IOException, InterruptedException {
         final Event testEvent = JacksonEvent.builder()
@@ -961,6 +1169,27 @@ public class OpenSearchSinkIT {
         );
     }
 
+    private String generateCustomRecordJson2(final String idField, final String documentId, final String key, final String value) throws IOException {
+        return Strings.toString(
+                XContentFactory.jsonBuilder()
+                        .startObject()
+                        .field(idField, documentId)
+                        .field(key, value)
+                        .endObject()
+        );
+    }
+
+    private String generateCustomRecordJson3(final String idField, final String documentId, final String key1, final String value1, final String key2, final String value2) throws IOException {
+        return Strings.toString(
+                XContentFactory.jsonBuilder()
+                        .startObject()
+                        .field(idField, documentId)
+                        .field(key1, value1)
+                        .field(key2, value2)
+                        .endObject()
+        );
+    }
+
     private String readDocFromFile(final String filename) throws IOException {
         final StringBuilder jsonBuilder = new StringBuilder();
         try (final InputStream inputStream = Objects.requireNonNull(
@@ -1089,6 +1318,7 @@ public class OpenSearchSinkIT {
                 .filter(Predicate.not(indexName -> indexName.startsWith(".opendistro_")))
                 .filter(Predicate.not(indexName -> indexName.startsWith(".opensearch-")))
                 .filter(Predicate.not(indexName -> indexName.startsWith(".opensearch_")))
+                .filter(Predicate.not(indexName -> indexName.startsWith(".plugins-ml-config")))
                 .forEach(indexName -> {
                     try {
                         client.performRequest(new Request("DELETE", "/" + indexName));

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.sink.opensearch;
 
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.SerializedJson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -45,7 +46,7 @@ public class BulkOperationWrapper {
 
     private final EventHandle eventHandle;
     private final BulkOperation bulkOperation;
-    private final JsonNode jsonNode;
+    private final SerializedJson jsonNode;
 
     public BulkOperationWrapper(final BulkOperation bulkOperation) {
         this.bulkOperation = bulkOperation;
@@ -53,7 +54,7 @@ public class BulkOperationWrapper {
         this.jsonNode = null;
     }
 
-    public BulkOperationWrapper(final BulkOperation bulkOperation, final EventHandle eventHandle, final JsonNode jsonNode) {
+    public BulkOperationWrapper(final BulkOperation bulkOperation, final EventHandle eventHandle, final SerializedJson jsonNode) {
         checkNotNull(bulkOperation);
         this.bulkOperation = bulkOperation;
         this.eventHandle = eventHandle;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkOperationWrapper.java
@@ -9,8 +9,6 @@ import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.SerializedJson;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -148,7 +148,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     dynamicIndexDroppedEvents = pluginMetrics.counter(DYNAMIC_INDEX_DROPPED_EVENTS);
     bulkRequestSizeBytesSummary = pluginMetrics.summary(BULKREQUEST_SIZE_BYTES);
 
-    this.openSearchSinkConfig = OpenSearchSinkConfiguration.readESConfig(pluginSetting);
+    this.openSearchSinkConfig = OpenSearchSinkConfiguration.readESConfig(pluginSetting, expressionEvaluator);
     this.bulkSize = ByteSizeUnit.MB.toBytes(openSearchSinkConfig.getIndexConfiguration().getBulkSize());
     this.flushTimeout = openSearchSinkConfig.getIndexConfiguration().getFlushTimeout();
     this.indexType = openSearchSinkConfig.getIndexConfiguration().getIndexType();

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -10,15 +10,12 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Timer;
 import org.apache.commons.lang3.StringUtils;
-import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.CreateOperation;
 import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
-import org.opensearch.client.opensearch.core.bulk.UpdateOperationData;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.opensearch.client.opensearch.core.bulk.DeleteOperation;
 import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import org.opensearch.client.transport.TransportOptions;
@@ -64,13 +61,7 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.index.TemplateStrategy
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.opensearch.client.json.JsonpMapper;
-import org.opensearch.client.json.jackson.JacksonJsonpMapper;
-import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
-import jakarta.json.stream.JsonGenerator;
-
 import java.io.BufferedWriter;
-import java.io.StringWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -86,7 +77,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.Iterator;
 
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.SENSITIVE;
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfiguration.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.sink.opensearch;
 
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfiguration;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -40,9 +41,13 @@ public class OpenSearchSinkConfiguration {
   }
 
   public static OpenSearchSinkConfiguration readESConfig(final PluginSetting pluginSetting) {
+    return readESConfig(pluginSetting, null);
+  }
+
+  public static OpenSearchSinkConfiguration readESConfig(final PluginSetting pluginSetting, final ExpressionEvaluator expressionEvaluator) {
     final ConnectionConfiguration connectionConfiguration =
             ConnectionConfiguration.readConnectionConfiguration(pluginSetting);
-    final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
+    final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting, expressionEvaluator);
     final RetryConfiguration retryConfiguration = RetryConfiguration.readRetryConfig(pluginSetting);
 
     return new OpenSearchSinkConfiguration(connectionConfiguration, indexConfiguration, retryConfiguration);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/BulkAction.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/BulkAction.java
@@ -14,6 +14,9 @@ import java.util.stream.Collectors;
 public enum BulkAction {
 
     CREATE("create"),
+    UPSERT("upsert"),
+    UPDATE("update"),
+    DELETE("delete"),
     INDEX("index");
 
     private static final Map<String, BulkAction> ACTIONS_MAP = Arrays.stream(BulkAction.values())
@@ -34,7 +37,7 @@ public enum BulkAction {
     }
 
     @JsonCreator
-    static BulkAction fromOptionValue(final String option) {
+    public static BulkAction fromOptionValue(final String option) {
         return ACTIONS_MAP.get(option.toLowerCase());
     }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingUncompressedBulkRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingUncompressedBulkRequest.java
@@ -5,6 +5,8 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -73,6 +75,10 @@ public class JavaClientAccumulatingUncompressedBulkRequest implements Accumulati
 
         if (anyDocument == null)
             return OPERATION_OVERHEAD;
+
+        if (anyDocument instanceof JsonNode) {
+            return OPERATION_OVERHEAD + ((JsonNode)anyDocument).toString().length();
+        }
 
         if (!(anyDocument instanceof SizedDocument)) {
             throw new IllegalArgumentException("Only SizedDocument is permitted for accumulating bulk requests. " + bulkOperation);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingUncompressedBulkRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingUncompressedBulkRequest.java
@@ -5,8 +5,6 @@ import org.opensearch.dataprepper.plugins.sink.opensearch.BulkOperationWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingUncompressedBulkRequest.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/JavaClientAccumulatingUncompressedBulkRequest.java
@@ -76,10 +76,6 @@ public class JavaClientAccumulatingUncompressedBulkRequest implements Accumulati
         if (anyDocument == null)
             return OPERATION_OVERHEAD;
 
-        if (anyDocument instanceof JsonNode) {
-            return OPERATION_OVERHEAD + ((JsonNode)anyDocument).toString().length();
-        }
-
         if (!(anyDocument instanceof SizedDocument)) {
             throw new IllegalArgumentException("Only SizedDocument is permitted for accumulating bulk requests. " + bulkOperation);
         }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/SerializedJson.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/SerializedJson.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.bulk;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Optional;
@@ -30,5 +31,8 @@ public interface SerializedJson extends SizedDocument {
         return new SerializedJsonImpl(jsonString.getBytes(StandardCharsets.UTF_8), docId, routingField);
     }
 
+    static SerializedJson fromJsonNode(final JsonNode jsonNode, SerializedJson document) {
+        return new SerializedJsonNode(jsonNode, document);
+    }
 }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/SerializedJsonNode.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/SerializedJsonNode.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch.bulk;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.Serializable;
+import java.util.Optional;
+
+class SerializedJsonNode implements SerializedJson, Serializable {
+    private byte[] document;
+    private JsonNode jsonNode;
+    private String documentId = null;
+    private String routingField = null;
+
+    public SerializedJsonNode(final JsonNode jsonNode, SerializedJson doc) {
+        this.jsonNode = jsonNode;
+        this.documentId = doc.getDocumentId().get();
+        this.routingField = doc.getRoutingField().get();
+        this.document = jsonNode.toString().getBytes();
+    }
+
+    public SerializedJsonNode(final JsonNode jsonNode) {
+        this.jsonNode = jsonNode;
+        this.document = jsonNode.toString().getBytes();
+    }
+
+    @Override
+    public long getDocumentSize() {
+        return document.length;
+    }
+
+    @Override
+    public byte[] getSerializedJson() {
+        return document;
+    }
+
+    @Override
+    public Optional<String> getDocumentId() {
+        return Optional.ofNullable(documentId);
+    }
+
+    @Override
+    public Optional<String> getRoutingField() {
+        return Optional.ofNullable(routingField);
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -8,7 +8,6 @@ package org.opensearch.dataprepper.plugins.sink.opensearch.index;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.EnumUtils;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.plugins.sink.opensearch.DistributionVersion;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkAction;

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
@@ -34,21 +34,6 @@ public class OpenSearchSinkConfigurationTests {
         assertEquals(BulkAction.INDEX.toString(), openSearchSinkConfiguration.getIndexConfiguration().getAction());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidAction() {
-
-        final Map<String, Object> metadata = new HashMap<>();
-        metadata.put(IndexConfiguration.INDEX_TYPE, IndexType.TRACE_ANALYTICS_RAW.getValue());
-        metadata.put(IndexConfiguration.ACTION, "invalid");
-        metadata.put(ConnectionConfiguration.HOSTS, TEST_HOSTS);
-
-        final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, metadata);
-        pluginSetting.setPipelineName(PIPELINE_NAME);
-
-        OpenSearchSinkConfiguration.readESConfig(pluginSetting);
-
-    }
-
     @Test
     public void testReadESConfigWithBulkActionCreate() {
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
@@ -10,11 +10,17 @@ import org.junit.Test;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkAction;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfiguration;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexType;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -23,6 +29,7 @@ public class OpenSearchSinkConfigurationTests {
     private final List<String> TEST_HOSTS = Collections.singletonList("http://localhost:9200");
     private static final String PLUGIN_NAME = "opensearch";
     private static final String PIPELINE_NAME = "integTestPipeline";
+    private ExpressionEvaluator expressionEvaluator;
 
     @Test
     public void testReadESConfig() {
@@ -32,6 +39,76 @@ public class OpenSearchSinkConfigurationTests {
         assertNotNull(openSearchSinkConfiguration.getIndexConfiguration());
         assertNotNull(openSearchSinkConfiguration.getRetryConfiguration());
         assertEquals(BulkAction.INDEX.toString(), openSearchSinkConfiguration.getIndexConfiguration().getAction());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidAction() {
+
+        final Map<String, Object> metadata = new HashMap<>();
+        metadata.put(IndexConfiguration.INDEX_TYPE, IndexType.TRACE_ANALYTICS_RAW.getValue());
+        metadata.put(IndexConfiguration.ACTION, "invalid");
+        metadata.put(ConnectionConfiguration.HOSTS, TEST_HOSTS);
+
+        final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, metadata);
+        pluginSetting.setPipelineName(PIPELINE_NAME);
+
+        OpenSearchSinkConfiguration.readESConfig(pluginSetting);
+
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidActions() {
+
+        final Map<String, Object> metadata = new HashMap<>();
+        metadata.put(IndexConfiguration.INDEX_TYPE, IndexType.TRACE_ANALYTICS_RAW.getValue());
+        List<Map<String, Object>> invalidActionList = new ArrayList<>();
+        Map<String, Object> actionMap = new HashMap<>();
+        actionMap.put("type", "invalid");
+        invalidActionList.add(actionMap);
+        metadata.put(IndexConfiguration.ACTIONS, invalidActionList);
+        metadata.put(ConnectionConfiguration.HOSTS, TEST_HOSTS);
+
+        final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, metadata);
+        pluginSetting.setPipelineName(PIPELINE_NAME);
+
+        OpenSearchSinkConfiguration.readESConfig(pluginSetting);
+
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidActionWithExpression() {
+
+        final Map<String, Object> metadata = new HashMap<>();
+        metadata.put(IndexConfiguration.INDEX_TYPE, IndexType.TRACE_ANALYTICS_RAW.getValue());
+        metadata.put(IndexConfiguration.ACTION, "${anInvalidFunction()}");
+        metadata.put(ConnectionConfiguration.HOSTS, TEST_HOSTS);
+
+        final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, metadata);
+        pluginSetting.setPipelineName(PIPELINE_NAME);
+
+        expressionEvaluator = mock(ExpressionEvaluator.class);
+        when(expressionEvaluator.isValidExpressionStatement(anyString())).thenReturn(false);
+        OpenSearchSinkConfiguration.readESConfig(pluginSetting, expressionEvaluator);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidActionsWithExpression() {
+
+        final Map<String, Object> metadata = new HashMap<>();
+        metadata.put(IndexConfiguration.INDEX_TYPE, IndexType.TRACE_ANALYTICS_RAW.getValue());
+        List<Map<String, Object>> invalidActionList = new ArrayList<>();
+        Map<String, Object> actionMap = new HashMap<>();
+        actionMap.put("type", "${anInvalidFunction()}");
+        invalidActionList.add(actionMap);
+        metadata.put(IndexConfiguration.ACTIONS, invalidActionList);
+        metadata.put(ConnectionConfiguration.HOSTS, TEST_HOSTS);
+
+        final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, metadata);
+        pluginSetting.setPipelineName(PIPELINE_NAME);
+
+        expressionEvaluator = mock(ExpressionEvaluator.class);
+        when(expressionEvaluator.isValidExpressionStatement(anyString())).thenReturn(false);
+        OpenSearchSinkConfiguration.readESConfig(pluginSetting, expressionEvaluator);
     }
 
     @Test
@@ -47,6 +124,27 @@ public class OpenSearchSinkConfigurationTests {
 
         final OpenSearchSinkConfiguration openSearchSinkConfiguration =
                 OpenSearchSinkConfiguration.readESConfig(pluginSetting);
+
+        assertNotNull(openSearchSinkConfiguration.getConnectionConfiguration());
+        assertNotNull(openSearchSinkConfiguration.getIndexConfiguration());
+        assertNotNull(openSearchSinkConfiguration.getRetryConfiguration());
+    }
+
+    @Test
+    public void testReadESConfigWithBulkActionCreateExpression() {
+
+        final Map<String, Object> metadata = new HashMap<>();
+        metadata.put(IndexConfiguration.INDEX_TYPE, IndexType.TRACE_ANALYTICS_RAW.getValue());
+        metadata.put(IndexConfiguration.ACTION, "${getMetadata(\"action\")}");
+        metadata.put(ConnectionConfiguration.HOSTS, TEST_HOSTS);
+
+        final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, metadata);
+        pluginSetting.setPipelineName(PIPELINE_NAME);
+
+        expressionEvaluator = mock(ExpressionEvaluator.class);
+        when(expressionEvaluator.isValidExpressionStatement(anyString())).thenReturn(true);
+        final OpenSearchSinkConfiguration openSearchSinkConfiguration =
+                OpenSearchSinkConfiguration.readESConfig(pluginSetting, expressionEvaluator);
 
         assertNotNull(openSearchSinkConfiguration.getConnectionConfiguration());
         assertNotNull(openSearchSinkConfiguration.getIndexConfiguration());

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/SerializedJsonNodeTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/SerializedJsonNodeTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.opensearch.bulk;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.lang3.RandomStringUtils;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class SerializedJsonNodeTest {
+    private int documentSize;
+    private byte[] documentBytes;
+    private String documentId;
+    private String routingField;
+    private JsonNode jsonNode;
+    private SerializedJson document;
+    private String jsonString;
+
+    @BeforeEach
+    void setUp() {
+        Random random = new Random();
+        jsonString = "{\"key\":\"value\"}";
+        documentSize = jsonString.length();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            jsonNode = objectMapper.readTree(jsonString);
+        } catch (Exception e) {
+            jsonNode = null;
+        }
+	    documentId = RandomStringUtils.randomAlphabetic(10);
+	    routingField = RandomStringUtils.randomAlphabetic(10);
+        document = SerializedJson.fromStringAndOptionals(jsonString, documentId, routingField);
+    }
+
+    private SerializedJsonNode createObjectUnderTest() {
+        return new SerializedJsonNode(jsonNode, document);
+    }
+
+    @Test
+    void getDocumentSize_returns_size_of_the_document_byte_array() {
+        assertThat(createObjectUnderTest().getDocumentSize(), equalTo((long) documentSize));
+    }
+
+    @Test
+    void getSerializedJson_returns_the_document_byte_array_and_fields() {
+        assertThat(createObjectUnderTest().getSerializedJson(), equalTo(jsonString.getBytes()));
+        assertThat(createObjectUnderTest().getDocumentId().get(), equalTo(documentId));
+        assertThat(createObjectUnderTest().getRoutingField().get(), equalTo(routingField));
+    }
+}
+

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/SerializedJsonNodeTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/SerializedJsonNodeTest.java
@@ -14,7 +14,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.lang3.RandomStringUtils;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class SerializedJsonNodeTest {

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/SerializedJsonTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/SerializedJsonTest.java
@@ -7,6 +7,8 @@ package org.opensearch.dataprepper.plugins.sink.opensearch.bulk;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.lang3.RandomStringUtils;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -26,13 +28,32 @@ class SerializedJsonTest {
 
     @Test
     void fromString_returns_SerializedJsonImpl_with_correctValues() {
-	String documentId = RandomStringUtils.randomAlphabetic(10);
-	String routingField = RandomStringUtils.randomAlphabetic(10);
-	SerializedJson serializedJson = SerializedJson.fromStringAndOptionals("{}", documentId, routingField);
-        assertThat(serializedJson, instanceOf(SerializedJsonImpl.class));
+        String documentId = RandomStringUtils.randomAlphabetic(10);
+        String routingField = RandomStringUtils.randomAlphabetic(10);
+        SerializedJson serializedJson = SerializedJson.fromStringAndOptionals("{}", documentId, routingField);
+            assertThat(serializedJson, instanceOf(SerializedJsonImpl.class));
         assertThat(serializedJson.getDocumentId().get(), equalTo(documentId));
         assertThat(serializedJson.getRoutingField().get(), equalTo(routingField));
         assertThat(serializedJson.getSerializedJson(), equalTo("{}".getBytes()));
     }
 
+    @Test
+    void fromString_returns_SerializedJsonNode_with_correctValues() {
+        String documentId = RandomStringUtils.randomAlphabetic(10);
+        String routingField = RandomStringUtils.randomAlphabetic(10);
+        final String jsonString = "{\"key\":\"value\"}";
+        JsonNode jsonNode;
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            jsonNode = objectMapper.readTree(jsonString);
+        } catch (Exception e) {
+            jsonNode = null;
+        }
+        SerializedJson document = SerializedJson.fromStringAndOptionals(jsonString, documentId, routingField);
+        SerializedJson serializedJson = SerializedJson.fromJsonNode(jsonNode, document);
+        assertThat(serializedJson, instanceOf(SerializedJsonNode.class));
+        assertThat(serializedJson.getDocumentId().get(), equalTo(documentId));
+        assertThat(serializedJson.getRoutingField().get(), equalTo(routingField));
+        assertThat(serializedJson.getSerializedJson(), equalTo(jsonString.getBytes()));
+    }
 }

--- a/data-prepper-plugins/opensearch/src/test/resources/test-bulk-template.json
+++ b/data-prepper-plugins/opensearch/src/test/resources/test-bulk-template.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "mappings": {
+    "date_detection": false,
+    "dynamic_templates": [
+      {
+        "strings_as_keyword": {
+          "mapping": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "match_mapping_type": "string"
+        }
+      }
+    ],
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "name": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
### Description
Add support for Update/Upsert/Delete operations in OpenSearch Sink
Actions can be specified with type = Create/Index/Update/Upsert/Delete and with condition
Adds support for expressions in "action" or actions "type".
 
Resolves #3109
### Issues Resolved
Resolves #3109 
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
