### PR TITLE
Add inline template_content support to the opensearch sink

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -5,18 +5,18 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;
 
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.EnumUtils;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.plugins.sink.opensearch.DistributionVersion;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkAction;
 import org.opensearch.dataprepper.plugins.sink.opensearch.s3.FileReader;
 import org.opensearch.dataprepper.plugins.sink.opensearch.s3.S3ClientProvider;
 import org.opensearch.dataprepper.plugins.sink.opensearch.s3.S3FileReader;
-import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.arns.Arn;
@@ -27,8 +27,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -44,6 +44,7 @@ public class IndexConfiguration {
     public static final String INDEX_TYPE = "index_type";
     public static final String TEMPLATE_TYPE = "template_type";
     public static final String TEMPLATE_FILE = "template_file";
+    public static final String TEMPLATE_CONTENT = "template_content";
     public static final String NUM_SHARDS = "number_of_shards";
     public static final String NUM_REPLICAS = "number_of_replicas";
     public static final String BULK_SIZE = "bulk_size";
@@ -105,7 +106,8 @@ public class IndexConfiguration {
         this.s3Client = builder.s3Client;
 
         determineTemplateType(builder);
-        this.indexTemplate = readIndexTemplate(builder.templateFile, indexType, templateType);
+
+        this.indexTemplate = builder.templateContent != null ? readTemplateContent(builder.templateContent) : readIndexTemplate(builder.templateFile, indexType, templateType);
 
         if (builder.numReplicas > 0) {
             indexTemplate.putIfAbsent(SETTINGS, new HashMap<>());
@@ -187,6 +189,16 @@ public class IndexConfiguration {
         if (templateFile != null) {
             builder = builder.withTemplateFile(templateFile);
         }
+
+        final String templateContent = pluginSetting.getStringOrDefault(TEMPLATE_CONTENT, null);
+        if (templateContent != null) {
+            builder = builder.withTemplateContent(templateContent);
+        }
+
+        if (templateContent != null && templateFile != null) {
+            LOG.warn("Both template_content and template_file are configured. Only template_content will be used");
+        }
+
         builder = builder.withNumShards(pluginSetting.getIntegerOrDefault(NUM_SHARDS, 0));
         builder = builder.withNumReplicas(pluginSetting.getIntegerOrDefault(NUM_REPLICAS, 0));
         final Long batchSize = pluginSetting.getLongOrDefault(BULK_SIZE, DEFAULT_BULK_SIZE);
@@ -365,6 +377,7 @@ public class IndexConfiguration {
                     templateURL = new File(templateFile).toURI().toURL();
                 }
             }
+
             if (templateURL != null) {
                 return new ObjectMapper().readValue(templateURL, new TypeReference<Map<String, Object>>() {
                 });
@@ -379,6 +392,14 @@ public class IndexConfiguration {
         }
     }
 
+    private Map<String, Object> readTemplateContent(final String templateContent) {
+        try {
+            return OBJECT_MAPPER.readValue(templateContent, new TypeReference<Map<String, Object>>() {});
+        } catch (IOException ex) {
+            throw new InvalidPluginConfigurationException(String.format("template_content is invalid: %s", ex.getMessage()));
+        }
+    }
+
     private URL loadExistingTemplate(TemplateType templateType, String predefinedTemplateName) {
         String resourcePath = templateType == TemplateType.V1 ? predefinedTemplateName : templateType.getTypeName() + "/" + predefinedTemplateName;
         return getClass().getClassLoader()
@@ -390,6 +411,7 @@ public class IndexConfiguration {
         private String indexType;
         private TemplateType templateType;
         private String templateFile;
+        private String templateContent;
         private int numShards;
         private int numReplicas;
         private String routingField;
@@ -434,6 +456,12 @@ public class IndexConfiguration {
         public Builder withTemplateFile(final String templateFile) {
             checkArgument(templateFile != null, "templateFile cannot be null.");
             this.templateFile = templateFile;
+            return this;
+        }
+
+        public Builder withTemplateContent(final String templateContent) {
+            checkArgument(templateContent != null, "templateContent cannot be null.");
+            this.templateContent = templateContent;
             return this;
         }
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -275,7 +275,7 @@ public class IndexConfigurationTests {
         final String testIndexAlias = "test";
         IndexConfiguration indexConfiguration = new IndexConfiguration.Builder()
                 .withIndexAlias(testIndexAlias)
-                .withTemplateContent(getTemplateContent())
+                .withTemplateContent(createTemplateContent())
                 .withBulkSize(10)
                 .build();
 
@@ -283,18 +283,18 @@ public class IndexConfigurationTests {
         assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
         assertEquals(10, indexConfiguration.getBulkSize());
         assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
-        assertThat(indexConfiguration.getIndexTemplate(), equalTo(OBJECT_MAPPER.readValue(getTemplateContent(), new TypeReference<>() {})));
+        assertThat(indexConfiguration.getIndexTemplate(), equalTo(OBJECT_MAPPER.readValue(createTemplateContent(), new TypeReference<>() {})));
     }
 
     @Test
     public void readIndexConfigWithTemplateFileAndTemplateContentUsesTemplateContent() throws JsonProcessingException {
-        final PluginSetting pluginSetting = generatePluginSetting("custom", "test", "test-file", getTemplateContent(), null, null, null);
+        final PluginSetting pluginSetting = generatePluginSetting("custom", "test", "test-file", createTemplateContent(), null, null, null);
 
         final IndexConfiguration objectUnderTest = IndexConfiguration.readIndexConfig(pluginSetting);
 
         assertThat(objectUnderTest, notNullValue());
         assertThat(objectUnderTest.getIndexTemplate(), notNullValue());
-        assertThat(objectUnderTest.getIndexTemplate(), equalTo(OBJECT_MAPPER.readValue(getTemplateContent(), new TypeReference<>() {})));
+        assertThat(objectUnderTest.getIndexTemplate(), equalTo(OBJECT_MAPPER.readValue(createTemplateContent(), new TypeReference<>() {})));
     }
 
     @Test
@@ -530,7 +530,7 @@ public class IndexConfigurationTests {
         return metadata;
     }
 
-    private String getTemplateContent() {
+    private String createTemplateContent() {
         return "{\"index_patterns\":[\"test-*\"]," +
                 "\"template\":{\"aliases\":{\"my_test_logs\":{}}," +
                 "\"settings\":{\"number_of_shards\":5,\"number_of_replicas\":2,\"refresh_interval\":-1}," +

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -5,11 +5,15 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.plugins.sink.opensearch.DistributionVersion;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.http.AbortableInputStream;
@@ -34,6 +38,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -52,6 +57,8 @@ import static org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexCons
 
 @SuppressWarnings("unchecked")
 public class IndexConfigurationTests {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     private static final String DEFAULT_TEMPLATE_FILE = "test-template-withshards.json";
     private static final String TEST_CUSTOM_INDEX_POLICY_FILE = "test-custom-index-policy-file.json";
 
@@ -193,7 +200,7 @@ public class IndexConfigurationTests {
     }
 
     @Test
-    public void testValidCustomWithNoTemplateFile() throws MalformedURLException {
+    public void testValidCustomWithNoTemplateFile() {
         final String testIndexAlias = "foo";
         IndexConfiguration indexConfiguration = new IndexConfiguration.Builder()
                 .withIndexAlias(testIndexAlias)
@@ -264,6 +271,43 @@ public class IndexConfigurationTests {
     }
 
     @Test
+    public void testValidCustomWithTemplateContent() throws JsonProcessingException {
+        final String testIndexAlias = "test";
+        IndexConfiguration indexConfiguration = new IndexConfiguration.Builder()
+                .withIndexAlias(testIndexAlias)
+                .withTemplateContent(getTemplateContent())
+                .withBulkSize(10)
+                .build();
+
+        assertEquals(IndexType.CUSTOM, indexConfiguration.getIndexType());
+        assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
+        assertEquals(10, indexConfiguration.getBulkSize());
+        assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
+        assertThat(indexConfiguration.getIndexTemplate(), equalTo(OBJECT_MAPPER.readValue(getTemplateContent(), new TypeReference<>() {})));
+    }
+
+    @Test
+    public void readIndexConfigWithTemplateFileAndTemplateContentUsesTemplateContent() throws JsonProcessingException {
+        final PluginSetting pluginSetting = generatePluginSetting("custom", "test", "test-file", getTemplateContent(), null, null, null);
+
+        final IndexConfiguration objectUnderTest = IndexConfiguration.readIndexConfig(pluginSetting);
+
+        assertThat(objectUnderTest, notNullValue());
+        assertThat(objectUnderTest.getIndexTemplate(), notNullValue());
+        assertThat(objectUnderTest.getIndexTemplate(), equalTo(OBJECT_MAPPER.readValue(getTemplateContent(), new TypeReference<>() {})));
+    }
+
+    @Test
+    public void invalidTemplateContentThrowsInvalidPluginConfigurationException() {
+        final String invalidTemplateContent = UUID.randomUUID().toString();
+
+        final PluginSetting pluginSetting = generatePluginSetting("custom", null, null, invalidTemplateContent, null, null, null);
+
+        assertThrows(InvalidPluginConfigurationException.class, () -> IndexConfiguration.readIndexConfig(pluginSetting));
+
+    }
+
+    @Test
     public void testInvalidCustom() {
         // Missing index alias
         final IndexConfiguration.Builder invalidBuilder = new IndexConfiguration.Builder();
@@ -274,7 +318,7 @@ public class IndexConfigurationTests {
     @Test
     public void testReadIndexConfig_RawIndexType() {
         final Map<String, Object> metadata = initializeConfigMetaData(
-                IndexType.TRACE_ANALYTICS_RAW.getValue(), null, null, null, null, null);
+                IndexType.TRACE_ANALYTICS_RAW.getValue(), null, null, null, null, null, null);
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         final URL expTemplateFile = indexConfiguration
@@ -292,7 +336,7 @@ public class IndexConfigurationTests {
     @Test
     public void testReadIndexConfig_InvalidIndexTypeValueString() {
         final Map<String, Object> metadata = initializeConfigMetaData(
-                "i-am-an-illegitimate-index-type", null, null, null, null, null);
+                "i-am-an-illegitimate-index-type", null, null, null, null, null, null);
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         assertThrows(IllegalArgumentException.class, () -> IndexConfiguration.readIndexConfig(pluginSetting));
     }
@@ -300,7 +344,7 @@ public class IndexConfigurationTests {
     @Test
     public void testReadIndexConfig_ServiceMapIndexType() {
         final Map<String, Object> metadata = initializeConfigMetaData(
-                IndexType.TRACE_ANALYTICS_SERVICE_MAP.getValue(), null, null, null, null, null);
+                IndexType.TRACE_ANALYTICS_SERVICE_MAP.getValue(), null, null, null, null, null, null);
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         final URL expTemplateFile = indexConfiguration
@@ -324,7 +368,7 @@ public class IndexConfigurationTests {
         final long testFlushTimeout = 30_000L;
         final String testIdField = "someId";
         final PluginSetting pluginSetting = generatePluginSetting(
-                null, testIndexAlias, defaultTemplateFilePath, testBulkSize, testFlushTimeout, testIdField);
+                null, testIndexAlias, defaultTemplateFilePath, null, testBulkSize, testFlushTimeout, testIdField);
         pluginSetting.getSettings().put(IndexConfiguration.ESTIMATE_BULK_SIZE_USING_COMPRESSION, true);
         pluginSetting.getSettings().put(IndexConfiguration.MAX_LOCAL_COMPRESSIONS_FOR_ESTIMATION, 5);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
@@ -348,7 +392,7 @@ public class IndexConfigurationTests {
         final long testFlushTimeout = 30_000L;
         final String testIdField = "someId";
         final Map<String, Object> metadata = initializeConfigMetaData(
-                testIndexType, testIndexAlias, defaultTemplateFilePath, testBulkSize, testFlushTimeout, testIdField);
+                testIndexType, testIndexAlias, defaultTemplateFilePath, null, testBulkSize, testFlushTimeout, testIdField);
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         assertEquals(IndexType.CUSTOM, indexConfiguration.getIndexType());
@@ -363,7 +407,7 @@ public class IndexConfigurationTests {
     public void testReadIndexConfig_awsOptionServerlessDefault() {
         final String testIndexAlias = "foo";
         final Map<String, Object> metadata = initializeConfigMetaData(
-                null, testIndexAlias, null, null, null, null);
+                null, testIndexAlias, null, null, null, null, null);
         metadata.put(AWS_OPTION, Map.of(SERVERLESS, true));
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
@@ -375,7 +419,7 @@ public class IndexConfigurationTests {
     public void testReadIndexConfig_awsServerlessIndexTypeOverride() {
         final String testIndexAlias = "foo";
         final Map<String, Object> metadata = initializeConfigMetaData(
-                IndexType.CUSTOM.getValue(), testIndexAlias, null, null, null, null);
+                IndexType.CUSTOM.getValue(), testIndexAlias, null, null, null, null, null);
         metadata.put(AWS_OPTION, Map.of(SERVERLESS, true));
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
@@ -387,7 +431,7 @@ public class IndexConfigurationTests {
     @Test
     public void testReadIndexConfig_distributionVersionDefault() {
         final Map<String, Object> metadata = initializeConfigMetaData(
-                null, "foo", null, null, null, null);
+                null, "foo", null,null, null, null, null);
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         assertEquals(indexConfiguration.getDistributionVersion(), DistributionVersion.DEFAULT);
@@ -396,7 +440,7 @@ public class IndexConfigurationTests {
     @Test
     public void testReadIndexConfig_es6Override() {
         final Map<String, Object> metadata = initializeConfigMetaData(
-                null, "foo", null, null, null, null);
+                null, "foo", null, null, null, null, null);
         metadata.put(DISTRIBUTION_VERSION, "es6");
         metadata.put(TEMPLATE_TYPE, TemplateType.INDEX_TEMPLATE.getTypeName());
         final PluginSetting pluginSetting = getPluginSetting(metadata);
@@ -409,7 +453,7 @@ public class IndexConfigurationTests {
     @Test
     public void testReadIndexConfig_documentRootKey() {
         final Map<String, Object> metadata = initializeConfigMetaData(
-            IndexType.CUSTOM.getValue(), "foo", null, null, null, null);
+            IndexType.CUSTOM.getValue(), "foo", null, null, null, null, null);
         final String expectedRootKey = UUID.randomUUID().toString();
         metadata.put(DOCUMENT_ROOT_KEY, expectedRootKey);
         final PluginSetting pluginSetting = getPluginSetting(metadata);
@@ -420,7 +464,7 @@ public class IndexConfigurationTests {
     @Test
     public void testReadIndexConfig_emptyDocumentRootKey() {
         final Map<String, Object> metadata = initializeConfigMetaData(
-            IndexType.CUSTOM.getValue(), "foo", null, null, null, null);
+            IndexType.CUSTOM.getValue(), "foo", null, null, null, null, null);
         metadata.put(DOCUMENT_ROOT_KEY, "");
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         assertThrows(IllegalArgumentException.class, () -> IndexConfiguration.readIndexConfig(pluginSetting));
@@ -429,7 +473,7 @@ public class IndexConfigurationTests {
     @Test
     void getTemplateType_defaults_to_V1() {
         final Map<String, Object> metadata = initializeConfigMetaData(
-                IndexType.CUSTOM.getValue(), "foo", null, null, null, null);
+                IndexType.CUSTOM.getValue(), "foo", null, null, null, null, null);
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         assertThat(indexConfiguration.getTemplateType(), equalTo(TemplateType.V1));
@@ -439,7 +483,7 @@ public class IndexConfigurationTests {
     @EnumSource(TemplateType.class)
     void getTemplateType_with_configured_templateType(final TemplateType templateType) {
         final Map<String, Object> metadata = initializeConfigMetaData(
-                IndexType.CUSTOM.getValue(), "foo", null, null, null, null);
+                IndexType.CUSTOM.getValue(), "foo", null, null, null, null, null);
         metadata.put(TEMPLATE_TYPE, templateType.getTypeName());
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
@@ -447,9 +491,9 @@ public class IndexConfigurationTests {
     }
 
     private PluginSetting generatePluginSetting(
-            final String indexType, final String indexAlias, final String templateFilePath,
+            final String indexType, final String indexAlias, final String templateFilePath, final String templateContent,
             final Long bulkSize, final Long flushTimeout, final String documentIdField) {
-        final Map<String, Object> metadata = initializeConfigMetaData(indexType, indexAlias, templateFilePath, bulkSize, flushTimeout, documentIdField);
+        final Map<String, Object> metadata = initializeConfigMetaData(indexType, indexAlias, templateFilePath, templateContent, bulkSize, flushTimeout, documentIdField);
         return getPluginSetting(metadata);
     }
 
@@ -458,7 +502,7 @@ public class IndexConfigurationTests {
     }
 
     private Map<String, Object> initializeConfigMetaData(
-            String indexType, String indexAlias, String templateFilePath, Long bulkSize, Long flushTimeout, String documentId) {
+            String indexType, String indexAlias, String templateFilePath, String templateContent, Long bulkSize, Long flushTimeout, String documentId) {
         final Map<String, Object> metadata = new HashMap<>();
         if (indexType != null) {
             metadata.put(IndexConfiguration.INDEX_TYPE, indexType);
@@ -469,6 +513,11 @@ public class IndexConfigurationTests {
         if (templateFilePath != null) {
             metadata.put(IndexConfiguration.TEMPLATE_FILE, templateFilePath);
         }
+
+        if (templateContent != null) {
+            metadata.put(IndexConfiguration.TEMPLATE_CONTENT, templateContent);
+        }
+
         if (bulkSize != null) {
             metadata.put(IndexConfiguration.BULK_SIZE, bulkSize);
         }
@@ -479,5 +528,13 @@ public class IndexConfigurationTests {
             metadata.put(IndexConfiguration.DOCUMENT_ID, documentId);
         }
         return metadata;
+    }
+
+    private String getTemplateContent() {
+        return "{\"index_patterns\":[\"test-*\"]," +
+                "\"template\":{\"aliases\":{\"my_test_logs\":{}}," +
+                "\"settings\":{\"number_of_shards\":5,\"number_of_replicas\":2,\"refresh_interval\":-1}," +
+                "\"mappings\":{\"properties\":{\"timestamp\":{\"type\":\"date\",\"format\":\"yyyy-MM-ddHH:mm:ss||yyyy-MM-dd||epoch_millis\"}," +
+                "\"value\":{\"type\":\"double\"}}}}}";
     }
 }


### PR DESCRIPTION
### Description
Adds a `template_content` parameter for inline index templates in the OpenSearch sink. This can be used as an alternative to `template_file`
 
### Issues Resolved
Resolves #3365 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
