### PR TITLE
Remove support for Enum and Duration values from secrets manager

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ObjectMapperConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ObjectMapperConfiguration.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public class ObjectMapperConfiguration {
     static final Set<Class> TRANSLATE_VALUE_SUPPORTED_JAVA_TYPES = Set.of(
             String.class, Number.class, Long.class, Short.class, Integer.class, Double.class, Float.class,
-            Boolean.class, Duration.class, Enum.class, Character.class);
+            Boolean.class, Character.class);
 
     @Bean(name = "extensionPluginConfigObjectMapper")
     ObjectMapper extensionPluginConfigObjectMapper() {
@@ -32,6 +32,7 @@ public class ObjectMapperConfiguration {
     @Bean(name = "pluginConfigObjectMapper")
     ObjectMapper pluginConfigObjectMapper(final VariableExpander variableExpander) {
         final SimpleModule simpleModule = new SimpleModule();
+        simpleModule.addDeserializer(Duration.class, new DataPrepperDurationDeserializer());
         TRANSLATE_VALUE_SUPPORTED_JAVA_TYPES.stream().forEach(clazz -> simpleModule.addDeserializer(
                 clazz, new DataPrepperScalarTypeDeserializer<>(variableExpander, clazz)));
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ObjectMapperConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ObjectMapperConfigurationTest.java
@@ -1,0 +1,81 @@
+package org.opensearch.dataprepper.plugin;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+@ExtendWith(MockitoExtension.class)
+class ObjectMapperConfigurationTest {
+    private final ObjectMapperConfiguration objectMapperConfiguration = new ObjectMapperConfiguration();
+
+    @Mock
+    private VariableExpander variableExpander;
+
+    @Test
+    void test_duration_with_pluginConfigObjectMapper() {
+        final String durationTestString = "10s";
+        final ObjectMapper objectMapper = objectMapperConfiguration.pluginConfigObjectMapper(variableExpander);
+        final Duration duration = objectMapper.convertValue(durationTestString, Duration.class);
+        assertThat(duration, equalTo(Duration.ofSeconds(10)));
+    }
+
+    @Test
+    void test_enum_with_pluginConfigObjectMapper() {
+        final String testString = "test";
+        final ObjectMapper objectMapper = objectMapperConfiguration.pluginConfigObjectMapper(variableExpander);
+        final TestType duration = objectMapper.convertValue(testString, TestType.class);
+        assertThat(duration, equalTo(TestType.fromOptionValue(testString)));
+    }
+
+    @Test
+    void test_duration_with_extensionPluginConfigObjectMapper() {
+        final String durationTestString = "10s";
+        final ObjectMapper objectMapper = objectMapperConfiguration.extensionPluginConfigObjectMapper();
+        final Duration duration = objectMapper.convertValue(durationTestString, Duration.class);
+        assertThat(duration, equalTo(Duration.ofSeconds(10)));
+    }
+
+    @Test
+    void test_enum_with_extensionPluginConfigObjectMapper() {
+        final String testString = "test";
+        final ObjectMapper objectMapper = objectMapperConfiguration.extensionPluginConfigObjectMapper();
+        final TestType duration = objectMapper.convertValue(testString, TestType.class);
+        assertThat(duration, equalTo(TestType.fromOptionValue(testString)));
+    }
+
+    private enum TestType {
+
+        TEST("test");
+
+        private static final Map<String, TestType> NAMES_MAP = Arrays.stream(TestType.values())
+                .collect(Collectors.toMap(TestType::toString, Function.identity()));
+
+        private final String name;
+
+        TestType(final String name) {
+            this.name = name;
+        }
+
+        public String toString() {
+            return this.name;
+        }
+
+        @JsonCreator
+        static TestType fromOptionValue(final String option) {
+            return NAMES_MAP.get(option);
+        }
+    }
+
+}


### PR DESCRIPTION
### Description
This change removed support for `Duration` and `Enum` in AWS secrets manager 
 
### Issues Resolved
Resolves #3376 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
