### PR TITLE
Kafka Fixes

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
@@ -143,7 +143,7 @@ public class KafkaCustomProducer<T> {
     }
 
     private void publishJsonMessage(final Record<Event> record, final String key) throws IOException, ProcessingException {
-        final JsonNode dataNode = new ObjectMapper().convertValue(record.getData().toJsonString(), JsonNode.class);
+        final JsonNode dataNode = record.getData().getJsonNode();
         if (validateJson(topicName, record.getData().toJsonString())) {
             send(topicName, key, dataNode);
         } else {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/service/TopicService.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/service/TopicService.java
@@ -6,6 +6,7 @@ package org.opensearch.dataprepper.plugins.kafka.service;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.errors.TopicExistsException;
 import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaProducerConfig;
 import org.opensearch.dataprepper.plugins.kafka.util.SinkPropertyConfigurer;
 import org.slf4j.Logger;
@@ -29,7 +30,9 @@ public class TopicService {
             LOG.info(topicName + " created successfully");
 
         } catch (Exception e) {
-            LOG.error("Caught exception creating topic with name: {}", topicName, e);
+            if (!(e.getCause() instanceof TopicExistsException)) {
+                LOG.error("Caught exception creating topic with name: {}", topicName, e);
+            }
         }
     }
 


### PR DESCRIPTION
### Description
1. Fix serialization/de-serialization
2. Fix publishJsonMessage() to not convert JSon to string when  the following is done. 
`final JsonNode dataNode = new ObjectMapper().convertValue(record.getData().toJsonString(), JsonNode.class);`
Instead use the new Event API to get the jsonNode 
`final JsonNode dataNode = record.getData().getJsonNode();`
3. Fix `setAuthProperties` to check for null auth configs
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
