### PR TITLE
Shutdown kafka buffer

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/Buffer.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/Buffer.java
@@ -58,4 +58,7 @@ public interface Buffer<T extends Record<?>> {
     default Duration getDrainTimeout() {
         return Duration.ZERO;
     }
+
+    default void shutdown() {
+    }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/BufferTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/BufferTest.java
@@ -22,4 +22,10 @@ public class BufferTest {
 
         Assert.assertEquals(Duration.ZERO, buffer.getDrainTimeout());
     }
+
+    @Test
+    public void testShutdown() {
+        final Buffer<Record<Event>> buffer = spy(Buffer.class);
+        buffer.shutdown();
+    }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/CircuitBreakingBuffer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/CircuitBreakingBuffer.java
@@ -77,4 +77,9 @@ class CircuitBreakingBuffer<T extends Record<?>> implements Buffer<T> {
     public Duration getDrainTimeout() {
         return buffer.getDrainTimeout();
     }
+
+    @Override
+    public void shutdown() {
+        buffer.shutdown();
+    }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/Pipeline.java
@@ -280,6 +280,8 @@ public class Pipeline {
         shutdownExecutorService(processorExecutorService, buffer.getDrainTimeout().toMillis() + processorShutdownTimeout.toMillis(), "processor");
 
         processorSets.forEach(processorSet -> processorSet.forEach(Processor::shutdown));
+        buffer.shutdown();
+
         sinks.stream()
                 .map(DataFlowComponent::getComponent)
                 .forEach(Sink::shutdown);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugins/MultiBufferDecorator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugins/MultiBufferDecorator.java
@@ -64,4 +64,10 @@ public class MultiBufferDecorator<T extends Record<?>> implements Buffer<T> {
                 .map(Buffer::getDrainTimeout)
                 .reduce(Duration.ZERO, Duration::plus);
     }
+
+    @Override
+    public void shutdown() {
+        primaryBuffer.shutdown();
+        secondaryBuffers.forEach(Buffer::shutdown);
+    }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/CircuitBreakingBufferTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/CircuitBreakingBufferTest.java
@@ -75,6 +75,12 @@ class CircuitBreakingBufferTest {
         assertThat(result, equalTo(duration));
     }
 
+    @Test
+    void shutdown_calls_buffer_shutdown() {
+        createObjectUnderTest().shutdown();
+        verify(buffer).shutdown();
+    }
+
     @Nested
     class NoCircuitBreakerChecks {
         @AfterEach

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineTests.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Spy;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.processor.Processor;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/PipelineTests.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Spy;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.processor.Processor;
@@ -107,7 +108,8 @@ class PipelineTests {
         final TestSink testSink = new TestSink();
         final DataFlowComponent<Sink> sinkDataFlowComponent = mock(DataFlowComponent.class);
         when(sinkDataFlowComponent.getComponent()).thenReturn(testSink);
-        final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
+        final Buffer buffer = spy(new BlockingBuffer(TEST_PIPELINE_NAME));
+        final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, buffer,
                 Collections.emptyList(), Collections.singletonList(sinkDataFlowComponent), router, eventFactory, 
                 acknowledgementSetManager, sourceCoordinatorFactory, TEST_PROCESSOR_THREADS, TEST_READ_BATCH_TIMEOUT,
                 processorShutdownTimeout, sinkShutdownTimeout, peerForwarderDrainTimeout);
@@ -119,6 +121,7 @@ class PipelineTests {
         testPipeline.shutdown();
         assertThat("Pipeline isStopRequested is expected to be true", testPipeline.isStopRequested(), is(true));
         assertThat("Sink shutdown should be called", testSink.isShutdown, is(true));
+        verify(buffer).shutdown();
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugins/MultiBufferDecoratorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugins/MultiBufferDecoratorTest.java
@@ -201,6 +201,26 @@ public class MultiBufferDecoratorTest {
         verify(secondaryBuffer, times(2)).getDrainTimeout();
     }
 
+    @Test
+    void shutdown_NoSecondaryBuffers_CallsPrimaryBufferShutdown() {
+        createObjectUnderTest(0).shutdown();
+        verify(primaryBuffer).shutdown();
+    }
+
+    @Test
+    void shutdown_OneSecondaryBuffers_CallsPrimaryAndSecondaryBufferShutdown() {
+        createObjectUnderTest(1).shutdown();
+        verify(primaryBuffer).shutdown();
+        verify(secondaryBuffer).shutdown();
+    }
+
+    @Test
+    void shutdown_MultipleSecondaryBuffers_CallsAllBuffersShutdown() {
+        createObjectUnderTest(2).shutdown();
+        verify(primaryBuffer).shutdown();
+        verify(secondaryBuffer, times(2)).shutdown();
+    }
+
     private MultiBufferDecorator createObjectUnderTest(final int secondaryBufferCount) {
         final List<Buffer> secondaryBuffers = IntStream.range(0, secondaryBufferCount)
                 .mapToObj(i -> secondaryBuffer)

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
@@ -37,7 +37,6 @@ public class KafkaBuffer<T extends Record<?>> extends AbstractBuffer<T> {
     public static final int INNER_BUFFER_CAPACITY = 1000000;
     public static final int INNER_BUFFER_BATCH_SIZE = 250000;
     private final KafkaCustomProducer producer;
-    private final List<KafkaCustomConsumer> emptyCheckingConsumers;
     private final AbstractBuffer innerBuffer;
     private final ExecutorService executorService;
     private final Duration drainTimeout;
@@ -54,8 +53,6 @@ public class KafkaBuffer<T extends Record<?>> extends AbstractBuffer<T> {
         this.shutdownInProgress = new AtomicBoolean(false);
         final List<KafkaCustomConsumer> consumers = kafkaCustomConsumerFactory.createConsumersForTopic(kafkaBufferConfig, kafkaBufferConfig.getTopic(),
             innerBuffer, pluginMetrics, acknowledgementSetManager, shutdownInProgress);
-        emptyCheckingConsumers = kafkaCustomConsumerFactory.createConsumersForTopic(kafkaBufferConfig, kafkaBufferConfig.getTopic(),
-                innerBuffer, pluginMetrics, acknowledgementSetManager, shutdownInProgress);
         this.executorService = Executors.newFixedThreadPool(consumers.size());
         consumers.forEach(this.executorService::submit);
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaBufferConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaBufferConfig.java
@@ -116,7 +116,7 @@ public class KafkaBufferConfig implements KafkaProducerConfig, KafkaConsumerConf
 
     @Override
     public boolean getAcknowledgementsEnabled() {
-        return true;
+        return false;
     }
 
     public Duration getDrainTimeout() {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaBufferConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaBufferConfig.java
@@ -116,7 +116,7 @@ public class KafkaBufferConfig implements KafkaProducerConfig, KafkaConsumerConf
 
     @Override
     public boolean getAcknowledgementsEnabled() {
-        return false;
+        return true;
     }
 
     public Duration getDrainTimeout() {


### PR DESCRIPTION
### Description
Adds a shutdown method to the buffer interface and implements the method for the kafka and decorator buffers.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
