### PR TITLE
Fix MSK integration test fix

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/MskGlueRegistryMultiTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/MskGlueRegistryMultiTypeIT.java
@@ -35,6 +35,7 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.AwsConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.AwsIamAuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.EncryptionConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.EncryptionType;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaKeyMode;
 import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaSourceConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.MskBrokerConnectionType;
 import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaConfig;
@@ -166,14 +167,19 @@ public class MskGlueRegistryMultiTypeIT {
         when(avroTopic.getAutoCommit()).thenReturn(false);
         when(avroTopic.getAutoOffsetReset()).thenReturn("earliest");
         when(avroTopic.getThreadWaitingTime()).thenReturn(Duration.ofSeconds(1));
-        when(avroTopic.getSessionTimeOut()).thenReturn(Duration.ofSeconds(5));
+        when(avroTopic.getMaxPollInterval()).thenReturn(Duration.ofSeconds(300));
+        when(avroTopic.getSessionTimeOut()).thenReturn(Duration.ofSeconds(10));
         when(avroTopic.getHeartBeatInterval()).thenReturn(Duration.ofSeconds(3));
+        when(avroTopic.getKafkaKeyMode()).thenReturn(KafkaKeyMode.INCLUDE_AS_FIELD);
         when(jsonTopic.getName()).thenReturn(testTopic);
+        when(jsonTopic.getMaxPollInterval()).thenReturn(Duration.ofSeconds(300));
         when(jsonTopic.getGroupId()).thenReturn(testGroup);
         when(jsonTopic.getWorkers()).thenReturn(1);
         when(jsonTopic.getAutoCommit()).thenReturn(false);
         when(jsonTopic.getAutoOffsetReset()).thenReturn("earliest");
         when(jsonTopic.getThreadWaitingTime()).thenReturn(Duration.ofSeconds(1));
+        when(jsonTopic.getSessionTimeOut()).thenReturn(Duration.ofSeconds(10));
+        when(jsonTopic.getKafkaKeyMode()).thenReturn(KafkaKeyMode.INCLUDE_AS_FIELD);
         when(jsonTopic.getHeartBeatInterval()).thenReturn(Duration.ofSeconds(3));
         bootstrapServers = System.getProperty("tests.kafka.bootstrap_servers");
         testRegistryName = System.getProperty("tests.kafka.glue_registry_name");
@@ -234,10 +240,10 @@ public class MskGlueRegistryMultiTypeIT {
 	for (int i = 0; i < numRecords; i++) {
             Record<Event> record = receivedRecords.get(i);
             Event event = (Event)record.getData();
-            Map<String, Object> val = event.get("message-"+i, Map.class);
-            assertThat(val.get("username"), equalTo(TEST_USER+i));
-            assertThat(val.get("message"), equalTo(TEST_MESSAGE+i));
-            assertThat(((Number)val.get("timestamp")).intValue(), equalTo(TEST_TIMESTAMP_INT+i));
+            assertThat(event.get("username", String.class), equalTo(TEST_USER+i));
+            assertThat(event.get("message", String.class), equalTo(TEST_MESSAGE+i));
+            assertThat(event.get("timestamp", Number.class).intValue(), equalTo(TEST_TIMESTAMP_INT+i));
+            assertThat(event.get("kafka_key", String.class), equalTo("message-"+i));
 	}
         try (AdminClient adminClient = AdminClient.create(props)) {
             try {
@@ -301,10 +307,10 @@ public class MskGlueRegistryMultiTypeIT {
 	for (int i = 0; i < numRecords; i++) {
             Record<Event> record = receivedRecords.get(i);
             Event event = (Event)record.getData();
-            Map<String, Object> val = event.get(TEST_USER+i, Map.class);
-            assertThat(val.get("username"), equalTo(TEST_USER+i));
-            assertThat(val.get("message"), equalTo(TEST_MESSAGE+i));
-            assertThat(((Number)val.get("timestamp")).longValue(), equalTo(TEST_TIMESTAMP+i));
+            assertThat(event.get("username", String.class), equalTo(TEST_USER+i));
+            assertThat(event.get("message", String.class), equalTo(TEST_MESSAGE+i));
+            assertThat(event.get("timestamp", Number.class).longValue(), equalTo(TEST_TIMESTAMP+i));
+            assertThat(event.get("kafka_key", String.class), equalTo(TEST_USER+i));
 	}
         try (AdminClient adminClient = AdminClient.create(props)) {
             try {


### PR DESCRIPTION
### Description
Fix MSK integration test.

This integration test can be run on CLI with the following command
```
./gradlew     data-prepper-plugins:kafka-plugins:integrationTest -Dtests.kafka.bootstrap_servers="b-1-public.krishkdkmskprov1.ck2ag7.c12.kafka.us-west-2.amazonaws.com:9198" -Dtests.kafka.glue_registry_name="krishkdk-schreg-1" -Dtests.kafka.glue_avro_schema_name="testSchema1" -Dtests.kafka.glue_json_schema_name="test-json-schema1" -Dtests.msk.region="us-west-2" -Dtests.msk.arn="arn:aws:kafka:us-west-2:578844260082:cluster/krishkdk-msk-prov-1/fa11470a-d8bb-4b8f-a53a-26bbbee75198-12"  --tests "*MskGlueRegistryMultiTypeIT*"
```

make sure to have AWS credentials properly exported before executing the above command
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
