### PR TITLE
[Backport] ENH: support index template for serverless (#3071)

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -296,7 +296,7 @@ if `exclude_keys` is set to ["message", "status"], the document written to OpenS
 * `region` (Optional) : The AWS region to use for credentials. Defaults to [standard SDK behavior to determine the region](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html).
 * `sts_role_arn` (Optional) : The STS role to assume for requests to AWS. Defaults to null, which will use the [standard SDK behavior for credentials](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html).
 * `sts_header_overrides` (Optional): A map of header overrides to make when assuming the IAM role for the sink plugin.
-* `serverless` (Optional): A boolean flag to indicate the OpenSearch backend is Amazon OpenSearch Serverless. Default to `false`.
+* `serverless` (Optional): A boolean flag to indicate the OpenSearch backend is Amazon OpenSearch Serverless. Default to `false`. Notice that [ISM policies.](https://opensearch.org/docs/latest/im-plugin/ism/policies/) is not supported in Amazon OpenSearch Serverless and thus any ISM related configuration value has no effect, i.e. `ism_policy_file`. 
 
 ## Metrics
 ### Management Disabled Index Type

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -151,11 +151,6 @@ public class IndexConfiguration {
         this.documentRootKey = builder.documentRootKey;
     }
 
-    private void determineTemplateType(Builder builder) {
-        this.templateType = DistributionVersion.ES6.equals(builder.distributionVersion) ? TemplateType.V1 :
-                (builder.templateType != null ? builder.templateType : TemplateType.V1);
-    }
-
     private void determineIndexType(Builder builder) {
         if(builder.indexType != null) {
             Optional<IndexType> mappedIndexType = IndexType.getByValue(builder.indexType);
@@ -166,6 +161,15 @@ public class IndexConfiguration {
             this.indexType = IndexType.MANAGEMENT_DISABLED;
         } else {
             this.indexType  = IndexType.CUSTOM;
+        }
+    }
+
+    private void determineTemplateType(Builder builder) {
+        if (builder.serverless) {
+            templateType = TemplateType.INDEX_TEMPLATE;
+        } else {
+            templateType = DistributionVersion.ES6.equals(builder.distributionVersion) ? TemplateType.V1 :
+                    (builder.templateType != null ? builder.templateType : TemplateType.V1);
         }
     }
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfigurationTests.java
@@ -409,6 +409,7 @@ public class IndexConfigurationTests {
         final Map<String, Object> metadata = initializeConfigMetaData(
                 null, testIndexAlias, null, null, null, null, null);
         metadata.put(AWS_OPTION, Map.of(SERVERLESS, true));
+        metadata.put(TEMPLATE_TYPE, TemplateType.V1.getTypeName());
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         assertEquals(IndexType.MANAGEMENT_DISABLED, indexConfiguration.getIndexType());
@@ -421,10 +422,12 @@ public class IndexConfigurationTests {
         final Map<String, Object> metadata = initializeConfigMetaData(
                 IndexType.CUSTOM.getValue(), testIndexAlias, null, null, null, null, null);
         metadata.put(AWS_OPTION, Map.of(SERVERLESS, true));
+        metadata.put(TEMPLATE_TYPE, TemplateType.V1.getTypeName());
         final PluginSetting pluginSetting = getPluginSetting(metadata);
         final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
         assertEquals(IndexType.CUSTOM, indexConfiguration.getIndexType());
         assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
+        assertEquals(TemplateType.INDEX_TEMPLATE, indexConfiguration.getTemplateType());
         assertEquals(true, indexConfiguration.getServerless());
     }
 


### PR DESCRIPTION
* ENH: support index template for serverless

Signed-off-by: George Chen <qchea@amazon.com>
(cherry picked from commit 73a80a12388faa6dd4285db2f8ea6e16fecf4a19)

### Description
Manual backport on serverless feature
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
