### PR TITLE
Fix CVE-2023-44487, HTTP/2 reset floods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ subprojects {
     }
     dependencies {
         implementation platform('com.fasterxml.jackson:jackson-bom:2.15.0')
-        implementation platform('org.eclipse.jetty:jetty-bom:11.0.16')
+        implementation platform('org.eclipse.jetty:jetty-bom:11.0.17')
         implementation platform('io.micrometer:micrometer-bom:1.10.5')
         implementation libs.guava.core
         implementation libs.slf4j.api
@@ -152,6 +152,18 @@ subprojects {
                 }
                 because 'CVE from transitive dependencies'
             }
+            implementation('org.eclipse.jetty:http2-common') {
+                version {
+                    require '11.0.17'
+                }
+                because 'Fixes CVE-2023-44487'
+            }
+            implementation('org.eclipse.jetty:http2-server') {
+                version {
+                    require '11.0.17'
+                }
+                because 'Fixes CVE-2023-44487'
+            }
             implementation('org.xerial.snappy:snappy-java') {
                 version {
                     require '1.1.10.5'
@@ -195,10 +207,10 @@ subprojects {
         resolutionStrategy.eachDependency { def details ->
             if (details.requested.group == 'io.netty') {
                 if (details.requested.name == 'netty') {
-                    details.useTarget group: 'io.netty', name: 'netty-all', version: '4.1.96.Final'
-                    // replace with your desired version
+                    details.useTarget group: 'io.netty', name: 'netty-all', version: '4.1.100.Final'
+                    details.because 'Fixes CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
                 } else if (!details.requested.name.startsWith('netty-tcnative')) {
-                    details.useVersion '4.1.96.Final'
+                    details.useVersion '4.1.100.Final'
                     details.because 'Fixes CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
                 }
             } else if (details.requested.group == 'log4j' && details.requested.name == 'log4j') {

--- a/examples/trace-analytics-sample-app/sample-app/analytics-service/build.gradle
+++ b/examples/trace-analytics-sample-app/sample-app/analytics-service/build.gradle
@@ -27,6 +27,9 @@ configurations.all {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
         if (details.requested.group == 'org.yaml') {
             details.useVersion '2.0'
+        } else if (details.requested.group == 'org.apache.tomcat.embed') {
+            details.useVersion '10.1.14'
+            details.because('Fixes CVE-2023-44487')
         }
     }
 }


### PR DESCRIPTION
### Description

Resolve Netty to 4.1.100.Final, require Jetty 11.0.17 in Data Prepper. Use Tomcat 10.1.14 in the example project. These changes fix CVE-2023-44487 to protect against HTTP/2 reset floods. 
 
### Issues Resolved

#3474
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
