### PR TITLE
Some updates to the 2.5.0 release notes.

### DIFF
--- a/release/release-notes/data-prepper.release-notes-2.5.0.md
+++ b/release/release-notes/data-prepper.release-notes-2.5.0.md
@@ -6,7 +6,7 @@
 * Support OpenSearch as source. ([#1985](https://github.com/opensearch-project/data-prepper/issues/1985))
 * Support translate processor. ([#1914](https://github.com/opensearch-project/data-prepper/issues/1914))
 * Support dissect processor. ([#3362](https://github.com/opensearch-project/data-prepper/issues/3362))
-* Support AWS secrets in pipeline and Data Prepper config. ([#2780](https://github.com/opensearch-project/data-prepper/issues/2780))
+* Support AWS secrets in pipeline and Data Prepper config as an experimental feature. ([#2780](https://github.com/opensearch-project/data-prepper/issues/2780))
 
 ### Enhancements
 * Support update, upsert, delete bulk actions in OpenSearch sink. ([#3109](https://github.com/opensearch-project/data-prepper/issues/3109))
@@ -22,6 +22,7 @@
 * Fix exemplar list in Histogram and Count aggregations. ([#3364](https://github.com/opensearch-project/data-prepper/pull/3364))
 
 ### Security
+* Fix CVE-2023-44487, HTTP/2 reset floods. ([#3474](https://github.com/opensearch-project/data-prepper/issues/3474))
 * Fix CVE-2023-39410. ([#3430](https://github.com/opensearch-project/data-prepper/issues/3430))
 
 ### Maintenance


### PR DESCRIPTION
### Description

This updates the 2.5.0 release notes with a recent CVE fix, and clarifies that the secrets management is experimental.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
