### PR TITLE
KMS encryption context in Kafka buffer

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KmsConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KmsConfig.java
@@ -1,0 +1,21 @@
+package org.opensearch.dataprepper.plugins.kafka.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public class KmsConfig {
+    @JsonProperty("key_id")
+    private String keyId;
+
+    @JsonProperty("encryption_context")
+    private Map<String, String> encryptionContext;
+
+    public String getKeyId() {
+        return keyId;
+    }
+
+    public Map<String, String> getEncryptionContext() {
+        return encryptionContext;
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConfig.java
@@ -128,8 +128,8 @@ public class TopicConfig {
     @JsonProperty("encryption_key")
     private String encryptionKey;
 
-    @JsonProperty("kms_key_id")
-    private String kmsKeyId;
+    @JsonProperty("kms")
+    private KmsConfig kmsConfig;
 
     public Long getRetentionPeriod() {
         return retentionPeriod;
@@ -151,8 +151,8 @@ public class TopicConfig {
         return encryptionKey;
     }
 
-    public String getKmsKeyId() {
-        return kmsKeyId;
+    public KmsConfig getKmsConfig() {
+        return kmsConfig;
     }
 
     public Boolean getAutoCommit() {


### PR DESCRIPTION
### Description

This change supports using the KMS `encryption_context` in the Kafka buffer.

* Introduces a new `kms` configuration
* Adds `encryption_context` as an option in `kms`
* Moves `kms_key_id` into `kms` as `key_id`.
 
### Issues Resolved

Resolves #3484
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
