### PR TITLE
Miscellaneous fixes/improvements to the DynamoDb source

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/opensearch/OpenSearchBulkActions.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/opensearch/OpenSearchBulkActions.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugins.sink.opensearch.bulk;
+package org.opensearch.dataprepper.model.opensearch;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public enum BulkAction {
+public enum OpenSearchBulkActions {
 
     CREATE("create"),
     UPSERT("upsert"),
@@ -19,15 +19,15 @@ public enum BulkAction {
     DELETE("delete"),
     INDEX("index");
 
-    private static final Map<String, BulkAction> ACTIONS_MAP = Arrays.stream(BulkAction.values())
-        .collect(Collectors.toMap(
-                value -> value.action,
-                value -> value
-        ));
+    private static final Map<String, OpenSearchBulkActions> ACTIONS_MAP = Arrays.stream(OpenSearchBulkActions.values())
+            .collect(Collectors.toMap(
+                    value -> value.action,
+                    value -> value
+            ));
 
     private final String action;
 
-    BulkAction(String action) {
+    OpenSearchBulkActions(String action) {
         this.action = action.toLowerCase();
     }
 
@@ -37,7 +37,7 @@ public enum BulkAction {
     }
 
     @JsonCreator
-    public static BulkAction fromOptionValue(final String option) {
+    public static OpenSearchBulkActions fromOptionValue(final String option) {
         return ACTIONS_MAP.get(option.toLowerCase());
     }
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/opensearch/OpenSearchBulkActionsTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/opensearch/OpenSearchBulkActionsTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.plugins.sink.opensearch.bulk;
+package org.opensearch.dataprepper.model.opensearch;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -12,13 +12,11 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class BulkActionTest {
-
+public class OpenSearchBulkActionsTest {
     @ParameterizedTest
-    @EnumSource(BulkAction.class)
-    void fromOptionValue(final BulkAction action) {
-        assertThat(BulkAction.fromOptionValue(action.name()), is(action));
-        assertThat(action, instanceOf(BulkAction.class));
+    @EnumSource(OpenSearchBulkActions.class)
+    void fromOptionValue(final OpenSearchBulkActions action) {
+        assertThat(OpenSearchBulkActions.fromOptionValue(action.name()), is(action));
+        assertThat(action, instanceOf(OpenSearchBulkActions.class));
     }
-
 }

--- a/data-prepper-plugins/dynamodb-source/README.md
+++ b/data-prepper-plugins/dynamodb-source/README.md
@@ -55,7 +55,7 @@ source:
 
 ### Stream Configurations
 
-* start_position (Optional):  start position of the stream, can be either BEGINNING or LATEST. If export is required,
+* start_position (Optional):  start position of the stream, can be either TRIM_HORIZON or LATEST. If export is required,
   this value will be ignored and set to LATEST by default. This is useful if customer don’t want to run initial export,
   so they can
   choose either from the beginning of the stream (up to 24 hours) or from latest (from the time point when pipeline is

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBService.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBService.java
@@ -12,6 +12,7 @@ import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationExcepti
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.StreamStartPosition;
 import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.TableConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.ExportPartition;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.GlobalState;
@@ -161,8 +162,8 @@ public class DynamoDBService {
 
             if (tableInfo.getMetadata().isStreamRequired()) {
                 List<String> shardIds;
-                // start position by default is beginning if not provided.
-                if (tableInfo.getMetadata().isExportRequired() || "LATEST".equals(tableInfo.getMetadata().getStreamStartPosition())) {
+                // start position by default is TRIM_HORIZON if not provided.
+                if (tableInfo.getMetadata().isExportRequired() || String.valueOf(StreamStartPosition.LATEST).equals(tableInfo.getMetadata().getStreamStartPosition())) {
                     // For a continued data extraction process that involves both export and stream
                     // The export must be completed and loaded before stream can start.
                     // Moreover, there should not be any gaps between the export time and the time start reading the stream
@@ -263,7 +264,7 @@ public class DynamoDBService {
             }
         }
 
-        String streamStartPosition = null;
+        StreamStartPosition streamStartPosition = null;
 
         if (tableConfig.getStreamConfig() != null) {
             // Validate if DynamoDB Stream is turn on or not

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfig.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfig.java
@@ -10,9 +10,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class StreamConfig {
     
     @JsonProperty(value = "start_position")
-    private String startPosition;
+    private StreamStartPosition startPosition = StreamStartPosition.LATEST;
 
-    public String getStartPosition() {
+    public StreamStartPosition getStartPosition() {
         return startPosition;
     }
 

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamStartPosition.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamStartPosition.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.dynamodb.configuration;
+
+public enum StreamStartPosition {
+    TRIM_HORIZON,
+    LATEST
+}

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/MetadataKeyAttributes.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/MetadataKeyAttributes.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.dynamodb.converter;
+
+public class MetadataKeyAttributes {
+     static final String COMPOSITE_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE = "_id";
+
+     static final String PARTITION_KEY_METADATA_ATTRIBUTE = "partition_key";
+
+     static final String SORT_KEY_METADATA_ATTRIBUTE = "sort_key";
+
+     static final String EVENT_TIMESTAMP_METADATA_ATTRIBUTE = "ts";
+
+     static final String STREAM_EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE = "op";
+
+     static final String EVENT_TABLE_NAME_METADATA_ATTRIBUTE = "table_name";
+}

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/model/TableInfo.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/model/TableInfo.java
@@ -5,20 +5,26 @@
 
 package org.opensearch.dataprepper.plugins.source.dynamodb.model;
 
+import software.amazon.awssdk.arns.Arn;
+
 public class TableInfo {
 
     private final String tableArn;
+    private final String tableName;
 
     private final TableMetadata metadata;
 
     public TableInfo(String tableArn, TableMetadata metadata) {
         this.tableArn = tableArn;
         this.metadata = metadata;
+        this.tableName = Arn.fromString(tableArn).resource().resource();
     }
 
     public String getTableArn() {
         return tableArn;
     }
+
+    public String getTableName() { return tableName; }
 
     public TableMetadata getMetadata() {
         return metadata;

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/model/TableMetadata.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/model/TableMetadata.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper.plugins.source.dynamodb.model;
 
+import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.StreamStartPosition;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,7 +24,7 @@ public class TableMetadata {
 
     private final String sortKeyAttributeName;
 
-    private final String streamStartPosition;
+    private final StreamStartPosition streamStartPosition;
 
     private final String streamArn;
 
@@ -68,7 +70,7 @@ public class TableMetadata {
 
         private String exportPrefix;
 
-        private String streamStartPosition;
+        private StreamStartPosition streamStartPosition;
 
 
         public Builder partitionKeyAttributeName(String partitionKeyAttributeName) {
@@ -106,7 +108,7 @@ public class TableMetadata {
             return this;
         }
 
-        public Builder streamStartPosition(String streamStartPosition) {
+        public Builder streamStartPosition(StreamStartPosition streamStartPosition) {
             this.streamStartPosition = streamStartPosition;
             return this;
         }
@@ -160,7 +162,7 @@ public class TableMetadata {
         return exportRequired;
     }
 
-    public String getStreamStartPosition() {
+    public StreamStartPosition getStreamStartPosition() {
         return streamStartPosition;
     }
 

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBServiceTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBServiceTest.java
@@ -19,6 +19,7 @@ import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSour
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
 import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.ExportConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.StreamConfig;
+import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.StreamStartPosition;
 import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.TableConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.InitPartition;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -143,7 +144,7 @@ class DynamoDBServiceTest {
         // Mock configurations
         lenient().when(exportConfig.getS3Bucket()).thenReturn(bucketName);
         lenient().when(exportConfig.getS3Prefix()).thenReturn(prefix);
-        lenient().when(streamConfig.getStartPosition()).thenReturn("LATEST");
+        lenient().when(streamConfig.getStartPosition()).thenReturn(StreamStartPosition.LATEST);
         lenient().when(tableConfig.getTableArn()).thenReturn(tableArn);
         lenient().when(tableConfig.getExportConfig()).thenReturn(exportConfig);
         lenient().when(tableConfig.getStreamConfig()).thenReturn(streamConfig);

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBSourceConfigTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBSourceConfigTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.AwsAuthenticationConfig;
+import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.StreamStartPosition;
 import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.TableConfig;
 import software.amazon.awssdk.regions.Region;
 
@@ -39,7 +40,7 @@ class DynamoDBSourceConfigTest {
                 "      s3_prefix: \"xxx/\"\n" +
                 "  - table_arn: \"arn:aws:dynamodb:us-west-2:123456789012:table/table-c\"\n" +
                 "    stream:\n" +
-                "      start_position: \"BEGINNING\"  \n" +
+                "      start_position: \"TRIM_HORIZON\"  \n" +
                 "aws:\n" +
                 "  region: \"us-west-2\"\n" +
                 "  sts_role_arn: \"arn:aws:iam::123456789012:role/DataPrepperRole\"";
@@ -66,7 +67,7 @@ class DynamoDBSourceConfigTest {
 
         TableConfig streamOnlyConfig = sourceConfiguration.getTableConfigs().get(2);
         assertThat(streamOnlyConfig.getStreamConfig(), notNullValue());
-        assertThat(streamOnlyConfig.getStreamConfig().getStartPosition(), equalTo("BEGINNING"));
+        assertThat(streamOnlyConfig.getStreamConfig().getStartPosition(), equalTo(StreamStartPosition.TRIM_HORIZON));
         assertNull(streamOnlyConfig.getExportConfig());
 
         AwsAuthenticationConfig awsAuthenticationConfig = sourceConfiguration.getAwsAuthenticationConfig();

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
@@ -86,15 +86,6 @@ class StreamRecordConverterTest {
     @Test
     void test_writeToBuffer() throws Exception {
 
-//        final String pk1 = UUID.randomUUID().toString();
-//        final String sk1 = UUID.randomUUID().toString();
-//        final String pk2 = UUID.randomUUID().toString();
-//        final String sk2 = UUID.randomUUID().toString();
-
-
-//        final String data = " $ion_1_0 {Item:{PK:\"" + pk1 + "\",SK:\"" + sk1 + "\"}}\n" +
-//                " $ion_1_0 {Item:{PK:\"" + pk2 + "\",SK:\"" + sk2 + "\"}}\n";
-
         final Random random = new Random();
 
         int numberOfRecords = random.nextInt(10);
@@ -108,11 +99,6 @@ class StreamRecordConverterTest {
 
 
         recordConverter.writeToBuffer(data);
-
-//        System.out.println(writeRequestArgumentCaptor.capture());
-//        System.out.println(writeRequestArgumentCaptor.getValue());
-
-//        assertThat(awsAuthenticationConfig.getAwsRegion(), equalTo(Region.US_WEST_2));
         assertThat(writeRequestArgumentCaptor.getValue().size(), equalTo(numberOfRecords));
         verify(changeEventSuccessCounter).increment(anyDouble());
 

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -42,10 +42,10 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.event.EventType;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.SinkContext;
-import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkAction;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.AbstractIndexManager;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfiguration;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConstants;
@@ -615,7 +615,7 @@ public class OpenSearchSinkIT {
     }
 
     @Test
-    public void testBulkActionCreate() throws IOException, InterruptedException {
+    public void testOpenSearchBulkActionsCreate() throws IOException, InterruptedException {
         final String testIndexAlias = "test-alias";
         final String testTemplateFile = Objects.requireNonNull(
                 getClass().getClassLoader().getResource(TEST_TEMPLATE_V1_FILE)).getFile();
@@ -624,7 +624,7 @@ public class OpenSearchSinkIT {
         final List<Record<Event>> testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson(testIdField, testId)));
         final PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFile);
         pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
-        pluginSetting.getSettings().put(IndexConfiguration.ACTION, BulkAction.CREATE.toString());
+        pluginSetting.getSettings().put(IndexConfiguration.ACTION, OpenSearchBulkActions.CREATE.toString());
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         sink.output(testRecords);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
@@ -642,7 +642,7 @@ public class OpenSearchSinkIT {
     }
 
     @Test
-    public void testBulkActionCreateWithExpression() throws IOException, InterruptedException {
+    public void testOpenSearchBulkActionsCreateWithExpression() throws IOException, InterruptedException {
         final String testIndexAlias = "test-alias";
         final String testTemplateFile = Objects.requireNonNull(
                 getClass().getClassLoader().getResource(TEST_TEMPLATE_V1_FILE)).getFile();
@@ -673,7 +673,7 @@ public class OpenSearchSinkIT {
     }
 
     @Test
-    public void testBulkActionCreateWithInvalidExpression() throws IOException, InterruptedException {
+    public void testOpenSearchBulkActionsCreateWithInvalidExpression() throws IOException, InterruptedException {
         final String testIndexAlias = "test-alias";
         final String testTemplateFile = Objects.requireNonNull(
                 getClass().getClassLoader().getResource(TEST_TEMPLATE_V1_FILE)).getFile();
@@ -708,7 +708,7 @@ public class OpenSearchSinkIT {
         pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
         List<Map<String, Object>> aList = new ArrayList<>();
         Map<String, Object> aMap = new HashMap<>();
-        aMap.put("type", BulkAction.CREATE.toString());
+        aMap.put("type", OpenSearchBulkActions.CREATE.toString());
         aList.add(aMap);
         pluginSetting.getSettings().put(IndexConfiguration.ACTIONS, aList);
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
@@ -741,7 +741,7 @@ public class OpenSearchSinkIT {
         pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
         List<Map<String, Object>> aList = new ArrayList<>();
         Map<String, Object> aMap = new HashMap<>();
-        aMap.put("type", BulkAction.CREATE.toString());
+        aMap.put("type", OpenSearchBulkActions.CREATE.toString());
         aList.add(aMap);
         pluginSetting.getSettings().put(IndexConfiguration.ACTIONS, aList);
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
@@ -761,7 +761,7 @@ public class OpenSearchSinkIT {
         testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson2(testIdField, testId, "name", "value2")));
         aList = new ArrayList<>();
         aMap = new HashMap<>();
-        aMap.put("type", BulkAction.UPDATE.toString());
+        aMap.put("type", OpenSearchBulkActions.UPDATE.toString());
         aList.add(aMap);
         pluginSetting.getSettings().put(IndexConfiguration.ACTIONS, aList);
         sink = createObjectUnderTest(pluginSetting, true);
@@ -789,7 +789,7 @@ public class OpenSearchSinkIT {
         pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
         List<Map<String, Object>> aList = new ArrayList<>();
         Map<String, Object> aMap = new HashMap<>();
-        aMap.put("type", BulkAction.CREATE.toString());
+        aMap.put("type", OpenSearchBulkActions.CREATE.toString());
         aList.add(aMap);
         pluginSetting.getSettings().put(IndexConfiguration.ACTIONS, aList);
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
@@ -809,7 +809,7 @@ public class OpenSearchSinkIT {
         testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson3(testIdField, testId, "name", "value3", "newKey", "newValue")));
         aList = new ArrayList<>();
         aMap = new HashMap<>();
-        aMap.put("type", BulkAction.UPSERT.toString());
+        aMap.put("type", OpenSearchBulkActions.UPSERT.toString());
         aList.add(aMap);
         pluginSetting.getSettings().put(IndexConfiguration.ACTIONS, aList);
         sink = createObjectUnderTest(pluginSetting, true);
@@ -837,7 +837,7 @@ public class OpenSearchSinkIT {
         pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
         List<Map<String, Object>> aList = new ArrayList<>();
         Map<String, Object> aMap = new HashMap<>();
-        aMap.put("type", BulkAction.UPSERT.toString());
+        aMap.put("type", OpenSearchBulkActions.UPSERT.toString());
         aList.add(aMap);
         pluginSetting.getSettings().put(IndexConfiguration.ACTIONS, aList);
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
@@ -873,7 +873,7 @@ public class OpenSearchSinkIT {
         pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
         List<Map<String, Object>> aList = new ArrayList<>();
         Map<String, Object> aMap = new HashMap<>();
-        aMap.put("type", BulkAction.DELETE.toString());
+        aMap.put("type", OpenSearchBulkActions.DELETE.toString());
         aList.add(aMap);
         pluginSetting.getSettings().put(IndexConfiguration.ACTIONS, aList);
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -11,9 +11,9 @@ import org.apache.commons.lang3.EnumUtils;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.plugins.sink.opensearch.DistributionVersion;
-import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkAction;
 import org.opensearch.dataprepper.plugins.sink.opensearch.s3.FileReader;
 import org.opensearch.dataprepper.plugins.sink.opensearch.s3.S3ClientProvider;
 import org.opensearch.dataprepper.plugins.sink.opensearch.s3.S3FileReader;
@@ -245,7 +245,7 @@ public class IndexConfiguration {
         if (actionsList != null) {
             builder.withActions(actionsList, expressionEvaluator);
         } else {
-            builder.withAction(pluginSetting.getStringOrDefault(ACTION, BulkAction.INDEX.toString()), expressionEvaluator);
+            builder.withAction(pluginSetting.getStringOrDefault(ACTION, OpenSearchBulkActions.INDEX.toString()), expressionEvaluator);
         }
 
         if ((builder.templateFile != null && builder.templateFile.startsWith(S3_PREFIX))
@@ -522,7 +522,7 @@ public class IndexConfiguration {
         }
 
         public Builder withAction(final String action, final ExpressionEvaluator expressionEvaluator) {
-            checkArgument((EnumUtils.isValidEnumIgnoreCase(BulkAction.class, action) || JacksonEvent.isValidFormatExpressions(action, expressionEvaluator)), "action must be one of the following: " + BulkAction.values());
+            checkArgument((EnumUtils.isValidEnumIgnoreCase(OpenSearchBulkActions.class, action) || JacksonEvent.isValidFormatExpressions(action, expressionEvaluator)), "action must be one of the following: " + OpenSearchBulkActions.values());
             this.action = action;
             return this;
         }
@@ -531,7 +531,7 @@ public class IndexConfiguration {
             for (final Map<String, Object> actionMap: actions) {
                 String action = (String)actionMap.get("type");
                 if (action != null) {
-                    checkArgument((EnumUtils.isValidEnumIgnoreCase(BulkAction.class, action) || JacksonEvent.isValidFormatExpressions(action, expressionEvaluator)), "action must be one of the following: " + BulkAction.values());
+                    checkArgument((EnumUtils.isValidEnumIgnoreCase(OpenSearchBulkActions.class, action) || JacksonEvent.isValidFormatExpressions(action, expressionEvaluator)), "action must be one of the following: " + OpenSearchBulkActions.values());
                 }
             }
             this.actions = actions;

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
@@ -5,25 +5,24 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;
 
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.junit.Test;
-import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.BulkAction;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfiguration;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexType;
-import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.ArrayList;
 import java.util.Map;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.ArgumentMatchers.anyString;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class OpenSearchSinkConfigurationTests {
     private final List<String> TEST_HOSTS = Collections.singletonList("http://localhost:9200");
@@ -38,7 +37,7 @@ public class OpenSearchSinkConfigurationTests {
         assertNotNull(openSearchSinkConfiguration.getConnectionConfiguration());
         assertNotNull(openSearchSinkConfiguration.getIndexConfiguration());
         assertNotNull(openSearchSinkConfiguration.getRetryConfiguration());
-        assertEquals(BulkAction.INDEX.toString(), openSearchSinkConfiguration.getIndexConfiguration().getAction());
+        assertEquals(OpenSearchBulkActions.INDEX.toString(), openSearchSinkConfiguration.getIndexConfiguration().getAction());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -116,7 +115,7 @@ public class OpenSearchSinkConfigurationTests {
 
         final Map<String, Object> metadata = new HashMap<>();
         metadata.put(IndexConfiguration.INDEX_TYPE, IndexType.TRACE_ANALYTICS_RAW.getValue());
-        metadata.put(IndexConfiguration.ACTION, BulkAction.CREATE.toString());
+        metadata.put(IndexConfiguration.ACTION, OpenSearchBulkActions.CREATE.toString());
         metadata.put(ConnectionConfiguration.HOSTS, TEST_HOSTS);
 
         final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, metadata);


### PR DESCRIPTION
### Description
This change makes a couple of fixes / improvements to the dynamo db source

* Replaces `source` metadata key (which was corresponding to the table ARN), with `table_name` metadata key for DDB table name
* Adds separate metadata keys `partition_key` and `sort_key`, instead of just `_id` (which is combination of the two)
* Change stream `start_position` of BEGINNING to TRIM_HORIZON to align with DDB naming conventions. Refactor to use `StreamStartPosition` enum
* Map `op` metadata from DDB actions (`INSERT`, `MODIFY`, `REMOVE`) to the corresponding OpenSearch bulk actions. Refactor bulk actions enum from the OpenSearch sink to `data-prepper-api`
```
INSERT -> create
MODIFY -> upsert
REMOVE -> delete
```
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
