### PR TITLE
Perform a full upgrade on the base Docker image

### DIFF
--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -11,6 +11,7 @@ ENV ENV_PIPELINE_FILEPATH=$PIPELINE_FILEPATH
 # Update all packages
 RUN apt -y update
 RUN apt -y install bash bc
+RUN apt -y full-upgrade
 
 RUN mkdir -p /var/log/data-prepper
 ADD $ARCHIVE_FILE /usr/share


### PR DESCRIPTION
### Description

Perform a full upgrade on the base Docker image when building the Data Prepper Docker image to get latest patches.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
