### PR TITLE
Update OpenSearch versions in integration testing

### DIFF
--- a/.github/workflows/opensearch-sink-opensearch-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-opensearch-integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         java: [11]
-        opensearch: [1.0.1, 1.1.0, 1.2.4, 1.3.9, 2.0.1, 2.1.0, 2.2.1, 2.3.0, 2.4.0, 2.5.0, 2.6.0]
+        opensearch: [1.0.1, 1.1.0, 1.2.4, 1.3.13, 2.0.1, 2.1.0, 2.3.0, 2.5.0, 2.7.0, 2.9.0, 2.11.0]
       fail-fast: false
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Test against newer versions of OpenSearch and use odd versions in the 2.x series to avoid testing against too many different versions. Updated to the latest 1.3 version.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
