### PR TITLE
Adds new AWS configurations for the KMS encryption. Resolves #3516.

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/key/KmsKeyProvider.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/key/KmsKeyProvider.java
@@ -27,11 +27,11 @@ class KmsKeyProvider implements InnerKeyProvider {
         KmsConfig kmsConfig = topicConfig.getKmsConfig();
         String kmsKeyId = kmsConfig.getKeyId();
 
-        AwsCredentialsProvider awsCredentialsProvider = awsContext.get();
+        AwsCredentialsProvider awsCredentialsProvider = awsContext.getOrDefault(kmsConfig);
 
         KmsClient kmsClient = KmsClient.builder()
                 .credentialsProvider(awsCredentialsProvider)
-                .region(awsContext.getRegion())
+                .region(awsContext.getRegionOrDefault(kmsConfig))
                 .build();
 
         byte[] decodedEncryptionKey = Base64.getDecoder().decode(topicConfig.getEncryptionKey());

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/AwsConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/AwsConfig.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.Size;
 import jakarta.validation.Valid;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 
-public class AwsConfig {
+public class AwsConfig implements AwsCredentialsConfig {
 
     public static class AwsMskConfig {
         @Valid
@@ -50,10 +50,12 @@ public class AwsConfig {
         return awsMskConfig;
     }
 
+    @Override
     public String getRegion() {
         return region;
     }
 
+    @Override
     public String getStsRoleArn() {
         return stsRoleArn;
     }
@@ -62,6 +64,7 @@ public class AwsConfig {
         return stsRoleSessionName;
     }
 
+    @Override
     public AwsCredentialsOptions toCredentialsOptions() {
         return AwsCredentialsOptions.builder()
                 .withRegion(region)

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/AwsCredentialsConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/AwsCredentialsConfig.java
@@ -1,0 +1,10 @@
+package org.opensearch.dataprepper.plugins.kafka.configuration;
+
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+
+public interface AwsCredentialsConfig {
+    String getRegion();
+    String getStsRoleArn();
+
+    AwsCredentialsOptions toCredentialsOptions();
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KmsConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KmsConfig.java
@@ -1,15 +1,31 @@
 package org.opensearch.dataprepper.plugins.kafka.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 
 import java.util.Map;
 
-public class KmsConfig {
+public class KmsConfig implements AwsCredentialsConfig {
     @JsonProperty("key_id")
     private String keyId;
 
     @JsonProperty("encryption_context")
     private Map<String, String> encryptionContext;
+
+    @Valid
+    @Size(min = 1, message = "Region cannot be empty string")
+    @JsonProperty("region")
+    private String region;
+
+    @Valid
+    @Size(min = 20, max = 2048, message = "sts_role_arn length should be between 20 and 2048 characters")
+    @JsonProperty("sts_role_arn")
+    private String stsRoleArn;
+
+    @JsonProperty("role_session_name")
+    private String stsRoleSessionName;
 
     public String getKeyId() {
         return keyId;
@@ -17,5 +33,23 @@ public class KmsConfig {
 
     public Map<String, String> getEncryptionContext() {
         return encryptionContext;
+    }
+
+    @Override
+    public String getRegion() {
+        return region;
+    }
+
+    @Override
+    public String getStsRoleArn() {
+        return stsRoleArn;
+    }
+
+    @Override
+    public AwsCredentialsOptions toCredentialsOptions() {
+        return AwsCredentialsOptions.builder()
+                .withRegion(region)
+                .withStsRoleArn(stsRoleArn)
+                .build();
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/key/KmsKeyProviderTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/key/KmsKeyProviderTest.java
@@ -83,8 +83,8 @@ class KmsKeyProviderTest {
             kmsKeyId = UUID.randomUUID().toString();
             region = mock(Region.class);
 
-            when(awsContext.get()).thenReturn(awsCredentialsProvider);
-            when(awsContext.getRegion()).thenReturn(region);
+            when(awsContext.getOrDefault(kmsConfig)).thenReturn(awsCredentialsProvider);
+            when(awsContext.getRegionOrDefault(kmsConfig)).thenReturn(region);
 
             encryptionKey = UUID.randomUUID().toString();
             String base64EncryptionKey = Base64.getEncoder().encodeToString(encryptionKey.getBytes());

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/KmsConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/KmsConfigTest.java
@@ -1,0 +1,40 @@
+package org.opensearch.dataprepper.plugins.kafka.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class KmsConfigTest {
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void toCredentialsOptions_returns_options_with_correct_values() {
+        String roleArn = UUID.randomUUID().toString();
+        String region = UUID.randomUUID().toString();
+        Map<String, Object> options = Map.of(
+                "sts_role_arn", roleArn,
+                "region", region
+        );
+
+        KmsConfig kmsConfig = objectMapper.convertValue(options, KmsConfig.class);
+
+        AwsCredentialsOptions credentialsOptions = kmsConfig.toCredentialsOptions();
+        assertThat(credentialsOptions, notNullValue());
+        assertThat(credentialsOptions.getStsRoleArn(), equalTo(roleArn));
+        assertThat(credentialsOptions.getRegion(), equalTo(Region.of(region)));
+    }
+}


### PR DESCRIPTION
### Description

Adds new AWS configurations for KMS encryption in the Kafka buffer. Now each topic's KMS configuration can have specific AWS configurations so that you can connect to an Amazon MSK with different configurations as the AWS credentials used to decrypt KMS keys.
 
### Issues Resolved

Resolves #3516
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
