### PR TITLE
Adding support for storing raw bytes in Kafka Buffer

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/AbstractBuffer.java
@@ -112,6 +112,11 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
         }
     }
 
+    @Override
+    public void writeBytes(final byte[] bytes, final String key, int timeoutInMillis) throws Exception {
+        throw new RuntimeException("not supported");
+    }
+
     /**
      * Records egress and time elapsed metrics, while calling the doRead function to
      * do the actual read

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/Buffer.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/Buffer.java
@@ -39,6 +39,20 @@ public interface Buffer<T extends Record<?>> {
     void writeAll(Collection<T> records, int timeoutInMillis) throws Exception;
 
     /**
+     * Atomically writes bytes into the buffer
+     *
+     * @param bytes the bytes to be written to the buffer
+     * @param key   key to use when writing to the buffer
+     * @param timeoutInMillis how long to wait before giving up
+     * @throws TimeoutException Unable to write to the buffer within the timeout
+     * @throws SizeOverflowException The number of records exceeds the total capacity of the buffer. This cannot be retried.
+     * @throws RuntimeException Other exceptions
+     */
+    default void writeBytes(final byte[] bytes, final String key, int timeoutInMillis) throws Exception {
+        throw new RuntimeException("Not supported");
+    }
+
+    /**
      * Retrieves and removes the batch of records from the head of the queue. The batch size is defined/determined by
      * the configuration attribute "batch_size" or the @param timeoutInMillis
      * @param timeoutInMillis how long to wait before giving up
@@ -53,12 +67,34 @@ public interface Buffer<T extends Record<?>> {
      */
     void checkpoint(CheckpointState checkpointState);
 
+    /**
+     * Checks if the buffer is empty
+     *
+     * @return true if the buffer is empty, false otherwise
+     */
     boolean isEmpty();
 
+    /**
+     * Checks if the buffer supports raw bytes
+     *
+     * @return true if the buffer supports raw bytes, false otherwise
+     */
+    default boolean isByteBuffer() {
+        return false;
+    }
+
+    /**
+     * Returns buffer's drain timeout as duration
+     *
+     * @return buffers drain timeout
+     */
     default Duration getDrainTimeout() {
         return Duration.ZERO;
     }
 
+    /**
+     * shuts down the buffer
+     */
     default void shutdown() {
     }
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/ByteDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/ByteDecoder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.codec;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.function.Consumer;
+
+public interface ByteDecoder extends Serializable{
+    /**
+     * Parses an {@link InputStream}. Implementors should call the {@link Consumer} for each
+     * {@link Record} loaded from the {@link InputStream}.
+     *
+     * @param inputStream   The input stream for code to process
+     * @param eventConsumer The consumer which handles each event from the stream
+     * @throws IOException throws IOException when invalid input is received or incorrect codec name is provided
+     */
+    void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException;
+    
+   // ByteDecoder getDecoder();
+
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/ByteDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/ByteDecoder.java
@@ -12,7 +12,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.util.function.Consumer;
 
-public interface ByteDecoder extends Serializable{
+public interface ByteDecoder extends Serializable {
     /**
      * Parses an {@link InputStream}. Implementors should call the {@link Consumer} for each
      * {@link Record} loaded from the {@link InputStream}.
@@ -23,6 +23,4 @@ public interface ByteDecoder extends Serializable{
      */
     void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException;
     
-   // ByteDecoder getDecoder();
-
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/HasByteDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/HasByteDecoder.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.codec;
+
+public interface HasByteDecoder {
+  default ByteDecoder getDecoder() {
+    return null;
+  }
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
@@ -24,12 +24,6 @@ public class JsonDecoder implements ByteDecoder {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final JsonFactory jsonFactory = new JsonFactory();
 
-    /*
-    public ByteDecoder getDecoder() {
-        return this;
-    }
-    */
-
     public void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException {
         Objects.requireNonNull(inputStream);
         Objects.requireNonNull(eventConsumer);

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.codec;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.log.JacksonLog;
+import org.opensearch.dataprepper.model.record.Record;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public class JsonDecoder implements ByteDecoder {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final JsonFactory jsonFactory = new JsonFactory();
+
+    /*
+    public ByteDecoder getDecoder() {
+        return this;
+    }
+    */
+
+    public void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException {
+        Objects.requireNonNull(inputStream);
+        Objects.requireNonNull(eventConsumer);
+
+        final JsonParser jsonParser = jsonFactory.createParser(inputStream);
+
+        while (!jsonParser.isClosed() && jsonParser.nextToken() != JsonToken.END_OBJECT) {
+            if (jsonParser.getCurrentToken() == JsonToken.START_ARRAY) {
+                parseRecordsArray(jsonParser, eventConsumer);
+            }
+        }
+    }
+
+    private void parseRecordsArray(final JsonParser jsonParser, final Consumer<Record<Event>> eventConsumer) throws IOException {
+        while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
+            final Map<String, Object> innerJson = objectMapper.readValue(jsonParser, Map.class);
+
+            final Record<Event> record = createRecord(innerJson);
+            eventConsumer.accept(record);
+        }
+    }
+
+    private Record<Event> createRecord(final Map<String, Object> json) {
+        final JacksonEvent event = (JacksonEvent)JacksonLog.builder()
+                .withData(json)
+                .getThis()
+                .build();
+
+        return new Record<>(event);
+    }
+
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
@@ -94,18 +94,6 @@ public class PluginSetting implements PipelineDescription {
         return settings == null ? defaultValue : settings.getOrDefault(attribute, defaultValue);
     }
 
-    public <T> T getTypedAttribute(final String attribute, final Class<T> type) {
-        Object object = getAttributeOrDefault(attribute, Collections.emptyList());
-        if (object == null) {
-            return null;
-        }
-
-        checkObjectForListType(attribute, object, type);
-        return (T)object;
-
-    }
-
-
     /**
      * Returns the value of the specified attribute as integer, or {@code defaultValue} if this settings contains no
      * value for the attribute.

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
@@ -94,6 +94,18 @@ public class PluginSetting implements PipelineDescription {
         return settings == null ? defaultValue : settings.getOrDefault(attribute, defaultValue);
     }
 
+    public <T> T getTypedAttribute(final String attribute, final Class<T> type) {
+        Object object = getAttributeOrDefault(attribute, Collections.emptyList());
+        if (object == null) {
+            return null;
+        }
+
+        checkObjectForListType(attribute, object, type);
+        return (T)object;
+
+    }
+
+
     /**
      * Returns the value of the specified attribute as integer, or {@code defaultValue} if this settings contains no
      * value for the attribute.

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginFactory.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginFactory.java
@@ -29,6 +29,19 @@ public interface PluginFactory {
     <T> T loadPlugin(final Class<T> baseClass, final PluginSetting pluginSetting);
 
     /**
+     * Loads a new instance of a plugin.
+     *
+     * @param baseClass The class type that the plugin is supporting.
+     * @param pluginSetting The {@link PluginSetting} to configure this plugin
+     * @param argument generic object that can be used as argument in the construction of the new object
+     * @param <T> The type
+     * @return A new instance of your plugin, configured
+     * @since 2.6
+     */
+    <T> T loadPlugin(final Class<T> baseClass, final PluginSetting pluginSetting, Object argument);
+
+    /**
+    /**
      * Loads a new instance of a plugin with SinkContext.
      *
      * @param baseClass The class type that the plugin is supporting.

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginFactory.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginFactory.java
@@ -26,19 +26,7 @@ public interface PluginFactory {
      * @return A new instance of your plugin, configured
      * @since 1.2
      */
-    <T> T loadPlugin(final Class<T> baseClass, final PluginSetting pluginSetting);
-
-    /**
-     * Loads a new instance of a plugin.
-     *
-     * @param baseClass The class type that the plugin is supporting.
-     * @param pluginSetting The {@link PluginSetting} to configure this plugin
-     * @param argument generic object that can be used as argument in the construction of the new object
-     * @param <T> The type
-     * @return A new instance of your plugin, configured
-     * @since 2.6
-     */
-    <T> T loadPlugin(final Class<T> baseClass, final PluginSetting pluginSetting, Object argument);
+    <T> T loadPlugin(final Class<T> baseClass, final PluginSetting pluginSetting, final Object ... args);
 
     /**
     /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/Source.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/Source.java
@@ -7,13 +7,13 @@ package org.opensearch.dataprepper.model.source;
 
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.record.Record;
-import org.opensearch.dataprepper.model.codec.ByteDecoder;
+import org.opensearch.dataprepper.model.codec.HasByteDecoder;
 
 /**
  * Data Prepper source interface. Source acts as receiver of the events that flow
  * through the transformation pipeline.
  */
-public interface Source<T extends Record<?>> {
+public interface Source<T extends Record<?>> extends HasByteDecoder {
 
     /**
      * Notifies the source to start writing the records into the buffer
@@ -37,7 +37,4 @@ public interface Source<T extends Record<?>> {
         return false;
     }
 
-    default ByteDecoder getDecoder() {
-        return null;
-    }
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/Source.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/Source.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.model.source;
 
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.codec.ByteDecoder;
 
 /**
  * Data Prepper source interface. Source acts as receiver of the events that flow
@@ -34,5 +35,9 @@ public interface Source<T extends Record<?>> {
      */
     default boolean areAcknowledgementsEnabled() {
         return false;
+    }
+
+    default ByteDecoder getDecoder() {
+        return null;
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/AbstractBufferTest.java
@@ -169,6 +169,13 @@ public class AbstractBufferTest {
     }
 
     @Test
+    public void testWriteBytes() throws TimeoutException {
+        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferTimeoutImpl(testPluginSetting);
+        byte[] bytes = new byte[2];
+        Assert.assertThrows(RuntimeException.class, () -> abstractBuffer.writeBytes(bytes, "", 10));
+    }
+
+    @Test
     public void testWriteTimeoutMetric() throws TimeoutException {
         // Given
         final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferTimeoutImpl(testPluginSetting);

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/BufferTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/BufferTest.java
@@ -28,4 +28,21 @@ public class BufferTest {
         final Buffer<Record<Event>> buffer = spy(Buffer.class);
         buffer.shutdown();
     }
+
+    @Test
+    public void testIsByteBuffer() {
+        final Buffer<Record<Event>> buffer = spy(Buffer.class);
+
+        Assert.assertEquals(false, buffer.isByteBuffer());
+    }
+
+    @Test
+    public void testWriteBytes() {
+        final Buffer<Record<Event>> buffer = spy(Buffer.class);
+
+        byte[] bytes = new byte[2];
+        Assert.assertThrows(RuntimeException.class, () -> buffer.writeBytes(bytes, "", 10));
+
+    }
+
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/HasByteDecoderTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/HasByteDecoderTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.codec;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.spy;
+
+public class HasByteDecoderTest {
+
+    @Test
+    public void testGetDecoder() {
+        final HasByteDecoder hasByteDecoder = spy(HasByteDecoder.class);
+
+        Assert.assertEquals(null, hasByteDecoder.getDecoder());
+    }
+
+}
+

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/JsonDecoderTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/JsonDecoderTest.java
@@ -1,0 +1,50 @@
+package org.opensearch.dataprepper.model.codec;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.io.ByteArrayInputStream;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+
+public class JsonDecoderTest {
+    private JsonDecoder jsonDecoder;
+    private Record<Event> receivedRecord;
+
+    private JsonDecoder createObjectUnderTest() {
+        return new JsonDecoder();
+    }
+
+    @BeforeEach
+    void setup() {
+        jsonDecoder = createObjectUnderTest();
+        receivedRecord = null;
+    }
+
+    @Test
+    void test_basicJsonDecoder() {
+        String stringValue = UUID.randomUUID().toString();
+        Random r = new Random();
+        int intValue = r.nextInt();
+        String inputString = "[{\"key1\":\""+stringValue+"\", \"key2\":"+intValue+"}]";
+        try {
+            jsonDecoder.parse(new ByteArrayInputStream(inputString.getBytes()), (record) -> {
+                receivedRecord = record;
+            });
+        } catch (Exception e){}
+        
+        assertNotEquals(receivedRecord, null);
+        Map<String, Object> map = receivedRecord.getData().toMap();
+        assertThat(map.get("key1"), equalTo(stringValue));
+        assertThat(map.get("key2"), equalTo(intValue));
+    }
+
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineTransformer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineTransformer.java
@@ -114,10 +114,8 @@ public class PipelineTransformer {
             final Source source = pipelineSource.orElseGet(() ->
                     pluginFactory.loadPlugin(Source.class, sourceSetting));
 
-
-
             LOG.info("Building buffer for the pipeline [{}]", pipelineName);
-            final Buffer pipelineDefinedBuffer = pluginFactory.loadPlugin(Buffer.class, pipelineConfiguration.getBufferPluginSetting());
+            final Buffer pipelineDefinedBuffer = pluginFactory.loadPlugin(Buffer.class, pipelineConfiguration.getBufferPluginSetting(), source.getDecoder());
 
             LOG.info("Building processors for the pipeline [{}]", pipelineName);
             final int processorThreads = pipelineConfiguration.getWorkers();

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContext.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContext.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 /**

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -72,13 +72,23 @@ public class DefaultPluginFactory implements PluginFactory {
     }
 
     @Override
+    public <T> T loadPlugin(final Class<T> baseClass, final PluginSetting pluginSetting, final Object argument) {
+        final String pluginName = pluginSetting.getName();
+        final Class<? extends T> pluginClass = getPluginClass(baseClass, pluginName);
+
+        final ComponentPluginArgumentsContext constructionContext = getConstructionContext(pluginSetting, pluginClass, null);
+
+        return pluginCreator.newPluginInstance(pluginClass, constructionContext, argument, pluginName);
+    }
+
+    @Override
     public <T> T loadPlugin(final Class<T> baseClass, final PluginSetting pluginSetting) {
         final String pluginName = pluginSetting.getName();
         final Class<? extends T> pluginClass = getPluginClass(baseClass, pluginName);
 
         final ComponentPluginArgumentsContext constructionContext = getConstructionContext(pluginSetting, pluginClass, null);
 
-        return pluginCreator.newPluginInstance(pluginClass, constructionContext, pluginName);
+        return pluginCreator.newPluginInstance(pluginClass, constructionContext, null, pluginName);
     }
 
     @Override
@@ -88,7 +98,7 @@ public class DefaultPluginFactory implements PluginFactory {
 
         final ComponentPluginArgumentsContext constructionContext = getConstructionContext(pluginSetting, pluginClass, sinkContext);
 
-        return pluginCreator.newPluginInstance(pluginClass, constructionContext, pluginName);
+        return pluginCreator.newPluginInstance(pluginClass, constructionContext, null, pluginName);
     }
 
     @Override
@@ -108,7 +118,7 @@ public class DefaultPluginFactory implements PluginFactory {
 
         final List<T> plugins = new ArrayList<>(numberOfInstances);
         for (int i = 0; i < numberOfInstances; i++) {
-            plugins.add(pluginCreator.newPluginInstance(pluginClass, constructionContext, pluginName));
+            plugins.add(pluginCreator.newPluginInstance(pluginClass, constructionContext, null, pluginName));
         }
         return plugins;
     }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -72,23 +72,13 @@ public class DefaultPluginFactory implements PluginFactory {
     }
 
     @Override
-    public <T> T loadPlugin(final Class<T> baseClass, final PluginSetting pluginSetting, final Object argument) {
+    public <T> T loadPlugin(final Class<T> baseClass, final PluginSetting pluginSetting, final Object ... args) {
         final String pluginName = pluginSetting.getName();
         final Class<? extends T> pluginClass = getPluginClass(baseClass, pluginName);
 
         final ComponentPluginArgumentsContext constructionContext = getConstructionContext(pluginSetting, pluginClass, null);
 
-        return pluginCreator.newPluginInstance(pluginClass, constructionContext, argument, pluginName);
-    }
-
-    @Override
-    public <T> T loadPlugin(final Class<T> baseClass, final PluginSetting pluginSetting) {
-        final String pluginName = pluginSetting.getName();
-        final Class<? extends T> pluginClass = getPluginClass(baseClass, pluginName);
-
-        final ComponentPluginArgumentsContext constructionContext = getConstructionContext(pluginSetting, pluginClass, null);
-
-        return pluginCreator.newPluginInstance(pluginClass, constructionContext, null, pluginName);
+        return pluginCreator.newPluginInstance(pluginClass, constructionContext, pluginName, args);
     }
 
     @Override
@@ -98,7 +88,7 @@ public class DefaultPluginFactory implements PluginFactory {
 
         final ComponentPluginArgumentsContext constructionContext = getConstructionContext(pluginSetting, pluginClass, sinkContext);
 
-        return pluginCreator.newPluginInstance(pluginClass, constructionContext, null, pluginName);
+        return pluginCreator.newPluginInstance(pluginClass, constructionContext, pluginName);
     }
 
     @Override
@@ -118,7 +108,7 @@ public class DefaultPluginFactory implements PluginFactory {
 
         final List<T> plugins = new ArrayList<>(numberOfInstances);
         for (int i = 0; i < numberOfInstances; i++) {
-            plugins.add(pluginCreator.newPluginInstance(pluginClass, constructionContext, null, pluginName));
+            plugins.add(pluginCreator.newPluginInstance(pluginClass, constructionContext, pluginName));
         }
         return plugins;
     }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ExtensionLoader.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ExtensionLoader.java
@@ -14,6 +14,7 @@ import javax.inject.Named;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Named
@@ -37,7 +38,7 @@ public class ExtensionLoader {
                 .stream()
                 .map(extensionClass -> {
                     final PluginArgumentsContext pluginArgumentsContext = getConstructionContext(extensionClass);
-                    return pluginCreator.newPluginInstance(extensionClass, pluginArgumentsContext, convertClassToName(extensionClass));
+                    return pluginCreator.newPluginInstance(extensionClass, pluginArgumentsContext, null, convertClassToName(extensionClass));
                 })
                 .collect(Collectors.toList());
     }
@@ -74,7 +75,7 @@ public class ExtensionLoader {
 
     protected static class NoArgumentsArgumentsContext implements PluginArgumentsContext {
         @Override
-        public Object[] createArguments(final Class<?>[] parameterTypes) {
+        public Object[] createArguments(final Class<?>[] parameterTypes, Optional<Object> arg) {
             if(parameterTypes.length != 0) {
                 throw new InvalidPluginDefinitionException("No arguments are permitted for extensions constructors.");
             }
@@ -90,7 +91,7 @@ public class ExtensionLoader {
         }
 
         @Override
-        public Object[] createArguments(Class<?>[] parameterTypes) {
+        public Object[] createArguments(Class<?>[] parameterTypes, Optional<Object> arg) {
             if (parameterTypes.length != 1 && (Objects.nonNull(extensionPluginConfiguration) &&
                     !parameterTypes[0].equals(extensionPluginConfiguration.getClass()))) {
                 throw new InvalidPluginDefinitionException(String.format(

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ExtensionLoader.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ExtensionLoader.java
@@ -38,7 +38,7 @@ public class ExtensionLoader {
                 .stream()
                 .map(extensionClass -> {
                     final PluginArgumentsContext pluginArgumentsContext = getConstructionContext(extensionClass);
-                    return pluginCreator.newPluginInstance(extensionClass, pluginArgumentsContext, null, convertClassToName(extensionClass));
+                    return pluginCreator.newPluginInstance(extensionClass, pluginArgumentsContext, convertClassToName(extensionClass));
                 })
                 .collect(Collectors.toList());
     }
@@ -75,7 +75,7 @@ public class ExtensionLoader {
 
     protected static class NoArgumentsArgumentsContext implements PluginArgumentsContext {
         @Override
-        public Object[] createArguments(final Class<?>[] parameterTypes, Optional<Object> arg) {
+        public Object[] createArguments(final Class<?>[] parameterTypes, final Object ... args) {
             if(parameterTypes.length != 0) {
                 throw new InvalidPluginDefinitionException("No arguments are permitted for extensions constructors.");
             }
@@ -91,7 +91,7 @@ public class ExtensionLoader {
         }
 
         @Override
-        public Object[] createArguments(Class<?>[] parameterTypes, Optional<Object> arg) {
+        public Object[] createArguments(Class<?>[] parameterTypes, final Object ... args) {
             if (parameterTypes.length != 1 && (Objects.nonNull(extensionPluginConfiguration) &&
                     !parameterTypes[0].equals(extensionPluginConfiguration.getClass()))) {
                 throw new InvalidPluginDefinitionException(String.format(

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ExtensionLoader.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ExtensionLoader.java
@@ -14,7 +14,6 @@ import javax.inject.Named;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Named

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginArgumentsContext.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginArgumentsContext.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper.plugin;
 
+import java.util.Optional;
+
 interface PluginArgumentsContext {
-    Object[] createArguments(final Class<?>[] parameterTypes);
+    Object[] createArguments(final Class<?>[] parameterTypes, final Optional<Object> optionalArgument);
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginArgumentsContext.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginArgumentsContext.java
@@ -5,8 +5,6 @@
 
 package org.opensearch.dataprepper.plugin;
 
-import java.util.Optional;
-
 interface PluginArgumentsContext {
-    Object[] createArguments(final Class<?>[] parameterTypes, final Optional<Object> optionalArgument);
+    Object[] createArguments(final Class<?>[] parameterTypes, final Object ... args);
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginCreator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginCreator.java
@@ -35,15 +35,15 @@ class PluginCreator {
 
     <T> T newPluginInstance(final Class<T> pluginClass,
                             final PluginArgumentsContext pluginArgumentsContext,
-                            final Object argument,
-                            final String pluginName) {
+                            final String pluginName,
+                            final Object... args) {
         Objects.requireNonNull(pluginClass);
         Objects.requireNonNull(pluginArgumentsContext);
         Objects.requireNonNull(pluginName);
 
         final Constructor<?> constructor = getConstructor(pluginClass, pluginName);
 
-        final Object[] constructorArguments = pluginArgumentsContext.createArguments(constructor.getParameterTypes(), argument == null ? Optional.empty() : Optional.of(argument));
+        final Object[] constructorArguments = pluginArgumentsContext.createArguments(constructor.getParameterTypes(), args);
 
         pluginConfigurationObservableRegister.registerPluginConfigurationObservables(constructorArguments);
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginCreator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginCreator.java
@@ -35,6 +35,7 @@ class PluginCreator {
 
     <T> T newPluginInstance(final Class<T> pluginClass,
                             final PluginArgumentsContext pluginArgumentsContext,
+                            final Object argument,
                             final String pluginName) {
         Objects.requireNonNull(pluginClass);
         Objects.requireNonNull(pluginArgumentsContext);
@@ -42,7 +43,7 @@ class PluginCreator {
 
         final Constructor<?> constructor = getConstructor(pluginClass, pluginName);
 
-        final Object[] constructorArguments = pluginArgumentsContext.createArguments(constructor.getParameterTypes());
+        final Object[] constructorArguments = pluginArgumentsContext.createArguments(constructor.getParameterTypes(), argument == null ? Optional.empty() : Optional.of(argument));
 
         pluginConfigurationObservableRegister.registerPluginConfigurationObservables(constructorArguments);
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugins/MultiBufferDecorator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugins/MultiBufferDecorator.java
@@ -42,6 +42,11 @@ public class MultiBufferDecorator<T extends Record<?>> implements Buffer<T> {
     }
 
     @Override
+    public void writeBytes(final byte[] bytes, final String key, int timeoutInMillis) throws Exception {
+        primaryBuffer.writeBytes(bytes, key, timeoutInMillis);
+    }
+
+    @Override
     public Map.Entry<Collection<T>, CheckpointState> read(final int timeoutInMillis) {
         return primaryBuffer.read(timeoutInMillis);
     }
@@ -49,6 +54,11 @@ public class MultiBufferDecorator<T extends Record<?>> implements Buffer<T> {
     @Override
     public void checkpoint(final CheckpointState checkpointState) {
         primaryBuffer.checkpoint(checkpointState);
+    }
+
+    @Override
+    public boolean isByteBuffer() {
+        return primaryBuffer.isByteBuffer();
     }
 
     @Override

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContextTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContextTest.java
@@ -158,6 +158,19 @@ class ComponentPluginArgumentsContextTest {
     }
 
     @Test
+    void createArguments_with_multiple_supplier_sources_with_varargs() {
+        final Object mock = mock(Object.class);
+
+        final ComponentPluginArgumentsContext objectUnderTest = new ComponentPluginArgumentsContext.Builder()
+                .withPluginSetting(pluginSetting)
+                .withPluginConfiguration(testPluginConfiguration)
+                .build();
+
+        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class, PluginSetting.class, Object.class}, mock),
+                equalTo(new Object[] {testPluginConfiguration, pluginSetting, mock}));
+    }
+
+    @Test
     void createArguments_with_two_classes() {
         final ComponentPluginArgumentsContext objectUnderTest = new ComponentPluginArgumentsContext.Builder()
                 .withPluginConfiguration(testPluginConfiguration)

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContextTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContextTest.java
@@ -21,7 +21,6 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 
 import java.util.Map;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContextTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContextTest.java
@@ -61,7 +61,7 @@ class ComponentPluginArgumentsContextTest {
                 .build();
 
         final Class<?>[] parameterTypes = {String.class};
-        assertThrows(InvalidPluginDefinitionException.class, () -> objectUnderTest.createArguments(parameterTypes, Optional.empty()));
+        assertThrows(InvalidPluginDefinitionException.class, () -> objectUnderTest.createArguments(parameterTypes));
     }
 
     @Test
@@ -71,7 +71,7 @@ class ComponentPluginArgumentsContextTest {
                 .withPluginSetting(pluginSetting)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class }, Optional.empty()),
+        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class }),
                 equalTo(new Object[] { testPluginConfiguration}));
     }
 
@@ -83,7 +83,7 @@ class ComponentPluginArgumentsContextTest {
                 .withPluginSetting(pluginSetting)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { PluginSetting.class }, Optional.empty()),
+        assertThat(objectUnderTest.createArguments(new Class[] { PluginSetting.class }),
                 equalTo(new Object[] { pluginSetting}));
     }
 
@@ -97,7 +97,7 @@ class ComponentPluginArgumentsContextTest {
                 .withBeanFactory(beanFactory)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { Object.class }, Optional.empty()),
+        assertThat(objectUnderTest.createArguments(new Class[] { Object.class }),
                 equalTo(new Object[] {mock}));
     }
 
@@ -110,7 +110,7 @@ class ComponentPluginArgumentsContextTest {
                 .withSinkContext(sinkContext)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { SinkContext.class }, Optional.empty()),
+        assertThat(objectUnderTest.createArguments(new Class[] { SinkContext.class }),
                 equalTo(new Object[] { sinkContext}));
     }
 
@@ -123,7 +123,7 @@ class ComponentPluginArgumentsContextTest {
                 .withPluginConfigurationObservable(pluginConfigObservable)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { PluginConfigObservable.class }, Optional.empty()),
+        assertThat(objectUnderTest.createArguments(new Class[] { PluginConfigObservable.class }),
                 equalTo(new Object[] {pluginConfigObservable}));
     }
 
@@ -138,7 +138,7 @@ class ComponentPluginArgumentsContextTest {
 
         final InvalidPluginDefinitionException throwable = assertThrows(
                 InvalidPluginDefinitionException.class,
-                () -> objectUnderTest.createArguments(new Class[]{Object.class}, Optional.empty())
+                () -> objectUnderTest.createArguments(new Class[]{Object.class})
         );
         assertTrue(throwable.getCause() instanceof BeansException);
     }
@@ -154,7 +154,7 @@ class ComponentPluginArgumentsContextTest {
                 .withBeanFactory(beanFactory)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class, PluginSetting.class, Object.class }, Optional.empty()),
+        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class, PluginSetting.class, Object.class }),
                 equalTo(new Object[] {testPluginConfiguration, pluginSetting, mock}));
     }
 
@@ -165,7 +165,7 @@ class ComponentPluginArgumentsContextTest {
                 .withPluginSetting(pluginSetting)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class, PluginSetting.class }, Optional.empty()),
+        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class, PluginSetting.class }),
                 equalTo(new Object[] { testPluginConfiguration, pluginSetting }));
     }
 
@@ -176,7 +176,7 @@ class ComponentPluginArgumentsContextTest {
                 .withPluginSetting(pluginSetting)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { PluginSetting.class, TestPluginConfiguration.class }, Optional.empty()),
+        assertThat(objectUnderTest.createArguments(new Class[] { PluginSetting.class, TestPluginConfiguration.class }),
                 equalTo(new Object[] { pluginSetting, testPluginConfiguration }));
     }
 
@@ -188,7 +188,7 @@ class ComponentPluginArgumentsContextTest {
                 .withPipelineDescription(pluginSetting)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class, PluginSetting.class, PipelineDescription.class}, Optional.empty()),
+        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class, PluginSetting.class, PipelineDescription.class}),
                 equalTo(new Object[] { testPluginConfiguration, pluginSetting, pluginSetting }));
     }
 
@@ -200,7 +200,7 @@ class ComponentPluginArgumentsContextTest {
                 .withPluginFactory(pluginFactory)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { PluginFactory.class }, Optional.empty()),
+        assertThat(objectUnderTest.createArguments(new Class[] { PluginFactory.class }),
                 equalTo(new Object[] { pluginFactory }));
     }
 
@@ -216,7 +216,7 @@ class ComponentPluginArgumentsContextTest {
         try(final MockedStatic<PluginMetrics> pluginMetricsMockedStatic = mockStatic(PluginMetrics.class)) {
             pluginMetricsMockedStatic.when(() -> PluginMetrics.fromPluginSetting(pluginSetting))
                     .thenReturn(pluginMetrics);
-            arguments = objectUnderTest.createArguments(new Class[]{PluginSetting.class, PluginMetrics.class}, Optional.empty());
+            arguments = objectUnderTest.createArguments(new Class[]{PluginSetting.class, PluginMetrics.class});
         }
         assertThat(arguments,
                 equalTo(new Object[] { pluginSetting, pluginMetrics }));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContextTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContextTest.java
@@ -21,6 +21,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -60,7 +61,7 @@ class ComponentPluginArgumentsContextTest {
                 .build();
 
         final Class<?>[] parameterTypes = {String.class};
-        assertThrows(InvalidPluginDefinitionException.class, () -> objectUnderTest.createArguments(parameterTypes));
+        assertThrows(InvalidPluginDefinitionException.class, () -> objectUnderTest.createArguments(parameterTypes, Optional.empty()));
     }
 
     @Test
@@ -70,7 +71,7 @@ class ComponentPluginArgumentsContextTest {
                 .withPluginSetting(pluginSetting)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class }),
+        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class }, Optional.empty()),
                 equalTo(new Object[] { testPluginConfiguration}));
     }
 
@@ -82,7 +83,7 @@ class ComponentPluginArgumentsContextTest {
                 .withPluginSetting(pluginSetting)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { PluginSetting.class }),
+        assertThat(objectUnderTest.createArguments(new Class[] { PluginSetting.class }, Optional.empty()),
                 equalTo(new Object[] { pluginSetting}));
     }
 
@@ -96,7 +97,7 @@ class ComponentPluginArgumentsContextTest {
                 .withBeanFactory(beanFactory)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { Object.class }),
+        assertThat(objectUnderTest.createArguments(new Class[] { Object.class }, Optional.empty()),
                 equalTo(new Object[] {mock}));
     }
 
@@ -109,7 +110,7 @@ class ComponentPluginArgumentsContextTest {
                 .withSinkContext(sinkContext)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { SinkContext.class }),
+        assertThat(objectUnderTest.createArguments(new Class[] { SinkContext.class }, Optional.empty()),
                 equalTo(new Object[] { sinkContext}));
     }
 
@@ -122,7 +123,7 @@ class ComponentPluginArgumentsContextTest {
                 .withPluginConfigurationObservable(pluginConfigObservable)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { PluginConfigObservable.class }),
+        assertThat(objectUnderTest.createArguments(new Class[] { PluginConfigObservable.class }, Optional.empty()),
                 equalTo(new Object[] {pluginConfigObservable}));
     }
 
@@ -137,7 +138,7 @@ class ComponentPluginArgumentsContextTest {
 
         final InvalidPluginDefinitionException throwable = assertThrows(
                 InvalidPluginDefinitionException.class,
-                () -> objectUnderTest.createArguments(new Class[]{Object.class})
+                () -> objectUnderTest.createArguments(new Class[]{Object.class}, Optional.empty())
         );
         assertTrue(throwable.getCause() instanceof BeansException);
     }
@@ -153,7 +154,7 @@ class ComponentPluginArgumentsContextTest {
                 .withBeanFactory(beanFactory)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class, PluginSetting.class, Object.class }),
+        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class, PluginSetting.class, Object.class }, Optional.empty()),
                 equalTo(new Object[] {testPluginConfiguration, pluginSetting, mock}));
     }
 
@@ -164,7 +165,7 @@ class ComponentPluginArgumentsContextTest {
                 .withPluginSetting(pluginSetting)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class, PluginSetting.class }),
+        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class, PluginSetting.class }, Optional.empty()),
                 equalTo(new Object[] { testPluginConfiguration, pluginSetting }));
     }
 
@@ -175,7 +176,7 @@ class ComponentPluginArgumentsContextTest {
                 .withPluginSetting(pluginSetting)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { PluginSetting.class, TestPluginConfiguration.class }),
+        assertThat(objectUnderTest.createArguments(new Class[] { PluginSetting.class, TestPluginConfiguration.class }, Optional.empty()),
                 equalTo(new Object[] { pluginSetting, testPluginConfiguration }));
     }
 
@@ -187,7 +188,7 @@ class ComponentPluginArgumentsContextTest {
                 .withPipelineDescription(pluginSetting)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class, PluginSetting.class, PipelineDescription.class}),
+        assertThat(objectUnderTest.createArguments(new Class[] { TestPluginConfiguration.class, PluginSetting.class, PipelineDescription.class}, Optional.empty()),
                 equalTo(new Object[] { testPluginConfiguration, pluginSetting, pluginSetting }));
     }
 
@@ -199,7 +200,7 @@ class ComponentPluginArgumentsContextTest {
                 .withPluginFactory(pluginFactory)
                 .build();
 
-        assertThat(objectUnderTest.createArguments(new Class[] { PluginFactory.class }),
+        assertThat(objectUnderTest.createArguments(new Class[] { PluginFactory.class }, Optional.empty()),
                 equalTo(new Object[] { pluginFactory }));
     }
 
@@ -215,7 +216,7 @@ class ComponentPluginArgumentsContextTest {
         try(final MockedStatic<PluginMetrics> pluginMetricsMockedStatic = mockStatic(PluginMetrics.class)) {
             pluginMetricsMockedStatic.when(() -> PluginMetrics.fromPluginSetting(pluginSetting))
                     .thenReturn(pluginMetrics);
-            arguments = objectUnderTest.createArguments(new Class[]{PluginSetting.class, PluginMetrics.class});
+            arguments = objectUnderTest.createArguments(new Class[]{PluginSetting.class, PluginMetrics.class}, Optional.empty());
         }
         assertThat(arguments,
                 equalTo(new Object[] { pluginSetting, pluginMetrics }));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
@@ -256,7 +256,7 @@ class DefaultPluginFactoryTest {
             verify(pluginCreator).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), eq(pluginName));
             final ComponentPluginArgumentsContext actualPluginArgumentsContext = pluginArgumentsContextArgCapture.getValue();
             final List<Class> classes = List.of(PipelineDescription.class);
-            final Object[] pipelineDescriptionObj = actualPluginArgumentsContext.createArguments(classes.toArray(new Class[1]), Optional.empty());
+            final Object[] pipelineDescriptionObj = actualPluginArgumentsContext.createArguments(classes.toArray(new Class[1]));
             assertThat(pipelineDescriptionObj.length, equalTo(1));
             assertThat(pipelineDescriptionObj[0], instanceOf(PipelineDescription.class));
             final PipelineDescription actualPipelineDescription = (PipelineDescription)pipelineDescriptionObj[0];
@@ -264,6 +264,32 @@ class DefaultPluginFactoryTest {
             assertThat(plugins, notNullValue());
             assertThat(plugins.size(), equalTo(1));
             assertThat(plugins.get(0), equalTo(expectedInstance));
+        }
+
+        @Test
+        void loadPlugin_with_varargs_should_return_a_single_instance_when_the_the_numberOfInstances_is_1() {
+            final Object object = new Object();
+            final TestSink expectedInstance = mock(TestSink.class);
+            final Object convertedConfiguration = mock(Object.class);
+            given(pluginConfigurationConverter.convert(PluginSetting.class, pluginSetting))
+                    .willReturn(convertedConfiguration);
+            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), eq(pluginName), eq(object)))
+                    .willReturn(expectedInstance);
+
+            final Object plugin = createObjectUnderTest().loadPlugin(baseClass, pluginSetting, object);
+
+            verify(beanFactoryProvider).get();
+            final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
+            verify(pluginCreator).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), eq(pluginName), eq(object));
+            final ComponentPluginArgumentsContext actualPluginArgumentsContext = pluginArgumentsContextArgCapture.getValue();
+            final List<Class> classes = List.of(PipelineDescription.class);
+            final Object[] pipelineDescriptionObj = actualPluginArgumentsContext.createArguments(classes.toArray(new Class[1]));
+            assertThat(pipelineDescriptionObj.length, equalTo(1));
+            assertThat(pipelineDescriptionObj[0], instanceOf(PipelineDescription.class));
+            final PipelineDescription actualPipelineDescription = (PipelineDescription)pipelineDescriptionObj[0];
+            assertThat(actualPipelineDescription.getPipelineName(), is(pipelineName));
+            assertThat(plugin, notNullValue());
+            assertThat(plugin, equalTo(expectedInstance));
         }
 
         @Test
@@ -292,7 +318,7 @@ class DefaultPluginFactoryTest {
             assertThat(actualPluginArgumentsContextList.size(), equalTo(3));
             actualPluginArgumentsContextList.forEach(pluginArgumentsContext -> {
                 final List<Class> classes = List.of(PipelineDescription.class);
-                final Object[] pipelineDescriptionObj = pluginArgumentsContext.createArguments(classes.toArray(new Class[1]), Optional.empty());
+                final Object[] pipelineDescriptionObj = pluginArgumentsContext.createArguments(classes.toArray(new Class[1]));
                 assertThat(pipelineDescriptionObj.length, equalTo(1));
                 assertThat(pipelineDescriptionObj[0], instanceOf(PipelineDescription.class));
                 final PipelineDescription actualPipelineDescription = (PipelineDescription)pipelineDescriptionObj[0];

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
@@ -196,7 +196,7 @@ class DefaultPluginFactoryTest {
             final Object convertedConfiguration = mock(Object.class);
             given(pluginConfigurationConverter.convert(PluginSetting.class, pluginSetting))
                     .willReturn(convertedConfiguration);
-            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), null, eq(pluginName)))
+            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), eq(pluginName)))
                     .willReturn(expectedInstance);
 
             assertThat(createObjectUnderTest().loadPlugin(baseClass, pluginSetting),
@@ -245,7 +245,7 @@ class DefaultPluginFactoryTest {
             final Object convertedConfiguration = mock(Object.class);
             given(pluginConfigurationConverter.convert(PluginSetting.class, pluginSetting))
                     .willReturn(convertedConfiguration);
-            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), null, eq(pluginName)))
+            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), eq(pluginName)))
                     .willReturn(expectedInstance);
 
             final List<?> plugins = createObjectUnderTest().loadPlugins(
@@ -253,7 +253,7 @@ class DefaultPluginFactoryTest {
 
             verify(beanFactoryProvider).get();
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
-            verify(pluginCreator).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), null, eq(pluginName));
+            verify(pluginCreator).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), eq(pluginName));
             final ComponentPluginArgumentsContext actualPluginArgumentsContext = pluginArgumentsContextArgCapture.getValue();
             final List<Class> classes = List.of(PipelineDescription.class);
             final Object[] pipelineDescriptionObj = actualPluginArgumentsContext.createArguments(classes.toArray(new Class[1]), Optional.empty());
@@ -274,7 +274,7 @@ class DefaultPluginFactoryTest {
             final Object convertedConfiguration = mock(Object.class);
             given(pluginConfigurationConverter.convert(PluginSetting.class, pluginSetting))
                     .willReturn(convertedConfiguration);
-            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), null, eq(pluginName)))
+            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), eq(pluginName)))
                     .willReturn(expectedInstance1)
                     .willReturn(expectedInstance2)
                     .willReturn(expectedInstance3);
@@ -287,7 +287,7 @@ class DefaultPluginFactoryTest {
 
             verify(beanFactoryProvider).get();
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
-            verify(pluginCreator, times(3)).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), null, eq(pluginName));
+            verify(pluginCreator, times(3)).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), eq(pluginName));
             final List<ComponentPluginArgumentsContext> actualPluginArgumentsContextList = pluginArgumentsContextArgCapture.getAllValues();
             assertThat(actualPluginArgumentsContextList.size(), equalTo(3));
             actualPluginArgumentsContextList.forEach(pluginArgumentsContext -> {
@@ -326,7 +326,7 @@ class DefaultPluginFactoryTest {
             final Object convertedConfiguration = mock(Object.class);
             given(pluginConfigurationConverter.convert(PluginSetting.class, pluginSetting))
                     .willReturn(convertedConfiguration);
-            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), null, eq(TEST_SINK_DEPRECATED_NAME)))
+            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), eq(TEST_SINK_DEPRECATED_NAME)))
                     .willReturn(expectedInstance);
 
             assertThat(createObjectUnderTest().loadPlugin(baseClass, pluginSetting), equalTo(expectedInstance));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
@@ -196,7 +196,7 @@ class DefaultPluginFactoryTest {
             final Object convertedConfiguration = mock(Object.class);
             given(pluginConfigurationConverter.convert(PluginSetting.class, pluginSetting))
                     .willReturn(convertedConfiguration);
-            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), eq(pluginName)))
+            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), null, eq(pluginName)))
                     .willReturn(expectedInstance);
 
             assertThat(createObjectUnderTest().loadPlugin(baseClass, pluginSetting),
@@ -245,7 +245,7 @@ class DefaultPluginFactoryTest {
             final Object convertedConfiguration = mock(Object.class);
             given(pluginConfigurationConverter.convert(PluginSetting.class, pluginSetting))
                     .willReturn(convertedConfiguration);
-            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), eq(pluginName)))
+            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), null, eq(pluginName)))
                     .willReturn(expectedInstance);
 
             final List<?> plugins = createObjectUnderTest().loadPlugins(
@@ -253,10 +253,10 @@ class DefaultPluginFactoryTest {
 
             verify(beanFactoryProvider).get();
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
-            verify(pluginCreator).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), eq(pluginName));
+            verify(pluginCreator).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), null, eq(pluginName));
             final ComponentPluginArgumentsContext actualPluginArgumentsContext = pluginArgumentsContextArgCapture.getValue();
             final List<Class> classes = List.of(PipelineDescription.class);
-            final Object[] pipelineDescriptionObj = actualPluginArgumentsContext.createArguments(classes.toArray(new Class[1]));
+            final Object[] pipelineDescriptionObj = actualPluginArgumentsContext.createArguments(classes.toArray(new Class[1]), Optional.empty());
             assertThat(pipelineDescriptionObj.length, equalTo(1));
             assertThat(pipelineDescriptionObj[0], instanceOf(PipelineDescription.class));
             final PipelineDescription actualPipelineDescription = (PipelineDescription)pipelineDescriptionObj[0];
@@ -274,7 +274,7 @@ class DefaultPluginFactoryTest {
             final Object convertedConfiguration = mock(Object.class);
             given(pluginConfigurationConverter.convert(PluginSetting.class, pluginSetting))
                     .willReturn(convertedConfiguration);
-            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), eq(pluginName)))
+            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), null, eq(pluginName)))
                     .willReturn(expectedInstance1)
                     .willReturn(expectedInstance2)
                     .willReturn(expectedInstance3);
@@ -287,12 +287,12 @@ class DefaultPluginFactoryTest {
 
             verify(beanFactoryProvider).get();
             final ArgumentCaptor<ComponentPluginArgumentsContext> pluginArgumentsContextArgCapture = ArgumentCaptor.forClass(ComponentPluginArgumentsContext.class);
-            verify(pluginCreator, times(3)).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), eq(pluginName));
+            verify(pluginCreator, times(3)).newPluginInstance(eq(expectedPluginClass), pluginArgumentsContextArgCapture.capture(), null, eq(pluginName));
             final List<ComponentPluginArgumentsContext> actualPluginArgumentsContextList = pluginArgumentsContextArgCapture.getAllValues();
             assertThat(actualPluginArgumentsContextList.size(), equalTo(3));
             actualPluginArgumentsContextList.forEach(pluginArgumentsContext -> {
                 final List<Class> classes = List.of(PipelineDescription.class);
-                final Object[] pipelineDescriptionObj = pluginArgumentsContext.createArguments(classes.toArray(new Class[1]));
+                final Object[] pipelineDescriptionObj = pluginArgumentsContext.createArguments(classes.toArray(new Class[1]), Optional.empty());
                 assertThat(pipelineDescriptionObj.length, equalTo(1));
                 assertThat(pipelineDescriptionObj[0], instanceOf(PipelineDescription.class));
                 final PipelineDescription actualPipelineDescription = (PipelineDescription)pipelineDescriptionObj[0];
@@ -326,7 +326,7 @@ class DefaultPluginFactoryTest {
             final Object convertedConfiguration = mock(Object.class);
             given(pluginConfigurationConverter.convert(PluginSetting.class, pluginSetting))
                     .willReturn(convertedConfiguration);
-            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), eq(TEST_SINK_DEPRECATED_NAME)))
+            given(pluginCreator.newPluginInstance(eq(expectedPluginClass), any(ComponentPluginArgumentsContext.class), null, eq(TEST_SINK_DEPRECATED_NAME)))
                     .willReturn(expectedInstance);
 
             assertThat(createObjectUnderTest().loadPlugin(baseClass, pluginSetting), equalTo(expectedInstance));

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ExtensionLoaderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ExtensionLoaderTest.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -77,6 +78,7 @@ class ExtensionLoaderTest {
         when(pluginCreator.newPluginInstance(
                 eq(pluginClass),
                 any(PluginArgumentsContext.class),
+                any(),
                 startsWith("extension_plugin")))
                 .thenReturn(expectedPlugin);
 
@@ -101,13 +103,14 @@ class ExtensionLoaderTest {
         when(pluginCreator.newPluginInstance(
                 eq(TestExtensionWithConfig.class),
                 any(PluginArgumentsContext.class),
+                any(),
                 eq(expectedPluginName)))
                 .thenReturn(expectedPlugin);
 
         final List<? extends ExtensionPlugin> extensionPlugins = createObjectUnderTest().loadExtensions();
 
         verify(pluginCreator).newPluginInstance(eq(TestExtensionWithConfig.class),
-                pluginArgumentsContextArgumentCaptor.capture(), eq(expectedPluginName));
+                pluginArgumentsContextArgumentCaptor.capture(), any(), eq(expectedPluginName));
         assertThat(pluginArgumentsContextArgumentCaptor.getValue(), instanceOf(
                 ExtensionLoader.SingleConfigArgumentArgumentsContext.class));
         assertThat(extensionPlugins, notNullValue());
@@ -131,6 +134,7 @@ class ExtensionLoaderTest {
             when(pluginCreator.newPluginInstance(
                     eq(pluginClass),
                     any(PluginArgumentsContext.class),
+                    any(),
                     eq(expectedPluginName)))
                     .thenReturn(extensionPlugin);
 
@@ -159,6 +163,7 @@ class ExtensionLoaderTest {
         when(pluginCreator.newPluginInstance(
                 any(Class.class),
                 any(PluginArgumentsContext.class),
+                any(),
                 anyString()))
                 .thenReturn(mock(ExtensionPlugin.class));
 
@@ -169,12 +174,13 @@ class ExtensionLoaderTest {
         verify(pluginCreator).newPluginInstance(
                 eq(pluginClass),
                 contextArgumentCaptor.capture(),
+                any(),
                 anyString());
 
         final PluginArgumentsContext actualPluginArgumentsContext = contextArgumentCaptor.getValue();
 
         final Class[] inputClasses = {String.class};
-        assertThrows(InvalidPluginDefinitionException.class, () -> actualPluginArgumentsContext.createArguments(inputClasses));
+        assertThrows(InvalidPluginDefinitionException.class, () -> actualPluginArgumentsContext.createArguments(inputClasses, Optional.empty()));
     }
 
     @Test
@@ -186,6 +192,7 @@ class ExtensionLoaderTest {
         when(pluginCreator.newPluginInstance(
                 any(Class.class),
                 any(PluginArgumentsContext.class),
+                any(),
                 anyString()))
                 .thenReturn(mock(ExtensionPlugin.class));
 
@@ -196,11 +203,12 @@ class ExtensionLoaderTest {
         verify(pluginCreator).newPluginInstance(
                 eq(pluginClass),
                 contextArgumentCaptor.capture(),
+                any(),
                 anyString());
 
         final PluginArgumentsContext actualPluginArgumentsContext = contextArgumentCaptor.getValue();
 
-        final Object[] arguments = actualPluginArgumentsContext.createArguments(new Class[]{});
+        final Object[] arguments = actualPluginArgumentsContext.createArguments(new Class[]{}, Optional.empty());
         assertThat(arguments, notNullValue());
         assertThat(arguments.length, equalTo(0));
     }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ExtensionLoaderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ExtensionLoaderTest.java
@@ -78,7 +78,6 @@ class ExtensionLoaderTest {
         when(pluginCreator.newPluginInstance(
                 eq(pluginClass),
                 any(PluginArgumentsContext.class),
-                any(),
                 startsWith("extension_plugin")))
                 .thenReturn(expectedPlugin);
 
@@ -103,14 +102,13 @@ class ExtensionLoaderTest {
         when(pluginCreator.newPluginInstance(
                 eq(TestExtensionWithConfig.class),
                 any(PluginArgumentsContext.class),
-                any(),
                 eq(expectedPluginName)))
                 .thenReturn(expectedPlugin);
 
         final List<? extends ExtensionPlugin> extensionPlugins = createObjectUnderTest().loadExtensions();
 
         verify(pluginCreator).newPluginInstance(eq(TestExtensionWithConfig.class),
-                pluginArgumentsContextArgumentCaptor.capture(), any(), eq(expectedPluginName));
+                pluginArgumentsContextArgumentCaptor.capture(), eq(expectedPluginName));
         assertThat(pluginArgumentsContextArgumentCaptor.getValue(), instanceOf(
                 ExtensionLoader.SingleConfigArgumentArgumentsContext.class));
         assertThat(extensionPlugins, notNullValue());
@@ -134,7 +132,6 @@ class ExtensionLoaderTest {
             when(pluginCreator.newPluginInstance(
                     eq(pluginClass),
                     any(PluginArgumentsContext.class),
-                    any(),
                     eq(expectedPluginName)))
                     .thenReturn(extensionPlugin);
 
@@ -163,7 +160,6 @@ class ExtensionLoaderTest {
         when(pluginCreator.newPluginInstance(
                 any(Class.class),
                 any(PluginArgumentsContext.class),
-                any(),
                 anyString()))
                 .thenReturn(mock(ExtensionPlugin.class));
 
@@ -174,7 +170,6 @@ class ExtensionLoaderTest {
         verify(pluginCreator).newPluginInstance(
                 eq(pluginClass),
                 contextArgumentCaptor.capture(),
-                any(),
                 anyString());
 
         final PluginArgumentsContext actualPluginArgumentsContext = contextArgumentCaptor.getValue();
@@ -192,7 +187,6 @@ class ExtensionLoaderTest {
         when(pluginCreator.newPluginInstance(
                 any(Class.class),
                 any(PluginArgumentsContext.class),
-                any(),
                 anyString()))
                 .thenReturn(mock(ExtensionPlugin.class));
 
@@ -203,8 +197,7 @@ class ExtensionLoaderTest {
         verify(pluginCreator).newPluginInstance(
                 eq(pluginClass),
                 contextArgumentCaptor.capture(),
-                any(),
-                anyString());
+                any());
 
         final PluginArgumentsContext actualPluginArgumentsContext = contextArgumentCaptor.getValue();
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ExtensionLoaderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ExtensionLoaderTest.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -175,7 +174,7 @@ class ExtensionLoaderTest {
         final PluginArgumentsContext actualPluginArgumentsContext = contextArgumentCaptor.getValue();
 
         final Class[] inputClasses = {String.class};
-        assertThrows(InvalidPluginDefinitionException.class, () -> actualPluginArgumentsContext.createArguments(inputClasses, Optional.empty()));
+        assertThrows(InvalidPluginDefinitionException.class, () -> actualPluginArgumentsContext.createArguments(inputClasses));
     }
 
     @Test
@@ -201,7 +200,7 @@ class ExtensionLoaderTest {
 
         final PluginArgumentsContext actualPluginArgumentsContext = contextArgumentCaptor.getValue();
 
-        final Object[] arguments = actualPluginArgumentsContext.createArguments(new Class[]{}, Optional.empty());
+        final Object[] arguments = actualPluginArgumentsContext.createArguments(new Class[]{});
         assertThat(arguments, notNullValue());
         assertThat(arguments.length, equalTo(0));
     }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/PluginCreatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/PluginCreatorTest.java
@@ -115,11 +115,11 @@ class PluginCreatorTest {
     void newPluginInstance_should_create_new_instance_from_annotated_constructor() {
 
         final AlternatePluginConfig alternatePluginConfig = mock(AlternatePluginConfig.class);
-        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class, AlternatePluginConfig.class}, Optional.empty()))
+        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class, AlternatePluginConfig.class}))
                 .willReturn(new Object[] { pluginSetting, alternatePluginConfig });
 
         final PluginClassWithMultipleConstructors instance = createObjectUnderTest()
-                .newPluginInstance(PluginClassWithMultipleConstructors.class, pluginConstructionContext, null, pluginName);
+                .newPluginInstance(PluginClassWithMultipleConstructors.class, pluginConstructionContext, pluginName);
 
         assertThat(instance, notNullValue());
         assertThat(instance.pluginSetting, equalTo(pluginSetting));
@@ -131,11 +131,11 @@ class PluginCreatorTest {
         final PluginCreator objectUnderTest = new PluginCreator(pluginConfigurationObservableRegister);
         final PluginConfigObservable pluginConfigObservable = mock(PluginConfigObservable.class);
         final Object[] constructorArgs = new Object[] { pluginSetting, pluginConfigObservable };
-        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class, PluginConfigObservable.class}, Optional.empty()))
+        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class, PluginConfigObservable.class}))
                 .willReturn(constructorArgs);
 
         final PluginClassWithPluginConfigurationObservableConstructor instance = objectUnderTest
-                .newPluginInstance(PluginClassWithPluginConfigurationObservableConstructor.class, pluginConstructionContext, null, pluginName);
+                .newPluginInstance(PluginClassWithPluginConfigurationObservableConstructor.class, pluginConstructionContext, pluginName);
 
         verify(pluginConfigurationObservableRegister).registerPluginConfigurationObservables(constructorArgs);
         assertThat(instance, notNullValue());
@@ -145,10 +145,10 @@ class PluginCreatorTest {
 
     @Test
     void newPluginInstance_should_create_new_instance_from_PluginSetting_if_the_constructor() {
-        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class}, Optional.empty()))
+        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class}))
                 .willReturn(new Object[] { pluginSetting });
 
-        final ValidPluginClass instance = createObjectUnderTest().newPluginInstance(ValidPluginClass.class, pluginConstructionContext, null, pluginName);
+        final ValidPluginClass instance = createObjectUnderTest().newPluginInstance(ValidPluginClass.class, pluginConstructionContext, pluginName);
 
         assertThat(instance, notNullValue());
         assertThat(instance.pluginSetting, equalTo(pluginSetting));
@@ -156,10 +156,10 @@ class PluginCreatorTest {
 
     @Test
     void newPluginInstance_should_create_new_instance_using_default_constructor_if_available() {
-        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class}, Optional.empty()))
+        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class}))
                 .willReturn(new Object[] { pluginSetting });
 
-        final PluginClassWithoutConstructor instance = createObjectUnderTest().newPluginInstance(PluginClassWithoutConstructor.class, pluginConstructionContext, null, pluginName);
+        final PluginClassWithoutConstructor instance = createObjectUnderTest().newPluginInstance(PluginClassWithoutConstructor.class, pluginConstructionContext, pluginName);
 
         assertThat(instance, notNullValue());
     }
@@ -174,16 +174,16 @@ class PluginCreatorTest {
 
         final PluginCreator objectUnderTest = createObjectUnderTest();
         assertThrows(InvalidPluginDefinitionException.class,
-                () -> objectUnderTest.newPluginInstance(invalidPluginClass, pluginConstructionContext, null, pluginName));
+                () -> objectUnderTest.newPluginInstance(invalidPluginClass, pluginConstructionContext, pluginName));
     }
 
     @Test
     void newPluginInstance_should_throw_if_plugin_throws_in_constructor() {
-        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class}, Optional.empty()))
+        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class}))
                 .willReturn(new Object[] { pluginSetting });
 
         final PluginCreator objectUnderTest = createObjectUnderTest();
         assertThrows(PluginInvocationException.class,
-                () -> objectUnderTest.newPluginInstance(AlwaysThrowingPluginClass.class, pluginConstructionContext, null, pluginName));
+                () -> objectUnderTest.newPluginInstance(AlwaysThrowingPluginClass.class, pluginConstructionContext, pluginName));
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/PluginCreatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/PluginCreatorTest.java
@@ -73,6 +73,22 @@ class PluginCreatorTest {
             this.pluginSetting = pluginSetting;
             this.alternatePluginConfig = alternatePluginConfig;
         }
+
+    }
+
+    public static class PluginClassWithThreeArgs extends PluginClassWithMultipleConstructors {
+        private Object obj;
+        private PluginSetting pluginSetting;
+        private AlternatePluginConfig alternatePluginConfig;
+
+        public PluginClassWithThreeArgs() {}
+        public PluginClassWithThreeArgs(final String ignored) { }
+        @DataPrepperPluginConstructor
+        public PluginClassWithThreeArgs(final PluginSetting pluginSetting, final AlternatePluginConfig alternatePluginConfig, Object obj) {
+            this.pluginSetting = pluginSetting;
+            this.alternatePluginConfig = alternatePluginConfig;
+            this.obj = obj;
+        }
     }
 
     public static class PluginClassWithPluginConfigurationObservableConstructor {
@@ -123,6 +139,23 @@ class PluginCreatorTest {
         assertThat(instance, notNullValue());
         assertThat(instance.pluginSetting, equalTo(pluginSetting));
         assertThat(instance.alternatePluginConfig, equalTo(alternatePluginConfig));
+    }
+
+    @Test
+    void newPluginInstance_should_create_new_instance_from_annotated_constructor_with_byte_decoder() {
+
+        Object obj = new Object();
+        final AlternatePluginConfig alternatePluginConfig = mock(AlternatePluginConfig.class);
+        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class, AlternatePluginConfig.class, Object.class}, obj))
+                .willReturn(new Object[] { pluginSetting, alternatePluginConfig, obj});
+
+        final PluginClassWithThreeArgs instance = createObjectUnderTest()
+                .newPluginInstance(PluginClassWithThreeArgs.class, pluginConstructionContext, pluginName, obj);
+
+        assertThat(instance, notNullValue());
+        assertThat(instance.pluginSetting, equalTo(pluginSetting));
+        assertThat(instance.alternatePluginConfig, equalTo(alternatePluginConfig));
+        assertThat(instance.obj, equalTo(obj));
     }
 
     @Test

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/PluginCreatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/PluginCreatorTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.UUID;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -114,11 +115,11 @@ class PluginCreatorTest {
     void newPluginInstance_should_create_new_instance_from_annotated_constructor() {
 
         final AlternatePluginConfig alternatePluginConfig = mock(AlternatePluginConfig.class);
-        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class, AlternatePluginConfig.class}))
+        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class, AlternatePluginConfig.class}, Optional.empty()))
                 .willReturn(new Object[] { pluginSetting, alternatePluginConfig });
 
         final PluginClassWithMultipleConstructors instance = createObjectUnderTest()
-                .newPluginInstance(PluginClassWithMultipleConstructors.class, pluginConstructionContext, pluginName);
+                .newPluginInstance(PluginClassWithMultipleConstructors.class, pluginConstructionContext, null, pluginName);
 
         assertThat(instance, notNullValue());
         assertThat(instance.pluginSetting, equalTo(pluginSetting));
@@ -130,11 +131,11 @@ class PluginCreatorTest {
         final PluginCreator objectUnderTest = new PluginCreator(pluginConfigurationObservableRegister);
         final PluginConfigObservable pluginConfigObservable = mock(PluginConfigObservable.class);
         final Object[] constructorArgs = new Object[] { pluginSetting, pluginConfigObservable };
-        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class, PluginConfigObservable.class}))
+        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class, PluginConfigObservable.class}, Optional.empty()))
                 .willReturn(constructorArgs);
 
         final PluginClassWithPluginConfigurationObservableConstructor instance = objectUnderTest
-                .newPluginInstance(PluginClassWithPluginConfigurationObservableConstructor.class, pluginConstructionContext, pluginName);
+                .newPluginInstance(PluginClassWithPluginConfigurationObservableConstructor.class, pluginConstructionContext, null, pluginName);
 
         verify(pluginConfigurationObservableRegister).registerPluginConfigurationObservables(constructorArgs);
         assertThat(instance, notNullValue());
@@ -144,10 +145,10 @@ class PluginCreatorTest {
 
     @Test
     void newPluginInstance_should_create_new_instance_from_PluginSetting_if_the_constructor() {
-        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class}))
+        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class}, Optional.empty()))
                 .willReturn(new Object[] { pluginSetting });
 
-        final ValidPluginClass instance = createObjectUnderTest().newPluginInstance(ValidPluginClass.class, pluginConstructionContext, pluginName);
+        final ValidPluginClass instance = createObjectUnderTest().newPluginInstance(ValidPluginClass.class, pluginConstructionContext, null, pluginName);
 
         assertThat(instance, notNullValue());
         assertThat(instance.pluginSetting, equalTo(pluginSetting));
@@ -155,10 +156,10 @@ class PluginCreatorTest {
 
     @Test
     void newPluginInstance_should_create_new_instance_using_default_constructor_if_available() {
-        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class}))
+        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class}, Optional.empty()))
                 .willReturn(new Object[] { pluginSetting });
 
-        final PluginClassWithoutConstructor instance = createObjectUnderTest().newPluginInstance(PluginClassWithoutConstructor.class, pluginConstructionContext, pluginName);
+        final PluginClassWithoutConstructor instance = createObjectUnderTest().newPluginInstance(PluginClassWithoutConstructor.class, pluginConstructionContext, null, pluginName);
 
         assertThat(instance, notNullValue());
     }
@@ -173,16 +174,16 @@ class PluginCreatorTest {
 
         final PluginCreator objectUnderTest = createObjectUnderTest();
         assertThrows(InvalidPluginDefinitionException.class,
-                () -> objectUnderTest.newPluginInstance(invalidPluginClass, pluginConstructionContext, pluginName));
+                () -> objectUnderTest.newPluginInstance(invalidPluginClass, pluginConstructionContext, null, pluginName));
     }
 
     @Test
     void newPluginInstance_should_throw_if_plugin_throws_in_constructor() {
-        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class}))
+        given(pluginConstructionContext.createArguments(new Class[] {PluginSetting.class}, Optional.empty()))
                 .willReturn(new Object[] { pluginSetting });
 
         final PluginCreator objectUnderTest = createObjectUnderTest();
         assertThrows(PluginInvocationException.class,
-                () -> objectUnderTest.newPluginInstance(AlwaysThrowingPluginClass.class, pluginConstructionContext, pluginName));
+                () -> objectUnderTest.newPluginInstance(AlwaysThrowingPluginClass.class, pluginConstructionContext, null, pluginName));
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/PluginCreatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/PluginCreatorTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.UUID;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugins/TestObjectPlugin.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugins/TestObjectPlugin.java
@@ -14,22 +14,23 @@ import org.opensearch.dataprepper.plugin.TestPluginConfiguration;
  * Used for integration testing the plugin framework.
  * TODO: Move this into the org.opensearch.dataprepper.plugin package once alternate packages are supported per #379.
  */
-@DataPrepperPlugin(name = "test_plugin", pluginType = TestPluggableInterface.class, pluginConfigurationType = TestPluginConfiguration.class)
-public class TestPlugin implements TestPluggableInterface {
+@DataPrepperPlugin(name = "test_object_plugin", pluginType = TestPluggableInterface.class, pluginConfigurationType = TestPluginConfiguration.class)
+public class TestObjectPlugin implements TestPluggableInterface {
     private final TestPluginConfiguration configuration;
-    private final Object obj;
+    private final Object object;
 
     @DataPrepperPluginConstructor
-    public TestPlugin(final TestPluginConfiguration configuration) {
+    public TestObjectPlugin(final TestPluginConfiguration configuration, Object obj) {
         this.configuration = configuration;
-        this.obj = null;
-    }
+        this.object = obj;
 
+    }
     public TestPluginConfiguration getConfiguration() {
         return configuration;
     }
 
     public Object getObject() {
-        return obj;
+        return object;
     }
 }
+

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
@@ -19,6 +19,8 @@ import org.opensearch.dataprepper.model.log.Log;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
+import org.opensearch.dataprepper.model.codec.ByteDecoder;
+import org.opensearch.dataprepper.model.codec.JsonDecoder;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -54,6 +56,7 @@ public class HTTPSource implements Source<Record<Log>> {
     private Server server;
     private final PluginMetrics pluginMetrics;
     private static final String HTTP_HEALTH_CHECK_PATH = "/health";
+    private ByteDecoder byteDecoder;
 
     @DataPrepperPluginConstructor
     public HTTPSource(final HTTPSourceConfig sourceConfig, final PluginMetrics pluginMetrics, final PluginFactory pluginFactory,
@@ -61,6 +64,7 @@ public class HTTPSource implements Source<Record<Log>> {
         this.sourceConfig = sourceConfig;
         this.pluginMetrics = pluginMetrics;
         this.pipelineName = pipelineDescription.getPipelineName();
+        this.byteDecoder = new JsonDecoder();
         this.certificateProviderFactory = new CertificateProviderFactory(sourceConfig);
         final PluginModel authenticationConfiguration = sourceConfig.getAuthentication();
         final PluginSetting authenticationPluginSetting;
@@ -130,7 +134,7 @@ public class HTTPSource implements Source<Record<Log>> {
 
             final String httpSourcePath = sourceConfig.getPath().replace(PIPELINE_NAME_PLACEHOLDER, pipelineName);
             sb.decorator(httpSourcePath, ThrottlingService.newDecorator(logThrottlingStrategy, logThrottlingRejectHandler));
-            final LogHTTPService logHTTPService = new LogHTTPService(sourceConfig.getBufferTimeoutInMillis(), buffer, pluginMetrics);
+            final LogHTTPService logHTTPService = new LogHTTPService(sourceConfig.getBufferTimeoutInMillis(), buffer, byteDecoder, pluginMetrics);
 
             if (CompressionOption.NONE.equals(sourceConfig.getCompression())) {
                 sb.annotatedService(httpSourcePath, logHTTPService, httpRequestExceptionHandler);
@@ -159,6 +163,11 @@ public class HTTPSource implements Source<Record<Log>> {
             throw new RuntimeException(ex);
         }
         LOG.info("Started http source on port " + sourceConfig.getPort() + "...");
+    }
+
+    @Override
+    public ByteDecoder getDecoder() {
+        return byteDecoder;
     }
 
     @Override

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPService.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPService.java
@@ -11,6 +11,7 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.log.JacksonLog;
 import org.opensearch.dataprepper.model.log.Log;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.codec.ByteDecoder;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpResponse;
@@ -51,6 +52,7 @@ public class LogHTTPService {
 
     public LogHTTPService(final int bufferWriteTimeoutInMillis,
                           final Buffer<Record<Log>> buffer,
+                          final ByteDecoder decoder,
                           final PluginMetrics pluginMetrics) {
         this.buffer = buffer;
         this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
@@ -74,23 +76,31 @@ public class LogHTTPService {
     }
 
     private HttpResponse processRequest(final AggregatedHttpRequest aggregatedHttpRequest) throws Exception {
-        List<String> jsonList;
         final HttpData content = aggregatedHttpRequest.content();
+        if (buffer.isByteBuffer()) {
+            try {
+                buffer.writeBytes(content.array(), null, bufferWriteTimeoutInMillis);
+            } catch (Exception e) {
+                LOG.error("Failed to do raw write the request of size {} due to: {}", content.length(), e.getMessage());
+            }
+        } else {
+            List<String> jsonList;
 
-        try {
-            jsonList = jsonCodec.parse(content);
-        } catch (IOException e) {
-            LOG.error("Failed to write the request of size {} due to: {}", content.length(), e.getMessage());
-            throw new IOException("Bad request data format. Needs to be json array.", e.getCause());
-        }
-        final List<Record<Log>> records = jsonList.stream()
-                .map(this::buildRecordLog)
-                .collect(Collectors.toList());
-        try {
-            buffer.writeAll(records, bufferWriteTimeoutInMillis);
-        } catch (Exception e) {
-            LOG.error("Failed to write the request of size {} due to: {}", content.length(), e.getMessage());
-            throw e;
+            try {
+                jsonList = jsonCodec.parse(content);
+            } catch (IOException e) {
+                LOG.error("Failed to write the request of size {} due to: {}", content.length(), e.getMessage());
+                throw new IOException("Bad request data format. Needs to be json array.", e.getCause());
+            }
+            final List<Record<Log>> records = jsonList.stream()
+                    .map(this::buildRecordLog)
+                    .collect(Collectors.toList());
+            try {
+                buffer.writeAll(records, bufferWriteTimeoutInMillis);
+            } catch (Exception e) {
+                LOG.error("Failed to write the request of size {} due to: {}", content.length(), e.getMessage());
+                throw e;
+            }
         }
         successRequestsCounter.increment();
         return HttpResponse.of(HttpStatus.OK);

--- a/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPServiceTest.java
+++ b/data-prepper-plugins/http-source/src/test/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPServiceTest.java
@@ -95,7 +95,7 @@ class LogHTTPServiceTest {
         );
 
         Buffer<Record<Log>> blockingBuffer = new BlockingBuffer<>(TEST_BUFFER_CAPACITY, 8, "test-pipeline");
-        logHTTPService = new LogHTTPService(TEST_TIMEOUT_IN_MILLIS, blockingBuffer, pluginMetrics);
+        logHTTPService = new LogHTTPService(TEST_TIMEOUT_IN_MILLIS, blockingBuffer, null, pluginMetrics);
     }
 
     @Test

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferIT.java
@@ -91,7 +91,7 @@ public class KafkaBufferIT {
     }
 
     private KafkaBuffer<Record<Event>> createObjectUnderTest() {
-        return new KafkaBuffer<>(pluginSetting, kafkaBufferConfig, pluginFactory, acknowledgementSetManager, pluginMetrics, null);
+        return new KafkaBuffer<>(pluginSetting, kafkaBufferConfig, pluginFactory, acknowledgementSetManager, pluginMetrics, null, null);
     }
 
     @Test

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
@@ -330,7 +330,6 @@ public class KafkaSourceJsonTypeIT {
         kafkaSource = createObjectUnderTest();
 
         kafkaSource.start(buffer);
-        assertThat(kafkaSource.getConsumer().groupMetadata().groupId(), equalTo(testGroup));
         produceJsonRecords(bootstrapServers, testTopic, numRecords);
         int numRetries = 0;
         while (numRetries++ < 10 && (receivedRecords.size() != numRecords)) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
@@ -18,6 +18,7 @@ import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManag
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.codec.ByteDecoder;
 import org.opensearch.dataprepper.plugins.kafka.common.KafkaDataConfig;
 import org.opensearch.dataprepper.plugins.kafka.common.KafkaDataConfigAdapter;
 import org.opensearch.dataprepper.plugins.kafka.common.PlaintextKafkaDataConfig;
@@ -64,6 +65,7 @@ public class KafkaCustomConsumerFactory {
     public List<KafkaCustomConsumer> createConsumersForTopic(final KafkaConsumerConfig kafkaConsumerConfig, final TopicConfig topic,
                                                              final Buffer<Record<Event>> buffer, final PluginMetrics pluginMetrics,
                                                              final AcknowledgementSetManager acknowledgementSetManager,
+                                                             final ByteDecoder byteDecoder,
                                                              final AtomicBoolean shutdownInProgress) {
         Properties authProperties = new Properties();
         KafkaSecurityConfigurer.setAuthProperties(authProperties, kafkaConsumerConfig, LOG);
@@ -91,7 +93,7 @@ public class KafkaCustomConsumerFactory {
                 final KafkaConsumer kafkaConsumer = new KafkaConsumer<>(consumerProperties, keyDeserializer, valueDeserializer);
 
                 consumers.add(new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, kafkaConsumerConfig, topic,
-                    schemaType, acknowledgementSetManager, topicMetrics));
+                    schemaType, acknowledgementSetManager, byteDecoder, topicMetrics));
 
             });
         } catch (Exception e) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
@@ -85,8 +85,14 @@ public class KafkaCustomProducer<T> {
         this.topicName = ObjectUtils.isEmpty(kafkaProducerConfig.getTopic()) ? null : kafkaProducerConfig.getTopic().getName();
         this.serdeFormat = ObjectUtils.isEmpty(kafkaProducerConfig.getSerdeFormat()) ? null : kafkaProducerConfig.getSerdeFormat();
         schemaService = new SchemaService.SchemaServiceBuilder().getFetchSchemaService(topicName, kafkaProducerConfig.getSchemaConfig()).build();
+    }
 
-
+    public void produceRawData(final byte[] bytes, final String key) {
+        try {
+            send(topicName, "", bytes);
+        } catch (Exception e) {
+            LOG.error("Error occurred while publishing " + e.getMessage());
+        }
     }
 
     public void produceRecords(final Record<Event> record) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
@@ -91,7 +91,7 @@ public class KafkaCustomProducer<T> {
         try {
             send(topicName, key, bytes).get();
         } catch (Exception e) {
-            LOG.error("Error occurred while publishing " + e.getMessage());
+            LOG.error("Error occurred while publishing {}", e.getMessage());
         }
     }
 
@@ -110,7 +110,7 @@ public class KafkaCustomProducer<T> {
                 publishPlaintextMessage(record, key);
             }
         } catch (Exception e) {
-            LOG.error("Error occurred while publishing " + e.getMessage());
+            LOG.error("Error occurred while publishing {}", e.getMessage());
             releaseEventHandles(false);
         }
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
@@ -89,7 +89,7 @@ public class KafkaCustomProducer<T> {
 
     public void produceRawData(final byte[] bytes, final String key) {
         try {
-            send(topicName, "", bytes);
+            send(topicName, key, bytes).get();
         } catch (Exception e) {
             LOG.error("Error occurred while publishing " + e.getMessage());
         }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -139,7 +139,7 @@ public class KafkaSource implements Source<Record<Event>> {
                         }
 
                     }
-                    consumer = new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType, acknowledgementSetManager, topicMetrics);
+                    consumer = new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType, acknowledgementSetManager, null, topicMetrics);
                     allTopicConsumers.add(consumer);
 
                     executorService.submit(consumer);

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
@@ -124,7 +124,7 @@ class KafkaBufferTest {
                  })) {
 
             executorsMockedStatic.when(() -> Executors.newFixedThreadPool(anyInt())).thenReturn(executorService);
-            return new KafkaBuffer<Record<Event>>(pluginSetting, bufferConfig, pluginFactory, acknowledgementSetManager, pluginMetrics, awsCredentialsSupplier);
+            return new KafkaBuffer<Record<Event>>(pluginSetting, bufferConfig, pluginFactory, acknowledgementSetManager, pluginMetrics, null, awsCredentialsSupplier);
         }
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
@@ -146,7 +146,7 @@ public class KafkaCustomConsumerTest {
 
     public KafkaCustomConsumer createObjectUnderTest(String schemaType, boolean acknowledgementsEnabled) {
         when(sourceConfig.getAcknowledgementsEnabled()).thenReturn(acknowledgementsEnabled);
-        return new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topicConfig, schemaType, acknowledgementSetManager, topicMetrics);
+        return new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topicConfig, schemaType, acknowledgementSetManager, null, topicMetrics);
     }
 
     private BlockingBuffer<Record<Event>> getBuffer() {

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodec.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodec.java
@@ -5,23 +5,15 @@
 
 package org.opensearch.dataprepper.plugins.codec.json;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.codec.DecompressionEngine;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.io.InputFile;
-import org.opensearch.dataprepper.model.log.JacksonLog;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.codec.JsonDecoder;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -30,9 +22,6 @@ import java.util.function.Consumer;
  */
 @DataPrepperPlugin(name = "json", pluginType = InputCodec.class)
 public class JsonInputCodec extends JsonDecoder implements InputCodec {
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
-    private final JsonFactory jsonFactory = new JsonFactory();
 
     @Override
     public void parse(


### PR DESCRIPTION
### Description
Adding support for storing raw bytes in Kafka Buffer.
- Added `writeBytes` api to Buffer
- Added ByteDecoder that's set in the buffer based on the source during pipeline creation
- HTTP source modified to call writeBytes API
- Kafka buffer producer writes bytes to kafka
- Kafka buffer consumer reads bytes and invokes decoder to create records
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
