### PR TITLE
Run the end-to-end tests on Java 21 in the GitHub Actions.

### DIFF
--- a/.github/workflows/data-prepper-log-analytics-basic-grok-e2e-tests.yml
+++ b/.github/workflows/data-prepper-log-analytics-basic-grok-e2e-tests.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 21]
         test: ['basicLogEndToEndTest', 'parallelGrokStringSubstituteTest']
       fail-fast: false
 

--- a/.github/workflows/data-prepper-peer-forwarder-local-node-e2e-tests.yml
+++ b/.github/workflows/data-prepper-peer-forwarder-local-node-e2e-tests.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 21]
       fail-fast: false
 
     runs-on: ubuntu-latest

--- a/.github/workflows/data-prepper-peer-forwarder-static-e2e-tests.yml
+++ b/.github/workflows/data-prepper-peer-forwarder-static-e2e-tests.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 21]
         test: ['staticAggregateEndToEndTest', 'staticLogMetricsEndToEndTest']
       fail-fast: false
 

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-compatibility-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-compatibility-e2e-tests.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 21]
       fail-fast: false
 
     runs-on: ubuntu-latest

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-e2e-tests.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 21]
         otelVersion: ['0.9.0-alpha', '0.16.0-alpha']
       fail-fast: false
 

--- a/.github/workflows/data-prepper-trace-analytics-raw-span-peer-forwarder-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-raw-span-peer-forwarder-e2e-tests.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 21]
       fail-fast: false
 
     runs-on: ubuntu-latest

--- a/.github/workflows/data-prepper-trace-analytics-service-map-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-service-map-e2e-tests.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 21]
       fail-fast: false
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Run our end-to-end tests using Java 21 when building in GitHub Actions. This is to help verify that Data Prepper does successfully run on Java 21 with the goal of making that our next target version.
 
### Issues Resolved

Contributes toward #3329.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
