### PR TITLE
Fix broken DefaultKafkaClusterConfigSupplier get API

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/extension/DefaultKafkaClusterConfigSupplier.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/extension/DefaultKafkaClusterConfigSupplier.java
@@ -10,6 +10,7 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.AwsConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.EncryptionConfig;
 
 import java.util.List;
+import java.util.Objects;
 
 public class DefaultKafkaClusterConfigSupplier implements KafkaClusterConfigSupplier {
     private final KafkaClusterConfig kafkaClusterConfig;
@@ -19,21 +20,21 @@ public class DefaultKafkaClusterConfigSupplier implements KafkaClusterConfigSupp
 
     @Override
     public List<String> getBootStrapServers() {
-        return kafkaClusterConfig.getBootStrapServers();
+        return Objects.nonNull(kafkaClusterConfig) ? kafkaClusterConfig.getBootStrapServers() : null;
     }
 
     @Override
     public AuthConfig getAuthConfig() {
-        return kafkaClusterConfig.getAuthConfig();
+        return Objects.nonNull(kafkaClusterConfig) ? kafkaClusterConfig.getAuthConfig() : null;
     }
 
     @Override
     public AwsConfig getAwsConfig() {
-        return kafkaClusterConfig.getAwsConfig();
+        return Objects.nonNull(kafkaClusterConfig) ? kafkaClusterConfig.getAwsConfig() : null;
     }
 
     @Override
     public EncryptionConfig getEncryptionConfig() {
-        return kafkaClusterConfig.getEncryptionConfig();
+        return Objects.nonNull(kafkaClusterConfig) ? kafkaClusterConfig.getEncryptionConfig() : null;
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/extension/DefaultKafkaClusterConfigSupplierTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/extension/DefaultKafkaClusterConfigSupplierTest.java
@@ -30,7 +30,7 @@ public class DefaultKafkaClusterConfigSupplierTest {
     }
 
     @Test
-    void test_getters() {
+    void testGetters() {
         final List<String> bootstrapServers = List.of("localhost:9092");
         final AuthConfig authConfig = mock(AuthConfig.class);
         final AwsConfig awsConfig = mock(AwsConfig.class);
@@ -44,5 +44,15 @@ public class DefaultKafkaClusterConfigSupplierTest {
         assertThat(defaultKafkaClusterConfigSupplier.getAuthConfig(), equalTo(authConfig));
         assertThat(defaultKafkaClusterConfigSupplier.getAwsConfig(), equalTo(awsConfig));
         assertThat(defaultKafkaClusterConfigSupplier.getEncryptionConfig(), equalTo(encryptionConfig));
+    }
+
+    @Test
+    void testGettersWithNullClusterConfig() {
+        DefaultKafkaClusterConfigSupplier defaultKafkaClusterConfigSupplier = 
+		new DefaultKafkaClusterConfigSupplier(null);
+        assertThat(defaultKafkaClusterConfigSupplier.getBootStrapServers(), equalTo(null));
+        assertThat(defaultKafkaClusterConfigSupplier.getAuthConfig(), equalTo(null));
+        assertThat(defaultKafkaClusterConfigSupplier.getAwsConfig(), equalTo(null));
+        assertThat(defaultKafkaClusterConfigSupplier.getEncryptionConfig(), equalTo(null));
     }
 }


### PR DESCRIPTION
### Description
Fix broken DefaultKafkaClusterConfigSupplier get API
The API doesn't check for the kafkaClusterConfig to be null or not. Modified to check for null config.

Resolves #3528 

### Issues Resolved
Resolves #3528 
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
