### PR TITLE
OpenSearch Sink: Add log messages when there is no exception

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -238,6 +238,13 @@ public final class BulkRetryStrategy {
         if (doRetry) {
             if (retryCount % 5 == 0) {
                 LOG.warn("Bulk Operation Failed. Number of retries {}. Retrying... ", retryCount, e);
+                if (Objects.isNull(e)) {
+                    for (final BulkResponseItem bulkItemResponse : bulkResponse.items()) {
+                        if (Objects.nonNull(bulkItemResponse.error())) {
+                            LOG.warn("operation = {}, error = {}", bulkItemResponse.operationType(), bulkItemResponse.error());
+                        }
+                    }
+                }
             }
             bulkRequestNumberOfRetries.increment();
             return new BulkOperationRequestResponse(bulkRequestForRetry, bulkResponse);
@@ -248,7 +255,13 @@ public final class BulkRetryStrategy {
     }
 
     private void handleFailures(final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequest, final BulkResponse bulkResponse, final Throwable failure) {
+        LOG.warn("Bulk Operation Failed.", failure);
         if (Objects.isNull(failure)) {
+            for (final BulkResponseItem bulkItemResponse : bulkResponse.items()) {
+                if (Objects.nonNull(bulkItemResponse.error())) {
+                    LOG.warn("operation = {}, error = {}", bulkItemResponse.operationType(), bulkItemResponse.error());
+                }
+            }
             handleFailures(bulkRequest, bulkResponse.items());
         } else {
             handleFailures(bulkRequest, failure);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -238,7 +238,7 @@ public final class BulkRetryStrategy {
         if (doRetry) {
             if (retryCount % 5 == 0) {
                 LOG.warn("Bulk Operation Failed. Number of retries {}. Retrying... ", retryCount, e);
-                if (Objects.isNull(e)) {
+                if (e == null) {
                     for (final BulkResponseItem bulkItemResponse : bulkResponse.items()) {
                         if (Objects.nonNull(bulkItemResponse.error())) {
                             LOG.warn("operation = {}, error = {}", bulkItemResponse.operationType(), bulkItemResponse.error());
@@ -256,7 +256,7 @@ public final class BulkRetryStrategy {
 
     private void handleFailures(final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequest, final BulkResponse bulkResponse, final Throwable failure) {
         LOG.warn("Bulk Operation Failed.", failure);
-        if (Objects.isNull(failure)) {
+        if (failure == null) {
             for (final BulkResponseItem bulkItemResponse : bulkResponse.items()) {
                 if (Objects.nonNull(bulkItemResponse.error())) {
                     LOG.warn("operation = {}, error = {}", bulkItemResponse.operationType(), bulkItemResponse.error());


### PR DESCRIPTION
### Description
OpenSearch Sink: Add log messages when there is no exception.
OpenSearch Sink BulkOperation failure logs messages only if there is an exception. It is possible that it fails without exception, it is good to log the error reasons for each operation in those cases as well.
 
Resolves #3508 
### Issues Resolved
Resolves #3508 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
