### PR TITLE
Reorder formatString expression check for JacksonEvent

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -354,12 +354,18 @@ public class JacksonEvent implements Event {
             result += format.substring(fromIndex, position);
             String name = format.substring(position + 2, endPosition);
 
-            Object val;
-            if (Objects.nonNull(expressionEvaluator) && expressionEvaluator.isValidExpressionStatement(name)) {
-                val = expressionEvaluator.evaluate(name, this);
-            } else {
+            Object val = null;
+
+            try {
                 val = this.get(name, Object.class);
-                if (val == null) {
+            } catch (final Exception e) {
+                LOG.debug("Received exception using Event key for formatting, now checking for Data Prepper expression: {}", e.getMessage());
+            }
+
+            if (val == null) {
+                if (Objects.nonNull(expressionEvaluator) && expressionEvaluator.isValidExpressionStatement(name)) {
+                    val = expressionEvaluator.evaluate(name, this);
+                } else {
                     throw new EventKeyNotFoundException(String.format("The key %s could not be found in the Event when formatting", name));
                 }
             }


### PR DESCRIPTION
### Description

Any call to JacksonEvent `formatString` method with an expression evaluator would call `isValidExpressionStatement`. A call to `isValidExpressionStatement` that was false, such as the configurations for normal keys (such as `${some_key}`) resulted in the ANTLR parser logging something like 

```
line 1:0 token recognition error at: 'spanId'
line 1:6 mismatched input '' expecting {Function, Integer, Float, Boolean, 'null', JsonPointer, EscapedJsonPointer, VariableIdentifier, String, NOT, '-', '(', '{', OTHER}
``` 
every time this occurs, which is very often when the format is a dynamic index that is evaluated for every Event. This causes cpu spikes and a thread freeze from timeouts for the logger writing to console. 

This mitigation includes swapping the order of the evaluation of the format expressions (`${}`), so that it is first evaluated whether or not the key is in the Event, and only if it is not do we evaluate whether the statement is a valid expression. The behavior should not change with this swap, but it will very heavily reduce the amount of logging that is seen from the ANTLR parser for this error. Eventually, we should try to keep this log from showing up completely when evaluating if an expression is valid.
 
### Issues Resolved
Resolves #3357 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
