### PR TITLE
Add support for OTEL metrics source to use Kafka buffer

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogram.java
@@ -27,8 +27,8 @@ public class JacksonExponentialHistogram extends JacksonMetric implements Expone
     private static final String SCALE_KEY = "scale";
     private static final String AGGREGATION_TEMPORALITY_KEY = "aggregationTemporality";
     private static final String ZERO_COUNT_KEY = "zeroCount";
-    private static final String POSITIVE_BUCKETS_KEY = "positiveBuckets";
-    private static final String NEGATIVE_BUCKETS_KEY = "negativeBuckets";
+    public static final String POSITIVE_BUCKETS_KEY = "positiveBuckets";
+    public static final String NEGATIVE_BUCKETS_KEY = "negativeBuckets";
     private static final String NEGATIVE_KEY = "negative";
     private static final String POSITIVE_KEY = "positive";
     private static final String NEGATIVE_OFFSET_KEY = "negativeOffset";

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonHistogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonHistogram.java
@@ -29,7 +29,7 @@ public class JacksonHistogram extends JacksonMetric implements Histogram {
     private static final String AGGREGATION_TEMPORALITY_KEY = "aggregationTemporality";
     private static final String BUCKET_COUNTS_KEY = "bucketCounts";
     private static final String EXPLICIT_BOUNDS_COUNT_KEY = "explicitBoundsCount";
-    private static final String BUCKETS_KEY = "buckets";
+    public static final String BUCKETS_KEY = "buckets";
     private static final String BUCKET_COUNTS_LIST_KEY = "bucketCountsList";
     private static final String EXPLICIT_BOUNDS_KEY = "explicitBounds";
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
@@ -28,7 +28,7 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
     protected static final String SERVICE_NAME_KEY = "serviceName";
     protected static final String KIND_KEY = "kind";
     protected static final String UNIT_KEY = "unit";
-    protected static final String ATTRIBUTES_KEY = "attributes";
+    public static final String ATTRIBUTES_KEY = "attributes";
     protected static final String SCHEMA_URL_KEY = "schemaUrl";
     protected static final String EXEMPLARS_KEY = "exemplars";
     protected static final String FLAGS_KEY = "flags";

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OTelMetricsRawProcessor.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OTelMetricsRawProcessor.java
@@ -83,15 +83,15 @@ public class OTelMetricsRawProcessor extends AbstractProcessor<Record<?>, Record
         AtomicInteger droppedCounter = new AtomicInteger(0);
 
         for (Record<?> rec : records) {
-            Record<? extends Metric> newRecord = (Record<? extends Metric>)rec;
             if ((rec.getData() instanceof Event)) {
+                Record<? extends Metric> newRecord = (Record<? extends Metric>)rec;
                 if (otelMetricsRawProcessorConfig.getFlattenAttributesFlag() ||
                     !otelMetricsRawProcessorConfig.getCalculateHistogramBuckets() ||
                     !otelMetricsRawProcessorConfig.getCalculateExponentialHistogramBuckets()) {
                     modifyRecord(newRecord, otelMetricsRawProcessorConfig.getFlattenAttributesFlag(), otelMetricsRawProcessorConfig.getCalculateHistogramBuckets(), otelMetricsRawProcessorConfig.getCalculateExponentialHistogramBuckets());
                 }
+                recordsOut.add(newRecord);
             }
-            recordsOut.add(newRecord);
 
             if (!(rec.getData() instanceof ExportMetricsServiceRequest)) {
                 continue;

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OTelMetricsRawProcessor.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OTelMetricsRawProcessor.java
@@ -6,35 +6,32 @@
 package org.opensearch.dataprepper.plugins.processor.otelmetrics;
 
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
-import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics;
-import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
-import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
-import org.opensearch.dataprepper.model.metric.JacksonExponentialHistogram;
-import org.opensearch.dataprepper.model.metric.JacksonGauge;
-import org.opensearch.dataprepper.model.metric.JacksonHistogram;
-import org.opensearch.dataprepper.model.metric.JacksonSum;
-import org.opensearch.dataprepper.model.metric.JacksonSummary;
+import static org.opensearch.dataprepper.model.metric.JacksonExponentialHistogram.POSITIVE_BUCKETS_KEY;
+import static org.opensearch.dataprepper.model.metric.JacksonExponentialHistogram.NEGATIVE_BUCKETS_KEY;
+import static org.opensearch.dataprepper.model.metric.JacksonHistogram.BUCKETS_KEY;
 import org.opensearch.dataprepper.model.metric.Metric;
+import static org.opensearch.dataprepper.model.metric.JacksonMetric.ATTRIBUTES_KEY;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCodec;
 import io.micrometer.core.instrument.Counter;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 @DataPrepperPlugin(name = "otel_metrics", deprecatedName = "otel_metrics_raw_processor", pluginType = Processor.class, pluginConfigurationType = OtelMetricsRawProcessorConfig.class)
-public class OTelMetricsRawProcessor extends AbstractProcessor<Record<ExportMetricsServiceRequest>, Record<? extends Metric>> {
+public class OTelMetricsRawProcessor extends AbstractProcessor<Record<?>, Record<? extends Metric>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(OTelMetricsRawProcessor.class);
     public static final String RECORDS_DROPPED_METRICS_RAW = "recordsDroppedMetricsRaw";
@@ -52,239 +49,60 @@ public class OTelMetricsRawProcessor extends AbstractProcessor<Record<ExportMetr
         this.flattenAttributesFlag = otelMetricsRawProcessorConfig.getFlattenAttributesFlag();
     }
 
+    private void modifyRecord(Record<? extends Metric> record,
+                              boolean flattenAttributes,
+                              boolean calcualteHistogramBuckets,
+                              boolean calcualteExponentialHistogramBuckets) {
+        Event event = (Event)record.getData();
+
+        if (flattenAttributes) {
+            Map<String, Object> attributes = event.get(ATTRIBUTES_KEY, Map.class);
+
+            for (Map.Entry<String, Object> entry : attributes.entrySet()) {
+                event.put(entry.getKey(), entry.getValue());
+            }
+            event.delete(ATTRIBUTES_KEY);
+        }
+        if (!calcualteHistogramBuckets && event.get(BUCKETS_KEY, List.class) != null) {
+            event.delete(BUCKETS_KEY);
+        }
+        if (!calcualteExponentialHistogramBuckets) {
+            if (event.get(POSITIVE_BUCKETS_KEY, List.class) != null) {
+                event.delete(POSITIVE_BUCKETS_KEY);
+            }
+            if (event.get(NEGATIVE_BUCKETS_KEY, List.class) != null) {
+                event.delete(NEGATIVE_BUCKETS_KEY);
+            }
+        }
+    }
+
     @Override
-    public Collection<Record<? extends Metric>> doExecute(Collection<Record<ExportMetricsServiceRequest>> records) {
+    public Collection<Record<? extends Metric>> doExecute(Collection<Record<?>> records) {
         Collection<Record<? extends Metric>> recordsOut = new ArrayList<>();
-        for (Record<ExportMetricsServiceRequest> ets : records) {
-            for (ResourceMetrics rs : ets.getData().getResourceMetricsList()) {
-                final String schemaUrl = rs.getSchemaUrl();
-                final Map<String, Object> resourceAttributes = OTelProtoCodec.getResourceAttributes(rs.getResource());
-                final String serviceName = OTelProtoCodec.getServiceName(rs.getResource()).orElse(null);
+        OTelProtoCodec.OTelProtoDecoder otelProtoDecoder = new OTelProtoCodec.OTelProtoDecoder();
+        AtomicInteger droppedCounter = new AtomicInteger(0);
 
-                for (InstrumentationLibraryMetrics is : rs.getInstrumentationLibraryMetricsList()) {
-                    final Map<String, Object> ils = OTelProtoCodec.getInstrumentationLibraryAttributes(is.getInstrumentationLibrary());
-                    recordsOut.addAll(processMetricsList(is.getMetricsList(), serviceName, ils, resourceAttributes, schemaUrl));
-                }
-
-                for (ScopeMetrics sm : rs.getScopeMetricsList()) {
-                    final Map<String, Object> ils = OTelProtoCodec.getInstrumentationScopeAttributes(sm.getScope());
-                    recordsOut.addAll(processMetricsList(sm.getMetricsList(), serviceName, ils, resourceAttributes, schemaUrl));
+        for (Record<?> rec : records) {
+            Record<? extends Metric> newRecord = (Record<? extends Metric>)rec;
+            if ((rec.getData() instanceof Event)) {
+                if (otelMetricsRawProcessorConfig.getFlattenAttributesFlag() ||
+                    !otelMetricsRawProcessorConfig.getCalculateHistogramBuckets() ||
+                    !otelMetricsRawProcessorConfig.getCalculateExponentialHistogramBuckets()) {
+                    modifyRecord(newRecord, otelMetricsRawProcessorConfig.getFlattenAttributesFlag(), otelMetricsRawProcessorConfig.getCalculateHistogramBuckets(), otelMetricsRawProcessorConfig.getCalculateExponentialHistogramBuckets());
                 }
             }
-        }
-        return recordsOut;
-    }
+            recordsOut.add(newRecord);
 
-    private List<? extends Record<? extends Metric>> processMetricsList(final List<io.opentelemetry.proto.metrics.v1.Metric> metricsList,
-                                                                        final String serviceName,
-                                                                        final Map<String, Object> ils,
-                                                                        final Map<String, Object> resourceAttributes,
-                                                                        final String schemaUrl) {
-        List<Record<? extends Metric>> recordsOut = new ArrayList<>();
-        for (io.opentelemetry.proto.metrics.v1.Metric metric : metricsList) {
-            try {
-                if (metric.hasGauge()) {
-                    recordsOut.addAll(mapGauge(metric, serviceName, ils, resourceAttributes, schemaUrl));
-                } else if (metric.hasSum()) {
-                    recordsOut.addAll(mapSum(metric, serviceName, ils, resourceAttributes, schemaUrl));
-                } else if (metric.hasSummary()) {
-                    recordsOut.addAll(mapSummary(metric, serviceName, ils, resourceAttributes, schemaUrl));
-                } else if (metric.hasHistogram()) {
-                    recordsOut.addAll(mapHistogram(metric, serviceName, ils, resourceAttributes, schemaUrl));
-                } else if (metric.hasExponentialHistogram()) {
-                    recordsOut.addAll(mapExponentialHistogram(metric, serviceName, ils, resourceAttributes, schemaUrl));
-                }
-            } catch (Exception e) {
-                LOG.warn("Error while processing metrics", e);
-                recordsDroppedMetricsRawCounter.increment();
+            if (!(rec.getData() instanceof ExportMetricsServiceRequest)) {
+                continue;
             }
+
+            ExportMetricsServiceRequest request = ((Record<ExportMetricsServiceRequest>)rec).getData();
+            recordsOut.addAll(otelProtoDecoder.parseExportMetricsServiceRequest(request, droppedCounter, otelMetricsRawProcessorConfig.getExponentialHistogramMaxAllowedScale(), otelMetricsRawProcessorConfig.getCalculateHistogramBuckets(), otelMetricsRawProcessorConfig.getCalculateExponentialHistogramBuckets(), flattenAttributesFlag));
         }
+        recordsDroppedMetricsRawCounter.increment(droppedCounter.get());
         return recordsOut;
     }
-
-    private List<? extends Record<? extends Metric>> mapGauge(io.opentelemetry.proto.metrics.v1.Metric metric,
-                                         String serviceName,
-                                         final Map<String, Object> ils,
-                                         final Map<String, Object> resourceAttributes,
-                                         final String schemaUrl) {
-        return metric.getGauge().getDataPointsList().stream()
-                .map(dp -> JacksonGauge.builder()
-                        .withUnit(metric.getUnit())
-                        .withName(metric.getName())
-                        .withDescription(metric.getDescription())
-                        .withStartTime(OTelProtoCodec.getStartTimeISO8601(dp))
-                        .withTime(OTelProtoCodec.getTimeISO8601(dp))
-                        .withServiceName(serviceName)
-                        .withValue(OTelProtoCodec.getValueAsDouble(dp))
-                        .withAttributes(OTelProtoCodec.mergeAllAttributes(
-                                Arrays.asList(
-                                        OTelProtoCodec.convertKeysOfDataPointAttributes(dp),
-                                        resourceAttributes,
-                                        ils
-                                )
-                        ))
-                        .withSchemaUrl(schemaUrl)
-                        .withExemplars(OTelProtoCodec.convertExemplars(dp.getExemplarsList()))
-                        .withFlags(dp.getFlags())
-                        .build(flattenAttributesFlag))
-                .map(Record::new)
-                .collect(Collectors.toList());
-    }
-
-    private List<? extends Record<? extends Metric>> mapSum(final io.opentelemetry.proto.metrics.v1.Metric metric,
-                                     final String serviceName,
-                                     final Map<String, Object> ils,
-                                     final Map<String, Object> resourceAttributes,
-                                     final String schemaUrl) {
-        return metric.getSum().getDataPointsList().stream()
-                .map(dp -> JacksonSum.builder()
-                        .withUnit(metric.getUnit())
-                        .withName(metric.getName())
-                        .withDescription(metric.getDescription())
-                        .withStartTime(OTelProtoCodec.getStartTimeISO8601(dp))
-                        .withTime(OTelProtoCodec.getTimeISO8601(dp))
-                        .withServiceName(serviceName)
-                        .withIsMonotonic(metric.getSum().getIsMonotonic())
-                        .withValue(OTelProtoCodec.getValueAsDouble(dp))
-                        .withAggregationTemporality(metric.getSum().getAggregationTemporality().toString())
-                        .withAttributes(OTelProtoCodec.mergeAllAttributes(
-                                Arrays.asList(
-                                        OTelProtoCodec.convertKeysOfDataPointAttributes(dp),
-                                        resourceAttributes,
-                                        ils
-                                )
-                        ))
-                        .withSchemaUrl(schemaUrl)
-                        .withExemplars(OTelProtoCodec.convertExemplars(dp.getExemplarsList()))
-                        .withFlags(dp.getFlags())
-                        .build(flattenAttributesFlag))
-                .map(Record::new)
-                .collect(Collectors.toList());
-    }
-
-    private List<? extends Record<? extends Metric>> mapSummary(final io.opentelemetry.proto.metrics.v1.Metric metric,
-                                             final String serviceName,
-                                             final Map<String, Object> ils,
-                                             final Map<String, Object> resourceAttributes,
-                                             final String schemaUrl) {
-        return metric.getSummary().getDataPointsList().stream()
-                .map(dp -> JacksonSummary.builder()
-                        .withUnit(metric.getUnit())
-                        .withName(metric.getName())
-                        .withDescription(metric.getDescription())
-                        .withStartTime(OTelProtoCodec.convertUnixNanosToISO8601(dp.getStartTimeUnixNano()))
-                        .withTime(OTelProtoCodec.convertUnixNanosToISO8601(dp.getTimeUnixNano()))
-                        .withServiceName(serviceName)
-                        .withCount(dp.getCount())
-                        .withSum(dp.getSum())
-                        .withQuantiles(OTelProtoCodec.getQuantileValues(dp.getQuantileValuesList()))
-                        .withQuantilesValueCount(dp.getQuantileValuesCount())
-                        .withAttributes(OTelProtoCodec.mergeAllAttributes(
-                                Arrays.asList(
-                                        OTelProtoCodec.unpackKeyValueList(dp.getAttributesList()),
-                                        resourceAttributes,
-                                        ils
-                                )
-                        ))
-                        .withSchemaUrl(schemaUrl)
-                        .withFlags(dp.getFlags())
-                        .build(flattenAttributesFlag))
-                .map(Record::new)
-                .collect(Collectors.toList());
-    }
-
-    private List<? extends Record<? extends Metric>> mapHistogram(final io.opentelemetry.proto.metrics.v1.Metric metric,
-                                                 final String serviceName,
-                                                 final Map<String, Object> ils,
-                                                 final Map<String, Object> resourceAttributes,
-                                                 final String schemaUrl) {
-        return metric.getHistogram().getDataPointsList().stream()
-                .map(dp -> {
-                    JacksonHistogram.Builder builder = JacksonHistogram.builder()
-                            .withUnit(metric.getUnit())
-                            .withName(metric.getName())
-                            .withDescription(metric.getDescription())
-                            .withStartTime(OTelProtoCodec.convertUnixNanosToISO8601(dp.getStartTimeUnixNano()))
-                            .withTime(OTelProtoCodec.convertUnixNanosToISO8601(dp.getTimeUnixNano()))
-                            .withServiceName(serviceName)
-                            .withSum(dp.getSum())
-                            .withCount(dp.getCount())
-                            .withBucketCount(dp.getBucketCountsCount())
-                            .withExplicitBoundsCount(dp.getExplicitBoundsCount())
-                            .withAggregationTemporality(metric.getHistogram().getAggregationTemporality().toString())
-                            .withBucketCountsList(dp.getBucketCountsList())
-                            .withExplicitBoundsList(dp.getExplicitBoundsList())
-                            .withAttributes(OTelProtoCodec.mergeAllAttributes(
-                                    Arrays.asList(
-                                            OTelProtoCodec.unpackKeyValueList(dp.getAttributesList()),
-                                            resourceAttributes,
-                                            ils
-                                    )
-                            ))
-                            .withSchemaUrl(schemaUrl)
-                            .withExemplars(OTelProtoCodec.convertExemplars(dp.getExemplarsList()))
-                            .withFlags(dp.getFlags());
-                    if (otelMetricsRawProcessorConfig.getCalculateHistogramBuckets()) {
-                        builder.withBuckets(OTelProtoCodec.createBuckets(dp.getBucketCountsList(), dp.getExplicitBoundsList()));
-                    }
-                    JacksonHistogram jh = builder.build(flattenAttributesFlag);
-                    return jh;
-
-                })
-                .map(Record::new)
-                .collect(Collectors.toList());
-    }
-
-    private List<? extends Record<? extends Metric>> mapExponentialHistogram(io.opentelemetry.proto.metrics.v1.Metric metric, String serviceName, Map<String, Object> ils, Map<String, Object> resourceAttributes, String schemaUrl) {
-        return metric.getExponentialHistogram().getDataPointsList().stream()
-                .filter(dp -> {
-                    if (otelMetricsRawProcessorConfig.getCalculateExponentialHistogramBuckets() &&
-                            otelMetricsRawProcessorConfig.getExponentialHistogramMaxAllowedScale() < Math.abs(dp.getScale())){
-                        LOG.error("Exponential histogram can not be processed since its scale of {} is bigger than the configured max of {}.", dp.getScale(), otelMetricsRawProcessorConfig.getExponentialHistogramMaxAllowedScale());
-                        return false;
-                    } else {
-                        return true;
-                    }
-                })
-                .map(dp -> {
-                    JacksonExponentialHistogram.Builder builder = JacksonExponentialHistogram.builder()
-                            .withUnit(metric.getUnit())
-                            .withName(metric.getName())
-                            .withDescription(metric.getDescription())
-                            .withStartTime(OTelProtoCodec.convertUnixNanosToISO8601(dp.getStartTimeUnixNano()))
-                            .withTime(OTelProtoCodec.convertUnixNanosToISO8601(dp.getTimeUnixNano()))
-                            .withServiceName(serviceName)
-                            .withSum(dp.getSum())
-                            .withCount(dp.getCount())
-                            .withZeroCount(dp.getZeroCount())
-                            .withScale(dp.getScale())
-                            .withPositive(dp.getPositive().getBucketCountsList())
-                            .withPositiveOffset(dp.getPositive().getOffset())
-                            .withNegative(dp.getNegative().getBucketCountsList())
-                            .withNegativeOffset(dp.getNegative().getOffset())
-                            .withAggregationTemporality(metric.getHistogram().getAggregationTemporality().toString())
-                            .withAttributes(OTelProtoCodec.mergeAllAttributes(
-                                    Arrays.asList(
-                                            OTelProtoCodec.unpackKeyValueList(dp.getAttributesList()),
-                                            resourceAttributes,
-                                            ils
-                                    )
-                            ))
-                            .withSchemaUrl(schemaUrl)
-                            .withExemplars(OTelProtoCodec.convertExemplars(dp.getExemplarsList()))
-                            .withFlags(dp.getFlags());
-
-                    if (otelMetricsRawProcessorConfig.getCalculateExponentialHistogramBuckets()) {
-                        builder.withPositiveBuckets(OTelProtoCodec.createExponentialBuckets(dp.getPositive(), dp.getScale()));
-                        builder.withNegativeBuckets(OTelProtoCodec.createExponentialBuckets(dp.getNegative(), dp.getScale()));
-                    }
-
-                    return builder.build(flattenAttributesFlag);
-                })
-                .map(Record::new)
-                .collect(Collectors.toList());
-    }
-
 
     @Override
     public void prepareForShutdown() {

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfig.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OtelMetricsRawProcessorConfig.java
@@ -4,6 +4,8 @@
  */
 
 package org.opensearch.dataprepper.plugins.processor.otelmetrics;
+
+import static org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCodec.DEFAULT_EXPONENTIAL_HISTOGRAM_MAX_ALLOWED_SCALE;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class OtelMetricsRawProcessorConfig {
@@ -15,7 +17,7 @@ public class OtelMetricsRawProcessorConfig {
 
     private Boolean calculateExponentialHistogramBuckets = true;
 
-    private Integer exponentialHistogramMaxAllowedScale = 10;
+    private Integer exponentialHistogramMaxAllowedScale = DEFAULT_EXPONENTIAL_HISTOGRAM_MAX_ALLOWED_SCALE;
 
     public Boolean getCalculateExponentialHistogramBuckets() {
         return calculateExponentialHistogramBuckets;

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/MetricsPluginSumTest.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/MetricsPluginSumTest.java
@@ -24,11 +24,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
-import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.metric.JacksonMetric;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -102,8 +103,9 @@ public class MetricsPluginSumTest {
 
         Record record = new Record<>(exportMetricRequest);
 
-        List<Record<Event>> rec = (List<Record<Event>>) rawProcessor.doExecute(Arrays.asList(record));
-        Record<Event> firstRecord = rec.get(0);
+        Collection<Record<?>> records = Arrays.asList((Record<?>)record);
+        List<Record<? extends org.opensearch.dataprepper.model.metric.Metric>> outputRecords = (List<Record<? extends org.opensearch.dataprepper.model.metric.Metric>>)rawProcessor.doExecute(records);
+        Record<JacksonMetric> firstRecord = (Record<JacksonMetric>)outputRecords.get(0);
 
         ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> map = objectMapper.readValue(firstRecord.getData().toJsonString(), Map.class);
@@ -182,8 +184,11 @@ public class MetricsPluginSumTest {
         Record record = new Record<>(exportMetricRequest);
         Record invalidRecord = new Record<>(exportMetricRequestWithInvalidMetric);
 
-        List<Record<Event>> rec = (List<Record<Event>>) rawProcessor.doExecute(Arrays.asList(record, invalidRecord));
-        org.hamcrest.MatcherAssert.assertThat(rec.size(), equalTo(1));
+        Collection<Record<?>> records = Arrays.asList((Record<?>)record, invalidRecord);
+        List<Record<? extends org.opensearch.dataprepper.model.metric.Metric>> outputRecords = (List<Record<? extends org.opensearch.dataprepper.model.metric.Metric>>)rawProcessor.doExecute(records);
+
+        //List<Record<Event>> rec = (List<Record<Event>>) rawProcessor.doExecute(Arrays.asList(record, invalidRecord));
+        org.hamcrest.MatcherAssert.assertThat(outputRecords.size(), equalTo(1));
     }
 
     private void assertSumProcessing(Map<String, Object> map) {

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/MetricsPluginSummaryTest.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/MetricsPluginSummaryTest.java
@@ -21,11 +21,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
-import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.metric.JacksonMetric;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -83,8 +84,9 @@ public class MetricsPluginSummaryTest {
 
         Record record = new Record<>(exportMetricRequest);
 
-        List<Record<Event>> rec =  (List<Record<Event>>) rawProcessor.doExecute(Arrays.asList(record));
-        Record<Event> firstRecord = rec.get(0);
+        Collection<Record<?>> records = Arrays.asList((Record<?>)record);
+        List<Record<? extends org.opensearch.dataprepper.model.metric.Metric>> outputRecords = (List<Record<? extends org.opensearch.dataprepper.model.metric.Metric>>)rawProcessor.doExecute(records);
+        Record<JacksonMetric> firstRecord = (Record<JacksonMetric>)outputRecords.get(0);
 
         ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> map = objectMapper.readValue(firstRecord.getData().toJsonString(), Map.class);

--- a/data-prepper-plugins/otel-metrics-source/build.gradle
+++ b/data-prepper-plugins/otel-metrics-source/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':data-prepper-plugins:blocking-buffer')
     implementation libs.commons.codec
     implementation project(':data-prepper-plugins:armeria-common')
+    implementation project(':data-prepper-plugins:otel-proto-common')
     testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation libs.opentelemetry.proto
     implementation libs.commons.io

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcService.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcService.java
@@ -19,7 +19,6 @@ import org.opensearch.dataprepper.exceptions.RequestCancelledException;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.record.Record;
-import org.opensearch.dataprepper.model.codec.ByteDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,16 +37,13 @@ public class OTelMetricsGrpcService extends MetricsServiceGrpc.MetricsServiceImp
     private final Counter successRequestsCounter;
     private final DistributionSummary payloadSizeSummary;
     private final Timer requestProcessDuration;
-    private final ByteDecoder byteDecoder;
 
 
     public OTelMetricsGrpcService(int bufferWriteTimeoutInMillis,
                                   Buffer<Record<ExportMetricsServiceRequest>> buffer,
-                                  final ByteDecoder byteDecoder,
                                   final PluginMetrics pluginMetrics) {
         this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
         this.buffer = buffer;
-        this.byteDecoder = byteDecoder;
 
         requestsReceivedCounter = pluginMetrics.counter(REQUESTS_RECEIVED);
         successRequestsCounter = pluginMetrics.counter(SUCCESS_REQUESTS);

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
@@ -101,7 +101,6 @@ public class OTelMetricsSource implements Source<Record<ExportMetricsServiceRequ
             final OTelMetricsGrpcService oTelMetricsGrpcService = new OTelMetricsGrpcService(
                     (int) (oTelMetricsSourceConfig.getRequestTimeoutInMillis() * 0.8),
                     buffer,
-                    byteDecoder,
                     pluginMetrics
             );
 

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
@@ -32,6 +32,8 @@ import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
+import org.opensearch.dataprepper.model.codec.ByteDecoder;
+import org.opensearch.dataprepper.plugins.otel.codec.OTelMetricDecoder;
 import org.opensearch.dataprepper.plugins.certificate.CertificateProvider;
 import org.opensearch.dataprepper.plugins.certificate.model.Certificate;
 import org.opensearch.dataprepper.plugins.health.HealthGrpcService;
@@ -62,6 +64,7 @@ public class OTelMetricsSource implements Source<Record<ExportMetricsServiceRequ
     private final CertificateProviderFactory certificateProviderFactory;
     private final GrpcRequestExceptionHandler requestExceptionHandler;
     private Server server;
+    private final ByteDecoder byteDecoder;
 
     @DataPrepperPluginConstructor
     public OTelMetricsSource(final OTelMetricsSourceConfig oTelMetricsSourceConfig, final PluginMetrics pluginMetrics,
@@ -79,6 +82,12 @@ public class OTelMetricsSource implements Source<Record<ExportMetricsServiceRequ
         this.pipelineName = pipelineDescription.getPipelineName();
         this.authenticationProvider = createAuthenticationProvider(pluginFactory);
         this.requestExceptionHandler = new GrpcRequestExceptionHandler(pluginMetrics);
+        this.byteDecoder = new OTelMetricDecoder();
+    }
+
+    @Override
+    public ByteDecoder getDecoder() {
+        return byteDecoder;
     }
 
     @Override
@@ -92,6 +101,7 @@ public class OTelMetricsSource implements Source<Record<ExportMetricsServiceRequ
             final OTelMetricsGrpcService oTelMetricsGrpcService = new OTelMetricsGrpcService(
                     (int) (oTelMetricsSourceConfig.getRequestTimeoutInMillis() * 0.8),
                     buffer,
+                    byteDecoder,
                     pluginMetrics
             );
 

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelMetricDecoder.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelMetricDecoder.java
@@ -12,7 +12,6 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.metric.Metric;
 
-import org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCodec;
 
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelMetricDecoder.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelMetricDecoder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.otel.codec;
+
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import org.opensearch.dataprepper.model.codec.ByteDecoder;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.metric.Metric;
+
+import org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCodec;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Consumer;
+
+
+public class OTelMetricDecoder implements ByteDecoder {
+    private final OTelProtoCodec.OTelProtoDecoder otelProtoDecoder;
+    public OTelMetricDecoder() {
+        otelProtoDecoder = new OTelProtoCodec.OTelProtoDecoder();
+    }
+    public void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException {
+        ExportMetricsServiceRequest request = ExportMetricsServiceRequest.parseFrom(inputStream);
+        AtomicInteger droppedCounter = new AtomicInteger(0);
+        Collection<Record<? extends Metric>> records =
+            otelProtoDecoder.parseExportMetricsServiceRequest(request, droppedCounter, OTelProtoCodec.DEFAULT_EXPONENTIAL_HISTOGRAM_MAX_ALLOWED_SCALE, true, true, false);
+        for (Record<? extends Metric> record: records) {
+            final JacksonEvent event = JacksonEvent.fromEvent(record.getData());
+            eventConsumer.accept(new Record<>(event));
+        }
+    }
+
+}

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodec.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodec.java
@@ -663,7 +663,7 @@ public class OTelProtoCodec {
 
         private List<? extends Record<? extends Metric>> mapExponentialHistogram(
                                             final io.opentelemetry.proto.metrics.v1.Metric metric,
-                                            final String serviceName, 
+                                            final String serviceName,
                                             final Map<String, Object> ils,
                                             final Map<String, Object> resourceAttributes,
                                             final String schemaUrl,

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-gauge-metrics.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-gauge-metrics.json
@@ -1,0 +1,44 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "resource-attr",
+            "value": {
+              "stringValue": "resource-attr-val-1"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {},
+          "metrics": [
+            {
+              "name": "counter-int",
+              "unit": 1,
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "label-1",
+                        "value": {
+                          "stringValue": "label-value-1"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "1581452773000000789",
+                    "timeUnixNano": "1581452773000000789",
+                    "asInt": "123"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-histogram-metrics.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-histogram-metrics.json
@@ -1,0 +1,50 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "resource-attr",
+            "value": {
+              "stringValue": "resource-attr-val-1"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {},
+          "metrics": [
+            {
+              "name": "histogram-int",
+              "unit": 1,
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "label-1",
+                        "value": {
+                          "stringValue": "label-value-1"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "1581452773000000789",
+                    "timeUnixNano": "1581452773000000789",
+                    "count": "30",
+                    "sum": "100",
+                    "bucket_counts": [3, 5, 15, 6, 1],
+                    "explicit_bounds": [1.0, 2.0, 3.0, 4.0],
+                    "exemplars": []
+                  }
+                ],
+                "aggregationTemporality":"2"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+

--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-sum-metrics.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-sum-metrics.json
@@ -1,0 +1,45 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "resource-attr",
+            "value": {
+              "stringValue": "resource-attr-val-1"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {},
+          "metrics": [
+            {
+              "name": "sum-int",
+              "unit": 1,
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "label-1",
+                        "value": {
+                          "stringValue": "label-value-1"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "1581452773000000789",
+                    "timeUnixNano": "1581452773000000789",
+                    "asInt": "456"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
### Description
Add support for OTEL metrics source to use Kafka buffer
Added OTEL Proto Decoder that is instantiated by OTEL metrics source. 
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
