### PR TITLE
Removes the deprecated annotation from Record and RecordMetadata

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/record/Record.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/record/Record.java
@@ -12,7 +12,6 @@ package org.opensearch.dataprepper.model.record;
  * TODO: The current implementation focuses on proving the bare bones for which this class only need to
  * TODO: support sample test cases.
  */
-@Deprecated
 public class Record<T> {
     private final T data;
     private final RecordMetadata metadata;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/record/RecordMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/record/RecordMetadata.java
@@ -13,7 +13,6 @@ import java.util.Map;
  * The <b>RecordMetadata</b> class provides a wrapper around the ImmutableMap making metadata management easier for the
  * user to access.
  */
-@Deprecated
 public class RecordMetadata {
     private static final RecordMetadata DEFAULT_METADATA = new RecordMetadata();
 


### PR DESCRIPTION
### Description

Removes the deprecated annotation from Record and RecordMetadata as these are currently still necessary. 
 
### Issues Resolved

Resolves #3536.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
