### PR TITLE
Add obfuscate_when parameter and tags_on_match failure to obfuscate processor

### DIFF
--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessor.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessor.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -107,7 +106,7 @@ public class ObfuscationProcessor extends AbstractProcessor<Record<Event>, Recor
         for (final Record<Event> record : records) {
             final Event recordEvent = record.getData();
 
-            if (Objects.nonNull(obfuscationProcessorConfig.getObfuscateWhen()) && !expressionEvaluator.evaluateConditional(obfuscationProcessorConfig.getObfuscateWhen(), recordEvent)) {
+            if (obfuscationProcessorConfig.getObfuscateWhen() != null && !expressionEvaluator.evaluateConditional(obfuscationProcessorConfig.getObfuscateWhen(), recordEvent)) {
                 continue;
             }
 

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessor.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessor.java
@@ -116,8 +116,14 @@ public class ObfuscationProcessor extends AbstractProcessor<Record<Event>, Recor
             }
 
             String rawValue = recordEvent.get(source, String.class);
+
             // Call obfuscation action
             String newValue = this.action.obfuscate(rawValue, patterns);
+
+            // No changes means it does not match any patterns
+            if (rawValue.equals(newValue)) {
+                recordEvent.getMetadata().addTags(obfuscationProcessorConfig.getTagsOnMatchFailure());
+            }
 
             // Update the event record.
             if (target == null || target.isEmpty()) {

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
@@ -8,7 +8,9 @@ package org.opensearch.dataprepper.plugins.processor.obfuscation;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 
 import java.util.List;
 
@@ -27,6 +29,10 @@ public class ObfuscationProcessorConfig {
 
     @JsonProperty("action")
     private PluginModel action;
+
+    @JsonProperty("obfuscate_when")
+    @NotEmpty
+    private String obfuscateWhen;
 
     public ObfuscationProcessorConfig() {
     }
@@ -52,5 +58,15 @@ public class ObfuscationProcessorConfig {
 
     public PluginModel getAction() {
         return action;
+    }
+
+    public String getObfuscateWhen() {
+        return obfuscateWhen;
+    }
+
+    void validateObfuscateWhen(final ExpressionEvaluator expressionEvaluator) {
+        if (obfuscateWhen != null && !expressionEvaluator.isValidExpressionStatement(obfuscateWhen)) {
+            throw new InvalidPluginConfigurationException(String.format("obfuscate_when value %s is not a valid Data Prepper expression statement", obfuscateWhen));
+        }
     }
 }

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
@@ -31,17 +31,20 @@ public class ObfuscationProcessorConfig {
     private PluginModel action;
 
     @JsonProperty("obfuscate_when")
-    @NotEmpty
     private String obfuscateWhen;
+
+    @JsonProperty("tags_on_match_failure")
+    private List<String> tagsOnMatchFailure;
 
     public ObfuscationProcessorConfig() {
     }
 
-    public ObfuscationProcessorConfig(String source, List<String> patterns, String target, PluginModel action) {
+    public ObfuscationProcessorConfig(String source, List<String> patterns, String target, PluginModel action, List<String> tagsOnMatchFailure) {
         this.source = source;
         this.patterns = patterns;
         this.target = target;
         this.action = action;
+        this.tagsOnMatchFailure = tagsOnMatchFailure;
     }
 
     public String getSource() {
@@ -62,6 +65,10 @@ public class ObfuscationProcessorConfig {
 
     public String getObfuscateWhen() {
         return obfuscateWhen;
+    }
+
+    public List<String> getTagsOnMatchFailure() {
+        return tagsOnMatchFailure;
     }
 
     void validateObfuscateWhen(final ExpressionEvaluator expressionEvaluator) {

--- a/data-prepper-plugins/obfuscate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorTest.java
+++ b/data-prepper-plugins/obfuscate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
@@ -27,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -53,6 +55,9 @@ class ObfuscationProcessorTest {
     @Mock
     private ObfuscationProcessorConfig mockConfig;
 
+    @Mock
+    private ExpressionEvaluator expressionEvaluator;
+
     private ObfuscationProcessor obfuscationProcessor;
 
     static Record<Event> buildRecordWithEvent(final Map<String, Object> data) {
@@ -75,7 +80,23 @@ class ObfuscationProcessorTest {
         lenient().when(mockConfig.getAction()).thenReturn(defaultConfig.getAction());
         lenient().when(mockConfig.getPatterns()).thenReturn(defaultConfig.getPatterns());
         lenient().when(mockConfig.getTarget()).thenReturn(defaultConfig.getTarget());
-        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory);
+        lenient().when(mockConfig.getObfuscateWhen()).thenReturn(null);
+        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator);
+    }
+
+    @Test
+    void obfuscate_when_evaluates_to_false_does_not_modify_event() {
+        final String expression = "/test == success";
+        final Record<Event> record = createRecord(UUID.randomUUID().toString());
+        when(mockConfig.getObfuscateWhen()).thenReturn(expression);
+        when(expressionEvaluator.evaluateConditional(expression, record.getData())).thenReturn(false);
+
+        final ObfuscationProcessor objectUnderTest = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator);
+
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) objectUnderTest.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.size(), equalTo(1));
+        assertThat(editedRecords.get(0), equalTo(record));
     }
 
 
@@ -102,7 +123,7 @@ class ObfuscationProcessorTest {
 
         when(mockFactory.loadPlugin(eq(ObfuscationAction.class), any(PluginSetting.class)))
                 .thenReturn(mockAction);
-        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory);
+        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator);
 
         final Record<Event> record = createRecord("Hello");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) obfuscationProcessor.doExecute(Collections.singletonList(record));
@@ -117,7 +138,7 @@ class ObfuscationProcessorTest {
     @ValueSource(strings = {"hello", "hello, world", "This is a message", "123", "你好"})
     void testProcessorWithTarget(String message) {
         when(mockConfig.getTarget()).thenReturn("new_message");
-        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory);
+        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator);
 
         final Record<Event> record = createRecord(message);
         final List<Record<Event>> editedRecords = (List<Record<Event>>) obfuscationProcessor.doExecute(Collections.singletonList(record));
@@ -135,7 +156,7 @@ class ObfuscationProcessorTest {
     @Test
     void testProcessorWithUnknownSource() {
         when(mockConfig.getSource()).thenReturn("email");
-        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory);
+        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator);
 
         final Record<Event> record = createRecord("Hello");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) obfuscationProcessor.doExecute(Collections.singletonList(record));
@@ -158,7 +179,7 @@ class ObfuscationProcessorTest {
     })
     void testProcessorWithPattern(String message, String pattern, String expected) {
         when(mockConfig.getPatterns()).thenReturn(List.of(pattern));
-        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory);
+        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator);
 
         final Record<Event> record = createRecord(message);
         final List<Record<Event>> editedRecords = (List<Record<Event>>) obfuscationProcessor.doExecute(Collections.singletonList(record));
@@ -171,13 +192,13 @@ class ObfuscationProcessorTest {
     @Test
     void testProcessorWithUnknownPattern() {
         when(mockConfig.getPatterns()).thenReturn(List.of("%{UNKNOWN}"));
-        assertThrows(InvalidPluginConfigurationException.class, () -> new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory));
+        assertThrows(InvalidPluginConfigurationException.class, () -> new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator));
     }
 
     @Test
     void testProcessorInvalidPattern() {
         when(mockConfig.getPatterns()).thenReturn(List.of("["));
-        assertThrows(InvalidPluginConfigurationException.class, () -> new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory));
+        assertThrows(InvalidPluginConfigurationException.class, () -> new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator));
     }
 
     @ParameterizedTest
@@ -194,7 +215,7 @@ class ObfuscationProcessorTest {
     })
     void testProcessorWithEmailAddressPattern(String message, String expected) {
         when(mockConfig.getPatterns()).thenReturn(List.of("%{EMAIL_ADDRESS}"));
-        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory);
+        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator);
 
         final Record<Event> record = createRecord(message);
 
@@ -221,7 +242,7 @@ class ObfuscationProcessorTest {
     })
     void testProcessorWithUSPhoneNumberPattern(String message, String expected) {
         when(mockConfig.getPatterns()).thenReturn(List.of("%{US_PHONE_NUMBER}"));
-        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory);
+        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator);
 
         final Record<Event> record = createRecord(message);
 
@@ -247,7 +268,7 @@ class ObfuscationProcessorTest {
     })
     void testProcessorWithCreditNumberPattern(String message, String expected) {
         when(mockConfig.getPatterns()).thenReturn(List.of("%{CREDIT_CARD_NUMBER}"));
-        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory);
+        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator);
 
         final Record<Event> record = createRecord(message);
 
@@ -271,7 +292,7 @@ class ObfuscationProcessorTest {
     })
     void testProcessorWithIPAddressV4Pattern(String message, String expected) {
         when(mockConfig.getPatterns()).thenReturn(List.of("%{IP_ADDRESS_V4}"));
-        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory);
+        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator);
 
         final Record<Event> record = createRecord(message);
         final List<Record<Event>> editedRecords = (List<Record<Event>>) obfuscationProcessor.doExecute(Collections.singletonList(record));
@@ -291,7 +312,7 @@ class ObfuscationProcessorTest {
     })
     void testProcessorWithUSSSNPattern(String message, String expected) {
         when(mockConfig.getPatterns()).thenReturn(List.of("%{US_SSN_NUMBER}"));
-        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory);
+        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator);
 
         final Record<Event> record = createRecord(message);
         final List<Record<Event>> editedRecords = (List<Record<Event>>) obfuscationProcessor.doExecute(Collections.singletonList(record));
@@ -314,7 +335,7 @@ class ObfuscationProcessorTest {
     })
     void testProcessorWithBaseNumberPattern(String message, String expected) {
         when(mockConfig.getPatterns()).thenReturn(List.of("%{BASE_NUMBER}"));
-        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory);
+        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator);
 
         final Record<Event> record = createRecord(message);
         final List<Record<Event>> editedRecords = (List<Record<Event>>) obfuscationProcessor.doExecute(Collections.singletonList(record));
@@ -333,7 +354,7 @@ class ObfuscationProcessorTest {
     })
     void testProcessorWithMultiplePatterns(String message, String expected) {
         when(mockConfig.getPatterns()).thenReturn(List.of("%{EMAIL_ADDRESS}", "%{IP_ADDRESS_V4}"));
-        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory);
+        obfuscationProcessor = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator);
 
         final Record<Event> record = createRecord(message);
         final List<Record<Event>> editedRecords = (List<Record<Event>>) obfuscationProcessor.doExecute(Collections.singletonList(record));

--- a/data-prepper-plugins/obfuscate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorTest.java
+++ b/data-prepper-plugins/obfuscate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorTest.java
@@ -103,9 +103,12 @@ class ObfuscationProcessorTest {
     }
 
     @Test
-    void event_is_tagged_with_match_failure_tags_when_it_does_not_match_any_patterns() {
+    void event_is_tagged_with_match_failure_tags_when_it_does_not_match_any_patterns_and_when_condition_is_true() {
         final Record<Event> record = createRecord(UUID.randomUUID().toString());
 
+        final String expression = UUID.randomUUID().toString();
+        when(mockConfig.getObfuscateWhen()).thenReturn(expression);
+        when(expressionEvaluator.evaluateConditional(expression, record.getData())).thenReturn(true);
         when(mockConfig.getPatterns()).thenReturn(List.of(UUID.randomUUID().toString()));
 
         final ObfuscationProcessor objectUnderTest = new ObfuscationProcessor(pluginMetrics, mockConfig, mockFactory, expressionEvaluator);


### PR DESCRIPTION
### Description
Add `obfuscate_when` parameter to obfuscate processor to support conditionally running obfuscate on Events
Add `tags_on_match_failure` parameter to tag events that don't obfuscate due to patterns not matching 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
