### PR TITLE
Check topic for emptiness during KafkaBuffer shutdown

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
@@ -128,9 +128,8 @@ public class KafkaBuffer<T extends Record<?>> extends AbstractBuffer<T> {
     @Override
     public boolean isEmpty() {
         final boolean areTopicsEmpty = emptyCheckingConsumers.stream()
-                .allMatch(KafkaCustomConsumer::isEmpty);
+                .allMatch(KafkaCustomConsumer::isTopicEmpty);
 
-        // TODO: check Kafka topic is empty as well.
         return areTopicsEmpty && innerBuffer.isEmpty();
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -70,9 +70,9 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
     private static final Long COMMIT_OFFSET_INTERVAL_MS = 300000L;
     private static final long IS_EMPTY_CHECK_INTERVAL_MS = 60000L;
     private static final int DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE = 1;
-    private static final ConcurrentHashMap<TopicPartition, Boolean> TOPIC_PARTITION_TO_IS_EMPTY = new ConcurrentHashMap<>();
-    private static Long topicEmptyCheckingOwnerThreadId = null;
-    private static long lastIsEmptyCheckTime = 0;
+    static final ConcurrentHashMap<TopicPartition, Boolean> TOPIC_PARTITION_TO_IS_EMPTY = new ConcurrentHashMap<>();
+    static Long topicEmptyCheckingOwnerThreadId = null;
+    static long lastIsEmptyCheckTime = 0;
     static final String DEFAULT_KEY = "message";
 
     private volatile long lastCommitTime;
@@ -557,8 +557,6 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         for (TopicPartition topicPartition : topicPartitions) {
             final OffsetAndMetadata offsetAndMetadata = committedOffsets.get(topicPartition);
             final Long endOffset = endOffsets.get(topicPartition);
-            LOG.info("Partition {} offsets: endOffset: {}, committedOffset: {}",
-                    topicPartition, endOffset, Objects.isNull(offsetAndMetadata) ? "-" : offsetAndMetadata.offset());
             TOPIC_PARTITION_TO_IS_EMPTY.put(topicPartition, true);
 
             // If there is data in the partition

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -541,7 +541,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         }
 
         if (currentThreadId != topicEmptinessMetadata.getTopicEmptyCheckingOwnerThreadId() ||
-                topicEmptinessMetadata.isCheckDurationExceeded(System.currentTimeMillis())) {
+                topicEmptinessMetadata.isWithinCheckInterval(System.currentTimeMillis())) {
             return topicEmptinessMetadata.isTopicEmpty();
         }
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -68,9 +68,11 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaCustomConsumer.class);
     private static final Long COMMIT_OFFSET_INTERVAL_MS = 300000L;
+    private static final long IS_EMPTY_CHECK_INTERVAL_MS = 60000L;
     private static final int DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE = 1;
     private static final ConcurrentHashMap<TopicPartition, Boolean> TOPIC_PARTITION_TO_IS_EMPTY = new ConcurrentHashMap<>();
     private static Long topicEmptyCheckingOwnerThreadId = null;
+    private static long lastIsEmptyCheckTime = 0;
     static final String DEFAULT_KEY = "message";
 
     private volatile long lastCommitTime;
@@ -540,7 +542,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
             topicEmptyCheckingOwnerThreadId = currentThreadId;
         }
 
-        if (currentThreadId != topicEmptyCheckingOwnerThreadId) {
+        if (currentThreadId != topicEmptyCheckingOwnerThreadId || System.currentTimeMillis() < lastIsEmptyCheckTime + IS_EMPTY_CHECK_INTERVAL_MS) {
             return TOPIC_PARTITION_TO_IS_EMPTY.values().stream().allMatch(isEmpty -> isEmpty);
         }
 
@@ -555,23 +557,20 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         for (TopicPartition topicPartition : topicPartitions) {
             final OffsetAndMetadata offsetAndMetadata = committedOffsets.get(topicPartition);
             final Long endOffset = endOffsets.get(topicPartition);
+            LOG.info("Partition {} offsets: endOffset: {}, committedOffset: {}",
+                    topicPartition, endOffset, Objects.isNull(offsetAndMetadata) ? "-" : offsetAndMetadata.offset());
+            TOPIC_PARTITION_TO_IS_EMPTY.put(topicPartition, true);
 
             // If there is data in the partition
             if (endOffset != 0L) {
-                // If there is no committed offset for the partition
-                if (Objects.isNull(offsetAndMetadata)) {
-                    TOPIC_PARTITION_TO_IS_EMPTY.put(topicPartition, false);
-                }
-
-                // If the committed offset is behind the end offset
-                if (offsetAndMetadata.offset() < endOffset) {
+                // If there is no committed offset for the partition or the committed offset is behind the end offset
+                if (Objects.isNull(offsetAndMetadata) || offsetAndMetadata.offset() < endOffset) {
                     TOPIC_PARTITION_TO_IS_EMPTY.put(topicPartition, false);
                 }
             }
-
-            TOPIC_PARTITION_TO_IS_EMPTY.put(topicPartition, true);
         }
 
+        lastIsEmptyCheckTime = System.currentTimeMillis();
         return TOPIC_PARTITION_TO_IS_EMPTY.values().stream().allMatch(isEmpty -> isEmpty);
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -531,7 +531,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         return Objects.isNull(offset) ? "-" : offset.toString();
     }
 
-    public boolean isEmpty() {
+    public boolean isTopicEmpty() {
         final List<PartitionInfo> partitions = consumer.partitionsFor(topicName);
         final List<TopicPartition> topicPartitions = partitions.stream()
                 .map(partitionInfo -> new TopicPartition(topicName, partitionInfo.partition()))
@@ -543,8 +543,6 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         for (TopicPartition topicPartition : topicPartitions) {
             final OffsetAndMetadata offsetAndMetadata = committedOffsets.get(topicPartition);
             final Long endOffset = endOffsets.get(topicPartition);
-            LOG.info("Partition {} offsets: endOffset: {}, committedOffset: {}",
-                    topicPartition, endOffset, Objects.isNull(offsetAndMetadata) ? "-" : offsetAndMetadata.offset());
 
             // If there is data in the partition
             if (endOffset != 0L) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
@@ -100,7 +100,7 @@ public class KafkaCustomConsumerFactory {
                 final KafkaConsumer kafkaConsumer = new KafkaConsumer<>(consumerProperties, keyDeserializer, valueDeserializer);
 
                 consumers.add(new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, kafkaConsumerConfig, topic,
-                    schemaType, acknowledgementSetManager, byteDecoder, topicMetrics));
+                    schemaType, acknowledgementSetManager, byteDecoder, topicMetrics, new TopicEmptinessMetadata()));
 
             });
         } catch (Exception e) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
@@ -87,6 +87,7 @@ public class KafkaCustomConsumerFactory {
 
         try {
             final int numWorkers = topic.getWorkers();
+            final TopicEmptinessMetadata topicEmptinessMetadata = new TopicEmptinessMetadata();
             IntStream.range(0, numWorkers).forEach(index -> {
                 KafkaDataConfig dataConfig = new KafkaDataConfigAdapter(keyFactory, topic);
                 Deserializer<Object> keyDeserializer = (Deserializer<Object>) serializationFactory.getDeserializer(PlaintextKafkaDataConfig.plaintextDataConfig(dataConfig));
@@ -100,7 +101,7 @@ public class KafkaCustomConsumerFactory {
                 final KafkaConsumer kafkaConsumer = new KafkaConsumer<>(consumerProperties, keyDeserializer, valueDeserializer);
 
                 consumers.add(new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, kafkaConsumerConfig, topic,
-                    schemaType, acknowledgementSetManager, byteDecoder, topicMetrics, new TopicEmptinessMetadata()));
+                    schemaType, acknowledgementSetManager, byteDecoder, topicMetrics, topicEmptinessMetadata));
 
             });
         } catch (Exception e) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/TopicEmptinessMetadata.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/TopicEmptinessMetadata.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.kafka.consumer;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class TopicEmptinessMetadata {
+    private static final long IS_EMPTY_CHECK_INTERVAL_MS = 60000L;
+
+    private long lastIsEmptyCheckTime;
+    private Long topicEmptyCheckingOwnerThreadId;
+    private ConcurrentHashMap<TopicPartition, Boolean> topicPartitionToIsEmpty;
+
+    public TopicEmptinessMetadata() {
+        this.lastIsEmptyCheckTime = 0;
+        this.topicEmptyCheckingOwnerThreadId = null;
+        this.topicPartitionToIsEmpty = new ConcurrentHashMap<>();
+    }
+
+    public void setLastIsEmptyCheckTime(final long timestamp) {
+        this.lastIsEmptyCheckTime = timestamp;
+    }
+
+    public void setTopicEmptyCheckingOwnerThreadId(final Long threadId) {
+        this.topicEmptyCheckingOwnerThreadId = threadId;
+    }
+
+    public void updateTopicEmptinessStatus(final TopicPartition topicPartition, final Boolean isEmpty) {
+        topicPartitionToIsEmpty.put(topicPartition, isEmpty);
+    }
+
+    public long getLastIsEmptyCheckTime() {
+        return this.lastIsEmptyCheckTime;
+    }
+
+    public Long getTopicEmptyCheckingOwnerThreadId() {
+        return this.topicEmptyCheckingOwnerThreadId;
+    }
+
+    public boolean isTopicEmpty() {
+        return topicPartitionToIsEmpty.values().stream().allMatch(isEmpty -> isEmpty);
+    }
+
+    public boolean isCheckDurationExceeded(final long epochTimestamp) {
+        return epochTimestamp < lastIsEmptyCheckTime + IS_EMPTY_CHECK_INTERVAL_MS;
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/TopicEmptinessMetadata.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/TopicEmptinessMetadata.java
@@ -9,7 +9,7 @@ import org.apache.kafka.common.TopicPartition;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class TopicEmptinessMetadata {
-    private static final long IS_EMPTY_CHECK_INTERVAL_MS = 60000L;
+    static final long IS_EMPTY_CHECK_INTERVAL_MS = 60000L;
 
     private long lastIsEmptyCheckTime;
     private Long topicEmptyCheckingOwnerThreadId;
@@ -41,11 +41,15 @@ public class TopicEmptinessMetadata {
         return this.topicEmptyCheckingOwnerThreadId;
     }
 
+    public ConcurrentHashMap<TopicPartition, Boolean> getTopicPartitionToIsEmpty() {
+        return this.topicPartitionToIsEmpty;
+    }
+
     public boolean isTopicEmpty() {
         return topicPartitionToIsEmpty.values().stream().allMatch(isEmpty -> isEmpty);
     }
 
-    public boolean isCheckDurationExceeded(final long epochTimestamp) {
+    public boolean isWithinCheckInterval(final long epochTimestamp) {
         return epochTimestamp < lastIsEmptyCheckTime + IS_EMPTY_CHECK_INTERVAL_MS;
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -117,6 +117,7 @@ public class KafkaSource implements Source<Record<Event>> {
                 int numWorkers = topic.getWorkers();
                 executorService = Executors.newFixedThreadPool(numWorkers);
                 allTopicExecutorServices.add(executorService);
+                final TopicEmptinessMetadata topicEmptinessMetadata = new TopicEmptinessMetadata();
 
                 IntStream.range(0, numWorkers).forEach(index -> {
                     while (true) {
@@ -140,7 +141,7 @@ public class KafkaSource implements Source<Record<Event>> {
 
                     }
                     consumer = new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType,
-                            acknowledgementSetManager, null, topicMetrics, new TopicEmptinessMetadata());
+                            acknowledgementSetManager, null, topicMetrics, topicEmptinessMetadata);
                     allTopicConsumers.add(consumer);
 
                     executorService.submit(consumer);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -37,6 +37,7 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaRegistryType;
 import org.opensearch.dataprepper.plugins.kafka.configuration.TopicConfig;
 import org.opensearch.dataprepper.plugins.kafka.consumer.KafkaCustomConsumer;
+import org.opensearch.dataprepper.plugins.kafka.consumer.TopicEmptinessMetadata;
 import org.opensearch.dataprepper.plugins.kafka.extension.KafkaClusterConfigSupplier;
 import org.opensearch.dataprepper.plugins.kafka.util.ClientDNSLookupType;
 import org.opensearch.dataprepper.plugins.kafka.util.KafkaSecurityConfigurer;
@@ -138,7 +139,8 @@ public class KafkaSource implements Source<Record<Event>> {
                         }
 
                     }
-                    consumer = new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType, acknowledgementSetManager, null, topicMetrics);
+                    consumer = new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType,
+                            acknowledgementSetManager, null, topicMetrics, new TopicEmptinessMetadata());
                     allTopicConsumers.add(consumer);
 
                     executorService.submit(consumer);

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
@@ -28,6 +28,8 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.AuthConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.EncryptionConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.EncryptionType;
 import org.opensearch.dataprepper.plugins.kafka.configuration.PlainTextAuthConfig;
+import org.opensearch.dataprepper.plugins.kafka.consumer.KafkaCustomConsumer;
+import org.opensearch.dataprepper.plugins.kafka.consumer.KafkaCustomConsumerFactory;
 import org.opensearch.dataprepper.plugins.kafka.producer.KafkaCustomProducer;
 import org.opensearch.dataprepper.plugins.kafka.producer.KafkaCustomProducerFactory;
 import org.opensearch.dataprepper.plugins.kafka.producer.ProducerWorker;
@@ -36,6 +38,7 @@ import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
@@ -59,7 +62,9 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.kafka.buffer.KafkaBuffer.EXECUTOR_SERVICE_SHUTDOWN_TIMEOUT;
 
@@ -108,19 +113,33 @@ class KafkaBufferTest {
     KafkaCustomProducer<Event> producer;
 
     @Mock
+    private KafkaCustomConsumerFactory consumerFactory;
+
+    @Mock
+    private KafkaCustomConsumer consumer;
+
+    @Mock
     BlockingBuffer<Record<Event>>  blockingBuffer;
 
     @Mock
     private AwsCredentialsSupplier awsCredentialsSupplier;
 
     public KafkaBuffer<Record<Event>> createObjectUnderTest() {
+        return createObjectUnderTest(List.of(consumer));
+    }
 
+    public KafkaBuffer<Record<Event>> createObjectUnderTest(final List<KafkaCustomConsumer> consumers) {
         try (
             final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class);
             final MockedConstruction<KafkaCustomProducerFactory> producerFactoryMock =
                 mockConstruction(KafkaCustomProducerFactory.class, (mock, context) -> {
                 producerFactory = mock;
                 when(producerFactory.createProducer(any() ,any(), any(), isNull(), isNull(), any(), anyBoolean())).thenReturn(producer);
+            });
+            final MockedConstruction<KafkaCustomConsumerFactory> consumerFactoryMock =
+                mockConstruction(KafkaCustomConsumerFactory.class, (mock, context) -> {
+                consumerFactory = mock;
+                when(consumerFactory.createConsumersForTopic(any(), any(), any(), any(), any(), any(), any())).thenReturn(consumers);
             });
             final MockedConstruction<BlockingBuffer> blockingBufferMock =
                  mockConstruction(BlockingBuffer.class, (mock, context) -> {
@@ -210,12 +229,100 @@ class KafkaBufferTest {
     }
 
     @Test
-    void test_kafkaBuffer_isEmpty() {
+    void test_kafkaBuffer_isEmpty_True() {
         kafkaBuffer = createObjectUnderTest();
         assertTrue(Objects.nonNull(kafkaBuffer));
+        when(blockingBuffer.isEmpty()).thenReturn(true);
+        when(consumer.isTopicEmpty()).thenReturn(true);
 
-        kafkaBuffer.isEmpty();
+        final boolean result = kafkaBuffer.isEmpty();
+        assertThat(result, equalTo(true));
+
         verify(blockingBuffer).isEmpty();
+        verify(consumer).isTopicEmpty();
+    }
+
+    @Test
+    void test_kafkaBuffer_isEmpty_BufferNotEmpty() {
+        kafkaBuffer = createObjectUnderTest();
+        assertTrue(Objects.nonNull(kafkaBuffer));
+        when(blockingBuffer.isEmpty()).thenReturn(false);
+        when(consumer.isTopicEmpty()).thenReturn(true);
+
+        final boolean result = kafkaBuffer.isEmpty();
+        assertThat(result, equalTo(false));
+
+        verify(blockingBuffer).isEmpty();
+        verify(consumer).isTopicEmpty();
+    }
+
+    @Test
+    void test_kafkaBuffer_isEmpty_TopicNotEmpty() {
+        kafkaBuffer = createObjectUnderTest();
+        assertTrue(Objects.nonNull(kafkaBuffer));
+        when(blockingBuffer.isEmpty()).thenReturn(true);
+        when(consumer.isTopicEmpty()).thenReturn(false);
+
+        final boolean result = kafkaBuffer.isEmpty();
+        assertThat(result, equalTo(false));
+
+        verifyNoInteractions(blockingBuffer);
+        verify(consumer).isTopicEmpty();
+    }
+
+    @Test
+    void test_kafkaBuffer_isEmpty_MultipleTopics_AllNotEmpty() {
+        kafkaBuffer = createObjectUnderTest(List.of(consumer, consumer));
+        assertTrue(Objects.nonNull(kafkaBuffer));
+        when(blockingBuffer.isEmpty()).thenReturn(true);
+        when(consumer.isTopicEmpty()).thenReturn(false).thenReturn(false);
+
+        final boolean result = kafkaBuffer.isEmpty();
+        assertThat(result, equalTo(false));
+
+        verifyNoInteractions(blockingBuffer);
+        verify(consumer).isTopicEmpty();
+    }
+
+    @Test
+    void test_kafkaBuffer_isEmpty_MultipleTopics_SomeNotEmpty() {
+        kafkaBuffer = createObjectUnderTest(List.of(consumer, consumer));
+        assertTrue(Objects.nonNull(kafkaBuffer));
+        when(blockingBuffer.isEmpty()).thenReturn(true);
+        when(consumer.isTopicEmpty()).thenReturn(true).thenReturn(false);
+
+        final boolean result = kafkaBuffer.isEmpty();
+        assertThat(result, equalTo(false));
+
+        verifyNoInteractions(blockingBuffer);
+        verify(consumer, times(2)).isTopicEmpty();
+    }
+
+    @Test
+    void test_kafkaBuffer_isEmpty_MultipleTopics_AllEmpty() {
+        kafkaBuffer = createObjectUnderTest(List.of(consumer, consumer));
+        assertTrue(Objects.nonNull(kafkaBuffer));
+        when(blockingBuffer.isEmpty()).thenReturn(true);
+        when(consumer.isTopicEmpty()).thenReturn(true).thenReturn(true);
+
+        final boolean result = kafkaBuffer.isEmpty();
+        assertThat(result, equalTo(true));
+
+        verify(blockingBuffer).isEmpty();
+        verify(consumer, times(2)).isTopicEmpty();
+    }
+
+    @Test
+    void test_kafkaBuffer_isEmpty_ZeroTopics() {
+        kafkaBuffer = createObjectUnderTest(Collections.emptyList());
+        assertTrue(Objects.nonNull(kafkaBuffer));
+        when(blockingBuffer.isEmpty()).thenReturn(true);
+
+        final boolean result = kafkaBuffer.isEmpty();
+        assertThat(result, equalTo(true));
+
+        verify(blockingBuffer).isEmpty();
+        verifyNoInteractions(consumer);
     }
 
     @Test

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
@@ -139,7 +139,7 @@ class KafkaBufferTest {
             final MockedConstruction<KafkaCustomConsumerFactory> consumerFactoryMock =
                 mockConstruction(KafkaCustomConsumerFactory.class, (mock, context) -> {
                 consumerFactory = mock;
-                when(consumerFactory.createConsumersForTopic(any(), any(), any(), any(), any(), any(), any())).thenReturn(consumers);
+                when(consumerFactory.createConsumersForTopic(any(), any(), any(), any(), any(), any(), any(), anyBoolean())).thenReturn(consumers);
             });
             final MockedConstruction<BlockingBuffer> blockingBufferMock =
                  mockConstruction(BlockingBuffer.class, (mock, context) -> {

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
@@ -94,6 +94,7 @@ public class KafkaCustomConsumerTest {
 
     @Mock
     private KafkaTopicConsumerMetrics topicMetrics;
+    @Mock
     private PartitionInfo partitionInfo;
     @Mock
     private OffsetAndMetadata offsetAndMetadata;

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/TopicEmptinessMetadataTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/TopicEmptinessMetadataTest.java
@@ -1,0 +1,101 @@
+package org.opensearch.dataprepper.plugins.kafka.consumer;
+
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.dataprepper.plugins.kafka.consumer.TopicEmptinessMetadata.IS_EMPTY_CHECK_INTERVAL_MS;
+
+public class TopicEmptinessMetadataTest {
+    @Mock
+    private TopicPartition topicPartition;
+    @Mock
+    private TopicPartition topicPartition2;
+
+    private TopicEmptinessMetadata topicEmptinessMetadata;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        this.topicEmptinessMetadata = new TopicEmptinessMetadata();
+    }
+
+    @Test
+    void updateTopicEmptinessStatus_AddEntry() {
+        topicEmptinessMetadata.updateTopicEmptinessStatus(topicPartition, false);
+        assertThat(topicEmptinessMetadata.getTopicPartitionToIsEmpty().containsKey(topicPartition), equalTo(true));
+        assertThat(topicEmptinessMetadata.getTopicPartitionToIsEmpty().get(topicPartition), equalTo(false));
+    }
+
+    @Test
+    void updateTopicEmptinessStatus_UpdateEntry() {
+        topicEmptinessMetadata.updateTopicEmptinessStatus(topicPartition, false);
+        assertThat(topicEmptinessMetadata.getTopicPartitionToIsEmpty().containsKey(topicPartition), equalTo(true));
+        assertThat(topicEmptinessMetadata.getTopicPartitionToIsEmpty().get(topicPartition), equalTo(false));
+
+        topicEmptinessMetadata.updateTopicEmptinessStatus(topicPartition, true);
+        assertThat(topicEmptinessMetadata.getTopicPartitionToIsEmpty().containsKey(topicPartition), equalTo(true));
+        assertThat(topicEmptinessMetadata.getTopicPartitionToIsEmpty().get(topicPartition), equalTo(true));
+    }
+
+    @Test
+    void isTopicEmpty_NoItems() {
+        assertThat(topicEmptinessMetadata.isTopicEmpty(), equalTo(true));
+    }
+
+    @Test
+    void isTopicEmpty_OnePartition_IsNotEmpty() {
+        topicEmptinessMetadata.updateTopicEmptinessStatus(topicPartition, false);
+        assertThat(topicEmptinessMetadata.isTopicEmpty(), equalTo(false));
+    }
+
+    @Test
+    void isTopicEmpty_OnePartition_IsEmpty() {
+        topicEmptinessMetadata.updateTopicEmptinessStatus(topicPartition, true);
+        assertThat(topicEmptinessMetadata.isTopicEmpty(), equalTo(true));
+    }
+
+    @Test
+    void isTopicEmpty_MultiplePartitions_OneNotEmpty() {
+        topicEmptinessMetadata.updateTopicEmptinessStatus(topicPartition, true);
+        topicEmptinessMetadata.updateTopicEmptinessStatus(topicPartition2, false);
+        assertThat(topicEmptinessMetadata.isTopicEmpty(), equalTo(false));
+    }
+
+    @Test
+    void isCheckDurationExceeded_NoPreviousChecks() {
+        assertThat(topicEmptinessMetadata.isWithinCheckInterval(System.currentTimeMillis()), equalTo(false));
+    }
+
+    @Test
+    void isCheckDurationExceeded_CurrentTimeBeforeLastCheck() {
+        final long time = System.currentTimeMillis();
+        topicEmptinessMetadata.setLastIsEmptyCheckTime(time);
+        assertThat(topicEmptinessMetadata.isWithinCheckInterval(time - 1), equalTo(true));
+    }
+
+    @Test
+    void isCheckDurationExceeded_CurrentTimeAfterLastCheck_BeforeInterval() {
+        final long time = System.currentTimeMillis();
+        topicEmptinessMetadata.setLastIsEmptyCheckTime(time);
+        assertThat(topicEmptinessMetadata.isWithinCheckInterval((time + IS_EMPTY_CHECK_INTERVAL_MS) - 1), equalTo(true));
+    }
+
+    @Test
+    void isCheckDurationExceeded_CurrentTimeAfterLastCheck_AtInterval() {
+        final long time = System.currentTimeMillis();
+        topicEmptinessMetadata.setLastIsEmptyCheckTime(time);
+        assertThat(topicEmptinessMetadata.isWithinCheckInterval(time + IS_EMPTY_CHECK_INTERVAL_MS), equalTo(false));
+    }
+
+    @Test
+    void isCheckDurationExceeded_CurrentTimeAfterLastCheck_AfterInterval() {
+        final long time = System.currentTimeMillis();
+        topicEmptinessMetadata.setLastIsEmptyCheckTime(time);
+        assertThat(topicEmptinessMetadata.isWithinCheckInterval(time + IS_EMPTY_CHECK_INTERVAL_MS + 1), equalTo(false));
+    }
+}


### PR DESCRIPTION
### Description
Adds logic to check that all partitions on the topic associated with a consumer are fully processed before shutdown. Wires this into the isEmpty method of the KafkaBuffer
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
