### PR TITLE
Add tests to InMemoryBufferTest and LocalFileBufferTest

### DIFF
--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/accumulator/InMemoryBufferTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/accumulator/InMemoryBufferTest.java
@@ -11,6 +11,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
 
 @ExtendWith(MockitoExtension.class)
 class InMemoryBufferTest {
@@ -19,6 +24,20 @@ class InMemoryBufferTest {
 
     private InMemoryBuffer inMemoryBuffer;
 
+    @Test
+    void test_with_write_event_into_buffer() throws IOException {
+        inMemoryBuffer = new InMemoryBuffer();
+
+        int i = 0;
+        while (inMemoryBuffer.getEventCount() < MAX_EVENTS) {
+            inMemoryBuffer.getOutputStream().write(generateByteArray());
+            inMemoryBuffer.setEventCount(++i);
+        }
+        assertThat(inMemoryBuffer.getSize(), greaterThanOrEqualTo(54110L));
+        assertThat(inMemoryBuffer.getEventCount(), equalTo(MAX_EVENTS));
+        assertThat(inMemoryBuffer.getDuration(), greaterThanOrEqualTo(0L));
+
+    }
 
     @Test
     void test_getSinkData_success() {

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/accumulator/LocalFileBufferTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/accumulator/LocalFileBufferTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.equalTo;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -23,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @ExtendWith(MockitoExtension.class)
 class LocalFileBufferTest {
+    public static final int MAX_EVENTS = 55;
 
     public static final String KEY = UUID.randomUUID().toString() + ".log";
     public static final String PREFIX = "local";
@@ -35,6 +37,21 @@ class LocalFileBufferTest {
     void setUp() throws IOException {
         tempFile = File.createTempFile(PREFIX, SUFFIX);
         localFileBuffer = new LocalFileBuffer(tempFile);
+    }
+
+    @Test
+    void test_with_write_events_into_buffer() throws IOException {
+        int i = 0;
+        while (localFileBuffer.getEventCount() < MAX_EVENTS) {
+            localFileBuffer.getOutputStream().write(generateByteArray());
+            localFileBuffer.setEventCount(++i);
+        }
+        assertThat(localFileBuffer.getSize(), greaterThan(1l));
+        assertThat(localFileBuffer.getEventCount(), equalTo(55));
+        assertThat(localFileBuffer.getDuration(), equalTo(0L));
+        localFileBuffer.flushAndCloseStream();
+        localFileBuffer.removeTemporaryFile();
+        assertFalse(tempFile.exists(), "The temp file has not been deleted.");
     }
 
     @Test


### PR DESCRIPTION
### Description
Add tests to InMemoryBufferTest and LocalFileBufferTest to fix broken test coverage issue
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
