### PR TITLE
Implement writeBytes and isByteBuffer in the CircuitBreakingBuffer

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/Buffer.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/Buffer.java
@@ -49,7 +49,7 @@ public interface Buffer<T extends Record<?>> {
      * @throws RuntimeException Other exceptions
      */
     default void writeBytes(final byte[] bytes, final String key, int timeoutInMillis) throws Exception {
-        throw new RuntimeException("Not supported");
+        throw new UnsupportedOperationException("This buffer type does not support bytes.");
     }
 
     /**

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/BufferTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/BufferTest.java
@@ -41,7 +41,7 @@ public class BufferTest {
         final Buffer<Record<Event>> buffer = spy(Buffer.class);
 
         byte[] bytes = new byte[2];
-        Assert.assertThrows(RuntimeException.class, () -> buffer.writeBytes(bytes, "", 10));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> buffer.writeBytes(bytes, "", 10));
 
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/CircuitBreakingBuffer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/CircuitBreakingBuffer.java
@@ -53,6 +53,13 @@ class CircuitBreakingBuffer<T extends Record<?>> implements Buffer<T> {
         buffer.writeAll(records, timeoutInMillis);
     }
 
+    @Override
+    public void writeBytes(byte[] bytes, String key, int timeoutInMillis) throws Exception {
+        checkBreaker();
+
+        buffer.writeBytes(bytes, key, timeoutInMillis);
+    }
+
     private void checkBreaker() throws TimeoutException {
         if(circuitBreaker.isOpen())
             throw new TimeoutException("Circuit breaker is open. Unable to write to buffer.");
@@ -71,6 +78,11 @@ class CircuitBreakingBuffer<T extends Record<?>> implements Buffer<T> {
     @Override
     public boolean isEmpty() {
         return buffer.isEmpty();
+    }
+
+    @Override
+    public boolean isByteBuffer() {
+        return buffer.isByteBuffer();
     }
 
     @Override


### PR DESCRIPTION
### Description

The `CircuitBreakingBuffer` did not implement the new methods on `Buffer` related to writing bytes. Thus, using this buffer with a circuit breaker applied would fail to write.

Also update the exception thrown by `Buffer` when `writeBytes` is called to be an `UnsupportedOperationException` with a clearer error.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
