### PR TITLE
Fix for Kafka buffer encryption with byte data

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/serialization/EncryptionSerializer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/serialization/EncryptionSerializer.java
@@ -28,6 +28,9 @@ class EncryptionSerializer<T> implements Serializer<T> {
 
     @Override
     public byte[] serialize(String topic, T data) {
+        if(data == null)
+            return null;
+
         byte[] unencryptedBytes = innerSerializer.serialize(topic, data);
         try {
             return cipher.doFinal(unencryptedBytes);

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/serialization/EncryptionSerializerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/serialization/EncryptionSerializerTest.java
@@ -16,7 +16,9 @@ import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,5 +55,13 @@ class EncryptionSerializerTest {
 
         assertThat(createObjectUnderTest().serialize(topicName, input),
                 equalTo(encryptedData));
+    }
+
+    @Test
+    void serialize_returns_null_and_does_not_call_cipher_if_input_is_null() throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {
+        assertThat(createObjectUnderTest().serialize(topicName, null),
+                nullValue());
+
+        verifyNoInteractions(cipher);
     }
 }


### PR DESCRIPTION
### Description

Using client-side encryption in the Kafka buffer with the `bytes` input was resulting in a null error.

```
2023-10-27T14:46:29,995 [pool-15-thread-1] ERROR org.opensearch.dataprepper.plugins.kafka.producer.KafkaCustomProducer - Error occurred while publishing Null input buffer
```

The existing `Serializer` implementations return `null` for `null` data. So this mimics this.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
