### PR TITLE
Add expiry monitor to adjust SQS viz timeout if processing has not yet completed

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSet.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSet.java
@@ -8,6 +8,8 @@ package org.opensearch.dataprepper.model.acknowledgements;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
 
+import java.time.Instant;
+
 /**
  * AcknowledgmentSet keeps track of set of events that
  * belong to the batch of events that a source creates.
@@ -58,4 +60,10 @@ public interface AcknowledgementSet {
       * initial events are going through the pipeline line.
      */
     public void complete();
+
+    Instant getExpiryTime();
+
+    void setExpiryTime(final Instant expiryTime);
+
+    boolean isDone();
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSetManager.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSetManager.java
@@ -9,7 +9,6 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.function.Consumer;
 
 /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSetManager.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSetManager.java
@@ -9,6 +9,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.function.Consumer;
 
 /**
@@ -29,6 +30,8 @@ public interface AcknowledgementSetManager {
      * @since 2.2
      */
     AcknowledgementSet create(final Consumer<Boolean> callback, final Duration timeout);
+
+    void addExpiryMonitor(final ExpiryItem expiryItem);
 
     /**
      * Releases an event's reference

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/ExpiryItem.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/ExpiryItem.java
@@ -1,0 +1,64 @@
+package org.opensearch.dataprepper.model.acknowledgements;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.Consumer;
+
+public class ExpiryItem {
+    private static final Logger LOG = LoggerFactory.getLogger(ExpiryItem.class);
+
+    private final String itemId;
+    private final Instant startTime;
+    private final long pollSeconds;
+    private final Consumer expiryCallback;
+    private Instant expirationTime;
+    private AcknowledgementSet acknowledgementSet;
+
+    public ExpiryItem(final String itemId, final Instant startTime, final long pollSeconds, final Instant expirationTime,
+                      final Consumer<ExpiryItem> expiryCallback, final AcknowledgementSet acknowledgementSet) {
+        this.itemId = itemId;
+        this.startTime = startTime;
+        if (pollSeconds <= 2) {
+            throw new UnsupportedOperationException("The poll interval must be at least 3 seconds to enable expiry monitoring");
+        }
+        this.pollSeconds = pollSeconds;
+        this.expirationTime = expirationTime;
+        this.expiryCallback = expiryCallback;
+        this.acknowledgementSet = acknowledgementSet;
+    }
+
+    public long getPollSeconds() {
+        return pollSeconds;
+    }
+
+    public String getItemId() {
+        return itemId;
+    }
+
+    public boolean executeExpiryCallback() {
+        try {
+            expiryCallback.accept(this);
+            return true;
+        } catch (final Exception e) {
+            LOG.error("Exception occurred when executing the expiry callback", e.getMessage());
+            return false;
+        }
+    }
+
+    public boolean isCompleteOrExpired() {
+        return acknowledgementSet.isDone() || Instant.now().isAfter(expirationTime);
+    }
+
+    public void updateExpirationTime() {
+        LOG.info("Updating expiration time for item ID {} to {}", itemId, expirationTime);
+        expirationTime = expirationTime.plusSeconds(pollSeconds);
+        acknowledgementSet.setExpiryTime(expirationTime);
+    }
+
+    public long getSecondsBetweenStartAndExpiration() {
+        return Duration.between(startTime, expirationTime).getSeconds();
+    }
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/ExpiryItem.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/ExpiryItem.java
@@ -3,7 +3,6 @@ package org.opensearch.dataprepper.model.acknowledgements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.util.function.Consumer;
 
@@ -11,16 +10,14 @@ public class ExpiryItem {
     private static final Logger LOG = LoggerFactory.getLogger(ExpiryItem.class);
 
     private final String itemId;
-    private final Instant startTime;
     private final long pollSeconds;
-    private final Consumer expiryCallback;
+    private final Consumer<ExpiryItem> expiryCallback;
     private Instant expirationTime;
     private AcknowledgementSet acknowledgementSet;
 
-    public ExpiryItem(final String itemId, final Instant startTime, final long pollSeconds, final Instant expirationTime,
+    public ExpiryItem(final String itemId, final long pollSeconds, final Instant expirationTime,
                       final Consumer<ExpiryItem> expiryCallback, final AcknowledgementSet acknowledgementSet) {
         this.itemId = itemId;
-        this.startTime = startTime;
         if (pollSeconds <= 2) {
             throw new UnsupportedOperationException("The poll interval must be at least 3 seconds to enable expiry monitoring");
         }
@@ -38,27 +35,26 @@ public class ExpiryItem {
         return itemId;
     }
 
+    public void setExpirationTime(final Instant expirationTime) {
+        this.expirationTime = expirationTime;
+    }
+
     public boolean executeExpiryCallback() {
         try {
             expiryCallback.accept(this);
             return true;
         } catch (final Exception e) {
-            LOG.error("Exception occurred when executing the expiry callback", e.getMessage());
+            LOG.error("Exception occurred when executing the expiry callback: {}", e.getMessage());
             return false;
         }
     }
 
     public boolean isCompleteOrExpired() {
-        return acknowledgementSet.isDone() || Instant.now().isAfter(expirationTime);
+        return Instant.now().isAfter(expirationTime) || acknowledgementSet.isDone();
     }
 
     public void updateExpirationTime() {
-        LOG.info("Updating expiration time for item ID {} to {}", itemId, expirationTime);
         expirationTime = expirationTime.plusSeconds(pollSeconds);
         acknowledgementSet.setExpiryTime(expirationTime);
-    }
-
-    public long getSecondsBetweenStartAndExpiration() {
-        return Duration.between(startTime, expirationTime).getSeconds();
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/acknowledgements/ExpiryItemTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/acknowledgements/ExpiryItemTest.java
@@ -1,0 +1,123 @@
+package org.opensearch.dataprepper.model.acknowledgements;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class ExpiryItemTest {
+    private static final String ITEM_ID = UUID.randomUUID().toString();
+    private static final long POLL_SECONDS = 27;
+
+    private Instant expirationTime = Instant.now();
+    @Mock
+    private Consumer<ExpiryItem> expiryCallback;
+    @Mock
+    private AcknowledgementSet acknowledgementSet;
+
+    public ExpiryItem expiryItem;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        this.expiryItem = new ExpiryItem(ITEM_ID, POLL_SECONDS, expirationTime, expiryCallback, acknowledgementSet);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(expiryCallback, acknowledgementSet);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {-1, 0, 1, 2})
+    void pollDelayTooLow_ThrowsUnsupportedOperationException(final long pollSeconds) {
+        assertThrows(UnsupportedOperationException.class,
+                () -> new ExpiryItem(ITEM_ID, pollSeconds, expirationTime, expiryCallback, acknowledgementSet));
+    }
+
+    @Test
+    void executeExpiryCallback_Success() {
+        doNothing().when(expiryCallback).accept(expiryItem);
+
+        final boolean result = expiryItem.executeExpiryCallback();
+        assertThat(result, equalTo(true));
+
+        verify(expiryCallback).accept(expiryItem);
+    }
+
+    @Test
+    void executeExpiryCallback_Failure() {
+        doThrow(new RuntimeException()).when(expiryCallback).accept(expiryItem);
+
+        final boolean result = expiryItem.executeExpiryCallback();
+        assertThat(result, equalTo(false));
+
+        verify(expiryCallback).accept(expiryItem);
+    }
+
+    @Test
+    void isCompleteOrExpired_false() {
+        when(acknowledgementSet.isDone()).thenReturn(false);
+        expiryItem.setExpirationTime(expirationTime.plusSeconds(60));
+
+        final boolean result = expiryItem.isCompleteOrExpired();
+        assertThat(result, equalTo(false));
+
+        verify(acknowledgementSet).isDone();
+    }
+
+    @Test
+    void isCompleteOrExpired_AckSetDone() {
+        when(acknowledgementSet.isDone()).thenReturn(true);
+        expiryItem.setExpirationTime(expirationTime.plusSeconds(60));
+
+        final boolean result = expiryItem.isCompleteOrExpired();
+        assertThat(result, equalTo(true));
+
+        verify(acknowledgementSet).isDone();
+    }
+
+    @Test
+    void isCompleteOrExpired_Expired() {
+        expiryItem.setExpirationTime(expirationTime.minusSeconds(60));
+
+        final boolean result = expiryItem.isCompleteOrExpired();
+        assertThat(result, equalTo(true));
+    }
+
+    @Test
+    void updateExpirationTime_Success() {
+        final Instant expectedUpdatedExpiryTime = expirationTime.plusSeconds(POLL_SECONDS);
+
+        expiryItem.updateExpirationTime();
+
+        verify(acknowledgementSet).setExpiryTime(expectedUpdatedExpiryTime);
+    }
+
+    @Test
+    void getItemId_Success() {
+        assertThat(expiryItem.getItemId(), equalTo(ITEM_ID));
+    }
+
+    @Test
+    void getPollSeconds_Success() {
+        assertThat(expiryItem.getPollSeconds(), equalTo(POLL_SECONDS));
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSet.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSet.java
@@ -26,7 +26,7 @@ import java.util.function.Consumer;
 public class DefaultAcknowledgementSet implements AcknowledgementSet {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultAcknowledgementSet.class);
     private final Consumer<Boolean> callback;
-    private final Instant expiryTime;
+    private Instant expiryTime;
     private final ExecutorService executor;
     // This lock protects all the non-final members
     private final ReentrantLock lock;
@@ -36,7 +36,8 @@ public class DefaultAcknowledgementSet implements AcknowledgementSet {
     private final DefaultAcknowledgementSetMetrics metrics;
     private boolean completed;
 
-    public DefaultAcknowledgementSet(final ExecutorService executor, final Consumer<Boolean> callback, final Duration expiryTime, final DefaultAcknowledgementSetMetrics metrics) {
+    public DefaultAcknowledgementSet(final ExecutorService executor, final Consumer<Boolean> callback, final Duration expiryTime,
+                                     final DefaultAcknowledgementSetMetrics metrics) {
         this.callback = callback;
         this.result = true;
         this.executor = executor;
@@ -76,6 +77,7 @@ public class DefaultAcknowledgementSet implements AcknowledgementSet {
         }
     }
 
+    @Override
     public boolean isDone() {
         lock.lock();
         try {
@@ -98,8 +100,14 @@ public class DefaultAcknowledgementSet implements AcknowledgementSet {
         return false;
     }
 
+    @Override
     public Instant getExpiryTime() {
         return expiryTime;
+    }
+
+    @Override
+    public void setExpiryTime(final Instant expiryTime) {
+        this.expiryTime = expiryTime;
     }
 
     @Override

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetManager.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetManager.java
@@ -42,7 +42,6 @@ public class DefaultAcknowledgementSetManager implements AcknowledgementSetManag
         acknowledgementSetMonitorThread.start();
         pluginMetrics = PluginMetrics.fromNames("acknowledgementSetManager", "acknowledgements");
         metrics = new DefaultAcknowledgementSetMetrics(pluginMetrics);
-
     }
 
     public AcknowledgementSet create(final Consumer<Boolean> callback, final Duration timeout) {
@@ -75,6 +74,9 @@ public class DefaultAcknowledgementSetManager implements AcknowledgementSetManag
 
     public void shutdown() {
         acknowledgementSetMonitorThread.stop();
+        if (Objects.nonNull(expiryMonitor)) {
+            expiryMonitor.shutdown();
+        }
     }
 
     /**

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/ExpiryMonitor.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/ExpiryMonitor.java
@@ -1,0 +1,48 @@
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.opensearch.dataprepper.model.acknowledgements.ExpiryItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public class ExpiryMonitor {
+    private static final Logger LOG = LoggerFactory.getLogger(ExpiryMonitor.class);
+
+    private static final long CANCEL_CHECK_INTERVAL_SECONDS = 15;
+    private static final ScheduledExecutorService SCHEDULED_EXECUTOR_SERVICE = Executors.newSingleThreadScheduledExecutor();
+    private static final ConcurrentHashMap<ExpiryItem, ScheduledFuture> EXPIRY_MONITORS = new ConcurrentHashMap<>();
+
+    public ExpiryMonitor() {
+        SCHEDULED_EXECUTOR_SERVICE.scheduleAtFixedRate(() -> {
+            EXPIRY_MONITORS.forEach((expiryItem, future) -> {
+                final boolean isCompleteOrExpired = expiryItem.isCompleteOrExpired();
+                LOG.error("ExpiryItem with ID {} has completion/expiry status {}", expiryItem.getItemId(), isCompleteOrExpired);
+
+                if (isCompleteOrExpired) {
+                    future.cancel(false);
+                    EXPIRY_MONITORS.remove(expiryItem);
+                }
+            });
+        }, 0, CANCEL_CHECK_INTERVAL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    public void addExpiryItem(final ExpiryItem expiryItem) {
+        final ScheduledFuture expiryMonitor = SCHEDULED_EXECUTOR_SERVICE.scheduleAtFixedRate(monitorExpiration(expiryItem),
+                0, expiryItem.getPollSeconds() - 2, TimeUnit.SECONDS);
+        EXPIRY_MONITORS.put(expiryItem, expiryMonitor);
+    }
+
+    private Runnable monitorExpiration(final ExpiryItem expiryItem) {
+        return () -> {
+            final boolean callBackSuccess = expiryItem.executeExpiryCallback();
+            if (callBackSuccess) {
+                expiryItem.updateExpirationTime();
+            }
+        };
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/InactiveAcknowledgementSetManager.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/InactiveAcknowledgementSetManager.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.acknowledgements;
 
+import org.opensearch.dataprepper.model.acknowledgements.ExpiryItem;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -24,6 +25,11 @@ public class InactiveAcknowledgementSetManager implements AcknowledgementSetMana
     
     public AcknowledgementSet create(final Consumer<Boolean> callback, final Duration timeout) {
         throw new UnsupportedOperationException("create operation not supported");
+    }
+
+    @Override
+    public void addExpiryMonitor(final ExpiryItem expiryItem) {
+        throw new UnsupportedOperationException("add expiry monitor operation not supported");
     }
 
     public void acquireEventReference(final Event event) {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/ExpiryMonitorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/ExpiryMonitorTest.java
@@ -1,0 +1,59 @@
+package org.opensearch.dataprepper.acknowledgements;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.dataprepper.model.acknowledgements.ExpiryItem;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ExpiryMonitorTest {
+    @Mock
+    private ExpiryItem expiryItem;
+    @Mock
+    private ScheduledFuture scheduledFuture;
+    @Mock
+    private ScheduledExecutorService scheduledExecutorService;
+
+    public ExpiryMonitor expiryMonitor;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        this.expiryMonitor = new ExpiryMonitor(scheduledExecutorService);
+    }
+
+    @Test
+    @Disabled("TODO - fix NPE")
+    void addExpiryItem_Success() {
+        when(expiryItem.getPollSeconds()).thenReturn(12L);
+        // NPE here, not sure why
+        when(scheduledExecutorService.scheduleAtFixedRate(any(), any(), any(), any()))
+                .thenReturn(scheduledFuture);
+
+        expiryMonitor.addExpiryItem(expiryItem);
+        assertThat(expiryMonitor.getExpiryMonitors().size(), equalTo(1));
+        assertThat(expiryMonitor.getExpiryMonitors().containsKey(expiryItem), equalTo(true));
+        assertThat(expiryMonitor.getExpiryMonitors().get(expiryItem), equalTo(scheduledFuture));
+
+        verify(scheduledExecutorService).scheduleAtFixedRate(any(), eq(0), eq(10L), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    void shutdown_Success() {
+        expiryMonitor.shutdown();
+
+        verify(scheduledExecutorService).shutdownNow();
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/InactiveAcknowledgementSetManagerTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/InactiveAcknowledgementSetManagerTests.java
@@ -31,6 +31,12 @@ public class InactiveAcknowledgementSetManagerTests {
     }
 
     @Test
+    void testAddExpiryMonitorAPI() {
+        assertThat(acknowledgementSetManager, notNullValue());
+        assertThrows(UnsupportedOperationException.class, () -> acknowledgementSetManager.addExpiryMonitor(null));
+    }
+
+    @Test
     void testEventAcquireAPI() {
         assertThat(acknowledgementSetManager, notNullValue());
         Event event = mock(Event.class);

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorkerTest.java
@@ -22,6 +22,7 @@ import org.mockito.ArgumentCaptor;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.model.acknowledgements.ExpiryItem;
 import org.opensearch.dataprepper.plugins.source.s3.configuration.AwsAuthenticationOptions;
 import org.opensearch.dataprepper.plugins.source.s3.configuration.NotificationSourceOption;
 import org.opensearch.dataprepper.plugins.source.s3.configuration.OnErrorOption;
@@ -107,6 +108,7 @@ class SqsWorkerTest {
 
         SqsOptions sqsOptions = mock(SqsOptions.class);
         when(sqsOptions.getSqsUrl()).thenReturn("https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue");
+        when(sqsOptions.getVisibilityTimeout()).thenReturn(Duration.ofSeconds(12));
 
         when(s3SourceConfig.getAwsAuthenticationOptions()).thenReturn(awsAuthenticationOptions);
         when(s3SourceConfig.getSqsOptions()).thenReturn(sqsOptions);
@@ -215,6 +217,8 @@ class SqsWorkerTest {
             verifyNoInteractions(sqsMessagesDeletedCounter);
             assertThat(actualDelay, lessThanOrEqualTo(Duration.ofHours(1).plus(Duration.ofSeconds(5))));
             assertThat(actualDelay, greaterThanOrEqualTo(Duration.ofHours(1).minus(Duration.ofSeconds(5))));
+
+            verify(acknowledgementSetManager).addExpiryMonitor(any(ExpiryItem.class));
         }
 
         @ParameterizedTest


### PR DESCRIPTION
### Description
Add monitor logic to readjust the visibility timeout before expiration
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
