### PR TITLE
Add acknowledgments for the ddb source

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/EnhancedSourceCoordinator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/enhanced/EnhancedSourceCoordinator.java
@@ -46,9 +46,10 @@ public interface EnhancedSourceCoordinator {
      *
      * @param partition The partition to be updated.
      * @param <T>       The progress state class
+     * @param ownershipTimeoutRenewal The amount of time to update ownership of the partition before another instance can acquire it.
      * @throws org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionUpdateException when the partition was not updated successfully
      */
-    <T> void saveProgressStateForPartition(EnhancedSourcePartition<T> partition);
+    <T> void saveProgressStateForPartition(EnhancedSourcePartition<T> partition, Duration ownershipTimeoutRenewal);
 
     /**
      * This method is used to release the lease of a partition in the coordination store.

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSet.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSet.java
@@ -135,7 +135,7 @@ public class DefaultAcknowledgementSet implements AcknowledgementSet {
                     callbackFuture = executor.submit(() -> callback.accept(this.result));
                     return true;
                 } else if (pendingAcknowledgments.size() == 0) {
-                    LOG.warn("Acknowledgement set is not completed. Delaying callback until it is completed");
+                    LOG.debug("Acknowledgement set is not completed. Delaying callback until it is completed");
                 }
             }
         } finally {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/enhanced/EnhancedLeaseBasedSourceCoordinator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/enhanced/EnhancedLeaseBasedSourceCoordinator.java
@@ -127,7 +127,7 @@ public class EnhancedLeaseBasedSourceCoordinator implements EnhancedSourceCoordi
 
 
     @Override
-    public <T> void saveProgressStateForPartition(EnhancedSourcePartition<T> partition) {
+    public <T> void saveProgressStateForPartition(EnhancedSourcePartition<T> partition, final Duration ownershipTimeoutRenewal) {
         String partitionType = partition.getPartitionType() == null ? DEFAULT_GLOBAL_STATE_PARTITION_TYPE : partition.getPartitionType();
         LOG.debug("Try to save progress for partition {} (Type {})", partition.getPartitionKey(), partitionType);
 
@@ -140,7 +140,7 @@ public class EnhancedLeaseBasedSourceCoordinator implements EnhancedSourceCoordi
         final SourcePartitionStoreItem updateItem = partition.getSourcePartitionStoreItem();
         // Also extend the timeout of the lease (ownership)
         if (updateItem.getPartitionOwnershipTimeout() != null) {
-            updateItem.setPartitionOwnershipTimeout(Instant.now().plus(DEFAULT_LEASE_TIMEOUT));
+            updateItem.setPartitionOwnershipTimeout(Instant.now().plus(ownershipTimeoutRenewal == null ? DEFAULT_LEASE_TIMEOUT : ownershipTimeoutRenewal));
         }
         updateItem.setPartitionProgressState(partition.convertPartitionProgressStatetoString(partition.getProgressState()));
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/enhanced/EnhancedLeaseBasedSourceCoordinatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/enhanced/EnhancedLeaseBasedSourceCoordinatorTest.java
@@ -163,7 +163,7 @@ class EnhancedLeaseBasedSourceCoordinatorTest {
         Optional<EnhancedSourcePartition> sourcePartition = coordinator.acquireAvailablePartition(DEFAULT_PARTITION_TYPE);
         assertThat(sourcePartition.isPresent(), equalTo(true));
         TestEnhancedSourcePartition partition = (TestEnhancedSourcePartition) sourcePartition.get();
-        coordinator.saveProgressStateForPartition(partition);
+        coordinator.saveProgressStateForPartition(partition, null);
 
         verify(sourceCoordinationStore).tryAcquireAvailablePartition(anyString(), anyString(), any(Duration.class));
         verify(sourceCoordinationStore).tryUpdateSourcePartitionItem(any(SourcePartitionStoreItem.class));

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBSource.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBSource.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.source.dynamodb;
 
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -39,19 +40,26 @@ public class DynamoDBSource implements Source<Record<Event>>, UsesEnhancedSource
 
     private final ClientFactory clientFactory;
 
+    private final AcknowledgementSetManager acknowledgementSetManager;
+
     private EnhancedSourceCoordinator coordinator;
 
     private DynamoDBService dynamoDBService;
 
 
     @DataPrepperPluginConstructor
-    public DynamoDBSource(PluginMetrics pluginMetrics, final DynamoDBSourceConfig sourceConfig, final PluginFactory pluginFactory, final AwsCredentialsSupplier awsCredentialsSupplier) {
+    public DynamoDBSource(final PluginMetrics pluginMetrics,
+                          final DynamoDBSourceConfig sourceConfig,
+                          final PluginFactory pluginFactory,
+                          final AwsCredentialsSupplier awsCredentialsSupplier,
+                          final AcknowledgementSetManager acknowledgementSetManager) {
         LOG.info("Create DynamoDB Source");
         this.pluginMetrics = pluginMetrics;
         this.sourceConfig = sourceConfig;
         this.pluginFactory = pluginFactory;
+        this.acknowledgementSetManager = acknowledgementSetManager;
 
-        clientFactory = new ClientFactory(awsCredentialsSupplier, sourceConfig.getAwsAuthenticationConfig());
+        clientFactory = new ClientFactory(awsCredentialsSupplier, sourceConfig.getAwsAuthenticationConfig(), sourceConfig.getTableConfigs().get(0).getExportConfig());
     }
 
     @Override
@@ -61,7 +69,7 @@ public class DynamoDBSource implements Source<Record<Event>>, UsesEnhancedSource
         coordinator.createPartition(new InitPartition());
 
         // Create DynamoDB Service
-        dynamoDBService = new DynamoDBService(coordinator, clientFactory, sourceConfig, pluginMetrics);
+        dynamoDBService = new DynamoDBService(coordinator, clientFactory, sourceConfig, pluginMetrics, acknowledgementSetManager);
         dynamoDBService.init();
 
         LOG.info("Start DynamoDB service");

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBSourceConfig.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBSourceConfig.java
@@ -7,10 +7,13 @@ package org.opensearch.dataprepper.plugins.source.dynamodb;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.AwsAuthenticationConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.TableConfig;
 
+import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -19,13 +22,21 @@ import java.util.List;
 public class DynamoDBSourceConfig {
 
     @JsonProperty("tables")
-    private List<TableConfig> tableConfigs;
-
+    private List<TableConfig> tableConfigs = Collections.emptyList();
 
     @JsonProperty("aws")
     @NotNull
     @Valid
     private AwsAuthenticationConfig awsAuthenticationConfig;
+
+    @JsonProperty("acknowledgments")
+    private boolean acknowledgments = false;
+
+    @JsonProperty("shard_acknowledgment_timeout")
+    private Duration shardAcknowledgmentTimeout = Duration.ofMinutes(10);
+
+    @JsonProperty("s3_data_file_acknowledgment_timeout")
+    private Duration dataFileAcknowledgmentTimeout = Duration.ofMinutes(15);
 
     public DynamoDBSourceConfig() {
     }
@@ -37,5 +48,20 @@ public class DynamoDBSourceConfig {
 
     public AwsAuthenticationConfig getAwsAuthenticationConfig() {
         return awsAuthenticationConfig;
+    }
+
+    public boolean isAcknowledgmentsEnabled() {
+        return acknowledgments;
+    }
+
+    public Duration getShardAcknowledgmentTimeout() {
+        return shardAcknowledgmentTimeout;
+    }
+
+    public Duration getDataFileAcknowledgmentTimeout() { return dataFileAcknowledgmentTimeout; }
+
+    @AssertTrue(message = "Exactly one table must be configured for the DynamoDb source.")
+    boolean isExactlyOneTableConfigured() {
+        return tableConfigs.size() == 1;
     }
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBSourceConfig.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBSourceConfig.java
@@ -33,10 +33,10 @@ public class DynamoDBSourceConfig {
     private boolean acknowledgments = false;
 
     @JsonProperty("shard_acknowledgment_timeout")
-    private Duration shardAcknowledgmentTimeout = Duration.ofMinutes(10);
+    private Duration shardAcknowledgmentTimeout = Duration.ofMinutes(3);
 
     @JsonProperty("s3_data_file_acknowledgment_timeout")
-    private Duration dataFileAcknowledgmentTimeout = Duration.ofMinutes(15);
+    private Duration dataFileAcknowledgmentTimeout = Duration.ofMinutes(5);
 
     public DynamoDBSourceConfig() {
     }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/ExportConfig.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/ExportConfig.java
@@ -7,14 +7,19 @@ package org.opensearch.dataprepper.plugins.source.dynamodb.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
+import software.amazon.awssdk.regions.Region;
 
 public class ExportConfig {
 
     @JsonProperty("s3_bucket")
     @NotBlank(message = "Bucket Name is required for export")
     private String s3Bucket;
+
     @JsonProperty("s3_prefix")
     private String s3Prefix;
+
+    @JsonProperty("s3_region")
+    private String s3Region;
 
     public String getS3Bucket() {
         return s3Bucket;
@@ -23,4 +28,9 @@ public class ExportConfig {
     public String getS3Prefix() {
         return s3Prefix;
     }
+
+    public Region getAwsRegion() {
+        return s3Region != null ? Region.of(s3Region) : null;
+    }
+
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/ExportRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/ExportRecordConverter.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.dataformat.ion.IonObjectMapper;
 import io.micrometer.core.instrument.Counter;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableInfo;
@@ -58,13 +59,13 @@ public class ExportRecordConverter extends RecordConverter {
         return "EXPORT";
     }
 
-    public void writeToBuffer(List<String> lines) {
+    public void writeToBuffer(final AcknowledgementSet acknowledgementSet, List<String> lines) {
 
         int eventCount = 0;
         for (String line : lines) {
             Map data = (Map<String, Object>) convertToMap(line).get(ITEM_KEY);
             try {
-                addToBuffer(data);
+                addToBuffer(acknowledgementSet, data);
                 eventCount++;
             } catch (Exception e) {
                 // will this cause too many logs?

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/RecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/RecordConverter.java
@@ -91,10 +91,10 @@ public abstract class RecordConverter {
         } else {
             eventMetadata.setAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE, partitionKey);
         }
-        bufferAccumulator.add(new Record<>(event));
         if (acknowledgementSet != null) {
             acknowledgementSet.add(event);
         }
+        bufferAccumulator.add(new Record<>(event));
     }
 
     public void addToBuffer(final AcknowledgementSet acknowledgementSet, Map<String, Object> data) throws Exception {

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.Counter;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableInfo;
 import org.slf4j.Logger;
@@ -53,7 +54,7 @@ public class StreamRecordConverter extends RecordConverter {
     }
 
 
-    public void writeToBuffer(List<Record> records) {
+    public void writeToBuffer(final AcknowledgementSet acknowledgementSet, List<Record> records) {
 
         int eventCount = 0;
         for (Record record : records) {
@@ -63,7 +64,7 @@ public class StreamRecordConverter extends RecordConverter {
             Map<String, Object> keys = convertKeys(record.dynamodb().keys());
 
             try {
-                addToBuffer(data, keys, record.dynamodb().approximateCreationDateTime().toEpochMilli(), record.eventNameAsString());
+                addToBuffer(acknowledgementSet, data, keys, record.dynamodb().approximateCreationDateTime().toEpochMilli(), record.eventNameAsString());
                 eventCount++;
             } catch (Exception e) {
                 // will this cause too many logs?

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/coordination/partition/DataFilePartition.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/coordination/partition/DataFilePartition.java
@@ -23,7 +23,7 @@ public class DataFilePartition extends EnhancedSourcePartition<DataFileProgressS
     private final String bucket;
     private final String key;
 
-    private final DataFileProgressState state;
+    private DataFileProgressState state;
 
     public DataFilePartition(SourcePartitionStoreItem sourcePartitionStoreItem) {
 

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileCheckpointer.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileCheckpointer.java
@@ -11,6 +11,7 @@ import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.state.Dat
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.Optional;
 
 /**
@@ -47,7 +48,7 @@ public class DataFileCheckpointer {
     public void checkpoint(int lineNumber) {
         LOG.debug("Checkpoint data file " + dataFilePartition.getKey() + " with line number " + lineNumber);
         setProgressState(lineNumber);
-        enhancedSourceCoordinator.saveProgressStateForPartition(dataFilePartition);
+        enhancedSourceCoordinator.saveProgressStateForPartition(dataFilePartition, null);
     }
 
     /**
@@ -74,5 +75,8 @@ public class DataFileCheckpointer {
         enhancedSourceCoordinator.giveUpPartition(dataFilePartition);
     }
 
+    public void updateDatafileForAcknowledgmentWait(final Duration acknowledgmentSetTimeout) {
+        enhancedSourceCoordinator.saveProgressStateForPartition(dataFilePartition, acknowledgmentSetTimeout);
+    }
 
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileScheduler.java
@@ -226,9 +226,9 @@ public class DataFileScheduler implements Runnable {
 
             GlobalState globalState = (GlobalState) globalPartition.get();
             LoadStatus loadStatus = LoadStatus.fromMap(globalState.getProgressState().get());
+            loadStatus.setLoadedFiles(loadStatus.getLoadedFiles() + 1);
             LOG.info("Current status: total {} loaded {}", loadStatus.getTotalFiles(), loadStatus.getLoadedFiles());
 
-            loadStatus.setLoadedFiles(loadStatus.getLoadedFiles() + 1);
             loadStatus.setLoadedRecords(loadStatus.getLoadedRecords() + loaded);
             globalState.setProgressState(loadStatus.toMap());
 

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileScheduler.java
@@ -7,8 +7,11 @@ package org.opensearch.dataprepper.plugins.source.dynamodb.export;
 
 import io.micrometer.core.instrument.Counter;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.dynamodb.DynamoDBSourceConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.DataFilePartition;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.GlobalState;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.LoadStatus;
@@ -54,15 +57,26 @@ public class DataFileScheduler implements Runnable {
 
     private final PluginMetrics pluginMetrics;
 
+    private final AcknowledgementSetManager acknowledgementSetManager;
+
+    private final DynamoDBSourceConfig dynamoDBSourceConfig;
+
 
     private final Counter exportFileSuccessCounter;
     private final AtomicLong activeExportS3ObjectConsumersGauge;
 
 
-    public DataFileScheduler(EnhancedSourceCoordinator coordinator, DataFileLoaderFactory loaderFactory, PluginMetrics pluginMetrics) {
+    public DataFileScheduler(final EnhancedSourceCoordinator coordinator,
+                             final DataFileLoaderFactory loaderFactory,
+                             final PluginMetrics pluginMetrics,
+                             final AcknowledgementSetManager acknowledgementSetManager,
+                             final DynamoDBSourceConfig dynamoDBSourceConfig) {
         this.coordinator = coordinator;
         this.pluginMetrics = pluginMetrics;
         this.loaderFactory = loaderFactory;
+        this.acknowledgementSetManager = acknowledgementSetManager;
+        this.dynamoDBSourceConfig = dynamoDBSourceConfig;
+
         executor = Executors.newFixedThreadPool(MAX_JOB_COUNT);
 
         this.exportFileSuccessCounter = pluginMetrics.counter(EXPORT_S3_OBJECTS_PROCESSED_COUNT);
@@ -74,16 +88,36 @@ public class DataFileScheduler implements Runnable {
         String tableArn = getTableArn(exportArn);
 
         TableInfo tableInfo = getTableInfo(tableArn);
-        
-        Runnable loader = loaderFactory.createDataFileLoader(dataFilePartition, tableInfo);
+
+        final boolean acknowledgmentsEnabled = dynamoDBSourceConfig.isAcknowledgmentsEnabled();
+
+        AcknowledgementSet acknowledgementSet = null;
+        if (acknowledgmentsEnabled) {
+            acknowledgementSet = acknowledgementSetManager.create((result) -> {
+                if (result == true) {
+                    completeDataLoader(dataFilePartition).accept(null, null);
+                    LOG.info("Received acknowledgment of completion from sink for data file {}", dataFilePartition.getKey());
+                } else {
+                    LOG.warn("Negative acknowledgment received for data file {}, retrying", dataFilePartition.getKey());
+                    coordinator.giveUpPartition(dataFilePartition);
+                }
+            }, dynamoDBSourceConfig.getDataFileAcknowledgmentTimeout());
+        }
+
+        Runnable loader = loaderFactory.createDataFileLoader(dataFilePartition, tableInfo, acknowledgementSet, dynamoDBSourceConfig.getDataFileAcknowledgmentTimeout());
         CompletableFuture runLoader = CompletableFuture.runAsync(loader, executor);
-        runLoader.whenComplete(completeDataLoader(dataFilePartition));
+
+        if (!acknowledgmentsEnabled) {
+            runLoader.whenComplete(completeDataLoader(dataFilePartition));
+        } else {
+            runLoader.whenComplete((v, ex) -> numOfWorkers.decrementAndGet());
+        }
         numOfWorkers.incrementAndGet();
     }
 
     @Override
     public void run() {
-        LOG.debug("Start running Data File Scheduler");
+        LOG.debug("Starting Data File Scheduler to process S3 data files for export");
 
         while (!Thread.currentThread().isInterrupted()) {
             try {
@@ -145,7 +179,10 @@ public class DataFileScheduler implements Runnable {
 
     private BiConsumer completeDataLoader(DataFilePartition dataFilePartition) {
         return (v, ex) -> {
-            numOfWorkers.decrementAndGet();
+
+            if (!dynamoDBSourceConfig.isAcknowledgmentsEnabled()) {
+                numOfWorkers.decrementAndGet();
+            }
             if (ex == null) {
                 exportFileSuccessCounter.increment();
                 // Update global state
@@ -155,8 +192,7 @@ public class DataFileScheduler implements Runnable {
 
             } else {
                 // The data loader must have already done one last checkpointing.
-                LOG.debug("Data Loader completed with exception");
-                LOG.error("{}", ex);
+                LOG.error("Loading S3 data files completed with an exception: {}", ex);
                 // Release the ownership
                 coordinator.giveUpPartition(dataFilePartition);
             }
@@ -190,27 +226,24 @@ public class DataFileScheduler implements Runnable {
 
             GlobalState globalState = (GlobalState) globalPartition.get();
             LoadStatus loadStatus = LoadStatus.fromMap(globalState.getProgressState().get());
-            LOG.debug("Current status: total {} loaded {}", loadStatus.getTotalFiles(), loadStatus.getLoadedFiles());
+            LOG.info("Current status: total {} loaded {}", loadStatus.getTotalFiles(), loadStatus.getLoadedFiles());
 
             loadStatus.setLoadedFiles(loadStatus.getLoadedFiles() + 1);
             loadStatus.setLoadedRecords(loadStatus.getLoadedRecords() + loaded);
             globalState.setProgressState(loadStatus.toMap());
 
             try {
-                coordinator.saveProgressStateForPartition(globalState);
+                coordinator.saveProgressStateForPartition(globalState, null);
                 // if all load are completed.
                 if (streamArn != null && loadStatus.getLoadedFiles() == loadStatus.getTotalFiles()) {
-                    LOG.debug("All Exports are done, streaming can continue...");
+                    LOG.info("All Exports are done, streaming can continue...");
                     coordinator.createPartition(new GlobalState(streamArn, Optional.empty()));
                 }
                 break;
             } catch (Exception e) {
-                LOG.error("Failed to update the global status, looks like the status was out of dated, will retry..");
+                LOG.error("Failed to update the global status, looks like the status was out of date, will retry..");
             }
-
         }
-
-
     }
 
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardManager.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardManager.java
@@ -129,9 +129,8 @@ public class ShardManager {
                     .shardIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER)
                     .sequenceNumber(sequenceNumber)
                     .build();
-
         } else {
-            LOG.debug("Get Shard Iterator from beginning (TRIM_HORIZON)");
+            LOG.info("Get Shard Iterator from beginning (TRIM_HORIZON) for shard {}", shardId);
             getShardIteratorRequest = GetShardIteratorRequest.builder()
                     .shardId(shardId)
                     .streamArn(streamArn)

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/StreamCheckpointer.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/StreamCheckpointer.java
@@ -12,6 +12,7 @@ import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.state.Str
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.Optional;
 
 /**
@@ -48,12 +49,10 @@ public class StreamCheckpointer {
      *
      * @param sequenceNumber The last sequence number
      */
-
     public void checkpoint(String sequenceNumber) {
         LOG.debug("Checkpoint shard " + streamPartition.getShardId() + " with sequenceNumber " + sequenceNumber);
         setSequenceNumber(sequenceNumber);
-        coordinator.saveProgressStateForPartition(streamPartition);
-
+        coordinator.saveProgressStateForPartition(streamPartition, null);
     }
 
     /**
@@ -88,4 +87,7 @@ public class StreamCheckpointer {
         return globalPartition.isPresent();
     }
 
+    public void updateShardForAcknowledgmentWait(final Duration acknowledgmentSetTimeout) {
+        coordinator.saveProgressStateForPartition(streamPartition, acknowledgmentSetTimeout);
+    }
 }

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBServiceTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
@@ -102,6 +103,9 @@ class DynamoDBServiceTest {
     @Mock
     private Buffer<Record<Event>> buffer;
 
+    @Mock
+    private AcknowledgementSetManager acknowledgementSetManager;
+
     private DynamoDBService dynamoDBService;
 
     private Collection<KeySchemaElement> keySchema;
@@ -162,7 +166,7 @@ class DynamoDBServiceTest {
     }
 
     private DynamoDBService createObjectUnderTest() {
-        DynamoDBService objectUnderTest = new DynamoDBService(coordinator, clientFactory, sourceConfig, pluginMetrics);
+        DynamoDBService objectUnderTest = new DynamoDBService(coordinator, clientFactory, sourceConfig, pluginMetrics, acknowledgementSetManager);
         return objectUnderTest;
     }
 

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/ExportRecordConverterTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/ExportRecordConverterTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
@@ -107,7 +108,7 @@ class ExportRecordConverterTest {
         List<String> data = generateData(numberOfRecords);
         ExportRecordConverter recordConverter = new ExportRecordConverter(bufferAccumulator, tableInfo, pluginMetrics);
 
-        recordConverter.writeToBuffer(data);
+        recordConverter.writeToBuffer(null, data);
         verify(bufferAccumulator, times(numberOfRecords)).add(any(Record.class));
         verify(exportRecordSuccess).increment(anyDouble());
 
@@ -127,7 +128,7 @@ class ExportRecordConverterTest {
         doNothing().when(bufferAccumulator).add(recordArgumentCaptor.capture());
 //        doNothing().when(bufferAccumulator).flush();
 
-        recordConverter.writeToBuffer(List.of(line));
+        recordConverter.writeToBuffer(eq(null), List.of(line));
         verify(bufferAccumulator).add(any(Record.class));
         verify(bufferAccumulator).flush();
         assertThat(recordArgumentCaptor.getValue().getData(), notNullValue());

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
@@ -102,7 +102,7 @@ class StreamRecordConverterTest {
 
         StreamRecordConverter recordConverter = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics);
 
-        recordConverter.writeToBuffer(records);
+        recordConverter.writeToBuffer(null, records);
         verify(bufferAccumulator, times(numberOfRecords)).add(any(Record.class));
         verify(bufferAccumulator).flush();
         verify(changeEventSuccessCounter).increment(anyDouble());
@@ -120,7 +120,7 @@ class StreamRecordConverterTest {
         StreamRecordConverter recordConverter = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics);
         doNothing().when(bufferAccumulator).add(recordArgumentCaptor.capture());
 
-        recordConverter.writeToBuffer(records);
+        recordConverter.writeToBuffer(null, records);
 
         verify(bufferAccumulator).add(any(Record.class));
         verify(bufferAccumulator).flush();

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoaderFactoryTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoaderFactoryTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
@@ -21,12 +22,14 @@ import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableInfo;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableMetadata;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class DataFileLoaderFactoryTest {
@@ -84,10 +87,19 @@ class DataFileLoaderFactoryTest {
 
     @Test
     void test_createDataFileLoader() {
+        DataFileLoaderFactory loaderFactory = new DataFileLoaderFactory(coordinator, s3Client, pluginMetrics, buffer);
+        Runnable loader = loaderFactory.createDataFileLoader(dataFilePartition, tableInfo, null, null);
+        assertThat(loader, notNullValue());
+    }
+
+    @Test
+    void test_createDataFileLoader_with_acknowledgments() {
+        final AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+        final Duration acknowledgmentTimeout = Duration.ofSeconds(30);
 
         DataFileLoaderFactory loaderFactory = new DataFileLoaderFactory(coordinator, s3Client, pluginMetrics, buffer);
-        Runnable loader = loaderFactory.createDataFileLoader(dataFilePartition, tableInfo);
-        assertThat(loader, notNullValue());
 
+        Runnable loader = loaderFactory.createDataFileLoader(dataFilePartition, tableInfo, acknowledgementSet, acknowledgmentTimeout);
+        assertThat(loader, notNullValue());
     }
 }

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileSchedulerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileSchedulerTest.java
@@ -12,8 +12,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.dynamodb.DynamoDBSourceConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.DataFilePartition;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.GlobalState;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.state.DataFileProgressState;
@@ -21,6 +24,7 @@ import org.opensearch.dataprepper.plugins.source.dynamodb.model.LoadStatus;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableInfo;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableMetadata;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -28,6 +32,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -35,7 +40,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.export.DataFileScheduler.ACTIVE_EXPORT_S3_OBJECT_CONSUMERS_GAUGE;
@@ -46,6 +53,12 @@ class DataFileSchedulerTest {
 
     @Mock
     private EnhancedSourceCoordinator coordinator;
+
+    @Mock
+    private DynamoDBSourceConfig dynamoDBSourceConfig;
+
+    @Mock
+    private AcknowledgementSetManager acknowledgementSetManager;
 
     @Mock
     private PluginMetrics pluginMetrics;
@@ -113,16 +126,18 @@ class DataFileSchedulerTest {
         lenient().when(coordinator.createPartition(any(EnhancedSourcePartition.class))).thenReturn(true);
         lenient().doNothing().when(coordinator).completePartition(any(EnhancedSourcePartition.class));
         lenient().doNothing().when(coordinator).giveUpPartition(any(EnhancedSourcePartition.class));
-
-        lenient().when(loaderFactory.createDataFileLoader(any(DataFilePartition.class), any(TableInfo.class))).thenReturn(() -> System.out.println("Hello"));
-
     }
 
     @Test
     public void test_run_DataFileLoader_correctly() throws InterruptedException {
-        given(coordinator.acquireAvailablePartition(DataFilePartition.PARTITION_TYPE)).willReturn(Optional.of(dataFilePartition)).willReturn(Optional.empty());
+        given(loaderFactory.createDataFileLoader(any(DataFilePartition.class), any(TableInfo.class), eq(null), any(Duration.class))).willReturn(() -> System.out.println("Hello"));
 
-        scheduler = new DataFileScheduler(coordinator, loaderFactory, pluginMetrics);
+
+        given(coordinator.acquireAvailablePartition(DataFilePartition.PARTITION_TYPE)).willReturn(Optional.of(dataFilePartition)).willReturn(Optional.empty());
+        given(dynamoDBSourceConfig.isAcknowledgmentsEnabled()).willReturn(false);
+        given(dynamoDBSourceConfig.getDataFileAcknowledgmentTimeout()).willReturn(Duration.ofSeconds(10));
+
+        scheduler = new DataFileScheduler(coordinator, loaderFactory, pluginMetrics, acknowledgementSetManager, dynamoDBSourceConfig);
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         final Future<?> future = executorService.submit(() -> scheduler.run());
@@ -134,11 +149,11 @@ class DataFileSchedulerTest {
         // Should acquire data file partition
         verify(coordinator).acquireAvailablePartition(DataFilePartition.PARTITION_TYPE);
         // Should create a loader
-        verify(loaderFactory).createDataFileLoader(any(DataFilePartition.class), any(TableInfo.class));
+        verify(loaderFactory).createDataFileLoader(any(DataFilePartition.class), any(TableInfo.class), eq(null), any(Duration.class));
         // Need to call getPartition for 3 times (3 global states, 2 TableInfo)
         verify(coordinator, times(3)).getPartition(anyString());
         // Should update global state with load status
-        verify(coordinator).saveProgressStateForPartition(any(GlobalState.class));
+        verify(coordinator).saveProgressStateForPartition(any(GlobalState.class), eq(null));
         // Should create a partition to inform streaming can start.
         verify(coordinator).createPartition(any(GlobalState.class));
         // Should mask the partition as completed.
@@ -148,14 +163,57 @@ class DataFileSchedulerTest {
 
         executorService.shutdownNow();
 
+    }
 
+    @Test
+    void run_DataFileLoader_with_acknowledgments_enabled_processes_correctly() throws InterruptedException {
+        given(coordinator.acquireAvailablePartition(DataFilePartition.PARTITION_TYPE)).willReturn(Optional.of(dataFilePartition)).willReturn(Optional.empty());
+        given(dynamoDBSourceConfig.isAcknowledgmentsEnabled()).willReturn(true);
+
+        final Duration dataFileAcknowledgmentTimeout = Duration.ofSeconds(30);
+        given(dynamoDBSourceConfig.getDataFileAcknowledgmentTimeout()).willReturn(dataFileAcknowledgmentTimeout);
+
+        final AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+        doAnswer(invocation -> {
+            Consumer<Boolean> consumer = invocation.getArgument(0);
+            consumer.accept(true);
+            return acknowledgementSet;
+        }).when(acknowledgementSetManager).create(any(Consumer.class), eq(dataFileAcknowledgmentTimeout));
+
+        given(loaderFactory.createDataFileLoader(any(DataFilePartition.class), any(TableInfo.class), eq(acknowledgementSet), eq(dataFileAcknowledgmentTimeout))).willReturn(() -> System.out.println("Hello"));
+
+        scheduler = new DataFileScheduler(coordinator, loaderFactory, pluginMetrics, acknowledgementSetManager, dynamoDBSourceConfig);
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        final Future<?> future = executorService.submit(() -> scheduler.run());
+        Thread.sleep(100);
+        executorService.shutdown();
+        future.cancel(true);
+        assertThat(executorService.awaitTermination(1000, TimeUnit.MILLISECONDS), equalTo(true));
+
+        // Should acquire data file partition
+        verify(coordinator).acquireAvailablePartition(DataFilePartition.PARTITION_TYPE);
+        // Should create a loader
+        verify(loaderFactory).createDataFileLoader(any(DataFilePartition.class), any(TableInfo.class), eq(acknowledgementSet), eq(dataFileAcknowledgmentTimeout));
+        // Need to call getPartition for 3 times (3 global states, 2 TableInfo)
+        verify(coordinator, times(3)).getPartition(anyString());
+        // Should update global state with load status
+        verify(coordinator).saveProgressStateForPartition(any(GlobalState.class), eq(null));
+        // Should create a partition to inform streaming can start.
+        verify(coordinator).createPartition(any(GlobalState.class));
+        // Should mask the partition as completed.
+        verify(coordinator).completePartition(any(DataFilePartition.class));
+        // Should update metrics.
+        verify(exportFileSuccess).increment();
+
+        executorService.shutdownNow();
     }
 
     @Test
     void run_catches_exception_and_retries_when_exception_is_thrown_during_processing() throws InterruptedException {
         given(coordinator.acquireAvailablePartition(DataFilePartition.PARTITION_TYPE)).willThrow(RuntimeException.class);
 
-        scheduler = new DataFileScheduler(coordinator, loaderFactory, pluginMetrics);
+        scheduler = new DataFileScheduler(coordinator, loaderFactory, pluginMetrics, acknowledgementSetManager, dynamoDBSourceConfig);
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         final Future<?> future = executorService.submit(() -> scheduler.run());

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactoryTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactoryTest.java
@@ -90,7 +90,7 @@ class ShardConsumerFactoryTest {
 
         ShardConsumerFactory consumerFactory = new ShardConsumerFactory(coordinator, dynamoDbStreamsClient, pluginMetrics, shardManager, buffer);
 
-        Runnable consumer = consumerFactory.createConsumer(streamPartition);
+        Runnable consumer = consumerFactory.createConsumer(streamPartition, null, null);
 
         assertThat(consumer, notNullValue());
     }

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/StreamSchedulerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/StreamSchedulerTest.java
@@ -11,12 +11,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.dynamodb.DynamoDBSourceConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.StreamPartition;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.state.StreamProgressState;
 import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClient;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -26,6 +30,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -33,7 +38,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.stream.StreamScheduler.ACTIVE_CHANGE_EVENT_CONSUMERS;
@@ -46,6 +53,12 @@ class StreamSchedulerTest {
 
     @Mock
     private DynamoDbStreamsClient dynamoDbStreamsClient;
+
+    @Mock
+    private AcknowledgementSetManager acknowledgementSetManager;
+
+    @Mock
+    private DynamoDBSourceConfig dynamoDBSourceConfig;
 
 
     @Mock
@@ -90,10 +103,8 @@ class StreamSchedulerTest {
         // Mock Coordinator methods
         lenient().when(coordinator.createPartition(any(EnhancedSourcePartition.class))).thenReturn(true);
         lenient().doNothing().when(coordinator).completePartition(any(EnhancedSourcePartition.class));
-        lenient().doNothing().when(coordinator).saveProgressStateForPartition(any(EnhancedSourcePartition.class));
+        lenient().doNothing().when(coordinator).saveProgressStateForPartition(any(EnhancedSourcePartition.class), eq(null));
         lenient().doNothing().when(coordinator).giveUpPartition(any(EnhancedSourcePartition.class));
-
-        lenient().when(consumerFactory.createConsumer(any(StreamPartition.class))).thenReturn(() -> System.out.println("Hello"));
         lenient().when(shardManager.getChildShardIds(anyString(), anyString())).thenReturn(List.of(shardId));
 
         when(pluginMetrics.gauge(eq(ACTIVE_CHANGE_EVENT_CONSUMERS), any(AtomicLong.class))).thenReturn(activeShardConsumers);
@@ -103,9 +114,10 @@ class StreamSchedulerTest {
 
     @Test
     public void test_normal_run() throws InterruptedException {
-        given(coordinator.acquireAvailablePartition(StreamPartition.PARTITION_TYPE)).willReturn(Optional.of(streamPartition)).willReturn(Optional.empty());
+        when(consumerFactory.createConsumer(any(StreamPartition.class), eq(null), any(Duration.class))).thenReturn(() -> System.out.println("Hello"));
+        when(coordinator.acquireAvailablePartition(StreamPartition.PARTITION_TYPE)).thenReturn(Optional.of(streamPartition)).thenReturn(Optional.empty());
 
-        scheduler = new StreamScheduler(coordinator, consumerFactory, shardManager, pluginMetrics);
+        scheduler = new StreamScheduler(coordinator, consumerFactory, shardManager, pluginMetrics, acknowledgementSetManager, dynamoDBSourceConfig);
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
 
@@ -117,7 +129,46 @@ class StreamSchedulerTest {
         // Should acquire the stream partition
         verify(coordinator).acquireAvailablePartition(StreamPartition.PARTITION_TYPE);
         // Should start a new consumer
-        verify(consumerFactory).createConsumer(any(StreamPartition.class));
+        verify(consumerFactory).createConsumer(any(StreamPartition.class), eq(null), any(Duration.class));
+        // Should create stream partition for child shards.
+        verify(coordinator).createPartition(any(StreamPartition.class));
+        // Should mask the stream partition as completed.
+        verify(coordinator).completePartition(any(StreamPartition.class));
+
+        executorService.shutdownNow();
+    }
+
+    @Test
+    public void test_normal_run_with_acknowledgments() throws InterruptedException {
+        given(coordinator.acquireAvailablePartition(StreamPartition.PARTITION_TYPE)).willReturn(Optional.of(streamPartition)).willReturn(Optional.empty());
+        given(dynamoDBSourceConfig.isAcknowledgmentsEnabled()).willReturn(true);
+
+        final Duration shardAcknowledgmentTimeout = Duration.ofSeconds(30);
+        given(dynamoDBSourceConfig.getShardAcknowledgmentTimeout()).willReturn(shardAcknowledgmentTimeout);
+
+        final AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
+        doAnswer(invocation -> {
+            Consumer<Boolean> consumer = invocation.getArgument(0);
+            consumer.accept(true);
+            return acknowledgementSet;
+        }).when(acknowledgementSetManager).create(any(Consumer.class), eq(shardAcknowledgmentTimeout));
+
+        when(consumerFactory.createConsumer(any(StreamPartition.class), eq(acknowledgementSet), eq(shardAcknowledgmentTimeout))).thenReturn(() -> System.out.println("Hello"));
+
+        scheduler = new StreamScheduler(coordinator, consumerFactory, shardManager, pluginMetrics, acknowledgementSetManager, dynamoDBSourceConfig);
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+        final Future<?> future = executorService.submit(() -> scheduler.run());
+        Thread.sleep(3000);
+        executorService.shutdown();
+        future.cancel(true);
+        assertThat(executorService.awaitTermination(1000, TimeUnit.MILLISECONDS), equalTo(true));
+
+        // Should acquire the stream partition
+        verify(coordinator).acquireAvailablePartition(StreamPartition.PARTITION_TYPE);
+        // Should start a new consumer
+        verify(consumerFactory).createConsumer(any(StreamPartition.class), any(AcknowledgementSet.class), any(Duration.class));
         // Should create stream partition for child shards.
         verify(coordinator).createPartition(any(StreamPartition.class));
         // Should mask the stream partition as completed.
@@ -129,8 +180,7 @@ class StreamSchedulerTest {
     @Test
     void run_catches_exception_and_retries_when_exception_is_thrown_during_processing() throws InterruptedException {
         given(coordinator.acquireAvailablePartition(StreamPartition.PARTITION_TYPE)).willThrow(RuntimeException.class);
-
-        scheduler = new StreamScheduler(coordinator, consumerFactory, shardManager, pluginMetrics);
+        scheduler = new StreamScheduler(coordinator, consumerFactory, shardManager, pluginMetrics, acknowledgementSetManager, dynamoDBSourceConfig);
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         final Future<?> future = executorService.submit(() -> scheduler.run());

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -5,21 +5,24 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;
 
-import com.linecorp.armeria.client.retry.Backoff;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
-import org.opensearch.dataprepper.metrics.PluginMetrics;
+import com.linecorp.armeria.client.retry.Backoff;
 import io.micrometer.core.instrument.Counter;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.AccumulatingBulkRequest;
 import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedBulkOperation;
 import org.opensearch.rest.RestStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -27,9 +30,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-import java.time.Duration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class BulkRetryStrategy {
     public static final String DOCUMENTS_SUCCESS = "documentsSuccess";
@@ -241,7 +241,7 @@ public final class BulkRetryStrategy {
                 if (e == null) {
                     for (final BulkResponseItem bulkItemResponse : bulkResponse.items()) {
                         if (Objects.nonNull(bulkItemResponse.error())) {
-                            LOG.warn("operation = {}, error = {}", bulkItemResponse.operationType(), bulkItemResponse.error());
+                            LOG.warn("operation = {}, error = {}", bulkItemResponse.operationType(), bulkItemResponse.error().reason());
                         }
                     }
                 }


### PR DESCRIPTION
### Description
This change adds end to end acknowledgments to the dynamodb source. This includes configurable acknowledgment timeouts for both shards and data files. 

the new parameters are

```
Boolean to enable acknowledgments
acknowledgments:  true
```

```
 Duration to timeout before data file is reprocessed (from the time the last line of data file is written to the buffer to the time that it is reached by the sink (Data Prepper duration format)).

s3_data_file_acknowledgment_timeout: "30s" // Default value is 5 minutes (is this too high?)
```

```
 Duration to timeout before shard is reprocessed (from the time the last record in the shard is written to buffer till it is reached by the sink (Data Prepper duration format)

shard_acknowledgment_timeout: "30s" // Default value is 3 minutes (is this too high?)
```

Additionally, another parameter was added in this PR for the `s3_region` for the export. The default will be to use the same region for the bucket as the `aws.region` for sts, but this can be set to something different now with the `s3_region` parameter. Setting this region on the client fixes an issue where `GetObject` requests would hang infinitely in some scenarios (for unknown reasons)
 
### Issues Resolved
Resolves #3538 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
