### PR TITLE
Add missing ISM rollover index setting for OTel span indices

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/resources/index-template/otel-v1-apm-span-index-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/index-template/otel-v1-apm-span-index-template.json
@@ -1,6 +1,9 @@
 {
   "version": 1,
   "template": {
+    "settings": {
+      "plugins.index_state_management.rollover_alias": "otel-v1-apm-span"
+    },
     "mappings": {
       "date_detection": false,
       "dynamic_templates": [

--- a/data-prepper-plugins/opensearch/src/main/resources/otel-v1-apm-span-index-template.json
+++ b/data-prepper-plugins/opensearch/src/main/resources/otel-v1-apm-span-index-template.json
@@ -1,5 +1,8 @@
 {
   "version": 1,
+  "settings": {
+    "plugins.index_state_management.rollover_alias": "otel-v1-apm-span"
+  },
   "mappings": {
     "date_detection": false,
     "dynamic_templates": [


### PR DESCRIPTION
Signed-off-by: Jannik Brand [jannik.brand@sap.com](mailto:jannik.brand@sap.com)

### Description
Indices require the `rollover_alias` ISM setting otherwise rollover actions by an ISM policy (raw-span-policy) are failing. Reference: https://opensearch.org/docs/2.11/im-plugin/ism/error-prevention/resolutions/#the-rollover-policy-misses-rollover_alias-index-setting
 
### Issues Resolved
Resolves #3506
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
