### PR TITLE
Change s3 scan and opensearch to only save state every 5 minutes, fix…

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -322,6 +322,7 @@ public class JacksonEvent implements Event {
         if (Objects.isNull(expressionEvaluator)) {
             return false;
         }
+
         int fromIndex = 0;
         int position = 0;
         while ((position = format.indexOf("${", fromIndex)) != -1) {

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorker.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorker.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.BACKOFF_ON_EXCEPTION;
+import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.DEFAULT_CHECKPOINT_INTERVAL_MILLS;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.calculateExponentialBackoffAndJitter;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.completeIndexPartition;
 import static org.opensearch.dataprepper.plugins.source.opensearch.worker.WorkerCommonUtils.createAcknowledgmentSet;
@@ -128,6 +129,8 @@ public class NoSearchContextWorker implements SearchWorker, Runnable {
     private void processIndex(final SourcePartition<OpenSearchIndexProgressState> openSearchIndexPartition,
                               final AcknowledgementSet acknowledgementSet) {
         final String indexName = openSearchIndexPartition.getPartitionKey();
+        long lastCheckpointTime = System.currentTimeMillis();
+
         LOG.info("Started processing for index: '{}'", indexName);
 
         Optional<OpenSearchIndexProgressState> openSearchIndexProgressStateOptional = openSearchIndexPartition.getPartitionState();
@@ -165,7 +168,12 @@ public class NoSearchContextWorker implements SearchWorker, Runnable {
             });
 
             openSearchIndexProgressState.setSearchAfter(searchWithSearchAfterResults.getNextSearchAfter());
-            sourceCoordinator.saveProgressStateForPartition(indexName, openSearchIndexProgressState);
+
+            if (System.currentTimeMillis() - lastCheckpointTime > DEFAULT_CHECKPOINT_INTERVAL_MILLS) {
+                LOG.debug("Renew ownership of index {}", indexName);
+                sourceCoordinator.saveProgressStateForPartition(indexName, openSearchIndexProgressState);
+                lastCheckpointTime = System.currentTimeMillis();
+            }
         } while (searchWithSearchAfterResults.getDocuments().size() == searchConfiguration.getBatchSize());
 
         try {

--- a/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
+++ b/data-prepper-plugins/opensearch-source/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/WorkerCommonUtils.java
@@ -27,7 +27,8 @@ public class WorkerCommonUtils {
 
     static final Duration BACKOFF_ON_EXCEPTION = Duration.ofSeconds(60);
 
-    static final Duration ACKNOWLEDGEMENT_SET_TIMEOUT = Duration.ofHours(2);
+    static final long DEFAULT_CHECKPOINT_INTERVAL_MILLS = 5 * 60_000;
+    static final Duration ACKNOWLEDGEMENT_SET_TIMEOUT = Duration.ofHours(1);
     static final Duration STARTING_BACKOFF = Duration.ofMillis(500);
     static final Duration MAX_BACKOFF = Duration.ofSeconds(60);
     static final int BACKOFF_RATE = 2;

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorkerTest.java
@@ -206,7 +206,7 @@ public class NoSearchContextWorkerTest {
         assertThat(executorService.awaitTermination(100, TimeUnit.MILLISECONDS), equalTo(true));
 
         verify(searchAccessor, times(2)).searchWithoutSearchContext(any(NoSearchContextSearchRequest.class));
-        verify(sourceCoordinator, times(2)).saveProgressStateForPartition(eq(partitionKey), any(OpenSearchIndexProgressState.class));
+        verify(sourceCoordinator, times(0)).saveProgressStateForPartition(eq(partitionKey), any(OpenSearchIndexProgressState.class));
 
         final List<NoSearchContextSearchRequest> noSearchContextSearchRequests = searchRequestArgumentCaptor.getAllValues();
         assertThat(noSearchContextSearchRequests.size(), equalTo(2));
@@ -283,7 +283,7 @@ public class NoSearchContextWorkerTest {
         assertThat(executorService.awaitTermination(100, TimeUnit.MILLISECONDS), equalTo(true));
 
         verify(searchAccessor, times(2)).searchWithoutSearchContext(any(NoSearchContextSearchRequest.class));
-        verify(sourceCoordinator, times(2)).saveProgressStateForPartition(eq(partitionKey), any(OpenSearchIndexProgressState.class));
+        verify(sourceCoordinator, times(0)).saveProgressStateForPartition(eq(partitionKey), any(OpenSearchIndexProgressState.class));
 
         final List<NoSearchContextSearchRequest> noSearchContextSearchRequests = searchRequestArgumentCaptor.getAllValues();
         assertThat(noSearchContextSearchRequests.size(), equalTo(2));

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
@@ -191,7 +191,7 @@ public class PitWorkerTest {
         assertThat(createPointInTimeRequest.getKeepAlive(), equalTo(STARTING_KEEP_ALIVE));
 
         verify(searchAccessor, times(2)).searchWithPit(any(SearchPointInTimeRequest.class));
-        verify(sourceCoordinator, times(2)).saveProgressStateForPartition(eq(partitionKey), any(OpenSearchIndexProgressState.class));
+        verify(sourceCoordinator, times(0)).saveProgressStateForPartition(eq(partitionKey), any(OpenSearchIndexProgressState.class));
 
         final List<SearchPointInTimeRequest> searchPointInTimeRequestList = searchPointInTimeRequestArgumentCaptor.getAllValues();
         assertThat(searchPointInTimeRequestList.size(), equalTo(2));
@@ -292,7 +292,7 @@ public class PitWorkerTest {
         assertThat(createPointInTimeRequest.getKeepAlive(), equalTo(STARTING_KEEP_ALIVE));
 
         verify(searchAccessor, times(2)).searchWithPit(any(SearchPointInTimeRequest.class));
-        verify(sourceCoordinator, times(2)).saveProgressStateForPartition(eq(partitionKey), any(OpenSearchIndexProgressState.class));
+        verify(sourceCoordinator, times(0)).saveProgressStateForPartition(eq(partitionKey), any(OpenSearchIndexProgressState.class));
 
         final List<SearchPointInTimeRequest> searchPointInTimeRequestList = searchPointInTimeRequestArgumentCaptor.getAllValues();
         assertThat(searchPointInTimeRequestList.size(), equalTo(2));
@@ -378,7 +378,7 @@ public class PitWorkerTest {
 
         verify(searchAccessor, never()).createPit(any(CreatePointInTimeRequest.class));
         verify(searchAccessor, times(2)).searchWithPit(any(SearchPointInTimeRequest.class));
-        verify(sourceCoordinator, times(2)).saveProgressStateForPartition(eq(partitionKey), eq(openSearchIndexProgressState));
+        verify(sourceCoordinator, times(0)).saveProgressStateForPartition(eq(partitionKey), eq(openSearchIndexProgressState));
         verify(sourceCoordinator, times(0)).updatePartitionForAcknowledgmentWait(anyString(), any(Duration.class));
 
         verify(documentsProcessedCounter, times(3)).increment();

--- a/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorkerTest.java
+++ b/data-prepper-plugins/opensearch-source/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorkerTest.java
@@ -191,7 +191,7 @@ public class ScrollWorkerTest {
         assertThat(createScrollRequest.getScrollTime(), equalTo(SCROLL_TIME_PER_BATCH));
 
         verify(searchAccessor, times(2)).searchWithScroll(any(SearchScrollRequest.class));
-        verify(sourceCoordinator, times(2)).saveProgressStateForPartition(eq(partitionKey), eq(null));
+        verify(sourceCoordinator, times(0)).saveProgressStateForPartition(eq(partitionKey), eq(null));
 
         final List<SearchScrollRequest> searchScrollRequests = searchScrollRequestArgumentCaptor.getAllValues();
         assertThat(searchScrollRequests.size(), equalTo(2));
@@ -286,7 +286,7 @@ public class ScrollWorkerTest {
         assertThat(createScrollRequest.getScrollTime(), equalTo(SCROLL_TIME_PER_BATCH));
 
         verify(searchAccessor, times(2)).searchWithScroll(any(SearchScrollRequest.class));
-        verify(sourceCoordinator, times(2)).saveProgressStateForPartition(eq(partitionKey), eq(null));
+        verify(sourceCoordinator, times(0)).saveProgressStateForPartition(eq(partitionKey), eq(null));
 
         final List<SearchScrollRequest> searchScrollRequests = searchScrollRequestArgumentCaptor.getAllValues();
         assertThat(searchScrollRequests.size(), equalTo(2));

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -259,7 +259,7 @@ public final class BulkRetryStrategy {
         if (failure == null) {
             for (final BulkResponseItem bulkItemResponse : bulkResponse.items()) {
                 if (Objects.nonNull(bulkItemResponse.error())) {
-                    LOG.warn("operation = {}, error = {}", bulkItemResponse.operationType(), bulkItemResponse.error());
+                    LOG.warn("operation = {}, error = {}", bulkItemResponse.operationType(), bulkItemResponse.error().reason());
                 }
             }
             handleFailures(bulkRequest, bulkResponse.items());

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -512,7 +512,6 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
 
   private void maybeUpdateServerlessNetworkPolicy() {
     final ConnectionConfiguration connectionConfiguration = openSearchSinkConfig.getConnectionConfiguration();
-    LOG.info(connectionConfiguration.toString());
     if (connectionConfiguration.isServerless() &&
         !StringUtils.isBlank(connectionConfiguration.getServerlessNetworkPolicyName()) &&
         !StringUtils.isBlank(connectionConfiguration.getServerlessCollectionName()) &&

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IndexConfiguration.java
@@ -26,11 +26,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -522,7 +524,8 @@ public class IndexConfiguration {
         }
 
         public Builder withAction(final String action, final ExpressionEvaluator expressionEvaluator) {
-            checkArgument((EnumUtils.isValidEnumIgnoreCase(OpenSearchBulkActions.class, action) || JacksonEvent.isValidFormatExpressions(action, expressionEvaluator)), "action must be one of the following: " + OpenSearchBulkActions.values());
+            checkArgument((EnumUtils.isValidEnumIgnoreCase(OpenSearchBulkActions.class, action) ||
+                    (action.contains("${") && JacksonEvent.isValidFormatExpressions(action, expressionEvaluator))), "Invalid action \"" + action + "\". action must be one of the following: " + Arrays.stream(OpenSearchBulkActions.values()).collect(Collectors.toList()));
             this.action = action;
             return this;
         }
@@ -531,7 +534,8 @@ public class IndexConfiguration {
             for (final Map<String, Object> actionMap: actions) {
                 String action = (String)actionMap.get("type");
                 if (action != null) {
-                    checkArgument((EnumUtils.isValidEnumIgnoreCase(OpenSearchBulkActions.class, action) || JacksonEvent.isValidFormatExpressions(action, expressionEvaluator)), "action must be one of the following: " + OpenSearchBulkActions.values());
+                    checkArgument((EnumUtils.isValidEnumIgnoreCase(OpenSearchBulkActions.class, action) ||
+                            (action.contains("${") && JacksonEvent.isValidFormatExpressions(action, expressionEvaluator))), "Invalid action \"" + action + "\". action must be one of the following: " + Arrays.stream(OpenSearchBulkActions.values()).collect(Collectors.toList()));
                 }
             }
             this.actions = actions;

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorker.java
@@ -111,8 +111,8 @@ class S3ObjectWorker implements S3ObjectHandler {
                     if (sourceCoordinator != null && partitionKey != null &&
                             (System.currentTimeMillis() - lastCheckpointTime.get() > DEFAULT_CHECKPOINT_INTERVAL_MILLS)) {
                         LOG.debug("Renew partition ownership for the object {}", partitionKey);
-                        lastCheckpointTime.set(System.currentTimeMillis());
                         sourceCoordinator.saveProgressStateForPartition(partitionKey, null);
+                        lastCheckpointTime.set(System.currentTimeMillis());
                         saveStateCounter.getAndIncrement();
                     }
                 } catch (final Exception e) {

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorkerTest.java
@@ -59,10 +59,10 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static org.opensearch.dataprepper.plugins.source.s3.S3ObjectWorker.RECORDS_TO_ACCUMULATE_TO_SAVE_STATE;
 
 @ExtendWith(MockitoExtension.class)
 class S3ObjectWorkerTest {
@@ -306,14 +306,12 @@ class S3ObjectWorkerTest {
         final Record<Event> record = mock(Record.class);
         final Event event = mock(Event.class);
         when(record.getData()).thenReturn(event);
-        when(bufferAccumulator.getTotalWritten()).thenReturn(RECORDS_TO_ACCUMULATE_TO_SAVE_STATE + 1);
-
         consumerUnderTest.accept(record);
 
         final InOrder inOrder = inOrder(eventConsumer, bufferAccumulator, sourceCoordinator);
         inOrder.verify(eventConsumer).accept(event, s3ObjectReference);
         inOrder.verify(bufferAccumulator).add(record);
-        inOrder.verify(sourceCoordinator).saveProgressStateForPartition(testPartitionKey, null);
+        inOrder.verify(sourceCoordinator, times(0)).saveProgressStateForPartition(testPartitionKey, null);
     }
 
     @Test


### PR DESCRIPTION
… bug where any action was valid in OpenSearch sink

Signed-off-by: Taylor Gray <tylgry@amazon.com>

### Description
* Changes the rate at which `saveProgressState` is called to the coordination store for partitions in s3 scan and the opensearch source. Before they were calling saveState every 10,000 Events, which was far too little. It is better to use a time based measurement

They were calling it too often, leading to wasted writes on the store. The default lease timeout is 10 minutes, so we have them call every 5 minutes. 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
