### PR TITLE
Replace Guava Cache with Caffeine for OpenSearch integration

### DIFF
--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     implementation libs.opensearch.java
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation libs.guava.core
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     implementation 'software.amazon.awssdk:auth'
     implementation 'software.amazon.awssdk:http-client-spi'
@@ -30,6 +29,7 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:opensearchserverless'
     implementation libs.commons.lang3
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
     implementation 'software.amazon.awssdk:apache-client'
     testImplementation testLibs.junit.vintage
     testImplementation libs.commons.io

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DynamicIndexManager.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/DynamicIndexManager.java
@@ -5,21 +5,20 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchSinkConfiguration;
-
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class DynamicIndexManager extends AbstractIndexManager {
-    private Cache<String, IndexManager> indexManagerCache;
-    final int CACHE_EXPIRE_AFTER_ACCESS_TIME_MINUTES = 30;
-    final int APPROXIMATE_INDEX_MANAGER_SIZE = 32;
+    private final Cache<String, IndexManager> indexManagerCache;
+    private static final int CACHE_EXPIRE_AFTER_ACCESS_TIME_MINUTES = 30;
+    private static final int APPROXIMATE_INDEX_MANAGER_SIZE = 32;
     private final long cacheSizeInKB = 1024;
     protected RestHighLevelClient restHighLevelClient;
     protected OpenSearchClient openSearchClient;
@@ -47,9 +46,8 @@ public class DynamicIndexManager extends AbstractIndexManager {
         this.restHighLevelClient = restHighLevelClient;
         this.openSearchSinkConfiguration = openSearchSinkConfiguration;
         this.clusterSettingsParser = clusterSettingsParser;
-        CacheBuilder<String, IndexManager> cacheBuilder = CacheBuilder.newBuilder()
+        Caffeine<String, IndexManager> cacheBuilder = Caffeine.newBuilder()
                         .recordStats()
-                        .concurrencyLevel(1)
                         .maximumWeight(cacheSizeInKB)
                         .expireAfterAccess(CACHE_EXPIRE_AFTER_ACCESS_TIME_MINUTES, TimeUnit.MINUTES)
                         .weigher((k, v) -> APPROXIMATE_INDEX_MANAGER_SIZE);

--- a/data-prepper-plugins/otel-trace-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-processor/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation libs.armeria.grpc
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation libs.guava.core
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
     testImplementation testLibs.junit.vintage
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation testLibs.mockito.inline


### PR DESCRIPTION
### Description
This PR replaces the usages of the legacy Guava Cache in favor of Caffeine — Guava maintainers themselves [recommend it](https://guava.dev/releases/31.0-jre/api/docs/com/google/common/cache/CacheBuilder.html). 

> Prefer [Caffeine](https://github.com/ben-manes/caffeine/wiki) over Guava's caching API
The successor to Guava's caching API is [Caffeine](https://github.com/ben-manes/caffeine/wiki). Its API is designed to make it a nearly drop-in replacement -- though it requires Java 8 APIs and is not available for Android or GWT/j2cl. Its equivalent to CacheBuilder is its [Caffeine](https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/latest/com.github.benmanes.caffeine/com/github/benmanes/caffeine/cache/Caffeine.html) class. Caffeine offers better performance, more features (including asynchronous loading), and fewer [bugs](https://github.com/google/guava/issues?q=is%3Aopen+is%3Aissue+label%3Apackage%3Dcache+label%3Atype%3Ddefect).
Caffeine defines its own interfaces ([ Cache](https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/latest/com.github.benmanes.caffeine/com/github/benmanes/caffeine/cache/Cache.html), [LoadingCache](https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/latest/com.github.benmanes.caffeine/com/github/benmanes/caffeine/cache/LoadingCache.html), [CacheLoader](https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/latest/com.github.benmanes.caffeine/com/github/benmanes/caffeine/cache/CacheLoader.html), etc.), so you can use Caffeine without needing to use any Guava types. Caffeine's types are better than Guava's, especially for [their deep support for asynchronous operations](https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/latest/com.github.benmanes.caffeine/com/github/benmanes/caffeine/cache/AsyncLoadingCache.html). But if you want to migrate to Caffeine with minimal code changes, you can use [its CaffeinatedGuava adapter class](https://www.javadoc.io/doc/com.github.ben-manes.caffeine/guava/latest/com.github.benmanes.caffeine.guava/com/github/benmanes/caffeine/guava/CaffeinatedGuava.html), which lets you build a Guava Cache or a Guava LoadingCache backed by a Guava CacheLoader.

 
### Check List
- [x] Existing functionality passes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has Javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on the following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
