### PR TITLE
Support ISM correctly when using composable index templates

### DIFF
--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/DeclaredOpenSearchVersion.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/DeclaredOpenSearchVersion.java
@@ -33,7 +33,7 @@ class DeclaredOpenSearchVersion implements Comparable<DeclaredOpenSearchVersion>
     }
 
     static DeclaredOpenSearchVersion parse(final String versionString) {
-        if(versionString == null) {
+        if(versionString == null || versionString.isEmpty()) {
             return DEFAULT;
         }
 

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -8,11 +8,11 @@ package org.opensearch.dataprepper.plugins.sink.opensearch;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
 import io.micrometer.core.instrument.Measurement;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.util.EntityUtils;
-import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -85,6 +85,7 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
@@ -173,17 +174,17 @@ public class OpenSearchSinkIT {
         final String indexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexType.TRACE_ANALYTICS_RAW);
         Request request = new Request(HttpMethod.HEAD, indexAlias);
         Response response = client.performRequest(request);
-        MatcherAssert.assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
         final String index = String.format("%s-000001", indexAlias);
         final Map<String, Object> mappings = getIndexMappings(index);
-        MatcherAssert.assertThat(mappings, notNullValue());
-        MatcherAssert.assertThat((boolean) mappings.get("date_detection"), equalTo(false));
+        assertThat(mappings, notNullValue());
+        assertThat((boolean) mappings.get("date_detection"), equalTo(false));
         sink.shutdown();
 
         if (isOSBundle()) {
             // Check managed index
             await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
-                        MatcherAssert.assertThat(getIndexPolicyId(index), equalTo(IndexConstants.RAW_ISM_POLICY));
+                        assertThat(getIndexPolicyId(index), equalTo(IndexConstants.RAW_ISM_POLICY));
                     }
             );
         }
@@ -192,7 +193,7 @@ public class OpenSearchSinkIT {
         request = new Request(HttpMethod.POST, String.format("%s/_rollover", indexAlias));
         request.setJsonEntity("{ \"conditions\" : { } }\n");
         response = client.performRequest(request);
-        MatcherAssert.assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
 
         // Instantiate sink again
         sink = createObjectUnderTest(pluginSetting, true);
@@ -200,12 +201,12 @@ public class OpenSearchSinkIT {
         final String rolloverIndexName = String.format("%s-000002", indexAlias);
         request = new Request(HttpMethod.GET, rolloverIndexName + "/_alias");
         response = client.performRequest(request);
-        MatcherAssert.assertThat(checkIsWriteIndex(EntityUtils.toString(response.getEntity()), indexAlias, rolloverIndexName), equalTo(true));
+        assertThat(checkIsWriteIndex(EntityUtils.toString(response.getEntity()), indexAlias, rolloverIndexName), equalTo(true));
         sink.shutdown();
 
         if (isOSBundle()) {
             // Check managed index
-            MatcherAssert.assertThat(getIndexPolicyId(rolloverIndexName), equalTo(IndexConstants.RAW_ISM_POLICY));
+            assertThat(getIndexPolicyId(rolloverIndexName), equalTo(IndexConstants.RAW_ISM_POLICY));
         }
     }
 
@@ -240,21 +241,21 @@ public class OpenSearchSinkIT {
 
         final String expIndexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexType.TRACE_ANALYTICS_RAW);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(expIndexAlias);
-        MatcherAssert.assertThat(retSources.size(), equalTo(2));
-        MatcherAssert.assertThat(retSources, hasItems(expData1, expData2));
-        MatcherAssert.assertThat(getDocumentCount(expIndexAlias, "_id", (String) expData1.get("spanId")), equalTo(Integer.valueOf(1)));
+        assertThat(retSources.size(), equalTo(2));
+        assertThat(retSources, hasItems(expData1, expData2));
+        assertThat(getDocumentCount(expIndexAlias, "_id", (String) expData1.get("spanId")), equalTo(Integer.valueOf(1)));
         sink.shutdown();
 
         // Verify metrics
         final List<Measurement> bulkRequestErrors = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(OpenSearchSink.BULKREQUEST_ERRORS).toString());
-        MatcherAssert.assertThat(bulkRequestErrors.size(), equalTo(1));
+        assertThat(bulkRequestErrors.size(), equalTo(1));
         Assert.assertEquals(0.0, bulkRequestErrors.get(0).getValue(), 0);
         final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(OpenSearchSink.BULKREQUEST_LATENCY).toString());
-        MatcherAssert.assertThat(bulkRequestLatencies.size(), equalTo(3));
+        assertThat(bulkRequestLatencies.size(), equalTo(3));
         // COUNT
         Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
         // TOTAL_TIME
@@ -264,18 +265,18 @@ public class OpenSearchSinkIT {
         final List<Measurement> documentsSuccessMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(BulkRetryStrategy.DOCUMENTS_SUCCESS).toString());
-        MatcherAssert.assertThat(documentsSuccessMeasurements.size(), equalTo(1));
-        MatcherAssert.assertThat(documentsSuccessMeasurements.get(0).getValue(), closeTo(2.0, 0));
+        assertThat(documentsSuccessMeasurements.size(), equalTo(1));
+        assertThat(documentsSuccessMeasurements.get(0).getValue(), closeTo(2.0, 0));
         final List<Measurement> documentsSuccessFirstAttemptMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(BulkRetryStrategy.DOCUMENTS_SUCCESS_FIRST_ATTEMPT).toString());
-        MatcherAssert.assertThat(documentsSuccessFirstAttemptMeasurements.size(), equalTo(1));
-        MatcherAssert.assertThat(documentsSuccessFirstAttemptMeasurements.get(0).getValue(), closeTo(2.0, 0));
+        assertThat(documentsSuccessFirstAttemptMeasurements.size(), equalTo(1));
+        assertThat(documentsSuccessFirstAttemptMeasurements.get(0).getValue(), closeTo(2.0, 0));
         final List<Measurement> documentErrorsMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(BulkRetryStrategy.DOCUMENT_ERRORS).toString());
-        MatcherAssert.assertThat(documentErrorsMeasurements.size(), equalTo(1));
-        MatcherAssert.assertThat(documentErrorsMeasurements.get(0).getValue(), closeTo(0.0, 0));
+        assertThat(documentErrorsMeasurements.size(), equalTo(1));
+        assertThat(documentErrorsMeasurements.get(0).getValue(), closeTo(0.0, 0));
 
         /**
          * Metrics: Bulk Request Size in Bytes
@@ -283,11 +284,11 @@ public class OpenSearchSinkIT {
         final List<Measurement> bulkRequestSizeBytesMetrics = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(OpenSearchSink.BULKREQUEST_SIZE_BYTES).toString());
-        MatcherAssert.assertThat(bulkRequestSizeBytesMetrics.size(), equalTo(3));
-        MatcherAssert.assertThat(bulkRequestSizeBytesMetrics.get(0).getValue(), closeTo(1.0, 0));
+        assertThat(bulkRequestSizeBytesMetrics.size(), equalTo(3));
+        assertThat(bulkRequestSizeBytesMetrics.get(0).getValue(), closeTo(1.0, 0));
         final double expectedBulkRequestSizeBytes = isRequestCompressionEnabled && estimateBulkSizeUsingCompression ? 773.0 : 2058.0;
-        MatcherAssert.assertThat(bulkRequestSizeBytesMetrics.get(1).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
-        MatcherAssert.assertThat(bulkRequestSizeBytesMetrics.get(2).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
+        assertThat(bulkRequestSizeBytesMetrics.get(1).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
+        assertThat(bulkRequestSizeBytesMetrics.get(2).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
     }
 
     @DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
@@ -317,11 +318,11 @@ public class OpenSearchSinkIT {
         final StringBuilder dlqContent = new StringBuilder();
         Files.lines(Paths.get(expDLQFile)).forEach(dlqContent::append);
         final String nonPrettyJsonString = mapper.writeValueAsString(mapper.readValue(testDoc1, JsonNode.class));
-        MatcherAssert.assertThat(dlqContent.toString(), containsString(nonPrettyJsonString));
+        assertThat(dlqContent.toString(), containsString(nonPrettyJsonString));
         final String expIndexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexType.TRACE_ANALYTICS_RAW);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(expIndexAlias);
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
-        MatcherAssert.assertThat(retSources.get(0), equalTo(expData));
+        assertThat(retSources.size(), equalTo(1));
+        assertThat(retSources.get(0), equalTo(expData));
 
         // clean up temporary directory
         FileUtils.deleteQuietly(tempDirectory);
@@ -330,13 +331,13 @@ public class OpenSearchSinkIT {
         final List<Measurement> documentsSuccessMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(BulkRetryStrategy.DOCUMENTS_SUCCESS).toString());
-        MatcherAssert.assertThat(documentsSuccessMeasurements.size(), equalTo(1));
-        MatcherAssert.assertThat(documentsSuccessMeasurements.get(0).getValue(), closeTo(1.0, 0));
+        assertThat(documentsSuccessMeasurements.size(), equalTo(1));
+        assertThat(documentsSuccessMeasurements.get(0).getValue(), closeTo(1.0, 0));
         final List<Measurement> documentErrorsMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(BulkRetryStrategy.DOCUMENT_ERRORS).toString());
-        MatcherAssert.assertThat(documentErrorsMeasurements.size(), equalTo(1));
-        MatcherAssert.assertThat(documentErrorsMeasurements.get(0).getValue(), closeTo(1.0, 0));
+        assertThat(documentErrorsMeasurements.size(), equalTo(1));
+        assertThat(documentErrorsMeasurements.get(0).getValue(), closeTo(1.0, 0));
 
         /**
          * Metrics: Bulk Request Size in Bytes
@@ -344,11 +345,11 @@ public class OpenSearchSinkIT {
         final List<Measurement> bulkRequestSizeBytesMetrics = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(OpenSearchSink.BULKREQUEST_SIZE_BYTES).toString());
-        MatcherAssert.assertThat(bulkRequestSizeBytesMetrics.size(), equalTo(3));
-        MatcherAssert.assertThat(bulkRequestSizeBytesMetrics.get(0).getValue(), closeTo(1.0, 0));
+        assertThat(bulkRequestSizeBytesMetrics.size(), equalTo(3));
+        assertThat(bulkRequestSizeBytesMetrics.get(0).getValue(), closeTo(1.0, 0));
         final double expectedBulkRequestSizeBytes = isRequestCompressionEnabled && estimateBulkSizeUsingCompression ? 1066.0 : 2072.0;
-        MatcherAssert.assertThat(bulkRequestSizeBytesMetrics.get(1).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
-        MatcherAssert.assertThat(bulkRequestSizeBytesMetrics.get(2).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
+        assertThat(bulkRequestSizeBytesMetrics.get(1).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
+        assertThat(bulkRequestSizeBytesMetrics.get(2).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
 
     }
 
@@ -360,15 +361,15 @@ public class OpenSearchSinkIT {
         final String indexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexType.TRACE_ANALYTICS_SERVICE_MAP);
         final Request request = new Request(HttpMethod.HEAD, indexAlias);
         final Response response = client.performRequest(request);
-        MatcherAssert.assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
         final Map<String, Object> mappings = getIndexMappings(indexAlias);
-        MatcherAssert.assertThat(mappings, notNullValue());
-        MatcherAssert.assertThat((boolean) mappings.get("date_detection"), equalTo(false));
+        assertThat(mappings, notNullValue());
+        assertThat((boolean) mappings.get("date_detection"), equalTo(false));
         sink.shutdown();
 
         if (isOSBundle()) {
             // Check managed index
-            MatcherAssert.assertThat(getIndexPolicyId(indexAlias), nullValue());
+            assertThat(getIndexPolicyId(indexAlias), nullValue());
         }
     }
 
@@ -387,18 +388,18 @@ public class OpenSearchSinkIT {
         sink.output(testRecords);
         final String expIndexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexType.TRACE_ANALYTICS_SERVICE_MAP);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(expIndexAlias);
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
-        MatcherAssert.assertThat(retSources.get(0), equalTo(expData));
-        MatcherAssert.assertThat(getDocumentCount(expIndexAlias, "_id", (String) expData.get("hashId")), equalTo(Integer.valueOf(1)));
+        assertThat(retSources.size(), equalTo(1));
+        assertThat(retSources.get(0), equalTo(expData));
+        assertThat(getDocumentCount(expIndexAlias, "_id", (String) expData.get("hashId")), equalTo(Integer.valueOf(1)));
         sink.shutdown();
 
         // verify metrics
         final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(OpenSearchSink.BULKREQUEST_LATENCY).toString());
-        MatcherAssert.assertThat(bulkRequestLatencies.size(), equalTo(3));
+        assertThat(bulkRequestLatencies.size(), equalTo(3));
         // COUNT
-        MatcherAssert.assertThat(bulkRequestLatencies.get(0).getValue(), closeTo(1.0, 0));
+        assertThat(bulkRequestLatencies.get(0).getValue(), closeTo(1.0, 0));
 
         /**
          * Metrics: Bulk Request Size in Bytes
@@ -406,11 +407,11 @@ public class OpenSearchSinkIT {
         final List<Measurement> bulkRequestSizeBytesMetrics = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(OpenSearchSink.BULKREQUEST_SIZE_BYTES).toString());
-        MatcherAssert.assertThat(bulkRequestSizeBytesMetrics.size(), equalTo(3));
-        MatcherAssert.assertThat(bulkRequestSizeBytesMetrics.get(0).getValue(), closeTo(1.0, 0));
+        assertThat(bulkRequestSizeBytesMetrics.size(), equalTo(3));
+        assertThat(bulkRequestSizeBytesMetrics.get(0).getValue(), closeTo(1.0, 0));
         final double expectedBulkRequestSizeBytes = isRequestCompressionEnabled && estimateBulkSizeUsingCompression ? 366.0 : 265.0;
-        MatcherAssert.assertThat(bulkRequestSizeBytesMetrics.get(1).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
-        MatcherAssert.assertThat(bulkRequestSizeBytesMetrics.get(2).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
+        assertThat(bulkRequestSizeBytesMetrics.get(1).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
+        assertThat(bulkRequestSizeBytesMetrics.get(2).getValue(), closeTo(expectedBulkRequestSizeBytes, 0));
 
         // Check restart for index already exists
         sink = createObjectUnderTest(pluginSetting, true);
@@ -428,7 +429,7 @@ public class OpenSearchSinkIT {
                 OpenSearchIntegrationHelper.getVersion()) >= 0 ? INCLUDE_TYPE_NAME_FALSE_URI : "";
         final Request request = new Request(HttpMethod.HEAD, testIndexAlias + extraURI);
         final Response response = client.performRequest(request);
-        MatcherAssert.assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
         sink.shutdown();
 
         // Check restart for index already exists
@@ -436,32 +437,54 @@ public class OpenSearchSinkIT {
         sink.shutdown();
     }
 
-    @Test
-    @DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
-    public void testInstantiateSinkCustomIndex_WithIsmPolicy() throws IOException {
+    @ParameterizedTest
+    @ArgumentsSource(CreateSingleWithTemplatesArgumentsProvider.class)
+    //@DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
+    public void testInstantiateSinkCustomIndex_WithIsmPolicy(
+            final String templateType,
+            final String templateFile) throws IOException {
         final String indexAlias = "sink-custom-index-ism-test-alias";
         final String testTemplateFile = Objects.requireNonNull(
-                getClass().getClassLoader().getResource(TEST_TEMPLATE_V1_FILE)).getFile();
+                getClass().getClassLoader().getResource(templateFile)).getFile();
         final Map<String, Object> metadata = initializeConfigurationMetadata(null, indexAlias, testTemplateFile);
         metadata.put(IndexConfiguration.ISM_POLICY_FILE, TEST_CUSTOM_INDEX_POLICY_FILE);
+        metadata.put(IndexConfiguration.TEMPLATE_TYPE, templateType);
         final PluginSetting pluginSetting = generatePluginSettingByMetadata(metadata);
+
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         final String extraURI = DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(
                 OpenSearchIntegrationHelper.getVersion()) >= 0 ? INCLUDE_TYPE_NAME_FALSE_URI : "";
         Request request = new Request(HttpMethod.HEAD, indexAlias + extraURI);
         Response response = client.performRequest(request);
-        MatcherAssert.assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
         final String index = String.format("%s-000001", indexAlias);
         final Map<String, Object> mappings = getIndexMappings(index);
-        MatcherAssert.assertThat(mappings, notNullValue());
-        MatcherAssert.assertThat((boolean) mappings.get("date_detection"), equalTo(false));
+        assertThat(mappings, notNullValue());
+        assertThat((boolean) mappings.get("date_detection"), equalTo(false));
+
         sink.shutdown();
+
+        JsonNode settings = getIndexSettings(index);
+
+        assertThat(settings, notNullValue());
+        JsonNode settingsIndexNode = settings.get("index");
+        assertThat(settingsIndexNode, notNullValue());
+        assertThat(settingsIndexNode.getNodeType(), equalTo(JsonNodeType.OBJECT));
+        //assertThat(settingsIndexNode.get("opendistro.index_state_management.rollover_alias"), notNullValue());
+        assertThat(settingsIndexNode.get("opendistro"), notNullValue());
+        assertThat(settingsIndexNode.get("opendistro").getNodeType(), equalTo(JsonNodeType.OBJECT));
+        JsonNode settingsIsmNode = settingsIndexNode.get("opendistro").get("index_state_management");
+        assertThat(settingsIsmNode, notNullValue());
+        assertThat(settingsIsmNode.getNodeType(), equalTo(JsonNodeType.OBJECT));
+        assertThat(settingsIsmNode.get("rollover_alias"), notNullValue());
+        assertThat(settingsIsmNode.get("rollover_alias").getNodeType(), equalTo(JsonNodeType.STRING));
+        assertThat(settingsIsmNode.get("rollover_alias").textValue(), equalTo(indexAlias));
 
         final String expectedIndexPolicyName = indexAlias + "-policy";
         if (isOSBundle()) {
             // Check managed index
             await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
-                        MatcherAssert.assertThat(getIndexPolicyId(index), equalTo(expectedIndexPolicyName));
+                        assertThat(getIndexPolicyId(index), equalTo(expectedIndexPolicyName));
                     }
             );
         }
@@ -470,7 +493,7 @@ public class OpenSearchSinkIT {
         request = new Request(HttpMethod.POST, String.format("%s/_rollover", indexAlias));
         request.setJsonEntity("{ \"conditions\" : { } }\n");
         response = client.performRequest(request);
-        MatcherAssert.assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(SC_OK));
 
         // Instantiate sink again
         sink = createObjectUnderTest(pluginSetting, true);
@@ -478,12 +501,12 @@ public class OpenSearchSinkIT {
         final String rolloverIndexName = String.format("%s-000002", indexAlias);
         request = new Request(HttpMethod.GET, rolloverIndexName + "/_alias");
         response = client.performRequest(request);
-        MatcherAssert.assertThat(checkIsWriteIndex(EntityUtils.toString(response.getEntity()), indexAlias, rolloverIndexName), equalTo(true));
+        assertThat(checkIsWriteIndex(EntityUtils.toString(response.getEntity()), indexAlias, rolloverIndexName), equalTo(true));
         sink.shutdown();
 
         if (isOSBundle()) {
             // Check managed index
-            MatcherAssert.assertThat(getIndexPolicyId(rolloverIndexName), equalTo(expectedIndexPolicyName));
+            assertThat(getIndexPolicyId(rolloverIndexName), equalTo(expectedIndexPolicyName));
         }
     }
 
@@ -509,14 +532,14 @@ public class OpenSearchSinkIT {
         Request getTemplateRequest = new Request(HttpMethod.GET,
                 "/" + templatePath + "/" + expectedIndexTemplateName + extraURI);
         Response getTemplateResponse = client.performRequest(getTemplateRequest);
-        MatcherAssert.assertThat(getTemplateResponse.getStatusLine().getStatusCode(), equalTo(SC_OK));
+        assertThat(getTemplateResponse.getStatusLine().getStatusCode(), equalTo(SC_OK));
 
         String responseBody = EntityUtils.toString(getTemplateResponse.getEntity());
         @SuppressWarnings("unchecked") final Integer firstResponseVersion =
                 extractVersionFunction.apply(createContentParser(XContentType.JSON.xContent(),
                         responseBody).map(), expectedIndexTemplateName);
 
-        MatcherAssert.assertThat(firstResponseVersion, equalTo(Integer.valueOf(1)));
+        assertThat(firstResponseVersion, equalTo(Integer.valueOf(1)));
         sink.shutdown();
 
         // Create sink with template version 2
@@ -526,14 +549,14 @@ public class OpenSearchSinkIT {
         getTemplateRequest = new Request(HttpMethod.GET,
                 "/" + templatePath + "/" + expectedIndexTemplateName + extraURI);
         getTemplateResponse = client.performRequest(getTemplateRequest);
-        MatcherAssert.assertThat(getTemplateResponse.getStatusLine().getStatusCode(), equalTo(SC_OK));
+        assertThat(getTemplateResponse.getStatusLine().getStatusCode(), equalTo(SC_OK));
 
         responseBody = EntityUtils.toString(getTemplateResponse.getEntity());
         @SuppressWarnings("unchecked") final Integer secondResponseVersion =
                 extractVersionFunction.apply(createContentParser(XContentType.JSON.xContent(),
                         responseBody).map(), expectedIndexTemplateName);
 
-        MatcherAssert.assertThat(secondResponseVersion, equalTo(Integer.valueOf(2)));
+        assertThat(secondResponseVersion, equalTo(Integer.valueOf(2)));
         sink.shutdown();
 
         // Create sink with template version 1 again
@@ -543,7 +566,7 @@ public class OpenSearchSinkIT {
         getTemplateRequest = new Request(HttpMethod.GET,
                 "/" + templatePath + "/" + expectedIndexTemplateName + extraURI);
         getTemplateResponse = client.performRequest(getTemplateRequest);
-        MatcherAssert.assertThat(getTemplateResponse.getStatusLine().getStatusCode(), equalTo(SC_OK));
+        assertThat(getTemplateResponse.getStatusLine().getStatusCode(), equalTo(SC_OK));
 
         responseBody = EntityUtils.toString(getTemplateResponse.getEntity());
         @SuppressWarnings("unchecked") final Integer thirdResponseVersion =
@@ -551,7 +574,7 @@ public class OpenSearchSinkIT {
                         responseBody).map(), expectedIndexTemplateName);
 
         // Assert version 2 was not overwritten by version 1
-        MatcherAssert.assertThat(thirdResponseVersion, equalTo(Integer.valueOf(2)));
+        assertThat(thirdResponseVersion, equalTo(Integer.valueOf(2)));
         sink.shutdown();
 
     }
@@ -568,7 +591,7 @@ public class OpenSearchSinkIT {
                     )
             );
 
-            if(OpenSearchIntegrationHelper.getVersion().compareTo(DeclaredOpenSearchVersion.OPENDISTRO_1_9) >= 0) {
+            if (OpenSearchIntegrationHelper.getVersion().compareTo(DeclaredOpenSearchVersion.OPENDISTRO_1_9) >= 0) {
                 arguments.add(
                         arguments("index-template", "_index_template",
                                 TEST_INDEX_TEMPLATE_V1_FILE, TEST_INDEX_TEMPLATE_V2_FILE,
@@ -576,6 +599,19 @@ public class OpenSearchSinkIT {
                                         (Integer) ((List<Map<String, Map<String, Object>>>) map.get("index_templates")).get(0).get("index_template").get("version")
                         )
                 );
+            }
+            return arguments.stream();
+        }
+    }
+
+    static class CreateSingleWithTemplatesArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            final List<Arguments> arguments = new ArrayList<>();
+            arguments.add(arguments("v1", TEST_TEMPLATE_V1_FILE));
+
+            if (OpenSearchIntegrationHelper.getVersion().compareTo(DeclaredOpenSearchVersion.OPENDISTRO_1_9) >= 0) {
+                arguments.add(arguments("index-template", TEST_INDEX_TEMPLATE_V1_FILE));
             }
             return arguments.stream();
         }
@@ -594,15 +630,15 @@ public class OpenSearchSinkIT {
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         sink.output(testRecords);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
-        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        assertThat(retSources.size(), equalTo(1));
+        assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
         sink.shutdown();
 
         // verify metrics
         final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(OpenSearchSink.BULKREQUEST_LATENCY).toString());
-        MatcherAssert.assertThat(bulkRequestLatencies.size(), equalTo(3));
+        assertThat(bulkRequestLatencies.size(), equalTo(3));
         // COUNT
         Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
     }
@@ -621,15 +657,15 @@ public class OpenSearchSinkIT {
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         sink.output(testRecords);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
-        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        assertThat(retSources.size(), equalTo(1));
+        assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
         sink.shutdown();
 
         // verify metrics
         final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(OpenSearchSink.BULKREQUEST_LATENCY).toString());
-        MatcherAssert.assertThat(bulkRequestLatencies.size(), equalTo(3));
+        assertThat(bulkRequestLatencies.size(), equalTo(3));
         // COUNT
         Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
     }
@@ -644,7 +680,7 @@ public class OpenSearchSinkIT {
         final List<Record<Event>> testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson(testIdField, testId)));
         final PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFile);
         pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
-        Event event = (Event)testRecords.get(0).getData();
+        Event event = (Event) testRecords.get(0).getData();
         event.getMetadata().setAttribute("action", "create");
         when(expressionEvaluator.isValidExpressionStatement("getMetadata(\"action\")")).thenReturn(true);
         when(expressionEvaluator.evaluate("getMetadata(\"action\")", event)).thenReturn(event.getMetadata().getAttribute("action"));
@@ -652,15 +688,15 @@ public class OpenSearchSinkIT {
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         sink.output(testRecords);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
-        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        assertThat(retSources.size(), equalTo(1));
+        assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
         sink.shutdown();
 
         // verify metrics
         final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(OpenSearchSink.BULKREQUEST_LATENCY).toString());
-        MatcherAssert.assertThat(bulkRequestLatencies.size(), equalTo(3));
+        assertThat(bulkRequestLatencies.size(), equalTo(3));
         // COUNT
         Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
     }
@@ -675,7 +711,7 @@ public class OpenSearchSinkIT {
         final List<Record<Event>> testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson(testIdField, testId)));
         final PluginSetting pluginSetting = generatePluginSetting(null, testIndexAlias, testTemplateFile);
         pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
-        Event event = (Event)testRecords.get(0).getData();
+        Event event = (Event) testRecords.get(0).getData();
         event.getMetadata().setAttribute("action", "unknown");
         when(expressionEvaluator.isValidExpressionStatement("getMetadata(\"action\")")).thenReturn(true);
         when(expressionEvaluator.evaluate("getMetadata(\"action\")", event)).thenReturn(event.getMetadata().getAttribute("action"));
@@ -683,8 +719,8 @@ public class OpenSearchSinkIT {
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         sink.output(testRecords);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
-        MatcherAssert.assertThat(retSources.size(), equalTo(0));
-        MatcherAssert.assertThat(sink.getInvalidActionErrorsCount(), equalTo(1.0));
+        assertThat(retSources.size(), equalTo(0));
+        assertThat(sink.getInvalidActionErrorsCount(), equalTo(1.0));
         sink.shutdown();
     }
 
@@ -707,15 +743,15 @@ public class OpenSearchSinkIT {
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         sink.output(testRecords);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
-        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        assertThat(retSources.size(), equalTo(1));
+        assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
         sink.shutdown();
 
         // verify metrics
         final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(OpenSearchSink.BULKREQUEST_LATENCY).toString());
-        MatcherAssert.assertThat(bulkRequestLatencies.size(), equalTo(3));
+        assertThat(bulkRequestLatencies.size(), equalTo(3));
         // COUNT
         Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
     }
@@ -740,15 +776,15 @@ public class OpenSearchSinkIT {
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         sink.output(testRecords);
         List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
-        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        assertThat(retSources.size(), equalTo(1));
+        assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
         sink.shutdown();
 
         // verify metrics
         final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(OpenSearchSink.BULKREQUEST_LATENCY).toString());
-        MatcherAssert.assertThat(bulkRequestLatencies.size(), equalTo(3));
+        assertThat(bulkRequestLatencies.size(), equalTo(3));
         // COUNT
         Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
         testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson2(testIdField, testId, "name", "value2")));
@@ -761,10 +797,10 @@ public class OpenSearchSinkIT {
         sink.output(testRecords);
         retSources = getSearchResponseDocSources(testIndexAlias);
 
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
+        assertThat(retSources.size(), equalTo(1));
         Map<String, Object> source = retSources.get(0);
-        MatcherAssert.assertThat((String)source.get("name"), equalTo("value2"));
-        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        assertThat((String) source.get("name"), equalTo("value2"));
+        assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
         sink.shutdown();
     }
 
@@ -788,15 +824,15 @@ public class OpenSearchSinkIT {
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         sink.output(testRecords);
         List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
-        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        assertThat(retSources.size(), equalTo(1));
+        assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
         sink.shutdown();
 
         // verify metrics
         final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(OpenSearchSink.BULKREQUEST_LATENCY).toString());
-        MatcherAssert.assertThat(bulkRequestLatencies.size(), equalTo(3));
+        assertThat(bulkRequestLatencies.size(), equalTo(3));
         // COUNT
         Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
         testRecords = Collections.singletonList(jsonStringToRecord(generateCustomRecordJson3(testIdField, testId, "name", "value3", "newKey", "newValue")));
@@ -809,11 +845,11 @@ public class OpenSearchSinkIT {
         sink.output(testRecords);
         retSources = getSearchResponseDocSources(testIndexAlias);
 
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
+        assertThat(retSources.size(), equalTo(1));
         Map<String, Object> source = retSources.get(0);
-        MatcherAssert.assertThat((String)source.get("name"), equalTo("value3"));
-        MatcherAssert.assertThat((String)source.get("newKey"), equalTo("newValue"));
-        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        assertThat((String) source.get("name"), equalTo("value3"));
+        assertThat((String) source.get("newKey"), equalTo("newValue"));
+        assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
         sink.shutdown();
     }
 
@@ -837,17 +873,17 @@ public class OpenSearchSinkIT {
         sink.output(testRecords);
         List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
 
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
+        assertThat(retSources.size(), equalTo(1));
         Map<String, Object> source = retSources.get(0);
-        MatcherAssert.assertThat((String)source.get("name"), equalTo("value1"));
-        MatcherAssert.assertThat((String)source.get("newKey"), equalTo("newValue"));
-        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        assertThat((String) source.get("name"), equalTo("value1"));
+        assertThat((String) source.get("newKey"), equalTo("newValue"));
+        assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
         sink.shutdown();
         // verify metrics
         final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(OpenSearchSink.BULKREQUEST_LATENCY).toString());
-        MatcherAssert.assertThat(bulkRequestLatencies.size(), equalTo(3));
+        assertThat(bulkRequestLatencies.size(), equalTo(3));
         // COUNT
         Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
     }
@@ -872,7 +908,7 @@ public class OpenSearchSinkIT {
         OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         sink.output(testRecords);
         List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
-        MatcherAssert.assertThat(retSources.size(), equalTo(0));
+        assertThat(retSources.size(), equalTo(0));
         sink.shutdown();
     }
 
@@ -898,9 +934,9 @@ public class OpenSearchSinkIT {
         expectedContent.put("log", "foobar");
         expectedContent.put(testTagsTargetKey, tagsList);
 
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
-        MatcherAssert.assertThat(retSources.containsAll(Arrays.asList(expectedContent)), equalTo(true));
-        MatcherAssert.assertThat(getDocumentCount(expIndexAlias, "log", "foobar"), equalTo(Integer.valueOf(1)));
+        assertThat(retSources.size(), equalTo(1));
+        assertThat(retSources.containsAll(Arrays.asList(expectedContent)), equalTo(true));
+        assertThat(getDocumentCount(expIndexAlias, "log", "foobar"), equalTo(Integer.valueOf(1)));
         sink.shutdown();
     }
 
@@ -924,9 +960,9 @@ public class OpenSearchSinkIT {
         final Map<String, Object> expectedContent = new HashMap<>();
         expectedContent.put("log", "foobar");
 
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
-        MatcherAssert.assertThat(retSources.containsAll(Arrays.asList(expectedContent)), equalTo(true));
-        MatcherAssert.assertThat(getDocumentCount(expIndexAlias, "log", "foobar"), equalTo(Integer.valueOf(1)));
+        assertThat(retSources.size(), equalTo(1));
+        assertThat(retSources.containsAll(Arrays.asList(expectedContent)), equalTo(true));
+        assertThat(getDocumentCount(expIndexAlias, "log", "foobar"), equalTo(Integer.valueOf(1)));
         sink.shutdown();
     }
 
@@ -950,7 +986,7 @@ public class OpenSearchSinkIT {
 
         final List<String> docIds = getSearchResponseDocIds(testIndexAlias);
         for (String docId : docIds) {
-            MatcherAssert.assertThat(docId, equalTo(expectedId));
+            assertThat(docId, equalTo(expectedId));
         }
         sink.shutdown();
     }
@@ -975,7 +1011,7 @@ public class OpenSearchSinkIT {
 
         final List<String> routingFields = getSearchResponseRoutingFields(testIndexAlias);
         for (String routingField : routingFields) {
-            MatcherAssert.assertThat(routingField, equalTo(expectedRoutingField));
+            assertThat(routingField, equalTo(expectedRoutingField));
         }
         sink.shutdown();
     }
@@ -1002,8 +1038,8 @@ public class OpenSearchSinkIT {
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         sink.output(testRecords);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
-        MatcherAssert.assertThat(retSources, hasItem(expectedMap));
+        assertThat(retSources.size(), equalTo(1));
+        assertThat(retSources, hasItem(expectedMap));
         sink.shutdown();
     }
 
@@ -1035,8 +1071,8 @@ public class OpenSearchSinkIT {
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         sink.output(testRecords);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(expectedIndexAlias);
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
-        MatcherAssert.assertThat(retSources, hasItem(expectedMap));
+        assertThat(retSources.size(), equalTo(1));
+        assertThat(retSources, hasItem(expectedMap));
         sink.shutdown();
     }
 
@@ -1063,8 +1099,8 @@ public class OpenSearchSinkIT {
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         sink.output(testRecords);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(expectedIndexName);
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
-        MatcherAssert.assertThat(retSources, hasItem(expectedMap));
+        assertThat(retSources.size(), equalTo(1));
+        assertThat(retSources, hasItem(expectedMap));
         sink.shutdown();
     }
 
@@ -1118,15 +1154,15 @@ public class OpenSearchSinkIT {
 
         sink.output(testRecords);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
-        MatcherAssert.assertThat(retSources.size(), equalTo(1));
-        MatcherAssert.assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
+        assertThat(retSources.size(), equalTo(1));
+        assertThat(getDocumentCount(testIndexAlias, "_id", testId), equalTo(Integer.valueOf(1)));
         sink.shutdown();
 
         // verify metrics
         final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add(OpenSearchSink.BULKREQUEST_LATENCY).toString());
-        MatcherAssert.assertThat(bulkRequestLatencies.size(), equalTo(3));
+        assertThat(bulkRequestLatencies.size(), equalTo(3));
         // COUNT
         Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
     }
@@ -1307,6 +1343,20 @@ public class OpenSearchSinkIT {
                 (Map<String, Object>) ((Map<String, Object>) createContentParser(XContentType.JSON.xContent(),
                         responseBody).map().get(index)).get("mappings");
         return mappings;
+    }
+
+    private JsonNode getIndexSettings(final String index) throws IOException {
+        final String extraURI = DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(
+                OpenSearchIntegrationHelper.getVersion()) >= 0 ? INCLUDE_TYPE_NAME_FALSE_URI : "";
+        final Request request = new Request(HttpMethod.GET, index + "/_settings" + extraURI);
+        final Response response = client.performRequest(request);
+        final String responseBody = EntityUtils.toString(response.getEntity());
+
+        Map<String, Object> responseMap = createContentParser(XContentType.JSON.xContent(), responseBody).map();
+
+        return new ObjectMapper().convertValue(responseMap, JsonNode.class)
+                .get(index)
+                .get("settings");
     }
 
     private String getIndexPolicyId(final String index) throws IOException {

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -439,7 +439,7 @@ public class OpenSearchSinkIT {
 
     @ParameterizedTest
     @ArgumentsSource(CreateSingleWithTemplatesArgumentsProvider.class)
-    //@DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
+    @DisabledIf(value = "isES6", disabledReason = TRACE_INGESTION_TEST_DISABLED_REASON)
     public void testInstantiateSinkCustomIndex_WithIsmPolicy(
             final String templateType,
             final String templateFile) throws IOException {
@@ -470,7 +470,6 @@ public class OpenSearchSinkIT {
         JsonNode settingsIndexNode = settings.get("index");
         assertThat(settingsIndexNode, notNullValue());
         assertThat(settingsIndexNode.getNodeType(), equalTo(JsonNodeType.OBJECT));
-        //assertThat(settingsIndexNode.get("opendistro.index_state_management.rollover_alias"), notNullValue());
         assertThat(settingsIndexNode.get("opendistro"), notNullValue());
         assertThat(settingsIndexNode.get("opendistro").getNodeType(), equalTo(JsonNodeType.OBJECT));
         JsonNode settingsIsmNode = settingsIndexNode.get("opendistro").get("index_state_management");

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/ComposableIndexTemplate.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/ComposableIndexTemplate.java
@@ -6,7 +6,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class ComposableIndexTemplate implements IndexTemplate {
+class ComposableIndexTemplate implements IndexTemplate {
+    static final String TEMPLATE_KEY = "template";
+    static final String INDEX_SETTINGS_KEY = "settings";
 
     private final Map<String, Object> indexTemplateMap;
     private String name;
@@ -18,7 +20,6 @@ public class ComposableIndexTemplate implements IndexTemplate {
     @Override
     public void setTemplateName(final String name) {
         this.name = name;
-
     }
 
     @Override
@@ -28,7 +29,11 @@ public class ComposableIndexTemplate implements IndexTemplate {
 
     @Override
     public void putCustomSetting(final String name, final Object value) {
+        Map<String, Object> template = (Map<String, Object>) indexTemplateMap.computeIfAbsent(TEMPLATE_KEY, key -> new HashMap<>());
 
+        Map<String, Object> settings = (Map<String, Object>) template.computeIfAbsent(INDEX_SETTINGS_KEY, key -> new HashMap<>());
+
+        settings.put(name, value);
     }
 
     @Override

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/ComposableTemplateAPIWrapper.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/ComposableTemplateAPIWrapper.java
@@ -1,26 +1,21 @@
 package org.opensearch.dataprepper.plugins.sink.opensearch.index;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.json.stream.JsonParser;
-import org.opensearch.client.json.JsonpDeserializer;
-import org.opensearch.client.json.JsonpMapper;
-import org.opensearch.client.json.ObjectBuilderDeserializer;
-import org.opensearch.client.json.ObjectDeserializer;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.ErrorResponse;
 import org.opensearch.client.opensearch.indices.ExistsIndexTemplateRequest;
 import org.opensearch.client.opensearch.indices.GetIndexTemplateRequest;
 import org.opensearch.client.opensearch.indices.GetIndexTemplateResponse;
-import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
-import org.opensearch.client.opensearch.indices.put_index_template.IndexTemplateMapping;
+import org.opensearch.client.opensearch.indices.PutIndexTemplateResponse;
+import org.opensearch.client.transport.Endpoint;
 import org.opensearch.client.transport.endpoints.BooleanResponse;
+import org.opensearch.client.transport.endpoints.SimpleEndpoint;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 public class ComposableTemplateAPIWrapper implements IndexTemplateAPIWrapper<GetIndexTemplateResponse> {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final OpenSearchClient openSearchClient;
 
     public ComposableTemplateAPIWrapper(final OpenSearchClient openSearchClient) {
@@ -34,19 +29,12 @@ public class ComposableTemplateAPIWrapper implements IndexTemplateAPIWrapper<Get
         }
 
         final ComposableIndexTemplate composableIndexTemplate = (ComposableIndexTemplate) indexTemplate;
-        final String indexTemplateString = OBJECT_MAPPER.writeValueAsString(
-                composableIndexTemplate.getIndexTemplateMap());
+        Map<String, Object> indexTemplateMap = composableIndexTemplate.getIndexTemplateMap();
 
-        final ByteArrayInputStream byteIn = new ByteArrayInputStream(
-                indexTemplateString.getBytes(StandardCharsets.UTF_8));
-        final JsonpMapper mapper = openSearchClient._transport().jsonpMapper();
-        final JsonParser parser = mapper.jsonProvider().createParser(byteIn);
-
-        final PutIndexTemplateRequest putIndexTemplateRequest = PutIndexTemplateRequestDeserializer
-                .getJsonpDeserializer(composableIndexTemplate.getName())
-                .deserialize(parser, mapper);
-
-        openSearchClient.indices().putIndexTemplate(putIndexTemplateRequest);
+        openSearchClient._transport().performRequest(
+                indexTemplateMap,
+                createEndpoint(composableIndexTemplate),
+                openSearchClient._transportOptions());
     }
 
     @Override
@@ -66,24 +54,15 @@ public class ComposableTemplateAPIWrapper implements IndexTemplateAPIWrapper<Get
         return Optional.of(openSearchClient.indices().getIndexTemplate(getRequest));
     }
 
-    private static class PutIndexTemplateRequestDeserializer {
-        private static void setupPutIndexTemplateRequestDeserializer(final ObjectDeserializer<PutIndexTemplateRequest.Builder> objectDeserializer) {
+    private Endpoint<Map<String, Object>, PutIndexTemplateResponse, ErrorResponse> createEndpoint(final ComposableIndexTemplate composableIndexTemplate) {
+        final String path = "/_index_template/" + composableIndexTemplate.getName();
 
-            objectDeserializer.add(PutIndexTemplateRequest.Builder::name, JsonpDeserializer.stringDeserializer(), "name");
-            objectDeserializer.add(PutIndexTemplateRequest.Builder::indexPatterns, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()),
-                    "index_patterns");
-            objectDeserializer.add(PutIndexTemplateRequest.Builder::version, JsonpDeserializer.longDeserializer(), "version");
-            objectDeserializer.add(PutIndexTemplateRequest.Builder::priority, JsonpDeserializer.integerDeserializer(), "priority");
-            objectDeserializer.add(PutIndexTemplateRequest.Builder::composedOf, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()),
-                    "composed_of");
-            objectDeserializer.add(PutIndexTemplateRequest.Builder::template, IndexTemplateMapping._DESERIALIZER, "template");
-        }
-
-        static JsonpDeserializer<PutIndexTemplateRequest> getJsonpDeserializer(final String name) {
-            return ObjectBuilderDeserializer
-                    .lazy(
-                            () -> new PutIndexTemplateRequest.Builder().name(name),
-                            PutIndexTemplateRequestDeserializer::setupPutIndexTemplateRequestDeserializer);
-        }
+        return new SimpleEndpoint<>(
+                request -> "PUT",
+                request -> path,
+                request -> Collections.emptyMap(),
+                SimpleEndpoint.emptyMap(),
+                true,
+                PutIndexTemplateResponse._DESERIALIZER);
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/LegacyIndexTemplate.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/LegacyIndexTemplate.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class LegacyIndexTemplate implements IndexTemplate {
+class LegacyIndexTemplate implements IndexTemplate {
 
     public static final String SETTINGS_KEY = "settings";
     private final Map<String, Object> templateMap;


### PR DESCRIPTION
### Description

The goal of this PR is to support ISM correctly when using composable index templates. There were two problems causing this.

1. The `ComposableIndexTemplate` class was not setting properties. This was easily resolved.
2. The opensearch-java client does not serialize custom properties. Thus, I had to write it as a `Map` instead of using the higher-level constructs.

There are a few other changes here as well.

1. The end-to-end tests can run without defining the OpenSearch version by using the default if it is an empty string.
2. Updates to imports in the `OpenSearchIT` test.
3. Made some classes package private.
 
### Issues Resolved

Resolves #3506 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
