### PR TITLE
Add document_version and document_version_type parameters to the open…

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/expression/ExpressionEvaluator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/expression/ExpressionEvaluator.java
@@ -34,4 +34,6 @@ public interface ExpressionEvaluator {
     }
 
     Boolean isValidExpressionStatement(final String statement);
+
+    Boolean isValidFormatExpressions(final String format);
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -387,12 +387,21 @@ public class JacksonEvent implements Event {
         return mapper.convertValue(jsonNode, MAP_TYPE_REFERENCE);
     }
 
+
+    public static boolean isValidEventKey(final String key) {
+        try {
+            checkKey(key);
+            return true;
+        } catch (final Exception e) {
+            return false;
+        }
+    }
     private String checkAndTrimKey(final String key) {
         checkKey(key);
         return trimKey(key);
     }
 
-    private void checkKey(final String key) {
+    private static void checkKey(final String key) {
         checkNotNull(key, "key cannot be null");
         checkArgument(!key.isEmpty(), "key cannot be an empty string");
         if (key.length() > MAX_KEY_LENGTH) {
@@ -409,7 +418,7 @@ public class JacksonEvent implements Event {
         return trimmedLeadingSlash.endsWith(SEPARATOR) ? trimmedLeadingSlash.substring(0, trimmedLeadingSlash.length() - 2) : trimmedLeadingSlash;
     }
 
-    private boolean isValidKey(final String key) {
+    private static boolean isValidKey(final String key) {
         for (int i = 0; i < key.length(); i++) {
             char c = key.charAt(i);
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -318,29 +318,6 @@ public class JacksonEvent implements Event {
         return formatStringInternal(format, expressionEvaluator);
     }
 
-    public static boolean isValidFormatExpressions(final String format, final ExpressionEvaluator expressionEvaluator) {
-        if (Objects.isNull(expressionEvaluator)) {
-            return false;
-        }
-
-        int fromIndex = 0;
-        int position = 0;
-        while ((position = format.indexOf("${", fromIndex)) != -1) {
-            int endPosition = format.indexOf("}", position + 1);
-            if (endPosition == -1) {
-                return false;
-            }
-            String name = format.substring(position + 2, endPosition);
-
-            Object val;
-            if (!expressionEvaluator.isValidExpressionStatement(name)) {
-                return false;
-            }
-            fromIndex = endPosition + 1;
-        }
-        return true;
-    }
-
     private String formatStringInternal(final String format, final ExpressionEvaluator expressionEvaluator) {
         int fromIndex = 0;
         String result = "";
@@ -362,7 +339,7 @@ public class JacksonEvent implements Event {
             }
 
             if (val == null) {
-                if (Objects.nonNull(expressionEvaluator) && expressionEvaluator.isValidExpressionStatement(name)) {
+                if (expressionEvaluator != null && expressionEvaluator.isValidExpressionStatement(name)) {
                     val = expressionEvaluator.evaluate(name, this);
                 } else {
                     throw new EventKeyNotFoundException(String.format("The key %s could not be found in the Event when formatting", name));

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/expression/ExpressionEvaluatorTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/expression/ExpressionEvaluatorTest.java
@@ -23,6 +23,11 @@ public class ExpressionEvaluatorTest {
         public Boolean isValidExpressionStatement(final String statement) {
             return true;
         }
+
+        @Override
+        public Boolean isValidFormatExpressions(String format) {
+            return true;
+        }
     }
 
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -535,25 +535,6 @@ public class JacksonEventTest {
         assertThat(event.formatString(formattedString), is(equalTo(finalString)));
     }
 
-    @ParameterizedTest
-    @CsvSource({
-            "abc-${/foo, false",
-            "abc-${/foo}, true",
-            "abc-${getMetadata(\"key\")}, true",
-            "abc-${getXYZ(\"key\")}, false"
-    })
-    public void testBuild_withIsValidFormatExpressions(final String format, final Boolean expectedResult) {
-        final ExpressionEvaluator expressionEvaluator = mock(ExpressionEvaluator.class);
-        when(expressionEvaluator.isValidExpressionStatement("/foo")).thenReturn(true);
-        when(expressionEvaluator.isValidExpressionStatement("getMetadata(\"key\")")).thenReturn(true);
-        assertThat(JacksonEvent.isValidFormatExpressions(format, expressionEvaluator), equalTo(expectedResult));
-    }
-
-    @Test
-    public void testBuild_withIsValidFormatExpressionsWithNullEvaluator() {
-        assertThat(JacksonEvent.isValidFormatExpressions("${}", null), equalTo(false));
-    }
-
     @Test
     public void formatString_with_expression_evaluator_catches_exception_when_Event_get_throws_exception() {
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -799,6 +799,11 @@ public class JacksonEventTest {
 
     }
 
+    @ParameterizedTest
+    @CsvSource(value = {"test_key, true", "/test_key, true", "inv(alid, false", "getMetadata(\"test_key\"), false"})
+    void isValidEventKey_returns_expected_result(final String key, final boolean isValid) {
+        assertThat(JacksonEvent.isValidEventKey(key), equalTo(isValid));
+    }
 
     private static Map<String, Object> createComplexDataMap() {
         final Map<String, Object> dataObject = new HashMap<>();

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator.java
@@ -52,4 +52,27 @@ class GenericExpressionEvaluator implements ExpressionEvaluator {
             return false;
         }
     }
+
+    @Override
+    public Boolean isValidFormatExpressions(final String format) {
+        int fromIndex = 0;
+        int position = 0;
+        while ((position = format.indexOf("${", fromIndex)) != -1) {
+            int endPosition = format.indexOf("}", position + 1);
+            if (endPosition == -1) {
+                return false;
+            }
+            String name = format.substring(position + 2, endPosition);
+
+            Object val;
+            // We only check the expression if it matches (.*) to mitigate the issue with the antlr logger ()
+            // These can't be keys because (, ) is invalid for keys, so we attempt to validate the expression. All expressions currently
+            // contain a function ( ) so this will detect them to validate against.
+            if (name.matches("(.*)") && !isValidExpressionStatement(name)) {
+                return false;
+            }
+            fromIndex = endPosition + 1;
+        }
+        return true;
+    }
 }

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.expression;
 
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -65,10 +66,8 @@ class GenericExpressionEvaluator implements ExpressionEvaluator {
             String name = format.substring(position + 2, endPosition);
 
             Object val;
-            // We only check the expression if it matches (.*) to mitigate the issue with the antlr logger ()
-            // These can't be keys because (, ) is invalid for keys, so we attempt to validate the expression. All expressions currently
-            // contain a function ( ) so this will detect them to validate against.
-            if (name.matches("(.*)") && !isValidExpressionStatement(name)) {
+            // Invalid if it is not a valid key and not a valid expression statement
+            if (!JacksonEvent.isValidEventKey(name) && !isValidExpressionStatement(name)) {
                 return false;
             }
             fromIndex = endPosition + 1;

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluatorTest.java
@@ -5,16 +5,18 @@
 
 package org.opensearch.dataprepper.expression;
 
-import org.opensearch.dataprepper.model.event.Event;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.event.Event;
 
-import java.util.UUID;
 import java.util.Random;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -117,6 +119,17 @@ class GenericExpressionEvaluatorTest {
         final boolean result = statementEvaluator.isValidExpressionStatement(statement);
 
         assertThat(result, equalTo(false));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "abc-${/foo, false",
+            "abc-${/foo}, true",
+            "abc-${getMetadata(\"key\")}, true",
+            "abc-${getXYZ(\"key\")}, true"
+    })
+    void isValidFormatExpressionsReturnsCorrectResult(final String format, final Boolean expectedResult) {
+        assertThat(statementEvaluator.isValidFormatExpressions(format), equalTo(expectedResult));
     }
 
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluatorTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -23,6 +24,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -126,10 +128,18 @@ class GenericExpressionEvaluatorTest {
             "abc-${/foo, false",
             "abc-${/foo}, true",
             "abc-${getMetadata(\"key\")}, true",
-            "abc-${getXYZ(\"key\")}, true"
+            "abc-${getXYZ(\"key\")}, true",
+            "abc-${invalid, false"
     })
     void isValidFormatExpressionsReturnsCorrectResult(final String format, final Boolean expectedResult) {
         assertThat(statementEvaluator.isValidFormatExpressions(format), equalTo(expectedResult));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"abc-${anyS(=tring}"})
+    void isValidFormatExpressionsReturnsFalseWhenIsValidKeyAndValidExpressionIsFalse(final String format) {
+        doThrow(RuntimeException.class).when(parser).parse(anyString());
+        assertThat(statementEvaluator.isValidFormatExpressions(format), equalTo(false));
     }
 
 }

--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -646,9 +646,11 @@ public class OpenSearchSinkIT {
         pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
         Event event = (Event)testRecords.get(0).getData();
         event.getMetadata().setAttribute("action", "create");
+        final String actionFormatExpression = "${getMetadata(\"action\")}";
+        when(expressionEvaluator.isValidFormatExpressions(actionFormatExpression)).thenReturn(true);
         when(expressionEvaluator.isValidExpressionStatement("getMetadata(\"action\")")).thenReturn(true);
         when(expressionEvaluator.evaluate("getMetadata(\"action\")", event)).thenReturn(event.getMetadata().getAttribute("action"));
-        pluginSetting.getSettings().put(IndexConfiguration.ACTION, "${getMetadata(\"action\")}");
+        pluginSetting.getSettings().put(IndexConfiguration.ACTION, actionFormatExpression);
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         sink.output(testRecords);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
@@ -677,9 +679,11 @@ public class OpenSearchSinkIT {
         pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
         Event event = (Event)testRecords.get(0).getData();
         event.getMetadata().setAttribute("action", "unknown");
+        final String actionFormatExpression = "${getMetadata(\"action\")}";
+        when(expressionEvaluator.isValidFormatExpressions(actionFormatExpression)).thenReturn(true);
         when(expressionEvaluator.isValidExpressionStatement("getMetadata(\"action\")")).thenReturn(true);
         when(expressionEvaluator.evaluate("getMetadata(\"action\")", event)).thenReturn(event.getMetadata().getAttribute("action"));
-        pluginSetting.getSettings().put(IndexConfiguration.ACTION, "${getMetadata(\"action\")}");
+        pluginSetting.getSettings().put(IndexConfiguration.ACTION, actionFormatExpression);
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
         sink.output(testRecords);
         final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -318,6 +318,10 @@ public final class BulkRetryStrategy {
                 if (bulkItemResponse.error() != null) {
                     if (!NON_RETRY_STATUS.contains(bulkItemResponse.status())) {
                         requestToReissue.addOperation(bulkOperation);
+                    } else if (VERSION_CONFLICT_EXCEPTION_TYPE.equals(bulkItemResponse.error().type())) {
+                        documentsVersionConflictErrors.increment();
+                        LOG.debug("Received version conflict from OpenSearch: {}", bulkItemResponse.error().reason());
+                        bulkOperation.releaseEventHandle(true);
                     } else {
                         nonRetryableFailures.add(FailedBulkOperation.builder()
                                 .withBulkOperation(bulkOperation)

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategy.java
@@ -43,8 +43,10 @@ public final class BulkRetryStrategy {
     public static final String BULK_REQUEST_NOT_FOUND_ERRORS = "bulkRequestNotFoundErrors";
     public static final String BULK_REQUEST_TIMEOUT_ERRORS = "bulkRequestTimeoutErrors";
     public static final String BULK_REQUEST_SERVER_ERRORS = "bulkRequestServerErrors";
+    public static final String DOCUMENTS_VERSION_CONFLICT_ERRORS = "documentsVersionConflictErrors";
     static final long INITIAL_DELAY_MS = 50;
     static final long MAXIMUM_DELAY_MS = Duration.ofMinutes(10).toMillis();
+    static final String VERSION_CONFLICT_EXCEPTION_TYPE = "version_conflict_engine_exception";
 
     private static final Set<Integer> NON_RETRY_STATUS = new HashSet<>(
             Arrays.asList(
@@ -116,6 +118,7 @@ public final class BulkRetryStrategy {
     private final Counter bulkRequestNotFoundErrors;
     private final Counter bulkRequestTimeoutErrors;
     private final Counter bulkRequestServerErrors;
+    private final Counter documentsVersionConflictErrors;
     private static final Logger LOG = LoggerFactory.getLogger(BulkRetryStrategy.class);
 
     static class BulkOperationRequestResponse {
@@ -160,6 +163,7 @@ public final class BulkRetryStrategy {
         bulkRequestNotFoundErrors = pluginMetrics.counter(BULK_REQUEST_NOT_FOUND_ERRORS);
         bulkRequestTimeoutErrors = pluginMetrics.counter(BULK_REQUEST_TIMEOUT_ERRORS);
         bulkRequestServerErrors = pluginMetrics.counter(BULK_REQUEST_SERVER_ERRORS);
+        documentsVersionConflictErrors = pluginMetrics.counter(DOCUMENTS_VERSION_CONFLICT_ERRORS);
     }
 
     private void incrementErrorCounters(final Exception e) {
@@ -240,7 +244,7 @@ public final class BulkRetryStrategy {
                 LOG.warn("Bulk Operation Failed. Number of retries {}. Retrying... ", retryCount, e);
                 if (e == null) {
                     for (final BulkResponseItem bulkItemResponse : bulkResponse.items()) {
-                        if (Objects.nonNull(bulkItemResponse.error())) {
+                        if (bulkItemResponse.error() != null) {
                             LOG.warn("operation = {}, error = {}", bulkItemResponse.operationType(), bulkItemResponse.error().reason());
                         }
                     }
@@ -255,15 +259,16 @@ public final class BulkRetryStrategy {
     }
 
     private void handleFailures(final AccumulatingBulkRequest<BulkOperationWrapper, BulkRequest> bulkRequest, final BulkResponse bulkResponse, final Throwable failure) {
-        LOG.warn("Bulk Operation Failed.", failure);
         if (failure == null) {
             for (final BulkResponseItem bulkItemResponse : bulkResponse.items()) {
-                if (Objects.nonNull(bulkItemResponse.error())) {
+                // Skip logging the error for version conflicts
+                if (bulkItemResponse.error() != null && !VERSION_CONFLICT_EXCEPTION_TYPE.equals(bulkItemResponse.error().type())) {
                     LOG.warn("operation = {}, error = {}", bulkItemResponse.operationType(), bulkItemResponse.error().reason());
                 }
             }
             handleFailures(bulkRequest, bulkResponse.items());
         } else {
+            LOG.warn("Bulk Operation Failed.", failure);
             handleFailures(bulkRequest, failure);
         }
         bulkRequestFailedCounter.increment();
@@ -338,10 +343,16 @@ public final class BulkRetryStrategy {
             final BulkResponseItem bulkItemResponse = itemResponses.get(i);
             final BulkOperationWrapper bulkOperation = accumulatingBulkRequest.getOperationAt(i);
             if (bulkItemResponse.error() != null) {
-                failures.add(FailedBulkOperation.builder()
-                    .withBulkOperation(bulkOperation)
-                    .withBulkResponseItem(bulkItemResponse)
-                    .build());
+                if (VERSION_CONFLICT_EXCEPTION_TYPE.equals(bulkItemResponse.error().type())) {
+                    documentsVersionConflictErrors.increment();
+                    LOG.debug("Received version conflict from OpenSearch: {}", bulkItemResponse.error().reason());
+                    bulkOperation.releaseEventHandle(true);
+                } else {
+                    failures.add(FailedBulkOperation.builder()
+                            .withBulkOperation(bulkOperation)
+                            .withBulkResponseItem(bulkItemResponse)
+                            .build());
+                }
                 documentErrorsCounter.increment();
             } else {
                 sentDocumentsCounter.increment();

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -13,6 +13,7 @@ import io.micrometer.core.instrument.Timer;
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.VersionType;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.CreateOperation;
@@ -87,6 +88,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
   public static final String INVALID_ACTION_ERRORS = "invalidActionErrors";
   public static final String BULKREQUEST_SIZE_BYTES = "bulkRequestSizeBytes";
   public static final String DYNAMIC_INDEX_DROPPED_EVENTS = "dynamicIndexDroppedEvents";
+  public static final String INVALID_VERSION_EXPRESSION_DROPPED_EVENTS = "invalidVersionExpressionDroppedEvents";
 
   private static final Logger LOG = LoggerFactory.getLogger(OpenSearchSink.class);
   private static final int INITIALIZE_RETRY_WAIT_TIME_MS = 5000;
@@ -112,12 +114,15 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
   private final String documentRootKey;
   private String configuredIndexAlias;
   private final ReentrantLock lock;
+  private final VersionType versionType;
+  private final String versionExpression;
 
   private final Timer bulkRequestTimer;
   private final Counter bulkRequestErrorsCounter;
   private final Counter invalidActionErrorsCounter;
   private final Counter dynamicIndexDroppedEvents;
   private final DistributionSummary bulkRequestSizeBytesSummary;
+  private final Counter versionExpressionDroppedEventsCounter;
   private OpenSearchClient openSearchClient;
   private ObjectMapper objectMapper;
   private volatile boolean initialized;
@@ -146,6 +151,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     invalidActionErrorsCounter = pluginMetrics.counter(INVALID_ACTION_ERRORS);
     dynamicIndexDroppedEvents = pluginMetrics.counter(DYNAMIC_INDEX_DROPPED_EVENTS);
     bulkRequestSizeBytesSummary = pluginMetrics.summary(BULKREQUEST_SIZE_BYTES);
+    versionExpressionDroppedEventsCounter = pluginMetrics.counter(INVALID_VERSION_EXPRESSION_DROPPED_EVENTS);
 
     this.openSearchSinkConfig = OpenSearchSinkConfiguration.readESConfig(pluginSetting, expressionEvaluator);
     this.bulkSize = ByteSizeUnit.MB.toBytes(openSearchSinkConfig.getIndexConfiguration().getBulkSize());
@@ -157,6 +163,8 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     this.action = openSearchSinkConfig.getIndexConfiguration().getAction();
     this.actions = openSearchSinkConfig.getIndexConfiguration().getActions();
     this.documentRootKey = openSearchSinkConfig.getIndexConfiguration().getDocumentRootKey();
+    this.versionType = openSearchSinkConfig.getIndexConfiguration().getVersionType();
+    this.versionExpression = openSearchSinkConfig.getIndexConfiguration().getVersionExpression();
     this.indexManagerFactory = new IndexManagerFactory(new ClusterSettingsParser());
     this.failedBulkOperationConverter = new FailedBulkOperationConverter(pluginSetting.getPipelineName(), pluginSetting.getName(),
         pluginSetting.getName());
@@ -260,7 +268,11 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
     return initialized;
   }
 
-  private BulkOperation getBulkOperationForAction(final String action, final SerializedJson document, final String indexName, final JsonNode jsonNode) {
+  private BulkOperation getBulkOperationForAction(final String action,
+                                                  final SerializedJson document,
+                                                  final Long version,
+                                                  final String indexName,
+                                                  final JsonNode jsonNode) {
     BulkOperation bulkOperation;
     final Optional<String> docId = document.getDocumentId();
     final Optional<String> routing = document.getRoutingField();
@@ -283,10 +295,14 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
               new UpdateOperation.Builder<>()
                   .index(indexName)
                   .document(jsonNode)
-                  .upsert(jsonNode) :
+                  .upsert(jsonNode)
+                  .versionType(versionType)
+                  .version(version) :
               new UpdateOperation.Builder<>()
                   .index(indexName)
-                  .document(jsonNode);
+                  .document(jsonNode)
+                  .versionType(versionType)
+                  .version(version);
           docId.ifPresent(updateOperationBuilder::id);
           routing.ifPresent(updateOperationBuilder::routing);
           bulkOperation = new BulkOperation.Builder()
@@ -300,13 +316,20 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
       docId.ifPresent(deleteOperationBuilder::id);
       routing.ifPresent(deleteOperationBuilder::routing);
       bulkOperation = new BulkOperation.Builder()
-                          .delete(deleteOperationBuilder.build())
+                          .delete(deleteOperationBuilder
+                                  .versionType(versionType)
+                                  .version(version)
+                                  .build())
                           .build();
       return bulkOperation;
     }
     // Default to "index"
     final IndexOperation.Builder<Object> indexOperationBuilder =
-      new IndexOperation.Builder<>().index(indexName).document(document);
+      new IndexOperation.Builder<>()
+              .index(indexName)
+              .document(document)
+              .version(version)
+              .versionType(versionType);
     docId.ifPresent(indexOperationBuilder::id);
     routing.ifPresent(indexOperationBuilder::routing);
     bulkOperation = new BulkOperation.Builder()
@@ -337,14 +360,25 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
       } catch (IOException | EventKeyNotFoundException e) {
           LOG.error("There was an exception when constructing the index name. Check the dlq if configured to see details about the affected Event: {}", e.getMessage());
           dynamicIndexDroppedEvents.increment();
-          logFailureForDlqObjects(List.of(DlqObject.builder()
-                  .withEventHandle(event.getEventHandle())
-                  .withFailedData(FailedDlqData.builder().withDocument(event.toJsonString()).withIndex(indexName).withMessage(e.getMessage()).build())
-                  .withPluginName(pluginSetting.getName())
-                  .withPipelineName(pluginSetting.getPipelineName())
-                  .withPluginId(pluginSetting.getName())
-                  .build()), e);
+          logFailureForDlqObjects(List.of(createDlqObjectFromEvent(event, indexName, e.getMessage())), e);
           continue;
+      }
+
+      Long version = null;
+      String versionExpressionEvaluationResult = null;
+      if (versionExpression != null) {
+        try {
+          versionExpressionEvaluationResult = event.formatString(versionExpression, expressionEvaluator);
+          version = Long.valueOf(event.formatString(versionExpression, expressionEvaluator));
+        } catch (final NumberFormatException e) {
+          LOG.warn("Unable to convert the result of evaluating version_expression {} to Long for an Event. {} must be a valid Long type", versionExpression, versionExpressionEvaluationResult);
+          logFailureForDlqObjects(List.of(createDlqObjectFromEvent(event, indexName, e.getMessage())), e);
+          versionExpressionDroppedEventsCounter.increment();
+        } catch (final RuntimeException e) {
+          LOG.error("There was an exception when evaluating the version_expression {}. Check the dlq if configured to see details about the affected Event: {}", versionExpression, e.getMessage());
+          logFailureForDlqObjects(List.of(createDlqObjectFromEvent(event, indexName, e.getMessage())), e);
+          versionExpressionDroppedEventsCounter.increment();
+        }
       }
 
       String eventAction = action;
@@ -373,7 +407,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
           StringUtils.equals(action, OpenSearchBulkActions.DELETE.toString())) {
             serializedJsonNode = SerializedJson.fromJsonNode(event.getJsonNode(), document);
       }
-      BulkOperation bulkOperation = getBulkOperationForAction(eventAction, document, indexName, event.getJsonNode());
+      BulkOperation bulkOperation = getBulkOperationForAction(eventAction, document, version, indexName, event.getJsonNode());
 
       BulkOperationWrapper bulkOperationWrapper = new BulkOperationWrapper(bulkOperation, event.getEventHandle(), serializedJsonNode);
       final long estimatedBytesBeforeAdd = bulkRequest.estimateSizeInBytesWithDocument(bulkOperationWrapper);
@@ -523,5 +557,21 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
           connectionConfiguration.getServerlessCollectionName(),
           connectionConfiguration.getServerlessVpceId());
     }
+  }
+
+  private DlqObject createDlqObjectFromEvent(final Event event,
+                                             final String index,
+                                             final String message) {
+    return DlqObject.builder()
+            .withEventHandle(event.getEventHandle())
+            .withFailedData(FailedDlqData.builder()
+                    .withDocument(event.toJsonString())
+                    .withIndex(index)
+                    .withMessage(message)
+                    .build())
+            .withPluginName(pluginSetting.getName())
+            .withPipelineName(pluginSetting.getPipelineName())
+            .withPluginId(pluginSetting.getName())
+            .build();
   }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
@@ -374,11 +374,13 @@ public class BulkRetryStrategyTests {
         final IndexOperation<SerializedJson> indexOperation2 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("2").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
+        final IndexOperation<SerializedJson> indexOperation5 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("5").document(arbitraryDocument()).build();
         final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build(), eventHandle1));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build(), eventHandle2));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build(), eventHandle3));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation4).build(), eventHandle4));
+        accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation5).build(), eventHandle5));
         bulkRetryStrategy.execute(accumulatingBulkRequest);
         MatcherAssert.assertThat(maxRetriesLimitReached, equalTo(true));
         assertEquals(numEventsSucceeded, 2);
@@ -407,7 +409,6 @@ public class BulkRetryStrategyTests {
         final IndexOperation<SerializedJson> indexOperation2 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("2").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
-        final IndexOperation<SerializedJson> indexOperation5 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("5").document(arbitraryDocument()).build();
         final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build(), eventHandle1));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build(), eventHandle2));
@@ -604,7 +605,7 @@ public class BulkRetryStrategyTests {
 
         private BulkResponse bulkSecondResponseWithFailures(final BulkRequest bulkRequest) {
             final int requestSize = bulkRequest.operations().size();
-            assert requestSize == 3;
+            assert requestSize == 2;
             final List<BulkResponseItem> bulkItemResponses = Arrays.asList(
                     internalServerErrorItemResponse(index), internalServerErrorItemResponse(index));
             return new BulkResponse.Builder().items(bulkItemResponses).errors(true).took(10).build();

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/BulkRetryStrategyTests.java
@@ -5,31 +5,31 @@
 
 package org.opensearch.dataprepper.plugins.sink.opensearch;
 
-import org.opensearch.client.opensearch._types.ErrorResponse;
-import org.opensearch.dataprepper.metrics.MetricNames;
-import org.opensearch.dataprepper.metrics.MetricsTestUtil;
-import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.model.event.EventHandle;
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import io.micrometer.core.instrument.Measurement;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.client.opensearch._types.ErrorCause;
+import org.opensearch.client.opensearch._types.ErrorResponse;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 import org.opensearch.client.opensearch.core.bulk.IndexOperation;
+import org.opensearch.dataprepper.metrics.MetricNames;
+import org.opensearch.dataprepper.metrics.MetricsTestUtil;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.AccumulatingBulkRequest;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.JavaClientAccumulatingUncompressedBulkRequest;
 import org.opensearch.dataprepper.plugins.sink.opensearch.bulk.SerializedJson;
 import org.opensearch.dataprepper.plugins.sink.opensearch.dlq.FailedBulkOperation;
 import org.opensearch.rest.RestStatus;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -43,13 +43,14 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.ArgumentMatchers.eq;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
+import static org.opensearch.dataprepper.plugins.sink.opensearch.BulkRetryStrategy.VERSION_CONFLICT_EXCEPTION_TYPE;
 
 @ExtendWith(MockitoExtension.class)
 public class BulkRetryStrategyTests {
@@ -65,6 +66,7 @@ public class BulkRetryStrategyTests {
     private EventHandle eventHandle2;
     private EventHandle eventHandle3;
     private EventHandle eventHandle4;
+    private EventHandle eventHandle5;
 
     @BeforeEach
     public void setUp() {
@@ -74,6 +76,7 @@ public class BulkRetryStrategyTests {
         eventHandle2 = mock(EventHandle.class);
         eventHandle3 = mock(EventHandle.class);
         eventHandle4 = mock(EventHandle.class);
+        eventHandle5 = mock(EventHandle.class);
 
         lenient().doAnswer(a -> {
             List<FailedBulkOperation> l = a.getArgument(0);
@@ -190,7 +193,6 @@ public class BulkRetryStrategyTests {
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build(), eventHandle2));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation3).build(), eventHandle3));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation4).build(), eventHandle4));
-
         bulkRetryStrategy.execute(accumulatingBulkRequest);
 
         assertEquals(3, client.attempt);
@@ -198,8 +200,8 @@ public class BulkRetryStrategyTests {
         assertFalse(client.finalResponse.errors());
         assertEquals("3", client.finalRequest.operations().get(0).index().id());
         assertEquals("4", client.finalRequest.operations().get(1).index().id());
-        assertEquals(numEventsSucceeded, 3);
-        assertEquals(numEventsFailed, 1);
+        assertEquals(3, numEventsSucceeded);
+        assertEquals(1, numEventsFailed);
 
         final ArgumentCaptor<List<FailedBulkOperation>> failedBulkOperationsCaptor = ArgumentCaptor.forClass(List.class);
         ArgumentCaptor<Throwable> throwableArgCaptor = ArgumentCaptor.forClass(Throwable.class);
@@ -208,12 +210,11 @@ public class BulkRetryStrategyTests {
 
         final List<FailedBulkOperation> failedBulkOperations = failedBulkOperationsCaptor.getValue();
         MatcherAssert.assertThat(failedBulkOperations.size(), equalTo(1));
-        failedBulkOperations.forEach(failedBulkOperation -> {
-            final BulkOperationWrapper bulkOperationWithHandle = failedBulkOperation.getBulkOperation();
-            final BulkOperation bulkOperation = bulkOperationWithHandle.getBulkOperation();
-            MatcherAssert.assertThat(bulkOperation.index().index(), equalTo(testIndex));
-            MatcherAssert.assertThat(bulkOperation.index().id(), equalTo(String.valueOf("2")));
-        });
+
+        final BulkOperationWrapper bulkOperationWithHandle = failedBulkOperations.get(0).getBulkOperation();
+        final BulkOperation bulkOperation = bulkOperationWithHandle.getBulkOperation();
+        MatcherAssert.assertThat(bulkOperation.index().index(), equalTo(testIndex));
+        MatcherAssert.assertThat(bulkOperation.index().id(), equalTo("2"));
 
         // verify metrics
         final List<Measurement> documentsSuccessFirstAttemptMeasurements = MetricsTestUtil.getMeasurementList(
@@ -382,6 +383,12 @@ public class BulkRetryStrategyTests {
         MatcherAssert.assertThat(maxRetriesLimitReached, equalTo(true));
         assertEquals(numEventsSucceeded, 2);
         assertEquals(numEventsFailed, 2);
+
+        final List<Measurement> documentVersionConflictMeasurement = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add(BulkRetryStrategy.DOCUMENTS_VERSION_CONFLICT_ERRORS).toString());
+        assertEquals(1, documentVersionConflictMeasurement.size());
+        assertEquals(1.0, documentVersionConflictMeasurement.get(0).getValue(), 0);
     }
 
     @Test
@@ -400,6 +407,7 @@ public class BulkRetryStrategyTests {
         final IndexOperation<SerializedJson> indexOperation2 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("2").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation3 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("3").document(arbitraryDocument()).build();
         final IndexOperation<SerializedJson> indexOperation4 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("4").document(arbitraryDocument()).build();
+        final IndexOperation<SerializedJson> indexOperation5 = new IndexOperation.Builder<SerializedJson>().index(testIndex).id("5").document(arbitraryDocument()).build();
         final AccumulatingBulkRequest accumulatingBulkRequest = new JavaClientAccumulatingUncompressedBulkRequest(new BulkRequest.Builder());
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation1).build(), eventHandle1));
         accumulatingBulkRequest.addOperation(new BulkOperationWrapper(new BulkOperation.Builder().index(indexOperation2).build(), eventHandle2));
@@ -458,8 +466,21 @@ public class BulkRetryStrategyTests {
         return customBulkFailureResponse(index, RestStatus.INTERNAL_SERVER_ERROR);
     }
 
+    private static BulkResponseItem versionConflictErrorItemResponse() {
+        return customBulkFailureResponse(RestStatus.CONFLICT, VERSION_CONFLICT_EXCEPTION_TYPE);
+    }
+
     private static BulkResponseItem customBulkFailureResponse(final String index, final RestStatus restStatus) {
         final ErrorCause errorCause = mock(ErrorCause.class);
+        final BulkResponseItem badResponse = mock(BulkResponseItem.class);
+        lenient().when(badResponse.status()).thenReturn(restStatus.getStatus());
+        lenient().when(badResponse.error()).thenReturn(errorCause);
+        return badResponse;
+    }
+
+    private static BulkResponseItem customBulkFailureResponse(final RestStatus restStatus, final String errorType) {
+        final ErrorCause errorCause = mock(ErrorCause.class);
+        lenient().when(errorCause.type()).thenReturn(errorType);
         final BulkResponseItem badResponse = mock(BulkResponseItem.class);
         lenient().when(badResponse.status()).thenReturn(restStatus.getStatus());
         lenient().when(badResponse.error()).thenReturn(errorCause);
@@ -548,7 +569,8 @@ public class BulkRetryStrategyTests {
                     internalServerErrorItemResponse(index),
                     successItemResponse(index),
                     successItemResponse(index),
-                    tooManyRequestItemResponse(index));
+                    tooManyRequestItemResponse(index),
+                    versionConflictErrorItemResponse());
             return new BulkResponse.Builder().items(bulkItemResponses).errors(true).took(10).build();
         }
 
@@ -582,7 +604,7 @@ public class BulkRetryStrategyTests {
 
         private BulkResponse bulkSecondResponseWithFailures(final BulkRequest bulkRequest) {
             final int requestSize = bulkRequest.operations().size();
-            assert requestSize == 2;
+            assert requestSize == 3;
             final List<BulkResponseItem> bulkItemResponses = Arrays.asList(
                     internalServerErrorItemResponse(index), internalServerErrorItemResponse(index));
             return new BulkResponse.Builder().items(bulkItemResponses).errors(true).took(10).build();

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkConfigurationTests.java
@@ -132,16 +132,17 @@ public class OpenSearchSinkConfigurationTests {
     @Test
     public void testReadESConfigWithBulkActionCreateExpression() {
 
+        final String actionFormatExpression = "${getMetadata(\"action\")}";
         final Map<String, Object> metadata = new HashMap<>();
         metadata.put(IndexConfiguration.INDEX_TYPE, IndexType.TRACE_ANALYTICS_RAW.getValue());
-        metadata.put(IndexConfiguration.ACTION, "${getMetadata(\"action\")}");
+        metadata.put(IndexConfiguration.ACTION, actionFormatExpression);
         metadata.put(ConnectionConfiguration.HOSTS, TEST_HOSTS);
 
         final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, metadata);
         pluginSetting.setPipelineName(PIPELINE_NAME);
 
         expressionEvaluator = mock(ExpressionEvaluator.class);
-        when(expressionEvaluator.isValidExpressionStatement(anyString())).thenReturn(true);
+        when(expressionEvaluator.isValidFormatExpressions(actionFormatExpression)).thenReturn(true);
         final OpenSearchSinkConfiguration openSearchSinkConfiguration =
                 OpenSearchSinkConfiguration.readESConfig(pluginSetting, expressionEvaluator);
 


### PR DESCRIPTION
…search sink for conditional indexing of documents

### Description
This change adds 2 new parameters to the OpenSearch sink

`document_version` - A Data Prepper format expression such as `${key}` or `${expression()}` 
`document_version_type` - One of `internal`, `external`, or `external_gte`

OpenSearch documentation on `version` and `version_type` (https://opensearch.org/docs/latest/api-reference/document-apis/index-document/). The documentation incorrectly states that `version` is an Integer. It is a Long. I tested this manually in OpenSearch 2.9 will epochMilli timestamps, and the SDK also has it as a Long.

Given the following documents being sent to OpenSearch

```
{"version": 123, "val": "4349", "action": "index"}
{"version": 126, "val": "4349", "action": "index"}
{"version": 125, "doc_id": "4349", "action": "index"}
{"version": 128, "doc_id": "4349", "action": "delete"}
{"version": 127, "doc_id": "4349", "action": "index"}
{"version": 130, "doc_id": "4349", "action": "index", "value": "result"}
```

and configuration

```
        document_version: "${/version}"
        document_version_type: "external"  
```

and enabled DEBUG logging, you would see the following response errors for version conflicts for the third index action (key `125` and the index action following the delete (key `127`), and the resultant document in OpenSearch would be the document will the highest `key`, which is the final request with `130`

```
2023-11-05T10:28:10,155 [log-pipeline-sink-worker-2-thread-1] INFO  org.opensearch.dataprepper.plugins.sink.opensearch.BulkRetryStrategy - Received version conflict from OpenSearch: [4349]: version conflict, current version [126] is higher or equal to the one provided [125]
2023-11-05T10:28:10,155 [log-pipeline-sink-worker-2-thread-1] INFO  org.opensearch.dataprepper.plugins.sink.opensearch.BulkRetryStrategy - Received version conflict from OpenSearch: [4349]: version conflict, current version [128] is higher or equal to the one provided [127]
```


 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
