### PR TITLE
Pause reading from Kafka in the Kafka buffer when the circuit breaker is open

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/breaker/CircuitBreaker.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/breaker/CircuitBreaker.java
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.dataprepper.breaker;
+package org.opensearch.dataprepper.model.breaker;
 
 /**
  * Represents a circuit breaker in Data Prepper.
  *
- * @since 2.1
+ * @since 2.6
  */
 public interface CircuitBreaker {
     /**
@@ -16,7 +16,7 @@ public interface CircuitBreaker {
      * been tripped.
      *
      * @return true if open; false if closed.
-     * @since 2.1
+     * @since 2.6
      */
     boolean isOpen();
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/DelegatingBuffer.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/DelegatingBuffer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.buffer;
+
+import org.opensearch.dataprepper.model.CheckpointState;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * An implementation of {@link Buffer} which delegates all calls to a delgate
+ * (or inner) buffer.
+ * <p>
+ * This class exists to help with writing decorators of the {@link Buffer} interface.
+ *
+ * @param <T> The type of data in the buffer
+ *
+ * @since 2.6
+ */
+public abstract class DelegatingBuffer<T extends Record<?>> implements Buffer<T> {
+    private final Buffer<T> delegateBuffer;
+
+    /**
+     * Constructor for subclasses to use.
+     *
+     * @param delegateBuffer The delegate (or inner) buffer.
+     *
+     * @since 2.6
+     */
+    protected DelegatingBuffer(final Buffer<T> delegateBuffer) {
+        this.delegateBuffer = Objects.requireNonNull(delegateBuffer);
+    }
+
+    @Override
+    public void write(final T record, final int timeoutInMillis) throws TimeoutException {
+        delegateBuffer.write(record, timeoutInMillis);
+    }
+
+    @Override
+    public void writeAll(final Collection<T> records, final int timeoutInMillis) throws Exception {
+        delegateBuffer.writeAll(records, timeoutInMillis);
+    }
+
+    @Override
+    public void writeBytes(final byte[] bytes, final String key, final int timeoutInMillis) throws Exception {
+        delegateBuffer.writeBytes(bytes, key, timeoutInMillis);
+    }
+
+    @Override
+    public Map.Entry<Collection<T>, CheckpointState> read(final int timeoutInMillis) {
+        return delegateBuffer.read(timeoutInMillis);
+    }
+
+    @Override
+    public void checkpoint(final CheckpointState checkpointState) {
+        delegateBuffer.checkpoint(checkpointState);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegateBuffer.isEmpty();
+    }
+
+    @Override
+    public boolean isByteBuffer() {
+        return delegateBuffer.isByteBuffer();
+    }
+
+    @Override
+    public Duration getDrainTimeout() {
+        return delegateBuffer.getDrainTimeout();
+    }
+
+    @Override
+    public void shutdown() {
+        delegateBuffer.shutdown();
+    }
+}

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/DelegatingBufferTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/DelegatingBufferTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.buffer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.CheckpointState;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DelegatingBufferTest {
+    @Mock
+    private Buffer<Record<String>> innerBuffer;
+
+    @Mock
+    private Record<String> record;
+
+    private Collection<Record<String>> records;
+
+    private int timeoutInMillis;
+    private Random random;
+
+    @BeforeEach
+    void setUp() {
+        random = new Random();
+        timeoutInMillis = random.nextInt(10_000) + 100;
+
+        records = List.of(record, mock(Record.class));
+    }
+
+    private static class TestDelegatingBuffer extends DelegatingBuffer<Record<String>> {
+        TestDelegatingBuffer(final Buffer<Record<String>> delegateBuffer) {
+            super(delegateBuffer);
+        }
+    }
+
+    private DelegatingBuffer<Record<String>> createObjectUnderTest() {
+        return new TestDelegatingBuffer(innerBuffer);
+    }
+
+    @Test
+    void constructor_throws_if_delegate_is_null() {
+        innerBuffer = null;
+
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void write_calls_inner_write() throws TimeoutException {
+        createObjectUnderTest().write(record, timeoutInMillis);
+
+        verify(innerBuffer).write(record, timeoutInMillis);
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {RuntimeException.class, TimeoutException.class})
+    void write_throws_exceptions_from_inner_write(final Class<Throwable> exceptionType) throws TimeoutException {
+        final Throwable exception = mock(exceptionType);
+        doThrow(exception).when(innerBuffer).write(any(), anyInt());
+
+        final DelegatingBuffer<Record<String>> objectUnderTest = createObjectUnderTest();
+        final Exception actualException = assertThrows(Exception.class, () -> objectUnderTest.write(record, timeoutInMillis));
+
+        assertThat(actualException, sameInstance(exception));
+    }
+
+    @Test
+    void writeAll_calls_inner_writeAll() throws Exception {
+        createObjectUnderTest().writeAll(records, timeoutInMillis);
+
+        verify(innerBuffer).writeAll(records, timeoutInMillis);
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {Exception.class, RuntimeException.class, TimeoutException.class})
+    void writeAll_throws_exceptions_from_inner_writeAll(final Class<Throwable> exceptionType) throws Exception {
+        final Throwable exception = mock(exceptionType);
+        doThrow(exception).when(innerBuffer).writeAll(any(), anyInt());
+
+        final DelegatingBuffer<Record<String>> objectUnderTest = createObjectUnderTest();
+        final Exception actualException = assertThrows(Exception.class, () -> objectUnderTest.writeAll(records, timeoutInMillis));
+
+        assertThat(actualException, sameInstance(exception));
+    }
+
+    @Test
+    void writeBytes_calls_inner_writeBytes() throws Exception {
+        final byte[] bytesToWrite = new byte[64];
+        random.nextBytes(bytesToWrite);
+        final String key = UUID.randomUUID().toString();
+        createObjectUnderTest().writeBytes(bytesToWrite, key, timeoutInMillis);
+
+        verify(innerBuffer).writeBytes(bytesToWrite, key, timeoutInMillis);
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {Exception.class, RuntimeException.class, TimeoutException.class})
+    void writeBytes_throws_exceptions_from_inner_writeBytes(final Class<Throwable> exceptionType) throws Exception {
+        final Throwable exception = mock(exceptionType);
+        doThrow(exception).when(innerBuffer).writeBytes(any(), any(), anyInt());
+
+        final byte[] bytesToWrite = new byte[64];
+        random.nextBytes(bytesToWrite);
+        final String key = UUID.randomUUID().toString();
+
+        final DelegatingBuffer<Record<String>> objectUnderTest = createObjectUnderTest();
+        final Exception actualException = assertThrows(Exception.class, () -> objectUnderTest.writeBytes(bytesToWrite, key, timeoutInMillis));
+
+        assertThat(actualException, sameInstance(exception));
+    }
+
+    @Test
+    void read_returns_inner_read() {
+        final Map.Entry<Collection<Record<String>>, CheckpointState> readResult = mock(Map.Entry.class);
+        when(innerBuffer.read(timeoutInMillis)).thenReturn(readResult);
+
+        assertThat(createObjectUnderTest().read(timeoutInMillis),
+                equalTo(readResult));
+    }
+
+    @Test
+    void read_throws_exceptions_from_inner_read() {
+        final RuntimeException exception = mock(RuntimeException.class);
+
+        when(innerBuffer.read(timeoutInMillis)).thenThrow(exception);
+
+        final DelegatingBuffer<Record<String>> objectUnderTest = createObjectUnderTest();
+        final Exception actualException = assertThrows(Exception.class, () -> objectUnderTest.read(timeoutInMillis));
+
+        assertThat(actualException, sameInstance(exception));
+    }
+
+    @Test
+    void checkpoint_calls_inner_checkpoint() {
+        final CheckpointState checkpointState = mock(CheckpointState.class);
+
+        createObjectUnderTest().checkpoint(checkpointState);
+
+        verify(innerBuffer).checkpoint(checkpointState);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void isEmpty_returns_inner_isEmpty(final boolean isEmpty) {
+        when(innerBuffer.isEmpty()).thenReturn(isEmpty);
+
+        assertThat(createObjectUnderTest().isEmpty(),
+                equalTo(isEmpty));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void isByteBuffer_returns_inner_isByteBuffer(final boolean isByteBuffer) {
+        when(innerBuffer.isByteBuffer()).thenReturn(isByteBuffer);
+
+        assertThat(createObjectUnderTest().isByteBuffer(),
+                equalTo(isByteBuffer));
+    }
+
+    @Test
+    void getDrainTimeout_returns_inner_getDrainTimeout() {
+        final Duration drainTimeout = Duration.ofSeconds(random.nextInt(10_000) + 100);
+        when(innerBuffer.getDrainTimeout()).thenReturn(drainTimeout);
+
+        assertThat(createObjectUnderTest().getDrainTimeout(),
+                equalTo(drainTimeout));
+    }
+
+    @Test
+    void shutdown_calls_inner_shutdown() {
+        createObjectUnderTest().shutdown();
+
+        verify(innerBuffer).shutdown();
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/breaker/CircuitBreakerAppConfig.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/breaker/CircuitBreakerAppConfig.java
@@ -5,12 +5,14 @@
 
 package org.opensearch.dataprepper.breaker;
 
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
 import org.opensearch.dataprepper.parser.model.CircuitBreakerConfig;
 import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The application config for circuit breakers. Used for wiring beans
@@ -33,5 +35,10 @@ public class CircuitBreakerAppConfig {
         } else {
             return null;
         }
+    }
+
+    @Bean
+    public Optional<CircuitBreaker> circuitBreaker(final CircuitBreakerManager circuitBreakerManager) {
+        return circuitBreakerManager.getGlobalCircuitBreaker();
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/breaker/CircuitBreakerManager.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/breaker/CircuitBreakerManager.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper.breaker;
 
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
+
 import java.util.List;
 import java.util.Optional;
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/breaker/HeapCircuitBreaker.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/breaker/HeapCircuitBreaker.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.breaker;
 
 import io.micrometer.core.instrument.Metrics;
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
 import org.opensearch.dataprepper.parser.model.HeapCircuitBreakerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/breaker/InnerCircuitBreaker.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/breaker/InnerCircuitBreaker.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper.breaker;
 
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
+
 /**
  * Interface to signal that this {@link CircuitBreaker} to prevent
  * access beyond the {@link CircuitBreakerManager}.

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/CircuitBreakingBuffer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/CircuitBreakingBuffer.java
@@ -5,14 +5,12 @@
 
 package org.opensearch.dataprepper.parser;
 
-import org.opensearch.dataprepper.breaker.CircuitBreaker;
-import org.opensearch.dataprepper.model.CheckpointState;
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
 import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.buffer.DelegatingBuffer;
 import org.opensearch.dataprepper.model.record.Record;
 
-import java.time.Duration;
 import java.util.Collection;
-import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 import static java.util.Objects.requireNonNull;
@@ -24,8 +22,7 @@ import static java.util.Objects.requireNonNull;
  * @param <T> The type of record.
  * @since 2.1
  */
-class CircuitBreakingBuffer<T extends Record<?>> implements Buffer<T> {
-    private final Buffer<T> buffer;
+class CircuitBreakingBuffer<T extends Record<?>> extends DelegatingBuffer<T> implements Buffer<T> {
     private final CircuitBreaker circuitBreaker;
 
     /**
@@ -35,7 +32,7 @@ class CircuitBreakingBuffer<T extends Record<?>> implements Buffer<T> {
      * @param circuitBreaker The circuit breaker to check
      */
     public CircuitBreakingBuffer(final Buffer<T> buffer, final CircuitBreaker circuitBreaker) {
-        this.buffer = requireNonNull(buffer);
+        super(buffer);
         this.circuitBreaker = requireNonNull(circuitBreaker);
     }
 
@@ -43,55 +40,25 @@ class CircuitBreakingBuffer<T extends Record<?>> implements Buffer<T> {
     public void write(final T record, final int timeoutInMillis) throws TimeoutException {
         checkBreaker();
 
-        buffer.write(record, timeoutInMillis);
+        super.write(record, timeoutInMillis);
     }
 
     @Override
     public void writeAll(final Collection<T> records, final int timeoutInMillis) throws Exception {
         checkBreaker();
 
-        buffer.writeAll(records, timeoutInMillis);
+        super.writeAll(records, timeoutInMillis);
     }
 
     @Override
-    public void writeBytes(byte[] bytes, String key, int timeoutInMillis) throws Exception {
+    public void writeBytes(final byte[] bytes, final String key, final int timeoutInMillis) throws Exception {
         checkBreaker();
 
-        buffer.writeBytes(bytes, key, timeoutInMillis);
+        super.writeBytes(bytes, key, timeoutInMillis);
     }
 
     private void checkBreaker() throws TimeoutException {
         if(circuitBreaker.isOpen())
             throw new TimeoutException("Circuit breaker is open. Unable to write to buffer.");
-    }
-
-    @Override
-    public Map.Entry<Collection<T>, CheckpointState> read(final int timeoutInMillis) {
-        return buffer.read(timeoutInMillis);
-    }
-
-    @Override
-    public void checkpoint(final CheckpointState checkpointState) {
-        buffer.checkpoint(checkpointState);
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return buffer.isEmpty();
-    }
-
-    @Override
-    public boolean isByteBuffer() {
-        return buffer.isByteBuffer();
-    }
-
-    @Override
-    public Duration getDrainTimeout() {
-        return buffer.getDrainTimeout();
-    }
-
-    @Override
-    public void shutdown() {
-        buffer.shutdown();
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContext.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContext.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugin;
 
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -74,6 +75,8 @@ class ComponentPluginArgumentsContext implements PluginArgumentsContext {
         if (builder.sinkContext != null) {
             typedArgumentsSuppliers.put(SinkContext.class, () -> builder.sinkContext);
         }
+
+        typedArgumentsSuppliers.put(CircuitBreaker.class, () -> builder.circuitBreaker);
     }
 
     @Override
@@ -135,6 +138,7 @@ class ComponentPluginArgumentsContext implements PluginArgumentsContext {
         private AcknowledgementSetManager acknowledgementSetManager;
         private PluginConfigObservable pluginConfigObservable;
         private SinkContext sinkContext;
+        private CircuitBreaker circuitBreaker;
 
         Builder withPluginConfiguration(final Object pluginConfiguration) {
             this.pluginConfiguration = pluginConfiguration;
@@ -178,6 +182,11 @@ class ComponentPluginArgumentsContext implements PluginArgumentsContext {
 
         Builder withPluginConfigurationObservable(final PluginConfigObservable pluginConfigObservable) {
             this.pluginConfigObservable = pluginConfigObservable;
+            return this;
+        }
+
+        Builder withCircuitBreaker(final CircuitBreaker circuitBreaker) {
+            this.circuitBreaker = circuitBreaker;
             return this;
         }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugin;
 
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
@@ -43,6 +44,7 @@ public class DefaultPluginFactory implements PluginFactory {
     private final DefaultEventFactory eventFactory;
     private final DefaultAcknowledgementSetManager acknowledgementSetManager;
     private final PluginConfigurationObservableFactory pluginConfigurationObservableFactory;
+    private final CircuitBreaker circuitBreaker;
 
     @Inject
     DefaultPluginFactory(
@@ -52,8 +54,10 @@ public class DefaultPluginFactory implements PluginFactory {
             final PluginBeanFactoryProvider pluginBeanFactoryProvider,
             final DefaultEventFactory eventFactory,
             final DefaultAcknowledgementSetManager acknowledgementSetManager,
-            final PluginConfigurationObservableFactory pluginConfigurationObservableFactory
-    ) {
+            final PluginConfigurationObservableFactory pluginConfigurationObservableFactory,
+            final CircuitBreaker circuitBreaker
+            ) {
+        this.circuitBreaker = circuitBreaker;
         Objects.requireNonNull(pluginProviderLoader);
         Objects.requireNonNull(pluginConfigurationObservableFactory);
         this.pluginCreator = Objects.requireNonNull(pluginCreator);
@@ -131,6 +135,7 @@ public class DefaultPluginFactory implements PluginFactory {
                 .withAcknowledgementSetManager(acknowledgementSetManager)
                 .withPluginConfigurationObservable(pluginConfigObservable)
                 .withSinkContext(sinkContext)
+                .withCircuitBreaker(circuitBreaker)
                 .build();
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -16,6 +16,7 @@ import org.opensearch.dataprepper.event.DefaultEventFactory;
 import org.opensearch.dataprepper.acknowledgements.DefaultAcknowledgementSetManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.DependsOn;
 
 import javax.inject.Inject;
@@ -55,7 +56,7 @@ public class DefaultPluginFactory implements PluginFactory {
             final DefaultEventFactory eventFactory,
             final DefaultAcknowledgementSetManager acknowledgementSetManager,
             final PluginConfigurationObservableFactory pluginConfigurationObservableFactory,
-            final CircuitBreaker circuitBreaker
+            @Autowired(required = false) final CircuitBreaker circuitBreaker
             ) {
         this.circuitBreaker = circuitBreaker;
         Objects.requireNonNull(pluginProviderLoader);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/breaker/CircuitBreakerIT.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/breaker/CircuitBreakerIT.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
 import org.opensearch.dataprepper.model.types.ByteCount;
 import org.opensearch.dataprepper.parser.model.CircuitBreakerConfig;
 import org.opensearch.dataprepper.parser.model.DataPrepperConfiguration;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/breaker/CircuitBreakerManagerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/breaker/CircuitBreakerManagerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
 
 import java.util.Collections;
 import java.util.List;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/CircuitBreakingBufferTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/CircuitBreakingBufferTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.opensearch.dataprepper.breaker.CircuitBreaker;
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
 import org.opensearch.dataprepper.model.CheckpointState;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.record.Record;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineTransformerTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineTransformerTests.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.TestDataProvider;
-import org.opensearch.dataprepper.breaker.CircuitBreaker;
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
 import org.opensearch.dataprepper.breaker.CircuitBreakerManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.configuration.PipelinesDataFlowModel;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/DefaultPluginFactoryTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugin;
 
 import org.mockito.ArgumentCaptor;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.NoPluginFoundException;
@@ -57,6 +58,7 @@ class DefaultPluginFactoryTest {
     private BeanFactory beanFactory;
     private String pipelineName;
     private DefaultAcknowledgementSetManager acknowledgementSetManager;
+    private CircuitBreaker circuitBreaker;
     private DefaultEventFactory eventFactory;
     private PluginConfigurationObservableFactory pluginConfigurationObservableFactory;
     private PluginConfigObservable pluginConfigObservable;
@@ -68,6 +70,7 @@ class DefaultPluginFactoryTest {
         pluginConfigurationConverter = mock(PluginConfigurationConverter.class);
 
         acknowledgementSetManager = mock(DefaultAcknowledgementSetManager.class);
+        circuitBreaker = mock(CircuitBreaker.class);
         eventFactory = mock(DefaultEventFactory.class);
         pluginProviders = new ArrayList<>();
         given(pluginProviderLoader.getPluginProviders()).willReturn(pluginProviders);
@@ -94,7 +97,7 @@ class DefaultPluginFactoryTest {
     private DefaultPluginFactory createObjectUnderTest() {
         return new DefaultPluginFactory(
                 pluginProviderLoader, pluginCreator, pluginConfigurationConverter, beanFactoryProvider, eventFactory,
-                acknowledgementSetManager, pluginConfigurationObservableFactory);
+                acknowledgementSetManager, pluginConfigurationObservableFactory, circuitBreaker);
     }
 
     @Test

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferIT.java
@@ -93,13 +93,13 @@ public class KafkaBufferIT {
         when(kafkaBufferConfig.getEncryptionConfig()).thenReturn(encryptionConfig);
     }
 
-    private KafkaBuffer<Record<Event>> createObjectUnderTest() {
-        return new KafkaBuffer<>(pluginSetting, kafkaBufferConfig, pluginFactory, acknowledgementSetManager, pluginMetrics, null, null);
+    private KafkaBuffer createObjectUnderTest() {
+        return new KafkaBuffer(pluginSetting, kafkaBufferConfig, pluginFactory, acknowledgementSetManager, pluginMetrics, null, null, null);
     }
 
     @Test
     void write_and_read() throws TimeoutException {
-        KafkaBuffer<Record<Event>> objectUnderTest = createObjectUnderTest();
+        KafkaBuffer objectUnderTest = createObjectUnderTest();
 
         Record<Event> record = createRecord();
         objectUnderTest.write(record, 1_000);
@@ -123,7 +123,7 @@ public class KafkaBufferIT {
     void write_and_read_encrypted() throws TimeoutException, NoSuchAlgorithmException {
         when(topicConfig.getEncryptionKey()).thenReturn(createAesKey());
 
-        KafkaBuffer<Record<Event>> objectUnderTest = createObjectUnderTest();
+        KafkaBuffer objectUnderTest = createObjectUnderTest();
 
         Record<Event> record = createRecord();
         objectUnderTest.write(record, 1_000);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.plugins.kafka.buffer;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.CheckpointState;
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
 import org.opensearch.dataprepper.model.codec.ByteDecoder;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
@@ -15,6 +16,7 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor
 import org.opensearch.dataprepper.model.buffer.AbstractBuffer;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
@@ -37,7 +39,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @DataPrepperPlugin(name = "kafka", pluginType = Buffer.class, pluginConfigurationType = KafkaBufferConfig.class)
-public class KafkaBuffer<T extends Record<?>> extends AbstractBuffer<T> {
+public class KafkaBuffer extends AbstractBuffer<Record<Event>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaBuffer.class);
     static final long EXECUTOR_SERVICE_SHUTDOWN_TIMEOUT = 30L;
@@ -47,7 +49,7 @@ public class KafkaBuffer<T extends Record<?>> extends AbstractBuffer<T> {
     static final String READ = "Read";
     private final KafkaCustomProducer producer;
     private final List<KafkaCustomConsumer> emptyCheckingConsumers;
-    private final AbstractBuffer innerBuffer;
+    private final AbstractBuffer<Record<Event>> innerBuffer;
     private final ExecutorService executorService;
     private final Duration drainTimeout;
     private AtomicBoolean shutdownInProgress;
@@ -56,7 +58,8 @@ public class KafkaBuffer<T extends Record<?>> extends AbstractBuffer<T> {
     @DataPrepperPluginConstructor
     public KafkaBuffer(final PluginSetting pluginSetting, final KafkaBufferConfig kafkaBufferConfig, final PluginFactory pluginFactory,
                        final AcknowledgementSetManager acknowledgementSetManager, final PluginMetrics pluginMetrics,
-                       final ByteDecoder byteDecoder, final AwsCredentialsSupplier awsCredentialsSupplier) {
+                       final ByteDecoder byteDecoder, final AwsCredentialsSupplier awsCredentialsSupplier,
+                       final CircuitBreaker circuitBreaker) {
         super(pluginSetting);
         SerializationFactory serializationFactory = new SerializationFactory();
         final KafkaCustomProducerFactory kafkaCustomProducerFactory = new KafkaCustomProducerFactory(serializationFactory, awsCredentialsSupplier);
@@ -69,9 +72,9 @@ public class KafkaBuffer<T extends Record<?>> extends AbstractBuffer<T> {
         this.shutdownInProgress = new AtomicBoolean(false);
         final PluginMetrics consumerMetrics = PluginMetrics.fromNames(metricPrefixName + READ, pluginSetting.getPipelineName());
         final List<KafkaCustomConsumer> consumers = kafkaCustomConsumerFactory.createConsumersForTopic(kafkaBufferConfig, kafkaBufferConfig.getTopic(),
-            innerBuffer, consumerMetrics, acknowledgementSetManager, byteDecoder, shutdownInProgress, false);
+            innerBuffer, consumerMetrics, acknowledgementSetManager, byteDecoder, shutdownInProgress, false, circuitBreaker);
         emptyCheckingConsumers = kafkaCustomConsumerFactory.createConsumersForTopic(kafkaBufferConfig, kafkaBufferConfig.getTopic(),
-                innerBuffer, pluginMetrics, acknowledgementSetManager, byteDecoder, shutdownInProgress, false);
+                innerBuffer, pluginMetrics, acknowledgementSetManager, byteDecoder, shutdownInProgress, false, null);
         this.executorService = Executors.newFixedThreadPool(consumers.size());
         consumers.forEach(this.executorService::submit);
 
@@ -89,7 +92,7 @@ public class KafkaBuffer<T extends Record<?>> extends AbstractBuffer<T> {
     }
 
     @Override
-    public void doWrite(T record, int timeoutInMillis) throws TimeoutException {
+    public void doWrite(Record<Event> record, int timeoutInMillis) throws TimeoutException {
         try {
             producer.produceRecords(record);
         } catch (final Exception e) {
@@ -104,14 +107,14 @@ public class KafkaBuffer<T extends Record<?>> extends AbstractBuffer<T> {
     }
 
     @Override
-    public void doWriteAll(Collection<T> records, int timeoutInMillis) throws Exception {
-        for ( T record: records ) {
+    public void doWriteAll(Collection<Record<Event>> records, int timeoutInMillis) throws Exception {
+        for ( Record<Event> record: records ) {
             doWrite(record, timeoutInMillis);
         }
     }
 
     @Override
-    public Map.Entry<Collection<T>, CheckpointState> doRead(int timeoutInMillis) {
+    public Map.Entry<Collection<Record<Event>>, CheckpointState> doRead(int timeoutInMillis) {
         return innerBuffer.doRead(timeoutInMillis);
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/PauseConsumePredicate.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/PauseConsumePredicate.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.consumer;
+
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
+
+/**
+ * Represents if the {@link KafkaCustomConsumer} should pause consuming
+ * from a Kafka topic due to an external reason.
+ */
+@FunctionalInterface
+public interface PauseConsumePredicate {
+    /**
+     * Returns whether to pause consumption of a Kafka topic.
+     *
+     * @return True if the consumer should pause. False if there is it does not need to pause.
+     */
+    boolean pauseConsuming();
+
+    /**
+     * Returns a {@link PauseConsumePredicate} from a {@link CircuitBreaker}. This value may
+     * be null, in which case, it will not pause.
+     *
+     * @param circuitBreaker The {@link CircuitBreaker} or <b>null</b>
+     * @return a predicate based on the circuit breaker.
+     */
+    static PauseConsumePredicate circuitBreakingPredicate(final CircuitBreaker circuitBreaker) {
+        if(circuitBreaker == null)
+            return noPause();
+        return circuitBreaker::isOpen;
+    }
+
+    /**
+     * Returns a {@link PauseConsumePredicate} that never pauses.
+     *
+     * @return a predicate that does not pause
+     */
+    static PauseConsumePredicate noPause() {
+        return () -> false;
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -37,6 +37,7 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaRegistryType;
 import org.opensearch.dataprepper.plugins.kafka.configuration.TopicConfig;
 import org.opensearch.dataprepper.plugins.kafka.consumer.KafkaCustomConsumer;
+import org.opensearch.dataprepper.plugins.kafka.consumer.PauseConsumePredicate;
 import org.opensearch.dataprepper.plugins.kafka.consumer.TopicEmptinessMetadata;
 import org.opensearch.dataprepper.plugins.kafka.extension.KafkaClusterConfigSupplier;
 import org.opensearch.dataprepper.plugins.kafka.util.ClientDNSLookupType;
@@ -141,7 +142,7 @@ public class KafkaSource implements Source<Record<Event>> {
 
                     }
                     consumer = new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType,
-                            acknowledgementSetManager, null, topicMetrics, topicEmptinessMetadata);
+                            acknowledgementSetManager, null, topicMetrics, topicEmptinessMetadata, PauseConsumePredicate.noPause());
                     allTopicConsumers.add(consumer);
 
                     executorService.submit(consumer);

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
@@ -99,6 +99,9 @@ public class KafkaCustomConsumerTest {
     @Mock
     private OffsetAndMetadata offsetAndMetadata;
 
+    @Mock
+    private PauseConsumePredicate pauseConsumePredicate;
+
     private KafkaCustomConsumer consumer;
 
     private ConsumerRecords consumerRecords;
@@ -166,7 +169,7 @@ public class KafkaCustomConsumerTest {
         topicEmptinessMetadata = new TopicEmptinessMetadata();
         when(sourceConfig.getAcknowledgementsEnabled()).thenReturn(acknowledgementsEnabled);
         return new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topicConfig, schemaType,
-                acknowledgementSetManager, null, topicMetrics, topicEmptinessMetadata);
+                acknowledgementSetManager, null, topicMetrics, topicEmptinessMetadata, pauseConsumePredicate);
     }
 
     private BlockingBuffer<Record<Event>> getBuffer() {

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/PauseConsumePredicateTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/PauseConsumePredicateTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.consumer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class PauseConsumePredicateTest {
+    @Test
+    void noPause_returns_predicate_with_pauseConsuming_returning_false() {
+        final PauseConsumePredicate pauseConsumePredicate = PauseConsumePredicate.noPause();
+
+        assertThat(pauseConsumePredicate, notNullValue());
+
+        assertThat(pauseConsumePredicate.pauseConsuming(), equalTo(false));
+    }
+
+    @Test
+    void circuitBreakingPredicate_with_a_null_circuit_breaker_returns_predicate_with_pauseConsuming_returning_false() {
+        final PauseConsumePredicate pauseConsumePredicate = PauseConsumePredicate.circuitBreakingPredicate(null);
+
+        assertThat(pauseConsumePredicate, notNullValue());
+
+        assertThat(pauseConsumePredicate.pauseConsuming(), equalTo(false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void circuitBreakingPredicate_with_a_circuit_breaker_returns_predicate_with_pauseConsuming_returning_value_of_isOpen(final boolean isOpen) {
+        final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
+
+        final PauseConsumePredicate pauseConsumePredicate = PauseConsumePredicate.circuitBreakingPredicate(circuitBreaker);
+
+        verifyNoInteractions(circuitBreaker);
+
+        assertThat(pauseConsumePredicate, notNullValue());
+
+        when(circuitBreaker.isOpen()).thenReturn(isOpen);
+
+        assertThat(pauseConsumePredicate.pauseConsuming(), equalTo(isOpen));
+    }
+}


### PR DESCRIPTION
### Description

This PR supports using the circuit breaker in the Kafka source to delay reading from the Kafka topic. It has the following significant changes:

* Moves the `CircuitBreaker` interface to data-prepper-api and renames the package to match existing conventions.
* Adds a `DelegatingBuffer` implementation to help with decorator buffers. We don't strictly need this, but I made the change for one variation I worked toward, so I included it.
* Support getting a `CircuitBreaker` object in an `@DataPrepperPluginConstructor`.
* Pause reading from the Kafka buffer when the circuit breaker is open.
 
### Issues Resolved

Resolves #3578
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
