### PR TITLE
Add dynamodb_item_version metadata that is derived from timestamp for…

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/MetadataKeyAttributes.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/MetadataKeyAttributes.java
@@ -14,6 +14,8 @@ public class MetadataKeyAttributes {
 
     static final String EVENT_TIMESTAMP_METADATA_ATTRIBUTE = "dynamodb_timestamp";
 
+    static final String EVENT_DYNAMODB_ITEM_VERSION = "dynamodb_item_version";
+
     static final String EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE = "opensearch_action";
 
     static final String DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE = "dynamodb_event_name";

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/RecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/RecordConverter.java
@@ -77,8 +77,8 @@ public abstract class RecordConverter {
     public void addToBuffer(final AcknowledgementSet acknowledgementSet,
                             final Map<String, Object> data,
                             final Map<String, Object> keys,
-                            long eventCreationTimeMillis,
-                            long eventVersionNumber,
+                            final long eventCreationTimeMillis,
+                            final long eventVersionNumber,
                             final String eventName) throws Exception {
         Event event = JacksonEvent.builder()
                 .withEventType(getEventType())
@@ -87,7 +87,9 @@ public abstract class RecordConverter {
 
         // Only set external origination time for stream events, not export
         if (eventName != null) {
-            event.getEventHandle().setExternalOriginationTime(Instant.ofEpochMilli(eventCreationTimeMillis));
+            final Instant externalOriginationTime = Instant.ofEpochMilli(eventCreationTimeMillis);
+            event.getEventHandle().setExternalOriginationTime(externalOriginationTime);
+            event.getMetadata().setExternalOriginationTime(externalOriginationTime);
         }
         EventMetadata eventMetadata = event.getMetadata();
 

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/RecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/RecordConverter.java
@@ -14,9 +14,11 @@ import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableInfo;
 
+import java.time.Instant;
 import java.util.Map;
 
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_DYNAMODB_ITEM_VERSION;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
@@ -72,17 +74,29 @@ public abstract class RecordConverter {
      * @param eventName               Event name
      * @throws Exception Exception if failed to write to buffer.
      */
-    public void addToBuffer(final AcknowledgementSet acknowledgementSet, Map<String, Object> data, Map<String, Object> keys, long eventCreationTimeMillis, String eventName) throws Exception {
+    public void addToBuffer(final AcknowledgementSet acknowledgementSet,
+                            final Map<String, Object> data,
+                            final Map<String, Object> keys,
+                            long eventCreationTimeMillis,
+                            long eventVersionNumber,
+                            final String eventName) throws Exception {
         Event event = JacksonEvent.builder()
                 .withEventType(getEventType())
                 .withData(data)
                 .build();
+
+        // Only set external origination time for stream events, not export
+        if (eventName != null) {
+            event.getEventHandle().setExternalOriginationTime(Instant.ofEpochMilli(eventCreationTimeMillis));
+        }
         EventMetadata eventMetadata = event.getMetadata();
 
         eventMetadata.setAttribute(EVENT_TABLE_NAME_METADATA_ATTRIBUTE, tableInfo.getTableName());
         eventMetadata.setAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE, eventCreationTimeMillis);
         eventMetadata.setAttribute(DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE, eventName);
         eventMetadata.setAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE, mapStreamEventNameToBulkAction(eventName));
+        eventMetadata.setAttribute(EVENT_DYNAMODB_ITEM_VERSION, eventVersionNumber);
+
         String partitionKey = getAttributeValue(keys, tableInfo.getMetadata().getPartitionKeyAttributeName());
         eventMetadata.setAttribute(PARTITION_KEY_METADATA_ATTRIBUTE, partitionKey);
 
@@ -101,8 +115,9 @@ public abstract class RecordConverter {
 
     public void addToBuffer(final AcknowledgementSet acknowledgementSet, Map<String, Object> data) throws Exception {
         // Export data doesn't have an event timestamp
-        // Default to current timestamp when the event is added to buffer
-        addToBuffer(acknowledgementSet, data, data, System.currentTimeMillis(), null);
+        // We consider this to be time of 0, meaning stream records will always be considered as newer
+        // than export records
+        addToBuffer(acknowledgementSet, data, data, System.currentTimeMillis(), 0L, null);
     }
 
     private String mapStreamEventNameToBulkAction(final String streamEventName) {

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.enhanced.dynamodb.document.EnhancedDocument;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.Record;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,9 @@ public class StreamRecordConverter extends RecordConverter {
 
     private final Counter changeEventSuccessCounter;
     private final Counter changeEventErrorCounter;
+
+    private Instant currentSecond;
+    private int recordsSeenThisSecond = 0;
 
     public StreamRecordConverter(final BufferAccumulator<org.opensearch.dataprepper.model.record.Record<Event>> bufferAccumulator, TableInfo tableInfo, PluginMetrics pluginMetrics) {
         super(bufferAccumulator, tableInfo);
@@ -64,7 +68,8 @@ public class StreamRecordConverter extends RecordConverter {
             Map<String, Object> keys = convertKeys(record.dynamodb().keys());
 
             try {
-                addToBuffer(acknowledgementSet, data, keys, record.dynamodb().approximateCreationDateTime().toEpochMilli(), record.eventNameAsString());
+                final long eventCreationTimeMillis = calculateTieBreakingVersionFromTimestamp(record.dynamodb().approximateCreationDateTime());
+                addToBuffer(acknowledgementSet, data, keys, record.dynamodb().approximateCreationDateTime().toEpochMilli(), eventCreationTimeMillis, record.eventNameAsString());
                 eventCount++;
             } catch (Exception e) {
                 // will this cause too many logs?
@@ -115,5 +120,20 @@ public class StreamRecordConverter extends RecordConverter {
         }));
         return result;
 
+    }
+
+    private long calculateTieBreakingVersionFromTimestamp(final Instant eventTimeInSeconds) {
+        if (currentSecond == null) {
+            currentSecond = eventTimeInSeconds;
+        } else if (currentSecond.isAfter(eventTimeInSeconds)) {
+            return eventTimeInSeconds.toEpochMilli() * 1000;
+        } else if (currentSecond.isBefore(eventTimeInSeconds)) {
+            recordsSeenThisSecond = 0;
+            currentSecond = eventTimeInSeconds;
+        } else {
+            recordsSeenThisSecond++;
+        }
+
+        return eventTimeInSeconds.toEpochMilli() * 1000 + recordsSeenThisSecond;
     }
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -126,7 +126,7 @@ public class StreamRecordConverter extends RecordConverter {
         if (currentSecond == null) {
             currentSecond = eventTimeInSeconds;
         } else if (currentSecond.isAfter(eventTimeInSeconds)) {
-            return eventTimeInSeconds.toEpochMilli() * 1000;
+            return eventTimeInSeconds.getEpochSecond() * 1_000_000;
         } else if (currentSecond.isBefore(eventTimeInSeconds)) {
             recordsSeenThisSecond = 0;
             currentSecond = eventTimeInSeconds;
@@ -134,6 +134,6 @@ public class StreamRecordConverter extends RecordConverter {
             recordsSeenThisSecond++;
         }
 
-        return eventTimeInSeconds.toEpochMilli() * 1000 + recordsSeenThisSecond;
+        return eventTimeInSeconds.getEpochSecond() * 1_000_000 + recordsSeenThisSecond;
     }
 }

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/ExportRecordConverterTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/ExportRecordConverterTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.ExportRecordConverter.EXPORT_RECORDS_PROCESSED_COUNT;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.ExportRecordConverter.EXPORT_RECORDS_PROCESSING_ERROR_COUNT;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_DYNAMODB_ITEM_VERSION;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.PARTITION_KEY_METADATA_ATTRIBUTE;
@@ -144,5 +145,9 @@ class ExportRecordConverterTest {
         assertThat(event.getMetadata().getAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE), equalTo(OpenSearchBulkActions.INDEX.toString()));
         assertThat(event.getMetadata().getAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE), notNullValue());
         assertThat(event.getMetadata().getAttribute(DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE), nullValue());
+        assertThat(event.getMetadata().getAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE), notNullValue());
+        assertThat(event.getMetadata().getAttribute(EVENT_DYNAMODB_ITEM_VERSION), equalTo(0L));
+        assertThat(event.getEventHandle(), notNullValue());
+        assertThat(event.getEventHandle().getExternalOriginationTime(), nullValue());
     }
 }

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_DYNAMODB_ITEM_VERSION;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.PARTITION_KEY_METADATA_ATTRIBUTE;
@@ -99,7 +100,7 @@ class StreamRecordConverterTest {
 
         int numberOfRecords = random.nextInt(10);
 
-        List<software.amazon.awssdk.services.dynamodb.model.Record> records = buildRecords(numberOfRecords);
+        List<software.amazon.awssdk.services.dynamodb.model.Record> records = buildRecords(numberOfRecords, Instant.now());
 
         StreamRecordConverter recordConverter = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics);
 
@@ -115,7 +116,7 @@ class StreamRecordConverterTest {
     @Test
     void test_writeSingleRecordToBuffer() throws Exception {
 
-        List<software.amazon.awssdk.services.dynamodb.model.Record> records = buildRecords(1);
+        List<software.amazon.awssdk.services.dynamodb.model.Record> records = buildRecords(1, Instant.now());
         final ArgumentCaptor<Record> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
         software.amazon.awssdk.services.dynamodb.model.Record record = records.get(0);
         StreamRecordConverter recordConverter = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics);
@@ -142,27 +143,119 @@ class StreamRecordConverterTest {
         verifyNoInteractions(changeEventErrorCounter);
     }
 
-    private List<software.amazon.awssdk.services.dynamodb.model.Record> buildRecords(int count) {
+    @Test
+    void writingToBuffer_with_nth_event_in_that_second_returns_expected_that_timestamp() throws Exception {
+        final long currentSecond = 1699336310;
+        final Instant timestamp = Instant.ofEpochSecond(currentSecond);
+        final Instant olderSecond = Instant.ofEpochSecond(currentSecond - 1);
+        final Instant newerSecond = Instant.ofEpochSecond(currentSecond + 1);
+
+        List<software.amazon.awssdk.services.dynamodb.model.Record> records = buildRecords(2, timestamp);
+        records.add(buildRecord(olderSecond));
+        records.add(buildRecord(newerSecond));
+
+        final ArgumentCaptor<Record> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
+        StreamRecordConverter recordConverter = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics);
+        doNothing().when(bufferAccumulator).add(recordArgumentCaptor.capture());
+
+        recordConverter.writeToBuffer(null, records);
+
+        verify(bufferAccumulator, times(4)).add(any(Record.class));
+        verify(bufferAccumulator).flush();
+        verify(changeEventSuccessCounter).increment(anyDouble());
+        assertThat(recordArgumentCaptor.getValue().getData(), notNullValue());
+
+        final List<Record> createdEvents = recordArgumentCaptor.getAllValues();
+
+        assertThat(createdEvents.size(), equalTo(records.size()));
+
+        JacksonEvent firstEventForSecond = (JacksonEvent) createdEvents.get(0).getData();
+
+        assertThat(firstEventForSecond.getMetadata(), notNullValue());
+        String partitionKey = records.get(0).dynamodb().keys().get(partitionKeyAttrName).s();
+        String sortKey = records.get(0).dynamodb().keys().get(sortKeyAttrName).s();
+        assertThat(firstEventForSecond.getMetadata().getAttribute(PARTITION_KEY_METADATA_ATTRIBUTE), equalTo(partitionKey));
+        assertThat(firstEventForSecond.getMetadata().getAttribute(SORT_KEY_METADATA_ATTRIBUTE), equalTo(sortKey));
+        assertThat(firstEventForSecond.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), equalTo(partitionKey + "|" + sortKey));
+        assertThat(firstEventForSecond.getMetadata().getAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE), equalTo(OpenSearchBulkActions.INDEX.toString()));
+        assertThat(firstEventForSecond.getMetadata().getAttribute(DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE), equalTo("INSERT"));
+        assertThat(firstEventForSecond.getMetadata().getAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE), equalTo(timestamp.toEpochMilli()));
+        assertThat(firstEventForSecond.getMetadata().getAttribute(EVENT_DYNAMODB_ITEM_VERSION), equalTo(timestamp.toEpochMilli() * 1000));
+        assertThat(firstEventForSecond.getEventHandle(), notNullValue());
+        assertThat(firstEventForSecond.getEventHandle().getExternalOriginationTime(), equalTo(timestamp));
+
+        JacksonEvent secondEventForSameSecond = (JacksonEvent) createdEvents.get(1).getData();
+
+        assertThat(secondEventForSameSecond.getMetadata(), notNullValue());
+        String secondPartitionKey = records.get(1).dynamodb().keys().get(partitionKeyAttrName).s();
+        String secondSortKey = records.get(1).dynamodb().keys().get(sortKeyAttrName).s();
+        assertThat(secondEventForSameSecond.getMetadata().getAttribute(PARTITION_KEY_METADATA_ATTRIBUTE), equalTo(secondPartitionKey));
+        assertThat(secondEventForSameSecond.getMetadata().getAttribute(SORT_KEY_METADATA_ATTRIBUTE), equalTo(secondSortKey));
+        assertThat(secondEventForSameSecond.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), equalTo(secondPartitionKey + "|" + secondSortKey));
+        assertThat(secondEventForSameSecond.getMetadata().getAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE), equalTo(OpenSearchBulkActions.INDEX.toString()));
+        assertThat(secondEventForSameSecond.getMetadata().getAttribute(DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE), equalTo("INSERT"));
+        assertThat(secondEventForSameSecond.getMetadata().getAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE), equalTo(timestamp.toEpochMilli()));
+        assertThat(secondEventForSameSecond.getMetadata().getAttribute(EVENT_DYNAMODB_ITEM_VERSION), equalTo(timestamp.toEpochMilli() * 1000 + 1));
+        assertThat(secondEventForSameSecond.getEventHandle(), notNullValue());
+        assertThat(secondEventForSameSecond.getEventHandle().getExternalOriginationTime(), equalTo(timestamp));
+
+        JacksonEvent thirdEventWithOlderSecond = (JacksonEvent) createdEvents.get(2).getData();
+
+        assertThat(thirdEventWithOlderSecond.getMetadata(), notNullValue());
+        String thirdPartitionKey = records.get(2).dynamodb().keys().get(partitionKeyAttrName).s();
+        String thirdSortKey = records.get(2).dynamodb().keys().get(sortKeyAttrName).s();
+        assertThat(thirdEventWithOlderSecond.getMetadata().getAttribute(PARTITION_KEY_METADATA_ATTRIBUTE), equalTo(thirdPartitionKey));
+        assertThat(thirdEventWithOlderSecond.getMetadata().getAttribute(SORT_KEY_METADATA_ATTRIBUTE), equalTo(thirdSortKey));
+        assertThat(thirdEventWithOlderSecond.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), equalTo(thirdPartitionKey + "|" + thirdSortKey));
+        assertThat(thirdEventWithOlderSecond.getMetadata().getAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE), equalTo(OpenSearchBulkActions.INDEX.toString()));
+        assertThat(thirdEventWithOlderSecond.getMetadata().getAttribute(DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE), equalTo("INSERT"));
+        assertThat(thirdEventWithOlderSecond.getMetadata().getAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE), equalTo(olderSecond.toEpochMilli()));
+        assertThat(thirdEventWithOlderSecond.getMetadata().getAttribute(EVENT_DYNAMODB_ITEM_VERSION), equalTo(olderSecond.toEpochMilli() * 1000));
+        assertThat(thirdEventWithOlderSecond.getEventHandle(), notNullValue());
+        assertThat(thirdEventWithOlderSecond.getEventHandle().getExternalOriginationTime(), equalTo(olderSecond));
+
+        JacksonEvent fourthEventWithNewerSecond = (JacksonEvent) createdEvents.get(3).getData();
+
+        assertThat(fourthEventWithNewerSecond.getMetadata(), notNullValue());
+        String fourthPartitionKey = records.get(3).dynamodb().keys().get(partitionKeyAttrName).s();
+        String fourthSortKey = records.get(3).dynamodb().keys().get(sortKeyAttrName).s();
+        assertThat(fourthEventWithNewerSecond.getMetadata().getAttribute(PARTITION_KEY_METADATA_ATTRIBUTE), equalTo(fourthPartitionKey));
+        assertThat(fourthEventWithNewerSecond.getMetadata().getAttribute(SORT_KEY_METADATA_ATTRIBUTE), equalTo(fourthSortKey));
+        assertThat(fourthEventWithNewerSecond.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), equalTo(fourthPartitionKey + "|" + fourthSortKey));
+        assertThat(fourthEventWithNewerSecond.getMetadata().getAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE), equalTo(OpenSearchBulkActions.INDEX.toString()));
+        assertThat(fourthEventWithNewerSecond.getMetadata().getAttribute(DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE), equalTo("INSERT"));
+        assertThat(fourthEventWithNewerSecond.getMetadata().getAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE), equalTo(newerSecond.toEpochMilli()));
+        assertThat(fourthEventWithNewerSecond.getMetadata().getAttribute(EVENT_DYNAMODB_ITEM_VERSION), equalTo(newerSecond.toEpochMilli() * 1000));
+        assertThat(fourthEventWithNewerSecond.getEventHandle(), notNullValue());
+        assertThat(fourthEventWithNewerSecond.getEventHandle().getExternalOriginationTime(), equalTo(newerSecond));
+
+        verifyNoInteractions(changeEventErrorCounter);
+    }
+
+    private List<software.amazon.awssdk.services.dynamodb.model.Record> buildRecords(int count, final Instant creationTime) {
         List<software.amazon.awssdk.services.dynamodb.model.Record> records = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            Map<String, AttributeValue> data = Map.of(
-                    partitionKeyAttrName, AttributeValue.builder().s(UUID.randomUUID().toString()).build(),
-                    sortKeyAttrName, AttributeValue.builder().s(UUID.randomUUID().toString()).build());
-
-            StreamRecord streamRecord = StreamRecord.builder()
-                    .newImage(data)
-                    .keys(data)
-                    .sequenceNumber(UUID.randomUUID().toString())
-                    .approximateCreationDateTime(Instant.now())
-                    .build();
-            software.amazon.awssdk.services.dynamodb.model.Record record = software.amazon.awssdk.services.dynamodb.model.Record.builder()
-                    .dynamodb(streamRecord)
-                    .eventName(OperationType.INSERT)
-                    .build();
-            records.add(record);
+            records.add(buildRecord(creationTime));
         }
 
         return records;
+    }
+
+    private software.amazon.awssdk.services.dynamodb.model.Record buildRecord(final Instant creationTime) {
+        Map<String, AttributeValue> data = Map.of(
+                partitionKeyAttrName, AttributeValue.builder().s(UUID.randomUUID().toString()).build(),
+                sortKeyAttrName, AttributeValue.builder().s(UUID.randomUUID().toString()).build());
+        StreamRecord streamRecord = StreamRecord.builder()
+                .newImage(data)
+                .keys(data)
+                .sequenceNumber(UUID.randomUUID().toString())
+                .approximateCreationDateTime(creationTime)
+                .build();
+        software.amazon.awssdk.services.dynamodb.model.Record record = software.amazon.awssdk.services.dynamodb.model.Record.builder()
+                .dynamodb(streamRecord)
+                .eventName(OperationType.INSERT)
+                .build();
+        return record;
     }
 
 }

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoaderTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoaderTest.java
@@ -93,7 +93,7 @@ class DataFileLoaderTest {
 
     private final Random random = new Random();
 
-    private final int total = random.nextInt(10);
+    private final int total = random.nextInt(10) + 1;
 
     @BeforeEach
     void setup() {


### PR DESCRIPTION
… stream events

### Description
This change adds a new metadata field for DymamoDB Events, `dynamodb_item_version`. This version is derived from the timestamp for stream events, and set to `0L` for export Events, in order to give stream events precedence over export

This change also writes stream event timestamps to the `externalOriginationMetadata` for stream Events. This will provide an out of the box external latency metric for ddb streams.

The `dynamodb_item_version` metadata is intended for use with the `document_version` field of the OpenSearch sink to always take the latest Events. 

Since the timestamp for stream Events is in seconds, we are differentiating stream events received in the same second for a shard with the formula `ddb_version = ddbEventTimestamp.getEpochSecond() * 1_000_000 + recordsSeenThisSecond`. 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
