### PR TITLE
Configurable wait delay in the random string source

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/source/RandomStringSource.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/source/RandomStringSource.java
@@ -6,69 +6,68 @@
 package org.opensearch.dataprepper.plugins.source;
 
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
  * Generates a random string every 500 milliseconds. Intended to be used for testing setups
  */
-@DataPrepperPlugin(name = "random", pluginType = Source.class)
+@DataPrepperPlugin(name = "random", pluginType = Source.class, pluginConfigurationType = RandomStringSourceConfig.class)
 public class RandomStringSource implements Source<Record<Event>> {
-
     private static final Logger LOG = LoggerFactory.getLogger(RandomStringSource.class);
+    private static final int BUFFER_WAIT = 500;
+    private final long waitTimeInMillis;
 
-    private ExecutorService executorService;
     private volatile boolean stop = false;
+    private Thread thread;
 
-    private void setExecutorService() {
-        if(executorService == null || executorService.isShutdown()) {
-            executorService = Executors.newSingleThreadExecutor(
-                    new ThreadFactoryBuilder().setDaemon(false).setNameFormat("random-source-pool-%d").build()
-            );
-        }
+    @DataPrepperPluginConstructor
+    public RandomStringSource(final RandomStringSourceConfig config) {
+        waitTimeInMillis = config.getWaitDelay().toMillis();
     }
 
     @Override
     public void start(final Buffer<Record<Event>> buffer) {
-        setExecutorService();
-        executorService.execute(() -> {
+        if(thread != null) {
+            throw new IllegalStateException("This source has already started.");
+        }
+
+        thread = new Thread(() -> {
             while (!stop) {
                 try {
                     LOG.debug("Writing to buffer");
                     final Record<Event> record = generateRandomStringEventRecord();
-                    buffer.write(record, 500);
-                    Thread.sleep(500);
+                    buffer.write(record, BUFFER_WAIT);
+                    Thread.sleep(waitTimeInMillis);
                 } catch (final InterruptedException e) {
                     break;
                 } catch (final TimeoutException e) {
                     // Do nothing
                 }
             }
-        });
+        },
+                "random-source");
+
+        thread.setDaemon(false);
+        thread.start();
     }
 
     @Override
     public void stop() {
         stop = true;
-        executorService.shutdown();
         try {
-            if (!executorService.awaitTermination(500, TimeUnit.MILLISECONDS)) {
-                executorService.shutdownNow();
-            }
-        } catch (final InterruptedException ex) {
-            executorService.shutdownNow();
+            thread.join(waitTimeInMillis + BUFFER_WAIT + 100);
+        } catch (final InterruptedException e) {
+            thread.interrupt();
         }
     }
 

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/source/RandomStringSourceConfig.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/source/RandomStringSourceConfig.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Duration;
+
+public class RandomStringSourceConfig {
+    @JsonProperty("wait_delay")
+    private Duration waitDelay = Duration.ofMillis(500);
+
+    public Duration getWaitDelay() {
+        return waitDelay;
+    }
+}


### PR DESCRIPTION
### Description

Adds the `wait_delay` configuration to the `random` source. Also, uses a single thread rather than an executor and increases test coverage in that class.
 
### Issues Resolved

Resolves #3601
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
