### PR TITLE
Visibility timeout extension configuration changes

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/SqsOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/SqsOptions.java
@@ -18,7 +18,7 @@ public class SqsOptions {
     private static final int DEFAULT_MAXIMUM_MESSAGES = 10;
     private static final Boolean DEFAULT_VISIBILITY_DUPLICATE_PROTECTION = false;
     private static final Duration DEFAULT_VISIBILITY_TIMEOUT_SECONDS = Duration.ofSeconds(30);
-    private static final Duration DEFAULT_MAX_VISIBILITY_TIMEOUT_EXTENSION = Duration.ofSeconds(1800); // 30 minutes
+    private static final Duration DEFAULT_MAX_VISIBILITY_TIMEOUT_EXTENSION = Duration.ofHours(2);
     private static final Duration DEFAULT_WAIT_TIME_SECONDS = Duration.ofSeconds(20);
     private static final Duration DEFAULT_POLL_DELAY_SECONDS = Duration.ofSeconds(0);
 
@@ -39,9 +39,9 @@ public class SqsOptions {
     @JsonProperty("visibility_duplication_protection")
     private Boolean visibilityDuplicateProtection = DEFAULT_VISIBILITY_DUPLICATE_PROTECTION;
 
-    @JsonProperty("max_visibility_timeout_extension")
+    @JsonProperty("maximum_visibility_timeout_extension")
     @DurationMin(seconds = 30)
-    @DurationMax(seconds = 3600)
+    @DurationMax(hours = 24)
     private Duration maxVisibilityTimeoutExtension = DEFAULT_MAX_VISIBILITY_TIMEOUT_EXTENSION;
 
     @JsonProperty("wait_time")


### PR DESCRIPTION
### Description

This makes a few changes to the new visibility timeout extension feature:

* Rename the configuration to `maximum_visibility_timeout_extension`. This remains consistent with other names such as `maximum_messages`.
* Increase the default maximum extension timeout to 2 hours.
* Increase the largest extension timeout allowed to 24 hours.
 
### Issues Resolved

N/A

Changes to the #3565 PR to help finish up #2485.
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
