### PR TITLE
Add Kafka Producer metrics for send record failures

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerFactory.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.kafka.producer;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
@@ -63,9 +64,11 @@ public class KafkaCustomProducerFactory {
         final KafkaProducer<Object, Object> producer = new KafkaProducer<>(properties, keyDeserializer, valueSerializer);
         final DLQSink dlqSink = new DLQSink(pluginFactory, kafkaProducerConfig, pluginSetting);
         final KafkaTopicProducerMetrics topicMetrics = new KafkaTopicProducerMetrics(topic.getName(), pluginMetrics, topicNameInMetrics);
+        final String topicName = ObjectUtils.isEmpty(kafkaProducerConfig.getTopic()) ? null : kafkaProducerConfig.getTopic().getName();
+        final SchemaService schemaService = new SchemaService.SchemaServiceBuilder().getFetchSchemaService(topicName, kafkaProducerConfig.getSchemaConfig()).build();
         return new KafkaCustomProducer(producer,
             kafkaProducerConfig, dlqSink,
-            expressionEvaluator, Objects.nonNull(sinkContext) ? sinkContext.getTagsTargetKey() : null, topicMetrics);
+            expressionEvaluator, Objects.nonNull(sinkContext) ? sinkContext.getTagsTargetKey() : null, topicMetrics, schemaService);
     }
     private void prepareTopicAndSchema(final KafkaProducerConfig kafkaProducerConfig) {
         checkTopicCreationCriteriaAndCreateTopic(kafkaProducerConfig);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicProducerMetrics.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/KafkaTopicProducerMetrics.java
@@ -28,13 +28,18 @@ public class KafkaTopicProducerMetrics {
     static final String BYTE_SEND_TOTAL = "byteSendTotal";
     static final String RECORD_SEND_RATE_MAP_VALUE = "recordSendRate";
     static final String RECORD_SEND_TOTAL_MAP_VALUE = "recordSendTotal";
-
+    static final String NUMBER_OF_RAW_DATA_SEND_ERRORS = "numberOfRawDataSendErrors";
+    static final String NUMBER_OF_RECORD_SEND_ERRORS = "numberOfRecordSendErrors";
+    static final String NUMBER_OF_RECORD_PROCESSING_ERRORS = "numberOfRecordProcessingErrors";
     private final String topicName;
     private Map<String, String> metricsNameMap;
     private Map<KafkaProducer, Map<String, Double>> metricValues;
     private final PluginMetrics pluginMetrics;
     private final Counter numberOfRecordsSent;
     private final Counter numberOfBytesSent;
+    private final Counter numberOfRawDataSendErrors;
+    private final Counter numberOfRecordSendErrors;
+    private final Counter numberOfRecordProcessingErrors;
 
     public KafkaTopicProducerMetrics(final String topicName, final PluginMetrics pluginMetrics,
                                      final boolean topicNameInMetrics) {
@@ -44,6 +49,9 @@ public class KafkaTopicProducerMetrics {
         initializeMetricNamesMap(topicNameInMetrics);
         this.numberOfRecordsSent = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_RECORDS_SENT, topicNameInMetrics));
         this.numberOfBytesSent = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_BYTES_SENT, topicNameInMetrics));
+        this.numberOfRawDataSendErrors = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_RAW_DATA_SEND_ERRORS, topicNameInMetrics));
+        this.numberOfRecordSendErrors = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_RECORD_SEND_ERRORS, topicNameInMetrics));
+        this.numberOfRecordProcessingErrors = pluginMetrics.counter(getTopicMetricName(NUMBER_OF_RECORD_PROCESSING_ERRORS, topicNameInMetrics));
     }
 
     private void initializeMetricNamesMap(final boolean topicNameInMetrics) {
@@ -83,6 +91,18 @@ public class KafkaTopicProducerMetrics {
 
     Counter getNumberOfBytesSent() {
         return numberOfBytesSent;
+    }
+
+    public Counter getNumberOfRawDataSendErrors() {
+        return numberOfRawDataSendErrors;
+    }
+
+    public Counter getNumberOfRecordSendErrors() {
+        return numberOfRecordSendErrors;
+    }
+
+    public Counter getNumberOfRecordProcessingErrors() {
+        return numberOfRecordProcessingErrors;
     }
 
     private String getTopicMetricName(final String metricName, final boolean topicNameInMetrics) {


### PR DESCRIPTION
### Description
Add Kafka Producer metrics for send record failures
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
