### PR TITLE
Split loading plugin arguments from the Application Context

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ApplicationContextToTypedSuppliers.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ApplicationContextToTypedSuppliers.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugin;
+
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Injects types from the Application Context and makes them available
+ * for plugin constructors.
+ * <p>
+ * If you are providing a direct pass-through from the Application Context
+ * to a plugin constructor, add it here. It is the simplest place for it.
+ * Otherwise, you can add it to the {@link DefaultPluginFactory} directly.
+ */
+@Named
+class ApplicationContextToTypedSuppliers {
+    private final Map<Class<?>, Supplier<Object>> typedSuppliers;
+
+    @Inject
+    ApplicationContextToTypedSuppliers(
+            final EventFactory eventFactory,
+            final AcknowledgementSetManager acknowledgementSetManager,
+            @Autowired(required = false) final CircuitBreaker circuitBreaker
+    ) {
+        Objects.requireNonNull(eventFactory);
+        Objects.requireNonNull(acknowledgementSetManager);
+
+        typedSuppliers = Map.of(
+                EventFactory.class, () -> eventFactory,
+                AcknowledgementSetManager.class, () -> acknowledgementSetManager,
+                CircuitBreaker.class, () -> circuitBreaker
+        );
+    }
+
+    /**
+     * Gets a map of {@link Class} to a {@link Supplier} for each class. The
+     * {@link Supplier} supplies an instance of that type. The supplied value
+     * may be <b>null</b> for some types.
+     *
+     * @return Map of types to suppliers of concrete implementations.
+     */
+    Map<Class<?>, Supplier<Object>> getArgumentsSuppliers() {
+        return typedSuppliers;
+    }
+}

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContext.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContext.java
@@ -5,16 +5,13 @@
 
 package org.opensearch.dataprepper.plugin;
 
-import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
-import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
-import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PipelineDescription;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginDefinitionException;
+import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
-import org.opensearch.dataprepper.model.event.EventFactory;
-import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 
@@ -60,32 +57,26 @@ class ComponentPluginArgumentsContext implements PluginArgumentsContext {
             typedArgumentsSuppliers.put(PluginFactory.class, () -> builder.pluginFactory);
         }
 
-        if (builder.eventFactory != null) {
-            typedArgumentsSuppliers.put(EventFactory.class, () -> builder.eventFactory);
-        }
-
-        if (builder.acknowledgementSetManager != null) {
-            typedArgumentsSuppliers.put(AcknowledgementSetManager.class, () -> builder.acknowledgementSetManager);
+        if (builder.sinkContext != null) {
+            typedArgumentsSuppliers.put(SinkContext.class, () -> builder.sinkContext);
         }
 
         if (builder.pluginConfigObservable != null) {
             typedArgumentsSuppliers.put(PluginConfigObservable.class, () -> builder.pluginConfigObservable);
         }
 
-        if (builder.sinkContext != null) {
-            typedArgumentsSuppliers.put(SinkContext.class, () -> builder.sinkContext);
+        if(builder.additionalTypeArgumentSuppliers != null) {
+            typedArgumentsSuppliers.putAll(builder.additionalTypeArgumentSuppliers);
         }
-
-        typedArgumentsSuppliers.put(CircuitBreaker.class, () -> builder.circuitBreaker);
     }
 
     @Override
     public Object[] createArguments(final Class<?>[] parameterTypes, final Object ... args) {
-        Map<Class<?>, Supplier<Object>> optionalArgumentsSuppliers = new HashMap<>();
+        final Map<Class<?>, Supplier<Object>> optionalArgumentsSuppliers = new HashMap<>();
         for (final Object arg: args) {
             if (Objects.nonNull(arg)) {
                 optionalArgumentsSuppliers.put(arg.getClass(), () -> arg);
-                for (final Class interfaceClass: arg.getClass().getInterfaces()) {
+                for (final Class<?> interfaceClass: arg.getClass().getInterfaces()) {
                     optionalArgumentsSuppliers.put(interfaceClass, () -> arg);
                 }
             }
@@ -134,11 +125,9 @@ class ComponentPluginArgumentsContext implements PluginArgumentsContext {
         private PluginFactory pluginFactory;
         private PipelineDescription pipelineDescription;
         private BeanFactory beanFactory;
-        private EventFactory eventFactory;
-        private AcknowledgementSetManager acknowledgementSetManager;
-        private PluginConfigObservable pluginConfigObservable;
         private SinkContext sinkContext;
-        private CircuitBreaker circuitBreaker;
+        private PluginConfigObservable pluginConfigObservable;
+        private Map<Class<?>, Supplier<Object>> additionalTypeArgumentSuppliers;
 
         Builder withPluginConfiguration(final Object pluginConfiguration) {
             this.pluginConfiguration = pluginConfiguration;
@@ -147,16 +136,6 @@ class ComponentPluginArgumentsContext implements PluginArgumentsContext {
 
         Builder withPluginSetting(final PluginSetting pluginSetting) {
             this.pluginSetting = pluginSetting;
-            return this;
-        }
-
-        Builder withEventFactory(final EventFactory eventFactory) {
-            this.eventFactory = eventFactory;
-            return this;
-        }
-
-        Builder withAcknowledgementSetManager(final AcknowledgementSetManager acknowledgementSetManager) {
-            this.acknowledgementSetManager = acknowledgementSetManager;
             return this;
         }
 
@@ -185,8 +164,8 @@ class ComponentPluginArgumentsContext implements PluginArgumentsContext {
             return this;
         }
 
-        Builder withCircuitBreaker(final CircuitBreaker circuitBreaker) {
-            this.circuitBreaker = circuitBreaker;
+        Builder withTypeArgumentSuppliers(final Map<Class<?>, Supplier<Object>> additionalTypeArgumentSuppliers) {
+            this.additionalTypeArgumentSuppliers = additionalTypeArgumentSuppliers;
             return this;
         }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginFactory.java
@@ -5,18 +5,14 @@
 
 package org.opensearch.dataprepper.plugin;
 
-import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
-import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
-import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.plugin.NoPluginFoundException;
+import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
-import org.opensearch.dataprepper.event.DefaultEventFactory;
-import org.opensearch.dataprepper.acknowledgements.DefaultAcknowledgementSetManager;
+import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.DependsOn;
 
 import javax.inject.Inject;
@@ -42,10 +38,8 @@ public class DefaultPluginFactory implements PluginFactory {
     private final PluginCreator pluginCreator;
     private final PluginConfigurationConverter pluginConfigurationConverter;
     private final PluginBeanFactoryProvider pluginBeanFactoryProvider;
-    private final DefaultEventFactory eventFactory;
-    private final DefaultAcknowledgementSetManager acknowledgementSetManager;
     private final PluginConfigurationObservableFactory pluginConfigurationObservableFactory;
-    private final CircuitBreaker circuitBreaker;
+    private final ApplicationContextToTypedSuppliers applicationContextToTypedSuppliers;
 
     @Inject
     DefaultPluginFactory(
@@ -53,12 +47,9 @@ public class DefaultPluginFactory implements PluginFactory {
             final PluginCreator pluginCreator,
             final PluginConfigurationConverter pluginConfigurationConverter,
             final PluginBeanFactoryProvider pluginBeanFactoryProvider,
-            final DefaultEventFactory eventFactory,
-            final DefaultAcknowledgementSetManager acknowledgementSetManager,
             final PluginConfigurationObservableFactory pluginConfigurationObservableFactory,
-            @Autowired(required = false) final CircuitBreaker circuitBreaker
-            ) {
-        this.circuitBreaker = circuitBreaker;
+            final ApplicationContextToTypedSuppliers applicationContextToTypedSuppliers) {
+        this.applicationContextToTypedSuppliers = applicationContextToTypedSuppliers;
         Objects.requireNonNull(pluginProviderLoader);
         Objects.requireNonNull(pluginConfigurationObservableFactory);
         this.pluginCreator = Objects.requireNonNull(pluginCreator);
@@ -66,8 +57,6 @@ public class DefaultPluginFactory implements PluginFactory {
 
         this.pluginProviders = Objects.requireNonNull(pluginProviderLoader.getPluginProviders());
         this.pluginBeanFactoryProvider = Objects.requireNonNull(pluginBeanFactoryProvider);
-        this.eventFactory = Objects.requireNonNull(eventFactory);
-        this.acknowledgementSetManager = Objects.requireNonNull(acknowledgementSetManager);
         this.pluginConfigurationObservableFactory = pluginConfigurationObservableFactory;
 
         if(pluginProviders.isEmpty()) {
@@ -131,12 +120,10 @@ public class DefaultPluginFactory implements PluginFactory {
                 .withPipelineDescription(pluginSetting)
                 .withPluginConfiguration(configuration)
                 .withPluginFactory(this)
-                .withBeanFactory(pluginBeanFactoryProvider.get())
-                .withEventFactory(eventFactory)
-                .withAcknowledgementSetManager(acknowledgementSetManager)
-                .withPluginConfigurationObservable(pluginConfigObservable)
                 .withSinkContext(sinkContext)
-                .withCircuitBreaker(circuitBreaker)
+                .withBeanFactory(pluginBeanFactoryProvider.get())
+                .withPluginConfigurationObservable(pluginConfigObservable)
+                .withTypeArgumentSuppliers(applicationContextToTypedSuppliers.getArgumentsSuppliers())
                 .build();
     }
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ApplicationContextToTypedSuppliersTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ApplicationContextToTypedSuppliersTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugin;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
+import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
+import org.opensearch.dataprepper.model.event.EventFactory;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationContextToTypedSuppliersTest {
+    @Mock
+    private EventFactory eventFactory;
+
+    @Mock
+    private AcknowledgementSetManager acknowledgementSetManager;
+
+    @Mock
+    private CircuitBreaker circuitBreaker;
+
+    private ApplicationContextToTypedSuppliers createObjectUnderTest() {
+        return new ApplicationContextToTypedSuppliers(
+                eventFactory,
+                acknowledgementSetManager,
+                circuitBreaker
+        );
+    }
+
+    @Test
+    void constructor_throws_with_null_EventFactory() {
+        eventFactory = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void constructor_throws_with_null_AcknowledgementSetManager() {
+        acknowledgementSetManager = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void getArgumentsSuppliers_returns_map_with_expected_classes() {
+        final Map<Class<?>, Supplier<Object>> argumentsSuppliers = createObjectUnderTest().getArgumentsSuppliers();
+
+        assertThat(argumentsSuppliers.size(), equalTo(3));
+
+        assertThat(argumentsSuppliers, hasKey(EventFactory.class));
+        assertThat(argumentsSuppliers.get(EventFactory.class), notNullValue());
+        assertThat(argumentsSuppliers.get(EventFactory.class).get(), equalTo(eventFactory));
+
+        assertThat(argumentsSuppliers, hasKey(AcknowledgementSetManager.class));
+        assertThat(argumentsSuppliers.get(AcknowledgementSetManager.class), notNullValue());
+        assertThat(argumentsSuppliers.get(AcknowledgementSetManager.class).get(), equalTo(acknowledgementSetManager));
+
+        assertThat(argumentsSuppliers, hasKey(CircuitBreaker.class));
+        assertThat(argumentsSuppliers.get(CircuitBreaker.class), notNullValue());
+        assertThat(argumentsSuppliers.get(CircuitBreaker.class).get(), equalTo(circuitBreaker));
+    }
+
+    @Test
+    void getArgumentsSuppliers_returns_map_with_null_optional_CircuitBreaker() {
+        circuitBreaker = null;
+
+        final Map<Class<?>, Supplier<Object>> argumentsSuppliers = createObjectUnderTest().getArgumentsSuppliers();
+
+        assertThat(argumentsSuppliers.size(), equalTo(3));
+
+        assertThat(argumentsSuppliers, hasKey(EventFactory.class));
+        assertThat(argumentsSuppliers.get(EventFactory.class), notNullValue());
+        assertThat(argumentsSuppliers.get(EventFactory.class).get(), equalTo(eventFactory));
+
+        assertThat(argumentsSuppliers, hasKey(AcknowledgementSetManager.class));
+        assertThat(argumentsSuppliers.get(AcknowledgementSetManager.class), notNullValue());
+        assertThat(argumentsSuppliers.get(AcknowledgementSetManager.class).get(), equalTo(acknowledgementSetManager));
+
+        assertThat(argumentsSuppliers, hasKey(CircuitBreaker.class));
+        assertThat(argumentsSuppliers.get(CircuitBreaker.class), notNullValue());
+        assertThat(argumentsSuppliers.get(CircuitBreaker.class).get(), nullValue());
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContextTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ComponentPluginArgumentsContextTest.java
@@ -21,6 +21,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -52,6 +53,10 @@ class ComponentPluginArgumentsContextTest {
             super(name, settings);
         }
     }
+
+    private static class ArgumentClass1 { }
+
+    private static class ArgumentClass2 { }
 
     @Test
     void createArguments_with_unavailable_argument_should_throw() {
@@ -124,6 +129,51 @@ class ComponentPluginArgumentsContextTest {
 
         assertThat(objectUnderTest.createArguments(new Class[] { PluginConfigObservable.class }),
                 equalTo(new Object[] {pluginConfigObservable}));
+    }
+
+    @Test
+    void createArguments_with_single_class_from_TypeArgumentSuppliers() {
+        final ArgumentClass1 argumentInstance1 = mock(ArgumentClass1.class);
+        final Map<Class<?>, Supplier<Object>> typeArgumentSuppliers = Map.of(ArgumentClass1.class, () -> argumentInstance1);
+
+        final ComponentPluginArgumentsContext objectUnderTest = new ComponentPluginArgumentsContext.Builder()
+                .withPluginSetting(pluginSetting)
+                .withTypeArgumentSuppliers(typeArgumentSuppliers)
+                .build();
+
+        assertThat(objectUnderTest.createArguments(new Class[] { ArgumentClass1.class }),
+                equalTo(new Object[] { argumentInstance1 }));
+    }
+
+    @Test
+    void createArguments_with_single_null_value_from_TypeArgumentSuppliers() {
+        final Map<Class<?>, Supplier<Object>> typeArgumentSuppliers = Map.of(ArgumentClass1.class, () -> null);
+
+        final ComponentPluginArgumentsContext objectUnderTest = new ComponentPluginArgumentsContext.Builder()
+                .withPluginSetting(pluginSetting)
+                .withTypeArgumentSuppliers(typeArgumentSuppliers)
+                .build();
+
+        assertThat(objectUnderTest.createArguments(new Class[] { ArgumentClass1.class }),
+                equalTo(new Object[] { null }));
+    }
+
+    @Test
+    void createArguments_with_multiple_classes_from_TypeArgumentSuppliers() {
+        final ArgumentClass1 argumentInstance1 = mock(ArgumentClass1.class);
+        final ArgumentClass2 argumentInstance2 = mock(ArgumentClass2.class);
+        final Map<Class<?>, Supplier<Object>> typeArgumentSuppliers = Map.of(
+                ArgumentClass1.class, () -> argumentInstance1,
+                ArgumentClass2.class, () -> argumentInstance2
+        );
+
+        final ComponentPluginArgumentsContext objectUnderTest = new ComponentPluginArgumentsContext.Builder()
+                .withPluginSetting(pluginSetting)
+                .withTypeArgumentSuppliers(typeArgumentSuppliers)
+                .build();
+
+        assertThat(objectUnderTest.createArguments(new Class[] { ArgumentClass2.class, ArgumentClass1.class }),
+                equalTo(new Object[] {argumentInstance2, argumentInstance1}));
     }
 
     @Test


### PR DESCRIPTION
### Description

When working on #3595, I found that adding a new type directly from the Application Context into a Data Prepper plugin constructor requires quite a few code touches. Not only that, but it becomes hard to test new types like `CircuitBreaker` that are optional and can be `null`.

This PR splits the work for getting instances from the Application Context into a new class - `ApplicationContextToTypedSuppliers`. Any type that is just passed directly can use this mechanisms. 

Some classes remain in `DefaultPluginFactory` because there is additional logic within the plugin framework for them. For example, they are special arguments per-plugin, or additional work is performed from them (e.g. BeanFactory and PluginConfigurationObservableFactory).
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
