### PR TITLE
Flaky test work: Updated the Router_ThreeRoutesIT test with a longer timeout.

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/Router_ThreeRoutesIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/Router_ThreeRoutesIT.java
@@ -79,7 +79,7 @@ class Router_ThreeRoutesIT {
 
         inMemorySourceAccessor.submit(TESTING_KEY, allEvents);
 
-        await().atMost(400, TimeUnit.MILLISECONDS)
+        await().atMost(2, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
                     assertThat(inMemorySinkAccessor.get(sourceKeyToReceiveAll), not(empty()));
                 });
@@ -101,7 +101,7 @@ class Router_ThreeRoutesIT {
 
         inMemorySourceAccessor.submit(TESTING_KEY, allEvents);
 
-        await().atMost(400, TimeUnit.MILLISECONDS)
+        await().atMost(2, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
                     assertThat(inMemorySinkAccessor.get(ALPHA_SOURCE_KEY), not(empty()));
                     assertThat(inMemorySinkAccessor.get(BETA_SOURCE_KEY), not(empty()));
@@ -136,9 +136,9 @@ class Router_ThreeRoutesIT {
 
         inMemorySourceAccessor.submit(TESTING_KEY, randomEvents);
 
-        Thread.sleep(1000);
-
-        assertThat(inMemorySinkAccessor.get(sourceKey), empty());
+        await().during(1200, TimeUnit.MILLISECONDS)
+                .pollDelay(50, TimeUnit.MILLISECONDS)
+                .until(() -> inMemorySinkAccessor.get(sourceKey), empty());
     }
 
     private List<Record<Event>> createEvents(final String value, final int numberToCreate) {


### PR DESCRIPTION
### Description

This has two changes:

* Updates the timeout for reaching a condition. This condition uses Awaitility, so it doesn't need to take that long, but this gives it more time. Hopefully this helps with some flaky tests.
* Use Awaitility's [`during()` method](https://github.com/awaitility/awaitility/wiki/Usage#assert-that-a-value-is-maintained) to assert that a condition is true over time rather than sleeping.
 
### Issues Resolved

None, but contributes toward some flaky tests in #3481.
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
