### PR TITLE
Updates data-prepper-api fully to JUnit 5

### DIFF
--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     implementation 'org.apache.parquet:parquet-common:1.13.1'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation libs.commons.lang3
-    testImplementation testLibs.junit.vintage
     testImplementation project(':data-prepper-test-common')
     testImplementation 'org.skyscreamer:jsonassert:1.5.1'
     testImplementation libs.commons.io

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/CheckpointStateTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/CheckpointStateTest.java
@@ -5,15 +5,16 @@
 
 package org.opensearch.dataprepper.model;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class CheckpointStateTest {
+
+class CheckpointStateTest {
     private static final int TEST_NUM_CHECKED_RECORDS = 3;
 
     @Test
-    public void testSimple() {
+    void testSimple() {
         final CheckpointState checkpointState = new CheckpointState(TEST_NUM_CHECKED_RECORDS);
         assertEquals(TEST_NUM_CHECKED_RECORDS, checkpointState.getNumRecordsToBeChecked());
     }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/AbstractBufferTest.java
@@ -7,7 +7,6 @@ package org.opensearch.dataprepper.model.buffer;
 
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Statistic;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.metrics.MetricNames;
@@ -29,6 +28,10 @@ import java.util.Queue;
 import java.util.StringJoiner;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AbstractBufferTest {
     private static final String BUFFER_NAME = "testBuffer";
@@ -58,10 +61,10 @@ public class AbstractBufferTest {
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.RECORDS_WRITTEN).toString());
         final List<Measurement> writeTimeMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.WRITE_TIME_ELAPSED).toString());
-        Assert.assertEquals(1, recordsWrittenMeasurements.size());
-        Assert.assertEquals(5.0, recordsWrittenMeasurements.get(0).getValue(), 0);
-        Assert.assertEquals(5.0, MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.COUNT).getValue(), 0);
-        Assert.assertTrue(
+        assertEquals(1, recordsWrittenMeasurements.size());
+        assertEquals(5.0, recordsWrittenMeasurements.get(0).getValue(), 0);
+        assertEquals(5.0, MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.COUNT).getValue(), 0);
+        assertTrue(
                 MetricsTestUtil.isBetween(
                         MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
                         0.45,
@@ -85,10 +88,10 @@ public class AbstractBufferTest {
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.RECORDS_WRITTEN).toString());
         final List<Measurement> writeTimeMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.WRITE_TIME_ELAPSED).toString());
-        Assert.assertEquals(1, recordsWrittenMeasurements.size());
-        Assert.assertEquals(5.0, recordsWrittenMeasurements.get(0).getValue(), 0);
-        Assert.assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.COUNT).getValue(), 0);
-        Assert.assertTrue(
+        assertEquals(1, recordsWrittenMeasurements.size());
+        assertEquals(5.0, recordsWrittenMeasurements.get(0).getValue(), 0);
+        assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.COUNT).getValue(), 0);
+        assertTrue(
                 MetricsTestUtil.isBetween(
                         MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
                         0.05,
@@ -117,17 +120,17 @@ public class AbstractBufferTest {
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(MetricNames.RECORDS_PROCESSED).toString());
         final List<Measurement> readTimeMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.READ_TIME_ELAPSED).toString());
-        Assert.assertEquals(1, recordsReadMeasurements.size());
-        Assert.assertEquals(5.0, recordsReadMeasurements.get(0).getValue(), 0);
-        Assert.assertEquals(1, recordsInFlightMeasurements.size());
-        Assert.assertEquals(5, abstractBuffer.getRecordsInFlight());
+        assertEquals(1, recordsReadMeasurements.size());
+        assertEquals(5.0, recordsReadMeasurements.get(0).getValue(), 0);
+        assertEquals(1, recordsInFlightMeasurements.size());
+        assertEquals(5, abstractBuffer.getRecordsInFlight());
         final Measurement recordsInFlightMeasurement = recordsInFlightMeasurements.get(0);
-        Assert.assertEquals(5.0, recordsInFlightMeasurement.getValue(), 0);
-        Assert.assertEquals(1, recordsProcessedMeasurements.size());
+        assertEquals(5.0, recordsInFlightMeasurement.getValue(), 0);
+        assertEquals(1, recordsProcessedMeasurements.size());
         final Measurement recordsProcessedMeasurement = recordsProcessedMeasurements.get(0);
-        Assert.assertEquals(0.0, recordsProcessedMeasurement.getValue(), 0);
-        Assert.assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(readTimeMeasurements, Statistic.COUNT).getValue(), 0);
-        Assert.assertTrue(MetricsTestUtil.isBetween(
+        assertEquals(0.0, recordsProcessedMeasurement.getValue(), 0);
+        assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(readTimeMeasurements, Statistic.COUNT).getValue(), 0);
+        assertTrue(MetricsTestUtil.isBetween(
                 MetricsTestUtil.getMeasurementFromList(readTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
                 0.05,
                 0.25));
@@ -145,24 +148,24 @@ public class AbstractBufferTest {
         final Map.Entry<Collection<Record<String>>, CheckpointState> readResult = abstractBuffer.read(1000);
         final List<Measurement> checkpointTimeMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.CHECKPOINT_TIME_ELAPSED).toString());
-        Assert.assertEquals(0.0, MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.COUNT).getValue(), 0);
-        Assert.assertEquals(0.0, MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.TOTAL_TIME).getValue(), 0);
+        assertEquals(0.0, MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.COUNT).getValue(), 0);
+        assertEquals(0.0, MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.TOTAL_TIME).getValue(), 0);
 
         // When
         abstractBuffer.checkpoint(readResult.getValue());
 
         // Then
-        Assert.assertEquals(0, abstractBuffer.getRecordsInFlight());
+        assertEquals(0, abstractBuffer.getRecordsInFlight());
         final List<Measurement> recordsInFlightMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.RECORDS_INFLIGHT).toString());
         final List<Measurement> recordsProcessedMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(MetricNames.RECORDS_PROCESSED).toString());
         final Measurement recordsInFlightMeasurement = recordsInFlightMeasurements.get(0);
         final Measurement recordsProcessedMeasurement = recordsProcessedMeasurements.get(0);
-        Assert.assertEquals(0.0, recordsInFlightMeasurement.getValue(), 0);
-        Assert.assertEquals(5.0, recordsProcessedMeasurement.getValue(), 0);
-        Assert.assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.COUNT).getValue(), 0);
-        Assert.assertTrue(MetricsTestUtil.isBetween(
+        assertEquals(0.0, recordsInFlightMeasurement.getValue(), 0);
+        assertEquals(5.0, recordsProcessedMeasurement.getValue(), 0);
+        assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.COUNT).getValue(), 0);
+        assertTrue(MetricsTestUtil.isBetween(
                 MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
                 0.0,
                 0.001));
@@ -172,7 +175,7 @@ public class AbstractBufferTest {
     public void testWriteBytes() throws TimeoutException {
         final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferTimeoutImpl(testPluginSetting);
         byte[] bytes = new byte[2];
-        Assert.assertThrows(RuntimeException.class, () -> abstractBuffer.writeBytes(bytes, "", 10));
+        assertThrows(RuntimeException.class, () -> abstractBuffer.writeBytes(bytes, "", 10));
     }
 
     @Test
@@ -181,12 +184,12 @@ public class AbstractBufferTest {
         final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferTimeoutImpl(testPluginSetting);
 
         // When/Then
-        Assert.assertThrows(TimeoutException.class, () -> abstractBuffer.write(new Record<>(UUID.randomUUID().toString()), 1000));
+        assertThrows(TimeoutException.class, () -> abstractBuffer.write(new Record<>(UUID.randomUUID().toString()), 1000));
 
         final List<Measurement> timeoutMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.WRITE_TIMEOUTS).toString());
-        Assert.assertEquals(1, timeoutMeasurements.size());
-        Assert.assertEquals(1.0, timeoutMeasurements.get(0).getValue(), 0);
+        assertEquals(1, timeoutMeasurements.size());
+        assertEquals(1.0, timeoutMeasurements.get(0).getValue(), 0);
     }
 
     @Test
@@ -195,12 +198,12 @@ public class AbstractBufferTest {
         final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferTimeoutImpl(testPluginSetting);
 
         // When/Then
-        Assert.assertThrows(TimeoutException.class, () -> abstractBuffer.write(new Record<>(UUID.randomUUID().toString()), 1000));
+        assertThrows(TimeoutException.class, () -> abstractBuffer.write(new Record<>(UUID.randomUUID().toString()), 1000));
 
         final List<Measurement> recordsWriteFailedMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.RECORDS_WRITE_FAILED).toString());
-        Assert.assertEquals(1, recordsWriteFailedMeasurements.size());
-        Assert.assertEquals(1.0, recordsWriteFailedMeasurements.get(0).getValue(), 0);
+        assertEquals(1, recordsWriteFailedMeasurements.size());
+        assertEquals(1.0, recordsWriteFailedMeasurements.get(0).getValue(), 0);
     }
 
     @Test
@@ -211,12 +214,12 @@ public class AbstractBufferTest {
                 new Record<>(UUID.randomUUID().toString()), new Record<>(UUID.randomUUID().toString()));
 
         // When/Then
-        Assert.assertThrows(TimeoutException.class, () -> abstractBuffer.writeAll(testRecords, 1000));
+        assertThrows(TimeoutException.class, () -> abstractBuffer.writeAll(testRecords, 1000));
 
         final List<Measurement> timeoutMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.WRITE_TIMEOUTS).toString());
-        Assert.assertEquals(1, timeoutMeasurements.size());
-        Assert.assertEquals(1.0, timeoutMeasurements.get(0).getValue(), 0);
+        assertEquals(1, timeoutMeasurements.size());
+        assertEquals(1.0, timeoutMeasurements.get(0).getValue(), 0);
     }
 
     @Test
@@ -227,12 +230,12 @@ public class AbstractBufferTest {
                 new Record<>(UUID.randomUUID().toString()), new Record<>(UUID.randomUUID().toString()));
 
         // When/Then
-        Assert.assertThrows(RuntimeException.class, () -> abstractBuffer.writeAll(testRecords, 1000));
+        assertThrows(RuntimeException.class, () -> abstractBuffer.writeAll(testRecords, 1000));
 
         final List<Measurement> recordsWriteFailedMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(BUFFER_NAME).add(MetricNames.RECORDS_WRITE_FAILED).toString());
-        Assert.assertEquals(1, recordsWriteFailedMeasurements.size());
-        Assert.assertEquals(2.0, recordsWriteFailedMeasurements.get(0).getValue(), 0);
+        assertEquals(1, recordsWriteFailedMeasurements.size());
+        assertEquals(2.0, recordsWriteFailedMeasurements.get(0).getValue(), 0);
     }
 
     @Test
@@ -243,7 +246,7 @@ public class AbstractBufferTest {
                 new Record<>(UUID.randomUUID().toString()), new Record<>(UUID.randomUUID().toString()));
 
         // When/Then
-        Assert.assertThrows(SizeOverflowException.class, () -> abstractBuffer.writeAll(testRecords, 1000));
+        assertThrows(SizeOverflowException.class, () -> abstractBuffer.writeAll(testRecords, 1000));
     }
 
     @Test
@@ -252,7 +255,7 @@ public class AbstractBufferTest {
         final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferNpeImpl(BUFFER_NAME, PIPELINE_NAME);
 
         // When/Then
-        Assert.assertThrows(NullPointerException.class, () -> abstractBuffer.write(new Record<>(UUID.randomUUID().toString()), 1000));
+        assertThrows(NullPointerException.class, () -> abstractBuffer.write(new Record<>(UUID.randomUUID().toString()), 1000));
     }
 
     @Test
@@ -263,7 +266,7 @@ public class AbstractBufferTest {
                 new Record<>(UUID.randomUUID().toString()), new Record<>(UUID.randomUUID().toString()));
 
         // When/Then
-        Assert.assertThrows(NullPointerException.class, () -> abstractBuffer.writeAll(testRecords, 1000));
+        assertThrows(NullPointerException.class, () -> abstractBuffer.writeAll(testRecords, 1000));
     }
 
     public static class AbstractBufferImpl extends AbstractBuffer<Record<String>> {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/HasByteDecoderTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/HasByteDecoderTest.java
@@ -5,9 +5,9 @@
 
 package org.opensearch.dataprepper.model.codec;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.spy;
 
 public class HasByteDecoderTest {
@@ -16,7 +16,7 @@ public class HasByteDecoderTest {
     public void testGetDecoder() {
         final HasByteDecoder hasByteDecoder = spy(HasByteDecoder.class);
 
-        Assert.assertEquals(null, hasByteDecoder.getDecoder());
+        assertEquals(null, hasByteDecoder.getDecoder());
     }
 
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/JsonDecoderTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/JsonDecoderTest.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.BeforeEach;
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/OutputCodecTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/codec/OutputCodecTest.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PluginSettingsTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/configuration/PluginSettingsTests.java
@@ -6,8 +6,8 @@
 package org.opensearch.dataprepper.model.configuration;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,9 +20,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class PluginSettingsTests {
+class PluginSettingsTests {
     private static final String TEST_PLUGIN_NAME = "test";
 
     private static final String TEST_STRING_DEFAULT_VALUE = "DEFAULT";
@@ -53,8 +53,8 @@ public class PluginSettingsTests {
     private static final String TEST_LONG_ATTRIBUTE = "long-attribute";
     private static final String NOT_PRESENT_ATTRIBUTE = "not-present";
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         TEST_STRINGLIST_VALUE.add("value1");
         TEST_STRINGLIST_VALUE.add("value2");
         TEST_STRINGLIST_VALUE.add("value3");
@@ -77,21 +77,21 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testPluginSetting() {
+    void testPluginSetting() {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, ImmutableMap.of());
 
         assertThat(pluginSetting, notNullValue());
     }
 
     @Test
-    public void testPluginSetting_Name() {
+    void testPluginSetting_Name() {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, ImmutableMap.of());
 
         assertThat(pluginSetting.getName(), is(TEST_PLUGIN_NAME));
     }
 
     @Test
-    public void testPluginSetting_PipelineName() {
+    void testPluginSetting_PipelineName() {
         final String TEST_PIPELINE = "test-pipeline";
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, ImmutableMap.of());
         pluginSetting.setPipelineName(TEST_PIPELINE);
@@ -100,7 +100,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testPluginSetting_NumberOfProcessWorkers() {
+    void testPluginSetting_NumberOfProcessWorkers() {
         final int TEST_WORKERS = 1;
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, ImmutableMap.of());
         pluginSetting.setProcessWorkers(TEST_WORKERS);
@@ -109,7 +109,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetAttributeFromSettings() {
+    void testGetAttributeFromSettings() {
         final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_INT_ATTRIBUTE, TEST_INT_VALUE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
 
@@ -117,7 +117,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetAttributeOrDefault() {
+    void testGetAttributeOrDefault() {
         final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_INT_ATTRIBUTE, TEST_INT_VALUE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
 
@@ -125,7 +125,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetStringOrDefault() {
+    void testGetStringOrDefault() {
         final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_STRING_ATTRIBUTE, TEST_STRING_VALUE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
 
@@ -134,7 +134,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetTypedList() {
+    void testGetTypedList() {
         final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_STRINGLIST_ATTRIBUTE, TEST_STRINGLIST_VALUE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
 
@@ -142,7 +142,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetTypedMap() {
+    void testGetTypedMap() {
         final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_STRINGMAP_ATTRIBUTE, TEST_STRINGMAP_VALUE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
 
@@ -150,7 +150,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetTypedListOfMaps() {
+    void testGetTypedListOfMaps() {
         final Map<String, String> TEST_SETTINGS_MAP = ImmutableMap.of(TEST_STRING_ATTRIBUTE, TEST_STRING_VALUE);
         final List<Map<String, String>> TEST_SETTINGS_LIST = List.of(TEST_SETTINGS_MAP);
         final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_LIST_OF_MAPS_ATTRIBUTE, TEST_SETTINGS_LIST);
@@ -160,7 +160,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetTypedListMap() {
+    void testGetTypedListMap() {
         final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_STRINGLISTMAP_ATTRIBUTE, TEST_STRINGLISTMAP_VALUE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
 
@@ -168,7 +168,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetBooleanOrDefault() {
+    void testGetBooleanOrDefault() {
         final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_BOOL_ATTRIBUTE, TEST_BOOL_VALUE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
 
@@ -176,7 +176,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetLongOrDefault() {
+    void testGetLongOrDefault() {
         final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_LONG_ATTRIBUTE, TEST_LONG_VALUE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
 
@@ -184,7 +184,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetIntegerOrDefault_AsString() {
+    void testGetIntegerOrDefault_AsString() {
         final String TEST_INT_VALUE_STRING = String.valueOf(TEST_INT_VALUE);
         final String TEST_INT_STRING_ATTRIBUTE = "int-string-attribute";
         final Map<String, Object> TEST_SETTINGS_AS_STRINGS = ImmutableMap.of(TEST_INT_STRING_ATTRIBUTE, TEST_INT_VALUE_STRING);
@@ -194,7 +194,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetBooleanOrDefault_AsString() {
+    void testGetBooleanOrDefault_AsString() {
         final String TEST_BOOL_VALUE_STRING = String.valueOf(TEST_BOOL_VALUE);
         final String TEST_BOOL_STRING_ATTRIBUTE = "bool-string-attribute";
 
@@ -205,7 +205,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetLongOrDefault_AsString() {
+    void testGetLongOrDefault_AsString() {
         final String TEST_LONG_VALUE_STRING = String.valueOf(TEST_LONG_VALUE);
         final String TEST_LONG_STRING_ATTRIBUTE = "long-string-attribute";
         final Map<String, Object> TEST_SETTINGS_AS_STRINGS = ImmutableMap.of(TEST_LONG_STRING_ATTRIBUTE, TEST_LONG_VALUE_STRING);
@@ -218,7 +218,7 @@ public class PluginSettingsTests {
      * Request attributes are present with null values, expect nulls to be returned
      */
     @Test
-    public void testGetIntegerOrDefault_AsNull() {
+    void testGetIntegerOrDefault_AsNull() {
         final String TEST_INT_NULL_ATTRIBUTE = "int-null-attribute";
         final Map<String, Object> TEST_SETTINGS_AS_NULL = new HashMap<>();
         TEST_SETTINGS_AS_NULL.put(TEST_INT_NULL_ATTRIBUTE, null);
@@ -232,7 +232,7 @@ public class PluginSettingsTests {
      * Request attributes are present with null values, expect nulls to be returned
      */
     @Test
-    public void testGetStringOrDefault_AsNull() {
+    void testGetStringOrDefault_AsNull() {
         final String TEST_STRING_NULL_ATTRIBUTE = "string-null-attribute";
         final Map<String, Object> TEST_SETTINGS_AS_NULL = new HashMap<>();
         TEST_SETTINGS_AS_NULL.put(TEST_STRING_NULL_ATTRIBUTE, null);
@@ -246,7 +246,7 @@ public class PluginSettingsTests {
      * Request attributes are present with null values, expect nulls to be returned
      */
     @Test
-    public void testGetTypedList_AsNull() {
+    void testGetTypedList_AsNull() {
         final String TEST_STRINGLIST_NULL_ATTRIBUTE = "typedlist-null-attribute";
         final Map<String, Object> TEST_SETTINGS_AS_NULL = new HashMap<>();
         TEST_SETTINGS_AS_NULL.put(TEST_STRINGLIST_NULL_ATTRIBUTE, null);
@@ -259,7 +259,7 @@ public class PluginSettingsTests {
      * Request attributes are present with null values, expect nulls to be returned
      */
     @Test
-    public void testGetTypedMap_AsNull() {
+    void testGetTypedMap_AsNull() {
         final String TEST_STRINGMAP_NULL_ATTRIBUTE = "typedgmap-null-attribute";
         final Map<String, Object> TEST_SETTINGS_AS_NULL = new HashMap<>();
         TEST_SETTINGS_AS_NULL.put(TEST_STRINGMAP_NULL_ATTRIBUTE, null);
@@ -272,7 +272,7 @@ public class PluginSettingsTests {
      * Request attributes are present with null values, expect nulls to be returned
      */
     @Test
-    public void testGetTypedListMap_AsNull() {
+    void testGetTypedListMap_AsNull() {
         final String TEST_STRINGLISTMAP_NULL_ATTRIBUTE = "typedlistmap-null-attribute";
         final Map<String, Object> TEST_SETTINGS_AS_NULL = new HashMap<>();
         TEST_SETTINGS_AS_NULL.put(TEST_STRINGLISTMAP_NULL_ATTRIBUTE, null);
@@ -285,7 +285,7 @@ public class PluginSettingsTests {
      * Request attributes are present with null values, expect nulls to be returned
      */
     @Test
-    public void testGetTypedListOfMaps_AsNull() {
+    void testGetTypedListOfMaps_AsNull() {
         final String TEST_STRINGLISTOFMAPS_NULL_ATTRIBUTE = "typedlistofmaps-null-attribute";
         final Map<String, Object> TEST_SETTINGS_AS_NULL = new HashMap<>();
 
@@ -299,7 +299,7 @@ public class PluginSettingsTests {
      * Request attributes are present with null values, expect nulls to be returned
      */
     @Test
-    public void testGetBooleanOrDefault_AsNull() {
+    void testGetBooleanOrDefault_AsNull() {
         final String TEST_BOOL_NULL_ATTRIBUTE = "bool-null-attribute";
         final Map<String, Object> TEST_SETTINGS_AS_NULL = new HashMap<>();
         TEST_SETTINGS_AS_NULL.put(TEST_BOOL_NULL_ATTRIBUTE, null);
@@ -313,7 +313,7 @@ public class PluginSettingsTests {
      * Request attributes are present with null values, expect nulls to be returned
      */
     @Test
-    public void testGetLongOrDefault_AsNull() {
+    void testGetLongOrDefault_AsNull() {
         final String TEST_LONG_NULL_ATTRIBUTE = "long-null-attribute";
         final Map<String, Object> TEST_SETTINGS_AS_NULL = new HashMap<>();
         TEST_SETTINGS_AS_NULL.put(TEST_LONG_NULL_ATTRIBUTE, null);
@@ -327,7 +327,7 @@ public class PluginSettingsTests {
      * Requested attributes are not present, expect default values to be returned
      */
     @Test
-    public void testGetSettings_Null() {
+    void testGetSettings_Null() {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
 
         assertThat(pluginSetting.getSettings(), nullValue());
@@ -337,7 +337,7 @@ public class PluginSettingsTests {
      * Requested attributes are not present, expect default values to be returned
      */
     @Test
-    public void testGetAttributeFromSettings_NotPresent() {
+    void testGetAttributeFromSettings_NotPresent() {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
 
         assertThat(pluginSetting.getAttributeFromSettings(NOT_PRESENT_ATTRIBUTE), nullValue());
@@ -347,7 +347,7 @@ public class PluginSettingsTests {
      * Requested attributes are not present, expect default values to be returned
      */
     @Test
-    public void testGetAttributeOrDefault_NotPresent() {
+    void testGetAttributeOrDefault_NotPresent() {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
 
         assertThat(pluginSetting.getAttributeOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_INT_DEFAULT_VALUE), is(TEST_INT_DEFAULT_VALUE));
@@ -357,7 +357,7 @@ public class PluginSettingsTests {
      * Requested attributes are not present, expect default values to be returned
      */
     @Test
-    public void testGetIntegerOrDefault_NotPresent() {
+    void testGetIntegerOrDefault_NotPresent() {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
 
         assertThat(pluginSetting.getIntegerOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_INT_DEFAULT_VALUE), is(TEST_INT_DEFAULT_VALUE));
@@ -367,7 +367,7 @@ public class PluginSettingsTests {
      * Requested attributes are not present, expect default values to be returned
      */
     @Test
-    public void testGetStringOrDefault_NotPresent() {
+    void testGetStringOrDefault_NotPresent() {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
 
         assertThat(pluginSetting.getStringOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_STRING_DEFAULT_VALUE),
@@ -378,7 +378,7 @@ public class PluginSettingsTests {
      * Requested attributes are not present, expect default values to be returned
      */
     @Test
-    public void testGetTypedList_NotPresent() {
+    void testGetTypedList_NotPresent() {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
 
         assertThat(pluginSetting.getTypedList(NOT_PRESENT_ATTRIBUTE, String.class),
@@ -389,7 +389,7 @@ public class PluginSettingsTests {
      * Requested attributes are not present, expect default values to be returned
      */
     @Test
-    public void testGetStringMapOrDefault_NotPresent() {
+    void testGetStringMapOrDefault_NotPresent() {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
 
         assertThat(pluginSetting.getTypedMap(NOT_PRESENT_ATTRIBUTE, String.class, String.class),
@@ -400,7 +400,7 @@ public class PluginSettingsTests {
      * Requested attributes are not present, expect default values to be returned
      */
     @Test
-    public void testGetTypedListMap_NotPresent() {
+    void testGetTypedListMap_NotPresent() {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
 
         assertThat(pluginSetting.getTypedListMap(NOT_PRESENT_ATTRIBUTE, String.class, String.class),
@@ -411,7 +411,7 @@ public class PluginSettingsTests {
      * Requested attributes are not present, expect default values to be returned
      */
     @Test
-    public void testGetBooleanOrDefault_NotPresent() {
+    void testGetBooleanOrDefault_NotPresent() {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
 
         assertThat(pluginSetting.getBooleanOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_BOOL_DEFAULT_VALUE), is(equalTo(TEST_BOOL_DEFAULT_VALUE)));
@@ -421,14 +421,14 @@ public class PluginSettingsTests {
      * Requested attributes are not present, expect default values to be returned
      */
     @Test
-    public void testGetLongOrDefault_NotPresent() {
+    void testGetLongOrDefault_NotPresent() {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
 
         assertThat(pluginSetting.getLongOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_LONG_DEFAULT_VALUE), is(equalTo(TEST_LONG_DEFAULT_VALUE)));
     }
 
     @Test
-    public void testGetIntegerOrDefault_UnsupportedType() {
+    void testGetIntegerOrDefault_UnsupportedType() {
         final Object UNSUPPORTED_TYPE = new ArrayList<>();
         final Map<String, Object> TEST_SETTINGS_WITH_UNSUPPORTED_TYPE = ImmutableMap.of(TEST_INT_ATTRIBUTE, UNSUPPORTED_TYPE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_WITH_UNSUPPORTED_TYPE);
@@ -438,7 +438,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetStringOrDefault_UnsupportedType() {
+    void testGetStringOrDefault_UnsupportedType() {
         final Object UNSUPPORTED_TYPE = new ArrayList<>();
         final Map<String, Object> TEST_SETTINGS_WITH_UNSUPPORTED_TYPE = ImmutableMap.of(TEST_STRING_ATTRIBUTE, UNSUPPORTED_TYPE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_WITH_UNSUPPORTED_TYPE);
@@ -447,7 +447,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetTypedList_UnsupportedType() {
+    void testGetTypedList_UnsupportedType() {
         final String UNSUPPORTED_TYPE = "not-stringlist";
         final Map<String, Object> TEST_SETTINGS_WITH_UNSUPPORTED_TYPE = ImmutableMap.of(TEST_STRINGLIST_ATTRIBUTE, UNSUPPORTED_TYPE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_WITH_UNSUPPORTED_TYPE);
@@ -456,7 +456,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetTypedList_UnsupportedListType() {
+    void testGetTypedList_UnsupportedListType() {
         final List<Integer> UNSUPPORTED_TYPE = new ArrayList<>();
         UNSUPPORTED_TYPE.add(1);
         UNSUPPORTED_TYPE.add(2);
@@ -469,7 +469,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetTypedMap_UnsupportedType() {
+    void testGetTypedMap_UnsupportedType() {
         final String UNSUPPORTED_TYPE = "not-stringmap";
         final Map<String, Object> TEST_SETTINGS_WITH_UNSUPPORTED_TYPE = ImmutableMap.of(TEST_STRINGMAP_ATTRIBUTE, UNSUPPORTED_TYPE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_WITH_UNSUPPORTED_TYPE);
@@ -479,7 +479,7 @@ public class PluginSettingsTests {
 
 
     @Test
-    public void testGetTypedMap_UnsupportedMapValueType() {
+    void testGetTypedMap_UnsupportedMapValueType() {
         final Map<String, Integer> UNSUPPORTED_TYPE = new HashMap<>();
         UNSUPPORTED_TYPE.put("key1", 1);
         UNSUPPORTED_TYPE.put("key2", 2);
@@ -492,7 +492,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetTypedListMap_UnsupportedType() {
+    void testGetTypedListMap_UnsupportedType() {
         final String UNSUPPORTED_TYPE = "not-stringmap";
         final Map<String, Object> TEST_SETTINGS_WITH_UNSUPPORTED_TYPE = ImmutableMap.of(TEST_STRINGLISTMAP_ATTRIBUTE, UNSUPPORTED_TYPE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_WITH_UNSUPPORTED_TYPE);
@@ -501,7 +501,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetTypedListMap_UnsupportedMapValueType() {
+    void testGetTypedListMap_UnsupportedMapValueType() {
         final Map<String, String> UNSUPPORTED_TYPE = new HashMap<>();
         UNSUPPORTED_TYPE.put("key1", "value1");
         UNSUPPORTED_TYPE.put("key2", "value2");
@@ -514,7 +514,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetTypedListMap_UnsupportedMapKeyType() {
+    void testGetTypedListMap_UnsupportedMapKeyType() {
         final Map<Integer, List<String>> UNSUPPORTED_TYPE = new HashMap<>();
         final List<String> STRING_LIST_VALUE = new ArrayList<>();
         STRING_LIST_VALUE.add("value1");
@@ -530,7 +530,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetTypedListMap_UnsupportedMapValueListType() {
+    void testGetTypedListMap_UnsupportedMapValueListType() {
         final Map<String, List<Integer>> UNSUPPORTED_TYPE = new HashMap<>();
         final List<Integer> INT_LIST_VALUE = new ArrayList<>();
         INT_LIST_VALUE.add(1);
@@ -546,7 +546,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetBooleanOrDefault_UnsupportedType() {
+    void testGetBooleanOrDefault_UnsupportedType() {
         final Object UNSUPPORTED_TYPE = new ArrayList<>();
         final Map<String, Object> TEST_SETTINGS_WITH_UNSUPPORTED_TYPE = ImmutableMap.of(TEST_BOOL_ATTRIBUTE, UNSUPPORTED_TYPE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_WITH_UNSUPPORTED_TYPE);
@@ -555,7 +555,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testGetLongOrDefault_UnsupportedType() {
+    void testGetLongOrDefault_UnsupportedType() {
         final Object UNSUPPORTED_TYPE = new ArrayList<>();
         final Map<String, Object> TEST_SETTINGS_WITH_UNSUPPORTED_TYPE = ImmutableMap.of(TEST_LONG_ATTRIBUTE, UNSUPPORTED_TYPE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_WITH_UNSUPPORTED_TYPE);
@@ -564,7 +564,7 @@ public class PluginSettingsTests {
     }
 
     @Test
-    public void testSetSettings() {
+    void testSetSettings() {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
 
         final Map<String, Object> settings = Map.of("test", 1);

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/record/RecordTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/record/RecordTests.java
@@ -5,8 +5,9 @@
 
 package org.opensearch.dataprepper.model.record;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -14,9 +15,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opensearch.dataprepper.model.record.RecordMetadata.RECORD_TYPE;
 
-public class RecordTests {
+class RecordTests {
     private static final String TEST_DATA = "TEST";
     private static final String TEST_RECORD_TYPE = "OTEL";
     private static final String TEST_RECORD_METADATA_V_TYPE = "VERSION";
@@ -25,7 +27,7 @@ public class RecordTests {
     private static final String TEST_RECORD_VERSION = "1.0";
 
     @Test
-    public void testRecordOperations() {
+    void testRecordOperations() {
         final Record<String> stringRecord = new Record<>(TEST_DATA);
         assertThat(stringRecord.getData(), is(equalTo(TEST_DATA)));
         final RecordMetadata recordMetadata = stringRecord.getMetadata();
@@ -36,7 +38,7 @@ public class RecordTests {
     }
 
     @Test
-    public void testRecordWithMetadata() {
+    void testRecordWithMetadata() {
         final Record<String> stringRecord = new Record<>(TEST_DATA, RecordMetadata.defaultMetadata());
         assertThat(stringRecord.getData(), is(equalTo(TEST_DATA)));
         final RecordMetadata recordMetadata = stringRecord.getMetadata();
@@ -47,7 +49,7 @@ public class RecordTests {
     }
 
     @Test
-    public void testRecordUsingDefaultMetadataAndNoMetadata() {
+    void testRecordUsingDefaultMetadataAndNoMetadata() {
         final Record<String> recordWithMetadata = new Record<>(TEST_DATA, RecordMetadata.defaultMetadata());
         final Record<String> recordWithDefaultMetadata = new Record<>(TEST_DATA);
         assertThat(recordWithMetadata.getData(), is(equalTo(recordWithDefaultMetadata.getData())));
@@ -58,7 +60,7 @@ public class RecordTests {
     }
 
     @Test
-    public void testRecordCreationWithMetadata() {
+    void testRecordCreationWithMetadata() {
         final Map<String, Object> metadataObjectMap = new HashMap<>();
         metadataObjectMap.put(RECORD_TYPE, TEST_RECORD_TYPE);
         metadataObjectMap.put(TEST_RECORD_METADATA_V_TYPE, TEST_RECORD_VERSION);
@@ -72,8 +74,9 @@ public class RecordTests {
         assertThat(actualMetadataObjectMap, is(equalTo(metadataObjectMap)));
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testRecordMetadataWithoutRecordType() {
-        final RecordMetadata recordMetadata = RecordMetadata.of(new HashMap<>());
+    @Test
+    void testRecordMetadataWithoutRecordType() {
+        final Map<String, Object> emptyMap = Collections.emptyMap();
+        assertThrows(RuntimeException.class, () -> RecordMetadata.of(emptyMap));
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/AbstractSinkTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/sink/AbstractSinkTest.java
@@ -7,8 +7,7 @@ package org.opensearch.dataprepper.model.sink;
 
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Statistic;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.metrics.MetricNames;
 import org.opensearch.dataprepper.metrics.MetricsTestUtil;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
@@ -17,6 +16,8 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.event.EventHandle;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 
@@ -30,10 +31,10 @@ import java.util.UUID;
 
 import static org.awaitility.Awaitility.await;
 
-public class AbstractSinkTest {
+class AbstractSinkTest {
     private int count;
     @Test
-    public void testMetrics() {
+    void testMetrics() {
         final String sinkName = "testSink";
         final String pipelineName = "pipelineName";
         MetricsTestUtil.initMetrics();
@@ -41,7 +42,7 @@ public class AbstractSinkTest {
         pluginSetting.setPipelineName(pipelineName);
         AbstractSink<Record<String>> abstractSink = new AbstractSinkImpl(pluginSetting);
         abstractSink.initialize();
-        Assert.assertEquals(abstractSink.isReady(), true);
+        assertEquals(abstractSink.isReady(), true);
         abstractSink.updateLatencyMetrics(Arrays.asList(
                 new Record<>(UUID.randomUUID().toString())));
         abstractSink.output(Arrays.asList(
@@ -57,20 +58,20 @@ public class AbstractSinkTest {
         final List<Measurement> elapsedTimeMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(sinkName).add(MetricNames.TIME_ELAPSED).toString());
 
-        Assert.assertEquals(1, recordsInMeasurements.size());
-        Assert.assertEquals(5.0, recordsInMeasurements.get(0).getValue(), 0);
-        Assert.assertEquals(3, elapsedTimeMeasurements.size());
-        Assert.assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(elapsedTimeMeasurements, Statistic.COUNT).getValue(), 0);
-        Assert.assertTrue(MetricsTestUtil.isBetween(
+        assertEquals(1, recordsInMeasurements.size());
+        assertEquals(5.0, recordsInMeasurements.get(0).getValue(), 0);
+        assertEquals(3, elapsedTimeMeasurements.size());
+        assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(elapsedTimeMeasurements, Statistic.COUNT).getValue(), 0);
+        assertTrue(MetricsTestUtil.isBetween(
                 MetricsTestUtil.getMeasurementFromList(elapsedTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
                 0.2,
                 0.3));
-        Assert.assertEquals(abstractSink.getRetryThreadState(), null);
+        assertEquals(abstractSink.getRetryThreadState(), null);
         abstractSink.shutdown();
     }
 
     @Test
-    public void testSinkNotReady() {
+    void testSinkNotReady() {
         final String sinkName = "testSink";
         final String pipelineName = "pipelineName";
         MetricsTestUtil.initMetrics();
@@ -78,19 +79,19 @@ public class AbstractSinkTest {
         pluginSetting.setPipelineName(pipelineName);
         AbstractSink<Record<String>> abstractSink = new AbstractSinkNotReadyImpl(pluginSetting);
         abstractSink.initialize();
-        Assert.assertEquals(abstractSink.isReady(), false);
-        Assert.assertEquals(abstractSink.getRetryThreadState(), Thread.State.RUNNABLE);
+        assertEquals(abstractSink.isReady(), false);
+        assertEquals(abstractSink.getRetryThreadState(), Thread.State.RUNNABLE);
         // Do another intialize to make sure the sink is still not ready
         abstractSink.initialize();
-        Assert.assertEquals(abstractSink.isReady(), false);
+        assertEquals(abstractSink.isReady(), false);
         await().atMost(Duration.ofSeconds(5))
                 .until(abstractSink::isReady);
-        Assert.assertEquals(abstractSink.getRetryThreadState(), Thread.State.TERMINATED);
+        assertEquals(abstractSink.getRetryThreadState(), Thread.State.TERMINATED);
         abstractSink.shutdown();
     }
 
     @Test
-    public void testSinkWithRegisterEventReleaseHandler() {
+    void testSinkWithRegisterEventReleaseHandler() {
         final String sinkName = "testSink";
         final String pipelineName = "pipelineName";
         MetricsTestUtil.initMetrics();
@@ -98,7 +99,7 @@ public class AbstractSinkTest {
         pluginSetting.setPipelineName(pipelineName);
         AbstractSink<Record<Event>> abstractSink = new AbstractEventSinkImpl(pluginSetting);
         abstractSink.initialize();
-        Assert.assertEquals(abstractSink.isReady(), true);
+        assertEquals(abstractSink.isReady(), true);
         count = 0;
         Event event = JacksonEvent.builder()
                 .withEventType("event")
@@ -116,7 +117,7 @@ public class AbstractSinkTest {
 
     private static class AbstractEventSinkImpl extends AbstractSink<Record<Event>> {
 
-        public AbstractEventSinkImpl(PluginSetting pluginSetting) {
+        AbstractEventSinkImpl(PluginSetting pluginSetting) {
             super(pluginSetting, 10, 1000);
         }
 
@@ -146,7 +147,7 @@ public class AbstractSinkTest {
 
     private static class AbstractSinkImpl extends AbstractSink<Record<String>> {
 
-        public AbstractSinkImpl(PluginSetting pluginSetting) {
+        AbstractSinkImpl(PluginSetting pluginSetting) {
             super(pluginSetting, 10, 1000);
         }
 
@@ -178,7 +179,7 @@ public class AbstractSinkTest {
 
         boolean initialized;
         int initCount;
-        public AbstractSinkNotReadyImpl(PluginSetting pluginSetting) {
+        AbstractSinkNotReadyImpl(PluginSetting pluginSetting) {
             super(pluginSetting);
             initialized = false;
             initCount = 0;

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/SourceTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/SourceTest.java
@@ -8,9 +8,10 @@ package org.opensearch.dataprepper.model.source;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.event.Event;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.junit.Assert.assertFalse;
 
 public class SourceTest {
     @Test


### PR DESCRIPTION
### Description

Updates the last tests in `data-prepper-api` using JUnit 4 to JUnit 5. Removes JUnit Vintage from the project. Some related code improvements.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
