### PR TITLE
Adds a Checkstyle validation to ensure that the Guava cache is not used.

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -64,5 +64,9 @@
         -->
         <module name="ModifierOrder" />
 
+        <module name="ImportControl">
+            <property name="file" value="${config_loc}/import-control.xml"/>
+        </module>
+
     </module>
 </module>

--- a/config/checkstyle/import-control.xml
+++ b/config/checkstyle/import-control.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright OpenSearch Contributors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<!DOCTYPE import-control PUBLIC
+        "-//Checkstyle//DTD ImportControl Configuration 1.4//EN"
+        "https://checkstyle.org/dtds/import_control_1_4.dtd">
+
+<import-control pkg="org.opensearch.dataprepper" strategyOnMismatch="allowed">
+    <!-- Prefer Caffeine -->
+    <disallow pkg="com.google.common.cache"/>
+</import-control>


### PR DESCRIPTION
### Description

With #3586 updating to the Caffeine cache, we may still end up with Guava's cache being used. This PR adds a Checkstyle violation to prevent importing the Guava cache.

It's not perfect. I found you can work-around it by qualifying the class:

```
com.google.common.cache.Cache cache
```

But, that is more likely to be noticed during a code review.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
