### PR TITLE
Add distribution_version flag to opensearch source

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/DistributionVersion.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/model/DistributionVersion.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model;
+
+public enum DistributionVersion {
+    ES7("es7"),
+    OPENSEARCH("opensearch");
+
+    private final String distributionVersion;
+    DistributionVersion(final String distributionVersion) {
+        this.distributionVersion = distributionVersion;
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfigurationTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceConfigurationTest.java
@@ -10,10 +10,12 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
+import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DistributionVersion;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OpenSearchSourceConfigurationTest {
@@ -82,6 +84,7 @@ public class OpenSearchSourceConfigurationTest {
         assertThat(sourceConfiguration.getPassword(), equalTo(null));
         assertThat(sourceConfiguration.getUsername(), equalTo(null));
         assertThat(sourceConfiguration.getAwsAuthenticationOptions(), equalTo(null));
+        assertThat(sourceConfiguration.getDistributionVersion(), nullValue());
     }
 
     @Test
@@ -90,6 +93,7 @@ public class OpenSearchSourceConfigurationTest {
                 "connection:\n" +
                 "  insecure: true\n" +
                 "  cert: \"cert\"\n" +
+                "distribution_version: \"es7\"\n" +
                 "indices:\n" +
                 "  include:\n" +
                 "    - index_name_regex: \"regex\"\n" +
@@ -111,6 +115,9 @@ public class OpenSearchSourceConfigurationTest {
 
         assertThat(sourceConfiguration.getAwsAuthenticationOptions().getAwsStsRoleArn(),
             equalTo("arn:aws:iam::123456789012:role/aos-role"));
+
+        assertThat(sourceConfiguration.isDistributionVersionValid(), equalTo(true));
+        assertThat(sourceConfiguration.getDistributionVersion(), equalTo(DistributionVersion.ES7));
     }
 
     @Test
@@ -119,6 +126,7 @@ public class OpenSearchSourceConfigurationTest {
             "connection:\n" +
             "  insecure: true\n" +
             "  cert: \"cert\"\n" +
+            "distribution_version: \"opensearch\"\n" +
             "indices:\n" +
             "  include:\n" +
             "    - index_name_regex: \"regex\"\n" +
@@ -143,6 +151,9 @@ public class OpenSearchSourceConfigurationTest {
             equalTo("arn:aws:iam::123456789012:role/aos-role"));
         assertThat(sourceConfiguration.getAwsAuthenticationOptions().getAwsStsExternalId(),
             equalTo("some-random-id"));
+
+        assertThat(sourceConfiguration.isDistributionVersionValid(), equalTo(true));
+        assertThat(sourceConfiguration.getDistributionVersion(), equalTo(DistributionVersion.OPENSEARCH));
     }
 
     @Test
@@ -154,6 +165,7 @@ public class OpenSearchSourceConfigurationTest {
                 "connection:\n" +
                 "  insecure: true\n" +
                 "  cert: \"cert\"\n" +
+                "distribution_version: \"invalid\"\n" +
                 "indices:\n" +
                 "  include:\n" +
                 "    - index_name_regex: \"regex\"\n" +
@@ -169,6 +181,7 @@ public class OpenSearchSourceConfigurationTest {
         final OpenSearchSourceConfiguration sourceConfiguration = objectMapper.readValue(sourceConfigurationYaml, OpenSearchSourceConfiguration.class);
 
         assertThrows(InvalidPluginConfigurationException.class, sourceConfiguration::validateAwsConfigWithUsernameAndPassword);
+        assertThat(sourceConfiguration.isDistributionVersionValid(), equalTo(false));
     }
 
     @Test


### PR DESCRIPTION
### Description
Adds a `distribution_version` option to the OpenSearch source, which can be either `es7` or `opensearch`. When set, the client can be forced to use the `OpenSearch` client. This fixes an issue where Amazon OpenSearch Service domains with compatibility mode enabled do not hit exceptions when making an `info` API call with the OpenSearch client.

This was tested with Amazon OpenSearch Service domains that were upgraded from ES 7.10 to OS 1.3 and OS 2.9 with compatibility mode enabled, and the data migration was successfull
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
