### PR TITLE
Refactor to use Admin client instead of second set of consumers for empty check

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/admin/KafkaAdminAccessor.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/admin/KafkaAdminAccessor.java
@@ -1,0 +1,103 @@
+package org.opensearch.dataprepper.plugins.kafka.admin;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.opensearch.dataprepper.plugins.kafka.consumer.TopicEmptinessMetadata;
+import org.opensearch.dataprepper.plugins.kafka.util.KafkaClusterAuthConfig;
+import org.opensearch.dataprepper.plugins.kafka.util.KafkaSecurityConfigurer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+public class KafkaAdminAccessor {
+    static final Logger LOG = LoggerFactory.getLogger(KafkaAdminAccessor.class);
+
+    private final AdminClient kafkaAdminClient;
+    private final TopicEmptinessMetadata topicEmptinessMetadata;
+    private final List<String> consumerGroupIds;
+
+    public KafkaAdminAccessor(final KafkaClusterAuthConfig kafkaClusterAuthConfig, final List<String> consumerGroupIds) {
+        Properties authProperties = new Properties();
+        KafkaSecurityConfigurer.setAuthProperties(authProperties, kafkaClusterAuthConfig, LOG);
+        this.kafkaAdminClient = KafkaAdminClient.create(authProperties);
+        this.topicEmptinessMetadata = new TopicEmptinessMetadata();
+        this.consumerGroupIds = consumerGroupIds;
+    }
+
+    @VisibleForTesting
+    KafkaAdminAccessor(final AdminClient kafkaAdminClient, final TopicEmptinessMetadata topicEmptinessMetadata, final List<String> consumerGroupIds) {
+        this.kafkaAdminClient = kafkaAdminClient;
+        this.topicEmptinessMetadata = topicEmptinessMetadata;
+        this.consumerGroupIds = consumerGroupIds;
+    }
+
+    public synchronized boolean areTopicsEmpty() {
+        final long currentThreadId = Thread.currentThread().getId();
+        if (Objects.isNull(topicEmptinessMetadata.getTopicEmptyCheckingOwnerThreadId())) {
+            topicEmptinessMetadata.setTopicEmptyCheckingOwnerThreadId(currentThreadId);
+        }
+
+        if (currentThreadId != topicEmptinessMetadata.getTopicEmptyCheckingOwnerThreadId() ||
+                topicEmptinessMetadata.isWithinCheckInterval(System.currentTimeMillis())) {
+            return topicEmptinessMetadata.isTopicEmpty();
+        }
+
+
+        final Map<TopicPartition, OffsetAndMetadata> committedOffsets = new HashMap<>();
+        for (String consumerGroupId: consumerGroupIds) {
+            final ListConsumerGroupOffsetsResult listConsumerGroupOffsets = kafkaAdminClient.listConsumerGroupOffsets(consumerGroupId);
+            try {
+                committedOffsets.putAll(listConsumerGroupOffsets.partitionsToOffsetAndMetadata().get());
+            } catch (final InterruptedException | ExecutionException e) {
+                LOG.error("Caught exception getting committed offset data", e);
+                return false;
+            }
+        }
+
+        final Map<TopicPartition, OffsetSpec> listOffsetsRequest = committedOffsets.keySet().stream()
+                .collect(Collectors.toMap(topicPartition -> topicPartition, topicPartition -> OffsetSpec.latest()));
+        final Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> endOffsets;
+        try {
+            endOffsets = kafkaAdminClient.listOffsets(listOffsetsRequest).all().get();
+        } catch (final InterruptedException | ExecutionException e) {
+            LOG.error("Caught exception getting end offset data", e);
+            return false;
+        }
+
+        for (TopicPartition topicPartition : committedOffsets.keySet()) {
+            final OffsetAndMetadata offsetAndMetadata = committedOffsets.get(topicPartition);
+
+            if (!endOffsets.containsKey(topicPartition)) {
+                LOG.warn("No end offset found for topic partition: {}", topicPartition);
+                return false;
+            }
+            final long endOffset = endOffsets.get(topicPartition).offset();
+
+            topicEmptinessMetadata.updateTopicEmptinessStatus(topicPartition, true);
+
+            // If there is data in the partition
+            if (endOffset != 0L) {
+                // If there is no committed offset for the partition or the committed offset is behind the end offset
+                if (Objects.isNull(offsetAndMetadata) || offsetAndMetadata.offset() < endOffset) {
+                    topicEmptinessMetadata.updateTopicEmptinessStatus(topicPartition, false);
+                }
+            }
+        }
+
+        topicEmptinessMetadata.setLastIsEmptyCheckTime(System.currentTimeMillis());
+        return topicEmptinessMetadata.isTopicEmpty();
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
@@ -182,7 +182,6 @@ public class KafkaCustomConsumerFactory {
     private void setPropertiesForPlaintextAndJsonWithoutSchemaRegistry(Properties properties, final TopicConfig topicConfig) {
         MessageFormat dataFormat = topicConfig.getSerdeFormat();
         schemaType = dataFormat.toString();
-        LOG.error("Setting schemaType to {}", schemaType);
     }
 
     private void setPropertiesForSchemaRegistryConnectivity(final KafkaConsumerConfig kafkaConsumerConfig, final Properties properties) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
@@ -91,7 +91,6 @@ public class KafkaCustomConsumerFactory {
 
         try {
             final int numWorkers = topic.getWorkers();
-            final TopicEmptinessMetadata topicEmptinessMetadata = new TopicEmptinessMetadata();
             IntStream.range(0, numWorkers).forEach(index -> {
                 KafkaDataConfig dataConfig = new KafkaDataConfigAdapter(keyFactory, topic);
                 Deserializer<Object> keyDeserializer = (Deserializer<Object>) serializationFactory.getDeserializer(PlaintextKafkaDataConfig.plaintextDataConfig(dataConfig));
@@ -105,7 +104,7 @@ public class KafkaCustomConsumerFactory {
                 final KafkaConsumer kafkaConsumer = new KafkaConsumer<>(consumerProperties, keyDeserializer, valueDeserializer);
 
                 consumers.add(new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, kafkaConsumerConfig, topic,
-                    schemaType, acknowledgementSetManager, byteDecoder, topicMetrics, topicEmptinessMetadata, pauseConsumePredicate));
+                    schemaType, acknowledgementSetManager, byteDecoder, topicMetrics, pauseConsumePredicate));
 
             });
         } catch (Exception e) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -38,7 +38,6 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaRegistryType
 import org.opensearch.dataprepper.plugins.kafka.configuration.TopicConfig;
 import org.opensearch.dataprepper.plugins.kafka.consumer.KafkaCustomConsumer;
 import org.opensearch.dataprepper.plugins.kafka.consumer.PauseConsumePredicate;
-import org.opensearch.dataprepper.plugins.kafka.consumer.TopicEmptinessMetadata;
 import org.opensearch.dataprepper.plugins.kafka.extension.KafkaClusterConfigSupplier;
 import org.opensearch.dataprepper.plugins.kafka.util.ClientDNSLookupType;
 import org.opensearch.dataprepper.plugins.kafka.util.KafkaSecurityConfigurer;
@@ -118,7 +117,6 @@ public class KafkaSource implements Source<Record<Event>> {
                 int numWorkers = topic.getWorkers();
                 executorService = Executors.newFixedThreadPool(numWorkers);
                 allTopicExecutorServices.add(executorService);
-                final TopicEmptinessMetadata topicEmptinessMetadata = new TopicEmptinessMetadata();
 
                 IntStream.range(0, numWorkers).forEach(index -> {
                     while (true) {
@@ -142,7 +140,7 @@ public class KafkaSource implements Source<Record<Event>> {
 
                     }
                     consumer = new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topic, schemaType,
-                            acknowledgementSetManager, null, topicMetrics, topicEmptinessMetadata, PauseConsumePredicate.noPause());
+                            acknowledgementSetManager, null, topicMetrics, PauseConsumePredicate.noPause());
                     allTopicConsumers.add(consumer);
 
                     executorService.submit(consumer);

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/admin/KafkaAdminAccessorTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/admin/KafkaAdminAccessorTest.java
@@ -1,0 +1,302 @@
+package org.opensearch.dataprepper.plugins.kafka.admin;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.dataprepper.plugins.kafka.consumer.TopicEmptinessMetadata;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class KafkaAdminAccessorTest {
+    private static final String CONSUMER_GROUP_ID = UUID.randomUUID().toString();
+    private static final String TOPIC_NAME = UUID.randomUUID().toString();
+    private static final Random RANDOM = new Random();
+
+    @Mock
+    private AdminClient kafkaAdminClient;
+    @Mock
+    private OffsetAndMetadata offsetAndMetadata;
+    @Mock
+    private ListConsumerGroupOffsetsResult listConsumerGroupOffsetsResult;
+    @Mock
+    private ListOffsetsResult listOffsetsResult;
+    @Mock
+    private KafkaFuture<Map<TopicPartition, OffsetAndMetadata>> committedOffsetsFuture;
+    @Mock
+    private KafkaFuture<Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo>> endOffsetsFuture;
+    @Mock
+    private ListOffsetsResult.ListOffsetsResultInfo listOffsetsResultInfo;
+    private TopicEmptinessMetadata topicEmptinessMetadata;
+
+    private KafkaAdminAccessor kafkaAdminAccessor;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    public KafkaAdminAccessor createObjectUnderTest() {
+        topicEmptinessMetadata = new TopicEmptinessMetadata();
+        return new KafkaAdminAccessor(kafkaAdminClient, topicEmptinessMetadata, List.of(CONSUMER_GROUP_ID));
+    }
+
+    @Test
+    public void areTopicsEmpty_OnePartition_IsEmpty() throws ExecutionException, InterruptedException {
+        final Long offset = RANDOM.nextLong();
+        final List<TopicPartition> topicPartitions = buildTopicPartitions(1);
+
+        kafkaAdminAccessor = createObjectUnderTest();
+        mockAdminClientCalls(topicPartitions, offset);
+
+        assertThat(kafkaAdminAccessor.areTopicsEmpty(), equalTo(true));
+
+        verifyAdminClientCalls(topicPartitions);
+    }
+
+    @Test
+    public void areTopicsEmpty_OnePartition_PartitionNeverHadData() throws ExecutionException, InterruptedException {
+        final Long offset = 0L;
+        final List<TopicPartition> topicPartitions = buildTopicPartitions(1);
+
+        kafkaAdminAccessor = createObjectUnderTest();
+        mockAdminClientCalls(topicPartitions, offset);
+        when(offsetAndMetadata.offset()).thenReturn(offset - 1);
+
+        assertThat(kafkaAdminAccessor.areTopicsEmpty(), equalTo(true));
+
+        verifyAdminClientCalls(topicPartitions);
+    }
+
+    @Test
+    public void areTopicsEmpty_OnePartition_IsNotEmpty() throws ExecutionException, InterruptedException {
+        final Long offset = RANDOM.nextLong();
+        final List<TopicPartition> topicPartitions = buildTopicPartitions(1);
+
+        kafkaAdminAccessor = createObjectUnderTest();
+        mockAdminClientCalls(topicPartitions, offset);
+        when(offsetAndMetadata.offset()).thenReturn(offset - 1);
+
+        assertThat(kafkaAdminAccessor.areTopicsEmpty(), equalTo(false));
+
+        verifyAdminClientCalls(topicPartitions);
+    }
+
+    @Test
+    public void areTopicsEmpty_OnePartition_NoCommittedPartition() throws ExecutionException, InterruptedException {
+        final Long offset = RANDOM.nextLong();
+        final List<TopicPartition> topicPartitions = buildTopicPartitions(1);
+
+        kafkaAdminAccessor = createObjectUnderTest();
+        mockAdminClientCalls(topicPartitions, offset);
+        final HashMap<TopicPartition, OffsetAndMetadata> committedOffsets = new HashMap<>();
+        committedOffsets.put(topicPartitions.get(0), null);
+        when(committedOffsetsFuture.get()).thenReturn(committedOffsets);
+
+        assertThat(kafkaAdminAccessor.areTopicsEmpty(), equalTo(false));
+
+        verifyAdminClientCalls(topicPartitions);
+    }
+
+    @Test
+    public void areTopicsEmpty_MultiplePartitions_AllEmpty() throws ExecutionException, InterruptedException {
+        final Long offset1 = RANDOM.nextLong();
+        final Long offset2 = RANDOM.nextLong();
+        final List<TopicPartition> topicPartitions = buildTopicPartitions(2);
+
+        kafkaAdminAccessor = createObjectUnderTest();
+        mockAdminClientCalls(topicPartitions, offset1);
+        when(listOffsetsResultInfo.offset()).thenReturn(offset1).thenReturn(offset2);
+        when(offsetAndMetadata.offset()).thenReturn(offset1).thenReturn(offset2);
+
+        assertThat(kafkaAdminAccessor.areTopicsEmpty(), equalTo(true));
+
+        verifyAdminClientCalls(topicPartitions);
+    }
+
+    @Test
+    public void areTopicsEmpty_MultiplePartitions_OneNotEmpty() throws ExecutionException, InterruptedException {
+        final Long offset1 = RANDOM.nextLong();
+        final Long offset2 = RANDOM.nextLong();
+        final List<TopicPartition> topicPartitions = buildTopicPartitions(2);
+
+        kafkaAdminAccessor = createObjectUnderTest();
+        mockAdminClientCalls(topicPartitions, offset1);
+        when(listOffsetsResultInfo.offset()).thenReturn(offset1).thenReturn(offset2);
+        when(offsetAndMetadata.offset()).thenReturn(offset1).thenReturn(offset2 - 1);
+
+        assertThat(kafkaAdminAccessor.areTopicsEmpty(), equalTo(false));
+
+        verifyAdminClientCalls(topicPartitions);
+    }
+
+    @Test
+    public void areTopicsEmpty_NonCheckerThread_ShortCircuits() {
+        kafkaAdminAccessor = createObjectUnderTest();
+
+        topicEmptinessMetadata.setTopicEmptyCheckingOwnerThreadId(Thread.currentThread().getId() - 1);
+        assertThat(kafkaAdminAccessor.areTopicsEmpty(), equalTo(true));
+
+        verifyNoInteractions(kafkaAdminClient);
+    }
+
+    @Test
+    public void areTopicsEmpty_CheckedWithinDelay_ShortCircuits() {
+        kafkaAdminAccessor = createObjectUnderTest();
+
+        topicEmptinessMetadata.setLastIsEmptyCheckTime(System.currentTimeMillis());
+        assertThat(kafkaAdminAccessor.areTopicsEmpty(), equalTo(true));
+
+        verifyNoInteractions(kafkaAdminClient);
+    }
+
+    @Test
+    public void areTopicsEmpty_ExceptionGettingCommittedOffsets_ReturnsFalse() throws ExecutionException, InterruptedException {
+        final Long offset = RANDOM.nextLong();
+        final List<TopicPartition> topicPartitions = buildTopicPartitions(1);
+
+        kafkaAdminAccessor = createObjectUnderTest();
+        mockAdminClientCalls(topicPartitions, offset);
+        when(committedOffsetsFuture.get()).thenThrow(new InterruptedException());
+
+        assertThat(kafkaAdminAccessor.areTopicsEmpty(), equalTo(false));
+
+        verify(kafkaAdminClient).listConsumerGroupOffsets(CONSUMER_GROUP_ID);
+        verifyNoMoreInteractions(kafkaAdminClient);
+    }
+
+    @Test
+    public void areTopicsEmpty_ExceptionGettingEndOffsets_ReturnsFalse() throws ExecutionException, InterruptedException {
+        final Long offset = RANDOM.nextLong();
+        final List<TopicPartition> topicPartitions = buildTopicPartitions(1);
+
+        kafkaAdminAccessor = createObjectUnderTest();
+        mockAdminClientCalls(topicPartitions, offset);
+        when(endOffsetsFuture.get()).thenThrow(new InterruptedException());
+
+        assertThat(kafkaAdminAccessor.areTopicsEmpty(), equalTo(false));
+
+        verifyAdminClientCalls(topicPartitions);
+    }
+
+    @Test
+    public void areTopicsEmpty_MissingEndOffset_ReturnsFalse() throws ExecutionException, InterruptedException {
+        final Long offset = RANDOM.nextLong();
+        final List<TopicPartition> topicPartitions = buildTopicPartitions(1);
+
+        kafkaAdminAccessor = createObjectUnderTest();
+        mockAdminClientCalls(topicPartitions, offset);
+        when(endOffsetsFuture.get()).thenReturn(Collections.emptyMap());
+
+        assertThat(kafkaAdminAccessor.areTopicsEmpty(), equalTo(false));
+
+        verifyAdminClientCalls(topicPartitions);
+    }
+
+    @Test
+    public void areTopicsEmpty_MultipleConsumerGroups() throws ExecutionException, InterruptedException {
+        final Long offset = RANDOM.nextLong();
+        final List<TopicPartition> topicPartitions1 = List.of(new TopicPartition(TOPIC_NAME, 0));
+        final List<TopicPartition> topicPartitions2 = List.of(new TopicPartition(UUID.randomUUID().toString(), 0));
+
+        topicEmptinessMetadata = new TopicEmptinessMetadata();
+        final String consumerGroupId2 = UUID.randomUUID().toString();
+        kafkaAdminAccessor = new KafkaAdminAccessor(kafkaAdminClient, topicEmptinessMetadata,
+                List.of(CONSUMER_GROUP_ID, consumerGroupId2));
+
+        mockAdminClientCalls(topicPartitions1, offset);
+        when(kafkaAdminClient.listConsumerGroupOffsets(CONSUMER_GROUP_ID)).thenReturn(listConsumerGroupOffsetsResult);
+        when(kafkaAdminClient.listConsumerGroupOffsets(consumerGroupId2)).thenReturn(listConsumerGroupOffsetsResult);
+        when(committedOffsetsFuture.get())
+                .thenReturn(getTopicPartitionToMap(topicPartitions1, offsetAndMetadata))
+                .thenReturn(getTopicPartitionToMap(topicPartitions2, offsetAndMetadata));
+        final Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> endOffsets = getTopicPartitionToMap(topicPartitions1, listOffsetsResultInfo);
+        endOffsets.putAll(getTopicPartitionToMap(topicPartitions2, listOffsetsResultInfo));
+        when(endOffsetsFuture.get()).thenReturn(endOffsets);
+
+        assertThat(kafkaAdminAccessor.areTopicsEmpty(), equalTo(true));
+
+        final ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(kafkaAdminClient, times(2)).listConsumerGroupOffsets(argumentCaptor.capture());
+        assertThat(argumentCaptor.getAllValues().size(), equalTo(2));
+        assertThat(argumentCaptor.getAllValues().get(0), equalTo(CONSUMER_GROUP_ID));
+        assertThat(argumentCaptor.getAllValues().get(1), equalTo(consumerGroupId2));
+
+        verify(kafkaAdminClient).listOffsets(argThat(r -> {
+            final List<TopicPartition> combinedTopicPartitions = Stream.concat(topicPartitions1.stream(), topicPartitions2.stream())
+                    .collect(Collectors.toList());
+            assertAll("ListOffsets request fields match",
+                    () -> assertThat("Request map size matches", r.size(), equalTo(combinedTopicPartitions.size())),
+                    () -> assertThat("TopicPartitions in keyset",
+                            combinedTopicPartitions.stream().allMatch(topicPartition -> r.containsKey(topicPartition))),
+                    () -> assertThat("OffsetSpec matches",
+                            combinedTopicPartitions.stream().allMatch(topicPartition -> r.get(topicPartition) instanceof OffsetSpec.LatestSpec))
+            );
+            return true;
+        }));
+    }
+
+    private void mockAdminClientCalls(final List<TopicPartition> topicPartitions, final long offset) throws ExecutionException, InterruptedException {
+        when(kafkaAdminClient.listConsumerGroupOffsets(CONSUMER_GROUP_ID)).thenReturn(listConsumerGroupOffsetsResult);
+        when(listConsumerGroupOffsetsResult.partitionsToOffsetAndMetadata()).thenReturn(committedOffsetsFuture);
+        when(committedOffsetsFuture.get()).thenReturn(getTopicPartitionToMap(topicPartitions, offsetAndMetadata));
+        when(kafkaAdminClient.listOffsets(any())).thenReturn(listOffsetsResult);
+        when(listOffsetsResult.all()).thenReturn(endOffsetsFuture);
+        when(endOffsetsFuture.get()).thenReturn(getTopicPartitionToMap(topicPartitions, listOffsetsResultInfo));
+        when(listOffsetsResultInfo.offset()).thenReturn(offset);
+        when(offsetAndMetadata.offset()).thenReturn(offset);
+    }
+
+    private void verifyAdminClientCalls(final List<TopicPartition> topicPartitions) {
+        verify(kafkaAdminClient).listConsumerGroupOffsets(CONSUMER_GROUP_ID);
+        verify(kafkaAdminClient).listOffsets(argThat(r -> {
+            assertAll("ListOffsets request fields match",
+                    () -> assertThat("Request map size matches", r.size(), equalTo(topicPartitions.size())),
+                    () -> assertThat("TopicPartitions in keyset",
+                            topicPartitions.stream().allMatch(topicPartition -> r.containsKey(topicPartition))),
+                    () -> assertThat("OffsetSpec matches",
+                            topicPartitions.stream().allMatch(topicPartition -> r.get(topicPartition) instanceof OffsetSpec.LatestSpec))
+            );
+            return true;
+        }));
+    }
+
+    private List<TopicPartition> buildTopicPartitions(final int partitionCount) {
+        return IntStream.range(0, partitionCount)
+                .mapToObj(i -> new TopicPartition(TOPIC_NAME, i))
+                .collect(Collectors.toList());
+    }
+
+    private <T> Map<TopicPartition, T> getTopicPartitionToMap(final List<TopicPartition> topicPartitions, final T value) {
+        return topicPartitions.stream()
+                .collect(Collectors.toMap(i -> i, i -> value));
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
@@ -14,7 +14,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RecordDeserializationException;
 import org.junit.jupiter.api.Assertions;
@@ -43,38 +42,26 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyCollection;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class KafkaCustomConsumerTest {
     private static final String TOPIC_NAME = "topic1";
-    private static final Random RANDOM = new Random();
 
     @Mock
     private KafkaConsumer<String, Object> kafkaConsumer;
@@ -94,10 +81,6 @@ public class KafkaCustomConsumerTest {
 
     @Mock
     private KafkaTopicConsumerMetrics topicMetrics;
-    @Mock
-    private PartitionInfo partitionInfo;
-    @Mock
-    private OffsetAndMetadata offsetAndMetadata;
 
     @Mock
     private PauseConsumePredicate pauseConsumePredicate;
@@ -126,7 +109,6 @@ public class KafkaCustomConsumerTest {
     private Duration delayTime;
     private double posCount;
     private double negCount;
-    private TopicEmptinessMetadata topicEmptinessMetadata;
 
     @BeforeEach
     public void setUp() {
@@ -166,10 +148,9 @@ public class KafkaCustomConsumerTest {
     }
 
     public KafkaCustomConsumer createObjectUnderTest(String schemaType, boolean acknowledgementsEnabled) {
-        topicEmptinessMetadata = new TopicEmptinessMetadata();
         when(sourceConfig.getAcknowledgementsEnabled()).thenReturn(acknowledgementsEnabled);
         return new KafkaCustomConsumer(kafkaConsumer, shutdownInProgress, buffer, sourceConfig, topicConfig, schemaType,
-                acknowledgementSetManager, null, topicMetrics, topicEmptinessMetadata, pauseConsumePredicate);
+                acknowledgementSetManager, null, topicMetrics, pauseConsumePredicate);
     }
 
     private BlockingBuffer<Record<Event>> getBuffer() {
@@ -476,172 +457,6 @@ public class KafkaCustomConsumerTest {
             Assertions.assertEquals(topicPartition.topic(), topic);
             Assertions.assertEquals(103L, offsetAndMetadata.offset());
         });
-    }
-
-    @Test
-    public void isTopicEmpty_OnePartition_IsEmpty() {
-        final Long offset = RANDOM.nextLong();
-        final List<TopicPartition> topicPartitions = buildTopicPartitions(1);
-
-        consumer = createObjectUnderTest("json", true);
-
-        when(kafkaConsumer.partitionsFor(TOPIC_NAME)).thenReturn(List.of(partitionInfo));
-        when(partitionInfo.partition()).thenReturn(0);
-        when(kafkaConsumer.committed(anySet())).thenReturn(getTopicPartitionToMap(topicPartitions, offsetAndMetadata));
-        when(kafkaConsumer.endOffsets(anyCollection())).thenReturn(getTopicPartitionToMap(topicPartitions, offset));
-        when(offsetAndMetadata.offset()).thenReturn(offset);
-
-        assertThat(consumer.isTopicEmpty(), equalTo(true));
-
-        verify(kafkaConsumer).partitionsFor(TOPIC_NAME);
-        verify(kafkaConsumer).committed(new HashSet<>(topicPartitions));
-        verify(kafkaConsumer).endOffsets(topicPartitions);
-        verify(partitionInfo).partition();
-        verify(offsetAndMetadata).offset();
-    }
-
-    @Test
-    public void isTopicEmpty_OnePartition_PartitionNeverHadData() {
-        final Long offset = 0L;
-        final List<TopicPartition> topicPartitions = buildTopicPartitions(1);
-
-        consumer = createObjectUnderTest("json", true);
-
-        when(kafkaConsumer.partitionsFor(TOPIC_NAME)).thenReturn(List.of(partitionInfo));
-        when(partitionInfo.partition()).thenReturn(0);
-        when(kafkaConsumer.committed(anySet())).thenReturn(getTopicPartitionToMap(topicPartitions, offsetAndMetadata));
-        when(kafkaConsumer.endOffsets(anyCollection())).thenReturn(getTopicPartitionToMap(topicPartitions, offset));
-        when(offsetAndMetadata.offset()).thenReturn(offset - 1);
-
-        assertThat(consumer.isTopicEmpty(), equalTo(true));
-
-        verify(kafkaConsumer).partitionsFor(TOPIC_NAME);
-        verify(kafkaConsumer).committed(new HashSet<>(topicPartitions));
-        verify(kafkaConsumer).endOffsets(topicPartitions);
-        verify(partitionInfo).partition();
-    }
-
-    @Test
-    public void isTopicEmpty_OnePartition_IsNotEmpty() {
-        final Long offset = RANDOM.nextLong();
-        final List<TopicPartition> topicPartitions = buildTopicPartitions(1);
-
-        consumer = createObjectUnderTest("json", true);
-
-        when(kafkaConsumer.partitionsFor(TOPIC_NAME)).thenReturn(List.of(partitionInfo));
-        when(partitionInfo.partition()).thenReturn(0);
-        when(kafkaConsumer.committed(anySet())).thenReturn(getTopicPartitionToMap(topicPartitions, offsetAndMetadata));
-        when(kafkaConsumer.endOffsets(anyCollection())).thenReturn(getTopicPartitionToMap(topicPartitions, offset));
-        when(offsetAndMetadata.offset()).thenReturn(offset - 1);
-
-        assertThat(consumer.isTopicEmpty(), equalTo(false));
-
-        verify(kafkaConsumer).partitionsFor(TOPIC_NAME);
-        verify(kafkaConsumer).committed(new HashSet<>(topicPartitions));
-        verify(kafkaConsumer).endOffsets(topicPartitions);
-        verify(partitionInfo).partition();
-        verify(offsetAndMetadata).offset();
-    }
-
-    @Test
-    public void isTopicEmpty_OnePartition_NoCommittedPartition() {
-        final Long offset = RANDOM.nextLong();
-        final List<TopicPartition> topicPartitions = buildTopicPartitions(1);
-
-        consumer = createObjectUnderTest("json", true);
-
-        when(kafkaConsumer.partitionsFor(TOPIC_NAME)).thenReturn(List.of(partitionInfo));
-        when(partitionInfo.partition()).thenReturn(0);
-        when(kafkaConsumer.committed(anySet())).thenReturn(Collections.emptyMap());
-        when(kafkaConsumer.endOffsets(anyCollection())).thenReturn(getTopicPartitionToMap(topicPartitions, offset));
-
-        assertThat(consumer.isTopicEmpty(), equalTo(false));
-
-        verify(kafkaConsumer).partitionsFor(TOPIC_NAME);
-        verify(kafkaConsumer).committed(new HashSet<>(topicPartitions));
-        verify(kafkaConsumer).endOffsets(topicPartitions);
-        verify(partitionInfo).partition();
-    }
-
-    @Test
-    public void isTopicEmpty_MultiplePartitions_AllEmpty() {
-        final Long offset1 = RANDOM.nextLong();
-        final Long offset2 = RANDOM.nextLong();
-        final List<TopicPartition> topicPartitions = buildTopicPartitions(2);
-
-        consumer = createObjectUnderTest("json", true);
-
-        when(kafkaConsumer.partitionsFor(TOPIC_NAME)).thenReturn(List.of(partitionInfo, partitionInfo));
-        when(partitionInfo.partition()).thenReturn(0).thenReturn(1);
-        when(kafkaConsumer.committed(anySet())).thenReturn(getTopicPartitionToMap(topicPartitions, offsetAndMetadata));
-        final Map<TopicPartition, Long> endOffsets = getTopicPartitionToMap(topicPartitions, offset1);
-        endOffsets.put(topicPartitions.get(1), offset2);
-        when(kafkaConsumer.endOffsets(anyCollection())).thenReturn(endOffsets);
-        when(offsetAndMetadata.offset()).thenReturn(offset1).thenReturn(offset2);
-
-        assertThat(consumer.isTopicEmpty(), equalTo(true));
-
-        verify(kafkaConsumer).partitionsFor(TOPIC_NAME);
-        verify(kafkaConsumer).committed(new HashSet<>(topicPartitions));
-        verify(kafkaConsumer).endOffsets(topicPartitions);
-        verify(partitionInfo, times(2)).partition();
-        verify(offsetAndMetadata, times(2)).offset();
-    }
-
-    @Test
-    public void isTopicEmpty_MultiplePartitions_OneNotEmpty() {
-        final Long offset1 = RANDOM.nextLong();
-        final Long offset2 = RANDOM.nextLong();
-        final List<TopicPartition> topicPartitions = buildTopicPartitions(2);
-
-        consumer = createObjectUnderTest("json", true);
-
-        when(kafkaConsumer.partitionsFor(TOPIC_NAME)).thenReturn(List.of(partitionInfo, partitionInfo));
-        when(partitionInfo.partition()).thenReturn(0).thenReturn(1);
-        when(kafkaConsumer.committed(anySet())).thenReturn(getTopicPartitionToMap(topicPartitions, offsetAndMetadata));
-        final Map<TopicPartition, Long> endOffsets = getTopicPartitionToMap(topicPartitions, offset1);
-        endOffsets.put(topicPartitions.get(1), offset2);
-        when(kafkaConsumer.endOffsets(anyCollection())).thenReturn(endOffsets);
-        when(offsetAndMetadata.offset()).thenReturn(offset1).thenReturn(offset2 - 1);
-
-        assertThat(consumer.isTopicEmpty(), equalTo(false));
-
-        verify(kafkaConsumer).partitionsFor(TOPIC_NAME);
-        verify(kafkaConsumer).committed(new HashSet<>(topicPartitions));
-        verify(kafkaConsumer).endOffsets(topicPartitions);
-        verify(partitionInfo, times(2)).partition();
-        verify(offsetAndMetadata, times(2)).offset();
-    }
-
-    @Test
-    public void isTopicEmpty_NonCheckerThread_ShortCircuits() {
-        consumer = createObjectUnderTest("json", true);
-
-        topicEmptinessMetadata.setTopicEmptyCheckingOwnerThreadId(Thread.currentThread().getId() - 1);
-        assertThat(consumer.isTopicEmpty(), equalTo(true));
-
-        verifyNoInteractions(kafkaConsumer);
-    }
-
-    @Test
-    public void isTopicEmpty_CheckedWithinDelay_ShortCircuits() {
-        consumer = createObjectUnderTest("json", true);
-
-        topicEmptinessMetadata.setLastIsEmptyCheckTime(System.currentTimeMillis());
-        assertThat(consumer.isTopicEmpty(), equalTo(true));
-
-        verifyNoInteractions(kafkaConsumer);
-    }
-
-    private List<TopicPartition> buildTopicPartitions(final int partitionCount) {
-        return IntStream.range(0, partitionCount)
-                .mapToObj(i -> new TopicPartition(TOPIC_NAME, i))
-                .collect(Collectors.toList());
-    }
-
-    private <T> Map<TopicPartition, T> getTopicPartitionToMap(final List<TopicPartition> topicPartitions, final T value) {
-        return topicPartitions.stream()
-                .collect(Collectors.toMap(i -> i, i -> value));
     }
 
     private ConsumerRecords createPlainTextRecords(String topic, final long startOffset) {


### PR DESCRIPTION
### Description
Followup from #3545 to use the admin client instead of a duplicate consumer set hack
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
