### PR TITLE
Remove verbose debug log from JacksonEvent

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -334,8 +334,8 @@ public class JacksonEvent implements Event {
 
             try {
                 val = this.get(name, Object.class);
-            } catch (final Exception e) {
-                LOG.debug("Received exception using Event key for formatting, now checking for Data Prepper expression: {}", e.getMessage());
+            } catch (final Exception ignored) {
+                // Exception likely indicates use of a Data Prepper expression
             }
 
             if (val == null) {


### PR DESCRIPTION
### Description
this DEBUG log would show up every time someone uses a Data Prepper expression, which is unnecessary and verbose
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
