### PR TITLE
MAINT: add bytes metrics into opensearch source

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchService.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchService.java
@@ -4,6 +4,7 @@
  */
 package org.opensearch.dataprepper.plugins.source.opensearch;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.buffer.Buffer;
@@ -32,6 +33,7 @@ public class OpenSearchService {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenSearchService.class);
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     static final Duration EXECUTOR_SERVICE_SHUTDOWN_TIMEOUT = Duration.ofSeconds(30);
     static final Duration BUFFER_TIMEOUT = Duration.ofSeconds(30);
 
@@ -83,13 +85,13 @@ public class OpenSearchService {
     public void start() {
         switch(searchAccessor.getSearchContextType()) {
             case POINT_IN_TIME:
-                searchWorker = new PitWorker(searchAccessor, openSearchSourceConfiguration, sourceCoordinator, bufferAccumulator, openSearchIndexPartitionCreationSupplier, acknowledgementSetManager, openSearchSourcePluginMetrics);
+                searchWorker = new PitWorker(OBJECT_MAPPER, searchAccessor, openSearchSourceConfiguration, sourceCoordinator, bufferAccumulator, openSearchIndexPartitionCreationSupplier, acknowledgementSetManager, openSearchSourcePluginMetrics);
                 break;
             case SCROLL:
-                searchWorker = new ScrollWorker(searchAccessor, openSearchSourceConfiguration, sourceCoordinator, bufferAccumulator, openSearchIndexPartitionCreationSupplier, acknowledgementSetManager, openSearchSourcePluginMetrics);
+                searchWorker = new ScrollWorker(OBJECT_MAPPER, searchAccessor, openSearchSourceConfiguration, sourceCoordinator, bufferAccumulator, openSearchIndexPartitionCreationSupplier, acknowledgementSetManager, openSearchSourcePluginMetrics);
                 break;
             case NONE:
-                searchWorker = new NoSearchContextWorker(searchAccessor, openSearchSourceConfiguration, sourceCoordinator, bufferAccumulator, openSearchIndexPartitionCreationSupplier, acknowledgementSetManager, openSearchSourcePluginMetrics);
+                searchWorker = new NoSearchContextWorker(OBJECT_MAPPER, searchAccessor, openSearchSourceConfiguration, sourceCoordinator, bufferAccumulator, openSearchIndexPartitionCreationSupplier, acknowledgementSetManager, openSearchSourcePluginMetrics);
                 break;
             default:
                 throw new IllegalArgumentException(

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/metrics/OpenSearchSourcePluginMetrics.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/metrics/OpenSearchSourcePluginMetrics.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.opensearch.metrics;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Timer;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 
@@ -15,11 +16,16 @@ public class OpenSearchSourcePluginMetrics {
     static final String INDICES_PROCESSED = "indicesProcessed";
     static final String INDEX_PROCESSING_TIME_ELAPSED = "indexProcessingTime";
     static final String PROCESSING_ERRORS = "processingErrors";
+    static final String BYTES_RECEIVED = "bytesReceived";
+    static final String BYTES_PROCESSED = "bytesProcessed";
 
     private final Counter documentsProcessedCounter;
     private final Counter indicesProcessedCounter;
     private final Counter processingErrorsCounter;
     private final Timer indexProcessingTimeTimer;
+
+    private final DistributionSummary bytesReceivedSummary;
+    private final DistributionSummary bytesProcessedSummary;
 
     public static OpenSearchSourcePluginMetrics create(final PluginMetrics pluginMetrics) {
         return new OpenSearchSourcePluginMetrics(pluginMetrics);
@@ -30,6 +36,8 @@ public class OpenSearchSourcePluginMetrics {
         indicesProcessedCounter = pluginMetrics.counter(INDICES_PROCESSED);
         processingErrorsCounter = pluginMetrics.counter(PROCESSING_ERRORS);
         indexProcessingTimeTimer = pluginMetrics.timer(INDEX_PROCESSING_TIME_ELAPSED);
+        bytesReceivedSummary = pluginMetrics.summary(BYTES_RECEIVED);
+        bytesProcessedSummary = pluginMetrics.summary(BYTES_PROCESSED);
     }
 
     public Counter getDocumentsProcessedCounter() {
@@ -46,5 +54,13 @@ public class OpenSearchSourcePluginMetrics {
 
     public Timer getIndexProcessingTimeTimer() {
         return indexProcessingTimeTimer;
+    }
+
+    public DistributionSummary getBytesReceivedSummary() {
+        return bytesReceivedSummary;
+    }
+
+    public DistributionSummary getBytesProcessedSummary() {
+        return bytesProcessedSummary;
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorkerTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/NoSearchContextWorkerTest.java
@@ -179,7 +179,6 @@ public class NoSearchContextWorkerTest {
     void run_with_getNextPartition_with_non_empty_partition_processes_and_closes_that_partition() throws Exception {
         mockTimerCallable();
 
-        when(objectMapper.writeValueAsBytes(any(JsonNode.class))).thenReturn(new byte[0]);
         final SourcePartition<OpenSearchIndexProgressState> sourcePartition = mock(SourcePartition.class);
         final String partitionKey = UUID.randomUUID().toString();
         when(sourcePartition.getPartitionKey()).thenReturn(partitionKey);
@@ -194,9 +193,15 @@ public class NoSearchContextWorkerTest {
         final Event testEvent1 = mock(Event.class);
         final Event testEvent2 = mock(Event.class);
         final Event testEvent3 = mock(Event.class);
-        when(testEvent1.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent2.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent3.getJsonNode()).thenReturn(mock(JsonNode.class));
+        final JsonNode testData1 = mock(JsonNode.class);
+        final JsonNode testData2 = mock(JsonNode.class);
+        final JsonNode testData3 = mock(JsonNode.class);
+        when(testEvent1.getJsonNode()).thenReturn(testData1);
+        when(testEvent2.getJsonNode()).thenReturn(testData2);
+        when(testEvent3.getJsonNode()).thenReturn(testData3);
+        when(objectMapper.writeValueAsBytes(testData1)).thenReturn(new byte[10]);
+        when(objectMapper.writeValueAsBytes(testData2)).thenReturn(new byte[20]);
+        when(objectMapper.writeValueAsBytes(testData3)).thenReturn(new byte[30]);
         when(searchWithSearchAfterResults.getDocuments()).thenReturn(List.of(testEvent1, testEvent2)).thenReturn(List.of(testEvent1, testEvent2))
                 .thenReturn(List.of(testEvent3)).thenReturn(List.of(testEvent3));
 
@@ -240,9 +245,13 @@ public class NoSearchContextWorkerTest {
         assertThat(noSearchContextSearchRequests.get(1).getPaginationSize(), equalTo(2));
         assertThat(noSearchContextSearchRequests.get(1).getSearchAfter(), equalTo(searchWithSearchAfterResults.getNextSearchAfter()));
 
-        verify(bytesReceivedSummary, times(3)).record(0L);
+        verify(bytesReceivedSummary).record(10L);
+        verify(bytesReceivedSummary).record(20L);
+        verify(bytesReceivedSummary).record(30L);
         verify(documentsProcessedCounter, times(3)).increment();
-        verify(bytesProcessedSummary, times(3)).record(0L);
+        verify(bytesProcessedSummary).record(10L);
+        verify(bytesProcessedSummary).record(20L);
+        verify(bytesProcessedSummary).record(30L);
         verify(indicesProcessedCounter).increment();
         verifyNoInteractions(processingErrorsCounter);
     }
@@ -251,7 +260,6 @@ public class NoSearchContextWorkerTest {
     void run_with_getNextPartition_with_acknowledgments_processes_and_closes_that_partition() throws Exception {
         mockTimerCallable();
 
-        when(objectMapper.writeValueAsBytes(any(JsonNode.class))).thenReturn(new byte[0]);
         final AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
         AtomicReference<Integer> numEventsAdded = new AtomicReference<>(0);
         doAnswer(a -> {
@@ -280,9 +288,15 @@ public class NoSearchContextWorkerTest {
         final Event testEvent1 = mock(Event.class);
         final Event testEvent2 = mock(Event.class);
         final Event testEvent3 = mock(Event.class);
-        when(testEvent1.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent2.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent3.getJsonNode()).thenReturn(mock(JsonNode.class));
+        final JsonNode testData1 = mock(JsonNode.class);
+        final JsonNode testData2 = mock(JsonNode.class);
+        final JsonNode testData3 = mock(JsonNode.class);
+        when(testEvent1.getJsonNode()).thenReturn(testData1);
+        when(testEvent2.getJsonNode()).thenReturn(testData2);
+        when(testEvent3.getJsonNode()).thenReturn(testData3);
+        when(objectMapper.writeValueAsBytes(testData1)).thenReturn(new byte[10]);
+        when(objectMapper.writeValueAsBytes(testData2)).thenReturn(new byte[20]);
+        when(objectMapper.writeValueAsBytes(testData3)).thenReturn(new byte[30]);
         when(searchWithSearchAfterResults.getDocuments()).thenReturn(List.of(testEvent1, testEvent2)).thenReturn(List.of(testEvent1, testEvent2))
                 .thenReturn(List.of(testEvent3)).thenReturn(List.of(testEvent3));
 
@@ -328,9 +342,13 @@ public class NoSearchContextWorkerTest {
 
         verify(acknowledgementSet).complete();
 
-        verify(bytesReceivedSummary, times(3)).record(0L);
+        verify(bytesReceivedSummary).record(10L);
+        verify(bytesReceivedSummary).record(20L);
+        verify(bytesReceivedSummary).record(30L);
         verify(documentsProcessedCounter, times(3)).increment();
-        verify(bytesProcessedSummary, times(3)).record(0L);
+        verify(bytesProcessedSummary).record(10L);
+        verify(bytesProcessedSummary).record(20L);
+        verify(bytesProcessedSummary).record(30L);
         verify(indicesProcessedCounter).increment();
         verifyNoInteractions(processingErrorsCounter);
     }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/PitWorkerTest.java
@@ -150,7 +150,6 @@ public class PitWorkerTest {
     void run_with_getNextPartition_with_non_empty_partition_creates_and_deletes_pit_and_closes_that_partition() throws Exception {
         mockTimerCallable();
 
-        when(objectMapper.writeValueAsBytes(any(JsonNode.class))).thenReturn(new byte[0]);
         final SourcePartition<OpenSearchIndexProgressState> sourcePartition = mock(SourcePartition.class);
         final String partitionKey = UUID.randomUUID().toString();
         when(sourcePartition.getPartitionKey()).thenReturn(partitionKey);
@@ -171,9 +170,15 @@ public class PitWorkerTest {
         final Event testEvent1 = mock(Event.class);
         final Event testEvent2 = mock(Event.class);
         final Event testEvent3 = mock(Event.class);
-        when(testEvent1.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent2.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent3.getJsonNode()).thenReturn(mock(JsonNode.class));
+        final JsonNode testData1 = mock(JsonNode.class);
+        final JsonNode testData2 = mock(JsonNode.class);
+        final JsonNode testData3 = mock(JsonNode.class);
+        when(testEvent1.getJsonNode()).thenReturn(testData1);
+        when(testEvent2.getJsonNode()).thenReturn(testData2);
+        when(testEvent3.getJsonNode()).thenReturn(testData3);
+        when(objectMapper.writeValueAsBytes(testData1)).thenReturn(new byte[10]);
+        when(objectMapper.writeValueAsBytes(testData2)).thenReturn(new byte[20]);
+        when(objectMapper.writeValueAsBytes(testData3)).thenReturn(new byte[30]);
         when(searchWithSearchAfterResults.getDocuments()).thenReturn(List.of(testEvent1, testEvent2)).thenReturn(List.of(testEvent1, testEvent2))
                 .thenReturn(List.of(testEvent3)).thenReturn(List.of(testEvent3));
 
@@ -234,9 +239,13 @@ public class PitWorkerTest {
 
         verifyNoInteractions(acknowledgementSetManager);
 
-        verify(bytesReceivedSummary, times(3)).record(0L);
+        verify(bytesReceivedSummary).record(10L);
+        verify(bytesReceivedSummary).record(20L);
+        verify(bytesReceivedSummary).record(30L);
         verify(documentsProcessedCounter, times(3)).increment();
-        verify(bytesProcessedSummary, times(3)).record(0L);
+        verify(bytesProcessedSummary).record(10L);
+        verify(bytesProcessedSummary).record(20L);
+        verify(bytesProcessedSummary).record(30L);
         verify(indicesProcessedCounter).increment();
         verifyNoInteractions(processingErrorsCounter);
     }
@@ -245,7 +254,6 @@ public class PitWorkerTest {
     void run_with_acknowledgments_enabled_creates_and_deletes_pit_and_closes_that_partition() throws Exception {
         mockTimerCallable();
 
-        when(objectMapper.writeValueAsBytes(any(JsonNode.class))).thenReturn(new byte[0]);
         final AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
         AtomicReference<Integer> numEventsAdded = new AtomicReference<>(0);
         doAnswer(a -> {
@@ -280,9 +288,15 @@ public class PitWorkerTest {
         final Event testEvent1 = mock(Event.class);
         final Event testEvent2 = mock(Event.class);
         final Event testEvent3 = mock(Event.class);
-        when(testEvent1.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent2.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent3.getJsonNode()).thenReturn(mock(JsonNode.class));
+        final JsonNode testData1 = mock(JsonNode.class);
+        final JsonNode testData2 = mock(JsonNode.class);
+        final JsonNode testData3 = mock(JsonNode.class);
+        when(testEvent1.getJsonNode()).thenReturn(testData1);
+        when(testEvent2.getJsonNode()).thenReturn(testData2);
+        when(testEvent3.getJsonNode()).thenReturn(testData3);
+        when(objectMapper.writeValueAsBytes(testData1)).thenReturn(new byte[10]);
+        when(objectMapper.writeValueAsBytes(testData2)).thenReturn(new byte[20]);
+        when(objectMapper.writeValueAsBytes(testData3)).thenReturn(new byte[30]);
         when(searchWithSearchAfterResults.getDocuments()).thenReturn(List.of(testEvent1, testEvent2)).thenReturn(List.of(testEvent1, testEvent2))
                 .thenReturn(List.of(testEvent3)).thenReturn(List.of(testEvent3));
 
@@ -344,9 +358,13 @@ public class PitWorkerTest {
 
         verify(acknowledgementSet).complete();
 
-        verify(bytesReceivedSummary, times(3)).record(0L);
+        verify(bytesReceivedSummary).record(10L);
+        verify(bytesReceivedSummary).record(20L);
+        verify(bytesReceivedSummary).record(30L);
         verify(documentsProcessedCounter, times(3)).increment();
-        verify(bytesProcessedSummary, times(3)).record(0L);
+        verify(bytesProcessedSummary).record(10L);
+        verify(bytesProcessedSummary).record(20L);
+        verify(bytesProcessedSummary).record(30L);
         verify(indicesProcessedCounter).increment();
         verifyNoInteractions(processingErrorsCounter);
     }
@@ -355,7 +373,6 @@ public class PitWorkerTest {
     void run_with_getNextPartition_with_valid_existing_point_in_time_does_not_create_another_point_in_time() throws Exception {
         mockTimerCallable();
 
-        when(objectMapper.writeValueAsBytes(any(JsonNode.class))).thenReturn(new byte[0]);
         final SourcePartition<OpenSearchIndexProgressState> sourcePartition = mock(SourcePartition.class);
         final String partitionKey = UUID.randomUUID().toString();
         when(sourcePartition.getPartitionKey()).thenReturn(partitionKey);
@@ -377,9 +394,15 @@ public class PitWorkerTest {
         final Event testEvent1 = mock(Event.class);
         final Event testEvent2 = mock(Event.class);
         final Event testEvent3 = mock(Event.class);
-        when(testEvent1.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent2.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent3.getJsonNode()).thenReturn(mock(JsonNode.class));
+        final JsonNode testData1 = mock(JsonNode.class);
+        final JsonNode testData2 = mock(JsonNode.class);
+        final JsonNode testData3 = mock(JsonNode.class);
+        when(testEvent1.getJsonNode()).thenReturn(testData1);
+        when(testEvent2.getJsonNode()).thenReturn(testData2);
+        when(testEvent3.getJsonNode()).thenReturn(testData3);
+        when(objectMapper.writeValueAsBytes(testData1)).thenReturn(new byte[10]);
+        when(objectMapper.writeValueAsBytes(testData2)).thenReturn(new byte[20]);
+        when(objectMapper.writeValueAsBytes(testData3)).thenReturn(new byte[30]);
         when(searchWithSearchAfterResults.getDocuments()).thenReturn(List.of(testEvent1, testEvent2)).thenReturn(List.of(testEvent1, testEvent2))
                 .thenReturn(List.of(testEvent3)).thenReturn(List.of(testEvent3));
 
@@ -419,9 +442,13 @@ public class PitWorkerTest {
         verify(sourceCoordinator, times(0)).saveProgressStateForPartition(eq(partitionKey), eq(openSearchIndexProgressState));
         verify(sourceCoordinator, times(0)).updatePartitionForAcknowledgmentWait(anyString(), any(Duration.class));
 
-        verify(bytesReceivedSummary, times(3)).record(0L);
+        verify(bytesReceivedSummary).record(10L);
+        verify(bytesReceivedSummary).record(20L);
+        verify(bytesReceivedSummary).record(30L);
         verify(documentsProcessedCounter, times(3)).increment();
-        verify(bytesProcessedSummary, times(3)).record(0L);
+        verify(bytesProcessedSummary).record(10L);
+        verify(bytesProcessedSummary).record(20L);
+        verify(bytesProcessedSummary).record(30L);
         verify(indicesProcessedCounter).increment();
         verifyNoInteractions(processingErrorsCounter);
     }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorkerTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/ScrollWorkerTest.java
@@ -149,7 +149,6 @@ public class ScrollWorkerTest {
     void run_with_getNextPartition_with_non_empty_partition_creates_and_deletes_scroll_and_closes_that_partition() throws Exception {
         mockTimerCallable();
 
-        when(objectMapper.writeValueAsBytes(any(JsonNode.class))).thenReturn(new byte[0]);
         final SourcePartition<OpenSearchIndexProgressState> sourcePartition = mock(SourcePartition.class);
         final String partitionKey = UUID.randomUUID().toString();
         when(sourcePartition.getPartitionKey()).thenReturn(partitionKey);
@@ -160,8 +159,12 @@ public class ScrollWorkerTest {
         when(createScrollResponse.getScrollId()).thenReturn(scrollId);
         final Event testEvent1 = mock(Event.class);
         final Event testEvent2 = mock(Event.class);
-        when(testEvent1.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent2.getJsonNode()).thenReturn(mock(JsonNode.class));
+        final JsonNode testData1 = mock(JsonNode.class);
+        final JsonNode testData2 = mock(JsonNode.class);
+        when(testEvent1.getJsonNode()).thenReturn(testData1);
+        when(testEvent2.getJsonNode()).thenReturn(testData2);
+        when(objectMapper.writeValueAsBytes(testData1)).thenReturn(new byte[10]);
+        when(objectMapper.writeValueAsBytes(testData2)).thenReturn(new byte[20]);
         when(createScrollResponse.getDocuments()).thenReturn(List.of(testEvent1, testEvent2));
         when(searchAccessor.createScroll(requestArgumentCaptor.capture())).thenReturn(createScrollResponse);
 
@@ -174,9 +177,15 @@ public class ScrollWorkerTest {
         final Event testEvent3 = mock(Event.class);
         final Event testEvent4 = mock(Event.class);
         final Event testEvent5 = mock(Event.class);
-        when(testEvent3.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent4.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent5.getJsonNode()).thenReturn(mock(JsonNode.class));
+        final JsonNode testData3 = mock(JsonNode.class);
+        final JsonNode testData4 = mock(JsonNode.class);
+        final JsonNode testData5 = mock(JsonNode.class);
+        when(testEvent3.getJsonNode()).thenReturn(testData3);
+        when(testEvent4.getJsonNode()).thenReturn(testData4);
+        when(testEvent5.getJsonNode()).thenReturn(testData5);
+        when(objectMapper.writeValueAsBytes(testData3)).thenReturn(new byte[30]);
+        when(objectMapper.writeValueAsBytes(testData4)).thenReturn(new byte[40]);
+        when(objectMapper.writeValueAsBytes(testData5)).thenReturn(new byte[50]);
         when(searchScrollResponse.getDocuments()).thenReturn(List.of(testEvent3, testEvent4))
                 .thenReturn(List.of(testEvent3, testEvent4)).thenReturn(List.of(testEvent5)).thenReturn(List.of(testEvent5));
 
@@ -232,9 +241,17 @@ public class ScrollWorkerTest {
         assertThat(deleteScrollRequest, notNullValue());
         assertThat(deleteScrollRequest.getScrollId(), equalTo(scrollId));
 
-        verify(bytesReceivedSummary, times(5)).record(0L);
+        verify(bytesReceivedSummary).record(10L);
+        verify(bytesReceivedSummary).record(20L);
+        verify(bytesReceivedSummary).record(30L);
+        verify(bytesReceivedSummary).record(40L);
+        verify(bytesReceivedSummary).record(50L);
         verify(documentsProcessedCounter, times(5)).increment();
-        verify(bytesProcessedSummary, times(5)).record(0L);
+        verify(bytesProcessedSummary).record(10L);
+        verify(bytesProcessedSummary).record(20L);
+        verify(bytesProcessedSummary).record(30L);
+        verify(bytesProcessedSummary).record(40L);
+        verify(bytesProcessedSummary).record(50L);
         verify(indicesProcessedCounter).increment();
         verifyNoInteractions(processingErrorsCounter);
     }
@@ -243,7 +260,6 @@ public class ScrollWorkerTest {
     void run_with_getNextPartition_with_acknowledgments_creates_and_deletes_scroll_and_closes_that_partition() throws Exception {
         mockTimerCallable();
 
-        when(objectMapper.writeValueAsBytes(any(JsonNode.class))).thenReturn(new byte[0]);
         final AcknowledgementSet acknowledgementSet = mock(AcknowledgementSet.class);
         AtomicReference<Integer> numEventsAdded = new AtomicReference<>(0);
         doAnswer(a -> {
@@ -268,8 +284,12 @@ public class ScrollWorkerTest {
         when(createScrollResponse.getScrollId()).thenReturn(scrollId);
         final Event testEvent1 = mock(Event.class);
         final Event testEvent2 = mock(Event.class);
-        when(testEvent1.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent2.getJsonNode()).thenReturn(mock(JsonNode.class));
+        final JsonNode testData1 = mock(JsonNode.class);
+        final JsonNode testData2 = mock(JsonNode.class);
+        when(testEvent1.getJsonNode()).thenReturn(testData1);
+        when(testEvent2.getJsonNode()).thenReturn(testData2);
+        when(objectMapper.writeValueAsBytes(testData1)).thenReturn(new byte[10]);
+        when(objectMapper.writeValueAsBytes(testData2)).thenReturn(new byte[20]);
         when(createScrollResponse.getDocuments()).thenReturn(List.of(testEvent1, testEvent2));
         when(searchAccessor.createScroll(requestArgumentCaptor.capture())).thenReturn(createScrollResponse);
 
@@ -282,9 +302,15 @@ public class ScrollWorkerTest {
         final Event testEvent3 = mock(Event.class);
         final Event testEvent4 = mock(Event.class);
         final Event testEvent5 = mock(Event.class);
-        when(testEvent3.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent4.getJsonNode()).thenReturn(mock(JsonNode.class));
-        when(testEvent5.getJsonNode()).thenReturn(mock(JsonNode.class));
+        final JsonNode testData3 = mock(JsonNode.class);
+        final JsonNode testData4 = mock(JsonNode.class);
+        final JsonNode testData5 = mock(JsonNode.class);
+        when(testEvent3.getJsonNode()).thenReturn(testData3);
+        when(testEvent4.getJsonNode()).thenReturn(testData4);
+        when(testEvent5.getJsonNode()).thenReturn(testData5);
+        when(objectMapper.writeValueAsBytes(testData3)).thenReturn(new byte[30]);
+        when(objectMapper.writeValueAsBytes(testData4)).thenReturn(new byte[40]);
+        when(objectMapper.writeValueAsBytes(testData5)).thenReturn(new byte[50]);
         when(searchScrollResponse.getDocuments()).thenReturn(List.of(testEvent3, testEvent4))
                 .thenReturn(List.of(testEvent3, testEvent4)).thenReturn(List.of(testEvent5)).thenReturn(List.of(testEvent5));
 
@@ -342,9 +368,17 @@ public class ScrollWorkerTest {
 
         verify(acknowledgementSet).complete();
 
-        verify(bytesReceivedSummary, times(5)).record(0L);
+        verify(bytesReceivedSummary).record(10L);
+        verify(bytesReceivedSummary).record(20L);
+        verify(bytesReceivedSummary).record(30L);
+        verify(bytesReceivedSummary).record(40L);
+        verify(bytesReceivedSummary).record(50L);
         verify(documentsProcessedCounter, times(5)).increment();
-        verify(bytesProcessedSummary, times(5)).record(0L);
+        verify(bytesProcessedSummary).record(10L);
+        verify(bytesProcessedSummary).record(20L);
+        verify(bytesProcessedSummary).record(30L);
+        verify(bytesProcessedSummary).record(40L);
+        verify(bytesProcessedSummary).record(50L);
         verify(indicesProcessedCounter).increment();
         verifyNoInteractions(processingErrorsCounter);
     }


### PR DESCRIPTION
### Description
This PR adds bytesReceived and bytesProcessed metrics into opensearch source.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
