### PR TITLE
MAINT: add bytes metrics into dynamo source

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
 import org.opensearch.dataprepper.buffer.common.BufferAccumulator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
@@ -31,6 +32,8 @@ public class StreamRecordConverter extends RecordConverter {
 
     static final String CHANGE_EVENTS_PROCESSED_COUNT = "changeEventsProcessed";
     static final String CHANGE_EVENTS_PROCESSING_ERROR_COUNT = "changeEventsProcessingErrors";
+    static final String BYTES_RECEIVED = "bytesReceived";
+    static final String BYTES_PROCESSED = "bytesProcessed";
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -41,6 +44,8 @@ public class StreamRecordConverter extends RecordConverter {
 
     private final Counter changeEventSuccessCounter;
     private final Counter changeEventErrorCounter;
+    private final DistributionSummary bytesReceivedSummary;
+    private final DistributionSummary bytesProcessedSummary;
 
     private Instant currentSecond;
     private int recordsSeenThisSecond = 0;
@@ -50,6 +55,8 @@ public class StreamRecordConverter extends RecordConverter {
         this.pluginMetrics = pluginMetrics;
         this.changeEventSuccessCounter = pluginMetrics.counter(CHANGE_EVENTS_PROCESSED_COUNT);
         this.changeEventErrorCounter = pluginMetrics.counter(CHANGE_EVENTS_PROCESSING_ERROR_COUNT);
+        this.bytesReceivedSummary = pluginMetrics.summary(BYTES_RECEIVED);
+        this.bytesProcessedSummary = pluginMetrics.summary(BYTES_PROCESSED);
     }
 
     @Override
@@ -62,14 +69,17 @@ public class StreamRecordConverter extends RecordConverter {
 
         int eventCount = 0;
         for (Record record : records) {
+            final long bytes = record.dynamodb().sizeBytes();
             // NewImage may be empty
             Map<String, Object> data = convertData(record.dynamodb().newImage());
             // Always get keys from dynamodb().keys()
             Map<String, Object> keys = convertKeys(record.dynamodb().keys());
 
             try {
+                bytesReceivedSummary.record(bytes);
                 final long eventCreationTimeMillis = calculateTieBreakingVersionFromTimestamp(record.dynamodb().approximateCreationDateTime());
                 addToBuffer(acknowledgementSet, data, keys, record.dynamodb().approximateCreationDateTime().toEpochMilli(), eventCreationTimeMillis, record.eventNameAsString());
+                bytesProcessedSummary.record(bytes);
                 eventCount++;
             } catch (Exception e) {
                 // will this cause too many logs?

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.dynamodb.stream;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,6 +59,7 @@ import static org.opensearch.dataprepper.plugins.source.dynamodb.stream.StreamCh
 
 @ExtendWith(MockitoExtension.class)
 class ShardConsumerTest {
+    private static final Random RANDOM = new Random();
 
     @Mock
     private EnhancedSourceCoordinator coordinator;
@@ -78,6 +80,9 @@ class ShardConsumerTest {
 
     @Mock
     private Counter testCounter;
+
+    @Mock
+    private DistributionSummary testSummary;
 
 
     private StreamCheckpointer checkpointer;
@@ -142,6 +147,7 @@ class ShardConsumerTest {
         when(dynamoDbStreamsClient.getRecords(any(GetRecordsRequest.class))).thenReturn(response);
 
         given(pluginMetrics.counter(anyString())).willReturn(testCounter);
+        given(pluginMetrics.summary(anyString())).willReturn(testSummary);
     }
 
 
@@ -220,6 +226,7 @@ class ShardConsumerTest {
                     sortKeyAttrName, AttributeValue.builder().s(UUID.randomUUID().toString()).build());
 
             StreamRecord streamRecord = StreamRecord.builder()
+                    .sizeBytes(RANDOM.nextLong())
                     .newImage(data)
                     .sequenceNumber(UUID.randomUUID().toString())
                     .approximateCreationDateTime(Instant.now())


### PR DESCRIPTION
### Description
This PR adds bytesReceived and bytesProcessed into dynamoDB source
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
