### PR TITLE
DynamoDB source: Full exception and stack trace for unexpected exceptions

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderScheduler.java
@@ -114,7 +114,7 @@ public class LeaderScheduler implements Runnable {
                 }
 
             } catch (Exception e) {
-                LOG.error("Exception occurred: {}", e.getMessage());
+                LOG.error("Exception occurred in primary scheduling loop", e);
             } finally {
                 try {
                     Thread.sleep(DEFAULT_LEASE_INTERVAL_MILLIS);


### PR DESCRIPTION
### Description

I've seen exceptions in `LeaderScheduler` that look like:

```
2023-11-13T14:22:14.631 [pool-15-thread-1] ERROR org.opensearch.dataprepper.plugins.source.dynamodb.leader.LeaderScheduler - Exception occurred: null
```

This PR changes this exception handling to include the full stack trace. As this is an unexpected error, that is most appropriate.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
