### PR TITLE
Convert Number types to BigDecimal plainString for consistency betwee…

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/RecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/RecordConverter.java
@@ -14,6 +14,7 @@ import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableInfo;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Map;
 
@@ -56,7 +57,11 @@ public abstract class RecordConverter {
      */
     private String getAttributeValue(final Map<String, Object> data, String attributeName) {
         if (data.containsKey(attributeName)) {
-            return String.valueOf(data.get(attributeName));
+            final Object value = data.get(attributeName);
+            if (value instanceof Number) {
+                return new BigDecimal(value.toString()).toPlainString();
+            }
+            return String.valueOf(value);
         }
         return null;
     }


### PR DESCRIPTION
…n partition and sort keys for export and streams

### Description
This change converts all partition and sort keys that are Number types to BigDecimal and then to plain string to get rid of inconsistencies with how decimals are written from ION format in export to streams with DDB Attributes. Long term we can consider changing from ION to DDB json, but for now there is no easy way to convert between DDB json and regular JSON in Java. 
 
### Issues Resolved
Resolves #3642 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
