### PR TITLE
Go back to processing only 1 data node file at a time instead of 3

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileScheduler.java
@@ -39,7 +39,7 @@ public class DataFileScheduler implements Runnable {
     /**
      * Maximum concurrent data loader per node
      */
-    private static final int MAX_JOB_COUNT = 3;
+    private static final int MAX_JOB_COUNT = 1;
 
     /**
      * Default interval to acquire a lease from coordination store


### PR DESCRIPTION
### Description

Limits to 1 data file per node, as 3 is more harmful than helpful
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
