### PR TITLE
Change latency metric names

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkLatencyMetrics.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/sink/SinkLatencyMetrics.java
@@ -13,8 +13,8 @@ import java.time.Duration;
 import java.time.Instant;
 
 public class SinkLatencyMetrics {
-    public static final String INTERNAL_LATENCY = "PipelineLatency";
-    public static final String EXTERNAL_LATENCY = "EndToEndLatency";
+    public static final String INTERNAL_LATENCY = "pipelineLatency";
+    public static final String EXTERNAL_LATENCY = "endToEndLatency";
     private final DistributionSummary internalLatencySummary;
     private final DistributionSummary externalLatencySummary;
 


### PR DESCRIPTION
### Description
Rename latency metrics to follow the convention
Renamed `PipelineLatency` to `pipelineLatency` and `EndToEndLatency` to `endToEndLatency`
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
