### PR TITLE
Correct single quote escape character in DynamoDB [#3664]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,7 @@ subprojects {
 
 configure(subprojects.findAll {it.name != 'data-prepper-api'}) {
     dependencies {
-        implementation platform('software.amazon.awssdk:bom:2.20.67')
+        implementation platform('software.amazon.awssdk:bom:2.21.23')
         implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
     }
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.dynamodb.converter;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,7 +36,8 @@ public class StreamRecordConverter extends RecordConverter {
     static final String BYTES_RECEIVED = "bytesReceived";
     static final String BYTES_PROCESSED = "bytesProcessed";
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, true);
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {
     };
@@ -70,10 +72,18 @@ public class StreamRecordConverter extends RecordConverter {
         int eventCount = 0;
         for (Record record : records) {
             final long bytes = record.dynamodb().sizeBytes();
-            // NewImage may be empty
-            Map<String, Object> data = convertData(record.dynamodb().newImage());
-            // Always get keys from dynamodb().keys()
-            Map<String, Object> keys = convertKeys(record.dynamodb().keys());
+            Map<String, Object> data;
+            Map<String, Object> keys;
+            try {
+                // NewImage may be empty
+                data = convertData(record.dynamodb().newImage());
+                // Always get keys from dynamodb().keys()
+                keys = convertKeys(record.dynamodb().keys());
+            } catch (final Exception e) {
+                LOG.error("Failed to parse and convert data from stream due to {}", e.getMessage());
+                changeEventErrorCounter.increment();
+                continue;
+            }
 
             try {
                 bytesReceivedSummary.record(bytes);
@@ -101,13 +111,9 @@ public class StreamRecordConverter extends RecordConverter {
     /**
      * Convert the DynamoDB attribute map to a normal map for data
      */
-    private Map<String, Object> convertData(Map<String, AttributeValue> data) {
-        try {
-            String jsonData = EnhancedDocument.fromAttributeValueMap(data).toJson();
-            return MAPPER.readValue(jsonData, MAP_TYPE_REFERENCE);
-        } catch (JsonProcessingException e) {
-            return null;
-        }
+    private Map<String, Object> convertData(Map<String, AttributeValue> data) throws JsonProcessingException {
+        String jsonData = EnhancedDocument.fromAttributeValueMap(data).toJson();
+        return MAPPER.readValue(jsonData, MAP_TYPE_REFERENCE);
     }
 
     /**

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -36,8 +36,7 @@ public class StreamRecordConverter extends RecordConverter {
     static final String BYTES_RECEIVED = "bytesReceived";
     static final String BYTES_PROCESSED = "bytesProcessed";
 
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, true);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {
     };

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.source.dynamodb.converter;
 
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
### Description

This PR adds unit tests which replicate the behavior in #3664 of single quotes causing data loss. It fixes this by updating the AWS SDK to 2.21.23. We probably should update the version anyway to keep up with the latest.

This PR also adds different error handling when failures occur from parsing data that cannot work. Now the failure is logged and the error metric is incremented.
 
### Issues Resolved

Resolves #3664
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
