### PR TITLE
Uses export time minus 5 minutes for export document version

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/RecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/RecordConverter.java
@@ -19,10 +19,10 @@ import java.time.Instant;
 import java.util.Map;
 
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_TABLE_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.PARTITION_KEY_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.SORT_KEY_METADATA_ATTRIBUTE;
@@ -35,7 +35,6 @@ import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.Metad
 public abstract class RecordConverter {
 
     private static final String DEFAULT_ACTION = OpenSearchBulkActions.INDEX.toString();
-
 
     private final BufferAccumulator<Record<Event>> bufferAccumulator;
 
@@ -120,11 +119,11 @@ public abstract class RecordConverter {
         bufferAccumulator.add(new Record<>(event));
     }
 
-    public void addToBuffer(final AcknowledgementSet acknowledgementSet, Map<String, Object> data) throws Exception {
-        // Export data doesn't have an event timestamp
-        // We consider this to be time of 0, meaning stream records will always be considered as newer
-        // than export records
-        addToBuffer(acknowledgementSet, data, data, System.currentTimeMillis(), 0L, null);
+    public void addToBuffer(final AcknowledgementSet acknowledgementSet,
+                            final Map<String, Object> data,
+                            final long timestamp,
+                            final long eventVersionNumber) throws Exception {
+        addToBuffer(acknowledgementSet, data, data, timestamp, eventVersionNumber, null);
     }
 
     private String mapStreamEventNameToBulkAction(final String streamEventName) {

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.source.dynamodb.converter;
 
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,8 +35,7 @@ public class StreamRecordConverter extends RecordConverter {
     static final String BYTES_RECEIVED = "bytesReceived";
     static final String BYTES_PROCESSED = "bytesProcessed";
 
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {
     };

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.dynamodb.converter;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,7 +36,8 @@ public class StreamRecordConverter extends RecordConverter {
     static final String BYTES_RECEIVED = "bytesReceived";
     static final String BYTES_PROCESSED = "bytesProcessed";
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {
     };

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/coordination/partition/DataFilePartition.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/coordination/partition/DataFilePartition.java
@@ -22,10 +22,9 @@ public class DataFilePartition extends EnhancedSourcePartition<DataFileProgressS
     private final String exportArn;
     private final String bucket;
     private final String key;
+    private final DataFileProgressState state;
 
-    private DataFileProgressState state;
-
-    public DataFilePartition(SourcePartitionStoreItem sourcePartitionStoreItem) {
+    public DataFilePartition(final SourcePartitionStoreItem sourcePartitionStoreItem) {
 
         setSourcePartitionStoreItem(sourcePartitionStoreItem);
         String[] keySplits = sourcePartitionStoreItem.getSourcePartitionKey().split("\\|");
@@ -36,7 +35,10 @@ public class DataFilePartition extends EnhancedSourcePartition<DataFileProgressS
 
     }
 
-    public DataFilePartition(String exportArn, String bucket, String key, Optional<DataFileProgressState> state) {
+    public DataFilePartition(final String exportArn,
+                             final String bucket,
+                             final String key,
+                             final Optional<DataFileProgressState> state) {
         this.exportArn = exportArn;
         this.bucket = bucket;
         this.key = key;

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/coordination/state/DataFileProgressState.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/coordination/state/DataFileProgressState.java
@@ -16,6 +16,9 @@ public class DataFileProgressState {
     @JsonProperty("loadedRecords")
     private int loaded;
 
+    @JsonProperty("exportStartTime")
+    private long startTime;
+
     public int getTotal() {
         return total;
     }
@@ -30,5 +33,13 @@ public class DataFileProgressState {
 
     public void setLoaded(int loaded) {
         this.loaded = loaded;
+    }
+
+    public void setStartTime(long startTime) {
+        this.startTime = startTime;
+    }
+
+    public long getStartTime() {
+        return startTime;
     }
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoader.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoader.java
@@ -75,7 +75,7 @@ public class DataFileLoader implements Runnable {
         this.checkpointer = builder.checkpointer;
         this.startLine = builder.startLine;
         final BufferAccumulator<Record<Event>> bufferAccumulator = BufferAccumulator.create(builder.buffer, DEFAULT_BUFFER_BATCH_SIZE, BUFFER_TIMEOUT);
-        recordConverter = new ExportRecordConverter(bufferAccumulator, builder.tableInfo, builder.pluginMetrics);
+        recordConverter = new ExportRecordConverter(bufferAccumulator, builder.tableInfo, builder.pluginMetrics, builder.exportStartTime);
         this.acknowledgementSet = builder.acknowledgementSet;
         this.dataFileAcknowledgmentTimeout = builder.dataFileAcknowledgmentTimeout;
     }
@@ -111,6 +111,8 @@ public class DataFileLoader implements Runnable {
 
         private int startLine;
 
+        private long exportStartTime;
+
         public Builder(final S3ObjectReader objectReader, final PluginMetrics pluginMetrics, final Buffer<Record<Event>> buffer) {
             this.objectReader = objectReader;
             this.pluginMetrics = pluginMetrics;
@@ -139,6 +141,11 @@ public class DataFileLoader implements Runnable {
 
         public Builder startLine(int startLine) {
             this.startLine = startLine;
+            return this;
+        }
+
+        public Builder exportStartTime(final long exportStartTime) {
+            this.exportStartTime = exportStartTime;
             return this;
         }
 

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoaderFactory.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoaderFactory.java
@@ -46,18 +46,17 @@ public class DataFileLoaderFactory {
         DataFileCheckpointer checkpointer = new DataFileCheckpointer(coordinator, dataFilePartition);
 
         // Start a data loader thread.
-        DataFileLoader loader = DataFileLoader.builder(objectReader, pluginMetrics, buffer)
+        return DataFileLoader.builder(objectReader, pluginMetrics, buffer)
                 .bucketName(dataFilePartition.getBucket())
                 .key(dataFilePartition.getKey())
                 .tableInfo(tableInfo)
+                .exportStartTime(dataFilePartition.getProgressState().get().getStartTime())
                 .checkpointer(checkpointer)
                 .acknowledgmentSet(acknowledgementSet)
                 .acknowledgmentSetTimeout(acknowledgmentTimeout)
                 // We can't checkpoint with acks enabled yet
                 .startLine(acknowledgementSet == null ? dataFilePartition.getProgressState().get().getLoaded() : 0)
                 .build();
-
-        return loader;
     }
 
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/LeaderScheduler.java
@@ -253,7 +253,7 @@ public class LeaderScheduler implements Runnable {
         if (tableConfig.getStreamConfig() != null) {
             // Validate if DynamoDB Stream is turn on or not
             if (describeTableResult.table().streamSpecification() == null) {
-                String errorMessage = "Steam is not enabled for table " + tableConfig.getTableArn();
+                String errorMessage = "Stream is not enabled for table " + tableConfig.getTableArn();
                 LOG.error(errorMessage);
                 throw new InvalidPluginConfigurationException(errorMessage);
             }

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoaderFactoryTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoaderFactoryTest.java
@@ -23,6 +23,7 @@ import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableMetadata;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
@@ -61,6 +62,7 @@ class DataFileLoaderFactoryTest {
     private final String prefix = UUID.randomUUID().toString();
 
     private final String exportArn = tableArn + "/export/01693291918297-bfeccbea";
+    private final String exportTime = "1976-01-01T00:00:00Z";
 
     private final Random random = new Random();
 
@@ -72,6 +74,7 @@ class DataFileLoaderFactoryTest {
         DataFileProgressState state = new DataFileProgressState();
         state.setLoaded(0);
         state.setTotal(total);
+        state.setStartTime(Instant.parse(exportTime).toEpochMilli());
         dataFilePartition = new DataFilePartition(exportArn, bucketName, manifestKey, Optional.of(state));
 
         // Mock Global Table Info

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoaderTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoaderTest.java
@@ -34,6 +34,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
@@ -90,6 +91,7 @@ class DataFileLoaderTest {
     private final String bucketName = UUID.randomUUID().toString();
 
     private final String exportArn = tableArn + "/export/01693291918297-bfeccbea";
+    private final String exportTime = "1976-01-01T00:00:00Z";
 
     private final Random random = new Random();
 
@@ -101,6 +103,7 @@ class DataFileLoaderTest {
         DataFileProgressState state = new DataFileProgressState();
         state.setLoaded(0);
         state.setTotal(total);
+        state.setStartTime(Instant.parse(exportTime).toEpochMilli());
 
         dataFilePartition = new DataFilePartition(exportArn, bucketName, manifestKey, Optional.of(state));
 

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileSchedulerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileSchedulerTest.java
@@ -25,6 +25,7 @@ import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableInfo;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableMetadata;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -90,6 +91,7 @@ class DataFileSchedulerTest {
     private final String prefix = UUID.randomUUID().toString();
 
     private final String exportArn = tableArn + "/export/01693291918297-bfeccbea";
+    private final String exportTime = "1976-01-01T00:00:00Z";
     private final String streamArn = tableArn + "/stream/2023-09-14T05:46:45.367";
 
 
@@ -100,6 +102,7 @@ class DataFileSchedulerTest {
         DataFileProgressState state = new DataFileProgressState();
         state.setLoaded(0);
         state.setTotal(100);
+        state.setStartTime(Instant.parse(exportTime).toEpochMilli());
         dataFilePartition = new DataFilePartition(exportArn, bucketName, manifestKey, Optional.of(state));
 
         // Mock Global Table Info

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileSchedulerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileSchedulerTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -74,7 +74,7 @@ class DataFileSchedulerTest {
     private Counter exportFileSuccess;
 
     @Mock
-    private AtomicLong activeExportS3ObjectConsumers;
+    private AtomicInteger activeExportS3ObjectConsumers;
 
     @Mock
     private DataFileLoaderFactory loaderFactory;
@@ -124,7 +124,7 @@ class DataFileSchedulerTest {
         lenient().when(exportInfoGlobalState.getProgressState()).thenReturn(Optional.of(loadStatus.toMap()));
 
         given(pluginMetrics.counter(EXPORT_S3_OBJECTS_PROCESSED_COUNT)).willReturn(exportFileSuccess);
-        given(pluginMetrics.gauge(eq(ACTIVE_EXPORT_S3_OBJECT_CONSUMERS_GAUGE), any(AtomicLong.class))).willReturn(activeExportS3ObjectConsumers);
+        given(pluginMetrics.gauge(eq(ACTIVE_EXPORT_S3_OBJECT_CONSUMERS_GAUGE), any(AtomicInteger.class))).willReturn(activeExportS3ObjectConsumers);
 
         lenient().when(coordinator.createPartition(any(EnhancedSourcePartition.class))).thenReturn(true);
         lenient().doNothing().when(coordinator).completePartition(any(EnhancedSourcePartition.class));

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportSchedulerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportSchedulerTest.java
@@ -107,6 +107,7 @@ class ExportSchedulerTest {
         lenient().when(manifestFileReader.parseSummaryFile(anyString(), anyString())).thenReturn(summary);
         lenient().when(summary.getS3Bucket()).thenReturn(bucketName);
         lenient().when(summary.getManifestFilesS3Key()).thenReturn(manifestKey);
+        lenient().when(summary.getExportTime()).thenReturn(exportTime.toString());
         lenient().when(manifestFileReader.parseDataFile(anyString(), anyString())).thenReturn(Map.of("Key1", 100, "Key2", 200));
 
         lenient().when(coordinator.createPartition(any(EnhancedSourcePartition.class))).thenReturn(true);


### PR DESCRIPTION
### Description
Changes the export version from being `0` to the `exportTime - 5 minutes`. This is so stream events still get priority over export Events, but new exports to the same index will not get version conflicts with OpenSearch with this change. 
 
Tested with export and streams, where updates/deletes were made after starting the pipeline, and the result was this in OpenSearch

```
Export version
1700033214421000

Update item
1700033604000000
```
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
