### PR TITLE
Use Amazon Linux 2023 as the base Docker image for Data Prepper

### DIFF
--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:17-jre-jammy
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
 ARG PIPELINE_FILEPATH
 ARG CONFIG_FILEPATH
 ARG ARCHIVE_FILE
@@ -9,9 +10,13 @@ ENV ENV_CONFIG_FILEPATH=$CONFIG_FILEPATH
 ENV ENV_PIPELINE_FILEPATH=$PIPELINE_FILEPATH
 
 # Update all packages
-RUN apt -y update
-RUN apt -y install bash bc
-RUN apt -y full-upgrade
+RUN dnf -y update
+RUN dnf -y install bash bc
+RUN dnf -y upgrade
+
+# Setup the Adoptium package repo and install Temurin Java
+ADD adoptium.repo /etc/yum.repos.d/adoptium.repo
+RUN dnf -y install temurin-17-jdk
 
 RUN mkdir -p /var/log/data-prepper
 ADD $ARCHIVE_FILE /usr/share

--- a/release/docker/adoptium.repo
+++ b/release/docker/adoptium.repo
@@ -1,0 +1,6 @@
+[adoptium]
+name=Adoptium
+baseurl=https://packages.adoptium.net/artifactory/rpm/amazonlinux/2/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public

--- a/release/docker/build.gradle
+++ b/release/docker/build.gradle
@@ -12,6 +12,7 @@ docker {
     tag "${project.rootProject.name}", "${project.version}"
     files project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archivePath
     files "${project.projectDir}/config/default-data-prepper-config.yaml", "${project.projectDir}/config/default-keystore.p12"
+    files 'adoptium.repo'
     buildArgs(['ARCHIVE_FILE' : project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archiveFileName.get(),
                'ARCHIVE_FILE_UNPACKED' : project(':release:archives:linux').tasks.getByName('linuxx64DistTar').archiveFileName.get().replace('.tar.gz', ''),
                'CONFIG_FILEPATH' : '/usr/share/data-prepper/config/data-prepper-config.yaml',


### PR DESCRIPTION
### Description

This updates the base image for Data Prepper to Amazon Linux 2023.

As this image does not have Java installed, it also installs Temurin using the Adoptium repository. It specifies the Amazon Linux 2 repository for this.
 
### Issues Resolved

Resolves #3505
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
