### PR TITLE
Add ddb source fixes/improvements

### DIFF
--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
@@ -231,13 +231,15 @@ public class DynamoDbClientWrapper {
 
                     // For ASSIGNED partitions we are sorting based on partitionOwnershipTimeout, so if any item has partitionOwnershipTimeout
                     // in the future, we can know that the remaining items will not be available.
-                    if (SourcePartitionStatus.ASSIGNED.equals(sourcePartitionStatus) && Instant.now().isBefore(item.getPartitionOwnershipTimeout())) {
+                    if (SourcePartitionStatus.ASSIGNED.equals(sourcePartitionStatus) && item.getPartitionOwnershipTimeout() != null &&
+                            Instant.now().isBefore(item.getPartitionOwnershipTimeout())) {
                         return Optional.empty();
                     }
 
                     // For CLOSED partitions we are sorting based on reOpenAt time, so if any item has reOpenAt in the future,
                     // we can know that the remaining items will not be ready to be acquired again.
-                    if (SourcePartitionStatus.CLOSED.equals(sourcePartitionStatus) && Instant.now().isBefore(item.getReOpenAt())) {
+                    if (SourcePartitionStatus.CLOSED.equals(sourcePartitionStatus) && item.getReOpenAt() != null &&
+                            Instant.now().isBefore(item.getReOpenAt())) {
                         return Optional.empty();
                     }
 

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBService.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBService.java
@@ -21,6 +21,7 @@ import org.opensearch.dataprepper.plugins.source.dynamodb.leader.LeaderScheduler
 import org.opensearch.dataprepper.plugins.source.dynamodb.leader.ShardManager;
 import org.opensearch.dataprepper.plugins.source.dynamodb.stream.ShardConsumerFactory;
 import org.opensearch.dataprepper.plugins.source.dynamodb.stream.StreamScheduler;
+import org.opensearch.dataprepper.plugins.source.dynamodb.utils.BackoffCalculator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -94,7 +95,7 @@ public class DynamoDBService {
         Runnable fileLoaderScheduler = new DataFileScheduler(coordinator, loaderFactory, pluginMetrics, acknowledgementSetManager, dynamoDBSourceConfig);
 
         ShardConsumerFactory consumerFactory = new ShardConsumerFactory(coordinator, dynamoDbStreamsClient, pluginMetrics, buffer);
-        Runnable streamScheduler = new StreamScheduler(coordinator, consumerFactory, pluginMetrics, acknowledgementSetManager, dynamoDBSourceConfig);
+        Runnable streamScheduler = new StreamScheduler(coordinator, consumerFactory, pluginMetrics, acknowledgementSetManager, dynamoDBSourceConfig, new BackoffCalculator());
         // leader scheduler will handle the initialization
         Runnable leaderScheduler = new LeaderScheduler(coordinator, dynamoDbClient, shardManager, tableConfigs);
 

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBSourceConfig.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBSourceConfig.java
@@ -33,7 +33,7 @@ public class DynamoDBSourceConfig {
     private boolean acknowledgments = false;
 
     @JsonProperty("shard_acknowledgment_timeout")
-    private Duration shardAcknowledgmentTimeout = Duration.ofMinutes(3);
+    private Duration shardAcknowledgmentTimeout = Duration.ofMinutes(10);
 
     @JsonProperty("s3_data_file_acknowledgment_timeout")
     private Duration dataFileAcknowledgmentTimeout = Duration.ofMinutes(5);

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoader.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileLoader.java
@@ -184,8 +184,8 @@ public class DataFileLoader implements Runnable {
             while ((line = reader.readLine()) != null) {
                 if (shouldStop) {
                     checkpointer.checkpoint(lastLineProcessed);
-                    LOG.debug("Should Stop flag is set to True, looks like shutdown has triggered");
-                    throw new RuntimeException("Load is interrupted");
+                    LOG.warn("Loading data file s3://{}/{} was interrupted by a shutdown signal, giving up ownership of data file", bucketName, key);
+                    throw new RuntimeException("Loading data file interrupted");
                 }
 
                 lineCount += 1;

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportScheduler.java
@@ -264,7 +264,7 @@ public class ExportScheduler implements Runnable {
             return state.getExportArn();
         }
 
-        LOG.info("Try to submit a new export job for table {} with export time {}", exportPartition.getTableArn(), exportPartition.getExportTime());
+        LOG.info("Submitting a new export job for table {} with export time {}", exportPartition.getTableArn(), exportPartition.getExportTime());
         // submit a new export request
         String exportArn = exportTaskManager.submitExportJob(exportPartition.getTableArn(), state.getBucket(), state.getPrefix(), state.getKmsKeyId(), exportPartition.getExportTime());
 

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumer.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumer.java
@@ -233,7 +233,9 @@ public class ShardConsumer implements Runnable {
             }
 
             if (System.currentTimeMillis() - lastCheckpointTime > DEFAULT_CHECKPOINT_INTERVAL_MILLS) {
-                LOG.info("{} records written to buffer for shard {}", recordsWrittenToBuffer, shardId);
+                if (shardId != null) {
+                    LOG.info("{} records written to buffer for shard {}", recordsWrittenToBuffer, shardId);
+                }
                 checkpointer.checkpoint(sequenceNumber);
                 lastCheckpointTime = System.currentTimeMillis();
             }
@@ -287,7 +289,9 @@ public class ShardConsumer implements Runnable {
             acknowledgementSet.complete();
         }
 
-        LOG.info("Completed writing shard {} to buffer after reaching the end of the shard", shardId);
+        if (shardId != null) {
+            LOG.info("Completed writing shard {} to buffer after reaching the end of the shard", shardId);
+        }
 
         if (waitForExport) {
             waitForExport();
@@ -353,10 +357,10 @@ public class ShardConsumer implements Runnable {
 
             Instant lastEventTime = response.records().get(response.records().size() - 1).dynamodb().approximateCreationDateTime();
             if (lastEventTime.isBefore(startTime)) {
-                LOG.info("LastShardIterator is provided, and Last Event Time is earlier than export time, skip processing");
+                LOG.info("LastShardIterator is provided, and Last Event Time is earlier than {}, skip processing", startTime);
                 return true;
             } else {
-                LOG.info("LastShardIterator is provided, and Last Event Time is later than export time, start processing");
+                LOG.info("LastShardIterator is provided, and Last Event Time is later than {}, start processing", startTime);
                 return false;
             }
         }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactory.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactory.java
@@ -58,7 +58,7 @@ public class ShardConsumerFactory {
                                    final AcknowledgementSet acknowledgementSet,
                                    final Duration shardAcknowledgmentTimeout) {
 
-        LOG.info("Try to start a Shard Consumer for " + streamPartition.getShardId());
+        LOG.info("Starting to consume shard " + streamPartition.getShardId());
 
         // Check and get the current state.
         Optional<StreamProgressState> progressState = streamPartition.getProgressState();
@@ -82,8 +82,7 @@ public class ShardConsumerFactory {
 
         String shardIterator = getShardIterator(streamPartition.getStreamArn(), streamPartition.getShardId(), sequenceNumber);
         if (shardIterator == null) {
-            LOG.info("Unable to get a shard iterator, looks like the shard has expired");
-            LOG.error("Failed to start a Shard Consumer for " + streamPartition.getShardId());
+            LOG.error("Failed to start consuming shard '{}'. Unable to get a shard iterator for this shard, this shard may have expired", streamPartition.getShardId());
             return null;
         }
 

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/utils/BackoffCalculator.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/utils/BackoffCalculator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.dynamodb.utils;
+
+import org.opensearch.dataprepper.plugins.source.dynamodb.stream.StreamScheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.google.common.math.LongMath.pow;
+import static com.google.common.primitives.Longs.min;
+import static java.lang.Math.max;
+
+public class BackoffCalculator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StreamScheduler.class);
+
+    private static final Random RANDOM = new Random();
+
+    static final Duration STARTING_BACKOFF = Duration.ofMillis(500);
+    static final Duration MAX_BACKOFF_WITH_SHARDS = Duration.ofSeconds(15);
+    static final Duration MAX_BACKOFF_NO_SHARDS_ACQUIRED = Duration.ofSeconds(15);
+    static final int BACKOFF_RATE = 2;
+    static final Duration MAX_JITTER = Duration.ofSeconds(2);
+    static final Duration MIN_JITTER = Duration.ofSeconds(-2);
+
+    public long calculateBackoffToAcquireNextShard(final int noAvailableShardCount, final AtomicInteger shardsAcquired) {
+
+        // When no shards are available to process we backoff exponentially based on how many consecutive attempts have been made without getting a shard
+        // This limits calls to the coordination store
+        if (noAvailableShardCount > 0) {
+            if (noAvailableShardCount % 10 == 0) {
+                LOG.info("No shards acquired after {} attempts", noAvailableShardCount);
+            }
+
+            final long jitterMillis = MIN_JITTER.toMillis() + RANDOM.nextInt((int) (MAX_JITTER.toMillis() - MIN_JITTER.toMillis() + 1));
+            return max(1, min(STARTING_BACKOFF.toMillis() * pow(BACKOFF_RATE, noAvailableShardCount - 1) + jitterMillis, MAX_BACKOFF_NO_SHARDS_ACQUIRED.toMillis()));
+        }
+
+        // When shards are being acquired we backoff linearly based on how many shards this node is actively processing, to encourage a fast start but still a balance of shards between nodes
+        return max(500, min(MAX_BACKOFF_WITH_SHARDS.toMillis(), shardsAcquired.get() * STARTING_BACKOFF.toMillis()));
+    }
+}

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/StreamSchedulerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/StreamSchedulerTest.java
@@ -124,10 +124,6 @@ class StreamSchedulerTest {
         executorService.shutdown();
         future.cancel(true);
 
-        // Should acquire the stream partition
-        verify(coordinator).acquireAvailablePartition(StreamPartition.PARTITION_TYPE);
-        // Should start a new consumer
-        verify(consumerFactory).createConsumer(any(StreamPartition.class), eq(null), any(Duration.class));
         // Should mask the stream partition as completed.
         verify(coordinator).completePartition(any(StreamPartition.class));
 
@@ -164,10 +160,6 @@ class StreamSchedulerTest {
         future.cancel(true);
         assertThat(executorService.awaitTermination(1000, TimeUnit.MILLISECONDS), equalTo(true));
 
-        // Should acquire the stream partition
-        verify(coordinator).acquireAvailablePartition(StreamPartition.PARTITION_TYPE);
-        // Should start a new consumer
-        verify(consumerFactory).createConsumer(any(StreamPartition.class), any(AcknowledgementSet.class), any(Duration.class));
         // Should mask the stream partition as completed.
         verify(coordinator).completePartition(any(StreamPartition.class));
 

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/utils/BackoffCalculatorTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/utils/BackoffCalculatorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.dynamodb.utils;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.dataprepper.plugins.source.dynamodb.utils.BackoffCalculator.MAX_BACKOFF_NO_SHARDS_ACQUIRED;
+
+public class BackoffCalculatorTest {
+
+    @ParameterizedTest
+    @MethodSource("countsToExpectedBackoffRange")
+    void calculateBackoffToAcquireNextShardReturnsExpectedBackoffValues(
+            final int noAvailableShardCount,
+            final int shardsAcquiredCount,
+            final long minExpectedBackoff,
+            final long maxExpectedBackoff
+    ) {
+
+        final BackoffCalculator objectUnderTest = new BackoffCalculator();
+
+        final long backOffForShardCounts = objectUnderTest.calculateBackoffToAcquireNextShard(noAvailableShardCount, new AtomicInteger(shardsAcquiredCount));
+
+        assertThat(backOffForShardCounts, Matchers.greaterThanOrEqualTo(minExpectedBackoff));
+        assertThat(backOffForShardCounts, Matchers.lessThanOrEqualTo(maxExpectedBackoff));
+    }
+
+    private static Stream<Arguments> countsToExpectedBackoffRange() {
+        return Stream.of(
+                Arguments.of(0, 0, 500, 500),
+                Arguments.of(0, 1, 500, 500),
+                Arguments.of(0, 2, 1000, 1000),
+                Arguments.of(0, 29, 14_500, 14_500),
+                Arguments.of(0, 30, 15_000, 15_000),
+                Arguments.of(2, 1, 1, 3_000),
+                Arguments.of(3, 0, 1, 4_000),
+                Arguments.of(4, 2, 2_000, 6_000),
+                Arguments.of(5, 6, 6_000, 10_000),
+                Arguments.of(6, 6, 14_000, 15_000),
+                Arguments.of(8, 2, MAX_BACKOFF_NO_SHARDS_ACQUIRED.toMillis(), MAX_BACKOFF_NO_SHARDS_ACQUIRED.toMillis())
+        );
+    }
+}


### PR DESCRIPTION
### Description

This change contains a couple fixes / improvements to the `dynamodb` source

1. Fixes a bug where empty acknowledgment sets for shards would be marked as complete on shutdown, which triggered the acknowledgment callback and attempted to mark the shard as completed in the coordination store
2. Fixes a bug where shutdown with `acknowledgments` enabled would not give up the partition (for both the shard and data file), which resulted in those partitions to not be available to other nodes until the `partitionOwnershipTimeout` expired, rather than immediately making those partitions available.
3. Fixes a potential NullPointerException in the `DynamoDbClientWrapper` for the coordination store
4. Increase default `shard_acknowledgment_timeout` from 3 minutes to 10 minutes. This is to encourage ease of initial pipeline setup
5. Miscellaneous logging improvements/additions
6. Change the backoff rate for acquiring the next shard from 15 seconds to being calculated based on 
     a. An exponential backoff and jitter of up to 15 seconds when no shards are available for processing
     b. A linear backoff from 0.5 -15 seconds when shards are available. This will result in the following waits for different shard counts that have been acquired

```
first 10 shards grabbed in 27.5 seconds
first 15 shards grabbed in 60 seconds
first 20 shards grabbed in 255 seconds
```
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
