### PR TITLE
ShardId is not passed to ShardConsumer, resulting in logs saying shar…

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumer.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumer.java
@@ -233,9 +233,7 @@ public class ShardConsumer implements Runnable {
             }
 
             if (System.currentTimeMillis() - lastCheckpointTime > DEFAULT_CHECKPOINT_INTERVAL_MILLS) {
-                if (shardId != null) {
-                    LOG.info("{} records written to buffer for shard {}", recordsWrittenToBuffer, shardId);
-                }
+                LOG.debug("{} records written to buffer for shard {}", recordsWrittenToBuffer, shardId);
                 checkpointer.checkpoint(sequenceNumber);
                 lastCheckpointTime = System.currentTimeMillis();
             }
@@ -287,10 +285,6 @@ public class ShardConsumer implements Runnable {
         if (acknowledgementSet != null) {
             checkpointer.updateShardForAcknowledgmentWait(shardAcknowledgmentTimeout);
             acknowledgementSet.complete();
-        }
-
-        if (shardId != null) {
-            LOG.info("Completed writing shard {} to buffer after reaching the end of the shard", shardId);
         }
 
         if (waitForExport) {

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactory.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactory.java
@@ -96,6 +96,7 @@ public class ShardConsumerFactory {
                 .tableInfo(tableInfo)
                 .checkpointer(checkpointer)
                 .shardIterator(shardIterator)
+                .shardId(streamPartition.getShardId())
                 .lastShardIterator(lastShardIterator)
                 .startTime(startTime)
                 .waitForExport(waitForExport)


### PR DESCRIPTION
…d is null on shutdown

### Description
ShardId was not passed to the `shardConsumer`, resulting in the following log on shutdown

```
2023-11-16T21:51:25.304 [pool-18-thread-5] WARN  org.opensearch.dataprepper.plugins.source.dynamodb.stream.ShardConsumer - Processing for shard null was interrupted by a shutdown signal, giving up shard
```
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
