### PR TITLE
Check if failedDeleteCount is positive before logging

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorker.java
@@ -339,7 +339,7 @@ public class SqsWorker implements Runnable {
                 final int failedDeleteCount = deleteMessageBatchResponse.failed().size();
                 sqsMessagesDeleteFailedCounter.increment(failedDeleteCount);
 
-                if(LOG.isErrorEnabled()) {
+                if(LOG.isErrorEnabled() && failedDeleteCount > 0) {
                     final String failedMessages = deleteMessageBatchResponse.failed().stream()
                             .map(failed -> failed.toString())
                             .collect(Collectors.joining(", "));


### PR DESCRIPTION
### Description
Saw these log messages in customer pipeline logs:
```
ERROR org.opensearch.dataprepper.plugins.source.s3.SqsWorker - Failed to delete 0 messages from SQS with errors: [].
```
This doesn't actually indicate any error. This change checks if failedDeleteCount is positive before logging
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
