### PR TITLE
Increase test coverage in the plugin common library

### DIFF
--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/hasher/IdentificationKeysHasherTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/hasher/IdentificationKeysHasherTest.java
@@ -124,4 +124,46 @@ public class IdentificationKeysHasherTest {
 
         assertThat(result, is(not(equalTo(secondResult))));
     }
+
+    @Test
+    void getKeyMap_returns_input_map() {
+        final Map<Object, Object> expectedKeyMap = Map.of(
+                UUID.randomUUID().toString(), UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(), UUID.randomUUID().toString()
+        );
+
+        final IdentificationKeysHasher.IdentificationKeysMap objectUnderTest = new IdentificationKeysHasher.IdentificationKeysMap(expectedKeyMap);
+
+        assertThat(objectUnderTest.getKeyMap(), equalTo(expectedKeyMap));
+    }
+
+    @Test
+    void hashCode_returns_same_value_for_same_maps() {
+        final Map<Object, Object> input = Map.of(
+                UUID.randomUUID().toString(), UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(), UUID.randomUUID().toString()
+        );
+
+        final IdentificationKeysHasher.IdentificationKeysMap objectUnderTest1 = new IdentificationKeysHasher.IdentificationKeysMap(input);
+        final IdentificationKeysHasher.IdentificationKeysMap objectUnderTest2 = new IdentificationKeysHasher.IdentificationKeysMap(input);
+
+        assertThat(objectUnderTest1.hashCode(), equalTo(objectUnderTest2.hashCode()));
+    }
+
+    @Test
+    void hashCode_returns_different_value_for_know_different_maps() {
+        final IdentificationKeysHasher.IdentificationKeysMap objectUnderTest1 = new IdentificationKeysHasher.IdentificationKeysMap(
+                Map.of(
+                        "aaa", "bbb",
+                        "ccc", "ddd"
+                ));
+        final IdentificationKeysHasher.IdentificationKeysMap objectUnderTest2 = new IdentificationKeysHasher.IdentificationKeysMap(
+                Map.of(
+                        "1", "22",
+                        "3", "4"
+                )
+        );
+
+        assertThat(objectUnderTest1.hashCode(), not(equalTo(objectUnderTest2.hashCode())));
+    }
 }


### PR DESCRIPTION
### Description

The common library for plugins is frequently failing with coverage ratio.

```
Execution failed for task ':data-prepper-plugins:common:jacocoTestCoverageVerification'.
> Rule violated for bundle common: instructions covered ratio is 0.89, but expected minimum is 0.90
```
 
This PR adds some additional coverage to this library to avoid this error.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
