### PR TITLE
Updates werkzeug to 3.0.1 fixing CVE-2023-46136

### DIFF
--- a/examples/trace-analytics-sample-app/sample-app/requirements.txt
+++ b/examples/trace-analytics-sample-app/sample-app/requirements.txt
@@ -1,4 +1,4 @@
-dash==2.13.0
+dash==2.14.1
 mysql-connector==2.2.9
 opentelemetry-exporter-otlp==1.20.0
 opentelemetry-instrumentation-flask==0.41b0
@@ -7,4 +7,4 @@ opentelemetry-instrumentation-requests==0.41b0
 opentelemetry-sdk==1.20.0
 protobuf==3.20.3
 urllib3==2.0.7
-werkzeug==2.2.3
+werkzeug==3.0.1


### PR DESCRIPTION
### Description

The goal is to resolve CVE-2023-46136 by updating werkzeug to 3.0.1. In order to update this version though, I also needed to update dash to 2.14.1.
 
### Issues Resolved

Resolves #3552.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
