### PR TITLE
Require Apache Avro 1.11.3 to fix CVE-2023-39410

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,12 @@ subprojects {
         testImplementation testLibs.hamcrest
         testImplementation testLibs.awaitility
         constraints {
+            implementation('org.apache.avro:avro') {
+                version {
+                    require '1.11.3'
+                }
+                because 'Fixes CVE-2023-39410.'
+            }
             implementation('org.apache.httpcomponents:httpclient') {
                 version {
                     require '4.5.14'


### PR DESCRIPTION
### Description

Require Apache Avro 1.11.3 to fix CVE-2023-39410. 
 
### Issues Resolved

Resolves #3430.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
