### PR TITLE
Gradle parallel max

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout Data Prepper
       uses: actions/checkout@v2
     - name: Build with Gradle
-      run: ./gradlew --parallel build
+      run: ./gradlew --parallel --max-workers 2 build
     - name: Upload Unit Test Results
       if: always()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Get Version
       run:  grep '^version=' gradle.properties >> $GITHUB_ENV
     - name: Build Jar Files
-      run: ./gradlew --parallel build
+      run: ./gradlew --parallel --max-workers 2 build
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -42,7 +42,7 @@ jobs:
         aws-region: us-east-1
 
     - name: Build Archives
-      run: ./gradlew --parallel :release:archives:buildArchives -Prelease
+      run: ./gradlew --parallel --max-workers 2 :release:archives:buildArchives -Prelease
 
     - name: Build Maven Artifacts
       run: ./gradlew publish


### PR DESCRIPTION
### Description

Limits the number of workers to 2 when building the main build and release builds on GitHub Actions.

I found that this increases the time to run from 10-11 minutes to 14-15 minutes. However, each test passed on the first run. So this might reduce flakiness significantly.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
