### PR TITLE
Build failures fixes

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/PipelinesWithAcksIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/PipelinesWithAcksIT.java
@@ -12,6 +12,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.InMemorySinkAccessor;
 import org.opensearch.dataprepper.plugins.InMemorySourceAccessor;
+import static org.opensearch.dataprepper.plugins.InMemorySource.ACK_EXPIRY_TIME;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.Assert.assertFalse;
 import org.slf4j.Logger;
@@ -38,6 +39,7 @@ class PipelinesWithAcksIT {
     private static final String THREE_PIPELINES_MULTI_SINK_CONFIGURATION_UNDER_TEST = "acknowledgements/three-pipelines-test-multi-sink.yaml";
     private static final String ONE_PIPELINE_THREE_SINKS_CONFIGURATION_UNDER_TEST = "acknowledgements/one-pipeline-three-sinks.yaml";
     private static final String ONE_PIPELINE_ACK_EXPIRY_CONFIGURATION_UNDER_TEST = "acknowledgements/one-pipeline-ack-expiry-test.yaml";
+    private static final long WAIT_TIME_MS = ACK_EXPIRY_TIME.minusMillis(5000L).toMillis();
     private DataPrepperTestRunner dataPrepperTestRunner;
     private InMemorySourceAccessor inMemorySourceAccessor;
     private InMemorySinkAccessor inMemorySinkAccessor;
@@ -65,7 +67,7 @@ class PipelinesWithAcksIT {
         final int numRecords = 1;
         inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, numRecords);
 
-        await().atMost(20000, TimeUnit.MILLISECONDS)
+        await().atMost(WAIT_TIME_MS, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
             List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
             assertThat(outputRecords, not(empty()));
@@ -81,7 +83,7 @@ class PipelinesWithAcksIT {
         final int numRecords = 100;
         inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, numRecords);
 
-        await().atMost(20000, TimeUnit.MILLISECONDS)
+        await().atMost(WAIT_TIME_MS, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
             List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
             assertThat(outputRecords, not(empty()));
@@ -96,7 +98,7 @@ class PipelinesWithAcksIT {
         final int numRecords = 100;
         inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, numRecords);
 
-        await().atMost(20000, TimeUnit.MILLISECONDS)
+        await().atMost(WAIT_TIME_MS, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
             List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
             assertThat(outputRecords, not(empty()));
@@ -111,7 +113,7 @@ class PipelinesWithAcksIT {
         final int numRecords = 100;
         inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, numRecords);
 
-        await().atMost(20000, TimeUnit.MILLISECONDS)
+        await().atMost(WAIT_TIME_MS, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
             List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
             assertThat(outputRecords, not(empty()));
@@ -126,7 +128,7 @@ class PipelinesWithAcksIT {
         final int numRecords = 100;
         inMemorySourceAccessor.submitWithStatus(IN_MEMORY_IDENTIFIER, numRecords);
 
-        await().atMost(20000, TimeUnit.MILLISECONDS)
+        await().atMost(WAIT_TIME_MS, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
             List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
             assertThat(outputRecords, not(empty()));
@@ -141,7 +143,7 @@ class PipelinesWithAcksIT {
         final int numRecords = 100;
         inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, numRecords);
 
-        await().atMost(20000, TimeUnit.MILLISECONDS)
+        await().atMost(WAIT_TIME_MS, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
             List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
             assertThat(outputRecords, not(empty()));
@@ -156,7 +158,7 @@ class PipelinesWithAcksIT {
         final int numRecords = 100;
         inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, numRecords);
 
-        await().atMost(20000, TimeUnit.MILLISECONDS)
+        await().atMost(WAIT_TIME_MS, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
             List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
             assertThat(outputRecords, not(empty()));
@@ -171,7 +173,7 @@ class PipelinesWithAcksIT {
         final int numRecords = 100;
         inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, numRecords);
 
-        await().atMost(20000, TimeUnit.MILLISECONDS)
+        await().atMost(WAIT_TIME_MS, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
             List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
             assertThat(outputRecords, not(empty()));
@@ -186,7 +188,7 @@ class PipelinesWithAcksIT {
         final int numRecords = 100;
         inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, numRecords);
 
-        await().atMost(20000, TimeUnit.MILLISECONDS)
+        await().atMost(WAIT_TIME_MS, TimeUnit.MILLISECONDS)
           .untilAsserted(() -> {
             List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
             assertThat(outputRecords, not(empty()));
@@ -202,7 +204,7 @@ class PipelinesWithAcksIT {
         inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, numRecords);
         inMemorySinkAccessor.setResult(false);
 
-        await().atMost(20000, TimeUnit.MILLISECONDS)
+        await().atMost(WAIT_TIME_MS, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
             List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
             assertThat(outputRecords, not(empty()));

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySource.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySource.java
@@ -26,6 +26,7 @@ import java.time.Duration;
  */
 @DataPrepperPlugin(name = "in_memory", pluginType = Source.class, pluginConfigurationType = InMemoryConfig.class)
 public class InMemorySource implements Source<Record<Event>> {
+    public static final Duration ACK_EXPIRY_TIME = Duration.ofSeconds(35);
     private static final Logger LOG = LoggerFactory.getLogger(InMemorySource.class);
 
     private final String testingKey;
@@ -123,7 +124,7 @@ public class InMemorySource implements Source<Record<Event>> {
                                 {
                                     inMemorySourceAccessor.setAckReceived(result);
                                 },
-                                Duration.ofSeconds(15));
+                                ACK_EXPIRY_TIME);
                     records.stream().forEach((record) -> { ackSet.add(record.getData()); });
                     ackSet.complete();
                     writeToBuffer(records);

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySource.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySource.java
@@ -26,7 +26,7 @@ import java.time.Duration;
  */
 @DataPrepperPlugin(name = "in_memory", pluginType = Source.class, pluginConfigurationType = InMemoryConfig.class)
 public class InMemorySource implements Source<Record<Event>> {
-    public static final Duration ACK_EXPIRY_TIME = Duration.ofSeconds(35);
+    public static final Duration ACK_EXPIRY_TIME = Duration.ofSeconds(60);
     private static final Logger LOG = LoggerFactory.getLogger(InMemorySource.class);
 
     private final String testingKey;

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
@@ -159,7 +159,7 @@ public class AggregateProcessorIT {
             });
         }
 
-        boolean allThreadsFinished = countDownLatch.await(5L, TimeUnit.SECONDS);
+        boolean allThreadsFinished = countDownLatch.await(20L, TimeUnit.SECONDS);
 
         assertThat(allThreadsFinished, equalTo(true));
         assertThat(aggregatedResult.size(), equalTo(NUM_UNIQUE_EVENTS_PER_BATCH));
@@ -198,7 +198,7 @@ public class AggregateProcessorIT {
             });
         }
 
-        boolean allThreadsFinished = countDownLatch.await(5L, TimeUnit.SECONDS);
+        boolean allThreadsFinished = countDownLatch.await(20L, TimeUnit.SECONDS);
 
         assertThat(allThreadsFinished, equalTo(true));
         assertThat(aggregatedResult.size(), equalTo(NUM_UNIQUE_EVENTS_PER_BATCH));
@@ -249,7 +249,7 @@ public class AggregateProcessorIT {
             });
         }
 
-        boolean allThreadsFinished = countDownLatch.await(5L, TimeUnit.SECONDS);
+        boolean allThreadsFinished = countDownLatch.await(20L, TimeUnit.SECONDS);
 
         assertThat(allThreadsFinished, equalTo(true));
         assertThat(aggregatedResult.size(), equalTo(NUM_UNIQUE_EVENTS_PER_BATCH/2));
@@ -285,10 +285,10 @@ public class AggregateProcessorIT {
             });
         }
 
-        boolean allThreadsFinished = countDownLatch.await(5L, TimeUnit.SECONDS);
+        boolean allThreadsFinished = countDownLatch.await(20L, TimeUnit.SECONDS);
 
         assertThat(allThreadsFinished, equalTo(true));
-        assertThat((double)allowedEventsCount.get(), closeTo(NUM_THREADS * NUM_EVENTS_PER_BATCH * testPercent/100, 1.0));
+        assertThat((double)allowedEventsCount.get(), closeTo(NUM_THREADS * NUM_EVENTS_PER_BATCH * testPercent/100, 5.0));
     }
 
     @RepeatedTest(value = 2)
@@ -320,7 +320,7 @@ public class AggregateProcessorIT {
             });
         }
 
-        boolean allThreadsFinished = countDownLatch.await(5L, TimeUnit.SECONDS);
+        boolean allThreadsFinished = countDownLatch.await(20L, TimeUnit.SECONDS);
 
         assertThat(allThreadsFinished, equalTo(true));
         // Expect less number of events to be received, because of rate limiting
@@ -355,7 +355,7 @@ public class AggregateProcessorIT {
             });
         }
 
-        boolean allThreadsFinished = countDownLatch.await(10L, TimeUnit.SECONDS);
+        boolean allThreadsFinished = countDownLatch.await(20L, TimeUnit.SECONDS);
 
         assertThat(allThreadsFinished, equalTo(true));
         // Expect all events to be received even with rate limiting because no events are dropped
@@ -385,7 +385,7 @@ public class AggregateProcessorIT {
         }
         Thread.sleep(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE * 1000);
 
-        boolean allThreadsFinished = countDownLatch.await(5L, TimeUnit.SECONDS);
+        boolean allThreadsFinished = countDownLatch.await(20L, TimeUnit.SECONDS);
         assertThat(allThreadsFinished, equalTo(true));
 
         Collection<Record<Event>> results = objectUnderTest.doExecute(new ArrayList<Record<Event>>());
@@ -431,7 +431,7 @@ public class AggregateProcessorIT {
         }
         Thread.sleep(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE * 1000);
 
-        boolean allThreadsFinished = countDownLatch.await(5L, TimeUnit.SECONDS);
+        boolean allThreadsFinished = countDownLatch.await(20L, TimeUnit.SECONDS);
         assertThat(allThreadsFinished, equalTo(true));
 
         Collection<Record<Event>> results = objectUnderTest.doExecute(new ArrayList<Record<Event>>());
@@ -490,7 +490,7 @@ public class AggregateProcessorIT {
         }
         Thread.sleep(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE * 1000);
 
-        boolean allThreadsFinished = countDownLatch.await(5L, TimeUnit.SECONDS);
+        boolean allThreadsFinished = countDownLatch.await(20L, TimeUnit.SECONDS);
         assertThat(allThreadsFinished, equalTo(true));
 
         Collection<Record<Event>> results = objectUnderTest.doExecute(new ArrayList<Record<Event>>());
@@ -544,7 +544,7 @@ public class AggregateProcessorIT {
             });
         }
         Thread.sleep(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE * 1000);
-        boolean allThreadsFinished = countDownLatch.await(5L, TimeUnit.SECONDS);
+        boolean allThreadsFinished = countDownLatch.await(20L, TimeUnit.SECONDS);
         assertThat(allThreadsFinished, equalTo(true));
         List<Event> errorEventList = eventBatch.stream().map(Record::getData).filter(event -> {
             Event ev = ((Event)event);


### PR DESCRIPTION
### Description
Build failures fixes
1. Increase InMemorySource acknowledgements expiry time and use that time in PipelineAcksIT tests
2. Change the order of `countDownLatch.await` and `Thread.sleep` so that the wait for the group duration starts after all threads finish.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
