### PR TITLE
Require nimbus-jose-jwt 9.37.1 to fix CVE-2021-31684 and CVE-2023-1370

### DIFF
--- a/data-prepper-plugins/parquet-codecs/build.gradle
+++ b/data-prepper-plugins/parquet-codecs/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     implementation 'org.apache.parquet:parquet-common:1.13.1'
     implementation 'org.apache.parquet:parquet-hadoop:1.13.1'
     testImplementation project(':data-prepper-test-common')
+
+    constraints {
+        implementation('com.nimbusds:nimbus-jose-jwt') {
+            version {
+                require '9.37.1'
+            }
+            because 'Fixes CVE-2021-31684 and CVE-2023-1370 by using a newer shaded version of json-smart.'
+        }
+    }
 }
 
 test {

--- a/data-prepper-plugins/s3-sink/build.gradle
+++ b/data-prepper-plugins/s3-sink/build.gradle
@@ -31,6 +31,15 @@ dependencies {
     testImplementation testLibs.slf4j.simple
     testImplementation 'software.amazon.awssdk:s3-transfer-manager'
     testImplementation 'software.amazon.awssdk.crt:aws-crt:0.25.0'
+
+    constraints {
+        implementation('com.nimbusds:nimbus-jose-jwt') {
+            version {
+                require '9.37.1'
+            }
+            because 'Fixes CVE-2021-31684 and CVE-2023-1370 by using a newer shaded version of json-smart.'
+        }
+    }
 }
 
 test {


### PR DESCRIPTION
### Description

Require `nimbus-jose-jwt` 9.37.1. This version fixes CVE-2021-31684 and CVE-2023-1370 by using a newer shaded version of json-smart.

See:
* https://bitbucket.org/connect2id/nimbus-jose-jwt/commits/c000d5245614e43eccfaaa07cdf0cfa87b471f4a
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
