### PR TITLE
Add aggregate metrics for ddb source export and stream

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/metrics/PluginMetrics.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/metrics/PluginMetrics.java
@@ -43,6 +43,16 @@ public class PluginMetrics {
                 .add(componentId).toString());
     }
 
+    /**
+     * Provides reference to APIs that register timer, counter, gauge into global registry.
+     *
+     * @param metricsPrefix the prefix to provide to metrics
+     * @return The {@link PluginMetrics}
+     */
+    public static PluginMetrics fromPrefix(final String metricsPrefix) {
+        return new PluginMetrics(metricsPrefix);
+    }
+
     private  PluginMetrics(final String metricsPrefix) {
         this.metricsPrefix = metricsPrefix;
     }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/metrics/PluginMetricsTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/metrics/PluginMetricsTest.java
@@ -15,6 +15,7 @@ import org.opensearch.dataprepper.model.configuration.PluginSetting;
 
 import java.util.Collections;
 import java.util.StringJoiner;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.emptyList;
@@ -39,6 +40,18 @@ public class PluginMetricsTest {
         when(pluginSetting.getPipelineName()).thenReturn(PIPELINE_NAME);
 
         objectUnderTest = PluginMetrics.fromPluginSetting(pluginSetting);
+    }
+
+    @Test
+    public void testCounterWithMetricsPrefix() {
+
+        final String prefix = UUID.randomUUID().toString();
+
+        objectUnderTest = PluginMetrics.fromPrefix(prefix);
+        final Counter counter = objectUnderTest.counter("counter");
+        assertEquals(
+                prefix + MetricNames.DELIMITER + "counter",
+                counter.getId().getName());
     }
 
     @Test

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileScheduler.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/DataFileScheduler.java
@@ -112,6 +112,7 @@ public class DataFileScheduler implements Runnable {
         } else {
             runLoader.whenComplete((v, ex) -> {
                 if (ex != null) {
+                    LOG.error("There was an exception while processing an S3 data file: {}", ex);
                     coordinator.giveUpPartition(dataFilePartition);
                 }
                 numOfWorkers.decrementAndGet();

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportTaskManager.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportTaskManager.java
@@ -79,9 +79,9 @@ public class ExportTaskManager {
 
         } catch (final InternalServerErrorException e) {
             dynamoAggregateMetrics.getExport5xxErrors().increment();
-            LOG.error("Unable to get manifest file for export " + exportArn);
+            LOG.error("Unable to get manifest file for export {}: {}", exportArn, e.getMessage());
         } catch (SdkException e) {
-            LOG.error("Unable to get manifest file for export " + exportArn);
+            LOG.error("Unable to get manifest file for export {}: {}", exportArn, e.getMessage());
         }
         return manifestKey;
     }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/utils/DynamoDBSourceAggregateMetrics.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/utils/DynamoDBSourceAggregateMetrics.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.source.dynamodb.utils;
+
+import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+
+public class DynamoDBSourceAggregateMetrics {
+
+    private static final String DYNAMO_DB = "dynamodb";
+
+    private static final String DDB_STREAM_5XX_EXCEPTIONS = "stream5xxErrors";
+    private static final String DDB_STREAM_API_INVOCATIONS = "streamApiInvocations";
+    private static final String DDB_EXPORT_5XX_ERRORS = "export5xxErrors";
+    private static final String DDB_EXPORT_API_INVOCATIONS = "exportApiInvocations";
+
+
+    private final PluginMetrics pluginMetrics;
+
+    private final Counter stream5xxErrors;
+    private final Counter streamApiInvocations;
+    private final Counter export5xxErrors;
+    private final Counter exportApiInvocations;
+
+    public DynamoDBSourceAggregateMetrics() {
+        this.pluginMetrics = PluginMetrics.fromPrefix(DYNAMO_DB);
+        this.stream5xxErrors = pluginMetrics.counter(DDB_STREAM_5XX_EXCEPTIONS);
+        this.streamApiInvocations = pluginMetrics.counter(DDB_STREAM_API_INVOCATIONS);
+        this.export5xxErrors = pluginMetrics.counter(DDB_EXPORT_5XX_ERRORS);
+        this.exportApiInvocations = pluginMetrics.counter(DDB_EXPORT_API_INVOCATIONS);
+    }
+
+    public Counter getStream5xxErrors() {
+        return stream5xxErrors;
+    }
+
+    public Counter getStreamApiInvocations() { return streamApiInvocations; }
+
+    public Counter getExport5xxErrors() {
+        return export5xxErrors;
+    }
+
+    public Counter getExportApiInvocations() { return exportApiInvocations; }
+}


### PR DESCRIPTION
### Description
This change adds the following aggregate metrics (metrics without a `sub-pipeline` prefix) to dynamoDB source pipelines

* `stream5xxErrors` - The number of errors encountered when calling stream APIs (`getRecords`, `getShardIterator`)

* `streamApiInvocations` - The number of invocations of stream APIs

* `export5xxErrors` - The number of errors encountered when calling export APIs (`exportTableToPointInTime`, `describeExport`)

* `exportApiInvocations` - The number of invocations of export APIs

 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
