### PR TITLE
Logback 1.4.12 in performance test project to fix CVE-2023-6378

### DIFF
--- a/examples/trace-analytics-sample-app/sample-app/analytics-service/build.gradle
+++ b/examples/trace-analytics-sample-app/sample-app/analytics-service/build.gradle
@@ -30,6 +30,9 @@ configurations.all {
         } else if (details.requested.group == 'org.apache.tomcat.embed') {
             details.useVersion '10.1.14'
             details.because('Fixes CVE-2023-44487')
+        } else if (details.requested.group == 'ch.qos.logback') {
+            details.useVersion '1.4.12'
+            details.because('Fixes CVE-2023-6378')
         }
     }
 }

--- a/performance-test/build.gradle
+++ b/performance-test/build.gradle
@@ -24,6 +24,18 @@ dependencies {
     testRuntimeOnly testLibs.junit.engine
 
     constraints {
+        gatling('ch.qos.logback:logback-classic') {
+            version {
+                require '1.4.12'
+            }
+            because 'Fixes CVE-2023-6378'
+        }
+        gatling('ch.qos.logback:logback-core') {
+            version {
+                require '1.4.12'
+            }
+            because 'Keeps the version synced with logback-classic.'
+        }
         zinc('org.scala-sbt:io_2.13') {
             version {
                 require '1.9.7'


### PR DESCRIPTION
### Description

Use Logback 1.4.12 in the performance test project to fix CVE-2023-6378.

Also uses Logback 1.4.12 in the example Spring Boot application.
 
### Issues Resolved

Resolves #3729
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
