### PR TITLE
Jackson 2.15.3; consistent Jackson, JUnit, Mockito usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ subprojects {
         }
     }
     dependencies {
-        implementation platform('com.fasterxml.jackson:jackson-bom:2.15.0')
+        implementation platform('com.fasterxml.jackson:jackson-bom:2.15.3')
         implementation platform('org.eclipse.jetty:jetty-bom:9.4.53.v20231009')
         implementation platform('io.micrometer:micrometer-bom:1.10.5')
         implementation libs.guava.core

--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.15.3'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
     implementation 'org.apache.parquet:parquet-common:1.13.1'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation libs.commons.lang3

--- a/data-prepper-plugins/avro-codecs/build.gradle
+++ b/data-prepper-plugins/avro-codecs/build.gradle
@@ -9,9 +9,7 @@ dependencies {
     implementation 'org.apache.parquet:parquet-common:1.13.1'
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:apache-client'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
     testImplementation 'org.json:json:20230227'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
     testImplementation project(':data-prepper-plugins:common')
 }
 

--- a/data-prepper-plugins/buffer-common/build.gradle
+++ b/data-prepper-plugins/buffer-common/build.gradle
@@ -4,8 +4,6 @@ plugins {
 
 dependencies {
     implementation project(path: ':data-prepper-api')
-    testImplementation platform('org.junit:junit-bom:5.9.1')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
 }
 
 test {

--- a/data-prepper-plugins/cloudwatch-logs/build.gradle
+++ b/data-prepper-plugins/cloudwatch-logs/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     implementation 'org.hibernate.validator:hibernate-validator:8.0.0.Final'
     testImplementation project(path: ':data-prepper-test-common')
     testImplementation testLibs.mockito.inline
-    testImplementation 'org.junit.jupiter:junit-jupiter'
     compileOnly 'org.projectlombok:lombok:1.18.24'
     annotationProcessor 'org.projectlombok:lombok:1.18.24'
 }

--- a/data-prepper-plugins/dissect-processor/build.gradle
+++ b/data-prepper-plugins/dissect-processor/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 dependencies {
     implementation project(':data-prepper-api')
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.0'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'io.micrometer:micrometer-core'
     implementation project(path: ':data-prepper-api')
     implementation project(path: ':data-prepper-plugins:mutate-event-processors')

--- a/data-prepper-plugins/dynamodb-source-coordination-store/build.gradle
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/build.gradle
@@ -6,8 +6,6 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     implementation 'software.amazon.awssdk:arns'
     implementation 'software.amazon.awssdk:dynamodb'
     implementation 'software.amazon.awssdk:dynamodb-enhanced'

--- a/data-prepper-plugins/dynamodb-source/build.gradle
+++ b/data-prepper-plugins/dynamodb-source/build.gradle
@@ -29,8 +29,6 @@ dependencies {
     implementation project(path: ':data-prepper-plugins:buffer-common')
 
 
-    testImplementation platform('org.junit:junit-bom:5.9.1')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation testLibs.mockito.inline
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 }

--- a/data-prepper-plugins/in-memory-source-coordination-store/build.gradle
+++ b/data-prepper-plugins/in-memory-source-coordination-store/build.gradle
@@ -4,8 +4,6 @@ plugins {
 
 dependencies {
     implementation project(':data-prepper-api')
-    testImplementation platform('org.junit:junit-bom:5.9.1')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
 }
 
 test {

--- a/data-prepper-plugins/kafka-connect-plugins/build.gradle
+++ b/data-prepper-plugins/kafka-connect-plugins/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     testImplementation project(':data-prepper-test-common')
     testImplementation project(':data-prepper-core')
     testImplementation 'org.yaml:snakeyaml:2.0'
-    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.2'
+    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     testImplementation testLibs.mockito.inline
 }
 

--- a/data-prepper-plugins/kafka-plugins/build.gradle
+++ b/data-prepper-plugins/kafka-plugins/build.gradle
@@ -40,14 +40,14 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:apache-client'
 
-    testImplementation 'org.mockito:mockito-inline:4.1.0'
+    testImplementation testLibs.mockito.inline
     testImplementation 'org.yaml:snakeyaml:2.0'
     testImplementation testLibs.spring.test
-    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
+    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     testImplementation project(':data-prepper-test-common')
     testImplementation project(':data-prepper-plugins:blocking-buffer')
     testImplementation project(':data-prepper-core')
-    testImplementation 'org.mockito:mockito-inline:4.1.0'
+    testImplementation testLibs.mockito.inline
     testImplementation 'org.apache.kafka:kafka_2.13:3.4.0'
     testImplementation 'org.apache.kafka:kafka_2.13:3.4.0:test'
     testImplementation 'org.apache.curator:curator-test:5.5.0'

--- a/data-prepper-plugins/mapdb-processor-state/build.gradle
+++ b/data-prepper-plugins/mapdb-processor-state/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21'
     testImplementation testLibs.junit.vintage
     testImplementation project(':data-prepper-plugins:common').sourceSets.test.output
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation testLibs.junit.vintage
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation libs.opensearch.java
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.0'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     implementation 'software.amazon.awssdk:auth'
     implementation 'software.amazon.awssdk:http-client-spi'

--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'joda-time:joda-time:2.11.1'
     implementation 'org.hibernate.validator:hibernate-validator:7.0.5.Final'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'org.xerial.snappy:snappy-java:1.1.10.1'
     implementation 'org.apache.parquet:parquet-common:1.13.1'
     implementation 'dev.failsafe:failsafe:3.3.2'

--- a/data-prepper-plugins/sqs-source/build.gradle
+++ b/data-prepper-plugins/sqs-source/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation 'software.amazon.awssdk:sts'
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation project(':data-prepper-plugins:blocking-buffer')
 }

--- a/data-prepper-plugins/translate-processor/build.gradle
+++ b/data-prepper-plugins/translate-processor/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 dependencies {
     implementation project(':data-prepper-api')
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.0'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.395'
     implementation 'com.amazonaws:aws-java-sdk-sts:1.12.395'
     implementation 'io.micrometer:micrometer-core'


### PR DESCRIPTION
### Description

Gradle project maintenance: Jackson 2.15.3, use the Jackson version from the BOM consistently, use the JUnit and Mockito from the version catalog consistently.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
