### PR TITLE
Fix kafka buffer metrics

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/AbstractBuffer.java
@@ -71,8 +71,10 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
 
         try {
             doWrite(record, timeoutInMillis);
-            recordsWrittenCounter.increment();
-            recordsInBuffer.incrementAndGet();
+            if (!isByteBuffer()) {
+                recordsWrittenCounter.increment();
+                recordsInBuffer.incrementAndGet();
+            }
             postProcess(recordsInBuffer.get());
         } catch (TimeoutException e) {
             recordsWriteFailed.increment();
@@ -98,8 +100,11 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
         final int size = records.size();
         try {
             doWriteAll(records, timeoutInMillis);
-            recordsWrittenCounter.increment(size);
-            recordsInBuffer.addAndGet(size);
+            // we do not know how many records when the buffer is bytebuffer
+            if (!isByteBuffer()) {
+                recordsWrittenCounter.increment(size);
+                recordsInBuffer.addAndGet(size);
+            }
             postProcess(recordsInBuffer.get());
         } catch (Exception e) {
             recordsWriteFailed.increment(size);
@@ -127,9 +132,12 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
     @Override
     public Map.Entry<Collection<T>, CheckpointState> read(int timeoutInMillis) {
         final Map.Entry<Collection<T>, CheckpointState> readResult = readTimer.record(() -> doRead(timeoutInMillis));
-        recordsReadCounter.increment(readResult.getKey().size() * 1.0);
-        recordsInFlight.addAndGet(readResult.getValue().getNumRecordsToBeChecked());
-        recordsInBuffer.addAndGet(-1 * readResult.getValue().getNumRecordsToBeChecked());
+        // we do not know how many records when the buffer is bytebuffer
+        if (!isByteBuffer()) {
+            recordsReadCounter.increment(readResult.getKey().size() * 1.0);
+            recordsInFlight.addAndGet(readResult.getValue().getNumRecordsToBeChecked());
+            recordsInBuffer.addAndGet(-1 * readResult.getValue().getNumRecordsToBeChecked());
+        }
         postProcess(recordsInBuffer.get());
         return readResult;
     }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
@@ -117,7 +117,7 @@ public class KafkaBuffer extends AbstractBuffer<Record<Event>> {
 
     @Override
     public Map.Entry<Collection<Record<Event>>, CheckpointState> doRead(int timeoutInMillis) {
-        return innerBuffer.doRead(timeoutInMillis);
+        return innerBuffer.read(timeoutInMillis);
     }
 
     @Override

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
@@ -205,7 +205,7 @@ class KafkaBufferTest {
         kafkaBuffer.doWrite(record, 10000);
         kafkaBuffer.doRead(10000);
         verify(producer).produceRecords(record);
-        verify(blockingBuffer).doRead(anyInt());
+        verify(blockingBuffer).read(anyInt());
     }
 
     @Test


### PR DESCRIPTION
### Description
Fix Kafka Buffer metrics
While reading from Kafka inner buffer `doRead` API was used. This skips updating the metrics. modified to use `read` API which calls `doRead` and also updates metrics.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
