### PR TITLE
FIX: deal with event with object size zero

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorker.java
@@ -53,6 +53,7 @@ public class SqsWorker implements Runnable {
     static final String SQS_MESSAGES_DELETED_METRIC_NAME = "sqsMessagesDeleted";
     static final String SQS_MESSAGES_FAILED_METRIC_NAME = "sqsMessagesFailed";
     static final String SQS_MESSAGES_DELETE_FAILED_METRIC_NAME = "sqsMessagesDeleteFailed";
+    static final String ZERO_SIZED_OBJECT_COUNT_METRIC_NAME = "zeroSizedObject";
     static final String SQS_MESSAGE_DELAY_METRIC_NAME = "sqsMessageDelay";
     static final String SQS_VISIBILITY_TIMEOUT_CHANGED_COUNT_METRIC_NAME = "sqsVisibilityTimeoutChangedCount";
     static final String SQS_VISIBILITY_TIMEOUT_CHANGE_FAILED_COUNT_METRIC_NAME = "sqsVisibilityTimeoutChangeFailedCount";
@@ -67,6 +68,7 @@ public class SqsWorker implements Runnable {
     private final Counter sqsMessagesReceivedCounter;
     private final Counter sqsMessagesDeletedCounter;
     private final Counter sqsMessagesFailedCounter;
+    private final Counter zeroSizedObjectCounter;
     private final Counter sqsMessagesDeleteFailedCounter;
     private final Counter acknowledgementSetCallbackCounter;
     private final Counter sqsVisibilityTimeoutChangedCount;
@@ -102,6 +104,7 @@ public class SqsWorker implements Runnable {
         sqsMessagesReceivedCounter = pluginMetrics.counter(SQS_MESSAGES_RECEIVED_METRIC_NAME);
         sqsMessagesDeletedCounter = pluginMetrics.counter(SQS_MESSAGES_DELETED_METRIC_NAME);
         sqsMessagesFailedCounter = pluginMetrics.counter(SQS_MESSAGES_FAILED_METRIC_NAME);
+        zeroSizedObjectCounter = pluginMetrics.counter(ZERO_SIZED_OBJECT_COUNT_METRIC_NAME);
         sqsMessagesDeleteFailedCounter = pluginMetrics.counter(SQS_MESSAGES_DELETE_FAILED_METRIC_NAME);
         sqsMessageDelayTimer = pluginMetrics.timer(SQS_MESSAGE_DELAY_METRIC_NAME);
         acknowledgementSetCallbackCounter = pluginMetrics.counter(ACKNOWLEDGEMENT_SET_CALLACK_METRIC_NAME);
@@ -214,6 +217,12 @@ public class SqsWorker implements Runnable {
                 if (s3SourceConfig.getOnErrorOption().equals(OnErrorOption.DELETE_MESSAGES)) {
                     deleteMessageBatchRequestEntryCollection.add(buildDeleteMessageBatchRequestEntry(parsedMessage.getMessage()));
                 }
+            } else if (parsedMessage.getObjectSize() == 0L) {
+                zeroSizedObjectCounter.increment();
+                LOG.debug("Received empty S3 object: {} in the SQS message. " +
+                                "The S3 object is skipped and the SQS message will be deleted.",
+                        parsedMessage.getObjectKey());
+                deleteMessageBatchRequestEntryCollection.add(buildDeleteMessageBatchRequestEntry(parsedMessage.getMessage()));
             } else {
                 if (s3SourceConfig.getNotificationSource().equals(NotificationSourceOption.S3)
                         && !parsedMessage.isEmptyNotification()

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorker.java
@@ -53,7 +53,7 @@ public class SqsWorker implements Runnable {
     static final String SQS_MESSAGES_DELETED_METRIC_NAME = "sqsMessagesDeleted";
     static final String SQS_MESSAGES_FAILED_METRIC_NAME = "sqsMessagesFailed";
     static final String SQS_MESSAGES_DELETE_FAILED_METRIC_NAME = "sqsMessagesDeleteFailed";
-    static final String ZERO_SIZED_OBJECT_COUNT_METRIC_NAME = "zeroSizedObject";
+    static final String S3_OBJECTS_WITH_SIZE_ZERO_METRIC_NAME = "s3ObjectsWithSizeZero";
     static final String SQS_MESSAGE_DELAY_METRIC_NAME = "sqsMessageDelay";
     static final String SQS_VISIBILITY_TIMEOUT_CHANGED_COUNT_METRIC_NAME = "sqsVisibilityTimeoutChangedCount";
     static final String SQS_VISIBILITY_TIMEOUT_CHANGE_FAILED_COUNT_METRIC_NAME = "sqsVisibilityTimeoutChangeFailedCount";
@@ -68,7 +68,7 @@ public class SqsWorker implements Runnable {
     private final Counter sqsMessagesReceivedCounter;
     private final Counter sqsMessagesDeletedCounter;
     private final Counter sqsMessagesFailedCounter;
-    private final Counter zeroSizedObjectCounter;
+    private final Counter s3ObjectsWithSizeZeroCounter;
     private final Counter sqsMessagesDeleteFailedCounter;
     private final Counter acknowledgementSetCallbackCounter;
     private final Counter sqsVisibilityTimeoutChangedCount;
@@ -104,7 +104,7 @@ public class SqsWorker implements Runnable {
         sqsMessagesReceivedCounter = pluginMetrics.counter(SQS_MESSAGES_RECEIVED_METRIC_NAME);
         sqsMessagesDeletedCounter = pluginMetrics.counter(SQS_MESSAGES_DELETED_METRIC_NAME);
         sqsMessagesFailedCounter = pluginMetrics.counter(SQS_MESSAGES_FAILED_METRIC_NAME);
-        zeroSizedObjectCounter = pluginMetrics.counter(ZERO_SIZED_OBJECT_COUNT_METRIC_NAME);
+        s3ObjectsWithSizeZeroCounter = pluginMetrics.counter(S3_OBJECTS_WITH_SIZE_ZERO_METRIC_NAME);
         sqsMessagesDeleteFailedCounter = pluginMetrics.counter(SQS_MESSAGES_DELETE_FAILED_METRIC_NAME);
         sqsMessageDelayTimer = pluginMetrics.timer(SQS_MESSAGE_DELAY_METRIC_NAME);
         acknowledgementSetCallbackCounter = pluginMetrics.counter(ACKNOWLEDGEMENT_SET_CALLACK_METRIC_NAME);
@@ -218,7 +218,7 @@ public class SqsWorker implements Runnable {
                     deleteMessageBatchRequestEntryCollection.add(buildDeleteMessageBatchRequestEntry(parsedMessage.getMessage()));
                 }
             } else if (parsedMessage.getObjectSize() == 0L) {
-                zeroSizedObjectCounter.increment();
+                s3ObjectsWithSizeZeroCounter.increment();
                 LOG.debug("Received empty S3 object: {} in the SQS message. " +
                                 "The S3 object is skipped and the SQS message will be deleted.",
                         parsedMessage.getObjectKey());

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorker.java
@@ -53,7 +53,7 @@ public class SqsWorker implements Runnable {
     static final String SQS_MESSAGES_DELETED_METRIC_NAME = "sqsMessagesDeleted";
     static final String SQS_MESSAGES_FAILED_METRIC_NAME = "sqsMessagesFailed";
     static final String SQS_MESSAGES_DELETE_FAILED_METRIC_NAME = "sqsMessagesDeleteFailed";
-    static final String S3_OBJECTS_WITH_SIZE_ZERO_METRIC_NAME = "s3ObjectsWithSizeZero";
+    static final String S3_OBJECTS_EMPTY_METRIC_NAME = "s3ObjectsEmpty";
     static final String SQS_MESSAGE_DELAY_METRIC_NAME = "sqsMessageDelay";
     static final String SQS_VISIBILITY_TIMEOUT_CHANGED_COUNT_METRIC_NAME = "sqsVisibilityTimeoutChangedCount";
     static final String SQS_VISIBILITY_TIMEOUT_CHANGE_FAILED_COUNT_METRIC_NAME = "sqsVisibilityTimeoutChangeFailedCount";
@@ -68,7 +68,7 @@ public class SqsWorker implements Runnable {
     private final Counter sqsMessagesReceivedCounter;
     private final Counter sqsMessagesDeletedCounter;
     private final Counter sqsMessagesFailedCounter;
-    private final Counter s3ObjectsWithSizeZeroCounter;
+    private final Counter s3ObjectsEmptyCounter;
     private final Counter sqsMessagesDeleteFailedCounter;
     private final Counter acknowledgementSetCallbackCounter;
     private final Counter sqsVisibilityTimeoutChangedCount;
@@ -104,7 +104,7 @@ public class SqsWorker implements Runnable {
         sqsMessagesReceivedCounter = pluginMetrics.counter(SQS_MESSAGES_RECEIVED_METRIC_NAME);
         sqsMessagesDeletedCounter = pluginMetrics.counter(SQS_MESSAGES_DELETED_METRIC_NAME);
         sqsMessagesFailedCounter = pluginMetrics.counter(SQS_MESSAGES_FAILED_METRIC_NAME);
-        s3ObjectsWithSizeZeroCounter = pluginMetrics.counter(S3_OBJECTS_WITH_SIZE_ZERO_METRIC_NAME);
+        s3ObjectsEmptyCounter = pluginMetrics.counter(S3_OBJECTS_EMPTY_METRIC_NAME);
         sqsMessagesDeleteFailedCounter = pluginMetrics.counter(SQS_MESSAGES_DELETE_FAILED_METRIC_NAME);
         sqsMessageDelayTimer = pluginMetrics.timer(SQS_MESSAGE_DELAY_METRIC_NAME);
         acknowledgementSetCallbackCounter = pluginMetrics.counter(ACKNOWLEDGEMENT_SET_CALLACK_METRIC_NAME);
@@ -218,7 +218,7 @@ public class SqsWorker implements Runnable {
                     deleteMessageBatchRequestEntryCollection.add(buildDeleteMessageBatchRequestEntry(parsedMessage.getMessage()));
                 }
             } else if (parsedMessage.getObjectSize() == 0L) {
-                s3ObjectsWithSizeZeroCounter.increment();
+                s3ObjectsEmptyCounter.increment();
                 LOG.debug("Received empty S3 object: {} in the SQS message. " +
                                 "The S3 object is skipped and the SQS message will be deleted.",
                         parsedMessage.getObjectKey());

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessage.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessage.java
@@ -17,6 +17,7 @@ public class ParsedMessage {
     private boolean failedParsing;
     private String bucketName;
     private String objectKey;
+    private long objectSize;
     private String eventName;
     private DateTime eventTime;
     private boolean emptyNotification;
@@ -33,6 +34,7 @@ public class ParsedMessage {
         this.message = message;
         this.bucketName = notificationRecords.get(0).getS3().getBucket().getName();
         this.objectKey = notificationRecords.get(0).getS3().getObject().getUrlDecodedKey();
+        this.objectSize = notificationRecords.get(0).getS3().getObject().getSizeAsLong();
         this.eventName = notificationRecords.get(0).getEventName();
         this.eventTime = notificationRecords.get(0).getEventTime();
         this.failedParsing = false;
@@ -43,6 +45,7 @@ public class ParsedMessage {
         this.message = message;
         this.bucketName = eventBridgeNotification.getDetail().getBucket().getName();
         this.objectKey = eventBridgeNotification.getDetail().getObject().getUrlDecodedKey();
+        this.objectSize = eventBridgeNotification.getDetail().getObject().getSize();
         this.detailType = eventBridgeNotification.getDetailType();
         this.eventTime = eventBridgeNotification.getTime();
     }
@@ -61,6 +64,10 @@ public class ParsedMessage {
 
     public String getObjectKey() {
         return objectKey;
+    }
+
+    public long getObjectSize() {
+        return objectSize;
     }
 
     public String getEventName() {

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorkerTest.java
@@ -75,7 +75,7 @@ import static org.opensearch.dataprepper.plugins.source.s3.SqsWorker.SQS_MESSAGE
 import static org.opensearch.dataprepper.plugins.source.s3.SqsWorker.SQS_MESSAGES_FAILED_METRIC_NAME;
 import static org.opensearch.dataprepper.plugins.source.s3.SqsWorker.SQS_MESSAGES_RECEIVED_METRIC_NAME;
 import static org.opensearch.dataprepper.plugins.source.s3.SqsWorker.SQS_MESSAGE_DELAY_METRIC_NAME;
-import static org.opensearch.dataprepper.plugins.source.s3.SqsWorker.S3_OBJECTS_WITH_SIZE_ZERO_METRIC_NAME;
+import static org.opensearch.dataprepper.plugins.source.s3.SqsWorker.S3_OBJECTS_EMPTY_METRIC_NAME;
 
 class SqsWorkerTest {
     private SqsWorker sqsWorker;
@@ -89,7 +89,7 @@ class SqsWorkerTest {
     private Counter sqsMessagesDeletedCounter;
     private Counter sqsMessagesFailedCounter;
     private Counter sqsMessagesDeleteFailedCounter;
-    private Counter s3ObjectsWithSizeZeroCounter;
+    private Counter s3ObjectsEmptyCounter;
     private Timer sqsMessageDelayTimer;
     private AcknowledgementSetManager acknowledgementSetManager;
     private AcknowledgementSet acknowledgementSet;
@@ -122,13 +122,13 @@ class SqsWorkerTest {
         sqsMessagesDeletedCounter = mock(Counter.class);
         sqsMessagesFailedCounter = mock(Counter.class);
         sqsMessagesDeleteFailedCounter = mock(Counter.class);
-        s3ObjectsWithSizeZeroCounter = mock(Counter.class);
+        s3ObjectsEmptyCounter = mock(Counter.class);
         sqsMessageDelayTimer = mock(Timer.class);
         when(pluginMetrics.counter(SQS_MESSAGES_RECEIVED_METRIC_NAME)).thenReturn(sqsMessagesReceivedCounter);
         when(pluginMetrics.counter(SQS_MESSAGES_DELETED_METRIC_NAME)).thenReturn(sqsMessagesDeletedCounter);
         when(pluginMetrics.counter(SQS_MESSAGES_FAILED_METRIC_NAME)).thenReturn(sqsMessagesFailedCounter);
         when(pluginMetrics.counter(SQS_MESSAGES_DELETE_FAILED_METRIC_NAME)).thenReturn(sqsMessagesDeleteFailedCounter);
-        when(pluginMetrics.counter(S3_OBJECTS_WITH_SIZE_ZERO_METRIC_NAME)).thenReturn(s3ObjectsWithSizeZeroCounter);
+        when(pluginMetrics.counter(S3_OBJECTS_EMPTY_METRIC_NAME)).thenReturn(s3ObjectsEmptyCounter);
         when(pluginMetrics.timer(SQS_MESSAGE_DELAY_METRIC_NAME)).thenReturn(sqsMessageDelayTimer);
 
         sqsWorker = new SqsWorker(acknowledgementSetManager, sqsClient, s3Service, s3SourceConfig, pluginMetrics, backoff);
@@ -139,7 +139,7 @@ class SqsWorkerTest {
         verifyNoMoreInteractions(sqsMessagesReceivedCounter);
         verifyNoMoreInteractions(sqsMessagesDeletedCounter);
         verifyNoMoreInteractions(sqsMessagesFailedCounter);
-        verifyNoMoreInteractions(s3ObjectsWithSizeZeroCounter);
+        verifyNoMoreInteractions(s3ObjectsEmptyCounter);
         verifyNoMoreInteractions(sqsMessageDelayTimer);
     }
 
@@ -308,7 +308,7 @@ class SqsWorkerTest {
 
             verify(sqsMessagesReceivedCounter).increment(1);
             verify(sqsMessagesDeletedCounter).increment(1);
-            verify(s3ObjectsWithSizeZeroCounter).increment();
+            verify(s3ObjectsEmptyCounter).increment();
         }
 
         @Test
@@ -341,7 +341,7 @@ class SqsWorkerTest {
 
             verify(sqsMessagesReceivedCounter).increment(1);
             verify(sqsMessagesDeletedCounter).increment(1);
-            verify(s3ObjectsWithSizeZeroCounter).increment();
+            verify(s3ObjectsEmptyCounter).increment();
         }
 
         @ParameterizedTest

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorkerTest.java
@@ -75,7 +75,7 @@ import static org.opensearch.dataprepper.plugins.source.s3.SqsWorker.SQS_MESSAGE
 import static org.opensearch.dataprepper.plugins.source.s3.SqsWorker.SQS_MESSAGES_FAILED_METRIC_NAME;
 import static org.opensearch.dataprepper.plugins.source.s3.SqsWorker.SQS_MESSAGES_RECEIVED_METRIC_NAME;
 import static org.opensearch.dataprepper.plugins.source.s3.SqsWorker.SQS_MESSAGE_DELAY_METRIC_NAME;
-import static org.opensearch.dataprepper.plugins.source.s3.SqsWorker.ZERO_SIZED_OBJECT_COUNT_METRIC_NAME;
+import static org.opensearch.dataprepper.plugins.source.s3.SqsWorker.S3_OBJECTS_WITH_SIZE_ZERO_METRIC_NAME;
 
 class SqsWorkerTest {
     private SqsWorker sqsWorker;
@@ -89,7 +89,7 @@ class SqsWorkerTest {
     private Counter sqsMessagesDeletedCounter;
     private Counter sqsMessagesFailedCounter;
     private Counter sqsMessagesDeleteFailedCounter;
-    private Counter zeroSizedObjectCounter;
+    private Counter s3ObjectsWithSizeZeroCounter;
     private Timer sqsMessageDelayTimer;
     private AcknowledgementSetManager acknowledgementSetManager;
     private AcknowledgementSet acknowledgementSet;
@@ -122,13 +122,13 @@ class SqsWorkerTest {
         sqsMessagesDeletedCounter = mock(Counter.class);
         sqsMessagesFailedCounter = mock(Counter.class);
         sqsMessagesDeleteFailedCounter = mock(Counter.class);
-        zeroSizedObjectCounter = mock(Counter.class);
+        s3ObjectsWithSizeZeroCounter = mock(Counter.class);
         sqsMessageDelayTimer = mock(Timer.class);
         when(pluginMetrics.counter(SQS_MESSAGES_RECEIVED_METRIC_NAME)).thenReturn(sqsMessagesReceivedCounter);
         when(pluginMetrics.counter(SQS_MESSAGES_DELETED_METRIC_NAME)).thenReturn(sqsMessagesDeletedCounter);
         when(pluginMetrics.counter(SQS_MESSAGES_FAILED_METRIC_NAME)).thenReturn(sqsMessagesFailedCounter);
         when(pluginMetrics.counter(SQS_MESSAGES_DELETE_FAILED_METRIC_NAME)).thenReturn(sqsMessagesDeleteFailedCounter);
-        when(pluginMetrics.counter(ZERO_SIZED_OBJECT_COUNT_METRIC_NAME)).thenReturn(zeroSizedObjectCounter);
+        when(pluginMetrics.counter(S3_OBJECTS_WITH_SIZE_ZERO_METRIC_NAME)).thenReturn(s3ObjectsWithSizeZeroCounter);
         when(pluginMetrics.timer(SQS_MESSAGE_DELAY_METRIC_NAME)).thenReturn(sqsMessageDelayTimer);
 
         sqsWorker = new SqsWorker(acknowledgementSetManager, sqsClient, s3Service, s3SourceConfig, pluginMetrics, backoff);
@@ -139,7 +139,7 @@ class SqsWorkerTest {
         verifyNoMoreInteractions(sqsMessagesReceivedCounter);
         verifyNoMoreInteractions(sqsMessagesDeletedCounter);
         verifyNoMoreInteractions(sqsMessagesFailedCounter);
-        verifyNoMoreInteractions(zeroSizedObjectCounter);
+        verifyNoMoreInteractions(s3ObjectsWithSizeZeroCounter);
         verifyNoMoreInteractions(sqsMessageDelayTimer);
     }
 
@@ -308,7 +308,7 @@ class SqsWorkerTest {
 
             verify(sqsMessagesReceivedCounter).increment(1);
             verify(sqsMessagesDeletedCounter).increment(1);
-            verify(zeroSizedObjectCounter).increment();
+            verify(s3ObjectsWithSizeZeroCounter).increment();
         }
 
         @Test
@@ -341,7 +341,7 @@ class SqsWorkerTest {
 
             verify(sqsMessagesReceivedCounter).increment(1);
             verify(sqsMessagesDeletedCounter).increment(1);
-            verify(zeroSizedObjectCounter).increment();
+            verify(s3ObjectsWithSizeZeroCounter).increment();
         }
 
         @ParameterizedTest

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessageTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/parser/ParsedMessageTest.java
@@ -8,6 +8,7 @@ import org.opensearch.dataprepper.plugins.source.s3.S3EventNotification;
 import software.amazon.awssdk.services.sqs.model.Message;
 
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -16,6 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class ParsedMessageTest {
+    private static final Random RANDOM = new Random();
     private Message message;
     private S3EventNotification.S3Entity s3Entity;
     private S3EventNotification.S3BucketEntity s3BucketEntity;
@@ -53,10 +55,12 @@ class ParsedMessageTest {
         final String  testDecodedObjectKey = UUID.randomUUID().toString();
         final String  testEventName = UUID.randomUUID().toString();
         final DateTime testEventTime = DateTime.now();
+        final long testSize = RANDOM.nextLong();
 
         when(s3EventNotificationRecord.getS3()).thenReturn(s3Entity);
         when(s3Entity.getBucket()).thenReturn(s3BucketEntity);
         when(s3Entity.getObject()).thenReturn(s3ObjectEntity);
+        when(s3ObjectEntity.getSizeAsLong()).thenReturn(testSize);
         when(s3BucketEntity.getName()).thenReturn(testBucketName);
         when(s3ObjectEntity.getUrlDecodedKey()).thenReturn(testDecodedObjectKey);
         when(s3EventNotificationRecord.getEventName()).thenReturn(testEventName);
@@ -67,6 +71,7 @@ class ParsedMessageTest {
         assertThat(parsedMessage.getMessage(), equalTo(message));
         assertThat(parsedMessage.getBucketName(), equalTo(testBucketName));
         assertThat(parsedMessage.getObjectKey(), equalTo(testDecodedObjectKey));
+        assertThat(parsedMessage.getObjectSize(), equalTo(testSize));
         assertThat(parsedMessage.getEventName(), equalTo(testEventName));
         assertThat(parsedMessage.getEventTime(), equalTo(testEventTime));
         assertThat(parsedMessage.isFailedParsing(), equalTo(false));
@@ -79,6 +84,7 @@ class ParsedMessageTest {
         final String  testDecodedObjectKey = UUID.randomUUID().toString();
         final String  testDetailType = UUID.randomUUID().toString();
         final DateTime testEventTime = DateTime.now();
+        final int testSize = RANDOM.nextInt();
 
         when(s3EventBridgeNotification.getDetail()).thenReturn(detail);
         when(s3EventBridgeNotification.getDetail().getBucket()).thenReturn(bucket);
@@ -86,6 +92,7 @@ class ParsedMessageTest {
 
         when(bucket.getName()).thenReturn(testBucketName);
         when(object.getUrlDecodedKey()).thenReturn(testDecodedObjectKey);
+        when(object.getSize()).thenReturn(testSize);
         when(s3EventBridgeNotification.getDetailType()).thenReturn(testDetailType);
         when(s3EventBridgeNotification.getTime()).thenReturn(testEventTime);
 
@@ -94,6 +101,7 @@ class ParsedMessageTest {
         assertThat(parsedMessage.getMessage(), equalTo(message));
         assertThat(parsedMessage.getBucketName(), equalTo(testBucketName));
         assertThat(parsedMessage.getObjectKey(), equalTo(testDecodedObjectKey));
+        assertThat(parsedMessage.getObjectSize(), equalTo((long) testSize));
         assertThat(parsedMessage.getDetailType(), equalTo(testDetailType));
         assertThat(parsedMessage.getEventTime(), equalTo(testEventTime));
         assertThat(parsedMessage.isFailedParsing(), equalTo(false));


### PR DESCRIPTION
### Description
This PR fixes parsing on empty folder creation S3 event in s3 source by skipping the zero size object processing.
 
### Issues Resolved
Resolves #3727 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
