### PR TITLE
Update to Logback 1.4.14 to fix CVE-2023-6481

### DIFF
--- a/examples/trace-analytics-sample-app/sample-app/analytics-service/build.gradle
+++ b/examples/trace-analytics-sample-app/sample-app/analytics-service/build.gradle
@@ -31,7 +31,7 @@ configurations.all {
             details.useVersion '10.1.14'
             details.because('Fixes CVE-2023-44487')
         } else if (details.requested.group == 'ch.qos.logback') {
-            details.useVersion '1.4.12'
+            details.useVersion '1.4.14'
             details.because('Fixes CVE-2023-6378')
         }
     }

--- a/performance-test/build.gradle
+++ b/performance-test/build.gradle
@@ -26,13 +26,13 @@ dependencies {
     constraints {
         gatling('ch.qos.logback:logback-classic') {
             version {
-                require '1.4.12'
+                require '1.4.14'
             }
             because 'Fixes CVE-2023-6378'
         }
         gatling('ch.qos.logback:logback-core') {
             version {
-                require '1.4.12'
+                require '1.4.14'
             }
             because 'Keeps the version synced with logback-classic.'
         }


### PR DESCRIPTION
### Description

Update to Logback 1.4.14 in performance test and sample app to fix CVE-2023-6481. This follows on #3746 to resolve a new CVE that came up this week.
 
### Issues Resolved

Resolves #3817.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
