### PR TITLE
Release notes for Data Prepper 2.6.1.

### DIFF
--- a/release/release-notes/data-prepper.release-notes-2.6.1.md
+++ b/release/release-notes/data-prepper.release-notes-2.6.1.md
@@ -2,6 +2,9 @@
 
 ---
 
+### Enhancements
+* Add aggregate metrics for ddb source export and stream ([#3728](https://github.com/opensearch-project/data-prepper/pull/3728))
+
 ### Bug Fixes
 * Update and upsert bulk actions do not include changes from document_root_key, exclude_keys, etc. ([#3745](https://github.com/opensearch-project/data-prepper/issues/3745))
 * S3 source processes SQS notification when S3 folder is created ([#3727](https://github.com/opensearch-project/data-prepper/issues/3727))

--- a/release/release-notes/data-prepper.release-notes-2.6.1.md
+++ b/release/release-notes/data-prepper.release-notes-2.6.1.md
@@ -1,0 +1,12 @@
+## 2023-12-07 Version 2.6.1
+
+---
+
+### Bug Fixes
+* Update and upsert bulk actions do not include changes from document_root_key, exclude_keys, etc. ([#3745](https://github.com/opensearch-project/data-prepper/issues/3745))
+* S3 source processes SQS notification when S3 folder is created ([#3727](https://github.com/opensearch-project/data-prepper/issues/3727))
+
+### Security
+* Fix CVE-2023-6378 and CVE-2023-6481 by updating logback to 1.4.14 ([#3729](https://github.com/opensearch-project/data-prepper/issues/3729), [#3817](https://github.com/opensearch-project/data-prepper/issues/3817))
+* Require nimbus-jose-jwt 9.37.1 to fix CVE-2021-31684 and CVE-2023-1370 ([#3731](https://github.com/opensearch-project/data-prepper/pull/3731))
+* Updates example analytics-service to Spring Boot 3.1.6 fixing CVE-2023-34055 ([#3732](https://github.com/opensearch-project/data-prepper/pull/3732))


### PR DESCRIPTION
### Description

Adds release notes for Data Prepper 2.6.1.

See the following milestone for the list of changes.

https://github.com/opensearch-project/data-prepper/milestone/25?closed=1
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
