### PR TITLE
Require Mozilla Rhino 1.7.12 to fix SNYK-JAVA-ORGMOZILLA-1314295.

### DIFF
--- a/data-prepper-plugins/kafka-plugins/build.gradle
+++ b/data-prepper-plugins/kafka-plugins/build.gradle
@@ -63,6 +63,15 @@ dependencies {
     testImplementation libs.protobuf.util
     testImplementation libs.commons.io
     testImplementation libs.armeria.grpc
+
+    constraints {
+        implementation('org.mozilla:rhino') {
+            version {
+                require '1.7.12'
+            }
+            because 'Fixes SNYK-JAVA-ORGMOZILLA-1314295.'
+        }
+    }
 }
 
 


### PR DESCRIPTION
### Description

Require Mozilla Rhino 1.7.12 in the Kafka plugins library.
 
### Issues Resolved

https://security.snyk.io/vuln/SNYK-JAVA-ORGMOZILLA-1314295
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
