### PR TITLE
Add sts_header_overrides to s3 dlq configuration

### DIFF
--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfig.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfig.java
@@ -19,6 +19,7 @@ import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -56,6 +57,9 @@ public class S3DlqWriterConfig {
     @Size(min = 2, max = 1224, message = "sts_external_id length should be between 2 and 1224 characters")
     private String stsExternalId;
 
+    @JsonProperty("sts_header_overrides")
+    private Map<String, String> stsHeaderOverrides;
+
     public String getBucket() {
         if (bucket.startsWith(S3_PREFIX)) {
             return bucket.substring(S3_PREFIX.length());
@@ -89,6 +93,11 @@ public class S3DlqWriterConfig {
 
         if (stsExternalId != null && !stsExternalId.isEmpty()) {
             assumeRoleRequestBuilder = assumeRoleRequestBuilder.externalId(stsExternalId);
+        }
+
+        if(stsHeaderOverrides != null && !stsHeaderOverrides.isEmpty()) {
+            assumeRoleRequestBuilder = assumeRoleRequestBuilder
+                    .overrideConfiguration(configuration -> stsHeaderOverrides.forEach(configuration::putHeader));
         }
 
         return StsAssumeRoleCredentialsProvider.builder()

--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfigTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterConfigTest.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.lang.reflect.Field;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -68,6 +69,7 @@ public class S3DlqWriterConfigTest {
         final S3DlqWriterConfig config = new S3DlqWriterConfig();
         reflectivelySetField(config, "stsRoleArn", stsRoleArn);
         reflectivelySetField(config, "stsExternalId", UUID.randomUUID().toString());
+        reflectivelySetField(config, "stsHeaderOverrides", Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
         final S3Client s3Client = config.getS3Client();
         assertThat(s3Client, is(notNullValue()));
     }


### PR DESCRIPTION
### Description
Adds support for passing a map of `sts_header_overrides` to the s3 dlq, and applies it to the `AssumeRoleRequest` to assume the `sts_role_arn`
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
