### PR TITLE
Handle stale changeVisibilityTimeout calls

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSet.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/acknowledgements/AcknowledgementSet.java
@@ -9,7 +9,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
 
 import java.time.Duration;
-import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * AcknowledgmentSet keeps track of set of events that
@@ -72,5 +72,5 @@ public interface AcknowledgementSet {
      * @param progressCheckInterval frequency of invocation of progress check callback
      * @since 2.6
      */
-    public void addProgressCheck(final Consumer<ProgressCheck> progressCheckCallback, final Duration progressCheckInterval);
+    public void addProgressCheck(final Function<ProgressCheck, Boolean> progressCheckCallback, final Duration progressCheckInterval);
 }


### PR DESCRIPTION
### Description
Handle stale changeVisibilityTimeout calls by not logging the error messages and returning different value so that the progress check callbacks can be cleaned up.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
