### PR TITLE
Add support for epoch timestamps and configurable output format

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/InputCodec.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/InputCodec.java
@@ -38,7 +38,6 @@ public interface InputCodec {
             Consumer<Record<Event>> eventConsumer) throws IOException {
         Objects.requireNonNull(inputFile);
         Objects.requireNonNull(eventConsumer);
-        System.out.println("======InputFile==="+inputFile);
         try (InputStream inputStream = inputFile.newStream()) {
             parse(decompressionEngine.createInputStream(inputStream), eventConsumer);
         }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/InputCodec.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/InputCodec.java
@@ -38,6 +38,7 @@ public interface InputCodec {
             Consumer<Record<Event>> eventConsumer) throws IOException {
         Objects.requireNonNull(inputFile);
         Objects.requireNonNull(eventConsumer);
+        System.out.println("======InputFile==="+inputFile);
         try (InputStream inputStream = inputFile.newStream()) {
             parse(decompressionEngine.createInputStream(inputStream), eventConsumer);
         }

--- a/data-prepper-plugins/date-processor/README.md
+++ b/data-prepper-plugins/date-processor/README.md
@@ -66,6 +66,7 @@ valid key and at least one pattern is required if match is configured.
     * `patterns`: List of possible patterns the timestamp value of key can have. The patterns are based on sequence of letters and symbols. 
       The `patterns` support all the patterns listed in Java 
       [DatetimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html).
+      and also supports `epoch_second`, `epoch_milli` and `epoch_nano` values which represents the timestamp as the number of seconds, milliseconds and nano seconds since epoch. Epoch values are always UTC time zone.
       * Type: `List<String>`
 
 The following example of date configuration will use `timestamp` key to match against given patterns and stores the timestamp in ISO 8601
@@ -105,6 +106,8 @@ processor:
     * Default: `Locale.ROOT`
 
 * `to_origination_metadata` (Optional): When this option is used, matched time is put into the event's metadata as an instance of `Instant`.
+
+* `output_format` (Optional): indicates the format of the `@timestamp`. Default is `yyyy-MM-dd'T'HH:mm:ss.SSSXXX`.
 
 ## Metrics
 

--- a/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessor.java
+++ b/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessor.java
@@ -20,11 +20,13 @@ import org.slf4j.LoggerFactory;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
@@ -33,12 +35,16 @@ import org.apache.commons.lang3.tuple.Pair;
 public class DateProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
     private static final Logger LOG = LoggerFactory.getLogger(DateProcessor.class);
     private static final String OUTPUT_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+    private static final int LENGTH_OF_EPOCH_IN_MILLIS = 13;
+    private static final int LENGTH_OF_EPOCH_SECONDS = 10;
 
     static final String DATE_PROCESSING_MATCH_SUCCESS = "dateProcessingMatchSuccess";
     static final String DATE_PROCESSING_MATCH_FAILURE = "dateProcessingMatchFailure";
 
     private String keyToParse;
     private List<DateTimeFormatter> dateTimeFormatters;
+    private Set<String> epochFormatters;
+    private String outputFormat;
     private final DateProcessorConfig dateProcessorConfig;
     private final ExpressionEvaluator expressionEvaluator;
 
@@ -50,6 +56,7 @@ public class DateProcessor extends AbstractProcessor<Record<Event>, Record<Event
         super(pluginMetrics);
         this.dateProcessorConfig = dateProcessorConfig;
         this.expressionEvaluator = expressionEvaluator;
+        this.outputFormat = dateProcessorConfig.getOutputFormat();
 
         dateProcessingMatchSuccessCounter = pluginMetrics.counter(DATE_PROCESSING_MATCH_SUCCESS);
         dateProcessingMatchFailureCounter = pluginMetrics.counter(DATE_PROCESSING_MATCH_FAILURE);
@@ -68,10 +75,10 @@ public class DateProcessor extends AbstractProcessor<Record<Event>, Record<Event
 
             String zonedDateTime = null;
 
-            if (Boolean.TRUE.equals(dateProcessorConfig.getFromTimeReceived()))
+            if (Boolean.TRUE.equals(dateProcessorConfig.getFromTimeReceived())) {
                 zonedDateTime =  getDateTimeFromTimeReceived(record);
 
-            else if (keyToParse != null && !keyToParse.isEmpty()) {
+            } else if (keyToParse != null && !keyToParse.isEmpty()) {
                 Pair<String, Instant> result = getDateTimeFromMatch(record);
                 if (result != null) {
                     zonedDateTime = result.getLeft();
@@ -85,8 +92,9 @@ public class DateProcessor extends AbstractProcessor<Record<Event>, Record<Event
                 populateDateProcessorMetrics(zonedDateTime);
             }
 
-            if (zonedDateTime != null)
+            if (zonedDateTime != null) {
                 record.getData().put(dateProcessorConfig.getDestination(), zonedDateTime);
+            }
         }
         return records;
     }
@@ -101,7 +109,8 @@ public class DateProcessor extends AbstractProcessor<Record<Event>, Record<Event
     private void extractKeyAndFormatters() {
         for (DateProcessorConfig.DateMatch entry: dateProcessorConfig.getMatch()) {
             keyToParse = entry.getKey();
-            dateTimeFormatters = entry.getPatterns().stream().map(this::getSourceFormatter).collect(Collectors.toList());
+            epochFormatters = entry.getPatterns().stream().filter(pattern -> pattern.contains("epoch")).collect(Collectors.toSet());
+            dateTimeFormatters = entry.getPatterns().stream().filter(pattern -> !pattern.contains("epoch")).map(this::getSourceFormatter).collect(Collectors.toList());
         }
     }
 
@@ -146,11 +155,71 @@ public class DateProcessor extends AbstractProcessor<Record<Event>, Record<Event
         }
     }
 
+    private Pair<String, Instant> getEpochFormatOutput(Instant time) {
+        if (outputFormat.equals("epoch_second")) {
+            return Pair.of(Long.toString(time.getEpochSecond()), time);
+        } else if (outputFormat.equals("epoch_milli")) {
+            return Pair.of(Long.toString(time.toEpochMilli()), time);
+        } else { // epoch_nano. validation for valid epoch_ should be
+                 // done at init time
+            long nano = (long)time.getEpochSecond() * 1000_000_000 + (long) time.getNano();
+            return Pair.of(Long.toString(nano), time);
+        } 
+    }
+
     private Pair<String, Instant> getFormattedDateTimeString(final String sourceTimestamp) {
+        ZoneId srcZoneId = dateProcessorConfig.getSourceZoneId();
+        ZoneId dstZoneId = dateProcessorConfig.getDestinationZoneId();
+        Long numberValue = null;
+        Instant epochTime;
+        
+        if (epochFormatters.size() > 0) {
+            try {
+                numberValue = Long.parseLong(sourceTimestamp);
+            } catch (NumberFormatException e) {
+                numberValue = null;
+            }
+        }
+        if (numberValue != null) {
+            int timestampLength = sourceTimestamp.length();
+            if (timestampLength > LENGTH_OF_EPOCH_IN_MILLIS) {
+                if (epochFormatters.contains("epoch_nano")) {
+                    epochTime = Instant.ofEpochSecond(numberValue/1000_000_000, numberValue % 1000_000_000);
+                } else {
+                    LOG.warn("Source time value is larger than epoch pattern configured. epoch_nano is expected but not present in the patterns list");
+                    return null;
+                }
+            } else if (timestampLength > LENGTH_OF_EPOCH_SECONDS) {
+                if (epochFormatters.contains("epoch_milli")) {
+                    epochTime = Instant.ofEpochMilli(numberValue);
+                } else {
+                    LOG.warn("Source time value is larger than epoch pattern configured. epoch_milli is expected but not present in the patterns list");
+                    return null;
+                }
+            } else {
+                epochTime = Instant.ofEpochSecond(numberValue);
+            }
+            // Epochs are always UTC zone
+            srcZoneId = ZoneId.of("UTC");
+            try {
+                if (outputFormat.startsWith("epoch_")) {
+                    return getEpochFormatOutput(epochTime);
+                } else {
+                    DateTimeFormatter outputFormatter = getOutputFormatter().withZone(dstZoneId);
+                    ZonedDateTime tmp = ZonedDateTime.ofInstant(epochTime, srcZoneId);
+                    return Pair.of(tmp.format(outputFormatter.withZone(dstZoneId)), tmp.toInstant());
+                }
+            } catch (Exception ignored) {
+            }
+        }
+
         for (DateTimeFormatter formatter : dateTimeFormatters) {
             try {
                 ZonedDateTime tmp = ZonedDateTime.parse(sourceTimestamp, formatter);
-                return Pair.of(tmp.format(getOutputFormatter().withZone(dateProcessorConfig.getDestinationZoneId())), tmp.toInstant());
+                if (outputFormat.startsWith("epoch_")) {
+                    return getEpochFormatOutput(tmp.toInstant());
+                }
+                return Pair.of(tmp.format(getOutputFormatter().withZone(dstZoneId)), tmp.toInstant());
             } catch (Exception ignored) {
             }
         }
@@ -160,7 +229,7 @@ public class DateProcessor extends AbstractProcessor<Record<Event>, Record<Event
     }
 
     private DateTimeFormatter getOutputFormatter() {
-        return DateTimeFormatter.ofPattern(OUTPUT_FORMAT);
+        return DateTimeFormatter.ofPattern(outputFormat);
     }
 
     @Override

--- a/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
+++ b/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
@@ -209,7 +209,7 @@ public class DateProcessorConfig {
         return true;
     }
 
-    @AssertTrue(message = "match can have a minimum and maximum of 1 entry and at least one pattern.")
+    @AssertTrue(message = "Invalid output format.")
     boolean isValidOutputFormat() {
         return DateMatch.isValidPattern(outputFormat);
     }
@@ -217,7 +217,7 @@ public class DateProcessorConfig {
     @AssertTrue(message = "Invalid source_timezone provided.")
     boolean isSourceTimezoneValid() {
         try {
-            sourceZoneId = buildZoneId(sourceTimezone);
+            sourceZoneId  = buildZoneId(sourceTimezone);
             return true;
         } catch (Exception e) {
             return false;

--- a/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
+++ b/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
@@ -46,6 +46,16 @@ public class DateProcessorConfig {
 
         @JsonIgnore
         public boolean isValidPatterns() {
+            // For now, allow only one of the three "epoch_" pattern
+            int count = 0;
+            for (final String pattern: patterns) {
+                if (pattern.startsWith("epoch_")) {
+                    count++;
+                }
+                if (count > 1) {
+                    return false;
+                }
+            }
             for (final String pattern: patterns) {
                 if (!isValidPattern(pattern)) {
                     return false;

--- a/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
+++ b/data-prepper-plugins/date-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfig.java
@@ -44,6 +44,7 @@ public class DateProcessorConfig {
             return patterns;
         }
 
+        @JsonIgnore
         public boolean isValidPatterns() {
             for (final String pattern: patterns) {
                 if (!isValidPattern(pattern)) {

--- a/data-prepper-plugins/date-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfigTest.java
+++ b/data-prepper-plugins/date-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfigTest.java
@@ -97,6 +97,16 @@ class DateProcessorConfigTest {
         }
 
         @Test
+        void isValidMatch_should_return_false_if_match_has_multiple_epoch_patterns() throws NoSuchFieldException, IllegalAccessException {
+            when(mockDateMatch.getPatterns()).thenReturn(List.of("epoch_second", "epoch_milli"));
+
+            List<DateProcessorConfig.DateMatch> dateMatches = Arrays.asList(mockDateMatch, mockDateMatch);
+            reflectivelySetField(dateProcessorConfig, "match", dateMatches);
+
+            assertThat(dateProcessorConfig.isValidMatch(), equalTo(false));
+        }
+
+        @Test
         void isValidMatch_should_return_false_if_match_has_multiple_entries() throws NoSuchFieldException, IllegalAccessException {
             when(mockDateMatch.getPatterns()).thenReturn(Collections.singletonList(random));
 

--- a/data-prepper-plugins/date-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfigTest.java
+++ b/data-prepper-plugins/date-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorConfigTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;   
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,6 +43,7 @@ class DateProcessorConfigTest {
         void setUp() {
             random = UUID.randomUUID().toString();
             mockDateMatch = mock(DateProcessorConfig.DateMatch.class);
+            when(mockDateMatch.isValidPatterns()).thenReturn(true);
         }
 
         @Test
@@ -65,6 +67,23 @@ class DateProcessorConfigTest {
             reflectivelySetField(dateProcessorConfig, "match", dateMatches);
 
             assertThat(dateProcessorConfig.isValidMatchAndFromTimestampReceived(), equalTo(false));
+        }
+
+        @Test
+        void testValidAndInvalidOutputFormats() throws NoSuchFieldException, IllegalAccessException {
+            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", random);
+            assertThat(dateProcessorConfig.isValidOutputFormat(), equalTo(false));
+
+            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", "epoch_second");
+            assertThat(dateProcessorConfig.isValidOutputFormat(), equalTo(true));
+            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", "epoch_milli");
+            assertThat(dateProcessorConfig.isValidOutputFormat(), equalTo(true));
+            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", "epoch_nano");
+            assertThat(dateProcessorConfig.isValidOutputFormat(), equalTo(true));
+            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", "epoch_xyz");
+            assertThat(dateProcessorConfig.isValidOutputFormat(), equalTo(false));
+            setField(DateProcessorConfig.class, dateProcessorConfig, "outputFormat", "yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnnXXX");
+            assertThat(dateProcessorConfig.isValidOutputFormat(), equalTo(true));
         }
 
         @Test


### PR DESCRIPTION
### Description
Supports input timestamp to be of `epoch_second`, `epoch_milli` or `epoch_nano`.
Also added support to configure output timestamp format. It can be also epoch timestamp or any of the formats allowed by DateTimeFormatter.
 
Resolves #2929 
### Issues Resolved
Resolves #2929 
 
### Check List
- [X ] New functionality includes testing.
- [X ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
