### PR TITLE
Date processor test corrections for other timezones

### DIFF
--- a/data-prepper-plugins/date-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorTests.java
+++ b/data-prepper-plugins/date-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/date/DateProcessorTests.java
@@ -330,7 +330,7 @@ class DateProcessorTests {
         testData.put("logDate", input);
         final Record<Event> record = buildRecordWithEvent(testData);
         final List<Record<Event>> processedRecords = (List<Record<Event>>) dateProcessor.doExecute(Collections.singletonList(record));
-        Object actualOutput = processedRecords.get(0).getData().get(TIMESTAMP_KEY, Object.class);
+        String actualOutput = processedRecords.get(0).getData().get(TIMESTAMP_KEY, String.class);
         assertThat(actualOutput, equalTo(expectedOutput));
         verify(dateProcessingMatchSuccessCounter, times(1)).increment();
     }


### PR DESCRIPTION
### Description

I ran the `DateProcessorTests` and they began to fail. There appears to be a disconnect between the timezone used in the tested code and the expected timezone in the expected string.

While I was working it, I also removed an unnecessary condition in the tests. It is generally better to avoid conditions in tests, especially in the assertions.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
