### PR TITLE
Add 4xx aggregate metric and shard progress metric for dynamodb source

### DIFF
--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportTaskManager.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/export/ExportTaskManager.java
@@ -63,6 +63,7 @@ public class ExportTaskManager {
             return null;
         } catch (SdkException e) {
             LOG.error("Failed to submit an export job with error " + e.getMessage());
+            dynamoAggregateMetrics.getExport4xxErrors().increment();
             return null;
         }
 
@@ -82,6 +83,7 @@ public class ExportTaskManager {
             LOG.error("Unable to get manifest file for export {}: {}", exportArn, e.getMessage());
         } catch (SdkException e) {
             LOG.error("Unable to get manifest file for export {}: {}", exportArn, e.getMessage());
+            dynamoAggregateMetrics.getExport4xxErrors().increment();
         }
         return manifestKey;
     }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/ShardManager.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/leader/ShardManager.java
@@ -3,6 +3,7 @@ package org.opensearch.dataprepper.plugins.source.dynamodb.leader;
 import org.opensearch.dataprepper.plugins.source.dynamodb.utils.DynamoDBSourceAggregateMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.dynamodb.model.DescribeStreamRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeStreamResponse;
 import software.amazon.awssdk.services.dynamodb.model.InternalServerErrorException;
@@ -175,6 +176,10 @@ public class ShardManager {
         } catch(final InternalServerErrorException e) {
             LOG.error("Received an internal server exception from DynamoDB while listing shards: {}", e.getMessage());
             dynamoDBSourceAggregateMetrics.getStream5xxErrors().increment();
+            return shards;
+        } catch (final SdkException e) {
+            LOG.error("Received an exception from DynamoDB while listing shards: {}", e.getMessage());
+            dynamoDBSourceAggregateMetrics.getStream4xxErrors().increment();
             return shards;
         }
 

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactory.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactory.java
@@ -162,6 +162,7 @@ public class ShardConsumerFactory {
             LOG.error("Received an internal server error from DynamoDB while getting a shard iterator: {}", e.getMessage());
             return null;
         } catch (SdkException e) {
+            dynamoDBSourceAggregateMetrics.getStream4xxErrors().increment();
             LOG.error("Exception when trying to get the shard iterator due to {}", e.getMessage());
             return null;
         }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/utils/DynamoDBSourceAggregateMetrics.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/utils/DynamoDBSourceAggregateMetrics.java
@@ -13,23 +13,30 @@ public class DynamoDBSourceAggregateMetrics {
     private static final String DYNAMO_DB = "dynamodb";
 
     private static final String DDB_STREAM_5XX_EXCEPTIONS = "stream5xxErrors";
+    private static final String DDB_STREAM_4XX_EXCEPTIONS = "stream4xxErrors";
     private static final String DDB_STREAM_API_INVOCATIONS = "streamApiInvocations";
     private static final String DDB_EXPORT_5XX_ERRORS = "export5xxErrors";
+    private static final String DDB_EXPORT_4XX_ERRORS = "export4xxErrors";
     private static final String DDB_EXPORT_API_INVOCATIONS = "exportApiInvocations";
+
 
 
     private final PluginMetrics pluginMetrics;
 
     private final Counter stream5xxErrors;
+    private final Counter stream4xxErrors;
     private final Counter streamApiInvocations;
     private final Counter export5xxErrors;
+    private final Counter export4xxErrors;
     private final Counter exportApiInvocations;
 
     public DynamoDBSourceAggregateMetrics() {
         this.pluginMetrics = PluginMetrics.fromPrefix(DYNAMO_DB);
         this.stream5xxErrors = pluginMetrics.counter(DDB_STREAM_5XX_EXCEPTIONS);
+        this.stream4xxErrors = pluginMetrics.counter(DDB_STREAM_4XX_EXCEPTIONS);
         this.streamApiInvocations = pluginMetrics.counter(DDB_STREAM_API_INVOCATIONS);
         this.export5xxErrors = pluginMetrics.counter(DDB_EXPORT_5XX_ERRORS);
+        this.export4xxErrors = pluginMetrics.counter(DDB_EXPORT_4XX_ERRORS);
         this.exportApiInvocations = pluginMetrics.counter(DDB_EXPORT_API_INVOCATIONS);
     }
 
@@ -37,11 +44,15 @@ public class DynamoDBSourceAggregateMetrics {
         return stream5xxErrors;
     }
 
+    public Counter getStream4xxErrors() { return stream4xxErrors; }
+
     public Counter getStreamApiInvocations() { return streamApiInvocations; }
 
     public Counter getExport5xxErrors() {
         return export5xxErrors;
     }
+
+    public Counter getExport4xxErrors() { return export4xxErrors; }
 
     public Counter getExportApiInvocations() { return exportApiInvocations; }
 }


### PR DESCRIPTION
### Description
This change adds 3 new metrics to the DynamoDB source

* `stream4xxErrors` - aggregate metric for stream 4xx errors
* `export4xxErrors` - aggregate metric for export 4xx errors
* `shardProgress` - Tracks that the pipeline is still processing shards correctly 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
