### PR TITLE
Updates Armeria to 1.26.4

### DIFF
--- a/data-prepper-plugins/otel-logs-source/build.gradle
+++ b/data-prepper-plugins/otel-logs-source/build.gradle
@@ -21,9 +21,10 @@ dependencies {
     implementation 'software.amazon.awssdk:auth'
     implementation 'software.amazon.awssdk:regions'
     implementation 'software.amazon.awssdk:s3'
-    implementation 'com.google.protobuf:protobuf-java-util:3.19.4'
-    implementation 'com.linecorp.armeria:armeria:1.15.0'
-    implementation 'com.linecorp.armeria:armeria-grpc:1.15.0'
+    implementation libs.protobuf.util
+    implementation libs.armeria.core
+    implementation libs.armeria.grpc
+    implementation libs.grpc.inprocess
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation libs.commons.lang3

--- a/data-prepper-plugins/otel-metrics-source/build.gradle
+++ b/data-prepper-plugins/otel-metrics-source/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation libs.protobuf.util
     implementation libs.armeria.core
     implementation libs.armeria.grpc
+    implementation libs.grpc.inprocess
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation libs.commons.lang3

--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation libs.protobuf.util
     implementation libs.armeria.core
     implementation libs.armeria.grpc
+    implementation libs.grpc.inprocess
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation libs.commons.lang3

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,10 +17,12 @@ dependencyResolutionManagement {
         libs {
             version('slf4j', '2.0.6')
             library('slf4j-api', 'org.slf4j', 'slf4j-api').versionRef('slf4j')
-            version('armeria', '1.25.2')
+            version('armeria', '1.26.4')
             library('armeria-core', 'com.linecorp.armeria', 'armeria').versionRef('armeria')
             library('armeria-grpc', 'com.linecorp.armeria', 'armeria-grpc').versionRef('armeria')
             library('armeria-junit', 'com.linecorp.armeria', 'armeria-junit5').versionRef('armeria')
+            version('grpc', '1.58.0')
+            library('grpc-inprocess', 'io.grpc', 'grpc-inprocess').versionRef('grpc')
             version('protobuf', '3.24.3')
             library('protobuf-core', 'com.google.protobuf', 'protobuf-java').versionRef('protobuf')
             library('protobuf-util', 'com.google.protobuf', 'protobuf-java-util').versionRef('protobuf')


### PR DESCRIPTION
### Description

Updates Armeria to 1.26.4.

This version of Armeria moves to `io.grpc` 1.58.0. This version split some class from the core library into a new library `grpc-inprocess`. Armeria does not depend on this, but Data Prepper uses some classes from this new library. So this PR also adds that dependency via the version catalog.

One goal is to remove possible memory leaks in Armeria per #3912.
 
### Issues Resolved

Unsure; maybe helps toward #3912
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
