### PR TITLE
Support larger message sizes in Kafka Buffer

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferIT.java
@@ -187,42 +187,6 @@ public class KafkaBufferIT {
     }
 
     @Test
-    void write_and_read_max_message_bytes() throws TimeoutException, NoSuchFieldException, IllegalAccessException {
-        KafkaProducerProperties kafkaProducerProperties = new KafkaProducerProperties();
-        final Map<String, Object> topicConfigMap = Map.of(
-                "name", topicName,
-                "max_message_bytes", 4*1024*1024,
-                "group_id", "buffergroup-" + RandomStringUtils.randomAlphabetic(6),
-                "create_topic", false
-        );
-        final Map<String, Object> bufferConfigMap = Map.of(
-                "topics", List.of(topicConfigMap),
-                "producer_properties", kafkaProducerProperties,
-                "bootstrap_servers", List.of(bootstrapServersCommaDelimited),
-                "encryption", Map.of("type", "none")
-        );
-        kafkaBufferConfig = objectMapper.convertValue(bufferConfigMap, KafkaBufferConfig.class);
-        KafkaBuffer objectUnderTest = createObjectUnderTest();
-
-        Record<Event> record = createLargeRecord();
-        objectUnderTest.write(record, 1_000);
-
-        Map.Entry<Collection<Record<Event>>, CheckpointState> readResult = objectUnderTest.read(10_000);
-
-        assertThat(readResult, notNullValue());
-        assertThat(readResult.getKey(), notNullValue());
-        assertThat(readResult.getKey().size(), equalTo(1));
-
-        Record<Event> onlyResult = readResult.getKey().stream().iterator().next();
-
-        assertThat(onlyResult, notNullValue());
-        assertThat(onlyResult.getData(), notNullValue());
-        // TODO: The metadata is not included. It needs to be included in the Buffer, though not in the Sink. This may be something we make configurable in the consumer/producer - whether to serialize the metadata or not.
-        //assertThat(onlyResult.getData().getMetadata(), equalTo(record.getData().getMetadata()));
-        assertThat(onlyResult.getData().toMap(), equalTo(record.getData().toMap()));
-    }
-
-    @Test
     void writeBytes_and_read() throws Exception {
         byteDecoder = new JsonDecoder();
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfig.java
@@ -18,6 +18,7 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.TopicProducerConfi
 import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 
 import java.time.Duration;
+import java.util.Optional;
 
 class BufferTopicConfig extends CommonTopicConfig implements TopicProducerConfig, TopicConsumerConfig {
     static final Duration DEFAULT_COMMIT_INTERVAL = Duration.ofSeconds(5);
@@ -28,6 +29,7 @@ class BufferTopicConfig extends CommonTopicConfig implements TopicProducerConfig
     static final ByteCount DEFAULT_FETCH_MAX_BYTES = ByteCount.parse("50mb");
     static final Duration DEFAULT_FETCH_MAX_WAIT = Duration.ofMillis(500);
     static final ByteCount DEFAULT_FETCH_MIN_BYTES = ByteCount.parse("1b");
+    static final ByteCount DEFAULT_MAX_MESSAGE_BYTES = ByteCount.parse("1mb");
     static final ByteCount DEFAULT_MAX_PARTITION_FETCH_BYTES = ByteCount.parse("1mb");
     static final Duration DEFAULT_SESSION_TIMEOUT = Duration.ofSeconds(45);
     static final String DEFAULT_AUTO_OFFSET_RESET = "earliest";
@@ -101,6 +103,9 @@ class BufferTopicConfig extends CommonTopicConfig implements TopicProducerConfig
 
     @JsonProperty("fetch_max_bytes")
     private ByteCount fetchMaxBytes = DEFAULT_FETCH_MAX_BYTES;
+
+    @JsonProperty("max_message_bytes")
+    private ByteCount maxMessageBytes = DEFAULT_MAX_MESSAGE_BYTES;
 
     @JsonProperty("fetch_max_wait")
     @Valid
@@ -210,6 +215,19 @@ class BufferTopicConfig extends CommonTopicConfig implements TopicProducerConfig
             throw new RuntimeException("Invalid Fetch Max Bytes");
         }
         return value;
+    }
+
+    @Override
+    public Optional<Long> getMaxMessageBytes() {
+        long value = maxMessageBytes.getBytes();
+        long defaultValue = DEFAULT_MAX_MESSAGE_BYTES.getBytes();
+        if (value < defaultValue || value > 4 * defaultValue) {
+            throw new RuntimeException("Invalid Max Message Bytes");
+        }
+        if (value == defaultValue) {
+            return Optional.empty();
+        }
+        return Optional.of(value);
     }
 
     @Override

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfig.java
@@ -28,7 +28,6 @@ class BufferTopicConfig extends CommonTopicConfig implements TopicProducerConfig
     static final ByteCount DEFAULT_FETCH_MAX_BYTES = ByteCount.parse("50mb");
     static final Duration DEFAULT_FETCH_MAX_WAIT = Duration.ofMillis(500);
     static final ByteCount DEFAULT_FETCH_MIN_BYTES = ByteCount.parse("1b");
-    static final ByteCount DEFAULT_MAX_MESSAGE_BYTES = ByteCount.parse("1mb");
     static final ByteCount DEFAULT_MAX_PARTITION_FETCH_BYTES = ByteCount.parse("1mb");
     static final Duration DEFAULT_SESSION_TIMEOUT = Duration.ofSeconds(45);
     static final String DEFAULT_AUTO_OFFSET_RESET = "earliest";
@@ -37,7 +36,6 @@ class BufferTopicConfig extends CommonTopicConfig implements TopicProducerConfig
     static final Integer DEFAULT_CONSUMER_MAX_POLL_RECORDS = 500;
     static final Integer DEFAULT_NUM_OF_WORKERS = 2;
     static final Duration DEFAULT_HEART_BEAT_INTERVAL_DURATION = Duration.ofSeconds(5);
-
 
     @JsonProperty("encryption_key")
     private String encryptionKey;
@@ -102,9 +100,6 @@ class BufferTopicConfig extends CommonTopicConfig implements TopicProducerConfig
 
     @JsonProperty("fetch_max_bytes")
     private ByteCount fetchMaxBytes = DEFAULT_FETCH_MAX_BYTES;
-
-    @JsonProperty("max_message_bytes")
-    private ByteCount maxMessageBytes = DEFAULT_MAX_MESSAGE_BYTES;
 
     @JsonProperty("fetch_max_wait")
     @Valid
@@ -214,19 +209,6 @@ class BufferTopicConfig extends CommonTopicConfig implements TopicProducerConfig
             throw new RuntimeException("Invalid Fetch Max Bytes");
         }
         return value;
-    }
-
-    @Override
-    public Long getMaxMessageBytes() {
-        long value = maxMessageBytes.getBytes();
-        long defaultValue = DEFAULT_MAX_MESSAGE_BYTES.getBytes();
-        if (value < defaultValue || value > 4 * defaultValue) {
-            throw new RuntimeException("Invalid Max Message Bytes");
-        }
-        if (value == defaultValue) {
-            return null;
-        }
-        return Long.valueOf(value);
     }
 
     @Override

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfig.java
@@ -18,7 +18,6 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.TopicProducerConfi
 import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 
 import java.time.Duration;
-import java.util.Optional;
 
 class BufferTopicConfig extends CommonTopicConfig implements TopicProducerConfig, TopicConsumerConfig {
     static final Duration DEFAULT_COMMIT_INTERVAL = Duration.ofSeconds(5);
@@ -218,16 +217,16 @@ class BufferTopicConfig extends CommonTopicConfig implements TopicProducerConfig
     }
 
     @Override
-    public Optional<Long> getMaxMessageBytes() {
+    public Long getMaxMessageBytes() {
         long value = maxMessageBytes.getBytes();
         long defaultValue = DEFAULT_MAX_MESSAGE_BYTES.getBytes();
         if (value < defaultValue || value > 4 * defaultValue) {
             throw new RuntimeException("Invalid Max Message Bytes");
         }
         if (value == defaultValue) {
-            return Optional.empty();
+            return null;
         }
-        return Optional.of(value);
+        return Long.valueOf(value);
     }
 
     @Override

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaProducerProperties.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaProducerProperties.java
@@ -21,7 +21,7 @@ public class KafkaProducerProperties {
     static final Duration DEFAULT_RECONNECT_BACKOFF_MAX_MS = Duration.ofMillis(1000);
     static final Duration DEFAULT_RECONNECT_BACKOFF_MS = Duration.ofMillis(50);
     static final Duration DEFAULT_RETRY_BACKOFF_MS = Duration.ofMillis(100);
-    static final int DEFAULT_MAX_REQUEST_SIZE = 1024*1024;
+    public static final int DEFAULT_MAX_REQUEST_SIZE = 1024*1024;
 
     @JsonProperty("buffer_memory")
     private String bufferMemory = DEFAULT_BYTE_CAPACITY;

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaProducerProperties.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaProducerProperties.java
@@ -6,7 +6,22 @@ import java.time.Duration;
 import java.util.List;
 
 public class KafkaProducerProperties {
-    private static final String DEFAULT_BYTE_CAPACITY = "50mb";
+    static final String DEFAULT_BYTE_CAPACITY = "50mb";
+    static final Duration DEFAULT_DELIVERY_TIMEOUT_MS = Duration.ofMillis(120000);
+    static final Long DEFAULT_LINGER_MS = 0L;
+    static final Duration DEFAULT_MAX_BLOCK_MS = Duration.ofMillis(60000);
+    static final Duration DEFAULT_CONNECTION_MAX_IDLE_MS = Duration.ofMillis(540000);
+    static final Duration DEFAULT_REQUEST_TIMEOUT_MS = Duration.ofMillis(30000);
+    static final Duration DEFAULT_SOCKET_CONNECTION_SETUP_MAX_TIMEOUT = Duration.ofMillis(30000);
+    static final Duration DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT = Duration.ofMillis(10000);
+    static final Duration DEFAULT_METADATA_MAX_AGE_MS = Duration.ofMillis(300000);
+    static final Duration DEFAULT_METADATA_MAX_IDLE_MS = Duration.ofMillis(300000);
+    static final Duration DEFAULT_METRICS_SAMPLE_WINDOW_MS = Duration.ofMillis(300000);
+    static final Duration DEFAULT_PARTITIONER_AVAILABILITY_TIMEOUT_MS = Duration.ofMillis(0);
+    static final Duration DEFAULT_RECONNECT_BACKOFF_MAX_MS = Duration.ofMillis(1000);
+    static final Duration DEFAULT_RECONNECT_BACKOFF_MS = Duration.ofMillis(50);
+    static final Duration DEFAULT_RETRY_BACKOFF_MS = Duration.ofMillis(100);
+    static final int DEFAULT_MAX_REQUEST_SIZE = 1024*1024;
 
     @JsonProperty("buffer_memory")
     private String bufferMemory = DEFAULT_BYTE_CAPACITY;
@@ -27,19 +42,19 @@ public class KafkaProducerProperties {
     private String clientId;
 
     @JsonProperty("connections_max_idle")
-    private Duration connectionsMaxIdleMs;
+    private Duration connectionsMaxIdleMs = DEFAULT_CONNECTION_MAX_IDLE_MS;
 
     @JsonProperty("delivery_timeout")
-    private Duration deliveryTimeoutMs;
+    private Duration deliveryTimeoutMs = DEFAULT_DELIVERY_TIMEOUT_MS;
 
     @JsonProperty("linger_ms")
-    private Long lingerMs;
+    private Long lingerMs = DEFAULT_LINGER_MS;
 
     @JsonProperty("max_block")
-    private Duration maxBlockMs;
+    private Duration maxBlockMs = DEFAULT_MAX_BLOCK_MS;
 
     @JsonProperty("max_request_size")
-    private int maxRequestSize;
+    private int maxRequestSize = DEFAULT_MAX_REQUEST_SIZE;
 
     @JsonProperty("partitioner_class")
     private Class partitionerClass;
@@ -51,16 +66,16 @@ public class KafkaProducerProperties {
     private String receiveBufferBytes=DEFAULT_BYTE_CAPACITY;
 
     @JsonProperty("request_timeout")
-    private Duration requestTimeoutMs;
+    private Duration requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS;
 
     @JsonProperty("send_buffer")
     private String sendBufferBytes=DEFAULT_BYTE_CAPACITY;
 
     @JsonProperty("socket_connection_setup_timeout_max")
-    private Duration socketConnectionSetupMaxTimeout;
+    private Duration socketConnectionSetupMaxTimeout = DEFAULT_SOCKET_CONNECTION_SETUP_MAX_TIMEOUT;
 
     @JsonProperty("socket_connection_setup_timeout")
-    private Duration socketConnectionSetupTimeout;
+    private Duration socketConnectionSetupTimeout = DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT;
 
     @JsonProperty("acks")
     private String acks;
@@ -75,10 +90,10 @@ public class KafkaProducerProperties {
     private int maxInFlightRequestsPerConnection;
 
     @JsonProperty("metadata_max_age")
-    private Duration metadataMaxAgeMs;
+    private Duration metadataMaxAgeMs = DEFAULT_METADATA_MAX_AGE_MS;
 
     @JsonProperty("metadata_max_idle")
-    private Duration metadataMaxIdleMs;
+    private Duration metadataMaxIdleMs = DEFAULT_METADATA_MAX_IDLE_MS;
 
     @JsonProperty("metric_reporters")
     private List metricReporters;
@@ -90,22 +105,22 @@ public class KafkaProducerProperties {
     private String metricsRecordingLevel;
 
     @JsonProperty("metrics_sample_window")
-    private Duration metricsSampleWindowMs;
+    private Duration metricsSampleWindowMs = DEFAULT_METRICS_SAMPLE_WINDOW_MS;
 
     @JsonProperty("partitioner_adaptive_partitioning_enable")
     private boolean partitionerAdaptivePartitioningEnable;
 
     @JsonProperty("partitioner_availability_timeout")
-    private Duration partitionerAvailabilityTimeoutMs;
+    private Duration partitionerAvailabilityTimeoutMs = DEFAULT_PARTITIONER_AVAILABILITY_TIMEOUT_MS;
 
     @JsonProperty("reconnect_backoff_max")
-    private Duration reconnectBackoffMaxMs;
+    private Duration reconnectBackoffMaxMs = DEFAULT_RECONNECT_BACKOFF_MAX_MS;
 
     @JsonProperty("reconnect_backoff")
-    private Duration reconnectBackoffMs;
+    private Duration reconnectBackoffMs = DEFAULT_RECONNECT_BACKOFF_MS;
 
     @JsonProperty("retry_backoff")
-    private Duration retryBackoffMs;
+    private Duration retryBackoffMs = DEFAULT_RETRY_BACKOFF_MS;
 
 
     public String getCompressionType() {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicProducerConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicProducerConfig.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper.plugins.kafka.configuration;
 
+import java.util.Optional;
+
 /**
  * An extension of the {@link TopicConfig} specifically for
  * producers to Kafka topics.
@@ -13,5 +15,6 @@ public interface TopicProducerConfig extends TopicConfig {
     Integer getNumberOfPartitions();
     Short getReplicationFactor();
     Long getRetentionPeriod();
+    Optional<Long> getMaxMessageBytes();
     boolean isCreateTopic();
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicProducerConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicProducerConfig.java
@@ -5,8 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.kafka.configuration;
 
-import java.util.Optional;
-
 /**
  * An extension of the {@link TopicConfig} specifically for
  * producers to Kafka topics.
@@ -15,6 +13,6 @@ public interface TopicProducerConfig extends TopicConfig {
     Integer getNumberOfPartitions();
     Short getReplicationFactor();
     Long getRetentionPeriod();
-    Optional<Long> getMaxMessageBytes();
+    Long getMaxMessageBytes();
     boolean isCreateTopic();
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicProducerConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicProducerConfig.java
@@ -13,6 +13,5 @@ public interface TopicProducerConfig extends TopicConfig {
     Integer getNumberOfPartitions();
     Short getReplicationFactor();
     Long getRetentionPeriod();
-    Long getMaxMessageBytes();
     boolean isCreateTopic();
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerFactory.java
@@ -61,7 +61,7 @@ public class KafkaCustomProducerFactory {
         KafkaProducerProperties producerProperties = kafkaProducerConfig.getKafkaProducerProperties();
         if (producerProperties != null) {
             int producerMaxRequestSize = producerProperties.getMaxRequestSize();
-            if (producerMaxRequestSize != KafkaProducerProperties.DEFAULT_MAX_REQUEST_SIZE) {
+            if (producerMaxRequestSize > KafkaProducerProperties.DEFAULT_MAX_REQUEST_SIZE) {
                 maxRequestSize = Integer.valueOf(producerMaxRequestSize);
             }
         }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/service/TopicService.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/service/TopicService.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 public class TopicService {
     private static final Logger LOG = LoggerFactory.getLogger(TopicService.class);
@@ -26,12 +25,12 @@ public class TopicService {
         this.adminClient = AdminClient.create(SinkPropertyConfigurer.getPropertiesForAdminClient(kafkaProducerConfig));
     }
 
-    public void createTopic(final String topicName, final Integer numberOfPartitions, final Short replicationFactor, final Optional<Long> maxMessageBytes) {
+    public void createTopic(final String topicName, final Integer numberOfPartitions, final Short replicationFactor, final Long maxMessageBytes) {
         try {
             final NewTopic newTopic = new NewTopic(topicName, numberOfPartitions, replicationFactor);
-            if (maxMessageBytes.isPresent()) {
+            if (maxMessageBytes != null) {
                 Map<String, String> configOptions = new HashMap<>();
-                configOptions.put(TopicConfig.MAX_MESSAGE_BYTES_CONFIG, Long.toString(maxMessageBytes.get()));
+                configOptions.put(TopicConfig.MAX_MESSAGE_BYTES_CONFIG, Long.toString(maxMessageBytes));
                 newTopic.configs(configOptions);
             }
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/service/TopicService.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/service/TopicService.java
@@ -6,12 +6,16 @@ package org.opensearch.dataprepper.plugins.kafka.service;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.config.TopicConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaProducerConfig;
 import org.opensearch.dataprepper.plugins.kafka.util.SinkPropertyConfigurer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 public class TopicService {
     private static final Logger LOG = LoggerFactory.getLogger(TopicService.class);
@@ -22,9 +26,15 @@ public class TopicService {
         this.adminClient = AdminClient.create(SinkPropertyConfigurer.getPropertiesForAdminClient(kafkaProducerConfig));
     }
 
-    public void createTopic(final String topicName, final Integer numberOfPartitions, final Short replicationFactor) {
+    public void createTopic(final String topicName, final Integer numberOfPartitions, final Short replicationFactor, final Optional<Long> maxMessageBytes) {
         try {
             final NewTopic newTopic = new NewTopic(topicName, numberOfPartitions, replicationFactor);
+            if (maxMessageBytes.isPresent()) {
+                Map<String, String> configOptions = new HashMap<>();
+                configOptions.put(TopicConfig.MAX_MESSAGE_BYTES_CONFIG, Long.toString(maxMessageBytes.get()));
+                newTopic.configs(configOptions);
+            }
+
             adminClient.createTopics(Collections.singletonList(newTopic)).all().get();
             LOG.info(topicName + " created successfully");
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSink.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSink.java
@@ -152,7 +152,7 @@ public class KafkaSink extends AbstractSink<Record<Event>> {
         final TopicProducerConfig topic = kafkaSinkConfig.getTopic();
         if (topic.isCreateTopic()) {
             final TopicService topicService = new TopicService(kafkaSinkConfig);
-            topicService.createTopic(kafkaSinkConfig.getTopic().getName(), topic.getNumberOfPartitions(), topic.getReplicationFactor());
+            topicService.createTopic(kafkaSinkConfig.getTopic().getName(), topic.getNumberOfPartitions(), topic.getReplicationFactor(), topic.getMaxMessageBytes());
             topicService.closeAdminClient();
         }
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSink.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSink.java
@@ -117,6 +117,8 @@ public class KafkaSink extends AbstractSink<Record<Event>> {
             return;
         }
         try {
+            // TODO: Looks like this call to prepareTopicAndSchema is unnecessary as it is 
+            // done in createProducer().
             prepareTopicAndSchema();
             final KafkaCustomProducer producer = createProducer();
             records.forEach(record -> {
@@ -152,7 +154,7 @@ public class KafkaSink extends AbstractSink<Record<Event>> {
         final TopicProducerConfig topic = kafkaSinkConfig.getTopic();
         if (topic.isCreateTopic()) {
             final TopicService topicService = new TopicService(kafkaSinkConfig);
-            topicService.createTopic(kafkaSinkConfig.getTopic().getName(), topic.getNumberOfPartitions(), topic.getReplicationFactor(), topic.getMaxMessageBytes());
+            topicService.createTopic(kafkaSinkConfig.getTopic().getName(), topic.getNumberOfPartitions(), topic.getReplicationFactor(), null);
             topicService.closeAdminClient();
         }
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/SinkTopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/SinkTopicConfig.java
@@ -10,11 +10,15 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.CommonTopicConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.KmsConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.TopicProducerConfig;
 import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
+import org.opensearch.dataprepper.model.types.ByteCount;
+
+import java.util.Optional;
 
 public class SinkTopicConfig extends CommonTopicConfig implements TopicProducerConfig {
     private static final Integer DEFAULT_NUM_OF_PARTITIONS = 1;
     private static final Short DEFAULT_REPLICATION_FACTOR = 1;
     private static final Long DEFAULT_RETENTION_PERIOD = 604800000L;
+    static final ByteCount DEFAULT_MAX_MESSAGE_BYTES = ByteCount.parse("1mb");
 
     @JsonProperty("serde_format")
     private MessageFormat serdeFormat = MessageFormat.PLAINTEXT;
@@ -30,6 +34,9 @@ public class SinkTopicConfig extends CommonTopicConfig implements TopicProducerC
 
     @JsonProperty("create_topic")
     private boolean isCreateTopic = false;
+
+    @JsonProperty("max_message_bytes")
+    private ByteCount maxMessageBytes = DEFAULT_MAX_MESSAGE_BYTES;
 
     @Override
     public MessageFormat getSerdeFormat() {
@@ -54,6 +61,19 @@ public class SinkTopicConfig extends CommonTopicConfig implements TopicProducerC
     @Override
     public Short getReplicationFactor() {
         return replicationFactor;
+    }
+
+    @Override
+    public Optional<Long> getMaxMessageBytes() {
+        long value = maxMessageBytes.getBytes();
+        long defaultValue = DEFAULT_MAX_MESSAGE_BYTES.getBytes();
+        if (value < defaultValue || value > 4 * defaultValue) {
+            throw new RuntimeException("Invalid Max Message Bytes");
+        }
+        if (value == defaultValue) {
+            return Optional.empty();
+        }
+        return Optional.of(value);
     }
 
     @Override

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/SinkTopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/SinkTopicConfig.java
@@ -62,19 +62,6 @@ public class SinkTopicConfig extends CommonTopicConfig implements TopicProducerC
     }
 
     @Override
-    public Long getMaxMessageBytes() {
-        long value = maxMessageBytes.getBytes();
-        long defaultValue = DEFAULT_MAX_MESSAGE_BYTES.getBytes();
-        if (value < defaultValue || value > 4 * defaultValue) {
-            throw new RuntimeException("Invalid Max Message Bytes");
-        }
-        if (value == defaultValue) {
-            return null;
-        }
-        return null;
-    }
-
-    @Override
     public Long getRetentionPeriod() {
         return retentionPeriod;
     }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/SinkTopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/SinkTopicConfig.java
@@ -12,8 +12,6 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.TopicProducerConfi
 import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 import org.opensearch.dataprepper.model.types.ByteCount;
 
-import java.util.Optional;
-
 public class SinkTopicConfig extends CommonTopicConfig implements TopicProducerConfig {
     private static final Integer DEFAULT_NUM_OF_PARTITIONS = 1;
     private static final Short DEFAULT_REPLICATION_FACTOR = 1;
@@ -64,16 +62,16 @@ public class SinkTopicConfig extends CommonTopicConfig implements TopicProducerC
     }
 
     @Override
-    public Optional<Long> getMaxMessageBytes() {
+    public Long getMaxMessageBytes() {
         long value = maxMessageBytes.getBytes();
         long defaultValue = DEFAULT_MAX_MESSAGE_BYTES.getBytes();
         if (value < defaultValue || value > 4 * defaultValue) {
             throw new RuntimeException("Invalid Max Message Bytes");
         }
         if (value == defaultValue) {
-            return Optional.empty();
+            return null;
         }
-        return Optional.of(value);
+        return null;
     }
 
     @Override

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfigTest.java
@@ -13,6 +13,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
+import java.util.Optional;
+
 class BufferTopicConfigTest {
     private BufferTopicConfig createObjectUnderTest() {
         return new BufferTopicConfig();
@@ -36,6 +38,7 @@ class BufferTopicConfigTest {
         assertThat(objectUnderTest.getConsumerMaxPollRecords(), equalTo(BufferTopicConfig.DEFAULT_CONSUMER_MAX_POLL_RECORDS));
         assertThat(objectUnderTest.getWorkers(), equalTo(BufferTopicConfig.DEFAULT_NUM_OF_WORKERS));
         assertThat(objectUnderTest.getHeartBeatInterval(), equalTo(BufferTopicConfig.DEFAULT_HEART_BEAT_INTERVAL_DURATION));
+        assertThat(objectUnderTest.getMaxMessageBytes(), equalTo(Optional.empty()));
     }
 
     @Test
@@ -53,4 +56,21 @@ class BufferTopicConfigTest {
         setField(BufferTopicConfig.class, objectUnderTest, "fetchMaxBytes", ByteCount.zeroBytes());
         assertThrows(RuntimeException.class, () -> objectUnderTest.getFetchMaxBytes());
     }
+
+    @Test
+    void valid_max_message_bytes() throws NoSuchFieldException, IllegalAccessException {
+        BufferTopicConfig objectUnderTest = createObjectUnderTest();
+
+        setField(BufferTopicConfig.class, objectUnderTest, "maxMessageBytes", ByteCount.parse("2mb"));
+        assertThat(objectUnderTest.getMaxMessageBytes(), equalTo(Optional.of(2 * 1024 * 1024L)));
+    }
+
+    @Test
+    void invalid_get_max_message_bytes() throws NoSuchFieldException, IllegalAccessException {
+        BufferTopicConfig objectUnderTest = createObjectUnderTest();
+
+        setField(BufferTopicConfig.class, objectUnderTest, "maxMessageBytes", ByteCount.parse("5mb"));
+        assertThrows(RuntimeException.class, () -> objectUnderTest.getMaxMessageBytes());
+    }
+
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfigTest.java
@@ -13,8 +13,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
-import java.util.Optional;
-
 class BufferTopicConfigTest {
     private BufferTopicConfig createObjectUnderTest() {
         return new BufferTopicConfig();
@@ -38,7 +36,7 @@ class BufferTopicConfigTest {
         assertThat(objectUnderTest.getConsumerMaxPollRecords(), equalTo(BufferTopicConfig.DEFAULT_CONSUMER_MAX_POLL_RECORDS));
         assertThat(objectUnderTest.getWorkers(), equalTo(BufferTopicConfig.DEFAULT_NUM_OF_WORKERS));
         assertThat(objectUnderTest.getHeartBeatInterval(), equalTo(BufferTopicConfig.DEFAULT_HEART_BEAT_INTERVAL_DURATION));
-        assertThat(objectUnderTest.getMaxMessageBytes(), equalTo(Optional.empty()));
+        assertThat(objectUnderTest.getMaxMessageBytes(), equalTo(null));
     }
 
     @Test
@@ -62,7 +60,7 @@ class BufferTopicConfigTest {
         BufferTopicConfig objectUnderTest = createObjectUnderTest();
 
         setField(BufferTopicConfig.class, objectUnderTest, "maxMessageBytes", ByteCount.parse("2mb"));
-        assertThat(objectUnderTest.getMaxMessageBytes(), equalTo(Optional.of(2 * 1024 * 1024L)));
+        assertThat(objectUnderTest.getMaxMessageBytes(), equalTo(2 * 1024 * 1024L));
     }
 
     @Test

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfigTest.java
@@ -36,7 +36,6 @@ class BufferTopicConfigTest {
         assertThat(objectUnderTest.getConsumerMaxPollRecords(), equalTo(BufferTopicConfig.DEFAULT_CONSUMER_MAX_POLL_RECORDS));
         assertThat(objectUnderTest.getWorkers(), equalTo(BufferTopicConfig.DEFAULT_NUM_OF_WORKERS));
         assertThat(objectUnderTest.getHeartBeatInterval(), equalTo(BufferTopicConfig.DEFAULT_HEART_BEAT_INTERVAL_DURATION));
-        assertThat(objectUnderTest.getMaxMessageBytes(), equalTo(null));
     }
 
     @Test
@@ -53,22 +52,6 @@ class BufferTopicConfigTest {
 
         setField(BufferTopicConfig.class, objectUnderTest, "fetchMaxBytes", ByteCount.zeroBytes());
         assertThrows(RuntimeException.class, () -> objectUnderTest.getFetchMaxBytes());
-    }
-
-    @Test
-    void valid_max_message_bytes() throws NoSuchFieldException, IllegalAccessException {
-        BufferTopicConfig objectUnderTest = createObjectUnderTest();
-
-        setField(BufferTopicConfig.class, objectUnderTest, "maxMessageBytes", ByteCount.parse("2mb"));
-        assertThat(objectUnderTest.getMaxMessageBytes(), equalTo(2 * 1024 * 1024L));
-    }
-
-    @Test
-    void invalid_get_max_message_bytes() throws NoSuchFieldException, IllegalAccessException {
-        BufferTopicConfig objectUnderTest = createObjectUnderTest();
-
-        setField(BufferTopicConfig.class, objectUnderTest, "maxMessageBytes", ByteCount.parse("5mb"));
-        assertThrows(RuntimeException.class, () -> objectUnderTest.getMaxMessageBytes());
     }
 
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaProducerPropertiesTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/KafkaProducerPropertiesTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.configuration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.time.Duration;
+import java.util.Random;
+
+class KafkaProducerPropertiesTest {
+
+    private KafkaProducerProperties kafkaProducerProperties;
+    private String randomTestString;
+    private Long randomTestLong;
+    private Integer randomTestInt;
+
+    KafkaProducerProperties createObjectUnderTest() {
+        return new KafkaProducerProperties();
+    }
+
+    @BeforeEach
+    void setUp() {
+        kafkaProducerProperties = createObjectUnderTest();
+        randomTestString = RandomStringUtils.randomAlphabetic(10);
+        Random random = new Random();
+        randomTestLong = random.nextLong();
+        randomTestInt = random.nextInt();
+    }
+
+    @Test
+    void test_defaultValues() {
+        assertThat(kafkaProducerProperties.getBufferMemory(), equalTo(KafkaProducerProperties.DEFAULT_BYTE_CAPACITY));
+        assertThat(kafkaProducerProperties.getConnectionsMaxIdleMs(), equalTo(KafkaProducerProperties.DEFAULT_CONNECTION_MAX_IDLE_MS.toMillis()));
+        assertThat(kafkaProducerProperties.getDeliveryTimeoutMs(), equalTo(KafkaProducerProperties.DEFAULT_DELIVERY_TIMEOUT_MS.toMillis()));
+        assertThat(kafkaProducerProperties.getMaxBlockMs(), equalTo(KafkaProducerProperties.DEFAULT_MAX_BLOCK_MS.toMillis()));
+        assertThat(kafkaProducerProperties.getLingerMs(), equalTo(KafkaProducerProperties.DEFAULT_LINGER_MS));
+        assertThat(kafkaProducerProperties.getMaxRequestSize(), equalTo(KafkaProducerProperties.DEFAULT_MAX_REQUEST_SIZE));
+        assertThat(kafkaProducerProperties.getReceiveBufferBytes(), equalTo(KafkaProducerProperties.DEFAULT_BYTE_CAPACITY));
+        assertThat(kafkaProducerProperties.getRequestTimeoutMs(), equalTo(KafkaProducerProperties.DEFAULT_REQUEST_TIMEOUT_MS.toMillis()));
+        assertThat(kafkaProducerProperties.getSendBufferBytes(), equalTo(KafkaProducerProperties.DEFAULT_BYTE_CAPACITY));
+        assertThat(kafkaProducerProperties.getSocketConnectionSetupMaxTimeout(), equalTo(KafkaProducerProperties.DEFAULT_SOCKET_CONNECTION_SETUP_MAX_TIMEOUT.toMillis()));
+        assertThat(kafkaProducerProperties.getSocketConnectionSetupTimeout(), equalTo(KafkaProducerProperties.DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT.toMillis()));
+        assertThat(kafkaProducerProperties.getMetadataMaxAgeMs(), equalTo(KafkaProducerProperties.DEFAULT_METADATA_MAX_AGE_MS.toMillis()));
+        assertThat(kafkaProducerProperties.getMetadataMaxIdleMs(), equalTo(KafkaProducerProperties.DEFAULT_METADATA_MAX_IDLE_MS.toMillis()));
+        assertThat(kafkaProducerProperties.getMetricsSampleWindowMs(), equalTo(KafkaProducerProperties.DEFAULT_METRICS_SAMPLE_WINDOW_MS.toMillis()));
+        assertThat(kafkaProducerProperties.getPartitionerAvailabilityTimeoutMs(), equalTo(KafkaProducerProperties.DEFAULT_PARTITIONER_AVAILABILITY_TIMEOUT_MS.toMillis()));
+        assertThat(kafkaProducerProperties.getReconnectBackoffMaxMs(), equalTo(KafkaProducerProperties.DEFAULT_RECONNECT_BACKOFF_MAX_MS.toMillis()));
+        assertThat(kafkaProducerProperties.getReconnectBackoffMs(), equalTo(KafkaProducerProperties.DEFAULT_RECONNECT_BACKOFF_MS.toMillis()));
+        assertThat(kafkaProducerProperties.getRetryBackoffMs(), equalTo(KafkaProducerProperties.DEFAULT_RETRY_BACKOFF_MS.toMillis()));
+    }
+
+    @Test
+    void test_nonDefaultValues() throws NoSuchFieldException, IllegalAccessException {
+        reflectivelySetField(kafkaProducerProperties, "bufferMemory", randomTestString);
+        
+        assertThat(kafkaProducerProperties.getBufferMemory(), equalTo(randomTestString));
+        reflectivelySetField(kafkaProducerProperties, "connectionsMaxIdleMs", Duration.ofMillis(randomTestLong));
+        assertThat(kafkaProducerProperties.getConnectionsMaxIdleMs(), equalTo(randomTestLong));
+
+        reflectivelySetField(kafkaProducerProperties, "deliveryTimeoutMs", Duration.ofMillis(randomTestLong));
+        assertThat(kafkaProducerProperties.getDeliveryTimeoutMs(), equalTo(randomTestLong));
+
+        reflectivelySetField(kafkaProducerProperties, "maxBlockMs", Duration.ofMillis(randomTestLong));
+        assertThat(kafkaProducerProperties.getMaxBlockMs(), equalTo(randomTestLong));
+
+        reflectivelySetField(kafkaProducerProperties, "lingerMs", randomTestLong);
+        assertThat(kafkaProducerProperties.getLingerMs(), equalTo(randomTestLong));
+
+        reflectivelySetField(kafkaProducerProperties, "maxRequestSize", randomTestInt);
+        assertThat(kafkaProducerProperties.getMaxRequestSize(), equalTo(randomTestInt));
+
+        reflectivelySetField(kafkaProducerProperties, "receiveBufferBytes", randomTestString);
+        assertThat(kafkaProducerProperties.getReceiveBufferBytes(), equalTo(randomTestString));
+
+        reflectivelySetField(kafkaProducerProperties, "requestTimeoutMs", Duration.ofMillis(randomTestLong));
+        assertThat(kafkaProducerProperties.getRequestTimeoutMs(), equalTo(randomTestLong));
+
+        reflectivelySetField(kafkaProducerProperties, "sendBufferBytes", randomTestString);
+        assertThat(kafkaProducerProperties.getSendBufferBytes(), equalTo(randomTestString));
+
+        reflectivelySetField(kafkaProducerProperties, "socketConnectionSetupMaxTimeout", Duration.ofMillis(randomTestLong));
+        assertThat(kafkaProducerProperties.getSocketConnectionSetupMaxTimeout(), equalTo(randomTestLong));
+
+        reflectivelySetField(kafkaProducerProperties, "socketConnectionSetupTimeout", Duration.ofMillis(randomTestLong));
+        assertThat(kafkaProducerProperties.getSocketConnectionSetupTimeout(), equalTo(randomTestLong));
+
+        reflectivelySetField(kafkaProducerProperties, "metadataMaxAgeMs", Duration.ofMillis(randomTestLong));
+        assertThat(kafkaProducerProperties.getMetadataMaxAgeMs(), equalTo(randomTestLong));
+
+        reflectivelySetField(kafkaProducerProperties, "metadataMaxIdleMs", Duration.ofMillis(randomTestLong));
+        assertThat(kafkaProducerProperties.getMetadataMaxIdleMs(), equalTo(randomTestLong));
+
+        reflectivelySetField(kafkaProducerProperties, "metricsSampleWindowMs", Duration.ofMillis(randomTestLong));
+        assertThat(kafkaProducerProperties.getMetricsSampleWindowMs(), equalTo(randomTestLong));
+
+        reflectivelySetField(kafkaProducerProperties, "partitionerAvailabilityTimeoutMs", Duration.ofMillis(randomTestLong));
+        assertThat(kafkaProducerProperties.getPartitionerAvailabilityTimeoutMs(), equalTo(randomTestLong));
+
+        reflectivelySetField(kafkaProducerProperties, "reconnectBackoffMaxMs", Duration.ofMillis(randomTestLong));
+        assertThat(kafkaProducerProperties.getReconnectBackoffMaxMs(), equalTo(randomTestLong));
+
+        reflectivelySetField(kafkaProducerProperties, "reconnectBackoffMs", Duration.ofMillis(randomTestLong));
+        assertThat(kafkaProducerProperties.getReconnectBackoffMs(), equalTo(randomTestLong));
+
+        reflectivelySetField(kafkaProducerProperties, "retryBackoffMs", Duration.ofMillis(randomTestLong));
+        assertThat(kafkaProducerProperties.getRetryBackoffMs(), equalTo(randomTestLong));
+    }
+
+    private void reflectivelySetField(final KafkaProducerProperties properties, final String fieldName, final Object value) throws NoSuchFieldException, IllegalAccessException {
+        final Field field = KafkaProducerProperties.class.getDeclaredField(fieldName);
+        try {
+            field.setAccessible(true);
+            field.set(properties, value);
+        } finally {
+            field.setAccessible(false);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Support larger message sizes in Kafka Buffer.

Supports setting max message size both in Kafka Buffer producer properties (for client side support) and setting max message size when topic is created by the buffer (for server side support). When server side support for a topic is enabled, it automatically enables client side support too. Kafka buffer config with new config options looks like this -
```
 buffer:                                                                                                                                              
    kafka:                                                                                                                                             
      bootstrap_servers: ["localhost:9092"]   
      producer_properties:
          max_request_size:  4194304                                                                                                       
      encryption:                                                                                                                                      
        type: none                                                                                                                                     
      topics:                                                                                                                                          
        - name: test-buf-topic-8                                                                                                                       
          group_id: "testgrp001"                                                                                                                       
          max_message_bytes: 4194304  

```
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
