### PR TITLE
ENH: support secret binary value

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/logging/SensitiveArgumentMaskingConverter.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/logging/SensitiveArgumentMaskingConverter.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.logging;
 
 import org.apache.logging.log4j.Marker;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelinesDataflowModelParser.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelinesDataflowModelParser.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.parser;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/codec/JacksonPeerForwarderCodec.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/codec/JacksonPeerForwarderCodec.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.peerforwarder.codec;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/codec/JavaPeerForwarderCodec.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/codec/JavaPeerForwarderCodec.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.peerforwarder.codec;
 
 import org.opensearch.dataprepper.peerforwarder.model.PeerForwardingEvents;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/codec/PeerForwarderCodec.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/codec/PeerForwarderCodec.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.peerforwarder.codec;
 
 import org.opensearch.dataprepper.peerforwarder.model.PeerForwardingEvents;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/DataPrepperScalarTypeDeserializer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/DataPrepperScalarTypeDeserializer.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import com.fasterxml.jackson.core.JsonParser;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginConfigObservable.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/DefaultPluginConfigObservable.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import org.opensearch.dataprepper.model.configuration.PluginSetting;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ExtensionPluginConfigurationConverter.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ExtensionPluginConfigurationConverter.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import com.fasterxml.jackson.core.JsonPointer;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ExtensionPluginConfigurationResolver.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ExtensionPluginConfigurationResolver.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import org.opensearch.dataprepper.model.configuration.PipelinesDataFlowModel;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ObjectMapperConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ObjectMapperConfiguration.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginConfigurationObservableFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginConfigurationObservableFactory.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import org.opensearch.dataprepper.model.configuration.PluginSetting;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginConfigurationObservableRegister.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/PluginConfigurationObservableRegister.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/SupportSecretString.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/SupportSecretString.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import java.lang.annotation.Documented;

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/VariableExpander.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/VariableExpander.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import com.fasterxml.jackson.core.JsonParser;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/logging/SensitiveArgumentMaskingConverterTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/logging/SensitiveArgumentMaskingConverterTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.logging;
 
 import org.apache.commons.lang3.RandomStringUtils;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelinesDataflowModelParserTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelinesDataflowModelParserTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.parser;
 
 import org.junit.jupiter.api.Test;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/codec/JacksonPeerForwarderCodecTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/codec/JacksonPeerForwarderCodecTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.peerforwarder.codec;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/codec/JavaPeerForwarderCodecTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/codec/JavaPeerForwarderCodecTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.peerforwarder.codec;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/DataPrepperScalarTypeDeserializerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/DataPrepperScalarTypeDeserializerTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import com.fasterxml.jackson.core.JsonParser;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ExtensionPluginConfigurationConverterTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ExtensionPluginConfigurationConverterTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ExtensionPluginConfigurationResolverTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ExtensionPluginConfigurationResolverTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import org.junit.jupiter.api.Test;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ObjectMapperConfigurationTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/ObjectMapperConfigurationTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/PluginConfigObservableFactoryTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/PluginConfigObservableFactoryTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import org.junit.jupiter.api.Test;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/PluginConfigurationObservableRegisterTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/PluginConfigurationObservableRegisterTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugin;
 
 import com.fasterxml.jackson.core.JsonFactory;

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugins/test/TestExtensionConfig.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugins/test/TestExtensionConfig.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.test;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretManagerConfiguration.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretManagerConfiguration.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPlugin.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPlugin.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPlugin.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPlugin.java
@@ -29,7 +29,8 @@ public class AwsSecretPlugin implements ExtensionPlugin {
     @DataPrepperPluginConstructor
     public AwsSecretPlugin(final AwsSecretPluginConfig awsSecretPluginConfig) {
         if (awsSecretPluginConfig != null) {
-            secretsSupplier = new AwsSecretsSupplier(awsSecretPluginConfig, OBJECT_MAPPER);
+            final SecretValueDecoder secretValueDecoder = new SecretValueDecoder();
+            secretsSupplier = new AwsSecretsSupplier(secretValueDecoder, awsSecretPluginConfig, OBJECT_MAPPER);
             this.pluginConfigPublisher = new AwsSecretsPluginConfigPublisher();
             pluginConfigValueTranslator = new AwsSecretsPluginConfigValueTranslator(secretsSupplier);
             scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPluginConfig.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPluginConfig.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigPublisher.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigPublisher.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import org.opensearch.dataprepper.model.plugin.PluginConfigPublisher;

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigPublisherExtensionProvider.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigPublisherExtensionProvider.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import org.opensearch.dataprepper.model.plugin.ExtensionProvider;

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigValueTranslator.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigValueTranslator.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import org.opensearch.dataprepper.model.plugin.PluginConfigValueTranslator;

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigValueTranslatorExtensionProvider.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigValueTranslatorExtensionProvider.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import org.opensearch.dataprepper.model.plugin.ExtensionProvider;

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsSupplier.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsSupplier.java
@@ -18,12 +18,16 @@ public class AwsSecretsSupplier implements SecretsSupplier {
     static final TypeReference<Map<String, String>> MAP_TYPE_REFERENCE = new TypeReference<>() {
     };
 
+    private final SecretValueDecoder secretValueDecoder;
     private final ObjectMapper objectMapper;
     private final Map<String, AwsSecretManagerConfiguration> awsSecretManagerConfigurationMap;
     private final Map<String, SecretsManagerClient> secretsManagerClientMap;
     private final ConcurrentMap<String, Object> secretIdToValue;
 
-    public AwsSecretsSupplier(final AwsSecretPluginConfig awsSecretPluginConfig, final ObjectMapper objectMapper) {
+    public AwsSecretsSupplier(
+            final SecretValueDecoder secretValueDecoder,
+            final AwsSecretPluginConfig awsSecretPluginConfig, final ObjectMapper objectMapper) {
+        this.secretValueDecoder = secretValueDecoder;
         this.objectMapper = objectMapper;
         awsSecretManagerConfigurationMap = awsSecretPluginConfig
                 .getAwsSecretManagerConfigurationMap();
@@ -112,9 +116,9 @@ public class AwsSecretsSupplier implements SecretsSupplier {
         }
 
         try {
-            return objectMapper.readValue(getSecretValueResponse.secretString(), MAP_TYPE_REFERENCE);
+            return objectMapper.readValue(secretValueDecoder.decode(getSecretValueResponse), MAP_TYPE_REFERENCE);
         } catch (JsonProcessingException e) {
-            return getSecretValueResponse.secretString();
+            return secretValueDecoder.decode(getSecretValueResponse);
         }
     }
 }

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsSupplier.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsSupplier.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/SecretValueDecoder.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/SecretValueDecoder.java
@@ -1,0 +1,13 @@
+package org.opensearch.dataprepper.plugins.aws;
+
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+
+public class SecretValueDecoder {
+    public String decode(final GetSecretValueResponse getSecretValueResponse) {
+        if (getSecretValueResponse.secretString() != null) {
+            return getSecretValueResponse.secretString();
+        } else {
+            return getSecretValueResponse.secretBinary().asUtf8String();
+        }
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/SecretValueDecoder.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/SecretValueDecoder.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/SecretsRefreshJob.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/SecretsRefreshJob.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import org.opensearch.dataprepper.model.plugin.PluginConfigPublisher;

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/SecretsSupplier.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/SecretsSupplier.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 public interface SecretsSupplier {

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretManagerConfigurationTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretManagerConfigurationTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPluginConfigTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPluginConfigTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPluginIT.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPluginIT.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import org.junit.jupiter.api.Test;

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigPublisherExtensionProviderTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigPublisherExtensionProviderTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import org.junit.jupiter.api.Test;

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigPublisherTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigPublisherTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import org.junit.jupiter.api.Test;

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigValueTranslatorExtensionProviderTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigValueTranslatorExtensionProviderTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import org.junit.jupiter.api.Test;

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigValueTranslatorTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigValueTranslatorTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsSupplierTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsSupplierTest.java
@@ -21,7 +21,6 @@ import java.util.UUID;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsSupplierTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsSupplierTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -35,6 +36,9 @@ class AwsSecretsSupplierTest {
 
     @Mock
     private AwsSecretManagerConfiguration awsSecretManagerConfiguration;
+
+    @Mock
+    private SecretValueDecoder secretValueDecoder;
 
     @Mock
     private AwsSecretPluginConfig awsSecretPluginConfig;
@@ -60,11 +64,11 @@ class AwsSecretsSupplierTest {
                 Map.of(TEST_AWS_SECRET_CONFIGURATION_NAME, awsSecretManagerConfiguration)
         );
         when(awsSecretManagerConfiguration.createSecretManagerClient()).thenReturn(secretsManagerClient);
-        when(getSecretValueResponse.secretString()).thenReturn(OBJECT_MAPPER.writeValueAsString(
+        when(secretValueDecoder.decode(eq(getSecretValueResponse))).thenReturn(OBJECT_MAPPER.writeValueAsString(
                 Map.of(TEST_KEY, TEST_VALUE)
         ));
         when(secretsManagerClient.getSecretValue(eq(getSecretValueRequest))).thenReturn(getSecretValueResponse);
-        objectUnderTest = new AwsSecretsSupplier(awsSecretPluginConfig, OBJECT_MAPPER);
+        objectUnderTest = new AwsSecretsSupplier(secretValueDecoder, awsSecretPluginConfig, OBJECT_MAPPER);
     }
 
     @Test
@@ -86,8 +90,8 @@ class AwsSecretsSupplierTest {
 
     @Test
     void testRetrieveValueInvalidKeyValuePair() {
-        when(getSecretValueResponse.secretString()).thenReturn(TEST_VALUE);
-        objectUnderTest = new AwsSecretsSupplier(awsSecretPluginConfig, OBJECT_MAPPER);
+        when(secretValueDecoder.decode(eq(getSecretValueResponse))).thenReturn(TEST_VALUE);
+        objectUnderTest = new AwsSecretsSupplier(secretValueDecoder, awsSecretPluginConfig, OBJECT_MAPPER);
         final Exception exception = assertThrows(IllegalArgumentException.class,
                 () -> objectUnderTest.retrieveValue(TEST_AWS_SECRET_CONFIGURATION_NAME, TEST_KEY));
         assertThat(exception.getMessage(), equalTo(String.format("The value under secretId: %s is not a valid json.",
@@ -107,8 +111,8 @@ class AwsSecretsSupplierTest {
         final String testValue = "{\"a\":\"b\"}";
         when(mockedObjectMapper.readValue(eq(testValue), eq(MAP_TYPE_REFERENCE))).thenReturn(Map.of("a", "b"));
         when(mockedObjectMapper.writeValueAsString(ArgumentMatchers.any())).thenThrow(mockedJsonProcessingException);
-        when(getSecretValueResponse.secretString()).thenReturn(testValue);
-        objectUnderTest = new AwsSecretsSupplier(awsSecretPluginConfig, mockedObjectMapper);
+        when(secretValueDecoder.decode(eq(getSecretValueResponse))).thenReturn(testValue);
+        objectUnderTest = new AwsSecretsSupplier(secretValueDecoder, awsSecretPluginConfig, mockedObjectMapper);
         final Exception exception = assertThrows(IllegalArgumentException.class,
                 () -> objectUnderTest.retrieveValue(TEST_AWS_SECRET_CONFIGURATION_NAME));
         assertThat(exception.getMessage(), equalTo(String.format("Unable to read the value under secretId: %s as string.",
@@ -118,26 +122,27 @@ class AwsSecretsSupplierTest {
     @ParameterizedTest
     @ValueSource(strings = {TEST_VALUE, "{\"a\":\"b\"}"})
     void testRetrieveValueWithoutKey(String testValue) {
-        when(getSecretValueResponse.secretString()).thenReturn(testValue);
-        objectUnderTest = new AwsSecretsSupplier(awsSecretPluginConfig, OBJECT_MAPPER);
+        when(secretValueDecoder.decode(eq(getSecretValueResponse))).thenReturn(testValue);
+        objectUnderTest = new AwsSecretsSupplier(secretValueDecoder, awsSecretPluginConfig, OBJECT_MAPPER);
         assertThat(objectUnderTest.retrieveValue(TEST_AWS_SECRET_CONFIGURATION_NAME), equalTo(testValue));
     }
 
     @Test
     void testConstructorWithGetSecretValueFailure() {
         when(secretsManagerClient.getSecretValue(eq(getSecretValueRequest))).thenThrow(secretsManagerException);
-        assertThrows(RuntimeException.class, () -> new AwsSecretsSupplier(awsSecretPluginConfig, OBJECT_MAPPER));
+        assertThrows(RuntimeException.class, () -> new AwsSecretsSupplier(
+                secretValueDecoder, awsSecretPluginConfig, OBJECT_MAPPER));
     }
 
     @Test
     void testRefreshSecretsWithKey() {
         final String testValue = "{\"key\":\"oldValue\"}";
-        when(getSecretValueResponse.secretString()).thenReturn(testValue);
-        objectUnderTest = new AwsSecretsSupplier(awsSecretPluginConfig, OBJECT_MAPPER);
+        when(secretValueDecoder.decode(eq(getSecretValueResponse))).thenReturn(testValue);
+        objectUnderTest = new AwsSecretsSupplier(secretValueDecoder, awsSecretPluginConfig, OBJECT_MAPPER);
         assertThat(objectUnderTest.retrieveValue(TEST_AWS_SECRET_CONFIGURATION_NAME, "key"),
                 equalTo("oldValue"));
         final String newTestValue = "{\"key\":\"newValue\"}";
-        when(getSecretValueResponse.secretString()).thenReturn(newTestValue);
+        when(secretValueDecoder.decode(eq(getSecretValueResponse))).thenReturn(newTestValue);
         objectUnderTest.refresh(TEST_AWS_SECRET_CONFIGURATION_NAME);
         assertThat(objectUnderTest.retrieveValue(TEST_AWS_SECRET_CONFIGURATION_NAME, "key"),
                 equalTo("newValue"));
@@ -146,11 +151,11 @@ class AwsSecretsSupplierTest {
     @Test
     void testRefreshSecretsWithoutKey() {
         final String testValue = UUID.randomUUID().toString();
-        when(getSecretValueResponse.secretString()).thenReturn(testValue);
-        objectUnderTest = new AwsSecretsSupplier(awsSecretPluginConfig, OBJECT_MAPPER);
+        when(secretValueDecoder.decode(eq(getSecretValueResponse))).thenReturn(testValue);
+        objectUnderTest = new AwsSecretsSupplier(secretValueDecoder, awsSecretPluginConfig, OBJECT_MAPPER);
         assertThat(objectUnderTest.retrieveValue(TEST_AWS_SECRET_CONFIGURATION_NAME), equalTo(testValue));
         final String newTestValue = testValue + "-mutated";
-        when(getSecretValueResponse.secretString()).thenReturn(newTestValue);
+        when(secretValueDecoder.decode(eq(getSecretValueResponse))).thenReturn(newTestValue);
         objectUnderTest.refresh(TEST_AWS_SECRET_CONFIGURATION_NAME);
         assertThat(objectUnderTest.retrieveValue(TEST_AWS_SECRET_CONFIGURATION_NAME), equalTo(newTestValue));
     }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsSupplierTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsSupplierTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/SecretValueDecoderTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/SecretValueDecoderTest.java
@@ -1,0 +1,33 @@
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SecretValueDecoderTest {
+    private static final String TEST_SECRET = "hello world";
+    @Mock
+    private GetSecretValueResponse getSecretValueResponse;
+
+    private final SecretValueDecoder objectUnderTest = new SecretValueDecoder();
+
+    @Test
+    void testDecodeSecretString() {
+        when(getSecretValueResponse.secretString()).thenReturn(TEST_SECRET);
+        assertThat(objectUnderTest.decode(getSecretValueResponse), equalTo(TEST_SECRET));
+    }
+
+    @Test
+    void testDecodeSecretBinary() {
+        when(getSecretValueResponse.secretBinary()).thenReturn(SdkBytes.fromUtf8String(TEST_SECRET));
+        assertThat(objectUnderTest.decode(getSecretValueResponse), equalTo(TEST_SECRET));
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/SecretValueDecoderTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/SecretValueDecoderTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import org.junit.jupiter.api.Test;

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/SecretValueDecoderTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/SecretValueDecoderTest.java
@@ -7,13 +7,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 
+import java.util.UUID;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SecretValueDecoderTest {
-    private static final String TEST_SECRET = "hello world";
     @Mock
     private GetSecretValueResponse getSecretValueResponse;
 
@@ -21,13 +22,15 @@ class SecretValueDecoderTest {
 
     @Test
     void testDecodeSecretString() {
-        when(getSecretValueResponse.secretString()).thenReturn(TEST_SECRET);
-        assertThat(objectUnderTest.decode(getSecretValueResponse), equalTo(TEST_SECRET));
+        final String testSecret = UUID.randomUUID().toString();
+        when(getSecretValueResponse.secretString()).thenReturn(testSecret);
+        assertThat(objectUnderTest.decode(getSecretValueResponse), equalTo(testSecret));
     }
 
     @Test
     void testDecodeSecretBinary() {
-        when(getSecretValueResponse.secretBinary()).thenReturn(SdkBytes.fromUtf8String(TEST_SECRET));
-        assertThat(objectUnderTest.decode(getSecretValueResponse), equalTo(TEST_SECRET));
+        final String testSecret = UUID.randomUUID().toString();
+        when(getSecretValueResponse.secretBinary()).thenReturn(SdkBytes.fromUtf8String(testSecret));
+        assertThat(objectUnderTest.decode(getSecretValueResponse), equalTo(testSecret));
     }
 }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/SecretsRefreshJobTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/SecretsRefreshJobTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.dataprepper.plugins.aws;
 
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
### Description
This PR supports binary secret value: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html#API_GetSecretValue_ResponseSyntax
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
