### PR TITLE
Fix Null Pointer Exception in KeyValue Processor

### DIFF
--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -236,6 +236,9 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
             final Map<String, Object> outputMap = new HashMap<>();
             final Event recordEvent = record.getData();
             final String groupsRaw = recordEvent.get(keyValueProcessorConfig.getSource(), String.class);
+            if (groupsRaw == null) {
+                continue;
+            }
             final String[] groups = fieldDelimiterPattern.split(groupsRaw, 0);
 
             if (keyValueProcessorConfig.getRecursive()) {

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -88,6 +88,18 @@ public class KeyValueProcessorTests {
     }
 
     @Test
+    void testKeyValueProcessorWithoutMessage() {
+        final Map<String, Object> testData = new HashMap();
+        testData.put("notMessage", "not a message");
+        final Record<Event> record = buildRecordWithEvent(testData);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
+        assertThat(editedRecords.size(), equalTo(1));
+        assertThat(editedRecords.get(0), notNullValue());
+        LinkedHashMap<String, Object> parsed_message = editedRecords.get(0).getData().get("parsed_message", LinkedHashMap.class);
+        assertThat(parsed_message, equalTo(null));
+    }
+
+    @Test
     void testMultipleKvToObjectKeyValueProcessor() {
         final Record<Event> record = getMessage("key1=value1&key2=value2");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));


### PR DESCRIPTION
### Description
Fix Null Pointer Exception in KeyValue Processor which is occurring when the input event does not have the "source" field

Resolves #3928 
### Issues Resolved
Resolves #3928
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
