### PR TITLE
Corrects BlockingBuffer's bufferUsage metric and adds capacityUsed metric

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/AbstractBuffer.java
@@ -35,7 +35,7 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
     private final Timer readTimer;
     private final Timer checkpointTimer;
 
-    public AbstractBuffer(final PluginSetting pluginSetting) {
+    AbstractBuffer(final PluginSetting pluginSetting) {
         this(PluginMetrics.fromPluginSetting(pluginSetting), pluginSetting.getPipelineName());
     }
 

--- a/data-prepper-plugins/blocking-buffer/src/test/java/org/opensearch/dataprepper/plugins/buffer/blockingbuffer/BlockingBufferTests.java
+++ b/data-prepper-plugins/blocking-buffer/src/test/java/org/opensearch/dataprepper/plugins/buffer/blockingbuffer/BlockingBufferTests.java
@@ -217,6 +217,8 @@ public class BlockingBufferTests {
             assertThat(record.getData(), equalTo("TEST" + i));
             i++;
         }
+        verifyBufferUsageMetric(38.46153846153847);
+        blockingBuffer.checkpoint(partialReadResult.getValue());
         verifyBufferUsageMetric(15.384615384615385);
         final Map.Entry<Collection<Record<String>>, CheckpointState> finalReadResult = blockingBuffer.read(readTimeout);
         final Collection<Record<String>> finalBatch = finalReadResult.getKey();
@@ -227,6 +229,8 @@ public class BlockingBufferTests {
             assertThat(record.getData(), equalTo("TEST" + i));
             i++;
         }
+        verifyBufferUsageMetric(15.384615384615385);
+        blockingBuffer.checkpoint(finalReadResult.getValue());
         verifyBufferUsageMetric(0.0);
     }
 


### PR DESCRIPTION
### Description

This PR has two changes for the `bounded_blocking` buffer:

1. Adds a new `capacityUsed` metric which tracks the capacity used within the buffer as determined by the semaphore which controls admission to the buffer.
2. Corrects the `bufferUsage` metric to track the percentage of the capacity used against the total capacity. This is done by tracking the semaphore. But, it is also logically equivalent to tracking the sum of `recordsInBuffer` and `recordsInFlight`. Previously, this metric only tracked `recordsInBuffer`.

I configured a tight buffer to fill it quickly and test the changes.

```
  buffer:
    bounded_blocking:
      buffer_size: 1000
      batch_size: 20
```
The following CloudWatch graphs show the metrics in action. 

This graph shows the metrics and how the values correspond to each other correctly.

![3936-new-metrics](https://github.com/opensearch-project/data-prepper/assets/293424/7f1d69ab-e94c-4a01-868c-8540164147d8)

This is the same graph, but I pinpointed a specific point it time to show the values at that time.
 
![3936-new-metrics-pinpoint](https://github.com/opensearch-project/data-prepper/assets/293424/e4a149a0-6123-4156-b49a-748080679d66)


### Issues Resolved

Resolves #3936.
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
