### PR TITLE
Updates the common plugin and mapdb-processor-state projects to JUnit 5.

### DIFF
--- a/data-prepper-plugins/common/build.gradle
+++ b/data-prepper-plugins/common/build.gradle
@@ -19,7 +19,6 @@ dependencies {
     implementation libs.bouncycastle.bcpkix
     implementation libs.reflections.core
     implementation 'io.micrometer:micrometer-core'
-    testImplementation testLibs.junit.vintage
     implementation 'org.apache.parquet:parquet-common:1.13.1'
     implementation 'org.xerial.snappy:snappy-java:1.1.10.5'
     testImplementation project(':data-prepper-plugins:blocking-buffer')

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/certificate/acm/ACMCertificateProviderTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/certificate/acm/ACMCertificateProviderTest.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/processor/state/ProcessorStateTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/processor/state/ProcessorStateTest.java
@@ -5,11 +5,9 @@
 
 package org.opensearch.dataprepper.plugins.processor.state;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.processor.state.ProcessorState;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -20,13 +18,16 @@ import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public abstract class ProcessorStateTest {
 
     protected static final Random random = new Random();
 
     protected ProcessorState<byte[], DataClass> processorState;
 
-    @Before
     public abstract void setProcessorState() throws Exception;
 
     @Test
@@ -41,7 +42,7 @@ public abstract class ProcessorStateTest {
         processorState.put(key1, data1);
         processorState.put(key2, data2);
 
-        Assert.assertEquals(2, processorState.size());
+        assertEquals(2, processorState.size());
     }
 
     @Test
@@ -57,9 +58,9 @@ public abstract class ProcessorStateTest {
         processorState.put(key2, data2);
 
         //Read them and assert that they are correctly read, and assert incorrect key gives back null value
-        Assert.assertEquals(data1, processorState.get(key1));
-        Assert.assertEquals(data2, processorState.get(key2));
-        Assert.assertNull(processorState.get(UUID.randomUUID().toString().getBytes()));
+        assertEquals(data1, processorState.get(key1));
+        assertEquals(data2, processorState.get(key2));
+        assertNull(processorState.get(UUID.randomUUID().toString().getBytes()));
     }
 
     @Test
@@ -79,12 +80,12 @@ public abstract class ProcessorStateTest {
                 .entrySet()
                 .stream()
                 .collect(Collectors.toMap( dataClassEntry -> new String(dataClassEntry.getKey()), dataClassEntry -> dataClassEntry.getValue()));
-        Assert.assertEquals(2, stateMap.size());
-        Assert.assertEquals(data1, stateMap.get(new String(key1)));
-        Assert.assertEquals(data2, stateMap.get(new String(key2)));
+        assertEquals(2, stateMap.size());
+        assertEquals(data1, stateMap.get(new String(key1)));
+        assertEquals(data2, stateMap.get(new String(key2)));
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         processorState.delete();
     }
@@ -108,9 +109,9 @@ public abstract class ProcessorStateTest {
             }
         });
 
-        Assert.assertEquals(2, iterateResult.size());
-        Assert.assertTrue(iterateResult.contains(data1.stringVal));
-        Assert.assertTrue(iterateResult.contains(data2.stringVal));
+        assertEquals(2, iterateResult.size());
+        assertTrue(iterateResult.contains(data1.stringVal));
+        assertTrue(iterateResult.contains(data2.stringVal));
     }
 
     public static class DataClass implements Serializable {

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/s3keyindex/S3ObjectIndexUtilityTest.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/s3keyindex/S3ObjectIndexUtilityTest.java
@@ -5,13 +5,14 @@
 
 package org.opensearch.dataprepper.plugins.s3keyindex;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.Test;

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/source/StdInSourceTests.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/source/StdInSourceTests.java
@@ -5,14 +5,14 @@
 
 package org.opensearch.dataprepper.plugins.source;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.CheckpointState;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.buffer.TestBuffer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -28,7 +28,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class StdInSourceTests {
+class StdInSourceTests {
     private static final String SOURCE_CONTENT = "THIS IS A TEST\nexit";
     private static final String READ_CONTENT = "THIS IS A TEST";
     private static final String TEST_PIPELINE_NAME = "test-pipeline";
@@ -36,27 +36,27 @@ public class StdInSourceTests {
 
     private InputStream defaultInputStream;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         defaultInputStream = System.in;
         final ByteArrayInputStream streamForTests = new ByteArrayInputStream(
                 SOURCE_CONTENT.getBytes(StandardCharsets.UTF_8));
         System.setIn(streamForTests);
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         System.setIn(defaultInputStream);
     }
 
     @Test
-    public void testStdInSourceCreationUsingParameters() {
+    void testStdInSourceCreationUsingParameters() {
         final StdInSource stdInSource = new StdInSource(TEST_WRITE_TIMEOUT, TEST_PIPELINE_NAME);
         assertThat(stdInSource, notNullValue());
     }
 
     @Test
-    public void testStdInSourceCreationUsingPluginSetting() {
+    void testStdInSourceCreationUsingPluginSetting() {
         final PluginSetting pluginSetting = new PluginSetting("stdin", null);
         pluginSetting.setPipelineName(TEST_PIPELINE_NAME);
         final StdInSource stdInSource = new StdInSource(pluginSetting);
@@ -64,7 +64,7 @@ public class StdInSourceTests {
     }
 
     @Test
-    public void testStdInSourceCreationWithNullPipelineName() {
+    void testStdInSourceCreationWithNullPipelineName() {
         try {
             new StdInSource(TEST_WRITE_TIMEOUT, null);
         } catch (NullPointerException ex) {
@@ -73,7 +73,7 @@ public class StdInSourceTests {
     }
 
     @Test
-    public void testStdInSourceCreationWithNullPluginSetting() {
+    void testStdInSourceCreationWithNullPluginSetting() {
         try {
             new StdInSource(null);
         } catch (NullPointerException ex) {
@@ -82,7 +82,7 @@ public class StdInSourceTests {
     }
 
     @Test
-    public void testStdInSourceWithNullBuffer() {
+    void testStdInSourceWithNullBuffer() {
         final StdInSource stdInSource = new StdInSource(TEST_WRITE_TIMEOUT, TEST_PIPELINE_NAME);
         try {
             stdInSource.start(null);
@@ -93,7 +93,7 @@ public class StdInSourceTests {
     }
 
     @Test
-    public void testStdInSourceSuccessfulWriteToBuffer() {
+    void testStdInSourceSuccessfulWriteToBuffer() {
         final Queue<Record<Event>> bufferQueue = new LinkedList<>();
         final TestBuffer buffer = new TestBuffer(bufferQueue, 1);
         final StdInSource stdInSource = new StdInSource(TEST_WRITE_TIMEOUT, TEST_PIPELINE_NAME);
@@ -108,7 +108,7 @@ public class StdInSourceTests {
     }
 
     @Test
-    public void testStdInSourceWhenStopped() {
+    void testStdInSourceWhenStopped() {
         final Queue<Record<Event>> bufferQueue = new LinkedList<>();
         final TestBuffer buffer = new TestBuffer(bufferQueue, 1);
         final StdInSource stdInSource = new StdInSource(TEST_WRITE_TIMEOUT, TEST_PIPELINE_NAME);
@@ -119,7 +119,7 @@ public class StdInSourceTests {
     }
 
     @Test
-    public void testStdInSourceWhenBufferTimesout() {
+    void testStdInSourceWhenBufferTimesout() {
         final Queue<Record<Event>> bufferQueue = new LinkedList<>();
         final TestBuffer buffer = new TestBuffer(bufferQueue, 1, true);
         final StdInSource stdInSource = new StdInSource(TEST_WRITE_TIMEOUT, TEST_PIPELINE_NAME);

--- a/data-prepper-plugins/mapdb-processor-state/build.gradle
+++ b/data-prepper-plugins/mapdb-processor-state/build.gradle
@@ -17,9 +17,7 @@ dependencies {
     implementation 'org.mapdb:mapdb:3.0.10'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.21'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21'
-    testImplementation testLibs.junit.vintage
     testImplementation project(':data-prepper-plugins:common').sourceSets.test.output
-    testImplementation testLibs.junit.vintage
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/mapdb-processor-state/src/test/java/org/opensearch/dataprepper/plugins/processor/state/MapDbProcessorStateTest.java
+++ b/data-prepper-plugins/mapdb-processor-state/src/test/java/org/opensearch/dataprepper/plugins/processor/state/MapDbProcessorStateTest.java
@@ -5,29 +5,32 @@
 
 package org.opensearch.dataprepper.plugins.processor.state;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.BiFunction;
 
-public class MapDbProcessorStateTest extends ProcessorStateTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+class MapDbProcessorStateTest extends ProcessorStateTest {
 
-    @Override
-    public void setProcessorState() throws Exception {
-        this.processorState = new MapDbProcessorState<>(temporaryFolder.newFolder(), "testDb", 16);
+    @TempDir
+    File temporaryFile;
+
+    @BeforeEach
+    public void setProcessorState() {
+        this.processorState = new MapDbProcessorState<>(temporaryFile, "testDb", 16);
     }
 
     @Test
-    public void testIterateSegment() throws IOException {
+    void testIterateSegment() throws IOException {
         final byte[] key1 = new byte[]{-64, 0, -64, 0};
         final byte[] key2 = new byte[]{0};
         final byte[] key3 = new byte[]{64, 64, 64, 64};
@@ -57,13 +60,13 @@ public class MapDbProcessorStateTest extends ProcessorStateTest {
             }
         }, 2, 1);
 
-        Assert.assertEquals(2, values.size());
-        Assert.assertEquals(2, values2.size());
-        Assert.assertTrue(values.containsAll(Arrays.asList(
+        assertEquals(2, values.size());
+        assertEquals(2, values2.size());
+        assertTrue(values.containsAll(Arrays.asList(
                 data1.stringVal,
                 data2.stringVal
         )));
-        Assert.assertTrue(values2.containsAll(Arrays.asList(
+        assertTrue(values2.containsAll(Arrays.asList(
                 data3.stringVal,
                 data4.stringVal
         )));


### PR DESCRIPTION
### Description

As part of a longer-term goal of removing JUnit 4, this updates two of our projects to JUnit 5:

* `data-prepper-plugins/common`
* `data-prepper-plugins/mapdb-processor-state`
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
