### PR TITLE
Updates the Gatling version in the performance-test to 3.10.3.

### DIFF
--- a/performance-test/README.md
+++ b/performance-test/README.md
@@ -44,6 +44,16 @@ For example, you can configure the port and use HTTPS with a custom certificate 
 * `aws_service` - The AWS service name to use in signing. Required with `aws_sigv4` authentication.
 
 
+### Using with Amazon OpenSearch Ingestion
+
+This performance tool also works with [Amazon OpenSearch Ingestion](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ingestion.html).
+
+Setup your AWS credentials to meet your needs. Then run a command similar to the following:
+
+```
+./gradlew -Dhost=<your-custom-dns>.<aws-region>.osis.amazonaws.com -Dprotocol=https -Dpath=<your-path> -Dport=443 -Dauthentication=aws_sigv4 -Daws_region=<aws-region> -Daws_service=osis :performance-test:gatlingRun-org.opensearch.dataprepper.test.performance.SingleRequestSimulation
+```
+
 ### Verify Gatling scenarios compile
 ```shell
 ./gradlew :performance-test:compileGatlingJava

--- a/performance-test/build.gradle
+++ b/performance-test/build.gradle
@@ -5,7 +5,7 @@
 
 plugins {
     id 'java'
-    id 'io.gatling.gradle' version '3.9.5.5'
+    id 'io.gatling.gradle' version '3.10.3'
 }
 
 configurations.all {

--- a/performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/tools/AwsRequestSigner.java
+++ b/performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/tools/AwsRequestSigner.java
@@ -19,10 +19,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class AwsRequestSigner implements Consumer<Request> {
+public class AwsRequestSigner implements Function<Request, Request> {
     static final String SIGNER_NAME = "aws_sigv4";
 
     /**
@@ -69,7 +68,7 @@ public class AwsRequestSigner implements Consumer<Request> {
     }
 
     @Override
-    public void accept(Request request) {
+    public Request apply(final Request request) {
         ExecutionAttributes attributes = new ExecutionAttributes();
         attributes.putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS, credentialsProvider.resolveCredentials());
         attributes.putAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME, service);
@@ -80,6 +79,8 @@ public class AwsRequestSigner implements Consumer<Request> {
         SdkHttpFullRequest signedRequest = awsSigner.sign(incomingSdkRequest, attributes);
 
         modifyOutgoingRequest(request, signedRequest);
+
+        return request;
     }
 
     private SdkHttpFullRequest convertIncomingRequest(Request request) {

--- a/performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/tools/SignerProvider.java
+++ b/performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/tools/SignerProvider.java
@@ -2,13 +2,13 @@ package org.opensearch.dataprepper.test.performance.tools;
 
 import io.gatling.http.client.Request;
 
-import java.util.function.Consumer;
+import java.util.function.Function;
 
 public class SignerProvider {
-    private static final Consumer<Request> NO_OP_SIGNER = r -> { };
+    private static final Function<Request, Request> NO_OP_SIGNER = r -> r;
 
-    public static Consumer<Request> getSigner() {
-        String authentication = System.getProperty("authentication");
+    public static Function<Request, Request> getSigner() {
+        final String authentication = System.getProperty("authentication");
 
         if(AwsRequestSigner.SIGNER_NAME.equals(authentication)) {
             return new AwsRequestSigner();


### PR DESCRIPTION
### Description

Updates the Gatling version in the performance-test to 3.10.3. The 3.10 release includes a breaking change that required updating a Consumer to a Function. Added some additional instructions for running the performance tests against Amazon OpenSearch Ingestion.

Upgrade guide: https://gatling.io/docs/gatling/reference/current/upgrading/3.9-to-3.10/#http-signaturecalculator-change

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
