### PR TITLE
Adds max_request_length as a configuration for the http and OTel sources

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/types/ByteCount.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/types/ByteCount.java
@@ -95,6 +95,20 @@ public class ByteCount {
         return new ByteCount(byteCount.longValue());
     }
 
+    /**
+     * Returns a {@link ByteCount} with the total number of bytes provided.
+     *
+     * @param bytes The number of bytes
+     * @return A new {@link ByteCount}
+     * @since 2.7
+     */
+    public static ByteCount ofBytes(final long bytes) {
+        if(bytes < 0)
+            throw new IllegalArgumentException("The argument provided for bytes is negative.");
+
+        return new ByteCount(bytes);
+    }
+
     public static ByteCount zeroBytes() {
         return ZERO_BYTES;
     }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/types/ByteCountTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/types/ByteCountTest.java
@@ -148,6 +148,21 @@ class ByteCountTest {
         assertThat(byteCount.getBytes(), equalTo(expectedBytes));
     }
 
+    @ParameterizedTest
+    @ValueSource(longs = {0, 1, 2, 1024, Integer.MAX_VALUE, (long) Integer.MAX_VALUE + 100})
+    void ofBytes_returns_with_same_bytes(final long bytes) {
+        final ByteCount byteCount = ByteCount.ofBytes(bytes);
+
+        assertThat(byteCount, notNullValue());
+        assertThat(byteCount.getBytes(), equalTo(bytes));
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {-1, -2, -1024, Integer.MIN_VALUE, (long) Integer.MIN_VALUE - 100})
+    void ofBytes_throws_with_invalid_bytes(final long bytes) {
+        assertThrows(IllegalArgumentException.class, () -> ByteCount.ofBytes(bytes));
+    }
+
     @Test
     void zeroBytes_returns_bytes_with_getBytes_equal_to_0() {
         assertThat(ByteCount.zeroBytes(), notNullValue());

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ObjectMapperConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ObjectMapperConfiguration.java
@@ -3,6 +3,8 @@ package org.opensearch.dataprepper.plugin;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.opensearch.dataprepper.model.types.ByteCount;
+import org.opensearch.dataprepper.parser.ByteCountDeserializer;
 import org.opensearch.dataprepper.parser.DataPrepperDurationDeserializer;
 import org.springframework.context.annotation.Bean;
 
@@ -33,6 +35,7 @@ public class ObjectMapperConfiguration {
     ObjectMapper pluginConfigObjectMapper(final VariableExpander variableExpander) {
         final SimpleModule simpleModule = new SimpleModule();
         simpleModule.addDeserializer(Duration.class, new DataPrepperDurationDeserializer());
+        simpleModule.addDeserializer(ByteCount.class, new ByteCountDeserializer());
         TRANSLATE_VALUE_SUPPORTED_JAVA_TYPES.stream().forEach(clazz -> simpleModule.addDeserializer(
                 clazz, new DataPrepperScalarTypeDeserializer<>(variableExpander, clazz)));
 

--- a/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/HttpRequestExceptionHandler.java
+++ b/data-prepper-plugins/armeria-common/src/main/java/org/opensearch/dataprepper/HttpRequestExceptionHandler.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper;
 
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.RequestTimeoutException;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
@@ -56,6 +57,9 @@ public class HttpRequestExceptionHandler implements ExceptionHandlerFunction {
     }
 
     private HttpStatus handleException(final Throwable e) {
+        if(e instanceof HttpStatusException) {
+            return ((HttpStatusException) e).httpStatus();
+        }
         if (e instanceof IOException) {
             badRequestsCounter.increment();
             return HttpStatus.BAD_REQUEST;

--- a/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/HttpRequestExceptionHandlerTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/HttpRequestExceptionHandlerTest.java
@@ -5,24 +5,23 @@
 
 package org.opensearch.dataprepper;
 
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.RequestTimeoutException;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
-import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
 import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.buffer.SizeOverflowException;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
@@ -124,6 +124,9 @@ public class HTTPSource implements Source<Record<Log>> {
 
             sb.maxNumConnections(sourceConfig.getMaxConnectionCount());
             sb.requestTimeout(Duration.ofMillis(sourceConfig.getRequestTimeoutInMillis()));
+            if(sourceConfig.getMaxRequestLength() != null) {
+                sb.maxRequestLength(sourceConfig.getMaxRequestLength().getBytes());
+            }
             final int threads = sourceConfig.getThreadCount();
             final ScheduledThreadPoolExecutor blockingTaskExecutor = new ScheduledThreadPoolExecutor(threads);
             sb.blockingTaskExecutor(blockingTaskExecutor, true);

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSourceConfig.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.source.loghttp;
 
 import jakarta.validation.constraints.Size;
+import org.opensearch.dataprepper.model.types.ByteCount;
 import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -91,6 +92,9 @@ public class HTTPSourceConfig {
 
     @JsonProperty(COMPRESSION)
     private CompressionOption compression = CompressionOption.NONE;
+
+    @JsonProperty("max_request_length")
+    private ByteCount maxRequestLength;
 
     private PluginModel authentication;
 
@@ -216,5 +220,9 @@ public class HTTPSourceConfig {
 
     public CompressionOption getCompression() {
         return compression;
+    }
+
+    public ByteCount getMaxRequestLength() {
+        return maxRequestLength;
     }
 }

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSource.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSource.java
@@ -141,6 +141,9 @@ public class OTelLogsSource implements Source<Record<Object>> {
                 sb.service(grpcServiceBuilder.build(), DecodingService.newDecorator());
             }
             sb.requestTimeoutMillis(oTelLogsSourceConfig.getRequestTimeoutInMillis());
+            if(oTelLogsSourceConfig.getMaxRequestLength() != null) {
+                sb.maxRequestLength(oTelLogsSourceConfig.getMaxRequestLength().getBytes());
+            }
 
             // ACM Cert for SSL takes preference
             if (oTelLogsSourceConfig.isSsl() || oTelLogsSourceConfig.useAcmCertForSSL()) {

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceConfig.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsSourceConfig.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
 import org.apache.commons.lang3.StringUtils;
+import org.opensearch.dataprepper.model.types.ByteCount;
 import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 
@@ -99,6 +100,9 @@ public class OTelLogsSourceConfig {
 
     @JsonProperty(COMPRESSION)
     private CompressionOption compression = CompressionOption.NONE;
+
+    @JsonProperty("max_request_length")
+    private ByteCount maxRequestLength;
 
     @AssertTrue(message = "path should start with /")
     boolean isPathValid() {
@@ -208,6 +212,10 @@ public class OTelLogsSourceConfig {
 
     public CompressionOption getCompression() {
         return compression;
+    }
+
+    public ByteCount getMaxRequestLength() {
+        return maxRequestLength;
     }
 }
 

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSource.java
@@ -159,6 +159,9 @@ public class OTelMetricsSource implements Source<Record<ExportMetricsServiceRequ
             }
 
             sb.requestTimeoutMillis(oTelMetricsSourceConfig.getRequestTimeoutInMillis());
+            if(oTelMetricsSourceConfig.getMaxRequestLength() != null) {
+                sb.maxRequestLength(oTelMetricsSourceConfig.getMaxRequestLength().getBytes());
+            }
 
             // ACM Cert for SSL takes preference
             if (oTelMetricsSourceConfig.isSsl() || oTelMetricsSourceConfig.useAcmCertForSSL()) {

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceConfig.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsSourceConfig.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
 import org.apache.commons.lang3.StringUtils;
+import org.opensearch.dataprepper.model.types.ByteCount;
 import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 
@@ -102,6 +103,9 @@ public class OTelMetricsSourceConfig {
 
     @JsonProperty(COMPRESSION)
     private CompressionOption compression = CompressionOption.NONE;
+
+    @JsonProperty("max_request_length")
+    private ByteCount maxRequestLength;
 
     @AssertTrue(message = "path should start with /")
     boolean isPathValid() {
@@ -219,6 +223,10 @@ public class OTelMetricsSourceConfig {
 
     public CompressionOption getCompression() {
         return compression;
+    }
+
+    public ByteCount getMaxRequestLength() {
+        return maxRequestLength;
     }
 }
 

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
@@ -161,6 +161,9 @@ public class OTelTraceSource implements Source<Record<Object>> {
             }
 
             sb.requestTimeoutMillis(oTelTraceSourceConfig.getRequestTimeoutInMillis());
+            if(oTelTraceSourceConfig.getMaxRequestLength() != null) {
+                sb.maxRequestLength(oTelTraceSourceConfig.getMaxRequestLength().getBytes());
+            }
 
             // ACM Cert for SSL takes preference
             if (oTelTraceSourceConfig.isSsl() || oTelTraceSourceConfig.useAcmCertForSSL()) {

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.source.oteltrace;
 
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
+import org.opensearch.dataprepper.model.types.ByteCount;
 import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -102,6 +103,9 @@ public class OTelTraceSourceConfig {
 
     @JsonProperty(COMPRESSION)
     private CompressionOption compression = CompressionOption.NONE;
+
+    @JsonProperty("max_request_length")
+    private ByteCount maxRequestLength;
 
     @AssertTrue(message = "path should start with /")
     boolean isPathValid() {
@@ -219,5 +223,9 @@ public class OTelTraceSourceConfig {
 
     public CompressionOption getCompression() {
         return compression;
+    }
+
+    public ByteCount getMaxRequestLength() {
+        return maxRequestLength;
     }
 }


### PR DESCRIPTION
### Description

Adds a new configuration `max_request_length` to the HTTP/gRPC sources (OTel). If the size of a request exceeds that size these sources will return a `413 Request Entity Too Large`.

This also adds support for parsing `ByteCount` to the plugin object mapper.

There is also a new method on `ByteCount` to create an instance of a given size to help with testing.
 
### Issues Resolved

Resolves #3931
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
