### PR TITLE
Release events that are not routed to any sinks

### DIFF
--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/PipelinesWithAcksIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/PipelinesWithAcksIT.java
@@ -36,6 +36,8 @@ class PipelinesWithAcksIT {
     private static final String TWO_PARALLEL_PIPELINES_CONFIGURATION_UNDER_TEST = "acknowledgements/two-parallel-pipelines-test.yaml";
     private static final String THREE_PIPELINES_CONFIGURATION_UNDER_TEST = "acknowledgements/three-pipelines-test.yaml";
     private static final String THREE_PIPELINES_WITH_ROUTE_CONFIGURATION_UNDER_TEST = "acknowledgements/three-pipeline-route-test.yaml";
+    private static final String THREE_PIPELINES_WITH_UNROUTED_CONFIGURATION_UNDER_TEST = "acknowledgements/three-pipeline-unrouted-test.yaml";
+    private static final String THREE_PIPELINES_WITH_DEFAULT_ROUTE_CONFIGURATION_UNDER_TEST = "acknowledgements/three-pipeline-route-default-test.yaml";
     private static final String THREE_PIPELINES_MULTI_SINK_CONFIGURATION_UNDER_TEST = "acknowledgements/three-pipelines-test-multi-sink.yaml";
     private static final String ONE_PIPELINE_THREE_SINKS_CONFIGURATION_UNDER_TEST = "acknowledgements/one-pipeline-three-sinks.yaml";
     private static final String ONE_PIPELINE_ACK_EXPIRY_CONFIGURATION_UNDER_TEST = "acknowledgements/one-pipeline-ack-expiry-test.yaml";
@@ -122,6 +124,22 @@ class PipelinesWithAcksIT {
     }
 
     @Test
+    void three_pipelines_with_all_unrouted_records() {
+        setUp(THREE_PIPELINES_WITH_UNROUTED_CONFIGURATION_UNDER_TEST);
+        final int numRecords = 2;
+        inMemorySourceAccessor.submitWithStatus(IN_MEMORY_IDENTIFIER, numRecords);
+
+        await().atMost(20000, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertTrue(inMemorySourceAccessor != null);
+            assertTrue(inMemorySourceAccessor.getAckReceived() != null);
+        });
+        List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
+        assertThat(outputRecords.size(), equalTo(0));
+        assertTrue(inMemorySourceAccessor.getAckReceived());
+    }
+
+    @Test
     void three_pipelines_with_route_and_multiple_records() {
         setUp(THREE_PIPELINES_WITH_ROUTE_CONFIGURATION_UNDER_TEST);
         final int numRecords = 100;
@@ -132,6 +150,22 @@ class PipelinesWithAcksIT {
             List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
             assertThat(outputRecords, not(empty()));
             assertThat(outputRecords.size(), lessThanOrEqualTo(numRecords));
+        });
+        assertTrue(inMemorySourceAccessor.getAckReceived());
+    }
+
+    @Test
+    void three_pipelines_with_default_route_and_multiple_records() {
+        setUp(THREE_PIPELINES_WITH_DEFAULT_ROUTE_CONFIGURATION_UNDER_TEST);
+        final int numRecords = 10;
+
+        inMemorySourceAccessor.submitWithStatus(IN_MEMORY_IDENTIFIER, numRecords);
+
+        await().atMost(20000, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
+            assertThat(outputRecords, not(empty()));
+            assertThat(outputRecords.size(), equalTo(2*numRecords));
         });
         assertTrue(inMemorySourceAccessor.getAckReceived());
     }

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/PipelinesWithAcksIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/PipelinesWithAcksIT.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -130,7 +131,7 @@ class PipelinesWithAcksIT {
                 .untilAsserted(() -> {
             List<Record<Event>> outputRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
             assertThat(outputRecords, not(empty()));
-            assertThat(outputRecords.size(), equalTo(numRecords));
+            assertThat(outputRecords.size(), lessThanOrEqualTo(numRecords));
         });
         assertTrue(inMemorySourceAccessor.getAckReceived());
     }

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipeline-route-default-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipeline-route-default-test.yaml
@@ -1,0 +1,40 @@
+three-pipelines-route-test-1:
+  delay: 2
+  source:
+    in_memory:
+      testing_key: PipelinesWithAcksIT
+      acknowledgments: true
+  route:
+    - 2xx_route: '/status >= 200 and /status < 300'
+    - other_route: '/status >= 300 or /status < 200'
+  sink:
+    - pipeline:
+        name: "three-pipelines-route-test-2"
+        routes:
+          - 2xx_route
+    - pipeline:
+        name: "three-pipelines-route-test-3"
+        routes:
+          - other_route
+    - in_memory:
+        testing_key: PipelinesWithAcksIT
+        acknowledgments: true
+
+three-pipelines-route-test-2:
+  source:
+    pipeline:
+      name: "three-pipelines-route-test-1"
+  sink:
+    - in_memory:
+        testing_key: PipelinesWithAcksIT
+        acknowledgments: true
+
+three-pipelines-route-test-3:
+  source:
+    pipeline:
+      name: "three-pipelines-route-test-1"
+  sink:
+    - in_memory:
+        testing_key: PipelinesWithAcksIT
+        acknowledgments: true
+

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipeline-route-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipeline-route-test.yaml
@@ -6,7 +6,7 @@ three-pipelines-route-test-1:
       acknowledgments: true
   route:
     - 2xx_route: '/status >= 200 and /status < 300'
-    - other_route: '/status >= 300 or /status < 200'
+    - other_route: '/status >= 300'
   sink:
     - pipeline:
         name: "three-pipelines-route-test-2"

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipeline-route-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipeline-route-test.yaml
@@ -6,7 +6,7 @@ three-pipelines-route-test-1:
       acknowledgments: true
   route:
     - 2xx_route: '/status >= 200 and /status < 300'
-    - other_route: '/status >= 300'
+    - other_route: '/status >= 300 or /status < 200'
   sink:
     - pipeline:
         name: "three-pipelines-route-test-2"

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipeline-unrouted-test.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/acknowledgements/three-pipeline-unrouted-test.yaml
@@ -1,0 +1,37 @@
+three-pipelines-unrouted-test-1:
+  delay: 2
+  source:
+    in_memory:
+      testing_key: PipelinesWithAcksIT
+      acknowledgments: true
+  route:
+    - 1xx_route: '/status >= 700 and /status < 800'
+    - other_route: '/status >= 800 and /status < 900'
+  sink:
+    - pipeline:
+        name: "three-pipelines-unrouted-test-2"
+        routes:
+          - 1xx_route
+    - pipeline:
+        name: "three-pipelines-unrouted-test-3"
+        routes:
+          - other_route
+
+three-pipelines-unrouted-test-2:
+  source:
+    pipeline:
+      name: "three-pipelines-unrouted-test-1"
+  sink:
+    - in_memory:
+        testing_key: PipelinesWithAcksIT
+        acknowledgments: true
+
+three-pipelines-unrouted-test-3:
+  source:
+    pipeline:
+      name: "three-pipelines-unrouted-test-1"
+  sink:
+    - in_memory:
+        testing_key: PipelinesWithAcksIT
+        acknowledgments: true
+

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterFactory.java
@@ -23,14 +23,6 @@ public class RouterFactory {
     public Router createRouter(final Set<ConditionalRoute> routes) {
         final RouteEventEvaluator routeEventEvaluator = new RouteEventEvaluator(expressionEvaluator, routes);
         return new Router(routeEventEvaluator, dataFlowComponentRouter,
-                event -> {
-                    // Release unrouted events ONLY if routes are defined.
-                    // If routes are not used in the config, then all
-                    // events will have zero size for the routes set and
-                    // we shouldn't be releasing such events here
-                    if (routes.size() > 0) {
-                        event.getEventHandle().release(true);
-                    }
-                });
+                event -> event.getEventHandle().release(true));
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterFactory.java
@@ -22,6 +22,15 @@ public class RouterFactory {
 
     public Router createRouter(final Set<ConditionalRoute> routes) {
         final RouteEventEvaluator routeEventEvaluator = new RouteEventEvaluator(expressionEvaluator, routes);
-        return new Router(routeEventEvaluator, dataFlowComponentRouter, event -> event.getEventHandle().release(true));
+        return new Router(routeEventEvaluator, dataFlowComponentRouter,
+                event -> {
+                    // Release unrouted events ONLY if routes are defined.
+                    // If routes are not used in the config, then all
+                    // events will have zero size for the routes set and
+                    // we shouldn't be releasing such events here
+                    if (routes.size() > 0) {
+                        event.getEventHandle().release(true);
+                    }
+                });
     }
 }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterFactory.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/RouterFactory.java
@@ -22,6 +22,6 @@ public class RouterFactory {
 
     public Router createRouter(final Set<ConditionalRoute> routes) {
         final RouteEventEvaluator routeEventEvaluator = new RouteEventEvaluator(expressionEvaluator, routes);
-        return new Router(routeEventEvaluator, dataFlowComponentRouter);
+        return new Router(routeEventEvaluator, dataFlowComponentRouter, event -> event.getEventHandle().release(true));
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/RouterFactoryTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/RouterFactoryTest.java
@@ -9,17 +9,24 @@ import org.opensearch.dataprepper.model.configuration.ConditionalRoute;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
-
-import java.util.Collections;
-import java.util.Set;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.model.event.Event;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Consumer;
 
 @ExtendWith(MockitoExtension.class)
 class RouterFactoryTest {
@@ -27,6 +34,7 @@ class RouterFactoryTest {
     @Mock
     private ExpressionEvaluator expressionEvaluator;
     private Set<ConditionalRoute> routes;
+    private Consumer<Event> consumer;
 
     @BeforeEach
     void setUp() {
@@ -57,5 +65,21 @@ class RouterFactoryTest {
         final Router router = createObjectUnderTest().createRouter(routes);
 
         assertThat(router, notNullValue());
+    }
+
+    @Test
+    void test_createRouterWithUnroutedHandler() {
+        try (final MockedConstruction<Router> ignored =
+                     mockConstruction(Router.class, (mock, context) -> {
+                        consumer = (Consumer<Event>) context.arguments().get(2);
+                     })) {
+            Event event = mock(Event.class);
+            EventHandle eventHandle = mock(EventHandle.class);
+            when(event.getEventHandle()).thenReturn(eventHandle);
+            final Router router = createObjectUnderTest().createRouter(routes);
+            consumer.accept(event);
+            verify(event.getEventHandle()).release(true);
+            verify(eventHandle).release(true);
+        }
     }
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/RouterTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/router/RouterTest.java
@@ -218,11 +218,8 @@ class RouterTest {
             for (int i = 0; i < 5; i++) {
                 final DataFlowComponent dataFlowComponent = mock(DataFlowComponent.class);
                 dataFlowComponents.add(dataFlowComponent);
-                if (i == 0) {
-                    when(dataFlowComponent.getRoutes()).thenReturn(Set.of());
-                } else {
-                    when(dataFlowComponent.getRoutes()).thenReturn(Set.of("aa"));
-                }
+                final Set<String> routes = i ==0 ? Collections.emptySet() : Set.of(UUID.randomUUID().toString());
+                when(dataFlowComponent.getRoutes()).thenReturn(routes);
             }
             when(getRecordStrategy.getAllRecords(any())).thenReturn(recordsIn);
 


### PR DESCRIPTION
### Description
Release events that are not routed to any sinks.
When an event is not routed any sink, acknowledgement is sent so that the events are dropped.

Resolves #3866 
### Issues Resolved
Resolves #3866 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
