### PR TITLE
[Backport 2.6 - Manual] Updates wiremock to 3.3.1.

### DIFF
--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'dev.failsafe:failsafe:3.3.2'
     implementation 'org.apache.httpcomponents:httpcore:4.4.15'
     testImplementation libs.commons.lang3
-    testImplementation 'com.github.tomakehurst:wiremock:3.0.0-beta-8'
+    testImplementation 'org.wiremock:wiremock:3.3.1'
     testImplementation 'org.eclipse.jetty:jetty-bom:11.0.17'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation testLibs.junit.vintage


### PR DESCRIPTION
### Description

Manual backport of https://github.com/opensearch-project/data-prepper/pull/3969
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
