### PR TITLE
Kafka buffer integration test to verify that data in the buffer is correctly read

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/util/TestProducer.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/util/TestProducer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.util;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+
+import java.util.Properties;
+import java.util.UUID;
+
+/**
+ * Utility class to produce data to Kafka to help with testing.
+ */
+public class TestProducer {
+    private final Producer<byte[], byte[]> kafkaProducer;
+    private final String topicName;
+
+    public TestProducer(final String bootstrapServersCommaDelimited, final String topicName) {
+        this.topicName = topicName;
+        final String testGroupId = UUID.randomUUID().toString();
+        final Properties kafkaProperties = new Properties();
+        kafkaProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServersCommaDelimited);
+        kafkaProperties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, testGroupId);
+        kafkaProperties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        kafkaProducer = new KafkaProducer<>(kafkaProperties, new ByteArraySerializer(), new ByteArraySerializer());
+        kafkaProducer.flush();
+    }
+
+    /**
+     * Publishes a single record to Kafka.
+     *
+     * @param key The key as a byte[]
+     * @param value The value as a byte[]
+     */
+    public void publishRecord(final byte[] key, final byte[] value) {
+        final ProducerRecord<byte[], byte[]> producerRecord = new ProducerRecord<>(topicName, key, value);
+        kafkaProducer.send(producerRecord);
+        kafkaProducer.flush();
+    }
+}


### PR DESCRIPTION
### Description

Adds a new integration test for the Kafka buffer which verifies that data written is correctly read and decrypted. This work will be used to verify upcoming changes to the Protobuf model.

 
### Issues Resolved

None, but this is preparing to help ensure that changes for #3655 are backward compatible.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
