### PR TITLE
Kafka error handling in KafkaBuffer

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
@@ -72,7 +72,7 @@ public class KafkaBuffer extends AbstractBuffer<Record<Event>> {
         this.byteDecoder = byteDecoder;
         final String metricPrefixName = kafkaBufferConfig.getCustomMetricPrefix().orElse(pluginSetting.getName());
         final PluginMetrics producerMetrics = PluginMetrics.fromNames(metricPrefixName + WRITE, pluginSetting.getPipelineName());
-        producer = kafkaCustomProducerFactory.createProducer(kafkaBufferConfig, pluginFactory, pluginSetting,  null, null, producerMetrics, false, false);
+        producer = kafkaCustomProducerFactory.createProducer(kafkaBufferConfig, pluginFactory, pluginSetting,  null, null, producerMetrics, null, false);
         final KafkaCustomConsumerFactory kafkaCustomConsumerFactory = new KafkaCustomConsumerFactory(serializationFactory, awsCredentialsSupplier);
         innerBuffer = new BlockingBuffer<>(INNER_BUFFER_CAPACITY, INNER_BUFFER_BATCH_SIZE, pluginSetting.getPipelineName());
         this.shutdownInProgress = new AtomicBoolean(false);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
@@ -87,7 +87,9 @@ public class KafkaCustomProducer<T> {
         this.bufferedEventHandles = new LinkedList<>();
         this.expressionEvaluator = expressionEvaluator;
         this.tagTargetKey = tagTargetKey;
+        System.out.println("______________"+kafkaProducerConfig.getTopic());
         this.topicName = ObjectUtils.isEmpty(kafkaProducerConfig.getTopic()) ? null : kafkaProducerConfig.getTopic().getName();
+        System.out.println("2______________"+topicName);
         this.serdeFormat = ObjectUtils.isEmpty(kafkaProducerConfig.getSerdeFormat()) ? null : kafkaProducerConfig.getSerdeFormat();
         this.schemaService = schemaService;
         this.topicMetrics = topicMetrics;
@@ -100,6 +102,7 @@ public class KafkaCustomProducer<T> {
 
     public void produceRawData(final byte[] bytes, final String key) throws Exception{
         try {
+            System.out.println("+++++++++++"+topicName+"...."+key+"...."+bytes);
             send(topicName, key, bytes).get();
             topicMetrics.update(producer);
         } catch (Exception e) {
@@ -168,11 +171,13 @@ public class KafkaCustomProducer<T> {
         send(topicName, key, genericRecord);
     }
 
-    private Future send(final String topicName, String key, final Object record) throws Exception {
+    Future send(final String topicName, String key, final Object record) throws Exception {
+        System.out.println("0---------"+topicName+"---------"+key+"-----"+record);
         if (Objects.isNull(key)) {
             return producer.send(new ProducerRecord(topicName, record), callBack(record));
         }
 
+        System.out.println("1---------"+topicName+"---------"+key+"-----"+record);
         return producer.send(new ProducerRecord(topicName, key, record), callBack(record));
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
@@ -87,9 +87,7 @@ public class KafkaCustomProducer<T> {
         this.bufferedEventHandles = new LinkedList<>();
         this.expressionEvaluator = expressionEvaluator;
         this.tagTargetKey = tagTargetKey;
-        System.out.println("______________"+kafkaProducerConfig.getTopic());
         this.topicName = ObjectUtils.isEmpty(kafkaProducerConfig.getTopic()) ? null : kafkaProducerConfig.getTopic().getName();
-        System.out.println("2______________"+topicName);
         this.serdeFormat = ObjectUtils.isEmpty(kafkaProducerConfig.getSerdeFormat()) ? null : kafkaProducerConfig.getSerdeFormat();
         this.schemaService = schemaService;
         this.topicMetrics = topicMetrics;
@@ -102,7 +100,6 @@ public class KafkaCustomProducer<T> {
 
     public void produceRawData(final byte[] bytes, final String key) throws Exception{
         try {
-            System.out.println("+++++++++++"+topicName+"...."+key+"...."+bytes);
             send(topicName, key, bytes).get();
             topicMetrics.update(producer);
         } catch (Exception e) {
@@ -172,12 +169,10 @@ public class KafkaCustomProducer<T> {
     }
 
     Future send(final String topicName, String key, final Object record) throws Exception {
-        System.out.println("0---------"+topicName+"---------"+key+"-----"+record);
         if (Objects.isNull(key)) {
             return producer.send(new ProducerRecord(topicName, record), callBack(record));
         }
 
-        System.out.println("1---------"+topicName+"---------"+key+"-----"+record);
         return producer.send(new ProducerRecord(topicName, key, record), callBack(record));
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
@@ -98,17 +98,18 @@ public class KafkaCustomProducer<T> {
         return topicMetrics;
     }
 
-    public void produceRawData(final byte[] bytes, final String key) {
+    public void produceRawData(final byte[] bytes, final String key) throws Exception{
         try {
             send(topicName, key, bytes).get();
             topicMetrics.update(producer);
         } catch (Exception e) {
             topicMetrics.getNumberOfRawDataSendErrors().increment();
             LOG.error("Error occurred while publishing raw data", e);
+            throw e;
         }
     }
 
-    public void produceRecords(final Record<Event> record) {
+    public void produceRecords(final Record<Event> record) throws Exception {
         bufferedEventHandles.add(record.getData().getEventHandle());
         Event event = getEvent(record);
         final String key = event.formatString(kafkaProducerConfig.getPartitionKey(), expressionEvaluator);
@@ -126,21 +127,21 @@ public class KafkaCustomProducer<T> {
         } catch (Exception e) {
             LOG.error("Error occurred while publishing record {}", e.getMessage());
             topicMetrics.getNumberOfRecordSendErrors().increment();
-            releaseEventHandles(false);
+            if (dlqSink != null) {
+                JsonNode dataNode = record.getData().getJsonNode();
+                dlqSink.perform(dataNode, e);
+            } else {
+                releaseEventHandles(false);
+                throw e;
+            }
         }
 
     }
 
-    private void publishJsonMessageAsBytes(Record<Event> record, String key) {
+    private void publishJsonMessageAsBytes(Record<Event> record, String key) throws Exception {
         JsonNode dataNode = record.getData().getJsonNode();
-
-        try {
-            byte[] bytes = objectMapper.writeValueAsBytes(dataNode);
-            send(topicName, key, bytes);
-        }
-        catch (Throwable ex) {
-            dlqSink.perform(dataNode, ex);
-        }
+        byte[] bytes = objectMapper.writeValueAsBytes(dataNode);
+        send(topicName, key, bytes);
     }
 
     private Event getEvent(final Record<Event> record) {
@@ -154,11 +155,11 @@ public class KafkaCustomProducer<T> {
     }
 
 
-    private void publishPlaintextMessage(final Record<Event> record, final String key) {
+    private void publishPlaintextMessage(final Record<Event> record, final String key) throws Exception {
         send(topicName, key, record.getData().toJsonString());
     }
 
-    private void publishAvroMessage(final Record<Event> record, final String key) {
+    private void publishAvroMessage(final Record<Event> record, final String key) throws Exception {
         final Schema avroSchema = schemaService.getSchema(topicName);
         if (avroSchema == null) {
             throw new RuntimeException("Schema definition is mandatory in case of type avro");
@@ -167,7 +168,7 @@ public class KafkaCustomProducer<T> {
         send(topicName, key, genericRecord);
     }
 
-    private Future send(final String topicName, String key, final Object record) {
+    private Future send(final String topicName, String key, final Object record) throws Exception {
         if (Objects.isNull(key)) {
             return producer.send(new ProducerRecord(topicName, record), callBack(record));
         }
@@ -175,14 +176,9 @@ public class KafkaCustomProducer<T> {
         return producer.send(new ProducerRecord(topicName, key, record), callBack(record));
     }
 
-    private void publishJsonMessage(final Record<Event> record, final String key) throws IOException, ProcessingException {
+    private void publishJsonMessage(final Record<Event> record, final String key) throws IOException, ProcessingException, Exception {
         JsonNode dataNode = record.getData().getJsonNode();
-        try {
-            send(topicName, key, dataNode);
-        }
-        catch (Throwable ex) {
-            dlqSink.perform(dataNode, ex);
-        }
+        send(topicName, key, dataNode);
     }
 
     public boolean validateSchema(final String jsonData, final String schemaJson) throws IOException, ProcessingException {
@@ -200,8 +196,6 @@ public class KafkaCustomProducer<T> {
             if (null != exception) {
                 LOG.error("Error occurred while publishing {}", exception.getMessage());
                 topicMetrics.getNumberOfRecordProcessingErrors().increment();
-                releaseEventHandles(false);
-                dlqSink.perform(dataForDlq, exception);
             } else {
                 releaseEventHandles(true);
             }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerFactory.java
@@ -51,7 +51,7 @@ public class KafkaCustomProducerFactory {
 
     public KafkaCustomProducer createProducer(final KafkaProducerConfig kafkaProducerConfig, final PluginFactory pluginFactory, final PluginSetting pluginSetting,
                                               final ExpressionEvaluator expressionEvaluator, final SinkContext sinkContext, final PluginMetrics pluginMetrics,
-                                              final boolean topicNameInMetrics) {
+                                              final boolean topicNameInMetrics, final boolean configureDlq) {
         AwsContext awsContext = new AwsContext(kafkaProducerConfig, awsCredentialsSupplier);
         KeyFactory keyFactory = new KeyFactory(awsContext);
         // If either or both of Producer's max_request_size or
@@ -80,7 +80,7 @@ public class KafkaCustomProducerFactory {
         final String topicName = ObjectUtils.isEmpty(kafkaProducerConfig.getTopic()) ? null : kafkaProducerConfig.getTopic().getName();
         final SchemaService schemaService = new SchemaService.SchemaServiceBuilder().getFetchSchemaService(topicName, kafkaProducerConfig.getSchemaConfig()).build();
         return new KafkaCustomProducer(producer,
-            kafkaProducerConfig, dlqSink,
+            kafkaProducerConfig, configureDlq ? dlqSink : null,
             expressionEvaluator, Objects.nonNull(sinkContext) ? sinkContext.getTagsTargetKey() : null, topicMetrics, schemaService);
     }
     private void prepareTopicAndSchema(final KafkaProducerConfig kafkaProducerConfig, final Integer maxRequestSize) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerFactory.java
@@ -51,7 +51,8 @@ public class KafkaCustomProducerFactory {
 
     public KafkaCustomProducer createProducer(final KafkaProducerConfig kafkaProducerConfig, final PluginFactory pluginFactory, final PluginSetting pluginSetting,
                                               final ExpressionEvaluator expressionEvaluator, final SinkContext sinkContext, final PluginMetrics pluginMetrics,
-                                              final boolean topicNameInMetrics, final boolean configureDlq) {
+                                              final DLQSink dlqSink,
+                                              final boolean topicNameInMetrics) {
         AwsContext awsContext = new AwsContext(kafkaProducerConfig, awsCredentialsSupplier);
         KeyFactory keyFactory = new KeyFactory(awsContext);
         // If either or both of Producer's max_request_size or
@@ -75,12 +76,11 @@ public class KafkaCustomProducerFactory {
         Serializer<Object> keyDeserializer = (Serializer<Object>) serializationFactory.getSerializer(PlaintextKafkaDataConfig.plaintextDataConfig(dataConfig));
         Serializer<Object> valueSerializer = (Serializer<Object>) serializationFactory.getSerializer(dataConfig);
         final KafkaProducer<Object, Object> producer = new KafkaProducer<>(properties, keyDeserializer, valueSerializer);
-        final DLQSink dlqSink = new DLQSink(pluginFactory, kafkaProducerConfig, pluginSetting);
         final KafkaTopicProducerMetrics topicMetrics = new KafkaTopicProducerMetrics(topic.getName(), pluginMetrics, topicNameInMetrics);
         final String topicName = ObjectUtils.isEmpty(kafkaProducerConfig.getTopic()) ? null : kafkaProducerConfig.getTopic().getName();
         final SchemaService schemaService = new SchemaService.SchemaServiceBuilder().getFetchSchemaService(topicName, kafkaProducerConfig.getSchemaConfig()).build();
         return new KafkaCustomProducer(producer,
-            kafkaProducerConfig, configureDlq ? dlqSink : null,
+            kafkaProducerConfig, dlqSink,
             expressionEvaluator, Objects.nonNull(sinkContext) ? sinkContext.getTagsTargetKey() : null, topicMetrics, schemaService);
     }
     private void prepareTopicAndSchema(final KafkaProducerConfig kafkaProducerConfig, final Integer maxRequestSize) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/ProducerWorker.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/ProducerWorker.java
@@ -8,6 +8,9 @@ package org.opensearch.dataprepper.plugins.kafka.producer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * * A Multithreaded helper class which helps to produce the records to multiple topics in an
  * asynchronous way.
@@ -15,6 +18,7 @@ import org.opensearch.dataprepper.model.record.Record;
 
 public class ProducerWorker implements Runnable {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ProducerWorker.class);
     private final Record<Event> record;
     private final KafkaCustomProducer producer;
 
@@ -27,7 +31,11 @@ public class ProducerWorker implements Runnable {
 
     @Override
     public void run() {
-        producer.produceRecords(record);
+        try {
+            producer.produceRecords(record);
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
     }
 
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/ProducerWorker.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/ProducerWorker.java
@@ -34,7 +34,7 @@ public class ProducerWorker implements Runnable {
         try {
             producer.produceRecords(record);
         } catch (Exception e) {
-            LOG.error(e.getMessage(), e);
+            LOG.error("The Kafka buffer failed to produce records to Kafka.", e);
         }
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/DLQSink.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/DLQSink.java
@@ -44,6 +44,9 @@ public class DLQSink {
 
     public void perform(final Object failedData, final Throwable e) {
         final DlqWriter dlqWriter = getDlqWriter();
+        if (dlqWriter == null) {
+            throw new RuntimeException("DLQ not configured");
+        }
         final DlqObject dlqObject = DlqObject.builder()
                 .withPluginId(randomUUID().toString())
                 .withPluginName(pluginSetting.getName())
@@ -54,6 +57,9 @@ public class DLQSink {
     }
 
     private DlqWriter getDlqWriter() {
+        if (dlqProvider == null) {
+            return null;
+        }
         final Optional<DlqWriter> potentialDlq = dlqProvider.getDlqWriter(new StringJoiner(MetricNames.DELIMITER)
                 .add(pluginSetting.getPipelineName())
                 .add(pluginSetting.getName()).toString());

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/DLQSink.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/DLQSink.java
@@ -45,7 +45,8 @@ public class DLQSink {
     public void perform(final Object failedData, final Throwable e) {
         final DlqWriter dlqWriter = getDlqWriter();
         if (dlqWriter == null) {
-            throw new RuntimeException("DLQ not configured");
+            LOG.error("Call to perform() when not DLQ is configured. This is possibly a programming error.");
+            return;
         }
         final DlqObject dlqObject = DlqObject.builder()
                 .withPluginId(randomUUID().toString())

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSink.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSink.java
@@ -28,7 +28,7 @@ import org.opensearch.dataprepper.plugins.kafka.producer.ProducerWorker;
 import org.opensearch.dataprepper.plugins.kafka.service.SchemaService;
 import org.opensearch.dataprepper.plugins.kafka.service.TopicService;
 import org.opensearch.dataprepper.plugins.kafka.util.RestUtils;
-import org.opensearch.dataprepper.plugins.kafka.sink.DLQSink;
+//import org.opensearch.dataprepper.plugins.kafka.sink.DLQSink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSink.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSink.java
@@ -162,8 +162,7 @@ public class KafkaSink extends AbstractSink<Record<Event>> {
     }
 
     private KafkaCustomProducer createProducer() {
-        // TODO: Add the DLQSink here. new DLQSink(pluginFactory, kafkaSinkConfig, pluginSetting)
-        return kafkaCustomProducerFactory.createProducer(kafkaSinkConfig, pluginFactory, pluginSetting, expressionEvaluator, sinkContext, pluginMetrics, true);
+        return kafkaCustomProducerFactory.createProducer(kafkaSinkConfig, pluginFactory, pluginSetting, expressionEvaluator, sinkContext, pluginMetrics, true, true);
     }
 
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSink.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSink.java
@@ -28,6 +28,7 @@ import org.opensearch.dataprepper.plugins.kafka.producer.ProducerWorker;
 import org.opensearch.dataprepper.plugins.kafka.service.SchemaService;
 import org.opensearch.dataprepper.plugins.kafka.service.TopicService;
 import org.opensearch.dataprepper.plugins.kafka.util.RestUtils;
+import org.opensearch.dataprepper.plugins.kafka.sink.DLQSink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -162,7 +163,8 @@ public class KafkaSink extends AbstractSink<Record<Event>> {
     }
 
     private KafkaCustomProducer createProducer() {
-        return kafkaCustomProducerFactory.createProducer(kafkaSinkConfig, pluginFactory, pluginSetting, expressionEvaluator, sinkContext, pluginMetrics, true, true);
+        final DLQSink dlqSink = new DLQSink(pluginFactory, kafkaSinkConfig, pluginSetting);
+        return kafkaCustomProducerFactory.createProducer(kafkaSinkConfig, pluginFactory, pluginSetting, expressionEvaluator, sinkContext, pluginMetrics, dlqSink, true);
     }
 
 

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
@@ -137,7 +137,7 @@ class KafkaBufferTest {
             final MockedConstruction<KafkaCustomProducerFactory> producerFactoryMock =
                 mockConstruction(KafkaCustomProducerFactory.class, (mock, context) -> {
                 producerFactory = mock;
-                when(producerFactory.createProducer(any() ,any(), any(), isNull(), isNull(), any(), anyBoolean())).thenReturn(producer);
+                when(producerFactory.createProducer(any() ,any(), any(), isNull(), isNull(), any(), anyBoolean(), anyBoolean())).thenReturn(producer);
             });
             final MockedConstruction<KafkaCustomConsumerFactory> consumerFactoryMock =
                 mockConstruction(KafkaCustomConsumerFactory.class, (mock, context) -> {
@@ -197,7 +197,7 @@ class KafkaBufferTest {
     }
 
     @Test
-    void test_kafkaBuffer_basicFunctionality() throws TimeoutException {
+    void test_kafkaBuffer_basicFunctionality() throws TimeoutException, Exception {
         kafkaBuffer = createObjectUnderTest();
         assertTrue(Objects.nonNull(kafkaBuffer));
 
@@ -209,7 +209,7 @@ class KafkaBufferTest {
     }
 
     @Test
-    void test_kafkaBuffer_producerThrows() throws TimeoutException {
+    void test_kafkaBuffer_producerThrows() throws TimeoutException, Exception {
 
         kafkaBuffer = createObjectUnderTest();
         Record<Event> record = new Record<Event>(JacksonEvent.fromMessage(UUID.randomUUID().toString()));

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
@@ -137,7 +137,7 @@ class KafkaBufferTest {
             final MockedConstruction<KafkaCustomProducerFactory> producerFactoryMock =
                 mockConstruction(KafkaCustomProducerFactory.class, (mock, context) -> {
                 producerFactory = mock;
-                when(producerFactory.createProducer(any() ,any(), any(), isNull(), isNull(), any(), anyBoolean(), anyBoolean())).thenReturn(producer);
+                when(producerFactory.createProducer(any() ,any(), any(), isNull(), isNull(), any(), any(), anyBoolean())).thenReturn(producer);
             });
             final MockedConstruction<KafkaCustomConsumerFactory> consumerFactoryMock =
                 mockConstruction(KafkaCustomConsumerFactory.class, (mock, context) -> {

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerTest.java
@@ -103,8 +103,10 @@ public class KafkaCustomProducerTest {
         sinkProducer = spy(producer);
         final String key = UUID.randomUUID().toString();
         final byte[] byteData = record.getData().toJsonString().getBytes();
-        sinkProducer.produceRawData(byteData, key);
-        verify(sinkProducer).produceRawData(record.getData().toJsonString().getBytes(), key);
+        try {
+            sinkProducer.produceRawData(byteData, key);
+            verify(sinkProducer).produceRawData(record.getData().toJsonString().getBytes(), key);
+        } catch (Exception e){}
         final ArgumentCaptor<ProducerRecord> recordArgumentCaptor = ArgumentCaptor.forClass(ProducerRecord.class);
         verify(kafkaProducer).send(recordArgumentCaptor.capture(), any(Callback.class));
         assertEquals(recordArgumentCaptor.getValue().topic(), kafkaSinkConfig.getTopic().getName());
@@ -124,8 +126,10 @@ public class KafkaCustomProducerTest {
         sinkProducer = spy(producer);
         final String key = UUID.randomUUID().toString();
         final byte[] byteData = record.getData().toJsonString().getBytes();
-        sinkProducer.produceRawData(byteData, key);
-        verify(sinkProducer).produceRawData(record.getData().toJsonString().getBytes(), key);
+        try {
+            sinkProducer.produceRawData(byteData, key);
+            verify(sinkProducer).produceRawData(record.getData().toJsonString().getBytes(), key);
+        } catch (Exception e){}
         final ArgumentCaptor<ProducerRecord> recordArgumentCaptor = ArgumentCaptor.forClass(ProducerRecord.class);
         verify(kafkaProducer).send(recordArgumentCaptor.capture(), any(Callback.class));
         assertEquals(recordArgumentCaptor.getValue().topic(), kafkaSinkConfig.getTopic().getName());
@@ -135,7 +139,7 @@ public class KafkaCustomProducerTest {
     }
 
     @Test
-    public void producePlainTextRecords() {
+    public void producePlainTextRecords() throws Exception {
         when(kafkaSinkConfig.getSerdeFormat()).thenReturn("plaintext");
         KafkaProducer kafkaProducer = mock(KafkaProducer.class);
         producer = new KafkaCustomProducer(kafkaProducer, kafkaSinkConfig, dlqSink, mock(ExpressionEvaluator.class),
@@ -151,7 +155,7 @@ public class KafkaCustomProducerTest {
     }
 
     @Test
-    public void producePlainTextRecords_sendError() {
+    public void producePlainTextRecords_sendError() throws Exception {
         when(kafkaSinkConfig.getSerdeFormat()).thenReturn("plaintext");
         KafkaProducer kafkaProducer = mock(KafkaProducer.class);
         producer = new KafkaCustomProducer(kafkaProducer, kafkaSinkConfig, dlqSink, mock(ExpressionEvaluator.class),
@@ -169,7 +173,7 @@ public class KafkaCustomProducerTest {
     }
 
     @Test
-    public void producePlainTextRecords_callbackException() {
+    public void producePlainTextRecords_callbackException() throws Exception {
         when(kafkaSinkConfig.getSerdeFormat()).thenReturn("plaintext");
         KafkaProducer kafkaProducer = mock(KafkaProducer.class);
         producer = new KafkaCustomProducer(kafkaProducer, kafkaSinkConfig, dlqSink, mock(ExpressionEvaluator.class),
@@ -189,7 +193,7 @@ public class KafkaCustomProducerTest {
     }
 
     @Test
-    public void produceJsonRecordsTest() {
+    public void produceJsonRecordsTest() throws Exception {
         when(kafkaSinkConfig.getSerdeFormat()).thenReturn("JSON");
         KafkaProducer kafkaProducer = mock(KafkaProducer.class);
         producer = new KafkaCustomProducer(kafkaProducer, kafkaSinkConfig, dlqSink, mock(ExpressionEvaluator.class),
@@ -217,7 +221,7 @@ public class KafkaCustomProducerTest {
     }
 
     @Test
-    public void produceAvroRecordsTest() {
+    public void produceAvroRecordsTest() throws Exception {
         when(kafkaSinkConfig.getSerdeFormat()).thenReturn("AVRO");
         KafkaProducer kafkaProducer = mock(KafkaProducer.class);
         producer = new KafkaCustomProducer(kafkaProducer, kafkaSinkConfig, dlqSink, mock(ExpressionEvaluator.class),

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSinkTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSinkTest.java
@@ -134,7 +134,7 @@ public class KafkaSinkTest {
     private KafkaSink createObjectUnderTest() {
         final KafkaSink objectUnderTest;
         try(final MockedConstruction<KafkaCustomProducerFactory> ignored = mockConstruction(KafkaCustomProducerFactory.class, (mock, context) -> {
-           when(mock.createProducer(any(), any(), any(), any(), any(), any(), anyBoolean())).thenReturn(kafkaCustomProducer);
+           when(mock.createProducer(any(), any(), any(), any(), any(), any(), anyBoolean(), anyBoolean())).thenReturn(kafkaCustomProducer);
         })) {
             objectUnderTest = new KafkaSink(pluginSetting, kafkaSinkConfig, pluginFactoryMock, pluginMetrics, mock(ExpressionEvaluator.class), sinkContext, awsCredentialsSupplier);
         }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSinkTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSinkTest.java
@@ -134,7 +134,7 @@ public class KafkaSinkTest {
     private KafkaSink createObjectUnderTest() {
         final KafkaSink objectUnderTest;
         try(final MockedConstruction<KafkaCustomProducerFactory> ignored = mockConstruction(KafkaCustomProducerFactory.class, (mock, context) -> {
-           when(mock.createProducer(any(), any(), any(), any(), any(), any(), anyBoolean(), anyBoolean())).thenReturn(kafkaCustomProducer);
+           when(mock.createProducer(any(), any(), any(), any(), any(), any(), any(), anyBoolean())).thenReturn(kafkaCustomProducer);
         })) {
             objectUnderTest = new KafkaSink(pluginSetting, kafkaSinkConfig, pluginFactoryMock, pluginMetrics, mock(ExpressionEvaluator.class), sinkContext, awsCredentialsSupplier);
         }


### PR DESCRIPTION
### Description
Kafka error handling in KafkaBuffer.
Errors occurred while storing in kafka are mapped to Source specific (HTTP source) errors and sent back.
Removed capability to configure DLQ  when Kafka used as Buffer
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
