### PR TITLE
Write encryption data to the Kafka protobuf messages

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/serialization/BufferMessageSerializer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/serialization/BufferMessageSerializer.java
@@ -8,6 +8,9 @@ package org.opensearch.dataprepper.plugins.kafka.buffer.serialization;
 import com.google.protobuf.ByteString;
 import org.apache.kafka.common.serialization.Serializer;
 import org.opensearch.dataprepper.plugins.kafka.buffer.KafkaBufferMessage;
+import org.opensearch.dataprepper.plugins.kafka.common.KafkaDataConfig;
+
+import java.util.Objects;
 
 /**
  * A Kafka {@link Serializer} which serializes data into a KafkaBuffer Protobuf message.
@@ -16,9 +19,11 @@ import org.opensearch.dataprepper.plugins.kafka.buffer.KafkaBufferMessage;
  */
 class BufferMessageSerializer<T> implements Serializer<T> {
     private final Serializer<T> dataSerializer;
+    private final KafkaDataConfig dataConfig;
 
-    public BufferMessageSerializer(final Serializer<T> dataSerializer) {
-        this.dataSerializer = dataSerializer;
+    public BufferMessageSerializer(final Serializer<T> dataSerializer, final KafkaDataConfig dataConfig) {
+        this.dataSerializer = Objects.requireNonNull(dataSerializer);
+        this.dataConfig = Objects.requireNonNull(dataConfig);
     }
 
     @Override
@@ -28,15 +33,27 @@ class BufferMessageSerializer<T> implements Serializer<T> {
 
         final byte[] serializedData = dataSerializer.serialize(topic, data);
 
-        final KafkaBufferMessage.BufferData bufferedData = KafkaBufferMessage.BufferData.newBuilder()
-                .setData(ByteString.copyFrom(serializedData))
-                .setMessageFormat(KafkaBufferMessage.MessageFormat.MESSAGE_FORMAT_BYTES)
-                .build();
+        final KafkaBufferMessage.BufferData bufferedData = buildProtobufMessage(serializedData);
 
         return bufferedData.toByteArray();
     }
 
     Serializer<T> getDataSerializer() {
         return dataSerializer;
+    }
+
+    private KafkaBufferMessage.BufferData buildProtobufMessage(final byte[] serializedData) {
+        KafkaBufferMessage.BufferData.Builder messageBuilder = KafkaBufferMessage.BufferData.newBuilder()
+                .setData(ByteString.copyFrom(serializedData))
+                .setMessageFormat(KafkaBufferMessage.MessageFormat.MESSAGE_FORMAT_BYTES);
+
+        if(dataConfig.getEncryptionKeySupplier() != null) {
+            messageBuilder = messageBuilder.setEncrypted(true);
+
+            if(dataConfig.getEncryptedDataKey() != null)
+                messageBuilder = messageBuilder.setEncryptedDataKey(ByteString.copyFromUtf8(dataConfig.getEncryptedDataKey()));
+        }
+
+        return messageBuilder.build();
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/serialization/BufferSerializationFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/serialization/BufferSerializationFactory.java
@@ -34,6 +34,6 @@ public class BufferSerializationFactory implements SerializationFactory {
 
     @Override
     public Serializer<?> getSerializer(final KafkaDataConfig dataConfig) {
-        return new BufferMessageSerializer<>(innerSerializationFactory.getSerializer(dataConfig));
+        return new BufferMessageSerializer<>(innerSerializationFactory.getSerializer(dataConfig), dataConfig);
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/KafkaDataConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/KafkaDataConfig.java
@@ -11,4 +11,12 @@ import java.util.function.Supplier;
 public interface KafkaDataConfig {
     MessageFormat getSerdeFormat();
     Supplier<byte[]> getEncryptionKeySupplier();
+
+    /**
+     * Returns an encrypted data key. If the encryption key is not encrypted,
+     * then this will return <code>null</code>.
+     *
+     * @return The encrypted data key provided in the configuration.
+     */
+    String getEncryptedDataKey();
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/KafkaDataConfigAdapter.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/KafkaDataConfigAdapter.java
@@ -19,7 +19,7 @@ public class KafkaDataConfigAdapter implements KafkaDataConfig {
     private final KeyFactory keyFactory;
     private final TopicConfig topicConfig;
 
-    public KafkaDataConfigAdapter(KeyFactory keyFactory, TopicConfig topicConfig) {
+    public KafkaDataConfigAdapter(final KeyFactory keyFactory, final TopicConfig topicConfig) {
         this.keyFactory = keyFactory;
         this.topicConfig = topicConfig;
     }
@@ -34,5 +34,12 @@ public class KafkaDataConfigAdapter implements KafkaDataConfig {
         if(topicConfig.getEncryptionKey() == null)
             return null;
         return keyFactory.getKeySupplier(topicConfig);
+    }
+
+    @Override
+    public String getEncryptedDataKey() {
+        if(topicConfig.getEncryptionKey() == null)
+            return null;
+        return keyFactory.getEncryptedDataKey(topicConfig);
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/PlaintextKafkaDataConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/PlaintextKafkaDataConfig.java
@@ -7,7 +7,7 @@ import java.util.function.Supplier;
 public class PlaintextKafkaDataConfig implements KafkaDataConfig {
     private final KafkaDataConfig dataConfig;
 
-    private PlaintextKafkaDataConfig(KafkaDataConfig dataConfig) {
+    private PlaintextKafkaDataConfig(final KafkaDataConfig dataConfig) {
         this.dataConfig = dataConfig;
     }
 
@@ -30,5 +30,10 @@ public class PlaintextKafkaDataConfig implements KafkaDataConfig {
     @Override
     public Supplier<byte[]> getEncryptionKeySupplier() {
         return dataConfig.getEncryptionKeySupplier();
+    }
+
+    @Override
+    public String getEncryptedDataKey() {
+        return dataConfig.getEncryptedDataKey();
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/key/InnerKeyProvider.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/key/InnerKeyProvider.java
@@ -6,4 +6,13 @@ import java.util.function.Function;
 
 interface InnerKeyProvider extends Function<TopicConfig, byte[]> {
     boolean supportsConfiguration(TopicConfig topicConfig);
+
+    /**
+     * Returns true if this {@link InnerKeyProvider} expects an encrypted
+     * data key. Returns false if the encryption key is in plain-text
+     * in the pipeline configuration.
+     *
+     * @return True if the key is encrypted.
+     */
+    boolean isKeyEncrypted();
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/key/KeyFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/key/KeyFactory.java
@@ -9,27 +9,43 @@ import java.util.function.Supplier;
 public class KeyFactory {
     private final List<InnerKeyProvider> orderedKeyProviders;
 
-    public KeyFactory(AwsContext awsContext) {
+    public KeyFactory(final AwsContext awsContext) {
         this(List.of(
                 new KmsKeyProvider(awsContext),
                 new UnencryptedKeyProvider()
         ));
     }
 
-    KeyFactory(List<InnerKeyProvider> orderedKeyProviders) {
+    KeyFactory(final List<InnerKeyProvider> orderedKeyProviders) {
         this.orderedKeyProviders = orderedKeyProviders;
     }
 
-    public Supplier<byte[]> getKeySupplier(TopicConfig topicConfig) {
+    public Supplier<byte[]> getKeySupplier(final TopicConfig topicConfig) {
         if (topicConfig.getEncryptionKey() == null)
             return null;
 
-        InnerKeyProvider keyProvider = orderedKeyProviders
+        final InnerKeyProvider keyProvider = getInnerKeyProvider(topicConfig);
+
+        return () -> keyProvider.apply(topicConfig);
+    }
+
+    public String getEncryptedDataKey(final TopicConfig topicConfig) {
+        if (topicConfig.getEncryptionKey() == null)
+            return null;
+
+        final InnerKeyProvider keyProvider = getInnerKeyProvider(topicConfig);
+
+        if(keyProvider.isKeyEncrypted())
+            return topicConfig.getEncryptionKey();
+
+        return null;
+    }
+
+    private InnerKeyProvider getInnerKeyProvider(final TopicConfig topicConfig) {
+        return orderedKeyProviders
                 .stream()
                 .filter(innerKeyProvider -> innerKeyProvider.supportsConfiguration(topicConfig))
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException("Unable to find an inner key provider. This is a programming error - UnencryptedKeyProvider should always work."));
-
-        return () -> keyProvider.apply(topicConfig);
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/key/UnencryptedKeyProvider.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/common/key/UnencryptedKeyProvider.java
@@ -6,12 +6,17 @@ import java.util.Base64;
 
 class UnencryptedKeyProvider implements InnerKeyProvider {
     @Override
-    public boolean supportsConfiguration(TopicConfig topicConfig) {
+    public boolean supportsConfiguration(final TopicConfig topicConfig) {
         return true;
     }
 
     @Override
-    public byte[] apply(TopicConfig topicConfig) {
+    public boolean isKeyEncrypted() {
+        return false;
+    }
+
+    @Override
+    public byte[] apply(final TopicConfig topicConfig) {
         return Base64.getDecoder().decode(topicConfig.getEncryptionKey());
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/main/proto/org/opensearch/dataprepper/plugins/kafka/KafkaBufferMessage.proto
+++ b/data-prepper-plugins/kafka-plugins/src/main/proto/org/opensearch/dataprepper/plugins/kafka/KafkaBufferMessage.proto
@@ -16,4 +16,13 @@ message BufferData {
    * is unencrypted data.
    */
   bytes data = 2;
+
+  /* Indicates if data is encrypted or not.
+   */
+  optional bool encrypted = 3;
+
+  /* The data key which encrypted the data field. This will be encrypted.
+   * The consuming Data Prepper node must have the ability to decrypt this key.
+   */
+  optional bytes encrypted_data_key = 4;
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/serialization/BufferMessageSerializerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/serialization/BufferMessageSerializerTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.kafka.buffer.serialization;
 
+import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.kafka.common.serialization.Serializer;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,14 +14,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.plugins.kafka.buffer.KafkaBufferMessage;
+import org.opensearch.dataprepper.plugins.kafka.common.KafkaDataConfig;
 
 import java.util.Random;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +35,9 @@ import static org.mockito.Mockito.when;
 class BufferMessageSerializerTest {
     @Mock
     private Serializer<Object> innerDataSerializer;
+
+    @Mock
+    private KafkaDataConfig dataConfig;
 
     private String topic;
     private Object inputData;
@@ -42,7 +52,19 @@ class BufferMessageSerializerTest {
     }
 
     private BufferMessageSerializer<Object> createObjectUnderTest() {
-        return new BufferMessageSerializer<>(innerDataSerializer);
+        return new BufferMessageSerializer<>(innerDataSerializer, dataConfig);
+    }
+
+    @Test
+    void constructor_throws_if_innerDataSerializer_is_null() {
+        innerDataSerializer = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void constructor_throws_if_dataConfig_is_null() {
+        innerDataSerializer = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
     }
 
     @Test
@@ -69,6 +91,62 @@ class BufferMessageSerializerTest {
         assertThat(actualBufferedData.getData(), notNullValue());
         assertThat(actualBufferedData.getData().toByteArray(),
                 equalTo(expectedBytes));
+
+        assertThat(actualBufferedData.getEncrypted(), equalTo(false));
+        assertThat(actualBufferedData.getEncryptedDataKey(), equalTo(ByteString.empty()));
+
+        verify(dataConfig, never()).getEncryptedDataKey();
+    }
+
+    @Test
+    void serialize_returns_bytes_wrapped_in_KafkaBufferMessage_with_encryption_data_when_encrypted() throws InvalidProtocolBufferException {
+        final byte[] expectedBytes = new byte[32];
+        random.nextBytes(expectedBytes);
+        final String encryptionKey = UUID.randomUUID().toString();
+        when(innerDataSerializer.serialize(topic, inputData)).thenReturn(expectedBytes);
+        when(dataConfig.getEncryptionKeySupplier()).thenReturn(mock(Supplier.class));
+        when(dataConfig.getEncryptedDataKey()).thenReturn(encryptionKey);
+        final byte[] actualBytes = createObjectUnderTest().serialize(topic, inputData);
+
+        assertThat(actualBytes, notNullValue());
+
+        final KafkaBufferMessage.BufferData actualBufferedData =
+                KafkaBufferMessage.BufferData.parseFrom(actualBytes);
+
+        assertThat(actualBufferedData.getMessageFormat(),
+                equalTo(KafkaBufferMessage.MessageFormat.MESSAGE_FORMAT_BYTES));
+
+        assertThat(actualBufferedData.getData(), notNullValue());
+        assertThat(actualBufferedData.getData().toByteArray(),
+                equalTo(expectedBytes));
+
+        assertThat(actualBufferedData.getEncrypted(), equalTo(true));
+        assertThat(actualBufferedData.getEncryptedDataKey(), equalTo(ByteString.copyFromUtf8(encryptionKey)));
+    }
+
+    @Test
+    void serialize_returns_bytes_wrapped_in_KafkaBufferMessage_without_encryption_data_when_encrypted_but_data_key_is_plaintext() throws InvalidProtocolBufferException {
+        final byte[] expectedBytes = new byte[32];
+        random.nextBytes(expectedBytes);
+        final String encryptionKey = UUID.randomUUID().toString();
+        when(innerDataSerializer.serialize(topic, inputData)).thenReturn(expectedBytes);
+        when(dataConfig.getEncryptionKeySupplier()).thenReturn(mock(Supplier.class));
+        final byte[] actualBytes = createObjectUnderTest().serialize(topic, inputData);
+
+        assertThat(actualBytes, notNullValue());
+
+        final KafkaBufferMessage.BufferData actualBufferedData =
+                KafkaBufferMessage.BufferData.parseFrom(actualBytes);
+
+        assertThat(actualBufferedData.getMessageFormat(),
+                equalTo(KafkaBufferMessage.MessageFormat.MESSAGE_FORMAT_BYTES));
+
+        assertThat(actualBufferedData.getData(), notNullValue());
+        assertThat(actualBufferedData.getData().toByteArray(),
+                equalTo(expectedBytes));
+
+        assertThat(actualBufferedData.getEncrypted(), equalTo(true));
+        assertThat(actualBufferedData.getEncryptedDataKey(), equalTo(ByteString.empty()));
     }
 
     @Test

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/KafkaDataConfigAdapterTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/KafkaDataConfigAdapterTest.java
@@ -54,4 +54,20 @@ class KafkaDataConfigAdapterTest {
         assertThat(createObjectUnderTest().getEncryptionKeySupplier(),
                 equalTo(keySupplier));
     }
+
+    @Test
+    void getEncryptionKey_returns_null_when_topic_encryptedDataKey_is_null() {
+        assertThat(createObjectUnderTest().getEncryptedDataKey(),
+                nullValue());
+    }
+
+    @Test
+    void getEncryptionKey_returns_value_of_getEncryptedDataKey_when_encryptedDataKey_is_not_null() {
+        final String encryptionKey = UUID.randomUUID().toString();
+        when(topicConfig.getEncryptionKey()).thenReturn(UUID.randomUUID().toString());
+        when(keyFactory.getEncryptedDataKey(topicConfig)).thenReturn(encryptionKey);
+
+        assertThat(createObjectUnderTest().getEncryptedDataKey(),
+                equalTo(encryptionKey));
+    }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/PlaintextKafkaDataConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/PlaintextKafkaDataConfigTest.java
@@ -1,41 +1,59 @@
 package org.opensearch.dataprepper.plugins.kafka.common;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.plugins.kafka.util.MessageFormat;
 
+import java.util.UUID;
 import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class PlaintextKafkaDataConfigTest {
+    @Mock
+    private KafkaDataConfig inputDataConfig;
+
     @ParameterizedTest
     @EnumSource(MessageFormat.class)
     void plaintextDataConfig_returns_KafkaDataConfig_with_getSerdeFormat_returning_PLAINTEXT(MessageFormat inputFormat) {
-        KafkaDataConfig inputDataConfig = mock(KafkaDataConfig.class);
-        when(inputDataConfig.getSerdeFormat()).thenReturn(inputFormat);
-
-        KafkaDataConfig outputDataConfig = PlaintextKafkaDataConfig.plaintextDataConfig(inputDataConfig);
+        final KafkaDataConfig outputDataConfig = PlaintextKafkaDataConfig.plaintextDataConfig(inputDataConfig);
 
         assertThat(outputDataConfig, notNullValue());
 
         assertThat(outputDataConfig.getSerdeFormat(), equalTo(MessageFormat.PLAINTEXT));
+        verify(inputDataConfig, never()).getSerdeFormat();
     }
 
     @Test
     void plaintextDataConfig_returns_KafkaDataConfig_with_getEncryptionKeySupplier_returning_from_inner_dataConfig() {
-        KafkaDataConfig inputDataConfig = mock(KafkaDataConfig.class);
-        Supplier<byte[]> keySupplier = mock(Supplier.class);
+        final Supplier<byte[]> keySupplier = mock(Supplier.class);
         when(inputDataConfig.getEncryptionKeySupplier()).thenReturn(keySupplier);
 
-        KafkaDataConfig outputDataConfig = PlaintextKafkaDataConfig.plaintextDataConfig(inputDataConfig);
+        final KafkaDataConfig outputDataConfig = PlaintextKafkaDataConfig.plaintextDataConfig(inputDataConfig);
 
         assertThat(outputDataConfig, notNullValue());
         assertThat(outputDataConfig.getEncryptionKeySupplier(), equalTo(keySupplier));
+    }
+
+    @Test
+    void plaintextDataConfig_returns_KafkaDataConfig_with_getEncryptionKey_returning_from_inner_dataConfig() {
+        final String encryptionKey = UUID.randomUUID().toString();
+        when(inputDataConfig.getEncryptedDataKey()).thenReturn(encryptionKey);
+
+        final KafkaDataConfig outputDataConfig = PlaintextKafkaDataConfig.plaintextDataConfig(inputDataConfig);
+
+        assertThat(outputDataConfig, notNullValue());
+        assertThat(outputDataConfig.getEncryptedDataKey(), equalTo(encryptionKey));
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/key/KeyFactoryTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/key/KeyFactoryTest.java
@@ -62,4 +62,35 @@ class KeyFactoryTest {
         InnerKeyProvider lastKeyProvider = innerKeyProviders.get(2);
         verifyNoInteractions(lastKeyProvider);
     }
+
+    @Test
+    void getEncryptedDataKey_returns_null_if_encryptionKey_is_null() {
+        assertThat(createObjectUnderTest().getEncryptedDataKey(topicConfig),
+                nullValue());
+    }
+
+    @Test
+    void getEncryptedDataKey_returns_null_if_encryptionKey_is_present_and_innerKeyProvider_indicates_unencrypted_data_key() {
+        when(topicConfig.getEncryptionKey()).thenReturn(UUID.randomUUID().toString());
+
+        final InnerKeyProvider middleKeyProvider = innerKeyProviders.get(1);
+        when(middleKeyProvider.supportsConfiguration(topicConfig)).thenReturn(true);
+        when(middleKeyProvider.isKeyEncrypted()).thenReturn(false);
+
+        assertThat(createObjectUnderTest().getEncryptedDataKey(topicConfig),
+                nullValue());
+    }
+
+    @Test
+    void getEncryptedDataKey_returns_null_if_encryptionKey_is_present_and_innerKeyProvider_indicates_encrypted_data_key() {
+        final String encryptionKey = UUID.randomUUID().toString();
+        when(topicConfig.getEncryptionKey()).thenReturn(encryptionKey);
+
+        final InnerKeyProvider middleKeyProvider = innerKeyProviders.get(1);
+        when(middleKeyProvider.supportsConfiguration(topicConfig)).thenReturn(true);
+        when(middleKeyProvider.isKeyEncrypted()).thenReturn(true);
+
+        assertThat(createObjectUnderTest().getEncryptedDataKey(topicConfig),
+                equalTo(encryptionKey));
+    }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/key/KmsKeyProviderTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/key/KmsKeyProviderTest.java
@@ -185,4 +185,9 @@ class KmsKeyProviderTest {
             verify(builder).encryptionContext(encryptionContext);
         }
     }
+
+    @Test
+    void isKeyEncrypted_returns_true() {
+        assertThat(createObjectUnderTest().isKeyEncrypted(), equalTo(true));
+    }
 }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/key/UnencryptedKeyProviderTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/common/key/UnencryptedKeyProviderTest.java
@@ -39,4 +39,9 @@ class UnencryptedKeyProviderTest {
         assertThat(actualBytes, notNullValue());
         assertThat(actualBytes, equalTo(unencodedInput.getBytes()));
     }
+
+    @Test
+    void isKeyEncrypted_returns_true() {
+        assertThat(createObjectUnderTest().isKeyEncrypted(), equalTo(false));
+    }
 }


### PR DESCRIPTION
### Description

When writing Kafka buffer events, save additional information about the encryption in the protobuf record.

This adds two new fields to the Protobuf message:
* `encrypted`
* `encrypted_data_key`

This work does not include using that data when reading. I plan to do that in a follow-on PR, but want to keep the PRs from getting too large.
 
### Issues Resolved

Contributes toward #3655.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
