### PR TITLE
Mark the EventHandle as transient to fix serialization

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -68,7 +69,7 @@ public class JacksonEvent implements Event {
 
     private final EventMetadata eventMetadata;
 
-    private EventHandle eventHandle;
+    private transient EventHandle eventHandle;
 
     private final JsonNode jsonNode;
 
@@ -657,7 +658,17 @@ public class JacksonEvent implements Event {
 
             }
         }
+    }
 
-
+    /**
+     * Provides custom Java object deserialization.
+     *
+     * @param objectInputStream The {@link ObjectInputStream} to deserialize from
+     * @throws IOException if an I/O error occurs
+     * @throws ClassNotFoundException if the class of a serialized object could not be found
+     */
+    private void readObject(final ObjectInputStream objectInputStream) throws IOException, ClassNotFoundException {
+        objectInputStream.defaultReadObject();
+        this.eventHandle = new DefaultEventHandle(eventMetadata.getTimeReceived());
     }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEvent_JavaSerializationTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEvent_JavaSerializationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+
+class JacksonEvent_JavaSerializationTest {
+
+    private ObjectOutputStream objectOutputStream;
+    private ByteArrayOutputStream byteArrayOutputStream;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        byteArrayOutputStream = new ByteArrayOutputStream(1000);
+        objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
+    }
+
+    private JacksonEvent createObjectUnderTest() {
+        return JacksonEvent.builder()
+                .withEventType("TEST")
+                .withData(Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString()))
+                .build();
+    }
+
+    @Test
+    void serialize_without_acknowledgementSet_includes_data() throws IOException, ClassNotFoundException {
+        final JacksonEvent objectUnderTest = createObjectUnderTest();
+
+        final Object deserializedObject = serializeAndDeserialize(objectUnderTest);
+
+        assertThat(deserializedObject, instanceOf(JacksonEvent.class));
+        final JacksonEvent deserializedEvent = (JacksonEvent) deserializedObject;
+
+        assertThat(deserializedEvent.toMap(), equalTo(objectUnderTest.toMap()));
+        assertThat(deserializedEvent.getMetadata(), equalTo(objectUnderTest.getMetadata()));
+
+        assertThat(deserializedEvent.getEventHandle(), instanceOf(InternalEventHandle.class));
+        assertThat(((InternalEventHandle) deserializedEvent.getEventHandle()).getAcknowledgementSet(), nullValue());
+        assertThat(deserializedEvent.getEventHandle().getInternalOriginationTime(), equalTo(objectUnderTest.getMetadata().getTimeReceived()));
+
+    }
+
+    @Test
+    void serialize_with_acknowledgementSet_does_not_include_old_acknowledgement_set() throws IOException, ClassNotFoundException {
+        final JacksonEvent objectUnderTest = createObjectUnderTest();
+        final InternalEventHandle internalEventHandle = (InternalEventHandle) objectUnderTest.getEventHandle();
+        internalEventHandle.setAcknowledgementSet(mock(AcknowledgementSet.class));
+
+        final Object deserializedObject = serializeAndDeserialize(objectUnderTest);
+
+        assertThat(deserializedObject, instanceOf(JacksonEvent.class));
+        final JacksonEvent deserializedEvent = (JacksonEvent) deserializedObject;
+
+        assertThat(deserializedEvent.toMap(), equalTo(objectUnderTest.toMap()));
+        assertThat(deserializedEvent.getMetadata(), equalTo(objectUnderTest.getMetadata()));
+
+        assertThat(deserializedEvent.getEventHandle(), instanceOf(InternalEventHandle.class));
+        assertThat(((InternalEventHandle) deserializedEvent.getEventHandle()).getAcknowledgementSet(), nullValue());
+        assertThat(deserializedEvent.getEventHandle().getInternalOriginationTime(), equalTo(objectUnderTest.getMetadata().getTimeReceived()));
+    }
+
+    private Object serializeAndDeserialize(final JacksonEvent objectUnderTest) throws IOException, ClassNotFoundException {
+        objectOutputStream.writeObject(objectUnderTest);
+        final ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(byteArrayOutputStream.toByteArray()));
+        return objectInputStream.readObject();
+    }
+
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/codec/JavaPeerForwarderCodecTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/codec/JavaPeerForwarderCodecTest.java
@@ -2,7 +2,9 @@ package org.opensearch.dataprepper.peerforwarder.codec;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.InternalEventHandle;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.log.JacksonLog;
 import org.opensearch.dataprepper.peerforwarder.model.PeerForwardingEvents;
@@ -54,6 +56,24 @@ class JavaPeerForwarderCodecTest {
         when(objectInputFilter.checkInput(any(ObjectInputFilter.FilterInfo.class))).thenReturn(ObjectInputFilter.Status.ALLOWED);
 
         final PeerForwardingEvents inputEvents = generatePeerForwardingEvents(2);
+        final byte[] bytes = createObjectUnderTest().serialize(inputEvents);
+        final PeerForwardingEvents outputEvents = createObjectUnderTest().deserialize(bytes);
+        assertThat(outputEvents.getDestinationPipelineName(), equalTo(inputEvents.getDestinationPipelineName()));
+        assertThat(outputEvents.getDestinationPluginId(), equalTo(inputEvents.getDestinationPluginId()));
+        assertThat(outputEvents.getEvents().size(), equalTo(inputEvents.getEvents().size()));
+
+        verify(objectInputFilter, atLeast(1)).checkInput(any(ObjectInputFilter.FilterInfo.class));
+    }
+
+    @Test
+    void testCodec_with_acknowledgementSet() throws IOException, ClassNotFoundException {
+        when(objectInputFilter.checkInput(any(ObjectInputFilter.FilterInfo.class))).thenReturn(ObjectInputFilter.Status.ALLOWED);
+
+        final PeerForwardingEvents inputEvents = generatePeerForwardingEvents(2);
+        inputEvents.getEvents().stream()
+                .map(Event::getEventHandle)
+                .map(handle -> (InternalEventHandle)handle)
+                .forEach(handle -> handle.setAcknowledgementSet(mock(AcknowledgementSet.class)));
         final byte[] bytes = createObjectUnderTest().serialize(inputEvents);
         final PeerForwardingEvents outputEvents = createObjectUnderTest().deserialize(bytes);
         assertThat(outputEvents.getDestinationPipelineName(), equalTo(inputEvents.getDestinationPipelineName()));


### PR DESCRIPTION
### Description

This PR marks the `eventHandle` field in `JacksonEvent` as `transient`. Re-create it by adding a `readObject()` method.

I added two different tests. Each one failed before making the change.
 
### Issues Resolved

Resolves #3981
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
