### PR TITLE
Use the official unit string for the 'b' in ByteCount::toString()

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/types/ByteCount.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/types/ByteCount.java
@@ -163,6 +163,6 @@ public class ByteCount {
      */
     @Override
     public String toString() {
-        return bytes + "b";
+        return bytes + Unit.BYTE.unitString;
     }
 }


### PR DESCRIPTION
### Description

Use the single source of truth for the byte unit in `ByteCount`.

Responding to a PR comment:

https://github.com/opensearch-project/data-prepper/pull/3960/files#r1459600545
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
