### PR TITLE
Otel metrics fix

### DIFF
--- a/data-prepper-plugins/otel-proto-common/src/test/resources/test-histogram-metrics-no-explicit-bounds.json
+++ b/data-prepper-plugins/otel-proto-common/src/test/resources/test-histogram-metrics-no-explicit-bounds.json
@@ -1,0 +1,51 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "resource-attr",
+            "value": {
+              "stringValue": "resource-attr-val-1"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {},
+          "metrics": [
+            {
+              "name": "histogram-int",
+              "unit": 1,
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "label-1",
+                        "value": {
+                          "stringValue": "label-value-1"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "1581452773000000789",
+                    "timeUnixNano": "1581452773000000789",
+                    "count": "30",
+                    "sum": "100",
+                    "bucket_counts": [10],
+                    "explicit_bounds": [],
+                    "exemplars": []
+                  }
+                ],
+                "aggregationTemporality":"2"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+


### PR DESCRIPTION
### Description
OTEL histograms may contain  bucket counts list with just one entry with no explicit bounds specified. This can cause the current code to not handle it correctly. When the explicit bounds array is empty, -infinity and +infinity should be used as bounds.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
