### PR TITLE
Log when Data Prepper is shutdown via the HTTP shutdown endpoint.

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandler.java
@@ -5,20 +5,20 @@
 
 package org.opensearch.dataprepper.pipeline.server;
 
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
 import org.opensearch.dataprepper.DataPrepper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.ws.rs.HttpMethod;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * HttpHandler to handle requests to shut down the data prepper instance
  */
 public class ShutdownHandler implements HttpHandler {
-
     private final DataPrepper dataPrepper;
     private static final Logger LOG = LoggerFactory.getLogger(ShutdownHandler.class);
 
@@ -27,8 +27,8 @@ public class ShutdownHandler implements HttpHandler {
     }
 
     @Override
-    public void handle(HttpExchange exchange) throws IOException {
-        String requestMethod = exchange.getRequestMethod();
+    public void handle(final HttpExchange exchange) throws IOException {
+        final String requestMethod = exchange.getRequestMethod();
         if (!requestMethod.equals(HttpMethod.POST)) {
             exchange.sendResponseHeaders(HttpURLConnection.HTTP_BAD_METHOD, 0);
             exchange.getResponseBody().close();
@@ -36,9 +36,10 @@ public class ShutdownHandler implements HttpHandler {
         }
 
         try {
+            LOG.info("Received HTTP shutdown request to shutdown Data Prepper. Shutdown pipelines and server.");
             dataPrepper.shutdownPipelines();
             exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             LOG.error("Caught exception shutting down data prepper", e);
             exchange.sendResponseHeaders(HttpURLConnection.HTTP_INTERNAL_ERROR, 0);
         } finally {


### PR DESCRIPTION
### Description

Right now, it can be unclear why Data Prepper is shutting down. This adds a log when the `POST /shutdown` API begins shutting down Data Prepper.
 
### Issues Resolved

Related to: #3986
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
