### PR TITLE
Added ByteCount to plugin parser

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ObjectMapperConfiguration.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/plugin/ObjectMapperConfiguration.java
@@ -25,6 +25,7 @@ public class ObjectMapperConfiguration {
     ObjectMapper extensionPluginConfigObjectMapper() {
         final SimpleModule simpleModule = new SimpleModule();
         simpleModule.addDeserializer(Duration.class, new DataPrepperDurationDeserializer());
+        simpleModule.addDeserializer(ByteCount.class, new ByteCountDeserializer());
 
         return new ObjectMapper()
                 .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)


### PR DESCRIPTION
### Description
Support ByteCount in plugin parser.
No tests were required because jacoco shows that this is covered.
<img width="872" alt="Screenshot 2024-01-23 at 11 36 43 AM" src="https://github.com/opensearch-project/data-prepper/assets/29149268/add5e151-e297-4b0e-97fc-603cd41d26de">

 
### Issues Resolved
Resolves https://github.com/opensearch-project/data-prepper/issues/3191
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
