### PR TITLE
Aggregator processor should evaluate aggregate_when condition before forwarding events to remote peer

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwarding.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwarding.java
@@ -22,13 +22,13 @@ public interface RequiresPeerForwarding {
     Collection<String> getIdentificationKeys();
 
     /**
-     * Returns events that are applicable for peer forwarding.
+     * Determines if an event should be forwarded to the remote peer
      *
-     * @param records collection of input records
+     * @param event input event
      *
-     * @return a collection of output records
+     * @return true if the event should be forwarded to the peer
      */
-    default Collection<Record<Event>> applicableEventsForPeerForwarding(Collection<Record<Event>> records) {
-        return records;
+    default boolean isApplicableEventForPeerForwarding(Event event) {
+        return true;
     }
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwarding.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwarding.java
@@ -4,6 +4,8 @@
  */
 
 package org.opensearch.dataprepper.model.peerforwarder;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.Collection;
 
@@ -18,4 +20,15 @@ public interface RequiresPeerForwarding {
      * @return A set of keys
      */
     Collection<String> getIdentificationKeys();
+
+    /**
+     * Returns events that are applicable for peer forwarding.
+     *
+     * @param records collection of input records
+     *
+     * @return a collection of output records
+     */
+    default Collection<Record<Event>> applicableEventsForPeerForwarding(Collection<Record<Event>> records) {
+        return records;
+    }
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwarding.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwarding.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.dataprepper.model.peerforwarder;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.Collection;
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwardingTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwardingTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.peerforwarder;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.event.Event;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collection;
+
+class RequiresPeerForwardingTest {
+
+    public class SimpleRequiresPeerForwarding implements RequiresPeerForwarding {
+        @Override
+        public Collection<String> getIdentificationKeys() {
+            return null;
+        }
+    }
+
+    @Test
+    void testRequiresPeerForwardingTest() {
+        Collection<Record<Event>> records = mock(Collection.class);
+        RequiresPeerForwarding requiresPeerForwarding = new SimpleRequiresPeerForwarding();
+        assertThat(requiresPeerForwarding.applicableEventsForPeerForwarding(records), equalTo(records));
+    }
+}
+
+

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwardingTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwardingTest.java
@@ -6,7 +6,6 @@
 package org.opensearch.dataprepper.model.peerforwarder;
 
 import org.junit.jupiter.api.Test;
-import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.event.Event;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -25,9 +24,9 @@ class RequiresPeerForwardingTest {
 
     @Test
     void testRequiresPeerForwardingTest() {
-        Collection<Record<Event>> records = mock(Collection.class);
+        Event event = mock(Event.class);
         RequiresPeerForwarding requiresPeerForwarding = new SimpleRequiresPeerForwarding();
-        assertThat(requiresPeerForwarding.applicableEventsForPeerForwarding(records), equalTo(records));
+        assertThat(requiresPeerForwarding.isApplicableEventForPeerForwarding(event), equalTo(true));
     }
 }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
@@ -82,17 +82,13 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
     public Collection<Record<Event>> execute(final Collection<Record<Event>> records) {
         final Collection<Record<Event>> recordsToProcess = new ArrayList<>();
         final Collection<Record<Event>> recordsSkipped = new ArrayList<>();
-        System.out.println("_____0____"+records.size());
         for (Record<Event> record: records) {
             if (((RequiresPeerForwarding)innerProcessor).isApplicableEventForPeerForwarding(record.getData())) {
-                System.out.println("_____1____"+record.getData().toJsonString());
                 recordsToProcess.add(record);
             } else {
-                System.out.println("_____2____"+record.getData().toJsonString());
                 recordsSkipped.add(record);
             }
         }
-        System.out.println("_____3____"+records.size());
         final Collection<Record<Event>> recordsToProcessOnLocalPeer = peerForwarder.forwardRecords(recordsToProcess);
 
         final Collection<Record<Event>> receivedRecordsFromBuffer = peerForwarder.receiveRecords();
@@ -101,7 +97,6 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
                 recordsToProcessOnLocalPeer, receivedRecordsFromBuffer);
 
         Collection<Record<Event>> recordsOut = innerProcessor.execute(recordsToProcessLocally);
-        System.out.println("====="+recordsOut+"====="+recordsSkipped);
         recordsOut.addAll(recordsSkipped);
         return recordsOut;
     }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
@@ -82,13 +82,17 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
     public Collection<Record<Event>> execute(final Collection<Record<Event>> records) {
         final Collection<Record<Event>> recordsToProcess = new ArrayList<>();
         final Collection<Record<Event>> recordsSkipped = new ArrayList<>();
+        System.out.println("_____0____"+records.size());
         for (Record<Event> record: records) {
             if (((RequiresPeerForwarding)innerProcessor).isApplicableEventForPeerForwarding(record.getData())) {
+                System.out.println("_____1____"+record.getData().toJsonString());
                 recordsToProcess.add(record);
             } else {
+                System.out.println("_____2____"+record.getData().toJsonString());
                 recordsSkipped.add(record);
             }
         }
+        System.out.println("_____3____"+records.size());
         final Collection<Record<Event>> recordsToProcessOnLocalPeer = peerForwarder.forwardRecords(recordsToProcess);
 
         final Collection<Record<Event>> receivedRecordsFromBuffer = peerForwarder.receiveRecords();
@@ -97,6 +101,7 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
                 recordsToProcessOnLocalPeer, receivedRecordsFromBuffer);
 
         Collection<Record<Event>> recordsOut = innerProcessor.execute(recordsToProcessLocally);
+        System.out.println("====="+recordsOut+"====="+recordsSkipped);
         recordsOut.addAll(recordsSkipped);
         return recordsOut;
     }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
@@ -15,6 +15,7 @@ import org.opensearch.dataprepper.peerforwarder.exception.UnsupportedPeerForward
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -79,7 +80,9 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
 
     @Override
     public Collection<Record<Event>> execute(final Collection<Record<Event>> records) {
-        final Collection<Record<Event>> recordsToProcessOnLocalPeer = peerForwarder.forwardRecords(records);
+        final Collection<Record<Event>> recordsToProcess = ((RequiresPeerForwarding)innerProcessor).applicableEventsForPeerForwarding(records);
+        final Collection<Record<Event>> recordsToProcessOnLocalPeer = peerForwarder.forwardRecords(recordsToProcess);
+
         final Collection<Record<Event>> receivedRecordsFromBuffer = peerForwarder.receiveRecords();
 
         final Collection<Record<Event>> recordsToProcessLocally = CollectionUtils.union(

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/ProcessWorker.java
@@ -93,8 +93,8 @@ public class ProcessWorker implements Runnable {
         }
     }
 
-    private void processAcknowledgements(List<Event> inputEvents, Collection outputRecords) {
-        Set<Event> outputEventsSet = ((ArrayList<Record<Event>>)outputRecords).stream().map(Record::getData).collect(Collectors.toSet());
+    private void processAcknowledgements(List<Event> inputEvents, Collection<Record<Event>> outputRecords) {
+        Set<Event> outputEventsSet = outputRecords.stream().map(Record::getData).collect(Collectors.toSet());
         // For each event in the input events list that is not present in the output events, send positive acknowledgement, if acknowledgements are enabled for it
         inputEvents.forEach(event -> {
             EventHandle eventHandle = event.getEventHandle();

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
@@ -129,9 +129,12 @@ class PeerForwardingProcessingDecoratorTest {
 
         @Test
         void PeerForwardingProcessingDecorator_execute_should_forwardRecords_with_correct_values() {
+            Event event = mock(Event.class);
+            when(record.getData()).thenReturn(event);
+            when(requiresPeerForwarding.isApplicableEventForPeerForwarding(event)).thenReturn(true);
             List<Record<Event>> testData = Collections.singletonList(record);
 
-            when(peerForwarder.forwardRecords(testData)).thenReturn(testData);
+            when(peerForwarder.forwardRecords(anyCollection())).thenReturn(testData);
 
             when(processor.execute(testData)).thenReturn(testData);
 
@@ -140,7 +143,7 @@ class PeerForwardingProcessingDecoratorTest {
             final Collection<Record<Event>> records = processors.get(0).execute(testData);
 
             verify(requiresPeerForwarding, times(2)).getIdentificationKeys();
-            verify(peerForwarder).forwardRecords(testData);
+            verify(peerForwarder).forwardRecords(anyCollection());
             Assertions.assertNotNull(records);
             assertThat(records.size(), equalTo(testData.size()));
             assertThat(records, equalTo(testData));
@@ -148,10 +151,13 @@ class PeerForwardingProcessingDecoratorTest {
 
         @Test
         void PeerForwardingProcessingDecorator_execute_should_receiveRecords() {
+            Event event = mock(Event.class);
+            when(record.getData()).thenReturn(event);
+            when(requiresPeerForwarding.isApplicableEventForPeerForwarding(event)).thenReturn(true);
             Collection<Record<Event>> forwardTestData = Collections.singletonList(record);
             Collection<Record<Event>> receiveTestData = Collections.singletonList(mock(Record.class));
 
-            when(peerForwarder.forwardRecords(forwardTestData)).thenReturn(forwardTestData);
+            when(peerForwarder.forwardRecords(anyCollection())).thenReturn(forwardTestData);
             when(peerForwarder.receiveRecords()).thenReturn(receiveTestData);
 
             final Collection<Record<Event>> expectedRecordsToProcessLocally = CollectionUtils.union(forwardTestData, receiveTestData);
@@ -163,7 +169,7 @@ class PeerForwardingProcessingDecoratorTest {
             final Collection<Record<Event>> records = processors.get(0).execute(forwardTestData);
 
             verify(requiresPeerForwarding, times(2)).getIdentificationKeys();
-            verify(peerForwarder).forwardRecords(forwardTestData);
+            verify(peerForwarder).forwardRecords(anyCollection());
             verify(peerForwarder).receiveRecords();
             Assertions.assertNotNull(records);
             assertThat(records.size(), equalTo(expectedRecordsToProcessLocally.size()));
@@ -172,6 +178,9 @@ class PeerForwardingProcessingDecoratorTest {
 
         @Test
         void PeerForwardingProcessingDecorator_execute_will_call_inner_processors_execute() {
+            Event event = mock(Event.class);
+            when(record.getData()).thenReturn(event);
+            when(requiresPeerForwarding.isApplicableEventForPeerForwarding(event)).thenReturn(true);
             final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
             Collection<Record<Event>> testData = Collections.singletonList(record);
 

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -20,7 +20,6 @@ import org.opensearch.dataprepper.model.record.Record;
 import io.micrometer.core.instrument.Counter;
 import org.opensearch.dataprepper.plugins.hasher.IdentificationKeysHasher;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -150,18 +149,11 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
     }
 
     @Override
-    public Collection<Record<Event>> applicableEventsForPeerForwarding(Collection<Record<Event>> records) {
+    public boolean isApplicableEventForPeerForwarding(Event event) {
         if (whenCondition == null) {
-            return records;
+            return true;
         }
-        final Collection<Record<Event>> recordsOut = new ArrayList<>();
-        for (Record<Event> record: records) {
-            Event event = record.getData();
-            if (expressionEvaluator.evaluateConditional(whenCondition, event)) {
-                recordsOut.add(record);
-            }
-        }
-        return recordsOut;
+        return expressionEvaluator.evaluateConditional(whenCondition, event);
     }
 
     @Override

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -20,6 +20,7 @@ import org.opensearch.dataprepper.model.record.Record;
 import io.micrometer.core.instrument.Counter;
 import org.opensearch.dataprepper.plugins.hasher.IdentificationKeysHasher;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -146,6 +147,21 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
     @Override
     public void shutdown() {
 
+    }
+
+    @Override
+    public Collection<Record<Event>> applicableEventsForPeerForwarding(Collection<Record<Event>> records) {
+        if (whenCondition == null) {
+            return records;
+        }
+        final Collection<Record<Event>> recordsOut = new ArrayList<>();
+        for (Record<Event> record: records) {
+            Event event = record.getData();
+            if (expressionEvaluator.evaluateConditional(whenCondition, event)) {
+                recordsOut.add(record);
+            }
+        }
+        return recordsOut;
     }
 
     @Override

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -228,6 +228,8 @@ public class AggregateProcessorTest {
             recordsIn.add(new Record<Event>(secondEvent));
             recordsIn.add(new Record<Event>(event));
             Collection<Record<Event>> c = recordsIn;
+            Collection<Record<Event>> applicableRecords = objectUnderTest.applicableEventsForPeerForwarding(recordsIn);
+            assertThat(applicableRecords.size(), equalTo(2));
             final List<Record<Event>> recordsOut = (List<Record<Event>>) objectUnderTest.doExecute(c);
 
             assertThat(recordsOut.size(), equalTo(2));

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -228,8 +228,9 @@ public class AggregateProcessorTest {
             recordsIn.add(new Record<Event>(secondEvent));
             recordsIn.add(new Record<Event>(event));
             Collection<Record<Event>> c = recordsIn;
-            Collection<Record<Event>> applicableRecords = objectUnderTest.applicableEventsForPeerForwarding(recordsIn);
-            assertThat(applicableRecords.size(), equalTo(2));
+            assertThat(objectUnderTest.isApplicableEventForPeerForwarding(event), equalTo(true));
+            assertThat(objectUnderTest.isApplicableEventForPeerForwarding(firstEvent), equalTo(true));
+            assertThat(objectUnderTest.isApplicableEventForPeerForwarding(secondEvent), equalTo(false));
             final List<Record<Event>> recordsOut = (List<Record<Event>>) objectUnderTest.doExecute(c);
 
             assertThat(recordsOut.size(), equalTo(2));


### PR DESCRIPTION
### Description
Aggregate processor support `aggregate_when` option which may evaluate to false to some events. But the current remote forwarder interface evaluates this condition after an event is forwarded to a remote peer which is unnecessary. The condition can be evaluated locally on a forwarding node before actually forwarding the event.

Modified the remote forwarding interface to allow local evaluation of events before forwarding events to remote peer.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
