### PR TITLE
Updates jline to 3.25.0 to resolve CVE-2023-50572.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,6 +206,12 @@ subprojects {
                 }
                 because 'CVE from transitive dependencies'
             }
+            implementation('org.jline:jline') {
+                version {
+                    require '3.25.0'
+                }
+                because 'CVE-2023-50572'
+            }
             implementation('org.json:json') {
                 version {
                     require '20231013'

--- a/performance-test/build.gradle
+++ b/performance-test/build.gradle
@@ -42,6 +42,12 @@ dependencies {
             }
             because 'Fixes CVE-2023-46122'
         }
+        zinc('org.jline:jline') {
+            version {
+                require '3.25.0'
+            }
+            because 'CVE-2023-50572'
+        }
     }
 }
 


### PR DESCRIPTION
### Description

Updates jline to 3.25.0 to resolve CVE-2023-50572.
 
### Issues Resolved
Resolves #3871
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
