### PR TITLE
Throw a more useful error when the S3 source is unable to determine t…

### DIFF
--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/ownership/ConfigBucketOwnerProviderFactoryTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/ownership/ConfigBucketOwnerProviderFactoryTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.plugins.source.s3.S3SourceConfig;
 import org.opensearch.dataprepper.plugins.source.s3.configuration.AwsAuthenticationOptions;
 import org.opensearch.dataprepper.plugins.source.s3.configuration.SqsOptions;
@@ -20,10 +21,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -86,6 +89,14 @@ class ConfigBucketOwnerProviderFactoryTest {
         assertThat(optionalOwner, notNullValue());
         assertThat(optionalOwner.isPresent(), equalTo(true));
         assertThat(optionalOwner.get(), equalTo(accountId));
+    }
+
+    @Test
+    void createBucketOwnerProvider_throws_exception_when_ownership_cannot_be_determined() {
+        final ConfigBucketOwnerProviderFactory objectUnderTest = createObjectUnderTest();
+        final InvalidPluginConfigurationException actualException = assertThrows(InvalidPluginConfigurationException.class, () -> objectUnderTest.createBucketOwnerProvider(s3SourceConfig));
+
+        assertThat(actualException.getMessage(), containsString("default_bucket_owner"));
     }
 
     @Nested


### PR DESCRIPTION
### Description

I ran a pipeline that performed an S3 scan without an STS role ARN. Data Prepper is unable to run because it can't deduce the bucket ownership automatically. This is expected, but the failure is currently a NullPointerException which users can't benefit from.

This PR catches this case and throws a clearer exception so that users can make an actionable decision.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
