### PR TITLE
Cancel the existing grok task when a timeout occurs

### DIFF
--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
@@ -319,7 +319,12 @@ public class GrokProcessor extends AbstractProcessor<Record<Event>, Record<Event
     }
 
     private void runWithTimeout(final Runnable runnable) throws TimeoutException, ExecutionException, InterruptedException {
-        Future<?> task = executorService.submit(runnable);
-        task.get(grokProcessorConfig.getTimeoutMillis(), TimeUnit.MILLISECONDS);
+        final Future<?> task = executorService.submit(runnable);
+        try {
+            task.get(grokProcessorConfig.getTimeoutMillis(), TimeUnit.MILLISECONDS);
+        } catch (final TimeoutException exception) {
+            task.cancel(true);
+            throw exception;
+        }
     }
 }


### PR DESCRIPTION
### Description

Cancel the existing grok task when a timeout occurs by catching a TimeoutException.
 
### Issues Resolved

Resolves #4026
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
