### PR TITLE
Tag events that fail for all exceptions in the grok processor. Resolves #4031

### DIFF
--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
@@ -131,18 +131,13 @@ public class GrokProcessor extends AbstractProcessor<Record<Event>, Record<Event
                     runWithTimeout(() -> grokProcessingTime.record(() -> matchAndMerge(event)));
                 }
 
-            } catch (TimeoutException e) {
+            } catch (final TimeoutException e) {
+                event.getMetadata().addTags(tagsOnMatchFailure);
                 LOG.error(EVENT, "Matching on record [{}] took longer than [{}] and timed out", record.getData(), grokProcessorConfig.getTimeoutMillis());
                 grokProcessingTimeoutsCounter.increment();
-            } catch (ExecutionException e) {
-                LOG.error(EVENT, "An exception occurred while matching on record [{}]", record.getData(), e);
-                grokProcessingErrorsCounter.increment();
-            } catch (InterruptedException e) {
-                LOG.error(EVENT, "Matching on record [{}] was interrupted", record.getData(), e);
-                grokProcessingErrorsCounter.increment();
-            } catch (RuntimeException e) {
+            } catch (final ExecutionException | InterruptedException | RuntimeException e) {
                 event.getMetadata().addTags(tagsOnMatchFailure);
-                LOG.error(EVENT, "Unknown exception occurred when matching record [{}]", record.getData(), e);
+                LOG.error(EVENT, "An exception occurred when matching record [{}]", record.getData(), e);
                 grokProcessingErrorsCounter.increment();
             }
          }

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
@@ -82,7 +82,7 @@ public class GrokProcessor extends AbstractProcessor<Record<Event>, Record<Event
     private final Set<String> keysToOverwrite;
     private final ExecutorService executorService;
     private final List<String> tagsOnMatchFailure;
-
+    private final List<String> tagsOnTimeout;
     private final ExpressionEvaluator expressionEvaluator;
 
     @DataPrepperPluginConstructor
@@ -99,6 +99,7 @@ public class GrokProcessor extends AbstractProcessor<Record<Event>, Record<Event
         this.executorService = executorService;
         this.expressionEvaluator = expressionEvaluator;
         this.tagsOnMatchFailure = grokProcessorConfig.getTagsOnMatchFailure();
+        this.tagsOnTimeout = grokProcessorConfig.getTagsOnTimeout();
         grokProcessingMatchCounter = pluginMetrics.counter(GROK_PROCESSING_MATCH);
         grokProcessingMismatchCounter = pluginMetrics.counter(GROK_PROCESSING_MISMATCH);
         grokProcessingErrorsCounter = pluginMetrics.counter(GROK_PROCESSING_ERRORS);
@@ -132,7 +133,7 @@ public class GrokProcessor extends AbstractProcessor<Record<Event>, Record<Event
                 }
 
             } catch (final TimeoutException e) {
-                event.getMetadata().addTags(tagsOnMatchFailure);
+                event.getMetadata().addTags(tagsOnTimeout);
                 LOG.error(EVENT, "Matching on record [{}] took longer than [{}] and timed out", record.getData(), grokProcessorConfig.getTimeoutMillis());
                 grokProcessingTimeoutsCounter.increment();
             } catch (final ExecutionException | InterruptedException | RuntimeException e) {

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -72,7 +72,7 @@ public class GrokProcessorConfig {
         this.targetKey = targetKey;
         this.grokWhen = grokWhen;
         this.tagsOnMatchFailure = tagsOnMatchFailure;
-        this.tagsOnTimeout = tagsOnTimeout;
+        this.tagsOnTimeout = tagsOnTimeout.isEmpty() ? tagsOnMatchFailure : tagsOnTimeout;
     }
 
     public static GrokProcessorConfig buildConfig(final PluginSetting pluginSetting) {

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -23,6 +23,7 @@ public class GrokProcessorConfig {
     static final String TARGET_KEY = "target_key";
     static final String GROK_WHEN = "grok_when";
     static final String TAGS_ON_MATCH_FAILURE = "tags_on_match_failure";
+    static final String TAGS_ON_TIMEOUT = "tags_on_timeout";
 
     static final boolean DEFAULT_BREAK_ON_MATCH = true;
     static final boolean DEFAULT_KEEP_EMPTY_CAPTURES = false;
@@ -43,6 +44,7 @@ public class GrokProcessorConfig {
     private final String targetKey;
     private final String grokWhen;
     private final List<String> tagsOnMatchFailure;
+    private final List<String> tagsOnTimeout;
 
     private GrokProcessorConfig(final boolean breakOnMatch,
                                 final boolean keepEmptyCaptures,
@@ -55,7 +57,8 @@ public class GrokProcessorConfig {
                                 final int timeoutMillis,
                                 final String targetKey,
                                 final String grokWhen,
-                                final List<String> tagsOnMatchFailure) {
+                                final List<String> tagsOnMatchFailure,
+                                final List<String> tagsOnTimeout) {
 
         this.breakOnMatch = breakOnMatch;
         this.keepEmptyCaptures = keepEmptyCaptures;
@@ -69,6 +72,7 @@ public class GrokProcessorConfig {
         this.targetKey = targetKey;
         this.grokWhen = grokWhen;
         this.tagsOnMatchFailure = tagsOnMatchFailure;
+        this.tagsOnTimeout = tagsOnTimeout;
     }
 
     public static GrokProcessorConfig buildConfig(final PluginSetting pluginSetting) {
@@ -83,7 +87,8 @@ public class GrokProcessorConfig {
                 pluginSetting.getIntegerOrDefault(TIMEOUT_MILLIS, DEFAULT_TIMEOUT_MILLIS),
                 pluginSetting.getStringOrDefault(TARGET_KEY, DEFAULT_TARGET_KEY),
                 pluginSetting.getStringOrDefault(GROK_WHEN, null),
-                pluginSetting.getTypedList(TAGS_ON_MATCH_FAILURE, String.class));
+                pluginSetting.getTypedList(TAGS_ON_MATCH_FAILURE, String.class),
+                pluginSetting.getTypedList(TAGS_ON_TIMEOUT, String.class));
     }
 
     public boolean isBreakOnMatch() {
@@ -132,4 +137,7 @@ public class GrokProcessorConfig {
         return tagsOnMatchFailure;
     }
 
+    public List<String> getTagsOnTimeout() {
+        return tagsOnTimeout;
+    }
 }

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfigTests.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfigTests.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -148,5 +149,49 @@ public class GrokProcessorConfigTests {
         settings.put(GrokProcessorConfig.TARGET_KEY, targetKey);
 
         return new PluginSetting(PLUGIN_NAME, settings);
+    }
+
+    @Test
+    void getTagsOnMatchFailure_returns_tagOnMatch() {
+        final List<String> tagsOnMatch = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        final GrokProcessorConfig objectUnderTest = GrokProcessorConfig.buildConfig(new PluginSetting(PLUGIN_NAME,
+                Map.of(GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, tagsOnMatch)
+        ));
+
+        assertThat(objectUnderTest.getTagsOnMatchFailure(), equalTo(tagsOnMatch));
+    }
+
+    @Test
+    void getTagsOnTimeout_returns_tagsOnMatch_if_no_tagsOnTimeout() {
+        final List<String> tagsOnMatch = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        final GrokProcessorConfig objectUnderTest = GrokProcessorConfig.buildConfig(new PluginSetting(PLUGIN_NAME,
+                Map.of(GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, tagsOnMatch)
+        ));
+
+        assertThat(objectUnderTest.getTagsOnTimeout(), equalTo(tagsOnMatch));
+    }
+
+    @Test
+    void getTagsOnTimeout_returns_tagsOnTimeout_if_present() {
+        final List<String> tagsOnMatch = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        final List<String> tagsOnTimeout = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        final GrokProcessorConfig objectUnderTest = GrokProcessorConfig.buildConfig(new PluginSetting(PLUGIN_NAME,
+                Map.of(
+                        GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, tagsOnMatch,
+                        GrokProcessorConfig.TAGS_ON_TIMEOUT, tagsOnTimeout
+                )
+        ));
+
+        assertThat(objectUnderTest.getTagsOnTimeout(), equalTo(tagsOnTimeout));
+    }
+
+    @Test
+    void getTagsOnTimeout_returns_tagsOnTimeout_if_present_and_no_tagsOnMatch() {
+        final List<String> tagsOnTimeout = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        final GrokProcessorConfig objectUnderTest = GrokProcessorConfig.buildConfig(new PluginSetting(PLUGIN_NAME,
+                Map.of(GrokProcessorConfig.TAGS_ON_TIMEOUT, tagsOnTimeout)
+        ));
+
+        assertThat(objectUnderTest.getTagsOnTimeout(), equalTo(tagsOnTimeout));
     }
 }

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfigTests.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfigTests.java
@@ -75,6 +75,7 @@ public class GrokProcessorConfigTests {
         assertThat(grokProcessorConfig.getTimeoutMillis(), equalTo(DEFAULT_TIMEOUT_MILLIS));
         assertThat(grokProcessorConfig.getGrokWhen(), equalTo(null));
         assertThat(grokProcessorConfig.getTagsOnMatchFailure(), equalTo(Collections.emptyList()));
+        assertThat(grokProcessorConfig.getTagsOnTimeout(), equalTo(Collections.emptyList()));
     }
 
     @Test

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorTests.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorTests.java
@@ -5,14 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.processor.grok;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.opensearch.dataprepper.expression.ExpressionEvaluator;
-import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
-import org.opensearch.dataprepper.model.record.Record;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,9 +17,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,7 +46,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
@@ -520,12 +520,17 @@ public class GrokProcessorTests {
         class WithTags {
             private String tagOnMatchFailure1;
             private String tagOnMatchFailure2;
+            private String tagOnTimeout1;
+            private String tagOnTimeout2;
 
             @BeforeEach
             void setUp() {
                 tagOnMatchFailure1 = UUID.randomUUID().toString();
                 tagOnMatchFailure2 = UUID.randomUUID().toString();
+                tagOnTimeout1 = UUID.randomUUID().toString();
+                tagOnTimeout2 = UUID.randomUUID().toString();
                 pluginSetting.getSettings().put(GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, List.of(tagOnMatchFailure1, tagOnMatchFailure2));
+                pluginSetting.getSettings().put(GrokProcessorConfig.TAGS_ON_TIMEOUT, List.of(tagOnTimeout1, tagOnTimeout2));
             }
 
             @Test
@@ -543,8 +548,10 @@ public class GrokProcessorTests {
                 assertThat(grokkedRecords.size(), equalTo(1));
                 assertThat(grokkedRecords.get(0), notNullValue());
                 assertRecordsAreEqual(grokkedRecords.get(0), record);
-                assertTrue(((Event) record.getData()).getMetadata().getTags().contains(tagOnMatchFailure1));
-                assertTrue(((Event) record.getData()).getMetadata().getTags().contains(tagOnMatchFailure2));
+                assertThat(record.getData().getMetadata().getTags(), hasItem(tagOnMatchFailure1));
+                assertThat(record.getData().getMetadata().getTags(), hasItem(tagOnMatchFailure2));
+                assertThat(record.getData().getMetadata().getTags(), not(hasItem(tagOnTimeout1)));
+                assertThat(record.getData().getMetadata().getTags(), not(hasItem(tagOnTimeout2)));
                 verify(grokProcessingMismatchCounter, times(1)).increment();
                 verify(grokProcessingTime, times(1)).record(any(Runnable.class));
                 verifyNoInteractions(grokProcessingErrorsCounter, grokProcessingMatchCounter, grokProcessingTimeoutsCounter);
@@ -569,8 +576,10 @@ public class GrokProcessorTests {
                 assertThat(grokkedRecords.size(), equalTo(1));
                 assertThat(grokkedRecords.get(0), notNullValue());
                 assertRecordsAreEqual(grokkedRecords.get(0), record);
-                assertThat(record.getData().getMetadata().getTags(), hasItem(tagOnMatchFailure1));
-                assertThat(record.getData().getMetadata().getTags(), hasItem(tagOnMatchFailure2));
+                assertThat(record.getData().getMetadata().getTags(), hasItem(tagOnTimeout1));
+                assertThat(record.getData().getMetadata().getTags(), hasItem(tagOnTimeout2));
+                assertThat(record.getData().getMetadata().getTags(), not(hasItem(tagOnMatchFailure1)));
+                assertThat(record.getData().getMetadata().getTags(), not(hasItem(tagOnMatchFailure2)));
                 verify(grokProcessingTimeoutsCounter, times(1)).increment();
                 verify(grokProcessingTime, times(1)).record(any(Runnable.class));
                 verifyNoInteractions(grokProcessingErrorsCounter, grokProcessingMismatchCounter);

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorTests.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorTests.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.dataprepper.plugins.processor.grok;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
@@ -41,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -513,30 +516,92 @@ public class GrokProcessorTests {
             verifyNoInteractions(grokProcessingErrorsCounter, grokProcessingMatchCounter, grokProcessingTimeoutsCounter);
         }
 
-        @Test
-        public void testNoCapturesWithTag() throws JsonProcessingException {
-            final String tagOnMatchFailure1 = UUID.randomUUID().toString();
-            final String tagOnMatchFailure2 = UUID.randomUUID().toString();
-            pluginSetting.getSettings().put(GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, List.of(tagOnMatchFailure1, tagOnMatchFailure2));
+        @Nested
+        class WithTags {
+            private String tagOnMatchFailure1;
+            private String tagOnMatchFailure2;
 
-            grokProcessor = createObjectUnderTest();
-            lenient().when(grokSecondMatch.match(messageInput)).thenReturn(secondMatch);
-            lenient().when(secondMatch.capture()).thenReturn(secondCapture);
+            @BeforeEach
+            void setUp() {
+                tagOnMatchFailure1 = UUID.randomUUID().toString();
+                tagOnMatchFailure2 = UUID.randomUUID().toString();
+                pluginSetting.getSettings().put(GrokProcessorConfig.TAGS_ON_MATCH_FAILURE, List.of(tagOnMatchFailure1, tagOnMatchFailure2));
+            }
 
-            final Map<String, Object> testData = new HashMap();
-            testData.put("message", messageInput);
-            final Record<Event> record = buildRecordWithEvent(testData);
+            @Test
+            public void testNoCapturesWithTag() throws JsonProcessingException {
+                grokProcessor = createObjectUnderTest();
+                lenient().when(grokSecondMatch.match(messageInput)).thenReturn(secondMatch);
+                lenient().when(secondMatch.capture()).thenReturn(secondCapture);
 
-            final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+                final Map<String, Object> testData = new HashMap();
+                testData.put("message", messageInput);
+                final Record<Event> record = buildRecordWithEvent(testData);
 
-            assertThat(grokkedRecords.size(), equalTo(1));
-            assertThat(grokkedRecords.get(0), notNullValue());
-            assertRecordsAreEqual(grokkedRecords.get(0), record);
-            assertTrue(((Event)record.getData()).getMetadata().getTags().contains(tagOnMatchFailure1));
-            assertTrue(((Event)record.getData()).getMetadata().getTags().contains(tagOnMatchFailure2));
-            verify(grokProcessingMismatchCounter, times(1)).increment();
-            verify(grokProcessingTime, times(1)).record(any(Runnable.class));
-            verifyNoInteractions(grokProcessingErrorsCounter, grokProcessingMatchCounter, grokProcessingTimeoutsCounter);
+                final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+
+                assertThat(grokkedRecords.size(), equalTo(1));
+                assertThat(grokkedRecords.get(0), notNullValue());
+                assertRecordsAreEqual(grokkedRecords.get(0), record);
+                assertTrue(((Event) record.getData()).getMetadata().getTags().contains(tagOnMatchFailure1));
+                assertTrue(((Event) record.getData()).getMetadata().getTags().contains(tagOnMatchFailure2));
+                verify(grokProcessingMismatchCounter, times(1)).increment();
+                verify(grokProcessingTime, times(1)).record(any(Runnable.class));
+                verifyNoInteractions(grokProcessingErrorsCounter, grokProcessingMatchCounter, grokProcessingTimeoutsCounter);
+            }
+
+            @Test
+            public void timeout_exception_tags_the_event() throws JsonProcessingException, TimeoutException, ExecutionException, InterruptedException {
+                when(task.get(GrokProcessorConfig.DEFAULT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).thenThrow(TimeoutException.class);
+
+                grokProcessor = createObjectUnderTest();
+
+                capture.put("key_capture_1", "value_capture_1");
+                capture.put("key_capture_2", "value_capture_2");
+                capture.put("key_capture_3", "value_capture_3");
+
+                final Map<String, Object> testData = new HashMap();
+                testData.put("message", messageInput);
+                final Record<Event> record = buildRecordWithEvent(testData);
+
+                final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+
+                assertThat(grokkedRecords.size(), equalTo(1));
+                assertThat(grokkedRecords.get(0), notNullValue());
+                assertRecordsAreEqual(grokkedRecords.get(0), record);
+                assertThat(record.getData().getMetadata().getTags(), hasItem(tagOnMatchFailure1));
+                assertThat(record.getData().getMetadata().getTags(), hasItem(tagOnMatchFailure2));
+                verify(grokProcessingTimeoutsCounter, times(1)).increment();
+                verify(grokProcessingTime, times(1)).record(any(Runnable.class));
+                verifyNoInteractions(grokProcessingErrorsCounter, grokProcessingMismatchCounter);
+            }
+
+            @ParameterizedTest
+            @ValueSource(classes = {ExecutionException.class, InterruptedException.class, RuntimeException.class})
+            public void execution_exception_tags_the_event(Class<Exception> exceptionClass) throws JsonProcessingException, TimeoutException, ExecutionException, InterruptedException {
+                when(task.get(GrokProcessorConfig.DEFAULT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).thenThrow(exceptionClass);
+
+                grokProcessor = createObjectUnderTest();
+
+                capture.put("key_capture_1", "value_capture_1");
+                capture.put("key_capture_2", "value_capture_2");
+                capture.put("key_capture_3", "value_capture_3");
+
+                final Map<String, Object> testData = new HashMap();
+                testData.put("message", messageInput);
+                final Record<Event> record = buildRecordWithEvent(testData);
+
+                final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+
+                assertThat(grokkedRecords.size(), equalTo(1));
+                assertThat(grokkedRecords.get(0), notNullValue());
+                assertRecordsAreEqual(grokkedRecords.get(0), record);
+                assertThat(record.getData().getMetadata().getTags(), hasItem(tagOnMatchFailure1));
+                assertThat(record.getData().getMetadata().getTags(), hasItem(tagOnMatchFailure2));
+                verify(grokProcessingErrorsCounter, times(1)).increment();
+                verify(grokProcessingTime, times(1)).record(any(Runnable.class));
+                verifyNoInteractions(grokProcessingTimeoutsCounter, grokProcessingMismatchCounter);
+            }
         }
 
         @Test


### PR DESCRIPTION
### Description

This PR tags events for all exceptions in the grok processor. This includes timeout exceptions and other runtime exceptions that the processor catches as it will still send those events further through the pipeline.

I also consolidated the exception handling. The error messages for exceptions other than timeouts do not seem to need different wording as they all will include the actual exception. Also, an "unknown exception" might seem confusing to a user, especially since it is handled the same as the "known" exceptions.
 
### Issues Resolved

Resolves #4031
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
