### PR TITLE
Enhancements to map_to_list processor

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -83,6 +83,12 @@ public class JacksonEventTest {
     }
 
     @Test
+    public void testPutKeyCannotBeEmptyString() {
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> event.put("", "value"));
+        assertThat(exception.getMessage(), containsStringIgnoringCase("key cannot be an empty string"));
+    }
+
+    @Test
     public void testPutAndGet_withMultLevelKey() {
         final String key = "foo/bar";
         final UUID value = UUID.randomUUID();

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -740,8 +740,7 @@ public class JacksonEventTest {
         // Include Keys must start with / and also ordered, This is pre-processed in SinkModel
         List<String> includeKeys1 = Arrays.asList("foo", "info");
         final String expectedJsonString1 = "{\"foo\":\"bar\",\"info\":{\"name\":\"hello\",\"foo\":\"bar\"}}";
-        final Event.JsonStringBuilder temp = event.jsonBuilder().rootKey(null).includeKeys(includeKeys1);
-        assertThat(temp.toJsonString(), equalTo(expectedJsonString1));
+        assertThat(event.jsonBuilder().rootKey(null).includeKeys(includeKeys1).toJsonString(), equalTo(expectedJsonString1));
 
         // Test child node
         List<String> includeKeys2 = Arrays.asList("foo", "info/name");

--- a/data-prepper-plugins/mutate-event-processors/README.md
+++ b/data-prepper-plugins/mutate-event-processors/README.md
@@ -541,6 +541,32 @@ The processed event will have the following data:
 }
 ```
 
+If we enable `convert_field_to_list` option:
+```yaml
+...
+processor:
+  - map_to_list:
+      source: "my-map"
+      target: "my-list"
+      convert_field_to_list: true
+...
+```
+the processed event will have the following data:
+```json
+{
+  "my-list": [
+    ["key1", "value1"],
+    ["key2", "value2"],
+    ["key3", "value3"]
+  ],
+  "my-map": {
+    "key1": "value1",
+    "key2": "value2",
+    "key3": "value3"
+  }
+}
+```
+
 ### Configuration
 * `source` - (required): the source map to perform the operation
 * `target` - (required): the target list to put the converted list
@@ -549,6 +575,8 @@ The processed event will have the following data:
 * `exclude_keys` - (optional): the keys in source map that will be excluded from processing, default is empty list
 * `remove_processed_fields` - (optional): default is false; if true, will remove processed fields from source map
 * `map_to_list_when` - (optional): used to configure a condition for event processing based on certain property of the incoming event. Default is null (all events will be processed).
+* `convert_field_to_list` - (optional): default to false; if true, will convert fields to lists instead of objects
+* `tags_on_failure` - (optional): a list of tags to add to event metadata when the event fails to process
 
 
 ## Developer Guide

--- a/data-prepper-plugins/mutate-event-processors/README.md
+++ b/data-prepper-plugins/mutate-event-processors/README.md
@@ -567,8 +567,40 @@ the processed event will have the following data:
 }
 ```
 
+If source is set to empty string (""), it will use the event root as source.
+```yaml
+...
+processor:
+  - map_to_list:
+      source: ""
+      target: "my-list"
+      convert_field_to_list: true
+...
+```
+Input data like this:
+```json
+{
+  "key1": "value1",
+  "key2": "value2",
+  "key3": "value3"
+}
+```
+will end up with this after processing:
+```json
+{
+  "my-list": [
+    ["key1", "value1"],
+    ["key2", "value2"],
+    ["key3", "value3"]
+  ],
+  "key1": "value1",
+  "key2": "value2",
+  "key3": "value3"
+}
+```
+
 ### Configuration
-* `source` - (required): the source map to perform the operation
+* `source` - (required): the source map to perform the operation; If set to empty string (""), it will use the event root as source.
 * `target` - (required): the target list to put the converted list
 * `key_name` - (optional): the key name of the field to hold the original key, default is "key"
 * `value_name` - (optional): the key name of the field to hold the original value, default is "value"

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessor.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 @DataPrepperPlugin(name = "map_to_list", pluginType = Processor.class, pluginConfigurationType = MapToListProcessorConfig.class)
@@ -88,12 +89,7 @@ public class MapToListProcessor extends AbstractProcessor<Record<Event>, Record<
 
     private Map<String, Object> getSourceMap(Event recordEvent) throws JsonProcessingException {
         final Map<String, Object> sourceMap;
-        if (config.getSource() == null) {
-            // Source is root
-            sourceMap = OBJECT_MAPPER.treeToValue(recordEvent.getJsonNode(), Map.class);
-        } else {
-            sourceMap = recordEvent.get(config.getSource(), Map.class);
-        }
+        sourceMap = recordEvent.get(config.getSource(), Map.class);
         return sourceMap;
     }
 
@@ -102,7 +98,7 @@ public class MapToListProcessor extends AbstractProcessor<Record<Event>, Record<
             return;
         }
 
-        if (config.getSource() == null) {
+        if (Objects.equals(config.getSource(), "")) {
             // Source is root
             for (final Map.Entry<String, Object> entry : sourceMap.entrySet()) {
                 if (excludeKeySet.contains(entry.getKey())) {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessor.java
@@ -83,7 +83,7 @@ public class MapToListProcessor extends AbstractProcessor<Record<Event>, Record<
                 }
             } catch (Exception e) {
                 LOG.error("Fail to perform Map to List operation", e);
-                //TODO: add tagging on failure
+                recordEvent.getMetadata().addTags(config.getTagsOnFailure());
             }
         }
         return records;

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
@@ -18,6 +18,7 @@ public class MapToListProcessorConfig {
     private static final List<String> DEFAULT_EXCLUDE_KEYS = new ArrayList<>();
     private static final boolean DEFAULT_REMOVE_PROCESSED_FIELDS = false;
 
+    @NotNull
     @JsonProperty("source")
     private String source;
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
@@ -18,8 +18,6 @@ public class MapToListProcessorConfig {
     private static final List<String> DEFAULT_EXCLUDE_KEYS = new ArrayList<>();
     private static final boolean DEFAULT_REMOVE_PROCESSED_FIELDS = false;
 
-    @NotEmpty
-    @NotNull
     @JsonProperty("source")
     private String source;
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
@@ -43,6 +43,9 @@ public class MapToListProcessorConfig {
     @JsonProperty("remove_processed_fields")
     private boolean removeProcessedFields = DEFAULT_REMOVE_PROCESSED_FIELDS;
 
+    @JsonProperty("convert_field_to_list")
+    private boolean convertFieldToList = false;
+
     public String getSource() {
         return source;
     }
@@ -69,5 +72,9 @@ public class MapToListProcessorConfig {
 
     public boolean getRemoveProcessedFields() {
         return removeProcessedFields;
+    }
+
+    public boolean getConvertFieldToList() {
+        return convertFieldToList;
     }
 }

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorConfig.java
@@ -46,6 +46,9 @@ public class MapToListProcessorConfig {
     @JsonProperty("convert_field_to_list")
     private boolean convertFieldToList = false;
 
+    @JsonProperty("tags_on_failure")
+    private List<String> tagsOnFailure;
+
     public String getSource() {
         return source;
     }
@@ -76,5 +79,9 @@ public class MapToListProcessorConfig {
 
     public boolean getConvertFieldToList() {
         return convertFieldToList;
+    }
+
+    public List<String> getTagsOnFailure() {
+        return tagsOnFailure;
     }
 }

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorTest.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorTest.java
@@ -96,7 +96,7 @@ class MapToListProcessorTest {
 
     @Test
     void testMapToListSuccessWithRootAsSource() {
-        when(mockConfig.getSource()).thenReturn(null);
+        when(mockConfig.getSource()).thenReturn("");
 
         final MapToListProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createFlatTestRecord();
@@ -176,7 +176,7 @@ class MapToListProcessorTest {
 
     @Test
     void testExcludedKeysAreNotProcessedWithRootAsSource() {
-        when(mockConfig.getSource()).thenReturn(null);
+        when(mockConfig.getSource()).thenReturn("");
         when(mockConfig.getExcludeKeys()).thenReturn(List.of("key1", "key3", "key5"));
 
         final MapToListProcessor processor = createObjectUnderTest();
@@ -220,7 +220,7 @@ class MapToListProcessorTest {
 
     @Test
     void testRemoveProcessedFieldsWithRootAsSource() {
-        when(mockConfig.getSource()).thenReturn(null);
+        when(mockConfig.getSource()).thenReturn("");
         when(mockConfig.getExcludeKeys()).thenReturn(List.of("key1", "key3", "key5"));
         when(mockConfig.getRemoveProcessedFields()).thenReturn(true);
 
@@ -287,7 +287,7 @@ class MapToListProcessorTest {
 
     @Test
     public void testConvertFieldToListSuccessWithRootAsSource() {
-        when(mockConfig.getSource()).thenReturn(null);
+        when(mockConfig.getSource()).thenReturn("");
         when(mockConfig.getConvertFieldToList()).thenReturn(true);
 
         final MapToListProcessor processor = createObjectUnderTest();

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorTest.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/MapToListProcessorTest.java
@@ -48,6 +48,7 @@ class MapToListProcessorTest {
         lenient().when(mockConfig.getMapToListWhen()).thenReturn(null);
         lenient().when(mockConfig.getExcludeKeys()).thenReturn(new ArrayList<>());
         lenient().when(mockConfig.getRemoveProcessedFields()).thenReturn(false);
+        lenient().when(mockConfig.getConvertFieldToList()).thenReturn(false);
     }
 
     @Test
@@ -153,6 +154,28 @@ class MapToListProcessorTest {
         assertThat(resultEvent.containsKey("my-map/key2"), is(false));
         assertThat(resultEvent.containsKey("my-map/key3"), is(true));
         assertThat(resultEvent.get("my-map/key3", String.class), is("value3"));
+    }
+
+    @Test
+    public void testConvertFieldToListSuccess() {
+        when(mockConfig.getConvertFieldToList()).thenReturn(true);
+
+        final MapToListProcessor processor = createObjectUnderTest();
+        final Record<Event> testRecord = createTestRecord();
+        final List<Record<Event>> resultRecord = (List<Record<Event>>) processor.doExecute(Collections.singletonList(testRecord));
+
+        assertThat(resultRecord.size(), is(1));
+
+        final Event resultEvent = resultRecord.get(0).getData();
+        List<List<Object>> resultList = resultEvent.get("my-list", List.class);
+
+        assertThat(resultList.size(), is(3));
+        assertThat(resultList, containsInAnyOrder(
+                List.of("key1", "value1"),
+                List.of("key2", "value2"),
+                List.of("key3", "value3")
+        ));
+        assertSourceMapUnchanged(resultEvent);
     }
 
     @Test


### PR DESCRIPTION
### Description
Adds some enhancements to to map_to_list processor:
- adds a `convert_field_to_list` option. If true, will convert fields to lists (`[key, value]`) instead of objects (`{key: value}`)
- allows source to be root when `source` is not specified
- adds `tags_on_failure` option to add tags when events failed to process
 
### Issues Resolved
Contributes to #3965 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
