### PR TITLE
Enhancements to list_to_map processor

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/README.md
+++ b/data-prepper-plugins/mutate-event-processors/README.md
@@ -485,11 +485,47 @@ the last element will be kept:
 }
 ```
 
+If `use_source_key` and `extract_value` are true:
+```yaml
+    - list_to_map:
+        source: "mylist"
+        use_source_key: true
+        extract_value: true
+```
+we will get:
+```json
+{
+  "mylist": [
+    {
+      "name": "a",
+      "value": "val-a"
+    },
+    {
+      "name": "b",
+      "value": "val-b1"
+    },
+    {
+      "name": "b",
+      "value": "val-b2"
+    },
+    {
+      "name": "c",
+      "value": "val-c"
+    }
+  ],
+  "name": ["a", "b", "b", "c"],
+  "value": ["val-a", "val-b1", "val-b2", "val-c"]
+}
+```
+
 ### Configuration
-* `key` - (required) - The key of the fields that will be extracted as keys in the generated map
+
 * `source` - (required) - The key in the event with a list of objects that will be converted to map
 * `target` - (optional) - The key of the field that will hold the generated map. If not specified, the generated map will be put in the root.
+* `key` - (optional) - The key of the fields that will be extracted as keys in the generated map
+* `use_source_key` - (optional) - A boolean value, default to false. If it's true, will use the source key as is in the result
 * `value_key` - (optional) - If specified, the values of the given `value_key` in the objects of the source list will be extracted and put into the values of the generated map; otherwise, original objects in the source list will be put into the values of the generated map.
+* `extract_value` - (optional) - A boolean value, default to false. It only applies when `use_source_key` is true. If it's true, the value corresponding to the source key will be extracted into the target; otherwise, original objects in the source list will be put into the target.
 * `flatten` - (optional) - A boolean value, default to false. If it's false, the values in the generated map will be lists; if it's true, the lists will be flattened into single items.
 * `flattened_element` - (optional) - Valid options are "first" and "last", default is "first". This specifies which element, first one or last one, to keep if `flatten` option is true.
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
@@ -91,7 +91,7 @@ public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<
         final ObjectNode targetNode = OBJECT_MAPPER.createObjectNode();
         if (sourceNode.isArray()) {
             for (final JsonNode itemNode : sourceNode) {
-                String itemKey = itemNode.get(config.getKey()).asText();
+                String itemKey = config.getKey() == null ? config.getValueKey() : itemNode.get(config.getKey()).asText();
 
                 if (!config.getFlatten()) {
                     final ArrayNode itemValueNode;

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
@@ -55,7 +55,7 @@ public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<
             } catch (final Exception e) {
                 LOG.warn(EVENT, "Given source path [{}] is not valid on record [{}]",
                         config.getSource(), recordEvent, e);
-                //TODO: Add tags on failure
+                recordEvent.getMetadata().addTags(config.getTagsOnFailure());
                 continue;
             }
 
@@ -65,11 +65,11 @@ public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<
             } catch (IllegalArgumentException e) {
                 LOG.warn(EVENT, "Cannot find a list at the given source path [{}} on record [{}]",
                         config.getSource(), recordEvent, e);
-                //TODO: Add tags on failure
+                recordEvent.getMetadata().addTags(config.getTagsOnFailure());
                 continue;
             } catch (final Exception e) {
                 LOG.error(EVENT, "Error converting source list to map on record [{}]", recordEvent, e);
-                //TODO: Add tags on failure
+                recordEvent.getMetadata().addTags(config.getTagsOnFailure());
                 continue;
             }
 
@@ -77,7 +77,7 @@ public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<
                 updateEvent(recordEvent, targetMap);
             } catch (final Exception e) {
                 LOG.error(EVENT, "Error updating record [{}] after converting source list to map", recordEvent, e);
-                //TODO: Add tags on failure
+                recordEvent.getMetadata().addTags(config.getTagsOnFailure());
             }
         }
         return records;

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
@@ -5,11 +5,6 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
@@ -21,7 +16,10 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -30,7 +28,6 @@ import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
 @DataPrepperPlugin(name = "list_to_map", pluginType = Processor.class, pluginConfigurationType = ListToMapProcessorConfig.class)
 public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Logger LOG = LoggerFactory.getLogger(ListToMapProcessor.class);
     private final ListToMapProcessorConfig config;
 
@@ -52,81 +49,73 @@ public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<
                 continue;
             }
 
-            final JsonNode sourceNode;
+            final List<Map<String, Object>> sourceList;
             try {
-                sourceNode = getSourceNode(recordEvent);
+                sourceList = recordEvent.get(config.getSource(), List.class);
             } catch (final Exception e) {
                 LOG.warn(EVENT, "Given source path [{}] is not valid on record [{}]",
                         config.getSource(), recordEvent, e);
+                //TODO: Add tags on failure
                 continue;
             }
 
-            ObjectNode targetNode;
+
+            final Map<String, Object> targetMap;
             try {
-                targetNode = constructTargetNode(sourceNode);
+                targetMap = constructTargetMap(sourceList);
             } catch (IllegalArgumentException e) {
                 LOG.warn(EVENT, "Cannot find a list at the given source path [{}} on record [{}]",
                         config.getSource(), recordEvent, e);
+                //TODO: Add tags on failure
                 continue;
             } catch (final Exception e) {
                 LOG.error(EVENT, "Error converting source list to map on record [{}]", recordEvent, e);
+                //TODO: Add tags on failure
                 continue;
             }
 
             try {
-                updateEvent(recordEvent, targetNode);
+                updateEvent(recordEvent, targetMap);
             } catch (final Exception e) {
                 LOG.error(EVENT, "Error updating record [{}] after converting source list to map", recordEvent, e);
+                //TODO: Add tags on failure
             }
         }
         return records;
     }
 
-    private JsonNode getSourceNode(final Event recordEvent) {
-        final Object sourceObject = recordEvent.get(config.getSource(), Object.class);
-        return OBJECT_MAPPER.convertValue(sourceObject, JsonNode.class);
-    }
-
-    private ObjectNode constructTargetNode(JsonNode sourceNode) {
-        final ObjectNode targetNode = OBJECT_MAPPER.createObjectNode();
-        if (sourceNode.isArray()) {
-            for (final JsonNode itemNode : sourceNode) {
-                String itemKey = config.getKey() == null ? config.getValueKey() : itemNode.get(config.getKey()).asText();
-
-                if (!config.getFlatten()) {
-                    final ArrayNode itemValueNode;
-                    if (!targetNode.has(itemKey)) {
-                        itemValueNode = OBJECT_MAPPER.createArrayNode();
-                        targetNode.set(itemKey, itemValueNode);
-                    } else {
-                        itemValueNode = (ArrayNode) targetNode.get(itemKey);
-                    }
-
-                    if (config.getValueKey() == null) {
-                        itemValueNode.add(itemNode);
-                    } else {
-                        itemValueNode.add(itemNode.get(config.getValueKey()));
-                    }
+    private Map<String, Object> constructTargetMap(final List<Map<String, Object>> sourceList) {
+        Map<String, Object> targetMap = new HashMap<>();
+        for (final Map<String, Object> item : sourceList) {
+            final String itemKey = (String) item.get(config.getKey());
+            if (!config.getFlatten()) {
+                final List<Object> itemValue;
+                if (!targetMap.containsKey(itemKey)) {
+                    itemValue = new ArrayList<>();
+                    targetMap.put((String)item.get(config.getKey()), itemValue);
                 } else {
-                    if (!targetNode.has(itemKey) || config.getFlattenedElement() == ListToMapProcessorConfig.FlattenedElement.LAST) {
-                        if (config.getValueKey() == null) {
-                            targetNode.set(itemKey, itemNode);
-                        } else  {
-                            targetNode.set(itemKey, itemNode.get(config.getValueKey()));
-                        }
+                    itemValue = (List<Object>) targetMap.get(itemKey);
+                }
+
+                if (config.getValueKey() == null) {
+                    itemValue.add(item);
+                } else {
+                    itemValue.add(item.get(config.getValueKey()));
+                }
+            } else {
+                if (!targetMap.containsKey(itemKey) || config.getFlattenedElement() == ListToMapProcessorConfig.FlattenedElement.LAST) {
+                    if (config.getValueKey() == null) {
+                        targetMap.put(itemKey, item);
+                    } else  {
+                        targetMap.put(itemKey, item.get(config.getValueKey()));
                     }
                 }
             }
-        } else {
-            throw new IllegalArgumentException("Cannot find a list at the given source path [{}]" + config.getSource());
         }
-        return targetNode;
+        return targetMap;
     }
 
-    private void updateEvent(Event recordEvent, ObjectNode targetNode) {
-        final TypeReference<Map<String, Object>> mapTypeReference = new TypeReference<>() {};
-        final Map<String, Object> targetMap = OBJECT_MAPPER.convertValue(targetNode, mapTypeReference);
-
+    private void updateEvent(Event recordEvent, Map<String, Object> targetMap) {
         final boolean doWriteToRoot = Objects.isNull(config.getTarget());
         if (doWriteToRoot) {
             for (final Map.Entry<String, Object> entry : targetMap.entrySet()) {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessor.java
@@ -62,7 +62,7 @@ public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<
             final Map<String, Object> targetMap;
             try {
                 targetMap = constructTargetMap(sourceList);
-            } catch (IllegalArgumentException e) {
+            } catch (final IllegalArgumentException e) {
                 LOG.warn(EVENT, "Cannot find a list at the given source path [{}} on record [{}]",
                         config.getSource(), recordEvent, e);
                 recordEvent.getMetadata().addTags(config.getTagsOnFailure());
@@ -109,7 +109,8 @@ public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<
         return targetMap;
     }
 
-    private void setTargetMapUnflattened(Map<String, Object> targetMap, Map<String, Object> itemMap, String itemKey, String itemValueKey, boolean doExtractValue) {
+    private void setTargetMapUnflattened(
+            final Map<String, Object> targetMap, final Map<String, Object> itemMap, final String itemKey, final String itemValueKey, final boolean doExtractValue) {
         if (!targetMap.containsKey(itemKey)) {
             targetMap.put(itemKey, new ArrayList<>());
         }
@@ -123,7 +124,8 @@ public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<
         }
     }
 
-    private void setTargetMapFlattened(Map<String, Object> targetMap, Map<String, Object> itemMap, String itemKey, String itemValueKey, boolean doExtractValue) {
+    private void setTargetMapFlattened(
+            final Map<String, Object> targetMap, final Map<String, Object> itemMap, final String itemKey, final String itemValueKey, final boolean doExtractValue) {
         if (!targetMap.containsKey(itemKey) || config.getFlattenedElement() == ListToMapProcessorConfig.FlattenedElement.LAST) {
             if (doExtractValue) {
                 targetMap.put(itemKey, itemMap.get(itemValueKey));
@@ -133,7 +135,7 @@ public class ListToMapProcessor extends AbstractProcessor<Record<Event>, Record<
         }
     }
 
-    private void updateEvent(Event recordEvent, Map<String, Object> targetMap) {
+    private void updateEvent(final Event recordEvent, final Map<String, Object> targetMap) {
         final boolean doWriteToRoot = Objects.isNull(config.getTarget());
         if (doWriteToRoot) {
             for (final Map.Entry<String, Object> entry : targetMap.entrySet()) {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -45,11 +45,19 @@ public class ListToMapProcessorConfig {
     @JsonProperty("target")
     private String target = null;
 
+    @NotEmpty
+    @NotNull
     @JsonProperty("key")
     private String key;
 
     @JsonProperty("value_key")
     private String valueKey = null;
+
+    @JsonProperty("use_source_key")
+    private boolean useSourceKey = false;
+
+    @JsonProperty("extract_value")
+    private boolean extractValue = false;
 
     @NotNull
     @JsonProperty("flatten")
@@ -76,6 +84,14 @@ public class ListToMapProcessorConfig {
 
     public String getValueKey() {
         return valueKey;
+    }
+
+    public boolean getUseSourceKey() {
+        return useSourceKey;
+    }
+
+    public boolean getExtractValue() {
+        return extractValue;
     }
 
     public boolean getFlatten() {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -70,6 +71,9 @@ public class ListToMapProcessorConfig {
     @JsonProperty("list_to_map_when")
     private String listToMapWhen;
 
+    @JsonProperty("tags_on_failure")
+    private List<String> tagsOnFailure;
+
     public String getSource() {
         return source;
     }
@@ -102,5 +106,9 @@ public class ListToMapProcessorConfig {
 
     public FlattenedElement getFlattenedElement() {
         return flattenedElement;
+    }
+
+    public List<String> getTagsOnFailure() {
+        return tagsOnFailure;
     }
 }

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -45,8 +45,6 @@ public class ListToMapProcessorConfig {
     @JsonProperty("target")
     private String target = null;
 
-    @NotEmpty
-    @NotNull
     @JsonProperty("key")
     private String key;
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorConfig.java
@@ -46,8 +46,6 @@ public class ListToMapProcessorConfig {
     @JsonProperty("target")
     private String target = null;
 
-    @NotEmpty
-    @NotNull
     @JsonProperty("key")
     private String key;
 

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorTest.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ListToMapProcessorTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -24,6 +25,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,14 +39,23 @@ class ListToMapProcessorTest {
     @Mock
     private ExpressionEvaluator expressionEvaluator;
 
+    @BeforeEach
+    void setUp() {
+        lenient().when(mockConfig.getTarget()).thenReturn(null);
+        lenient().when(mockConfig.getValueKey()).thenReturn(null);
+        lenient().when(mockConfig.getFlatten()).thenReturn(false);
+        lenient().when(mockConfig.getFlattenedElement()).thenReturn(ListToMapProcessorConfig.FlattenedElement.FIRST);
+        lenient().when(mockConfig.getListToMapWhen()).thenReturn(null);
+        lenient().when(mockConfig.getUseSourceKey()).thenReturn(false);
+        lenient().when(mockConfig.getExtractValue()).thenReturn(false);
+    }
+
     @Test
     public void testValueExtractionWithFlattenAndWriteToRoot() {
         when(mockConfig.getValueKey()).thenReturn("value");
         when(mockConfig.getSource()).thenReturn("mylist");
         when(mockConfig.getKey()).thenReturn("name");
         when(mockConfig.getFlatten()).thenReturn(true);
-        when(mockConfig.getFlattenedElement()).thenReturn(ListToMapProcessorConfig.FlattenedElement.FIRST);
-        when(mockConfig.getListToMapWhen()).thenReturn(null);
 
         final ListToMapProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createTestRecord();


### PR DESCRIPTION
### Description
Adds some enhancements to to list_to_map processor:
- adds `use_source_key` and `extract_value` option to dynamically extract values and put them in a list under the source key
- adds `tags_on_failure` option to add tags when events failed to process
- simplifies existing code that uses JsonNode unnecessarily (see this [comment](https://github.com/opensearch-project/data-prepper/pull/2453#discussion_r1160015928) on original PR)
 
### Issues Resolved
Resolves #3867 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
