### PR TITLE
ENH: error handling in opensearch client refreshment and metrics

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/ClientRefresher.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/ClientRefresher.java
@@ -49,7 +49,7 @@ public class ClientRefresher<Client>
     @Override
     public void update(final OpenSearchSourceConfiguration openSearchSourceConfiguration) {
         if (basicAuthChanged(openSearchSourceConfiguration)) {
-            openSearchSourcePluginMetrics.getBasicCredentialsChangeCounter().increment();
+            openSearchSourcePluginMetrics.getCredentialsChangeCounter().increment();
             readWriteLock.writeLock().lock();
             try {
                 currentClient = clientFunction.apply(openSearchSourceConfiguration);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/ClientRefresher.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/ClientRefresher.java
@@ -1,6 +1,9 @@
 package org.opensearch.dataprepper.plugins.source.opensearch;
 
 import org.opensearch.dataprepper.model.plugin.PluginComponentRefresher;
+import org.opensearch.dataprepper.plugins.source.opensearch.metrics.OpenSearchSourcePluginMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -9,15 +12,19 @@ import java.util.function.Function;
 
 public class ClientRefresher<Client>
         implements PluginComponentRefresher<Client, OpenSearchSourceConfiguration> {
+    private static final Logger LOG = LoggerFactory.getLogger(ClientRefresher.class);
     private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+    private final OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics;
     private final Function<OpenSearchSourceConfiguration, Client> clientFunction;
     private OpenSearchSourceConfiguration existingConfig;
     private final Class<Client> clientClass;
     private Client currentClient;
 
-    public ClientRefresher(final Class<Client> clientClass,
+    public ClientRefresher(final OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics,
+                           final Class<Client> clientClass,
                            final Function<OpenSearchSourceConfiguration, Client> clientFunction,
                            final OpenSearchSourceConfiguration openSearchSourceConfiguration) {
+        this.openSearchSourcePluginMetrics = openSearchSourcePluginMetrics;
         this.clientClass = clientClass;
         this.clientFunction = clientFunction;
         existingConfig = openSearchSourceConfiguration;
@@ -42,10 +49,14 @@ public class ClientRefresher<Client>
     @Override
     public void update(final OpenSearchSourceConfiguration openSearchSourceConfiguration) {
         if (basicAuthChanged(openSearchSourceConfiguration)) {
+            openSearchSourcePluginMetrics.getBasicCredentialsChangeCounter().increment();
             readWriteLock.writeLock().lock();
             try {
                 currentClient = clientFunction.apply(openSearchSourceConfiguration);
                 existingConfig = openSearchSourceConfiguration;
+            } catch (Exception e) {
+                openSearchSourcePluginMetrics.getClientRefreshErrorsCounter().increment();
+                LOG.error("Refreshing {} failed.", getComponentClass(), e);
             } finally {
                 readWriteLock.writeLock().unlock();
             }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSource.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSource.java
@@ -69,7 +69,7 @@ public class OpenSearchSource implements Source<Record<Event>>, UsesSourceCoordi
         final OpenSearchClientFactory openSearchClientFactory = OpenSearchClientFactory.create(awsCredentialsSupplier);
         final OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics = OpenSearchSourcePluginMetrics.create(pluginMetrics);
         final SearchAccessorStrategy searchAccessorStrategy = SearchAccessorStrategy.create(
-                openSearchSourceConfiguration, openSearchClientFactory, pluginConfigObservable);
+                openSearchSourcePluginMetrics, openSearchSourceConfiguration, openSearchClientFactory, pluginConfigObservable);
 
         final SearchAccessor searchAccessor = searchAccessorStrategy.getSearchAccessor();
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/metrics/OpenSearchSourcePluginMetrics.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/metrics/OpenSearchSourcePluginMetrics.java
@@ -18,7 +18,7 @@ public class OpenSearchSourcePluginMetrics {
     static final String PROCESSING_ERRORS = "processingErrors";
     static final String BYTES_RECEIVED = "bytesReceived";
     static final String BYTES_PROCESSED = "bytesProcessed";
-    static final String BASIC_CREDENTIALS_CHANGED = "basicCredentialsChanged";
+    static final String CREDENTIALS_CHANGED = "credentialsChanged";
     static final String CLIENT_REFRESH_ERRORS = "clientRefreshErrors";
 
     private final Counter documentsProcessedCounter;
@@ -28,7 +28,7 @@ public class OpenSearchSourcePluginMetrics {
 
     private final DistributionSummary bytesReceivedSummary;
     private final DistributionSummary bytesProcessedSummary;
-    private final Counter basicCredentialsChangeCounter;
+    private final Counter credentialsChangeCounter;
     private final Counter clientRefreshErrorsCounter;
 
     public static OpenSearchSourcePluginMetrics create(final PluginMetrics pluginMetrics) {
@@ -42,7 +42,7 @@ public class OpenSearchSourcePluginMetrics {
         indexProcessingTimeTimer = pluginMetrics.timer(INDEX_PROCESSING_TIME_ELAPSED);
         bytesReceivedSummary = pluginMetrics.summary(BYTES_RECEIVED);
         bytesProcessedSummary = pluginMetrics.summary(BYTES_PROCESSED);
-        basicCredentialsChangeCounter = pluginMetrics.counter(BASIC_CREDENTIALS_CHANGED);
+        credentialsChangeCounter = pluginMetrics.counter(CREDENTIALS_CHANGED);
         clientRefreshErrorsCounter = pluginMetrics.counter(CLIENT_REFRESH_ERRORS);
     }
 
@@ -70,8 +70,8 @@ public class OpenSearchSourcePluginMetrics {
         return bytesProcessedSummary;
     }
 
-    public Counter getBasicCredentialsChangeCounter() {
-        return basicCredentialsChangeCounter;
+    public Counter getCredentialsChangeCounter() {
+        return credentialsChangeCounter;
     }
 
     public Counter getClientRefreshErrorsCounter() {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/metrics/OpenSearchSourcePluginMetrics.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/metrics/OpenSearchSourcePluginMetrics.java
@@ -18,6 +18,8 @@ public class OpenSearchSourcePluginMetrics {
     static final String PROCESSING_ERRORS = "processingErrors";
     static final String BYTES_RECEIVED = "bytesReceived";
     static final String BYTES_PROCESSED = "bytesProcessed";
+    static final String BASIC_CREDENTIALS_CHANGED = "basicCredentialsChanged";
+    static final String CLIENT_REFRESH_ERRORS = "clientRefreshErrors";
 
     private final Counter documentsProcessedCounter;
     private final Counter indicesProcessedCounter;
@@ -26,6 +28,8 @@ public class OpenSearchSourcePluginMetrics {
 
     private final DistributionSummary bytesReceivedSummary;
     private final DistributionSummary bytesProcessedSummary;
+    private final Counter basicCredentialsChangeCounter;
+    private final Counter clientRefreshErrorsCounter;
 
     public static OpenSearchSourcePluginMetrics create(final PluginMetrics pluginMetrics) {
         return new OpenSearchSourcePluginMetrics(pluginMetrics);
@@ -38,6 +42,8 @@ public class OpenSearchSourcePluginMetrics {
         indexProcessingTimeTimer = pluginMetrics.timer(INDEX_PROCESSING_TIME_ELAPSED);
         bytesReceivedSummary = pluginMetrics.summary(BYTES_RECEIVED);
         bytesProcessedSummary = pluginMetrics.summary(BYTES_PROCESSED);
+        basicCredentialsChangeCounter = pluginMetrics.counter(BASIC_CREDENTIALS_CHANGED);
+        clientRefreshErrorsCounter = pluginMetrics.counter(CLIENT_REFRESH_ERRORS);
     }
 
     public Counter getDocumentsProcessedCounter() {
@@ -62,5 +68,13 @@ public class OpenSearchSourcePluginMetrics {
 
     public DistributionSummary getBytesProcessedSummary() {
         return bytesProcessedSummary;
+    }
+
+    public Counter getBasicCredentialsChangeCounter() {
+        return basicCredentialsChangeCounter;
+    }
+
+    public Counter getClientRefreshErrorsCounter() {
+        return clientRefreshErrorsCounter;
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/ClientRefresherTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/ClientRefresherTest.java
@@ -1,11 +1,13 @@
 package org.opensearch.dataprepper.plugins.source.opensearch;
 
+import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.dataprepper.plugins.source.opensearch.metrics.OpenSearchSourcePluginMetrics;
 
 import java.util.function.Function;
 
@@ -13,6 +15,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,10 +30,20 @@ class ClientRefresherTest {
     private OpenSearchSourceConfiguration openSearchSourceConfiguration;
 
     @Mock
+    private OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics;
+
+    @Mock
+    private Counter basicAuthChangedCounter;
+
+    @Mock
+    private Counter clientRefreshErrors;
+
+    @Mock
     private Object client;
 
     private ClientRefresher createObjectUnderTest() {
-        return new ClientRefresher(Object.class, clientFunction, openSearchSourceConfiguration);
+        return new ClientRefresher(
+                openSearchSourcePluginMetrics, Object.class, clientFunction, openSearchSourceConfiguration);
     }
 
     @BeforeEach
@@ -58,6 +71,7 @@ class ClientRefresherTest {
 
     @Test
     void testGetAfterUpdateWithUsernameChanged() {
+        when(openSearchSourcePluginMetrics.getBasicCredentialsChangeCounter()).thenReturn(basicAuthChangedCounter);
         final ClientRefresher objectUnderTest = createObjectUnderTest();
         when(openSearchSourceConfiguration.getUsername()).thenReturn(TEST_USERNAME);
         final OpenSearchSourceConfiguration newConfig = mock(OpenSearchSourceConfiguration.class);
@@ -66,10 +80,12 @@ class ClientRefresherTest {
         when(clientFunction.apply(eq(newConfig))).thenReturn(newClient);
         objectUnderTest.update(newConfig);
         assertThat(objectUnderTest.get(), equalTo(newClient));
+        verify(basicAuthChangedCounter).increment();
     }
 
     @Test
     void testGetAfterUpdateWithPasswordChanged() {
+        when(openSearchSourcePluginMetrics.getBasicCredentialsChangeCounter()).thenReturn(basicAuthChangedCounter);
         final ClientRefresher objectUnderTest = createObjectUnderTest();
         when(openSearchSourceConfiguration.getUsername()).thenReturn(TEST_USERNAME);
         when(openSearchSourceConfiguration.getPassword()).thenReturn(TEST_PASSWORD);
@@ -80,5 +96,23 @@ class ClientRefresherTest {
         when(clientFunction.apply(eq(newConfig))).thenReturn(newClient);
         objectUnderTest.update(newConfig);
         assertThat(objectUnderTest.get(), equalTo(newClient));
+        verify(basicAuthChangedCounter).increment();
+    }
+
+    @Test
+    void testGetAfterUpdateClientFailure() {
+        when(openSearchSourcePluginMetrics.getBasicCredentialsChangeCounter()).thenReturn(basicAuthChangedCounter);
+        when(openSearchSourcePluginMetrics.getClientRefreshErrorsCounter()).thenReturn(clientRefreshErrors);
+        final ClientRefresher objectUnderTest = createObjectUnderTest();
+        when(openSearchSourceConfiguration.getUsername()).thenReturn(TEST_USERNAME);
+        when(openSearchSourceConfiguration.getPassword()).thenReturn(TEST_PASSWORD);
+        final OpenSearchSourceConfiguration newConfig = mock(OpenSearchSourceConfiguration.class);
+        when(newConfig.getUsername()).thenReturn(TEST_USERNAME);
+        when(newConfig.getPassword()).thenReturn(TEST_PASSWORD + "_changed");
+        when(clientFunction.apply(eq(newConfig))).thenThrow(RuntimeException.class);
+        objectUnderTest.update(newConfig);
+        assertThat(objectUnderTest.get(), equalTo(client));
+        verify(basicAuthChangedCounter).increment();
+        verify(clientRefreshErrors).increment();
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/ClientRefresherTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/ClientRefresherTest.java
@@ -71,7 +71,7 @@ class ClientRefresherTest {
 
     @Test
     void testGetAfterUpdateWithUsernameChanged() {
-        when(openSearchSourcePluginMetrics.getBasicCredentialsChangeCounter()).thenReturn(basicAuthChangedCounter);
+        when(openSearchSourcePluginMetrics.getCredentialsChangeCounter()).thenReturn(basicAuthChangedCounter);
         final ClientRefresher objectUnderTest = createObjectUnderTest();
         when(openSearchSourceConfiguration.getUsername()).thenReturn(TEST_USERNAME);
         final OpenSearchSourceConfiguration newConfig = mock(OpenSearchSourceConfiguration.class);
@@ -85,7 +85,7 @@ class ClientRefresherTest {
 
     @Test
     void testGetAfterUpdateWithPasswordChanged() {
-        when(openSearchSourcePluginMetrics.getBasicCredentialsChangeCounter()).thenReturn(basicAuthChangedCounter);
+        when(openSearchSourcePluginMetrics.getCredentialsChangeCounter()).thenReturn(basicAuthChangedCounter);
         final ClientRefresher objectUnderTest = createObjectUnderTest();
         when(openSearchSourceConfiguration.getUsername()).thenReturn(TEST_USERNAME);
         when(openSearchSourceConfiguration.getPassword()).thenReturn(TEST_PASSWORD);
@@ -101,7 +101,7 @@ class ClientRefresherTest {
 
     @Test
     void testGetAfterUpdateClientFailure() {
-        when(openSearchSourcePluginMetrics.getBasicCredentialsChangeCounter()).thenReturn(basicAuthChangedCounter);
+        when(openSearchSourcePluginMetrics.getCredentialsChangeCounter()).thenReturn(basicAuthChangedCounter);
         when(openSearchSourcePluginMetrics.getClientRefreshErrorsCounter()).thenReturn(clientRefreshErrors);
         final ClientRefresher objectUnderTest = createObjectUnderTest();
         when(openSearchSourceConfiguration.getUsername()).thenReturn(TEST_USERNAME);

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/OpenSearchSourceTest.java
@@ -109,7 +109,7 @@ public class OpenSearchSourceTest {
              final MockedStatic<ServerlessOptionsFactory> serverlessOptionsFactoryMockedStatic = mockStatic(ServerlessOptionsFactory.class)) {
             openSearchClientFactoryMockedStatic.when(() -> OpenSearchClientFactory.create(awsCredentialsSupplier)).thenReturn(openSearchClientFactory);
             searchAccessorStrategyMockedStatic.when(() -> SearchAccessorStrategy.create(
-                    openSearchSourceConfiguration, openSearchClientFactory, pluginConfigObservable)).thenReturn(searchAccessorStrategy);
+                    openSearchSourcePluginMetrics, openSearchSourceConfiguration, openSearchClientFactory, pluginConfigObservable)).thenReturn(searchAccessorStrategy);
             openSearchSourcePluginMetricsMockedStatic.when(() -> OpenSearchSourcePluginMetrics.create(pluginMetrics)).thenReturn(openSearchSourcePluginMetrics);
 
             openSearchServiceMockedStatic.when(() -> OpenSearchService.createOpenSearchService(searchAccessor, sourceCoordinator, openSearchSourceConfiguration, buffer, acknowledgementSetManager, openSearchSourcePluginMetrics))
@@ -137,7 +137,7 @@ public class OpenSearchSourceTest {
              final MockedStatic<ServerlessNetworkPolicyUpdaterFactory> serverlessNetworkPolicyUpdaterFactoryMockedStatic = mockStatic(ServerlessNetworkPolicyUpdaterFactory.class)) {
             openSearchClientFactoryMockedStatic.when(() -> OpenSearchClientFactory.create(awsCredentialsSupplier)).thenReturn(openSearchClientFactory);
             searchAccessorStrategyMockedStatic.when(() -> SearchAccessorStrategy.create(
-                openSearchSourceConfiguration, openSearchClientFactory, pluginConfigObservable)).thenReturn(searchAccessorStrategy);
+                    openSearchSourcePluginMetrics, openSearchSourceConfiguration, openSearchClientFactory, pluginConfigObservable)).thenReturn(searchAccessorStrategy);
             openSearchSourcePluginMetricsMockedStatic.when(() -> OpenSearchSourcePluginMetrics.create(pluginMetrics)).thenReturn(openSearchSourcePluginMetrics);
 
             openSearchServiceMockedStatic.when(() -> OpenSearchService.createOpenSearchService(searchAccessor, sourceCoordinator, openSearchSourceConfiguration, buffer, acknowledgementSetManager, openSearchSourcePluginMetrics))

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessStrategyTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/SearchAccessStrategyTest.java
@@ -23,6 +23,7 @@ import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.plugins.source.opensearch.OpenSearchSourceConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.AwsAuthenticationConfiguration;
 import org.opensearch.dataprepper.plugins.source.opensearch.configuration.SearchConfiguration;
+import org.opensearch.dataprepper.plugins.source.opensearch.metrics.OpenSearchSourcePluginMetrics;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.DistributionVersion;
 import org.opensearch.dataprepper.plugins.source.opensearch.worker.client.model.SearchContextType;
 
@@ -49,11 +50,15 @@ public class SearchAccessStrategyTest {
     private OpenSearchSourceConfiguration openSearchSourceConfiguration;
 
     @Mock
+    private OpenSearchSourcePluginMetrics openSearchSourcePluginMetrics;
+
+    @Mock
     private PluginConfigObservable pluginConfigObservable;
 
     private SearchAccessorStrategy createObjectUnderTest() {
         return SearchAccessorStrategy.create(
-                openSearchSourceConfiguration, openSearchClientFactory, pluginConfigObservable);
+                openSearchSourcePluginMetrics, openSearchSourceConfiguration, openSearchClientFactory,
+                pluginConfigObservable);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Description
This PR 
* handles runtime exception in creating new client (connection) in ClientRefresher
* adds metrics to track auth change as well as client refreshment failure
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
