### PR TITLE
Runs the Kafka buffer KMS tests as part of the GitHub Actions

### DIFF
--- a/.github/workflows/kafka-plugin-integration-tests.yml
+++ b/.github/workflows/kafka-plugin-integration-tests.yml
@@ -43,7 +43,11 @@ jobs:
           ./gradlew data-prepper-plugins:kafka-plugins:integrationTest -Dtests.kafka.bootstrap_servers=localhost:9092 -Dtests.kafka.authconfig.username=admin -Dtests.kafka.authconfig.password=admin --tests KafkaStartIT
       - name: Run Kafka integration tests
         run: |
-          ./gradlew data-prepper-plugins:kafka-plugins:integrationTest -Dtests.kafka.bootstrap_servers=localhost:9092 -Dtests.kafka.authconfig.username=admin -Dtests.kafka.authconfig.password=admin --tests KafkaSourceJsonTypeIT --tests KafkaBufferIT --tests KafkaBufferOTelIT
+          ./gradlew data-prepper-plugins:kafka-plugins:integrationTest \
+            -Dtests.kafka.bootstrap_servers=localhost:9092 \
+            -Dtests.kafka.authconfig.username=admin -Dtests.kafka.authconfig.password=admin \
+            -Dtests.kafka.kms_key=alias/DataPrepperTesting \
+            --tests '*kafka.buffer*'
 
       - name: Upload Unit Test Results
         if: always()

--- a/.github/workflows/kafka-plugin-integration-tests.yml
+++ b/.github/workflows/kafka-plugin-integration-tests.yml
@@ -14,6 +14,9 @@ on:
       - '*gradle*'
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   integration-tests:
@@ -41,6 +44,21 @@ jobs:
       - name: Wait for Kafka
         run: |
           ./gradlew data-prepper-plugins:kafka-plugins:integrationTest -Dtests.kafka.bootstrap_servers=localhost:9092 -Dtests.kafka.authconfig.username=admin -Dtests.kafka.authconfig.password=admin --tests KafkaStartIT
+
+      - name: Configure AWS credentials
+        id: aws-credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.TEST_IAM_ROLE_ARN }}
+          aws-region: ${{ secrets.TEST_REGION }}
+          output-credentials: true
+      - name: Configure AWS default credentials
+        run: |
+          aws configure set default.region ${{ secrets.TEST_REGION }}
+          aws configure set default.aws_access_key_id ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          aws configure set default.aws_secret_access_key ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          aws configure set default.aws_session_token ${{ steps.aws-credentials.outputs.aws-session-token }}
+
       - name: Run Kafka integration tests
         run: |
           ./gradlew data-prepper-plugins:kafka-plugins:integrationTest \


### PR DESCRIPTION
### Description

Runs the Kafka buffer KMS tests using the DataPrepperTesting KMS key.
 
### Issues Resolved

Resolves #4040
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
