### PR TITLE
Add join function

### DIFF
--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/JoinExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/JoinExpressionFunction.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.opensearch.dataprepper.model.event.Event;
+
+import java.util.HashMap;
+import java.util.List;
+import javax.inject.Named;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Named
+public class JoinExpressionFunction implements  ExpressionFunction {
+
+    private static final String FUNCTION_NAME = "join";
+
+    @Override
+    public String getFunctionName() {
+        return FUNCTION_NAME;
+    }
+
+    @Override
+    public Object evaluate(final List<Object> args, Event event, Function<Object, Object> convertLiteralType) {
+        if (args.isEmpty() || args.size() > 2) {
+            throw new IllegalArgumentException(FUNCTION_NAME + "() takes one or two arguments");
+        }
+
+        final List<String> argStrings;
+        try {
+            argStrings = args.stream()
+                    .map(arg -> ((String)arg).trim())
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Arguments in " + FUNCTION_NAME + "() function should be of Json Pointer type or String type");
+        }
+
+        final String delimiter;
+        if (argStrings.size() == 2) {
+            final String trimmedDelimiter = argStrings.get(1).substring(1, argStrings.get(1).length() - 1);
+
+            // remove slashes used to escape comma
+            delimiter = trimmedDelimiter.replace("\\\\,", ",");
+        } else {
+            delimiter = ",";
+        }
+
+        final String sourceKey = argStrings.get(0);
+        try {
+            final List<Object> sourceList = event.get(sourceKey, List.class);
+            return joinList(sourceList, delimiter);
+        } catch (Exception e) {
+            try {
+                final Map<String, Object> sourceMap = event.get(sourceKey, Map.class);
+                return joinListsInMap(sourceMap, delimiter);
+            } catch (Exception ex) {
+                throw new RuntimeException("Unable to perform join function on " + sourceKey, ex);
+            }
+        }
+    }
+
+    private String joinList(final List<Object> sourceList, final String delimiter) {
+        final List<String> stringList = sourceList.stream()
+                .map(Object::toString)
+                .collect(Collectors.toList());
+        return String.join(delimiter, stringList);
+    }
+
+    private Map<String, Object> joinListsInMap(final Map<String, Object> sourceMap, final String delimiter) {
+        final Map<String, Object> resultMap = new HashMap<>();
+        for (final Map.Entry<String, Object> entry : sourceMap.entrySet()) {
+            try {
+                final String joinedEntryValue = joinList((List<Object>)entry.getValue(), delimiter);
+                resultMap.put(entry.getKey(), joinedEntryValue);
+            } catch (Exception e) {
+                resultMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return resultMap;
+    }
+}

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/JoinExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/JoinExpressionFunction.java
@@ -41,16 +41,18 @@ public class JoinExpressionFunction implements  ExpressionFunction {
         }
 
         final String delimiter;
+        final String sourceKey;
         if (argStrings.size() == 2) {
-            final String trimmedDelimiter = argStrings.get(1).substring(1, argStrings.get(1).length() - 1);
+            final String trimmedDelimiter = argStrings.get(0).substring(1, argStrings.get(0).length() - 1);
 
             // remove slashes used to escape comma
             delimiter = trimmedDelimiter.replace("\\\\,", ",");
+            sourceKey = argStrings.get(1);
         } else {
             delimiter = ",";
+            sourceKey = argStrings.get(0);
         }
 
-        final String sourceKey = argStrings.get(0);
         try {
             final List<Object> sourceList = event.get(sourceKey, List.class);
             return joinList(sourceList, delimiter);

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -45,7 +45,8 @@ class ParseTreeCoercionService {
                 final String functionName = nodeStringValue.substring(0, funcNameIndex);
                 final int argsEndIndex = nodeStringValue.indexOf(")", funcNameIndex);
                 final String argsStr = nodeStringValue.substring(funcNameIndex+1, argsEndIndex);
-                final String[] args = argsStr.split(",");
+                // Split at commas if there's no backslash before the commas, because commas can be part of a function parameter
+                final String[] args = argsStr.split("(?<!\\\\),");
                 List<Object> argList = new ArrayList<>();
                 for (final String arg: args) {
                     String trimmedArg = arg.trim();
@@ -53,7 +54,7 @@ class ParseTreeCoercionService {
                         argList.add(trimmedArg);
                     } else if (trimmedArg.charAt(0) == '"') {
                         if (trimmedArg.length() < 2 || trimmedArg.charAt(trimmedArg.length()-1) != '"') {
-                            throw new RuntimeException("Invalid string argument. Missing double quote at the end");
+                            throw new RuntimeException("Invalid string argument: check if any argument is missing a closing double quote or contains comma that's not escaped with `\\`.");
                         }
                         argList.add(trimmedArg);
                     } else {

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_MultiTypeIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_MultiTypeIT.java
@@ -142,8 +142,8 @@ class GenericExpressionEvaluator_MultiTypeIT {
                 Arguments.of("/status_message+/message", event("{\"status_message\": \""+testString+"\", \"message\":\""+testString2+"\"}"), testString+testString2, String.class),
                 Arguments.of("getMetadata(\"strAttr\")+\""+testString2+"\"+/key", testEvent, testString+testString2+"value", String.class),
                 Arguments.of("join(/list)", testEvent, "string,1,true", String.class),
-                Arguments.of("join(/list, \"\\\\, \")", testEvent, "string, 1, true", String.class),
-                Arguments.of("join(/list, \" \")", testEvent, "string 1 true", String.class)
+                Arguments.of("join(\"\\\\, \", /list)", testEvent, "string, 1, true", String.class),
+                Arguments.of("join(\" \", /list)", testEvent, "string 1 true", String.class)
         );
     }
 
@@ -152,8 +152,8 @@ class GenericExpressionEvaluator_MultiTypeIT {
         Event testEvent2 = event("{\"list\":{\"key1\": [\"string\", 1, true], \"key2\": [1,2,3], \"key3\": \"value3\"}}");
         return Stream.of(
                 Arguments.of("join(/list)", testEvent1, Map.of("key", "string,1,true")),
-                Arguments.of("join(/list, \"\\\\, \")", testEvent1, Map.of("key", "string, 1, true")),
-                Arguments.of("join(/list, \" \")", testEvent1, Map.of("key", "string 1 true")),
+                Arguments.of("join(\"\\\\, \", /list)", testEvent1, Map.of("key", "string, 1, true")),
+                Arguments.of("join(\" \", /list)", testEvent1, Map.of("key", "string 1 true")),
                 Arguments.of("join(/list)", testEvent2, Map.of("key1", "string,1,true", "key2", "1,2,3", "key3", "value3"))
         );
     }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_MultiTypeIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_MultiTypeIT.java
@@ -6,7 +6,6 @@
 package org.opensearch.dataprepper.expression;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,14 +27,12 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.apache.commons.lang3.RandomStringUtils;
 
-class GenericExpressionEvaluator_StringIT {
+class GenericExpressionEvaluator_MultiTypeIT {
 
     private AnnotationConfigApplicationContext applicationContext;
 
@@ -46,34 +43,8 @@ class GenericExpressionEvaluator_StringIT {
         applicationContext.refresh();
     }
 
-    @Test
-    void testStringExpressionEvaluatorBeanAvailable() {
-        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
-        assertThat(evaluator, isA(GenericExpressionEvaluator.class));
-    }
-
-    @Test
-    void testStringExpressionEvaluatorBeanSingleton() {
-        final GenericExpressionEvaluator instanceA = applicationContext.getBean(GenericExpressionEvaluator.class);
-        final GenericExpressionEvaluator instanceB = applicationContext.getBean(GenericExpressionEvaluator.class);
-        assertThat(instanceA, sameInstance(instanceB));
-    }
-
-    @Test
-    void testParserBeanInstanceOfMultiThreadParser() {
-        final Parser instance = applicationContext.getBean(Parser.class);
-        assertThat(instance, instanceOf(MultiThreadParser.class));
-    }
-
-    @Test
-    void testSingleThreadParserBeanNotSingleton() {
-        final Parser instanceA = applicationContext.getBean(ParseTreeParser.SINGLE_THREAD_PARSER_NAME, Parser.class);
-        final Parser instanceB = applicationContext.getBean(ParseTreeParser.SINGLE_THREAD_PARSER_NAME, Parser.class);
-        assertThat(instanceA, not(sameInstance(instanceB)));
-    }
-
     @ParameterizedTest
-    @MethodSource("validExpressionArguments")
+    @MethodSource("validStringExpressionArguments")
     void testStringExpressionEvaluator(final String expression, final Event event, final String expected, final Class expectedClass) {
         final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
 
@@ -84,7 +55,17 @@ class GenericExpressionEvaluator_StringIT {
     }
 
     @ParameterizedTest
-    @MethodSource("validExpressionArguments")
+    @MethodSource("validMapExpressionArguments")
+    void testMapExpressionEvaluator(final String expression, final Event event, final Map<String, Object> expected) {
+        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
+
+        final Map<String, Object> actual = (Map<String, Object>)evaluator.evaluate(expression, event);
+
+        assertThat(actual, is(expected));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validStringExpressionArguments")
     void testStringExpressionEvaluatorWithMultipleThreads(final String expression, final Event event, final String expected, final Class expectedClass) {
         final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
 
@@ -108,8 +89,31 @@ class GenericExpressionEvaluator_StringIT {
     }
 
     @ParameterizedTest
+    @MethodSource("validMapExpressionArguments")
+    void testMapExpressionEvaluatorWithMultipleThreads(final String expression, final Event event, final Map<String, Object> expected) {
+        final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
+
+        final int numberOfThreads = 50;
+        final ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        List<Map<String, Object>> evaluationResults = Collections.synchronizedList(new ArrayList<>());
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.execute(() -> evaluationResults.add((Map<String, Object>)evaluator.evaluate(expression, event)));
+        }
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> evaluationResults.size() == numberOfThreads);
+
+        assertThat(evaluationResults.size(), equalTo(numberOfThreads));
+        for (Map<String, Object> evaluationResult : evaluationResults) {
+            assertThat(evaluationResult, equalTo(expected));
+        }
+    }
+
+    @ParameterizedTest
     @MethodSource("exceptionExpressionArguments")
-    void testArithmeticExpressionEvaluatorInvalidInput(final String expression, final Event event) {
+    void testExpressionEvaluatorCausesException(final String expression, final Event event) {
         final GenericExpressionEvaluator evaluator = applicationContext.getBean(GenericExpressionEvaluator.class);
         assertThrows(ExpressionEvaluationException.class, () -> evaluator.evaluate(expression, event));
     }
@@ -123,20 +127,44 @@ class GenericExpressionEvaluator_StringIT {
         assertThat(result, not(instanceOf(expectedClass)));
     }
 
-    private static Stream<Arguments> validExpressionArguments() {
+    private static Stream<Arguments> validStringExpressionArguments() {
         Random random = new Random();
         int testStringLength = random.nextInt(30);
         String testString = RandomStringUtils.randomAlphabetic(testStringLength);
         String testString2 = RandomStringUtils.randomAlphabetic(testStringLength);
         Map<String, Object> attributes = Map.of("strAttr", testString);
-        String testData = "{\"key\": \"value\"}";
-        JacksonEvent testEvent =  JacksonEvent.builder().withEventType("event").withEventMetadataAttributes(attributes).withData(testData).build();
+        String testData = "{\"key\": \"value\", \"list\":[\"string\", 1, true]}";
+        JacksonEvent testEvent = JacksonEvent.builder().withEventType("event").withEventMetadataAttributes(attributes).withData(testData).build();
         return Stream.of(
                 Arguments.of("\""+testString+"\"", event("{}"), testString, String.class),
                 Arguments.of("/status_message", event("{\"status_message\": \""+testString+"\"}"), testString, String.class),
                 Arguments.of("\""+testString+"\"+\""+testString2+"\"", event("{}"), testString+testString2, String.class),
                 Arguments.of("/status_message+/message", event("{\"status_message\": \""+testString+"\", \"message\":\""+testString2+"\"}"), testString+testString2, String.class),
-                Arguments.of("getMetadata(\"strAttr\")+\""+testString2+"\"+/key", testEvent, testString+testString2+"value", String.class)
+                Arguments.of("getMetadata(\"strAttr\")+\""+testString2+"\"+/key", testEvent, testString+testString2+"value", String.class),
+                Arguments.of("join(/list)", testEvent, "string,1,true", String.class),
+                Arguments.of("join(/list, \"\\\\, \")", testEvent, "string, 1, true", String.class),
+                Arguments.of("join(/list, \" \")", testEvent, "string 1 true", String.class)
+        );
+    }
+
+    private static Stream<Arguments> validMapExpressionArguments() {
+        Event testEvent1 = event("{\"list\":{\"key\": [\"string\", 1, true]}}");
+        Event testEvent2 = event("{\"list\":{\"key1\": [\"string\", 1, true], \"key2\": [1,2,3], \"key3\": \"value3\"}}");
+        return Stream.of(
+                Arguments.of("join(/list)", testEvent1, Map.of("key", "string,1,true")),
+                Arguments.of("join(/list, \"\\\\, \")", testEvent1, Map.of("key", "string, 1, true")),
+                Arguments.of("join(/list, \" \")", testEvent1, Map.of("key", "string 1 true")),
+                Arguments.of("join(/list)", testEvent2, Map.of("key1", "string,1,true", "key2", "1,2,3", "key3", "value3"))
+        );
+    }
+
+    private static Stream<Arguments> exceptionExpressionArguments() {
+        return Stream.of(
+                // Can't mix Numbers and Strings when using operators
+                Arguments.of("/status + /message", event("{\"status\": 200, \"message\":\"msg\"}")),
+                // Wrong number of arguments
+                Arguments.of("join()", event("{\"list\":[\"string\", 1, true]}")),
+                Arguments.of("join(/list, \" \", \"third_arg\")", event("{\"list\":[\"string\", 1, true]}"))
         );
     }
 
@@ -148,14 +176,8 @@ class GenericExpressionEvaluator_StringIT {
         return Stream.of(
                 Arguments.of("/missing", event("{}"), String.class),
                 Arguments.of("/value", event("{\"value\": "+randomInt+"}"), String.class),
-                Arguments.of("length(/message)", event("{\"message\": \""+testString+"\"}"), String.class)
-        );
-    }
-
-    private static Stream<Arguments> exceptionExpressionArguments() {
-        return Stream.of(
-                // Can't mix Numbers and Strings when using operators
-                Arguments.of("/status + /message", event("{\"status\": 200, \"message\":\"msg\"}"))
+                Arguments.of("length(/message)", event("{\"message\": \""+testString+"\"}"), String.class),
+                Arguments.of("join(/list)", event("{\"list\":{\"key\": [\"string\", 1, true]}}"), String.class)
         );
     }
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/JoinExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/JoinExpressionFunctionTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.expression;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JoinExpressionFunctionTest {
+
+    private JoinExpressionFunction joinExpressionFunction;
+    private Event testEvent;
+
+    @Mock
+    private Function<Object, Object> testFunction;
+
+    @BeforeEach
+    public void setUp() {
+        joinExpressionFunction = createObjectUnderTest();
+    }
+
+    @ParameterizedTest
+    @MethodSource("joinSingleList")
+    void testJoinSingleListSuccess(final String sourceKey, final String delimiter, final String inputData, final String expectedOutput) {
+        testEvent = createTestEvent(inputData);
+        List<Object> args;
+        if (delimiter == null) {
+            args = List.of(sourceKey);
+        } else {
+            args = List.of(sourceKey, delimiter);
+        }
+        Object expressionResult = joinExpressionFunction.evaluate(args, testEvent, testFunction);
+        assertThat((String)expressionResult, equalTo(expectedOutput));
+    }
+
+    @ParameterizedTest
+    @MethodSource("joinListsInMap")
+    void testJoinListsInMapSuccess(final String sourceKey, final String delimiter, final String inputData, final Map<String, Object> expectedOutput) {
+        testEvent = createTestEvent(inputData);
+        List<Object> args;
+        if (delimiter == null) {
+            args = List.of(sourceKey);
+        } else {
+            args = List.of(sourceKey, delimiter);
+        }
+        Object expressionResult = joinExpressionFunction.evaluate(args, testEvent, testFunction);
+        assertThat((Map<String, Object>)expressionResult, equalTo(expectedOutput));
+    }
+
+    @Test
+    void testNoArgumentThrowsException() {
+        testEvent = createTestEvent(Map.of("key", "value"));
+        assertThrows(IllegalArgumentException.class,
+                () -> joinExpressionFunction.evaluate(List.of(), testEvent, testFunction));
+    }
+
+    @Test
+    void testTooManyArgumentsThrowsException() {
+        testEvent = createTestEvent(Map.of("key", "value"));
+        assertThrows(IllegalArgumentException.class,
+                () -> joinExpressionFunction.evaluate(List.of("/list", " ", false), testEvent, testFunction));
+    }
+
+    @Test
+    void testArgumentTypeNotSupportedThrowsException() {
+        testEvent = createTestEvent(Map.of("key", "value"));
+        Throwable exception = assertThrows(IllegalArgumentException.class,
+                () -> joinExpressionFunction.evaluate(List.of("/list", Map.of("key", "value")), testEvent, testFunction));
+        assertThat(exception.getMessage(), containsStringIgnoringCase("should be of Json Pointer type or String type"));
+    }
+
+    @Test
+    void testSourceFieldNotExistsInEventThrowsException() {
+        testEvent = createTestEvent(Map.of("key", "value"));
+        assertThrows(RuntimeException.class,
+                () -> joinExpressionFunction.evaluate(List.of("/missingKey"), testEvent, testFunction));
+    }
+
+    private static Stream<Arguments> joinSingleList() {
+        final String inputData = "{\"list\":[\"string\", 1, true]}";
+        return Stream.of(
+                Arguments.of("/list", null, inputData, "string,1,true"),
+                Arguments.of("/list", "\"\\\\, \"", inputData, "string, 1, true"),
+                Arguments.of("/list", "\" \"", inputData, "string 1 true")
+        );
+    }
+
+    private static Stream<Arguments> joinListsInMap() {
+        String testData1 = "{\"list\":{\"key\": [\"string\", 1, true]}}";
+        String testData2 = "{\"list\":{\"key1\": [\"string\", 1, true], \"key2\": [1,2,3], \"key3\": \"value3\"}}";
+        return Stream.of(
+                Arguments.of("/list", null, testData1, Map.of("key", "string,1,true")),
+                Arguments.of("/list", "\"\\\\, \"", testData1, Map.of("key", "string, 1, true")),
+                Arguments.of("/list", "\" \"", testData1, Map.of("key", "string 1 true")),
+                Arguments.of("/list", null, testData2, Map.of("key1", "string,1,true", "key2", "1,2,3", "key3", "value3"))
+        );
+    }
+
+    private JoinExpressionFunction createObjectUnderTest() {
+        return new JoinExpressionFunction();
+    }
+
+    private Event createTestEvent(final Object data) {
+        return JacksonEvent.builder().withEventType("event").withData(data).build();
+    }
+}

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/JoinExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/JoinExpressionFunctionTest.java
@@ -45,7 +45,7 @@ class JoinExpressionFunctionTest {
         if (delimiter == null) {
             args = List.of(sourceKey);
         } else {
-            args = List.of(sourceKey, delimiter);
+            args = List.of(delimiter, sourceKey);
         }
         Object expressionResult = joinExpressionFunction.evaluate(args, testEvent, testFunction);
         assertThat((String)expressionResult, equalTo(expectedOutput));
@@ -59,7 +59,7 @@ class JoinExpressionFunctionTest {
         if (delimiter == null) {
             args = List.of(sourceKey);
         } else {
-            args = List.of(sourceKey, delimiter);
+            args = List.of(delimiter, sourceKey);
         }
         Object expressionResult = joinExpressionFunction.evaluate(args, testEvent, testFunction);
         assertThat((Map<String, Object>)expressionResult, equalTo(expectedOutput));

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
@@ -28,6 +28,7 @@ import java.util.Random;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -289,6 +290,31 @@ class ParseTreeCoercionServiceTest {
         when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
         when(terminalNode.getText()).thenReturn("xyz(arg1)");
         assertThrows(RuntimeException.class, () -> objectUnderTest.coercePrimaryTerminalNode(terminalNode, null));
+    }
+
+    @Test
+    void testCoerceTerminalNodeFunctionTypeWithCommaInArgumentsThrowsException() {
+        final String key = RandomStringUtils.randomAlphabetic(5);
+        final String value = RandomStringUtils.randomAlphabetic(10);
+        final Event testEvent = createTestEvent(Map.of(key, value));
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn("join(/"+key+", \",\")");
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
+        Throwable exception = assertThrows(RuntimeException.class, () -> objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent));
+        assertThat(exception.getMessage(), containsStringIgnoringCase("check if any argument is missing a closing double quote or contains comma that's not escaped with `\\`"));
+    }
+
+    @Test
+    void testCoerceTerminalNodeFunctionTypeWithEscapedCommaInArgumentsReturnsExpectedResult() {
+        final String key = RandomStringUtils.randomAlphabetic(5);
+        final String value = RandomStringUtils.randomAlphabetic(10);
+        final String output = RandomStringUtils.randomAlphabetic(10);
+        final Event testEvent = createTestEvent(Map.of(key, value));
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn("join(/"+key+", \"\\\\,\")");
+        when(expressionFunctionProvider.provideFunction(eq("join"), any(List.class), any(Event.class), any(Function.class))).thenReturn(output);
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
+        assertThat(objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent), equalTo(output));
     }
 
     private Event createTestEvent(final Object data) {

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
@@ -298,7 +298,7 @@ class ParseTreeCoercionServiceTest {
         final String value = RandomStringUtils.randomAlphabetic(10);
         final Event testEvent = createTestEvent(Map.of(key, value));
         when(terminalNode.getSymbol()).thenReturn(token);
-        when(terminalNode.getText()).thenReturn("join(/"+key+", \",\")");
+        when(terminalNode.getText()).thenReturn("join(\",\" /" +key+")");
         when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
         Throwable exception = assertThrows(RuntimeException.class, () -> objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent));
         assertThat(exception.getMessage(), containsStringIgnoringCase("check if any argument is missing a closing double quote or contains comma that's not escaped with `\\`"));
@@ -311,7 +311,7 @@ class ParseTreeCoercionServiceTest {
         final String output = RandomStringUtils.randomAlphabetic(10);
         final Event testEvent = createTestEvent(Map.of(key, value));
         when(terminalNode.getSymbol()).thenReturn(token);
-        when(terminalNode.getText()).thenReturn("join(/"+key+", \"\\\\,\")");
+        when(terminalNode.getText()).thenReturn("join(\"\\\\,\", /"+key+")");
         when(expressionFunctionProvider.provideFunction(eq("join"), any(List.class), any(Event.class), any(Function.class))).thenReturn(output);
         when(token.getType()).thenReturn(DataPrepperExpressionParser.Function);
         assertThat(objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent), equalTo(output));

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
@@ -293,7 +293,7 @@ class ParseTreeCoercionServiceTest {
     }
 
     @Test
-    void testCoerceTerminalNodeFunctionTypeWithCommaInArgumentsThrowsException() {
+    void testCoerceTerminalNodeFunctionTypeWithUnescapedCommaInArgumentsThrowsException() {
         final String key = RandomStringUtils.randomAlphabetic(5);
         final String value = RandomStringUtils.randomAlphabetic(10);
         final Event testEvent = createTestEvent(Map.of(key, value));


### PR DESCRIPTION
### Description
Adds a join function that takes a source key to a list or a map where values are all of list type, and joins list to string with the given delimiter (optional). 

It can be used in processors that support value_expression such as `add_entries`:
```yaml
  processor:
    - add_entries:
        entries:
          - key: result
            value_expression: join(/source)
```
With input `{"source": [1, 2, 3]}`, it will get you `{"result": "1,2,3"}`
With input 
```json
{"source": {"key1": [1, 2, 3], "key2": ["a", "b", "c"]}}
```
, it will get you 
```json
{"result": {"key1": "1,2,3", "key2": "a,b,c"}}
```

### Issues Resolved
Contributes to #3965
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
