### PR TITLE
Lower min duration validation for scheduled s3 scan interval from 30 seconds to 1 second

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/S3ScanSchedulingOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/S3ScanSchedulingOptions.java
@@ -17,7 +17,7 @@ public class S3ScanSchedulingOptions {
 
     @JsonProperty("interval")
     @NotNull
-    @DurationMin(seconds = 30L, message = "S3 scan interval must be at least 30 seconds")
+    @DurationMin(seconds = 1L, message = "S3 scan interval must be at least 1 second")
     @DurationMax(days = 365L, message = "S3 scan interval must be less than or equal to 365 days")
     private Duration interval;
 


### PR DESCRIPTION

### Description
This change lowers the minimum interval value to wait between scheduled scans from 30 seconds to 1 second. This means that when there are a small number of objects to scan, the scans will happen more quickly if the objects are completed before the interval is reached. There is no great reason to require 30 seconds in between scans.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
