### PR TITLE
Enhance copy_values processor to selectively copy entries from lists

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessor.java
@@ -14,19 +14,23 @@ import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.record.Record;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @DataPrepperPlugin(name = "copy_values", pluginType = Processor.class, pluginConfigurationType = CopyValueProcessorConfig.class)
 public class CopyValueProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
+    private final CopyValueProcessorConfig config;
     private final List<CopyValueProcessorConfig.Entry> entries;
-
     private final ExpressionEvaluator expressionEvaluator;
 
     @DataPrepperPluginConstructor
     public CopyValueProcessor(final PluginMetrics pluginMetrics, final CopyValueProcessorConfig config, final ExpressionEvaluator expressionEvaluator) {
         super(pluginMetrics);
+        this.config = config;
         this.entries = config.getEntries();
         this.expressionEvaluator = expressionEvaluator;
     }
@@ -35,19 +39,44 @@ public class CopyValueProcessor extends AbstractProcessor<Record<Event>, Record<
     public Collection<Record<Event>> doExecute(final Collection<Record<Event>> records) {
         for(final Record<Event> record : records) {
             final Event recordEvent = record.getData();
-            for(CopyValueProcessorConfig.Entry entry : entries) {
-                if (Objects.nonNull(entry.getCopyWhen()) && !expressionEvaluator.evaluateConditional(entry.getCopyWhen(), recordEvent)) {
-                    continue;
-                }
+            if (config.getMode() == CopyValueProcessorConfig.Mode.NORMAL) {
+                for (CopyValueProcessorConfig.Entry entry : entries) {
+                    if (Objects.nonNull(entry.getCopyWhen()) && !expressionEvaluator.evaluateConditional(entry.getCopyWhen(), recordEvent)) {
+                        continue;
+                    }
 
-                if (entry.getFromKey().equals(entry.getToKey()) || !recordEvent.containsKey(entry.getFromKey())) {
-                    continue;
-                }
+                    if (entry.getFromKey().equals(entry.getToKey()) || !recordEvent.containsKey(entry.getFromKey())) {
+                        continue;
+                    }
 
-                if (!recordEvent.containsKey(entry.getToKey()) || entry.getOverwriteIfToKeyExists()) {
-                    final Object source = recordEvent.get(entry.getFromKey(), Object.class);
-                    recordEvent.put(entry.getToKey(), source);
+                    if (!recordEvent.containsKey(entry.getToKey()) || entry.getOverwriteIfToKeyExists()) {
+                        final Object source = recordEvent.get(entry.getFromKey(), Object.class);
+                        recordEvent.put(entry.getToKey(), source);
+                    }
                 }
+            } else if (config.getMode() == CopyValueProcessorConfig.Mode.LIST) {
+                List<Map<String, Object>> sourceList = recordEvent.get(config.getSource(), List.class);
+                List<Map<String, Object>> targetList = new ArrayList<>();
+
+                Map<CopyValueProcessorConfig.Entry, Boolean> whenConditions = new HashMap<>();
+                for (CopyValueProcessorConfig.Entry entry : entries) {
+                    if (Objects.nonNull(entry.getCopyWhen()) && !expressionEvaluator.evaluateConditional(entry.getCopyWhen(), recordEvent)) {
+                        whenConditions.put(entry, Boolean.FALSE);
+                    } else {
+                        whenConditions.put(entry, Boolean.TRUE);
+                    }
+                }
+                for (Map<String, Object> sourceField : sourceList) {
+                    final Map<String, Object> targetItem = new HashMap<>();
+                    for (CopyValueProcessorConfig.Entry entry : entries) {
+                        if (!whenConditions.get(entry) || !sourceField.containsKey(entry.getFromKey())) {
+                            continue;
+                        }
+                        targetItem.put(entry.getToKey(), sourceField.get(entry.getFromKey()));
+                    }
+                    targetList.add(targetItem);
+                }
+                recordEvent.put(config.getTarget(), targetList);
             }
         }
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessor.java
@@ -74,15 +74,7 @@ public class CopyValueProcessor extends AbstractProcessor<Record<Event>, Record<
                 } else {
                     // Copying individual entries
                     for (final CopyValueProcessorConfig.Entry entry : entries) {
-                        if (Objects.nonNull(entry.getCopyWhen()) && !expressionEvaluator.evaluateConditional(entry.getCopyWhen(), recordEvent)) {
-                            continue;
-                        }
-
-                        if (entry.getFromKey().equals(entry.getToKey()) || !recordEvent.containsKey(entry.getFromKey())) {
-                            continue;
-                        }
-
-                        if (!recordEvent.containsKey(entry.getToKey()) || entry.getOverwriteIfToKeyExists()) {
+                        if (shouldCopyEntry(entry, recordEvent)) {
                             final Object source = recordEvent.get(entry.getFromKey(), Object.class);
                             recordEvent.put(entry.getToKey(), source);
                         }
@@ -95,6 +87,18 @@ public class CopyValueProcessor extends AbstractProcessor<Record<Event>, Record<
         }
 
         return records;
+    }
+
+    private boolean shouldCopyEntry(final CopyValueProcessorConfig.Entry entry, final Event recordEvent) {
+        if (Objects.nonNull(entry.getCopyWhen()) && !expressionEvaluator.evaluateConditional(entry.getCopyWhen(), recordEvent)) {
+            return false;
+        }
+
+        if (entry.getFromKey().equals(entry.getToKey()) || !recordEvent.containsKey(entry.getFromKey())) {
+            return false;
+        }
+
+        return !recordEvent.containsKey(entry.getToKey()) || entry.getOverwriteIfToKeyExists();
     }
 
     @Override

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
@@ -5,40 +5,15 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class CopyValueProcessorConfig {
-    enum Mode {
-        NORMAL("normal"),
-        LIST("list");
-
-        private final String name;
-
-        private static final Map<String, Mode> ACTIONS_MAP = Arrays.stream(Mode.values())
-                .collect(Collectors.toMap(
-                        value -> value.name,
-                        value -> value
-                ));
-
-        Mode(String name) {
-            this.name = name.toLowerCase();
-        }
-
-        @JsonCreator
-        static Mode fromOptionValue(final String option) {
-            return ACTIONS_MAP.get(option);
-        }
-    }
-
     public static class Entry {
         @NotEmpty
         @NotNull
@@ -87,28 +62,33 @@ public class CopyValueProcessorConfig {
     @Valid
     private List<Entry> entries;
 
-    @JsonProperty("source")
-    private String source;
+    @JsonProperty("from_list")
+    private String fromList;
 
-    @JsonProperty("target")
-    private String target;
+    @JsonProperty("to_list")
+    private String toList;
 
-    @JsonProperty("mode")
-    private Mode mode = Mode.NORMAL;
+    @JsonProperty("overwrite_if_to_list_exists")
+    private boolean overwriteIfToListExists = false;
+
+    @AssertTrue(message = "Both from_list and to_list should be specified when copying entries between lists.")
+    boolean isBothFromListAndToListProvided() {
+        return (fromList == null && toList == null) || (fromList != null && toList != null);
+    }
 
     public List<Entry> getEntries() {
         return entries;
     }
 
-    public String getSource() {
-        return source;
+    public String getFromList() {
+        return fromList;
     }
 
-    public String getTarget() {
-        return target;
+    public String getToList() {
+        return toList;
     }
 
-    public Mode getMode() {
-        return mode;
+    public boolean getOverwriteIfToListExists() {
+        return overwriteIfToListExists;
     }
 }

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorConfig.java
@@ -5,15 +5,41 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class CopyValueProcessorConfig {
-   public static class Entry {
+    enum Mode {
+        NORMAL("normal"),
+        LIST("list");
+
+        private final String name;
+
+        private static final Map<String, Mode> ACTIONS_MAP = Arrays.stream(Mode.values())
+                .collect(Collectors.toMap(
+                        value -> value.name,
+                        value -> value
+                ));
+
+        Mode(String name) {
+            this.name = name.toLowerCase();
+        }
+
+        @JsonCreator
+        static Mode fromOptionValue(final String option) {
+            return ACTIONS_MAP.get(option);
+        }
+    }
+
+    public static class Entry {
         @NotEmpty
         @NotNull
         @JsonProperty("from_key")
@@ -61,7 +87,28 @@ public class CopyValueProcessorConfig {
     @Valid
     private List<Entry> entries;
 
+    @JsonProperty("source")
+    private String source;
+
+    @JsonProperty("target")
+    private String target;
+
+    @JsonProperty("mode")
+    private Mode mode = Mode.NORMAL;
+
     public List<Entry> getEntries() {
         return entries;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public Mode getMode() {
+        return mode;
     }
 }

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessorTests.java
@@ -6,15 +6,15 @@
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.record.Record;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,9 +27,7 @@ import java.util.UUID;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
### Description
The configurations are like this:
```yaml
  processor:
    - copy_values:
        from_list: mylist
        to_list: newlist
        entries:
          - from_key: name
            to_key: fruit_name
```
Example input:
```json
{
  "mylist": [
    {"name": "apple", "color": "red"},
    {"name": "orange", "color": "orange"}
  ]
}
```
Example output:
```json
{
  "newlist": [
    {"fruit_name": "apple"},
    {"fruit_name": "orange"}
  ]
}
```
 
### Issues Resolved
Resolves #3962
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
