### PR TITLE
Fixes a bug where the Kafka buffer inverted the relationship for the create_topic configuration

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferIT.java
@@ -127,7 +127,7 @@ public class KafkaBufferIT {
     }
 
     private KafkaBuffer createObjectUnderTest() {
-        return new KafkaBuffer(pluginSetting, kafkaBufferConfig, pluginFactory, acknowledgementSetManager, null, null, null);
+        return new KafkaBuffer(pluginSetting, kafkaBufferConfig, acknowledgementSetManager, null, null, null);
     }
 
     @Test
@@ -159,7 +159,7 @@ public class KafkaBufferIT {
         final Map<String, Object> topicConfigMap = Map.of(
                 "name", topicName,
                 "group_id", "buffergroup-" + RandomStringUtils.randomAlphabetic(6),
-                "create_topic", false
+                "create_topic", true
         );
         final Map<String, Object> bufferConfigMap = Map.of(
                 "topics", List.of(topicConfigMap),

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferOTelIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferOTelIT.java
@@ -295,7 +295,7 @@ public class KafkaBufferOTelIT {
 
     @Test
     void test_otel_metrics_with_kafka_buffer() throws Exception {
-        KafkaBuffer kafkaBuffer = new KafkaBuffer(pluginSetting, kafkaBufferConfig, pluginFactory, acknowledgementSetManager, new OTelMetricDecoder(), null, null);
+        KafkaBuffer kafkaBuffer = new KafkaBuffer(pluginSetting, kafkaBufferConfig, acknowledgementSetManager, new OTelMetricDecoder(), null, null);
         buffer = new KafkaDelegatingBuffer(kafkaBuffer);
         final ExportMetricsServiceRequest request = createExportMetricsServiceRequest();
         buffer.writeBytes(request.toByteArray(), null, 10_000);
@@ -367,7 +367,7 @@ public class KafkaBufferOTelIT {
 
     @Test
     void test_otel_logs_with_kafka_buffer() throws Exception {
-        KafkaBuffer kafkaBuffer = new KafkaBuffer(pluginSetting, kafkaBufferConfig, pluginFactory, acknowledgementSetManager, new OTelLogsDecoder(), null, null);
+        KafkaBuffer kafkaBuffer = new KafkaBuffer(pluginSetting, kafkaBufferConfig, acknowledgementSetManager, new OTelLogsDecoder(), null, null);
         buffer = new KafkaDelegatingBuffer(kafkaBuffer);
         final ExportLogsServiceRequest request = createExportLogsRequest();
         buffer.writeBytes(request.toByteArray(), null, 10_000);
@@ -453,7 +453,7 @@ public class KafkaBufferOTelIT {
 
     @Test
     void test_otel_traces_with_kafka_buffer() throws Exception {
-        KafkaBuffer kafkaBuffer = new KafkaBuffer(pluginSetting, kafkaBufferConfig, pluginFactory, acknowledgementSetManager, new OTelTraceDecoder(), null, null);
+        KafkaBuffer kafkaBuffer = new KafkaBuffer(pluginSetting, kafkaBufferConfig, acknowledgementSetManager, new OTelTraceDecoder(), null, null);
         buffer = new KafkaDelegatingBuffer(kafkaBuffer);
         final ExportTraceServiceRequest request = createExportTraceRequest();
         buffer.writeBytes(request.toByteArray(), null, 10_000);

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer_KmsIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer_KmsIT.java
@@ -124,7 +124,7 @@ public class KafkaBuffer_KmsIT {
     }
 
     private KafkaBuffer createObjectUnderTest() {
-        return new KafkaBuffer(pluginSetting, kafkaBufferConfig, pluginFactory, acknowledgementSetManager, null, ignored -> DefaultCredentialsProvider.create(), null);
+        return new KafkaBuffer(pluginSetting, kafkaBufferConfig, acknowledgementSetManager, null, ignored -> DefaultCredentialsProvider.create(), null);
     }
 
     @Nested

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerFactory.java
@@ -11,8 +11,6 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
-import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.sink.SinkContext;
 import org.opensearch.dataprepper.plugins.kafka.common.KafkaDataConfig;
 import org.opensearch.dataprepper.plugins.kafka.common.KafkaDataConfigAdapter;
@@ -22,12 +20,12 @@ import org.opensearch.dataprepper.plugins.kafka.common.key.KeyFactory;
 import org.opensearch.dataprepper.plugins.kafka.common.serialization.SerializationFactory;
 import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaProducerConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaProducerProperties;
-
-import org.opensearch.dataprepper.plugins.kafka.configuration.TopicProducerConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.TopicProducerConfig;
 import org.opensearch.dataprepper.plugins.kafka.consumer.KafkaCustomConsumerFactory;
 import org.opensearch.dataprepper.plugins.kafka.service.SchemaService;
 import org.opensearch.dataprepper.plugins.kafka.service.TopicService;
+import org.opensearch.dataprepper.plugins.kafka.service.TopicServiceFactory;
 import org.opensearch.dataprepper.plugins.kafka.sink.DLQSink;
 import org.opensearch.dataprepper.plugins.kafka.util.KafkaSecurityConfigurer;
 import org.opensearch.dataprepper.plugins.kafka.util.KafkaTopicProducerMetrics;
@@ -43,13 +41,18 @@ public class KafkaCustomProducerFactory {
     private static final Logger LOG = LoggerFactory.getLogger(KafkaCustomConsumerFactory.class);
     private final SerializationFactory serializationFactory;
     private final AwsCredentialsSupplier awsCredentialsSupplier;
+    private final TopicServiceFactory topicServiceFactory;
 
-    public KafkaCustomProducerFactory(final SerializationFactory serializationFactory, AwsCredentialsSupplier awsCredentialsSupplier) {
+    public KafkaCustomProducerFactory(
+            final SerializationFactory serializationFactory,
+            final AwsCredentialsSupplier awsCredentialsSupplier,
+            final TopicServiceFactory topicServiceFactory) {
         this.serializationFactory = serializationFactory;
         this.awsCredentialsSupplier = awsCredentialsSupplier;
+        this.topicServiceFactory = topicServiceFactory;
     }
 
-    public KafkaCustomProducer createProducer(final KafkaProducerConfig kafkaProducerConfig, final PluginFactory pluginFactory, final PluginSetting pluginSetting,
+    public KafkaCustomProducer createProducer(final KafkaProducerConfig kafkaProducerConfig,
                                               final ExpressionEvaluator expressionEvaluator, final SinkContext sinkContext, final PluginMetrics pluginMetrics,
                                               final DLQSink dlqSink,
                                               final boolean topicNameInMetrics) {
@@ -102,8 +105,8 @@ public class KafkaCustomProducerFactory {
 
     private void checkTopicCreationCriteriaAndCreateTopic(final KafkaProducerConfig kafkaProducerConfig, final Integer maxRequestSize) {
         final TopicProducerConfig topic = kafkaProducerConfig.getTopic();
-        if (!topic.isCreateTopic()) {
-            final TopicService topicService = new TopicService(kafkaProducerConfig);
+        if (topic.isCreateTopic()) {
+            final TopicService topicService = topicServiceFactory.createTopicService(kafkaProducerConfig);
             Long maxMessageBytes = null;
             if (maxRequestSize != null) {
                 maxMessageBytes = Long.valueOf(maxRequestSize);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/service/TopicService.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/service/TopicService.java
@@ -21,7 +21,7 @@ public class TopicService {
     private final AdminClient adminClient;
 
 
-    public TopicService(final KafkaProducerConfig kafkaProducerConfig) {
+    TopicService(final KafkaProducerConfig kafkaProducerConfig) {
         this.adminClient = AdminClient.create(SinkPropertyConfigurer.getPropertiesForAdminClient(kafkaProducerConfig));
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/service/TopicServiceFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/service/TopicServiceFactory.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.service;
+
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaProducerConfig;
+
+public class TopicServiceFactory {
+    public TopicService createTopicService(final KafkaProducerConfig kafkaProducerConfig) {
+        return new TopicService(kafkaProducerConfig);
+    }
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
@@ -137,7 +137,7 @@ class KafkaBufferTest {
             final MockedConstruction<KafkaCustomProducerFactory> producerFactoryMock =
                 mockConstruction(KafkaCustomProducerFactory.class, (mock, context) -> {
                 producerFactory = mock;
-                when(producerFactory.createProducer(any() ,any(), any(), isNull(), isNull(), any(), any(), anyBoolean())).thenReturn(producer);
+                when(producerFactory.createProducer(any(), isNull(), isNull(), any(), any(), anyBoolean())).thenReturn(producer);
             });
             final MockedConstruction<KafkaCustomConsumerFactory> consumerFactoryMock =
                 mockConstruction(KafkaCustomConsumerFactory.class, (mock, context) -> {
@@ -152,7 +152,7 @@ class KafkaBufferTest {
                  })) {
 
             executorsMockedStatic.when(() -> Executors.newFixedThreadPool(anyInt())).thenReturn(executorService);
-            return new KafkaBuffer(pluginSetting, bufferConfig, pluginFactory, acknowledgementSetManager, null, awsCredentialsSupplier, circuitBreaker);
+            return new KafkaBuffer(pluginSetting, bufferConfig, acknowledgementSetManager, null, awsCredentialsSupplier, circuitBreaker);
         }
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerFactoryTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducerFactoryTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.kafka.producer;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.sink.SinkContext;
+import org.opensearch.dataprepper.plugins.kafka.common.serialization.SerializationFactory;
+import org.opensearch.dataprepper.plugins.kafka.configuration.EncryptionConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.KafkaProducerConfig;
+import org.opensearch.dataprepper.plugins.kafka.configuration.TopicProducerConfig;
+import org.opensearch.dataprepper.plugins.kafka.service.TopicService;
+import org.opensearch.dataprepper.plugins.kafka.service.TopicServiceFactory;
+import org.opensearch.dataprepper.plugins.kafka.sink.DLQSink;
+
+import java.util.Collections;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaCustomProducerFactoryTest {
+    private static final Random RANDOM = new Random();
+    @Mock
+    private SerializationFactory serializationFactory;
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
+    @Mock
+    private TopicServiceFactory topicServiceFactory;
+
+    @Mock
+    private KafkaProducerConfig kafkaProducerConfig;
+    @Mock
+    private ExpressionEvaluator expressionEvaluator;
+    @Mock
+    private SinkContext sinkContext;
+    @Mock
+    private PluginMetrics pluginMetrics;
+    @Mock
+    private DLQSink dlqSink;
+
+    @Mock
+    private TopicProducerConfig topicProducerConfig;
+    @Mock
+    private EncryptionConfig encryptionConfig;
+
+    @BeforeEach
+    void setUp() {
+        when(kafkaProducerConfig.getTopic()).thenReturn(topicProducerConfig);
+        when(kafkaProducerConfig.getEncryptionConfig()).thenReturn(encryptionConfig);
+        when(kafkaProducerConfig.getBootstrapServers()).thenReturn(Collections.singletonList(UUID.randomUUID().toString()));
+
+        final Serializer serializer = mock(Serializer.class);
+        when(serializationFactory.getSerializer(any())).thenReturn(serializer);
+    }
+
+    private KafkaCustomProducerFactory createObjectUnderTest() {
+        return new KafkaCustomProducerFactory(serializationFactory, awsCredentialsSupplier, topicServiceFactory);
+    }
+
+    @Test
+    void createProducer_does_not_create_TopicService_when_createTopic_is_false() {
+        final KafkaCustomProducerFactory objectUnderTest = createObjectUnderTest();
+        try(final MockedConstruction<KafkaProducer> ignored = mockConstruction(KafkaProducer.class)) {
+            objectUnderTest.createProducer(kafkaProducerConfig, expressionEvaluator, sinkContext, pluginMetrics, dlqSink, false);
+        }
+
+        verify(topicServiceFactory, never()).createTopicService(any());
+    }
+
+    @Test
+    void createProducer_creates_TopicService_and_creates_topic_when_createTopic_is_true() {
+        final TopicService topicService = mock(TopicService.class);
+        when(topicServiceFactory.createTopicService(kafkaProducerConfig)).thenReturn(topicService);
+
+        final String topicName = UUID.randomUUID().toString();
+        final int numberOfPartitions = RANDOM.nextInt(1000);
+        final short replicationFactor = (short) RANDOM.nextInt(1000);
+        when(topicProducerConfig.getName()).thenReturn(topicName);
+        when(topicProducerConfig.getNumberOfPartitions()).thenReturn(numberOfPartitions);
+        when(topicProducerConfig.getReplicationFactor()).thenReturn(replicationFactor);
+
+
+        final KafkaCustomProducerFactory objectUnderTest = createObjectUnderTest();
+
+        when(topicProducerConfig.isCreateTopic()).thenReturn(true);
+
+        try(final MockedConstruction<KafkaProducer> ignored = mockConstruction(KafkaProducer.class)) {
+            objectUnderTest.createProducer(kafkaProducerConfig, expressionEvaluator, sinkContext, pluginMetrics, dlqSink, false);
+        }
+
+        final InOrder inOrder = inOrder(topicService);
+        inOrder.verify(topicService).createTopic(topicName, numberOfPartitions, replicationFactor, null);
+        inOrder.verify(topicService).closeAdminClient();
+
+    }
+
+}

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSinkTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/sink/KafkaSinkTest.java
@@ -134,7 +134,7 @@ public class KafkaSinkTest {
     private KafkaSink createObjectUnderTest() {
         final KafkaSink objectUnderTest;
         try(final MockedConstruction<KafkaCustomProducerFactory> ignored = mockConstruction(KafkaCustomProducerFactory.class, (mock, context) -> {
-           when(mock.createProducer(any(), any(), any(), any(), any(), any(), any(), anyBoolean())).thenReturn(kafkaCustomProducer);
+           when(mock.createProducer(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(kafkaCustomProducer);
         })) {
             objectUnderTest = new KafkaSink(pluginSetting, kafkaSinkConfig, pluginFactoryMock, pluginMetrics, mock(ExpressionEvaluator.class), sinkContext, awsCredentialsSupplier);
         }


### PR DESCRIPTION
### Description

The core of this PR is to fix an inverted boolean check for the `create_topic` configuration.

Additionally, I wanted to add unit tests. To do this well, I did some refactoring to add a `TopicServiceFactory` and then hide the constructor for `TopicService`.
 
### Issues Resolved
Resolves #4111
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
