### PR TITLE
Corrections to Kafka integration tests in GitHub

### DIFF
--- a/.github/workflows/kafka-plugin-integration-tests.yml
+++ b/.github/workflows/kafka-plugin-integration-tests.yml
@@ -65,7 +65,7 @@ jobs:
             -Dtests.kafka.bootstrap_servers=localhost:9092 \
             -Dtests.kafka.authconfig.username=admin -Dtests.kafka.authconfig.password=admin \
             -Dtests.kafka.kms_key=alias/DataPrepperTesting \
-            --tests '*kafka.buffer*'
+            --tests '*kafka.buffer*' --tests KafkaSourceJsonTypeIT --tests KafkaBufferOTelIT
 
       - name: Upload Unit Test Results
         if: always()

--- a/.github/workflows/kafka-plugin-integration-tests.yml
+++ b/.github/workflows/kafka-plugin-integration-tests.yml
@@ -8,7 +8,8 @@ on:
     paths:
       - 'data-prepper-plugins/kafka-plugins/**'
       - '*gradle*'
-  pull_request:
+  pull_request_target:
+    types: [ opened, synchronize, reopened ]
     paths:
       - 'data-prepper-plugins/kafka-plugins/**'
       - '*gradle*'


### PR DESCRIPTION
### Description

Fix 1:

Replaces missing tests in the Kafka integration tests: 

* `KafkaSourceJsonTypeIT`
* `KafkaBufferOTelIT`
 
These were incorrectly removed in #4041

Fix 2:

The tests now run using `pull_request_target`. This will cause GitHub to run against the target repository and thus access the necessary secrets.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
