### PR TITLE
Allow . and @ characters to be part of json pointer in expressions

### DIFF
--- a/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
+++ b/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
@@ -217,7 +217,7 @@ JsonPointerCharacters
 
 fragment
 JsonPointerCharacter
-    : [A-Za-z0-9_]
+    : [A-Za-z0-9_.@]
     ;
 
 EscapedJsonPointer

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator_ConditionalIT.java
@@ -152,6 +152,8 @@ class GenericExpressionEvaluator_ConditionalIT {
                 Arguments.of("/status_code == 200", event("{}"), false),
                 Arguments.of("/success == /status_code", event("{\"success\": true, \"status_code\": 200}"), false),
                 Arguments.of("/success != /status_code", event("{\"success\": true, \"status_code\": 200}"), true),
+                Arguments.of("/part1@part2.part3 != 111", event("{\"success\": true, \"part1@part2.part3\":111, \"status_code\": 200}"), false),
+                Arguments.of("/part1.part2@part3 != 111", event("{\"success\": true, \"part1.part2@part3\":222, \"status_code\": 200}"), true),
                 Arguments.of("/pi == 3.14159", event("{\"pi\": 3.14159}"), true),
                 Arguments.of("/value == 12345.678", event("{\"value\": 12345.678}"), true),
                 Arguments.of("/value == 12345.678E12", event("{\"value\": 12345.678E12}"), true),

--- a/docs/expression_syntax.md
+++ b/docs/expression_syntax.md
@@ -137,7 +137,7 @@ Hard coded token that identifies the operation use in an _Expression_.
 
 ### Json Pointer
 A Literal used to reference a value within the Event provided as context for the _Expression String_. Json Pointers are identified by a 
-leading `/` containing alphanumeric character or underscores, delimited by `/`. Json Pointers can use an extended character set if wrapped 
+leading `/` containing one of more of characters from the set `a-zA-Z0-9_.@` , delimited by `/`. Json Pointers can use an extended character set if wrapped
 in double quotes (`"`) using the escape character `\`. Note, Json Pointer require `~` and `/` that should be used as part of the path and 
 not a delimiter to be escaped.
 


### PR DESCRIPTION
### Description
Allow . and @ characters to be part of json pointer in expressions.

Allows expressions with json pointers containing "." and "@". For example
```
/part1.part2@part3 == "xyz"
``
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ X] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
