### PR TITLE
Require json-path 2.9.0 to fix CVE-2023-51074. Resolves #3919

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,6 +194,12 @@ subprojects {
                 }
                 because 'CVE from transitive dependencies'
             }
+            implementation('com.jayway.jsonpath:json-path') {
+                version {
+                    require '2.9.0'
+                }
+                because 'Fixes CVE-2023-51074 from transitive dependencies'
+            }
             implementation('org.bitbucket.b_c:jose4j') {
                 version {
                     require '0.9.3'


### PR DESCRIPTION
### Description

Require json-path 2.9.0 to fix CVE-2023-51074. 
 
### Issues Resolved

Resolves #3919
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
