### PR TITLE
Jackson to 2.16.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ subprojects {
         }
     }
     dependencies {
-        implementation platform('com.fasterxml.jackson:jackson-bom:2.15.3')
+        implementation platform('com.fasterxml.jackson:jackson-bom:2.16.1')
         implementation platform('org.eclipse.jetty:jetty-bom:9.4.53.v20231009')
         implementation platform('io.micrometer:micrometer-bom:1.10.5')
         implementation libs.guava.core

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodecTest.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodecTest.java
@@ -75,7 +75,6 @@ public class AvroOutputCodecTest {
         RuntimeException actualException = assertThrows(RuntimeException.class, this::createObjectUnderTest);
 
         assertThat(actualException.getMessage(), notNullValue());
-        assertThat(actualException.getMessage(), containsString(invalidSchema));
         assertThat(actualException.getMessage(), containsString("was expecting comma"));
     }
 

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodecTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetOutputCodecTest.java
@@ -97,7 +97,6 @@ public class ParquetOutputCodecTest {
         RuntimeException actualException = assertThrows(RuntimeException.class, this::createObjectUnderTest);
 
         assertThat(actualException.getMessage(), notNullValue());
-        assertThat(actualException.getMessage(), containsString(invalidSchema));
         assertThat(actualException.getMessage(), containsString("was expecting comma"));
     }
 


### PR DESCRIPTION
### Description

Updates Jackson to 2.16.1. Jackson 2.16 now redacts input data in exceptions. So a couple tests needed modifications. 

Additionally, this uses ion-java 1.10.5 which has a fix for  CVE-2024-21634.

 
### Issues Resolved

Resolves #3926 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
