### PR TITLE
Delay reading from the Kafka buffer as long as the circuit breaker is open

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -352,12 +352,13 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
                     LOG.debug("Pause consuming from Kafka topic due a previous exception.");
                     Thread.sleep(10000);
                 } else if (pauseConsumePredicate.pauseConsuming()) {
-                    LOG.debug("Pause and skip the next consume from Kafka topic due to an external condition: {}", pauseConsumePredicate);
+                    LOG.debug("Pause and skip consuming from Kafka topic due to an external condition: {}", pauseConsumePredicate);
                     paused = true;
                     consumer.pause(consumer.assignment());
                     Thread.sleep(10000);
                     continue;
                 } else if(paused) {
+                    LOG.debug("Resume consuming from Kafka topic.");
                     consumer.resume(consumer.assignment());
                 }
                 synchronized(this) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -348,9 +348,13 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         boolean retryingAfterException = false;
         while (!shutdownInProgress.get()) {
             try {
-                if (retryingAfterException || pauseConsumePredicate.pauseConsuming()) {
-                    LOG.debug("Pause consuming from Kafka topic.");
+                if (retryingAfterException) {
+                    LOG.debug("Pause consuming from Kafka topic due a previous exception.");
                     Thread.sleep(10000);
+                } else if (pauseConsumePredicate.pauseConsuming()) {
+                    LOG.debug("Pause and skip the next consume from Kafka topic due to an external condition: {}", pauseConsumePredicate);
+                    Thread.sleep(10000);
+                    continue;
                 }
                 synchronized(this) {
                     commitOffsets(false);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -359,6 +359,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
                     continue;
                 } else if(paused) {
                     LOG.debug("Resume consuming from Kafka topic.");
+                    paused = false;
                     consumer.resume(consumer.assignment());
                 }
                 synchronized(this) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/PauseConsumePredicate.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/PauseConsumePredicate.java
@@ -30,7 +30,17 @@ public interface PauseConsumePredicate {
     static PauseConsumePredicate circuitBreakingPredicate(final CircuitBreaker circuitBreaker) {
         if(circuitBreaker == null)
             return noPause();
-        return circuitBreaker::isOpen;
+        return new PauseConsumePredicate() {
+            @Override
+            public boolean pauseConsuming() {
+                return circuitBreaker.isOpen();
+            }
+
+            @Override
+            public String toString() {
+                return "Circuit Breaker";
+            }
+        };
     }
 
     /**

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/PauseConsumePredicateTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/PauseConsumePredicateTest.java
@@ -51,4 +51,13 @@ class PauseConsumePredicateTest {
 
         assertThat(pauseConsumePredicate.pauseConsuming(), equalTo(isOpen));
     }
+
+    @Test
+    void circuitBreakingPredicate_with_a_circuit_breaker_returns_predicate_with_toString() {
+        final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
+
+        final PauseConsumePredicate pauseConsumePredicate = PauseConsumePredicate.circuitBreakingPredicate(circuitBreaker);
+
+        assertThat(pauseConsumePredicate.toString(), equalTo("Circuit Breaker"));
+    }
 }


### PR DESCRIPTION
### Description

The `kafka` buffer was pausing 10 seconds to wait for the circuit breaker to close. However, it would then consume after that. This change will keep holding until the circuit breaker closes again. This is similar to how inputs into buffers work.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
