### PR TITLE
JDK 17 release update

### DIFF
--- a/release/build-resources.gradle
+++ b/release/build-resources.gradle
@@ -9,7 +9,7 @@ ext {
             linux: ['x64']
     ]
     jdkSources = [
-            linux_x64: 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.8_7.tar.gz',
+            linux_x64: 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.10_7.tar.gz',
             linux_arm64: 'https://hg.openjdk.java.net/aarch64-port/jdk8/archive/tip.tar.gz'
     ]
     awsResources = [


### PR DESCRIPTION
### Description

Updates the JDK in the released artifacts to jdk-17.0.10+7.

https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.10%2B7
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
