### PR TITLE
Replace a try-catch with conditional in join function

### DIFF
--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/JoinExpressionFunction.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/JoinExpressionFunction.java
@@ -54,15 +54,15 @@ public class JoinExpressionFunction implements  ExpressionFunction {
         }
 
         try {
-            final List<Object> sourceList = event.get(sourceKey, List.class);
-            return joinList(sourceList, delimiter);
-        } catch (Exception e) {
-            try {
+            if (event.isValueAList(sourceKey)) {
+                final List<Object> sourceList = event.get(sourceKey, List.class);
+                return joinList(sourceList, delimiter);
+            } else {
                 final Map<String, Object> sourceMap = event.get(sourceKey, Map.class);
                 return joinListsInMap(sourceMap, delimiter);
-            } catch (Exception ex) {
-                throw new RuntimeException("Unable to perform join function on " + sourceKey, ex);
             }
+        } catch (Exception ex) {
+            throw new RuntimeException("Unable to perform join function on " + sourceKey, ex);
         }
     }
 

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/JoinExpressionFunctionTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/JoinExpressionFunctionTest.java
@@ -94,6 +94,13 @@ class JoinExpressionFunctionTest {
                 () -> joinExpressionFunction.evaluate(List.of("/missingKey"), testEvent, testFunction));
     }
 
+    @Test
+    void testSourceFieldNotListOrMapThrowsException() {
+        testEvent = createTestEvent(Map.of("key", "value"));
+        assertThrows(RuntimeException.class,
+                () -> joinExpressionFunction.evaluate(List.of("/key"), testEvent, testFunction));
+    }
+
     private static Stream<Arguments> joinSingleList() {
         final String inputData = "{\"list\":[\"string\", 1, true]}";
         return Stream.of(


### PR DESCRIPTION
### Description
`join` function supports joining either a list or a map containing lists. Currently it will log an error message ("ERROR org.opensearch.dataprepper.model.event.JacksonEvent - Unable to map /source to interface java.util.List") with a long trackback when the source field is a map, which is expected but can confuse users to think it's not working properly.

This PR replaces the try-catch with a conditional to avoid the confusing error message.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
