### PR TITLE
Add select_entries processor

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessor.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.mutateevent;
+
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.processor.AbstractProcessor;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+@DataPrepperPlugin(name = "select_entries", pluginType = Processor.class, pluginConfigurationType = SelectEntriesProcessorConfig.class)
+public class SelectEntriesProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
+    private final List<String> entries;
+    private final String selectWhen;
+
+    private final ExpressionEvaluator expressionEvaluator;
+
+    @DataPrepperPluginConstructor
+    public SelectEntriesProcessor(final PluginMetrics pluginMetrics, final SelectEntriesProcessorConfig config, final ExpressionEvaluator expressionEvaluator) {
+        super(pluginMetrics);
+        this.entries = Arrays.asList(config.getIncludeKeys());
+        this.selectWhen = config.getSelectWhen();
+        this.expressionEvaluator = expressionEvaluator;
+    }
+
+    @Override
+    public Collection<Record<Event>> doExecute(final Collection<Record<Event>> records) {
+        for(final Record<Event> record : records) {
+            final Event recordEvent = record.getData();
+
+            if (Objects.nonNull(selectWhen) && !expressionEvaluator.evaluateConditional(selectWhen, recordEvent)) {
+                continue;
+            }
+            // To handle nested case, just get the values and store
+            // in a temporary map.
+            Map<String, Object> outMap = new HashMap<>();
+            for (String entry: entries) {
+                Object val = recordEvent.get(entry, Object.class);
+                if (val != null) {
+                    outMap.put(entry, val);
+                }
+            }
+            // Delete all entries from the event
+            Set keysToDelete = recordEvent.toMap().keySet();
+            Iterator iter = keysToDelete.iterator();
+            while (iter.hasNext()) {
+                recordEvent.delete((String)iter.next());
+            }
+    
+            // add back only the keys selected
+            for (Map.Entry<String, Object> entry: outMap.entrySet()) {
+                recordEvent.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return records;
+    }
+
+    @Override
+    public void prepareForShutdown() {
+    }
+
+    @Override
+    public boolean isReadyForShutdown() {
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+    }
+}
+

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.mutateevent;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public class SelectEntriesProcessorConfig {
+    @NotEmpty
+    @NotNull
+    @JsonProperty("include_keys")
+    private String[] includeKeys;
+
+    @JsonProperty("select_when")
+    private String selectWhen;
+
+    public String[] getIncludeKeys() {
+        return includeKeys;
+    }
+
+    public String getSelectWhen() {
+        return selectWhen;
+    }
+}
+

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/SelectEntriesProcessorTests.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.mutateevent;
+
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class SelectEntriesProcessorTests {
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private SelectEntriesProcessorConfig mockConfig;
+
+    @Mock
+    private ExpressionEvaluator expressionEvaluator;
+
+    @Test
+    public void testSelectEntriesProcessorTest() {
+        when(mockConfig.getIncludeKeys()).thenReturn(new String[] { "key1", "key2"});
+        when(mockConfig.getSelectWhen()).thenReturn(null);
+        final SelectEntriesProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("thisisamessage");
+        record.getData().put("newMessage", "test");
+        final String value1 = UUID.randomUUID().toString();
+        final String value2 = UUID.randomUUID().toString();
+        record.getData().put("key1", value1);
+        record.getData().put("key2", value2);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+        assertThat(editedRecords.get(0).getData().containsKey("key1"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("key2"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("newMessage"), is(false));
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(false));
+        assertThat(editedRecords.get(0).getData().get("key1", String.class), equalTo(value1));
+        assertThat(editedRecords.get(0).getData().get("key2", String.class), equalTo(value2));
+    }
+
+    @Test
+    public void testWithKeyDneSelectEntriesProcessorTest() {
+        when(mockConfig.getIncludeKeys()).thenReturn(new String[] { "key1", "key2"});
+        when(mockConfig.getSelectWhen()).thenReturn(null);
+        final SelectEntriesProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("thisisamessage");
+        record.getData().put("newMessage", "test");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+        assertThat(editedRecords.get(0).getData().containsKey("key1"), is(false));
+        assertThat(editedRecords.get(0).getData().containsKey("key2"), is(false));
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(false));
+        assertThat(editedRecords.get(0).getData().containsKey("newMessage"), is(false));
+    }
+
+    @Test
+    public void testSelectEntriesProcessorWithConditionTest() {
+        when(mockConfig.getIncludeKeys()).thenReturn(new String[] { "key1", "key2"});
+        final String selectWhen = UUID.randomUUID().toString();
+        when(mockConfig.getSelectWhen()).thenReturn(selectWhen);
+        final SelectEntriesProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("thisisamessage");
+        record.getData().put("newMessage", "test");
+        final String value1 = UUID.randomUUID().toString();
+        final String value2 = UUID.randomUUID().toString();
+        record.getData().put("key1", value1);
+        record.getData().put("key2", value2);
+        when(expressionEvaluator.evaluateConditional(selectWhen, record.getData())).thenReturn(false);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+        assertThat(editedRecords.get(0).getData().containsKey("key1"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("key2"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("newMessage"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("key1", String.class), equalTo(value1));
+        assertThat(editedRecords.get(0).getData().get("key2", String.class), equalTo(value2));
+    }
+
+    @Test
+    public void testNestedSelectEntriesProcessorTest() {
+        when(mockConfig.getIncludeKeys()).thenReturn(new String[] { "nested/key1", "nested/nested2/key2"});
+        when(mockConfig.getSelectWhen()).thenReturn(null);
+        final String value1 = UUID.randomUUID().toString();
+        final String value2 = UUID.randomUUID().toString();
+        Map<String, Object> nested2 = Map.of("key2", value2, "key3", "value3");
+        Map<String, Object> nested = Map.of("key1", value1, "fizz", 42, "nested2", nested2);
+        final SelectEntriesProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("thisisamessage");
+        record.getData().put("nested", nested);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+        assertThat(editedRecords.get(0).getData().containsKey("nested/key1"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("nested/nested2/key2"), is(true));
+        assertThat(editedRecords.get(0).getData().containsKey("nested/nested2/key3"), is(false));
+        assertThat(editedRecords.get(0).getData().containsKey("nested/fizz"), is(false));
+        assertThat(editedRecords.get(0).getData().containsKey("newMessage"), is(false));
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(false));
+
+        assertThat(editedRecords.get(0).getData().get("nested/key1", String.class), equalTo(value1));
+        assertThat(editedRecords.get(0).getData().get("nested/nested2/key2", String.class), equalTo(value2));
+    }
+
+
+    private SelectEntriesProcessor createObjectUnderTest() {
+        return new SelectEntriesProcessor(pluginMetrics, mockConfig, expressionEvaluator);
+    }
+
+    private Record<Event> getEvent(String message) {
+        final Map<String, Object> testData = new HashMap();
+        testData.put("message", message);
+        return buildRecordWithEvent(testData);
+    }
+
+    private static Record<Event> buildRecordWithEvent(final Map<String, Object> data) {
+        return new Record<>(JacksonEvent.builder()
+                .withData(data)
+                .withEventType("event")
+                .build());
+    }
+}


### PR DESCRIPTION
### Description
Added `select_entries` processor to select a few entries from input events.

Configuration

```
  processor:
    - select_entries:
         include_keys: ["key1", "key2"]
         select_when: '/key1 = "K1"'
```
If the input event is as follows

```
{"key1" : "K1", "key2": "K2", "key3": "K3", "message": "new message"}
```
Then the output event would be
```
{"key1" : "K1", "key2": "K2"}
```
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
