### PR TITLE
Removes unnecessary mavenCentral() declarations in Gradle sub-projects.

### DIFF
--- a/data-prepper-plugins/cloudwatch-logs/build.gradle
+++ b/data-prepper-plugins/cloudwatch-logs/build.gradle
@@ -3,10 +3,6 @@ plugins {
     id 'java-library'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(':data-prepper-plugins:aws-plugin-api')
     implementation project(path: ':data-prepper-plugins:common')

--- a/data-prepper-plugins/dynamodb-source/build.gradle
+++ b/data-prepper-plugins/dynamodb-source/build.gradle
@@ -3,10 +3,6 @@ plugins {
 }
 
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(path: ':data-prepper-api')
 

--- a/data-prepper-plugins/mapdb-processor-state/build.gradle
+++ b/data-prepper-plugins/mapdb-processor-state/build.gradle
@@ -7,10 +7,6 @@ plugins {
     id 'java'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')

--- a/data-prepper-plugins/newline-codecs/build.gradle
+++ b/data-prepper-plugins/newline-codecs/build.gradle
@@ -2,11 +2,6 @@ plugins {
     id 'java'
 }
 
-
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(':data-prepper-api')
     implementation 'com.fasterxml.jackson.core:jackson-annotations'

--- a/data-prepper-plugins/parse-json-processor/build.gradle
+++ b/data-prepper-plugins/parse-json-processor/build.gradle
@@ -7,10 +7,6 @@ plugins {
     id 'java'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')

--- a/data-prepper-plugins/rss-source/build.gradle
+++ b/data-prepper-plugins/rss-source/build.gradle
@@ -7,10 +7,6 @@ plugins {
     id 'java'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(':data-prepper-api')
     implementation 'io.micrometer:micrometer-core'

--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -7,10 +7,6 @@ plugins {
     id 'java'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:buffer-common')

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -7,10 +7,6 @@ plugins {
     id 'java'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')

--- a/data-prepper-test-common/build.gradle
+++ b/data-prepper-test-common/build.gradle
@@ -7,10 +7,6 @@ plugins {
     id 'java'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation testLibs.hamcrest
     testRuntimeOnly testLibs.junit.engine

--- a/performance-test/build.gradle
+++ b/performance-test/build.gradle
@@ -14,10 +14,6 @@ configurations.all {
 
 group 'org.opensearch.dataprepper.test.performance'
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     gatlingImplementation 'software.amazon.awssdk:auth:2.23.13'
     implementation 'com.fasterxml.jackson.core:jackson-core'


### PR DESCRIPTION
### Description

The root Gradle project declares the `mavenCentral()` repository. These `repositories` declarations are all unnecessary, so this PR removes them.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
