### PR TITLE
Catch processor exceptions instead of shutting down

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/ProcessWorker.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
@@ -125,17 +126,25 @@ public class ProcessWorker implements Runnable {
         }
         //Should Empty list from buffer should be sent to the processors? For now sending as the Stateful processors expects it.
         for (final Processor processor : processors) {
+
+            List<Event> inputEvents = null;
+            if (acknowledgementsEnabled) {
+                inputEvents = ((ArrayList<Record<Event>>) records).stream().map(Record::getData).collect(Collectors.toList());
+            }
+
             try {
-                List<Event> inputEvents = null;
-                if (acknowledgementsEnabled) {
-                    inputEvents = ((ArrayList<Record<Event>>) records).stream().map(Record::getData).collect(Collectors.toList());
-                }
                 records = processor.execute(records);
                 if (inputEvents != null) {
                     processAcknowledgements(inputEvents, records);
                 }
             } catch (final Exception e) {
-                LOG.error("A processor threw an exception. This processor will be skipped for the remaining Events in this batch: ", e);
+                LOG.error("A processor threw an exception. This batch of Events will be dropped, and there EventHandles will be released: ", e);
+                if (inputEvents != null) {
+                    processAcknowledgements(inputEvents, Collections.emptyList());
+                }
+
+                records = Collections.emptyList();
+                break;
             }
         }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/ProcessWorker.java
@@ -138,7 +138,7 @@ public class ProcessWorker implements Runnable {
                     processAcknowledgements(inputEvents, records);
                 }
             } catch (final Exception e) {
-                LOG.error("A processor threw an exception. This batch of Events will be dropped, and there EventHandles will be released: ", e);
+                LOG.error("A processor threw an exception. This batch of Events will be dropped, and their EventHandles will be released: ", e);
                 if (inputEvents != null) {
                     processAcknowledgements(inputEvents, Collections.emptyList());
                 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/ProcessWorkerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/ProcessWorkerTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/ProcessWorkerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/ProcessWorkerTest.java
@@ -1,0 +1,159 @@
+package org.opensearch.dataprepper.pipeline;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.CheckpointState;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
+import org.opensearch.dataprepper.model.buffer.Buffer;
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.source.Source;
+import org.opensearch.dataprepper.pipeline.common.FutureHelper;
+import org.opensearch.dataprepper.pipeline.common.FutureHelperResult;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ProcessWorkerTest {
+
+    @Mock
+    private Pipeline pipeline;
+
+    @Mock
+    private Buffer buffer;
+
+    @Mock
+    private Source source;
+
+    private List<Future<Void>> sinkFutures;
+
+    private List<Processor> processors;
+
+    @BeforeEach
+    void setup() {
+        when(pipeline.isStopRequested()).thenReturn(false).thenReturn(true);
+        when(source.areAcknowledgementsEnabled()).thenReturn(false);
+        when(pipeline.getSource()).thenReturn(source);
+        when(buffer.isEmpty()).thenReturn(true);
+        when(pipeline.getPeerForwarderDrainTimeout()).thenReturn(Duration.ofMillis(100));
+        when(pipeline.getReadBatchTimeoutInMillis()).thenReturn(500);
+
+        final Future<Void> sinkFuture = mock(Future.class);
+        sinkFutures = List.of(sinkFuture);
+        when(pipeline.publishToSinks(any())).thenReturn(sinkFutures);
+    }
+
+    private ProcessWorker createObjectUnderTest() {
+        return new ProcessWorker(buffer, processors, pipeline);
+    }
+
+    @Test
+    void testProcessWorkerHappyPath() {
+
+        final List<Record> records = List.of(mock(Record.class));
+        final CheckpointState checkpointState = mock(CheckpointState.class);
+        final Map.Entry<Collection, CheckpointState> readResult = Map.entry(records, checkpointState);
+        when(buffer.read(pipeline.getReadBatchTimeoutInMillis())).thenReturn(readResult);
+
+        final Processor processor = mock(Processor.class);
+        when(processor.execute(records)).thenReturn(records);
+        when(processor.isReadyForShutdown()).thenReturn(true);
+        processors = List.of(processor);
+
+        final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
+        when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
+
+
+        try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
+            futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
+                    .thenReturn(futureHelperResult);
+
+            final ProcessWorker processWorker = createObjectUnderTest();
+
+            processWorker.run();
+        }
+    }
+
+    @Test
+    void testProcessWorkerHappyPathWithAcknowledgments() {
+
+        when(source.areAcknowledgementsEnabled()).thenReturn(true);
+
+        final List<Record<Event>> records = new ArrayList<>();
+        final Record<Event> mockRecord = mock(Record.class);
+        final Event mockEvent = mock(Event.class);
+        final EventHandle eventHandle = mock(DefaultEventHandle.class);
+        when(((DefaultEventHandle) eventHandle).getAcknowledgementSet()).thenReturn(mock(AcknowledgementSet.class));
+        when(mockRecord.getData()).thenReturn(mockEvent);
+        when(mockEvent.getEventHandle()).thenReturn(eventHandle);
+
+        records.add(mockRecord);
+
+        final CheckpointState checkpointState = mock(CheckpointState.class);
+        final Map.Entry<Collection, CheckpointState> readResult = Map.entry(records, checkpointState);
+        when(buffer.read(pipeline.getReadBatchTimeoutInMillis())).thenReturn(readResult);
+
+        final Processor processor = mock(Processor.class);
+        when(processor.execute(records)).thenReturn(records);
+        when(processor.isReadyForShutdown()).thenReturn(true);
+        processors = List.of(processor);
+
+        final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
+        when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
+
+
+        try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
+            futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
+                    .thenReturn(futureHelperResult);
+
+            final ProcessWorker processWorker = createObjectUnderTest();
+
+            processWorker.run();
+        }
+    }
+
+    @Test
+    void testProcessWorkerWithProcessorThrowingExceptionIsCaughtProperly() {
+
+        final List<Record> records = List.of(mock(Record.class));
+        final CheckpointState checkpointState = mock(CheckpointState.class);
+        final Map.Entry<Collection, CheckpointState> readResult = Map.entry(records, checkpointState);
+        when(buffer.read(pipeline.getReadBatchTimeoutInMillis())).thenReturn(readResult);
+
+        final Processor processor = mock(Processor.class);
+        when(processor.execute(records)).thenThrow(RuntimeException.class);
+        when(processor.isReadyForShutdown()).thenReturn(true);
+        processors = List.of(processor);
+
+        final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
+        when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
+
+
+        try (final MockedStatic<FutureHelper> futureHelperMockedStatic = mockStatic(FutureHelper.class)) {
+            futureHelperMockedStatic.when(() -> FutureHelper.awaitFuturesIndefinitely(sinkFutures))
+                    .thenReturn(futureHelperResult);
+
+            final ProcessWorker processWorker = createObjectUnderTest();
+
+            processWorker.run();
+        }
+    }
+}

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/ProcessWorkerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/ProcessWorkerTest.java
@@ -26,11 +26,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -143,7 +145,10 @@ public class ProcessWorkerTest {
         final Processor processor = mock(Processor.class);
         when(processor.execute(records)).thenThrow(RuntimeException.class);
         when(processor.isReadyForShutdown()).thenReturn(true);
-        processors = List.of(processor);
+
+        final Processor skippedProcessor = mock(Processor.class);
+        when(skippedProcessor.isReadyForShutdown()).thenReturn(true);
+        processors = List.of(processor, skippedProcessor);
 
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
@@ -157,6 +162,8 @@ public class ProcessWorkerTest {
 
             processWorker.run();
         }
+
+        verify(skippedProcessor, never()).execute(any());
     }
 
     @Test
@@ -182,7 +189,10 @@ public class ProcessWorkerTest {
         final Processor processor = mock(Processor.class);
         when(processor.execute(records)).thenThrow(RuntimeException.class);
         when(processor.isReadyForShutdown()).thenReturn(true);
-        processors = List.of(processor);
+
+        final Processor skippedProcessor = mock(Processor.class);
+        when(skippedProcessor.isReadyForShutdown()).thenReturn(true);
+        processors = List.of(processor, skippedProcessor);
 
         final FutureHelperResult<Void> futureHelperResult = mock(FutureHelperResult.class);
         when(futureHelperResult.getFailedReasons()).thenReturn(Collections.emptyList());
@@ -196,5 +206,7 @@ public class ProcessWorkerTest {
 
             processWorker.run();
         }
+
+        verify(skippedProcessor, never()).execute(any());
     }
 }


### PR DESCRIPTION
### Description
This change makes it so exceptions thrown from `Processors` in `ProcessWorker` to not shut down the thread.

Instead of shutting down, we will just pass the batch of Events that resulted in the exception to the next processor in the chain
 
### Issues Resolved
Resolves #4103 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
