### PR TITLE
Moves the repository declarations to the settings.gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,21 +5,6 @@
 import com.github.jk1.license.render.TextReportRenderer
 
 buildscript {
-    repositories {
-        mavenCentral() {
-            metadataSources {
-                mavenPom()
-                ignoreGradleMetadataRedirection()
-            }
-        }
-        maven {
-            url 'https://plugins.gradle.org/m2/'
-            metadataSources {
-                mavenPom()
-                ignoreGradleMetadataRedirection()
-            }
-        }
-    }
     dependencies {
         classpath 'com.github.jk1:gradle-license-report:2.1'
     }
@@ -40,14 +25,6 @@ allprojects {
 
     ext {
         mavenPublicationRootFile = file("${rootProject.buildDir}/m2")
-    }
-    
-    repositories {
-        mavenCentral()
-        maven { url 'https://jitpack.io' }
-        maven {
-            url 'https://packages.confluent.io/maven/'
-        }
     }
 
     spotless {

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,19 @@ pluginManagement {
     }
 }
 
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        maven {
+            url 'https://packages.confluent.io/maven/'
+        }
+        maven {
+            url 'https://jitpack.io'
+            content { includeGroup 'com.github.fge' }
+        }
+    }
+}
+
 rootProject.name = 'opensearch-data-prepper'
 
 dependencyResolutionManagement {


### PR DESCRIPTION
### Description

This PR moves the Maven repository declarations to the `settings.gradle` file. This consolidates all usage there.

Additionally, this PR adds a limit the groups used by the JitPack Maven repository. This repository is only needed for the `com.github.fge:json-schema-validator` dependency in the Kafka plugins. Now, Data Prepper will not pull anything other than that Maven group from JitPack.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
