### PR TITLE
Catch exceptions instead of throwing for processors that can handle Events event by event

### DIFF
--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessor.java
@@ -58,16 +58,16 @@ public class CsvProcessor extends AbstractProcessor<Record<Event>, Record<Event>
 
             final Event event = record.getData();
 
-            final String message = event.get(config.getSource(), String.class);
-
-            if (Objects.isNull(message)) {
-                continue;
-            }
-
-            final boolean userDidSpecifyHeaderEventKey = Objects.nonNull(config.getColumnNamesSourceKey());
-            final boolean thisEventHasHeaderSource = userDidSpecifyHeaderEventKey && event.containsKey(config.getColumnNamesSourceKey());
-
             try {
+                final String message = event.get(config.getSource(), String.class);
+
+                if (Objects.isNull(message)) {
+                    continue;
+                }
+
+                final boolean userDidSpecifyHeaderEventKey = Objects.nonNull(config.getColumnNamesSourceKey());
+                final boolean thisEventHasHeaderSource = userDidSpecifyHeaderEventKey && event.containsKey(config.getColumnNamesSourceKey());
+
                 final MappingIterator<List<String>> messageIterator = mapper.readerFor(List.class).with(schema).readValues(message);
 
                 // otherwise the message is empty

--- a/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessor.java
+++ b/data-prepper-plugins/dissect-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/dissect/DissectProcessor.java
@@ -55,18 +55,17 @@ public class DissectProcessor extends AbstractProcessor<Record<Event>, Record<Ev
     public Collection<Record<Event>> doExecute(Collection<Record<Event>> records) {
         for (final Record<Event> record : records) {
             Event event = record.getData();
-            String dissectWhen = dissectConfig.getDissectWhen();
-            if (Objects.nonNull(dissectWhen) && !expressionEvaluator.evaluateConditional(dissectWhen, event)) {
-                continue;
-            }
             try{
-                for(String field: dissectorMap.keySet()){
+                String dissectWhen = dissectConfig.getDissectWhen();
+                if (Objects.nonNull(dissectWhen) && !expressionEvaluator.evaluateConditional(dissectWhen, event)) {
+                    continue;
+                }
+                for (String field: dissectorMap.keySet()){
                     if(event.containsKey(field)){
                         dissectField(event, field);
                     }
                 }
-            }
-            catch (Exception ex){
+            } catch (Exception ex){
                 LOG.error(EVENT, "Error dissecting the event [{}] ", record.getData(), ex);
             }
         }

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/CopyValueProcessor.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
+
 @DataPrepperPlugin(name = "copy_values", pluginType = Processor.class, pluginConfigurationType = CopyValueProcessorConfig.class)
 public class CopyValueProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
     private static final Logger LOG = LoggerFactory.getLogger(CopyValueProcessor.class);
@@ -41,8 +43,9 @@ public class CopyValueProcessor extends AbstractProcessor<Record<Event>, Record<
     @Override
     public Collection<Record<Event>> doExecute(final Collection<Record<Event>> records) {
         for(final Record<Event> record : records) {
+            final Event recordEvent = record.getData();
+
             try {
-                final Event recordEvent = record.getData();
                 if (config.getFromList() != null || config.getToList() != null) {
                     // Copying entries between lists
                     if (recordEvent.containsKey(config.getToList()) && !config.getOverwriteIfToListExists()) {
@@ -80,9 +83,8 @@ public class CopyValueProcessor extends AbstractProcessor<Record<Event>, Record<
                         }
                     }
                 }
-            } catch (Exception e) {
-                LOG.error("Fail to perform copy values operation", e);
-                //TODO: add tagging on failure
+            } catch (final Exception e) {
+                LOG.error(EVENT, "There was an exception while processing Event [{}]", recordEvent, e);
             }
         }
 

--- a/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/AbstractStringProcessor.java
+++ b/data-prepper-plugins/mutate-string-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutatestring/AbstractStringProcessor.java
@@ -33,7 +33,11 @@ public abstract class AbstractStringProcessor<T> extends AbstractProcessor<Recor
     public Collection<Record<Event>> doExecute(final Collection<Record<Event>> records) {
         for(final Record<Event> record : records) {
             final Event recordEvent = record.getData();
-            performStringAction(recordEvent);
+            try {
+                performStringAction(recordEvent);
+            } catch (final Exception e) {
+                LOG.error(EVENT, "There was an exception while processing Event [{}]", recordEvent, e);
+            }
         }
 
         return records;


### PR DESCRIPTION
### Description
This change makes it so any processors (other than stateful processors) will catch runtime exceptions for individual Events, and then log the error and tag the Event, before continuing on to the next Event.

This included the following processors

* csv
* dissect
* key_value
* convert_entry_type
* mutate events processors
* mutate string processors
* map_to_list
* obfuscate
* truncate
 
### Issues Resolved
Related to #4103
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
