### PR TITLE
Fix OpenSearchSink upsert operation

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -309,7 +309,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
         }
 
 
-          final UpdateOperation.Builder<Object> updateOperationBuilder = (action.toLowerCase().equals(OpenSearchBulkActions.UPSERT.toString())) ?
+          final UpdateOperation.Builder<Object> updateOperationBuilder = (StringUtils.equals(action.toLowerCase(), OpenSearchBulkActions.UPSERT.toString())) ?
               new UpdateOperation.Builder<>()
                   .index(indexName)
                   .document(filteredJsonNode)

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -309,7 +309,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
         }
 
 
-          final UpdateOperation.Builder<Object> updateOperationBuilder = (action.toLowerCase() == OpenSearchBulkActions.UPSERT.toString()) ?
+          final UpdateOperation.Builder<Object> updateOperationBuilder = (action.toLowerCase().equals(OpenSearchBulkActions.UPSERT.toString())) ?
               new UpdateOperation.Builder<>()
                   .index(indexName)
                   .document(filteredJsonNode)


### PR DESCRIPTION
### Description
Upsert operation code incorrectly uses "==" to compare two string. It should use equals()
 
Resolves #4036 #3934 
### Issues Resolved
Resolves #4036  #3934
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
