### PR TITLE
Add csv_when parameter to the csv processor

### DIFF
--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorConfig.java
@@ -37,6 +37,9 @@ public class CsvProcessorConfig {
     @JsonProperty("column_names")
     private List<String> columnNames;
 
+    @JsonProperty("csv_when")
+    private String csvWhen;
+
     /**
      * The field of the Event that contains the CSV data to be processed.
      *
@@ -92,6 +95,8 @@ public class CsvProcessorConfig {
     public List<String> getColumnNames() {
         return columnNames;
     }
+
+    public String getCsvWhen() { return csvWhen; }
 
     @AssertTrue(message = "delimiter must be exactly one character.")
     boolean isValidDelimiter() {

--- a/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorIT.java
+++ b/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorIT.java
@@ -5,6 +5,10 @@
 
 package org.opensearch.dataprepper.plugins.processor.csv;
 
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
@@ -20,6 +24,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.dataprepper.test.helper.ReflectivelySetField.setField;
 
+@ExtendWith(MockitoExtension.class)
 public class CsvProcessorIT {
     private static final String PLUGIN_NAME = "csv";
     private static final String TEST_PIPELINE_NAME = "test_pipeline";
@@ -27,6 +32,9 @@ public class CsvProcessorIT {
     private CsvProcessorConfig csvProcessorConfig;
     private CsvProcessor csvProcessor;
     private VpcFlowLogTypeGenerator vpcFlowLogTypeGenerator;
+
+    @Mock
+    private ExpressionEvaluator expressionEvaluator;
 
     @BeforeEach
     void setup() {
@@ -39,7 +47,7 @@ public class CsvProcessorIT {
 
         PluginMetrics pluginMetrics = PluginMetrics.fromNames(PLUGIN_NAME, TEST_PIPELINE_NAME);
 
-        csvProcessor = new CsvProcessor(pluginMetrics, csvProcessorConfig);
+        csvProcessor = new CsvProcessor(pluginMetrics, csvProcessorConfig, expressionEvaluator);
         vpcFlowLogTypeGenerator = new VpcFlowLogTypeGenerator();
     }
 

--- a/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorTest.java
+++ b/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/csv/CsvProcessorTest.java
@@ -5,16 +5,18 @@
 
 package org.opensearch.dataprepper.plugins.processor.csv;
 
-import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
-import org.opensearch.dataprepper.model.record.Record;
 import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
+import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,6 +27,7 @@ import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -38,6 +41,9 @@ class CsvProcessorTest {
     private PluginMetrics pluginMetrics;
     @Mock
     private Counter csvInvalidEventsCounter;
+
+    @Mock
+    private ExpressionEvaluator expressionEvaluator;
 
     private CsvProcessor csvProcessor;
 
@@ -57,13 +63,21 @@ class CsvProcessorTest {
     }
 
     private CsvProcessor createObjectUnderTest() {
-        return new CsvProcessor(pluginMetrics, processorConfig);
+        return new CsvProcessor(pluginMetrics, processorConfig, expressionEvaluator);
     }
 
     @Test
     void do_nothing_when_source_is_null_value_or_does_not_exist_in_the_Event() {
+
         final Record<Event> eventUnderTest = createMessageEvent("");
+
+        final String csvWhen = UUID.randomUUID().toString();
+        when(processorConfig.getCsvWhen()).thenReturn(csvWhen);
+        when(expressionEvaluator.isValidExpressionStatement(csvWhen)).thenReturn(true);
+        when(expressionEvaluator.evaluateConditional(csvWhen, eventUnderTest.getData())).thenReturn(true);
         when(processorConfig.getSource()).thenReturn(UUID.randomUUID().toString());
+
+        csvProcessor = createObjectUnderTest();
 
 
         final List<Record<Event>> editedEvents = (List<Record<Event>>) csvProcessor.doExecute(Collections.singletonList(eventUnderTest));
@@ -326,6 +340,35 @@ class CsvProcessorTest {
         assertThat(parsedEvent.containsKey("column1"), equalTo(false));
         assertThat(parsedEvent.containsKey("column2"), equalTo(false));
         assertThat(parsedEvent.containsKey("column3"), equalTo(false));
+    }
+
+    @Test
+    void invalid_csv_when_throws_InvalidPluginConfigurationException() {
+        final String csvWhen = UUID.randomUUID().toString();
+
+        when(processorConfig.getCsvWhen()).thenReturn(csvWhen);
+        when(expressionEvaluator.isValidExpressionStatement(csvWhen)).thenReturn(false);
+
+        assertThrows(InvalidPluginConfigurationException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void do_nothing_when_expression_evaluation_returns_false_for_event() {
+        final String csvWhen = UUID.randomUUID().toString();
+
+        when(processorConfig.getCsvWhen()).thenReturn(csvWhen);
+        when(expressionEvaluator.isValidExpressionStatement(csvWhen)).thenReturn(true);
+
+        final Record<Event> eventUnderTest = createMessageEvent("");
+        when(expressionEvaluator.evaluateConditional(csvWhen, eventUnderTest.getData())).thenReturn(false);
+
+        csvProcessor = createObjectUnderTest();
+
+
+        final List<Record<Event>> editedEvents = (List<Record<Event>>) csvProcessor.doExecute(Collections.singletonList(eventUnderTest));
+        final Event parsedEvent = getSingleEvent(editedEvents);
+
+        assertThat(parsedEvent, equalTo(eventUnderTest.getData()));
     }
 
     private Record<Event> createMessageEvent(final String message) {


### PR DESCRIPTION
### Description
Adds the `csv_when` parameter to the csv processor
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR: https://github.com/opensearch-project/documentation-website/issues/6503
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
