### PR TITLE
Allow format expression in keys in add_entries processor

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessor.java
@@ -54,7 +54,7 @@ public class AddEntryProcessor extends AbstractProcessor<Record<Event>, Record<E
                     }
 
                     try {
-                        final String key = (entry.getKey() == null) ? null : recordEvent.formatString(entry.getKey());
+                        final String key = (entry.getKey() == null) ? null : recordEvent.formatString(entry.getKey(), expressionEvaluator);
                         final String metadataKey = entry.getMetadataKey();
                         Object value;
                         if (!Objects.isNull(entry.getValueExpression())) {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessor.java
@@ -54,7 +54,7 @@ public class AddEntryProcessor extends AbstractProcessor<Record<Event>, Record<E
                     }
 
                     try {
-                        final String key = entry.getKey();
+                        final String key = (entry.getKey() == null) ? null : recordEvent.formatString(entry.getKey());
                         final String metadataKey = entry.getMetadataKey();
                         Object value;
                         if (!Objects.isNull(entry.getValueExpression())) {

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
@@ -653,6 +653,22 @@ public class AddEntryProcessorTests {
     }
 
     @Test
+    public void testAddSingleFieldWithDynamicExpression() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}_${getMetadata(\"id\")}", null, 3, null, null, false, false,null)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEventWithMetadata("value_as_name", Map.of("id", 1));
+        when(expressionEvaluator.isValidExpressionStatement("getMetadata(\"id\")")).thenReturn(true);
+        when(expressionEvaluator.evaluate("getMetadata(\"id\")", record.getData())).thenReturn(1);
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", Object.class), equalTo("value_as_name"));
+        assertThat(editedRecords.get(0).getData().containsKey("value_as_name_1"), is(true));
+        assertThat(editedRecords.get(0).getData().get("value_as_name_1", Object.class), equalTo(3));
+    }
+
+    @Test
     public void testAddMultipleFieldsWithDynamicKeys() {
         when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null),
                 createEntry("${message}_2", null, 4, null, null, false, false,null)));

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/AddEntryProcessorTests.java
@@ -638,6 +638,64 @@ public class AddEntryProcessorTests {
         assertThat(attributes.get("newkey"), equalTo(randomString));
     }
 
+    @Test
+    public void testAddSingleFieldWithDynamicKey() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("value_as_name");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", Object.class), equalTo("value_as_name"));
+        assertThat(editedRecords.get(0).getData().containsKey("value_as_name"), is(true));
+        assertThat(editedRecords.get(0).getData().get("value_as_name", Object.class), equalTo(3));
+    }
+
+    @Test
+    public void testAddMultipleFieldsWithDynamicKeys() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null),
+                createEntry("${message}_2", null, 4, null, null, false, false,null)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("value_as_name");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", Object.class), equalTo("value_as_name"));
+        assertThat(editedRecords.get(0).getData().containsKey("value_as_name"), is(true));
+        assertThat(editedRecords.get(0).getData().get("value_as_name", Object.class), equalTo(3));
+        assertThat(editedRecords.get(0).getData().containsKey("value_as_name_2"), is(true));
+        assertThat(editedRecords.get(0).getData().get("value_as_name_2", Object.class), equalTo(4));
+    }
+
+    @Test
+    public void testAddFieldWithInvalidInputKeyThenNoChangeToEvent() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message", null, 3, null, null, false, false,null)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("value_as_name");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", Object.class), equalTo("value_as_name"));
+        assertThat(editedRecords.get(0).getData().containsKey("value_as_name"), is(false));
+        assertThat(editedRecords.get(0).getData().toMap().size(), is(1));
+    }
+
+    @Test
+    public void testAddFieldWithInvalidDynamicKeyThenNoChangeToEvent() {
+        when(mockConfig.getEntries()).thenReturn(createListOfEntries(createEntry("${message}", null, 3, null, null, false, false,null)));
+
+        final AddEntryProcessor processor = createObjectUnderTest();
+        final Record<Event> record = getEvent("name_with_invalid_chars|[$");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) processor.doExecute(Collections.singletonList(record));
+
+        assertThat(editedRecords.get(0).getData().containsKey("message"), is(true));
+        assertThat(editedRecords.get(0).getData().get("message", Object.class), equalTo("name_with_invalid_chars|[$"));
+        assertThat(editedRecords.get(0).getData().toMap().size(), is(1));
+    }
+
     private AddEntryProcessor createObjectUnderTest() {
         return new AddEntryProcessor(pluginMetrics, mockConfig, expressionEvaluator);
     }


### PR DESCRIPTION
### Description
Allow format expression in keys in add_entries processor
 
### Issues Resolved
Resolves #4175
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
