### PR TITLE
Support certificate content in Opensearch Source configuration to sup…

### DIFF
--- a/data-prepper-plugins/http-common/src/main/java/org/opensearch/dataprepper/plugins/truststore/TrustStoreProvider.java
+++ b/data-prepper-plugins/http-common/src/main/java/org/opensearch/dataprepper/plugins/truststore/TrustStoreProvider.java
@@ -26,7 +26,7 @@ import java.security.cert.X509Certificate;
 public class TrustStoreProvider {
     private static final Logger LOG = LoggerFactory.getLogger(TrustStoreProvider.class);
 
-    public TrustManager[] createTrustManager(final Path certificatePath) {
+    public static TrustManager[] createTrustManager(final Path certificatePath) {
         LOG.info("Using the certificate path {} to create trust manager.", certificatePath.toString());
         try {
             final KeyStore keyStore = createKeyStore(certificatePath);
@@ -38,7 +38,7 @@ public class TrustStoreProvider {
         }
     }
 
-    public TrustManager[] createTrustManager(final String certificateContent) {
+    public static TrustManager[] createTrustManager(final String certificateContent) {
         LOG.info("Using the certificate content to create trust manager.");
         try (InputStream certificateInputStream = new ByteArrayInputStream(certificateContent.getBytes())) {
             final KeyStore keyStore = createKeyStore(certificateInputStream);
@@ -50,20 +50,20 @@ public class TrustStoreProvider {
         }
     }
 
-    public TrustManager[] createTrustAllManager() {
+    public static TrustManager[] createTrustAllManager() {
         LOG.info("Using the trust all manager to create trust manager.");
         return new TrustManager[]{
             new X509TrustAllManager()
         };
     }
 
-    private KeyStore createKeyStore(final Path certificatePath) throws Exception {
+    private static KeyStore createKeyStore(final Path certificatePath) throws Exception {
         try (InputStream certificateInputStream = Files.newInputStream(certificatePath)) {
             return createKeyStore(certificateInputStream);
         }
     }
 
-    private KeyStore createKeyStore(final InputStream certificateInputStream) throws Exception {
+    private static KeyStore createKeyStore(final InputStream certificateInputStream) throws Exception {
         final CertificateFactory factory = CertificateFactory.getInstance("X.509");
         final Certificate trustedCa = factory.generateCertificate(certificateInputStream);
         final KeyStore trustStore = KeyStore.getInstance("pkcs12");
@@ -72,7 +72,7 @@ public class TrustStoreProvider {
         return trustStore;
     }
 
-    public SSLContext createSSLContext(final Path certificatePath) {
+    public static SSLContext createSSLContext(final Path certificatePath) {
         LOG.info("Using the certificate path to create SSL context.");
         try (InputStream is = Files.newInputStream(certificatePath)) {
             return createSSLContext(is);
@@ -81,7 +81,7 @@ public class TrustStoreProvider {
         }
     }
 
-    public SSLContext createSSLContext(final String certificateContent) {
+    public static SSLContext createSSLContext(final String certificateContent) {
         LOG.info("Using the certificate content to create SSL context.");
         try (InputStream certificateInputStream = new ByteArrayInputStream(certificateContent.getBytes())) {
             return createSSLContext(certificateInputStream);
@@ -90,14 +90,14 @@ public class TrustStoreProvider {
         }
     }
 
-    private SSLContext createSSLContext(final InputStream certificateInputStream) throws Exception {
+    private static SSLContext createSSLContext(final InputStream certificateInputStream) throws Exception {
         KeyStore trustStore = createKeyStore(certificateInputStream);
         SSLContextBuilder sslContextBuilder = SSLContexts.custom()
                 .loadTrustMaterial(trustStore, null);
         return sslContextBuilder.build();
     }
 
-    public SSLContext createSSLContextWithTrustAllStrategy() {
+    public static SSLContext createSSLContextWithTrustAllStrategy() {
         LOG.info("Using the trust all strategy to create SSL context.");
         try {
             return SSLContexts.custom().loadTrustMaterial(null, new TrustStrategy() {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/CustomClientSslEngineFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/util/CustomClientSslEngineFactory.java
@@ -28,12 +28,11 @@ public class CustomClientSslEngineFactory implements SslEngineFactory {
     }
 
     private TrustManager[] getTrustManager() {
-        final TrustStoreProvider trustStoreProvider = new TrustStoreProvider();
         final TrustManager[] trustManagers;
         if (Objects.nonNull(certificateContent)) {
-            trustManagers = trustStoreProvider.createTrustManager(certificateContent);
+            trustManagers = TrustStoreProvider.createTrustManager(certificateContent);
         } else {
-            trustManagers = trustStoreProvider.createTrustAllManager();
+            trustManagers = TrustStoreProvider.createTrustAllManager();
         }
         return trustManagers;
     }

--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation project(':data-prepper-plugins:buffer-common')
     implementation project(':data-prepper-plugins:common')
     implementation project(':data-prepper-plugins:failures-common')
+    implementation project(':data-prepper-plugins:http-common')
     implementation libs.opensearch.client
     implementation libs.opensearch.rhlc
     implementation libs.opensearch.java

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfiguration.java
@@ -14,6 +14,9 @@ public class ConnectionConfiguration {
   @JsonProperty("cert")
   private Path certPath;
 
+  @JsonProperty("certificate_content")
+  private String certificateContent;
+
   @JsonProperty("socket_timeout")
   private Duration socketTimeout;
 
@@ -25,6 +28,10 @@ public class ConnectionConfiguration {
 
   public Path getCertPath() {
     return certPath;
+  }
+
+  public String getCertificateContent() {
+    return certificateContent;
   }
 
   public Duration getSocketTimeout() {

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfiguration.java
@@ -5,6 +5,7 @@
 package org.opensearch.dataprepper.plugins.source.opensearch.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.AssertTrue;
 
 import java.nio.file.Path;
 import java.time.Duration;
@@ -44,5 +45,13 @@ public class ConnectionConfiguration {
 
   public boolean isInsecure() {
     return insecure;
+  }
+
+  @AssertTrue(message = "Certificate file path and certificate content both are configured. " +
+          "Please use only one configuration.")
+  boolean certificateFileAndContentAreMutuallyExclusive() {
+    if(certPath == null && certificateContent == null)
+      return true;
+    return certPath != null ^ certificateContent != null;
   }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfigurationTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfigurationTest.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
 
 public class ConnectionConfigurationTest {
     private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS));
@@ -35,6 +36,22 @@ public class ConnectionConfigurationTest {
                 "  insecure: true\n";
         final ConnectionConfiguration connectionConfig = objectMapper.readValue(connectionYaml, ConnectionConfiguration.class);
         assertThat(connectionConfig.getCertPath(),equalTo(Path.of("cert")));
+        assertThat(connectionConfig.getSocketTimeout(),equalTo(null));
+        assertThat(connectionConfig.getConnectTimeout(),equalTo(null));
+        assertThat(connectionConfig.isInsecure(),equalTo(true));
+    }
+
+    @Test
+    void connection_configuration_certificate_values_test() throws JsonProcessingException {
+
+        final String connectionYaml =
+                "  cert: \"cert\"\n" +
+                "  certificate_content: \"certificate content\"\n" +
+                "  insecure: true\n";
+        final ConnectionConfiguration connectionConfig = objectMapper.readValue(connectionYaml, ConnectionConfiguration.class);
+        assertThat(connectionConfig.getCertPath(),equalTo(Path.of("cert")));
+        assertThat(connectionConfig.getCertificateContent(),equalTo("certificate content"));
+        assertThat(connectionConfig.certificateFileAndContentAreMutuallyExclusive(), is(false));
         assertThat(connectionConfig.getSocketTimeout(),equalTo(null));
         assertThat(connectionConfig.getConnectTimeout(),equalTo(null));
         assertThat(connectionConfig.isInsecure(),equalTo(true));

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchClientFactoryTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/worker/client/OpenSearchClientFactoryTest.java
@@ -220,32 +220,32 @@ public class OpenSearchClientFactoryTest {
 
     @Test
     void provideOpenSearchClient_with_self_signed_certificate() {
+        final Path path = mock(Path.class);
+        final SSLContext sslContext = mock(SSLContext.class);
+        final String username = UUID.randomUUID().toString();
+        final String password = UUID.randomUUID().toString();
+        when(openSearchSourceConfiguration.getUsername()).thenReturn(username);
+        when(openSearchSourceConfiguration.getPassword()).thenReturn(password);
+        when(connectionConfiguration.getCertPath()).thenReturn(path);
         try (MockedStatic<TrustStoreProvider> trustStoreProviderMockedStatic = mockStatic(TrustStoreProvider.class)) {
-            final Path path = mock(Path.class);
-            final SSLContext sslContext = mock(SSLContext.class);
-            final String username = UUID.randomUUID().toString();
-            final String password = UUID.randomUUID().toString();
-            when(openSearchSourceConfiguration.getUsername()).thenReturn(username);
-            when(openSearchSourceConfiguration.getPassword()).thenReturn(password);
-            when(connectionConfiguration.getCertPath()).thenReturn(path);
             trustStoreProviderMockedStatic.when(() -> TrustStoreProvider.createSSLContext(path))
                     .thenReturn(sslContext);
             final OpenSearchClient openSearchClient = createObjectUnderTest().provideOpenSearchClient(openSearchSourceConfiguration);
-            assertThat(openSearchClient, notNullValue());
             trustStoreProviderMockedStatic.verify(() -> TrustStoreProvider.createSSLContext(path));
+            assertThat(openSearchClient, notNullValue());
         }
     }
 
     @Test
     void provideElasticSearchClient_with_self_signed_certificate() {
+        final Path path = mock(Path.class);
+        final SSLContext sslContext = mock(SSLContext.class);
+        final String username = UUID.randomUUID().toString();
+        final String password = UUID.randomUUID().toString();
+        when(openSearchSourceConfiguration.getUsername()).thenReturn(username);
+        when(openSearchSourceConfiguration.getPassword()).thenReturn(password);
+        when(connectionConfiguration.getCertPath()).thenReturn(path);
         try (MockedStatic<TrustStoreProvider> trustStoreProviderMockedStatic = mockStatic(TrustStoreProvider.class)) {
-            final Path path = mock(Path.class);
-            final SSLContext sslContext = mock(SSLContext.class);
-            final String username = UUID.randomUUID().toString();
-            final String password = UUID.randomUUID().toString();
-            when(openSearchSourceConfiguration.getUsername()).thenReturn(username);
-            when(openSearchSourceConfiguration.getPassword()).thenReturn(password);
-            when(connectionConfiguration.getCertPath()).thenReturn(path);
             trustStoreProviderMockedStatic.when(() -> TrustStoreProvider.createSSLContext(path))
                     .thenReturn(sslContext);
             final ElasticsearchClient elasticsearchClient = createObjectUnderTest().provideElasticSearchClient(openSearchSourceConfiguration);
@@ -257,16 +257,16 @@ public class OpenSearchClientFactoryTest {
 
     @Test
     void createSdkAsyncHttpClient_with_self_signed_certificate() {
+        final Path path = mock(Path.class);
+        final Duration duration = mock(Duration.class);
+        final String username = UUID.randomUUID().toString();
+        final String password = UUID.randomUUID().toString();
+        lenient().when(openSearchSourceConfiguration.getUsername()).thenReturn(username);
+        lenient().when(openSearchSourceConfiguration.getPassword()).thenReturn(password);
+        lenient().when(connectionConfiguration.getConnectTimeout()).thenReturn(duration);
+        lenient().when(openSearchSourceConfiguration.getConnectionConfiguration()).thenReturn(connectionConfiguration);
+        lenient().when(connectionConfiguration.getCertPath()).thenReturn(path);
         try (MockedStatic<TrustStoreProvider> trustStoreProviderMockedStatic = mockStatic(TrustStoreProvider.class)) {
-            final Path path = mock(Path.class);
-            final Duration duration = mock(Duration.class);
-            final String username = UUID.randomUUID().toString();
-            final String password = UUID.randomUUID().toString();
-            lenient().when(openSearchSourceConfiguration.getUsername()).thenReturn(username);
-            lenient().when(openSearchSourceConfiguration.getPassword()).thenReturn(password);
-            lenient().when(connectionConfiguration.getConnectTimeout()).thenReturn(duration);
-            lenient().when(openSearchSourceConfiguration.getConnectionConfiguration()).thenReturn(connectionConfiguration);
-            lenient().when(connectionConfiguration.getCertPath()).thenReturn(path);
             final SdkAsyncHttpClient sdkAsyncHttpClient = createObjectUnderTest().createSdkAsyncHttpClient(openSearchSourceConfiguration);
             assertThat(sdkAsyncHttpClient, notNullValue());
             trustStoreProviderMockedStatic.verify(() -> TrustStoreProvider.createTrustManager(path));


### PR DESCRIPTION
Support certificate content in Opensearch Source configuration to support TLS and Truststore for Opensearch client.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
