### PR TITLE
Create file on shutdown to indicate that data prepper is shutdown

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandler.java
@@ -14,6 +14,9 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.HttpMethod;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * HttpHandler to handle requests to shut down the data prepper instance
@@ -21,6 +24,9 @@ import java.net.HttpURLConnection;
 public class ShutdownHandler implements HttpHandler {
     private final DataPrepper dataPrepper;
     private static final Logger LOG = LoggerFactory.getLogger(ShutdownHandler.class);
+
+    static final Path SHUTDOWN_FILE_PATH = Path.of("Is-Shutdown.log");
+    static final String SHUTDOWN_MESSAGE = "Data Prepper is shut down.";
 
     public ShutdownHandler(final DataPrepper dataPrepper) {
         this.dataPrepper = dataPrepper;
@@ -44,6 +50,7 @@ public class ShutdownHandler implements HttpHandler {
             exchange.sendResponseHeaders(HttpURLConnection.HTTP_INTERNAL_ERROR, 0);
         } finally {
             exchange.getResponseBody().close();
+            Files.write(SHUTDOWN_FILE_PATH, SHUTDOWN_MESSAGE.getBytes(StandardCharsets.UTF_8));
             dataPrepper.shutdownServers();
         }
     }


### PR DESCRIPTION
### Description
This change creates a file named `Is-Shutdown.log` when data prepper is shutdown. This can be used as an alternative method to check if a data prepper container has shutdown.

This was tested with a Docker volume to ensure this file was created successfully.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
