### PR TITLE
Fix pipeline latency to calculate correct latency when persistent buffer is used

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/ByteDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/ByteDecoder.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.util.function.Consumer;
+import java.time.Instant;
 
 public interface ByteDecoder extends Serializable {
     /**
@@ -18,9 +19,10 @@ public interface ByteDecoder extends Serializable {
      * {@link Record} loaded from the {@link InputStream}.
      *
      * @param inputStream   The input stream for code to process
+     * @param timeReceived  The time received value to be populated in the Record
      * @param eventConsumer The consumer which handles each event from the stream
      * @throws IOException throws IOException when invalid input is received or incorrect codec name is provided
      */
-    void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException;
+    void parse(InputStream inputStream, Instant timeReceived, Consumer<Record<Event>> eventConsumer) throws IOException;
     
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/codec/JsonDecoder.java
@@ -25,7 +25,7 @@ public class JsonDecoder implements ByteDecoder {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final JsonFactory jsonFactory = new JsonFactory();
 
-    public void parse(InputStream inputStream, Instant timeReceivedMs, Consumer<Record<Event>> eventConsumer) throws IOException {
+    public void parse(InputStream inputStream, Instant timeReceived, Consumer<Record<Event>> eventConsumer) throws IOException {
         Objects.requireNonNull(inputStream);
         Objects.requireNonNull(eventConsumer);
 
@@ -33,26 +33,26 @@ public class JsonDecoder implements ByteDecoder {
 
         while (!jsonParser.isClosed() && jsonParser.nextToken() != JsonToken.END_OBJECT) {
             if (jsonParser.getCurrentToken() == JsonToken.START_ARRAY) {
-                parseRecordsArray(jsonParser, timeReceivedMs, eventConsumer);
+                parseRecordsArray(jsonParser, timeReceived, eventConsumer);
             }
         }
     }
 
-    private void parseRecordsArray(final JsonParser jsonParser, final Instant timeReceivedMs, final Consumer<Record<Event>> eventConsumer) throws IOException {
+    private void parseRecordsArray(final JsonParser jsonParser, final Instant timeReceived, final Consumer<Record<Event>> eventConsumer) throws IOException {
         while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
             final Map<String, Object> innerJson = objectMapper.readValue(jsonParser, Map.class);
 
-            final Record<Event> record = createRecord(innerJson, timeReceivedMs);
+            final Record<Event> record = createRecord(innerJson, timeReceived);
             eventConsumer.accept(record);
         }
     }
 
-    private Record<Event> createRecord(final Map<String, Object> json, final Instant timeReceivedMs) {
+    private Record<Event> createRecord(final Map<String, Object> json, final Instant timeReceived) {
         final JacksonLog.Builder logBuilder = JacksonLog.builder()
                 .withData(json)
                 .getThis();
-        if (timeReceivedMs != null) {
-            logBuilder.withTimeReceived(timeReceivedMs);
+        if (timeReceived != null) {
+            logBuilder.withTimeReceived(timeReceived);
         }
         final JacksonEvent event = (JacksonEvent)logBuilder.build();
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonOtelLog.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/log/JacksonOtelLog.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.opensearch.dataprepper.model.event.EventType;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -159,6 +160,18 @@ public class JacksonOtelLog extends JacksonEvent implements OpenTelemetryLog {
         public Builder withAttributes(final Map<String, Object> attributes) {
             data.put(ATTRIBUTES_KEY, attributes);
             return getThis();
+        }
+
+        /**
+         * Sets the time received for populating event origination time in event handle
+         *
+         * @param timeReceived time received
+         * @return the builder
+         * @since 2.7
+         */
+        @Override
+        public Builder withTimeReceived(final Instant timeReceived) {
+            return (Builder)super.withTimeReceived(timeReceived);
         }
 
         /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogram.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.model.metric;
 
 import org.opensearch.dataprepper.model.event.EventType;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -235,6 +236,18 @@ public class JacksonExponentialHistogram extends JacksonMetric implements Expone
         public JacksonExponentialHistogram.Builder withPositiveOffset(int offset) {
             data.put(POSITIVE_OFFSET_KEY, offset);
             return this;
+        }
+
+        /**
+         * Sets the time received for populating event origination time in event handle
+         *
+         * @param timeReceived time received
+         * @return the builder
+         * @since 2.7
+         */
+        @Override
+        public JacksonExponentialHistogram.Builder withTimeReceived(final Instant timeReceived) {
+            return (JacksonExponentialHistogram.Builder)super.withTimeReceived(timeReceived);
         }
 
         /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonGauge.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonGauge.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.model.metric;
 
 import org.opensearch.dataprepper.model.event.EventType;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,6 +66,18 @@ public class JacksonGauge extends JacksonMetric implements Gauge {
                 data.put(VALUE_KEY, value);
             }
             return this;
+        }
+
+        /**
+         * Sets the time received for populating event origination time in event handle
+         *
+         * @param timeReceived time received
+         * @return the builder
+         * @since 2.7
+         */
+        @Override
+        public Builder withTimeReceived(final Instant timeReceived) {
+            return (Builder)super.withTimeReceived(timeReceived);
         }
 
         /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonHistogram.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonHistogram.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.model.metric;
 
 import org.opensearch.dataprepper.model.event.EventType;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -188,6 +189,18 @@ public class JacksonHistogram extends JacksonMetric implements Histogram {
         public  JacksonHistogram.Builder withAggregationTemporality(String aggregationTemporality) {
             data.put(AGGREGATION_TEMPORALITY_KEY, aggregationTemporality);
             return this;
+        }
+
+        /**
+         * Sets the time received for populating event origination time in event handle
+         *
+         * @param timeReceived time received
+         * @return the builder
+         * @since 2.7
+         */
+        @Override
+        public JacksonHistogram.Builder withTimeReceived(final Instant timeReceived) {
+            return (JacksonHistogram.Builder)super.withTimeReceived(timeReceived);
         }
 
         /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -233,6 +234,19 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
             data.put(SCHEMA_URL_KEY, schemaUrl);
             return getThis();
         }
+
+        /**
+         * Sets the time received for populating event origination time in event handle
+         *
+         * @param timeReceived time received
+         * @return the builder
+         * @since 2.7
+         */
+        @Override
+        public T withTimeReceived(final Instant timeReceived) {
+            return (T)super.withTimeReceived(timeReceived);
+        }
+
 
         /**
          * Sets the exemplars that are associated with this metric event

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonSum.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonSum.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.model.metric;
 
 import org.opensearch.dataprepper.model.event.EventType;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -99,6 +100,18 @@ public class JacksonSum extends JacksonMetric implements Sum {
         public Builder withIsMonotonic(final boolean isMonotonic) {
             data.put(IS_MONOTONIC_KEY, isMonotonic);
             return this;
+        }
+
+        /**
+         * Sets the time received for populating event origination time in event handle
+         *
+         * @param timeReceived time received
+         * @return the builder
+         * @since 2.7
+         */
+        @Override
+        public Builder withTimeReceived(final Instant timeReceived) {
+            return (Builder)super.withTimeReceived(timeReceived);
         }
 
         /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonSummary.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonSummary.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.model.metric;
 
 import org.opensearch.dataprepper.model.event.EventType;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -104,6 +105,18 @@ public class JacksonSummary extends JacksonMetric implements Summary {
         public Builder withSum(double sum) {
             data.put(SUM_KEY, sum);
             return this;
+        }
+
+        /**
+         * Sets the time received for populating event origination time in event handle
+         *
+         * @param timeReceived time received
+         * @return the builder
+         * @since 2.7
+         */
+        @Override
+        public Builder withTimeReceived(final Instant timeReceived) {
+            return (Builder)super.withTimeReceived(timeReceived);
         }
 
         /**

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/trace/JacksonSpan.java
@@ -15,6 +15,7 @@ import org.opensearch.dataprepper.model.event.EventMetadata;
 import org.opensearch.dataprepper.model.event.EventType;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -442,6 +443,18 @@ public class JacksonSpan extends JacksonEvent implements Span {
         public Builder withTraceGroup(final String traceGroup) {
             data.put(TRACE_GROUP_KEY, traceGroup);
             return this;
+        }
+
+        /**
+         * Sets the time received for populating event origination time in event handle
+         *
+         * @param timeReceived time received
+         * @return the builder
+         * @since 2.7
+         */
+        @Override
+        public Builder withTimeReceived(final Instant timeReceived) {
+            return (Builder)super.withTimeReceived(timeReceived);
         }
 
         /**

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonOtelLogTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/log/JacksonOtelLogTest.java
@@ -12,7 +12,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
@@ -81,6 +83,14 @@ public class JacksonOtelLogTest {
     public void testGetServiceName() {
         final String name = log.getServiceName();
         assertThat(name, is(equalTo(TEST_SERVICE_NAME)));
+    }
+
+    @Test
+    public void testGetTimeReceived() {
+        Instant now = Instant.now();
+        builder.withTimeReceived(now);
+        log = builder.build();
+        assertThat(((DefaultEventHandle)log.getEventHandle()).getInternalOriginationTime(), is(now));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogramTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogramTest.java
@@ -11,8 +11,10 @@ import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.event.TestObject;
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 import org.skyscreamer.jsonassert.JSONAssert;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -244,6 +246,14 @@ public class JacksonExponentialHistogramTest {
         JacksonExponentialHistogram histogram = builder.build();
         histogram.toJsonString();
         assertThat(histogram.getAttributes(), is(anEmptyMap()));
+    }
+
+    @Test
+    public void testGetTimeReceived() {
+        Instant now = Instant.now();
+        builder.withTimeReceived(now);
+        JacksonExponentialHistogram histogram = builder.build();
+        assertThat(((DefaultEventHandle)histogram.getEventHandle()).getInternalOriginationTime(), is(now));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonGaugeTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonGaugeTest.java
@@ -11,8 +11,10 @@ import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.event.TestObject;
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 import org.skyscreamer.jsonassert.JSONAssert;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -87,6 +89,14 @@ class JacksonGaugeTest {
     public void testGetName() {
         final String name = gauge.getName();
         assertThat(name, is(equalTo(TEST_NAME)));
+    }
+
+    @Test
+    public void testGetTimeReceived() {
+        Instant now = Instant.now();
+        builder.withTimeReceived(now);
+        gauge = builder.build();
+        assertThat(((DefaultEventHandle)gauge.getEventHandle()).getInternalOriginationTime(), is(now));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonHistogramTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonHistogramTest.java
@@ -11,8 +11,10 @@ import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.event.TestObject;
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 import org.skyscreamer.jsonassert.JSONAssert;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -138,6 +140,14 @@ class JacksonHistogramTest {
     public void testGetCount() {
         final Long count = histogram.getCount();
         assertThat(count, is(equalTo(TEST_COUNT)));
+    }
+
+    @Test
+    public void testGetTimeReceived() {
+        Instant now = Instant.now();
+        builder.withTimeReceived(now);
+        histogram = builder.build();
+        assertThat(((DefaultEventHandle)histogram.getEventHandle()).getInternalOriginationTime(), is(now));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonSumTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonSumTest.java
@@ -9,6 +9,9 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
+
+import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
@@ -94,6 +97,14 @@ public class JacksonSumTest {
     public void testGetServiceName() {
         final String name = sum.getServiceName();
         assertThat(name, is(equalTo(TEST_SERVICE_NAME)));
+    }
+
+    @Test
+    public void testGetTimeReceived() {
+        Instant now = Instant.now();
+        builder.withTimeReceived(now);
+        sum = builder.build();
+        assertThat(((DefaultEventHandle)sum.getEventHandle()).getInternalOriginationTime(), is(now));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonSummaryTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonSummaryTest.java
@@ -10,6 +10,9 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
+
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -114,6 +117,14 @@ public class JacksonSummaryTest {
     public void testGetSum() {
         final Double sum = summary.getSum();
         assertThat(sum, is(equalTo(TEST_SUM)));
+    }
+
+    @Test
+    public void testGetTimeReceived() {
+        Instant now = Instant.now();
+        builder.withTimeReceived(now);
+        summary = builder.build();
+        assertThat(((DefaultEventHandle)summary.getEventHandle()).getInternalOriginationTime(), is(now));
     }
 
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonSpanTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/trace/JacksonSpanTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.event.EventMetadata;
 import org.opensearch.dataprepper.model.event.EventType;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -438,6 +439,13 @@ public class JacksonSpanTest {
     public void testBuilder_withNullDroppedAttributesCount_createsSpanWithDefaultValue() {
         final JacksonSpan span = builder.withDroppedAttributesCount(null).build();
         assertThat(span.getDroppedAttributesCount(), is(equalTo(0)));
+    }
+
+    @Test
+    public void testGetTimeReceived() {
+        Instant now = Instant.now();
+        final JacksonSpan span = builder.withTimeReceived(now).build();
+        assertThat(((DefaultEventHandle)span.getEventHandle()).getInternalOriginationTime(), is(now));
     }
 
     @Test

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -381,6 +381,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
     }
 
     private <T> Record<Event> getRecord(ConsumerRecord<String, T> consumerRecord, int partition) {
+        Instant now = Instant.now();
         Map<String, Object> data = new HashMap<>();
         Event event;
         Object value = consumerRecord.value();
@@ -496,7 +497,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
                 if (schema == MessageFormat.BYTES) {
                     InputStream inputStream = new ByteArrayInputStream((byte[])consumerRecord.value());
                     if(byteDecoder != null) {
-                        byteDecoder.parse(inputStream, (record) -> {
+                        byteDecoder.parse(inputStream, Instant.ofEpochMilli(consumerRecord.timestamp()), (record) -> {
                             processRecord(acknowledgementSet, record);
                         });
                     } else {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Future;
@@ -169,11 +170,11 @@ public class KafkaCustomProducer<T> {
     }
 
     Future send(final String topicName, String key, final Object record) throws Exception {
-        if (Objects.isNull(key)) {
-            return producer.send(new ProducerRecord(topicName, record), callBack(record));
-        }
+        ProducerRecord producerRecord = Objects.isNull(key) ?
+            new ProducerRecord(topicName, record) :
+            new ProducerRecord(topicName, key, record);
 
-        return producer.send(new ProducerRecord(topicName, key, record), callBack(record));
+        return producer.send(producerRecord, callBack(record));
     }
 
     private void publishJsonMessage(final Record<Event> record, final String key) throws IOException, ProcessingException, Exception {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/producer/KafkaCustomProducer.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
-import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Future;

--- a/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
+++ b/data-prepper-plugins/otel-logs-source/src/main/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcService.java
@@ -25,6 +25,7 @@ import org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCodec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -84,7 +85,7 @@ public class OTelLogsGrpcService extends LogsServiceGrpc.LogsServiceImplBase {
         final List<OpenTelemetryLog> logs;
 
         try {
-            logs = oTelProtoDecoder.parseExportLogsServiceRequest(request);
+            logs = oTelProtoDecoder.parseExportLogsServiceRequest(request, Instant.now());
         } catch (Exception e) {
             LOG.error("Failed to parse the request {} due to:", request, e);
             throw new BadRequestException(e.getMessage(), e);

--- a/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcServiceTest.java
+++ b/data-prepper-plugins/otel-logs-source/src/test/java/org/opensearch/dataprepper/plugins/source/otellogs/OTelLogsGrpcServiceTest.java
@@ -35,6 +35,7 @@ import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCodec;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -189,7 +190,7 @@ public class OTelLogsGrpcServiceTest {
     public void export_BadRequest_responseObserverOnError() {
         final String testMessage = "test message";
         final RuntimeException testException = new RuntimeException(testMessage);
-        when(mockOTelProtoDecoder.parseExportLogsServiceRequest(any())).thenThrow(testException);
+        when(mockOTelProtoDecoder.parseExportLogsServiceRequest(any(), any(Instant.class))).thenThrow(testException);
         objectUnderTest = generateOTelLogsGrpcService(mockOTelProtoDecoder);
 
         try (MockedStatic<ServiceRequestContext> mockedStatic = mockStatic(ServiceRequestContext.class)) {

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OTelMetricsRawProcessor.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OTelMetricsRawProcessor.java
@@ -23,6 +23,7 @@ import io.micrometer.core.instrument.Counter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -92,7 +93,7 @@ public class OTelMetricsRawProcessor extends AbstractProcessor<Record<?>, Record
             }
 
             ExportMetricsServiceRequest request = ((Record<ExportMetricsServiceRequest>)rec).getData();
-            recordsOut.addAll(otelProtoDecoder.parseExportMetricsServiceRequest(request, droppedCounter, otelMetricsRawProcessorConfig.getExponentialHistogramMaxAllowedScale(), otelMetricsRawProcessorConfig.getCalculateHistogramBuckets(), otelMetricsRawProcessorConfig.getCalculateExponentialHistogramBuckets(), flattenAttributesFlag));
+            recordsOut.addAll(otelProtoDecoder.parseExportMetricsServiceRequest(request, droppedCounter, otelMetricsRawProcessorConfig.getExponentialHistogramMaxAllowedScale(), Instant.now(), otelMetricsRawProcessorConfig.getCalculateHistogramBuckets(), otelMetricsRawProcessorConfig.getCalculateExponentialHistogramBuckets(), flattenAttributesFlag));
         }
         recordsDroppedMetricsRawCounter.increment(droppedCounter.get());
         return recordsOut;

--- a/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcService.java
+++ b/data-prepper-plugins/otel-metrics-source/src/main/java/org/opensearch/dataprepper/plugins/source/otelmetrics/OTelMetricsGrpcService.java
@@ -25,6 +25,7 @@ import org.opensearch.dataprepper.model.metric.Metric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -90,7 +91,7 @@ public class OTelMetricsGrpcService extends MetricsServiceGrpc.MetricsServiceImp
                 Collection<Record<? extends Metric>> metrics;
 
                 AtomicInteger droppedCounter = new AtomicInteger(0);
-                metrics = oTelProtoDecoder.parseExportMetricsServiceRequest(request, droppedCounter, DEFAULT_EXPONENTIAL_HISTOGRAM_MAX_ALLOWED_SCALE, true, true, true);
+                metrics = oTelProtoDecoder.parseExportMetricsServiceRequest(request, droppedCounter, DEFAULT_EXPONENTIAL_HISTOGRAM_MAX_ALLOWED_SCALE, Instant.now(), true, true, true);
                 recordsDroppedCounter.increment(droppedCounter.get());
                 recordsCreatedCounter.increment(metrics.size());
                 buffer.writeAll(metrics, bufferWriteTimeoutInMillis);

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsDecoder.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsDecoder.java
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.function.Consumer;
+import java.time.Instant;
 
 
 public class OTelLogsDecoder implements ByteDecoder {
@@ -23,10 +24,10 @@ public class OTelLogsDecoder implements ByteDecoder {
     public OTelLogsDecoder() {
         otelProtoDecoder = new OTelProtoCodec.OTelProtoDecoder();
     }
-    public void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException {
+    public void parse(InputStream inputStream, Instant timeReceivedMs, Consumer<Record<Event>> eventConsumer) throws IOException {
         ExportLogsServiceRequest request = ExportLogsServiceRequest.parseFrom(inputStream);
         AtomicInteger droppedCounter = new AtomicInteger(0);
-        List<OpenTelemetryLog> logs = otelProtoDecoder.parseExportLogsServiceRequest(request);
+        List<OpenTelemetryLog> logs = otelProtoDecoder.parseExportLogsServiceRequest(request, timeReceivedMs);
         for (OpenTelemetryLog log: logs) {
             eventConsumer.accept(new Record<>(log));
         }

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelMetricDecoder.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelMetricDecoder.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.function.Consumer;
 
 
@@ -24,11 +25,11 @@ public class OTelMetricDecoder implements ByteDecoder {
     public OTelMetricDecoder() {
         otelProtoDecoder = new OTelProtoCodec.OTelProtoDecoder();
     }
-    public void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException {
+    public void parse(InputStream inputStream, Instant timeReceivedMs, Consumer<Record<Event>> eventConsumer) throws IOException {
         ExportMetricsServiceRequest request = ExportMetricsServiceRequest.parseFrom(inputStream);
         AtomicInteger droppedCounter = new AtomicInteger(0);
         Collection<Record<? extends Metric>> records =
-            otelProtoDecoder.parseExportMetricsServiceRequest(request, droppedCounter, OTelProtoCodec.DEFAULT_EXPONENTIAL_HISTOGRAM_MAX_ALLOWED_SCALE, true, true, false);
+            otelProtoDecoder.parseExportMetricsServiceRequest(request, droppedCounter, OTelProtoCodec.DEFAULT_EXPONENTIAL_HISTOGRAM_MAX_ALLOWED_SCALE, timeReceivedMs, true, true, false);
         for (Record<? extends Metric> record: records) {
             eventConsumer.accept((Record)record);
         }

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelTraceDecoder.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelTraceDecoder.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.function.Consumer;
+import java.time.Instant;
 
 
 public class OTelTraceDecoder implements ByteDecoder {
@@ -25,11 +26,10 @@ public class OTelTraceDecoder implements ByteDecoder {
     public OTelTraceDecoder() {
         otelProtoDecoder = new OTelProtoCodec.OTelProtoDecoder();
     }
-    public void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException {
+    public void parse(InputStream inputStream, Instant timeReceivedMs, Consumer<Record<Event>> eventConsumer) throws IOException {
         ExportTraceServiceRequest request = ExportTraceServiceRequest.parseFrom(inputStream);
         AtomicInteger droppedCounter = new AtomicInteger(0);
-        List<Span> spans =
-            otelProtoDecoder.parseExportTraceServiceRequest(request);
+        List<Span> spans = otelProtoDecoder.parseExportTraceServiceRequest(request, timeReceivedMs);
         for (Span span: spans) {
             eventConsumer.accept(new Record<>(span));
         }

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsDecoderTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelLogsDecoderTest.java
@@ -12,6 +12,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
 
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Map;
 import com.google.protobuf.util.JsonFormat;
@@ -65,7 +66,7 @@ public class OTelLogsDecoderTest {
     public void testParse() throws Exception {
         final ExportLogsServiceRequest request = buildExportLogsServiceRequestFromJsonFile(TEST_REQUEST_LOGS_FILE);
         InputStream inputStream = new ByteArrayInputStream((byte[])request.toByteArray());
-        createObjectUnderTest().parse(inputStream, (record) -> {
+        createObjectUnderTest().parse(inputStream, Instant.now(), (record) -> {
             validateLog((OpenTelemetryLog)record.getData());
         });
         

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelMetricsDecoderTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelMetricsDecoderTest.java
@@ -27,6 +27,7 @@ import org.opensearch.dataprepper.model.metric.JacksonGauge;
 import org.opensearch.dataprepper.model.metric.JacksonSum;
 import org.opensearch.dataprepper.model.metric.JacksonHistogram;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -87,7 +88,7 @@ public class OTelMetricsDecoderTest {
     public void testParse() throws Exception {
         final ExportMetricsServiceRequest request = buildExportMetricsServiceRequestFromJsonFile(TEST_REQUEST_METRICS_FILE);
         InputStream inputStream = new ByteArrayInputStream((byte[])request.toByteArray());
-        createObjectUnderTest().parse(inputStream, (record) -> {
+        createObjectUnderTest().parse(inputStream, Instant.now(), (record) -> {
             validateMetric((Event)record.getData());
         });
         

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodecTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodecTest.java
@@ -211,28 +211,28 @@ public class OTelProtoCodecTest {
         @Test
         public void testParseExportTraceServiceRequest() throws IOException {
             final ExportTraceServiceRequest exportTraceServiceRequest = buildExportTraceServiceRequestFromJsonFile(TEST_REQUEST_TRACE_JSON_FILE);
-            final List<Span> spans = decoderUnderTest.parseExportTraceServiceRequest(exportTraceServiceRequest);
+            final List<Span> spans = decoderUnderTest.parseExportTraceServiceRequest(exportTraceServiceRequest, Instant.now());
             validateSpans(spans);
         }
 
         @Test
         public void testParseExportTraceServiceRequest_InstrumentationLibrarySpans() throws IOException {
             final ExportTraceServiceRequest exportTraceServiceRequest = buildExportTraceServiceRequestFromJsonFile(TEST_REQUEST_INSTRUMENTATION_LIBRARY_TRACE_JSON_FILE);
-            final List<Span> spans = decoderUnderTest.parseExportTraceServiceRequest(exportTraceServiceRequest);
+            final List<Span> spans = decoderUnderTest.parseExportTraceServiceRequest(exportTraceServiceRequest, Instant.now());
             validateSpans(spans);
         }
 
         @Test
         public void testParseExportTraceServiceRequest_ScopeSpansTakesPrecedenceOverInstrumentationLibrarySpans() throws IOException {
             final ExportTraceServiceRequest exportTraceServiceRequest = buildExportTraceServiceRequestFromJsonFile(TEST_REQUEST_BOTH_SPAN_TYPES_JSON_FILE);
-            final List<Span> spans = decoderUnderTest.parseExportTraceServiceRequest(exportTraceServiceRequest);
+            final List<Span> spans = decoderUnderTest.parseExportTraceServiceRequest(exportTraceServiceRequest, Instant.now());
             validateSpans(spans);
         }
 
         @Test
         public void testParseExportTraceServiceRequest_NoSpans() throws IOException {
             final ExportTraceServiceRequest exportTraceServiceRequest = buildExportTraceServiceRequestFromJsonFile(TEST_REQUEST_NO_SPANS_JSON_FILE);
-            final List<Span> spans = decoderUnderTest.parseExportTraceServiceRequest(exportTraceServiceRequest);
+            final List<Span> spans = decoderUnderTest.parseExportTraceServiceRequest(exportTraceServiceRequest, Instant.now());
             assertThat(spans.size(), is(equalTo(0)));
         }
 
@@ -492,7 +492,7 @@ public class OTelProtoCodecTest {
         @Test
         public void testParseExportLogsServiceRequest_ScopedLogs() throws IOException {
             final ExportLogsServiceRequest exportLogsServiceRequest = buildExportLogsServiceRequestFromJsonFile(TEST_REQUEST_LOGS_JSON_FILE);
-            List<OpenTelemetryLog> logs = decoderUnderTest.parseExportLogsServiceRequest(exportLogsServiceRequest);
+            List<OpenTelemetryLog> logs = decoderUnderTest.parseExportLogsServiceRequest(exportLogsServiceRequest, Instant.now());
 
             assertThat(logs.size() , is(equalTo(1)));
             validateLog(logs.get(0));
@@ -501,7 +501,7 @@ public class OTelProtoCodecTest {
         @Test
         public void testParseExportLogsServiceRequest_InstrumentationLibraryLogs() throws IOException {
             final ExportLogsServiceRequest exportLogsServiceRequest = buildExportLogsServiceRequestFromJsonFile(TEST_REQUEST_LOGS_IS_JSON_FILE);
-            List<OpenTelemetryLog> logs = decoderUnderTest.parseExportLogsServiceRequest(exportLogsServiceRequest);
+            List<OpenTelemetryLog> logs = decoderUnderTest.parseExportLogsServiceRequest(exportLogsServiceRequest, Instant.now());
 
             assertThat(logs.size() , is(equalTo(1)));
             validateLog(logs.get(0));
@@ -527,7 +527,7 @@ public class OTelProtoCodecTest {
         @Test
         public void testParseExportLogsServiceRequest_InstrumentationLibrarySpans() throws IOException {
             final ExportTraceServiceRequest exportTraceServiceRequest = buildExportTraceServiceRequestFromJsonFile(TEST_REQUEST_INSTRUMENTATION_LIBRARY_TRACE_JSON_FILE);
-            final List<Span> spans = decoderUnderTest.parseExportTraceServiceRequest(exportTraceServiceRequest);
+            final List<Span> spans = decoderUnderTest.parseExportTraceServiceRequest(exportTraceServiceRequest, Instant.now());
             validateSpans(spans);
         }
 
@@ -535,7 +535,7 @@ public class OTelProtoCodecTest {
         public void testParseExportMetricsServiceRequest_Guage() throws IOException {
             final ExportMetricsServiceRequest exportMetricsServiceRequest = buildExportMetricsServiceRequestFromJsonFile(TEST_REQUEST_GAUGE_METRICS_JSON_FILE);
             AtomicInteger droppedCount = new AtomicInteger(0);
-            final Collection<Record<? extends Metric>> metrics = decoderUnderTest.parseExportMetricsServiceRequest(exportMetricsServiceRequest, droppedCount, 10, true, true, true);
+            final Collection<Record<? extends Metric>> metrics = decoderUnderTest.parseExportMetricsServiceRequest(exportMetricsServiceRequest, droppedCount, 10, Instant.now(), true, true, true);
 
             validateGaugeMetricRequest(metrics);
         }
@@ -544,7 +544,7 @@ public class OTelProtoCodecTest {
         public void testParseExportMetricsServiceRequest_Sum() throws IOException {
             final ExportMetricsServiceRequest exportMetricsServiceRequest = buildExportMetricsServiceRequestFromJsonFile(TEST_REQUEST_SUM_METRICS_JSON_FILE);
             AtomicInteger droppedCount = new AtomicInteger(0);
-            final Collection<Record<? extends Metric>> metrics = decoderUnderTest.parseExportMetricsServiceRequest(exportMetricsServiceRequest, droppedCount, 10, true, true, true);
+            final Collection<Record<? extends Metric>> metrics = decoderUnderTest.parseExportMetricsServiceRequest(exportMetricsServiceRequest, droppedCount, 10, Instant.now(), true, true, true);
             validateSumMetricRequest(metrics);
         }
 
@@ -552,7 +552,7 @@ public class OTelProtoCodecTest {
         public void testParseExportMetricsServiceRequest_Histogram() throws IOException {
             final ExportMetricsServiceRequest exportMetricsServiceRequest = buildExportMetricsServiceRequestFromJsonFile(TEST_REQUEST_HISTOGRAM_METRICS_JSON_FILE);
             AtomicInteger droppedCount = new AtomicInteger(0);
-            final Collection<Record<? extends Metric>> metrics = decoderUnderTest.parseExportMetricsServiceRequest(exportMetricsServiceRequest, droppedCount, 10, true, true, true);
+            final Collection<Record<? extends Metric>> metrics = decoderUnderTest.parseExportMetricsServiceRequest(exportMetricsServiceRequest, droppedCount, 10, Instant.now(), true, true, true);
             validateHistogramMetricRequest(metrics);
         }
 
@@ -560,7 +560,7 @@ public class OTelProtoCodecTest {
         public void testParseExportMetricsServiceRequest_Histogram_WithNoExplicitBounds() throws IOException {
             final ExportMetricsServiceRequest exportMetricsServiceRequest = buildExportMetricsServiceRequestFromJsonFile(TEST_REQUEST_HISTOGRAM_METRICS_NO_EXPLICIT_BOUNDS_JSON_FILE);
             AtomicInteger droppedCount = new AtomicInteger(0);
-            final Collection<Record<? extends Metric>> metrics = decoderUnderTest.parseExportMetricsServiceRequest(exportMetricsServiceRequest, droppedCount, 10, true, true, true);
+            final Collection<Record<? extends Metric>> metrics = decoderUnderTest.parseExportMetricsServiceRequest(exportMetricsServiceRequest, droppedCount, 10, Instant.now(), true, true, true);
             validateHistogramMetricRequestNoExplicitBounds(metrics);
         }
 
@@ -944,13 +944,13 @@ public class OTelProtoCodecTest {
     @Test
     public void testOTelProtoCodecConsistency() throws IOException, DecoderException {
         final ExportTraceServiceRequest request = buildExportTraceServiceRequestFromJsonFile(TEST_REQUEST_TRACE_JSON_FILE);
-        final List<Span> spansFirstDec = decoderUnderTest.parseExportTraceServiceRequest(request);
+        final List<Span> spansFirstDec = decoderUnderTest.parseExportTraceServiceRequest(request, Instant.now());
         final List<ResourceSpans> resourceSpansList = new ArrayList<>();
         for (final Span span : spansFirstDec) {
             resourceSpansList.add(encoderUnderTest.convertToResourceSpans(span));
         }
         final List<Span> spansSecondDec = resourceSpansList.stream()
-                .flatMap(rs -> decoderUnderTest.parseResourceSpans(rs).stream()).collect(Collectors.toList());
+                .flatMap(rs -> decoderUnderTest.parseResourceSpans(rs, Instant.now()).stream()).collect(Collectors.toList());
         assertThat(spansFirstDec.size(), equalTo(spansSecondDec.size()));
         for (int i = 0; i < spansFirstDec.size(); i++) {
             assertThat(spansFirstDec.get(i).toJsonString(), equalTo(spansSecondDec.get(i).toJsonString()));

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelTraceDecoderTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelTraceDecoderTest.java
@@ -12,6 +12,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
 
+import java.time.Instant;
 import java.util.Objects;
 import com.google.protobuf.util.JsonFormat;
 import org.opensearch.dataprepper.model.trace.Span;
@@ -66,7 +67,7 @@ public class OTelTraceDecoderTest {
     public void testParse() throws Exception {
         final ExportTraceServiceRequest request = buildExportTraceServiceRequestFromJsonFile(TEST_REQUEST_TRACES_FILE);
         InputStream inputStream = new ByteArrayInputStream((byte[])request.toByteArray());
-        createObjectUnderTest().parse(inputStream, (record) -> {
+        createObjectUnderTest().parse(inputStream, Instant.now(), (record) -> {
             validateSpan((Span)record.getData());
         });
         

--- a/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcService.java
@@ -26,6 +26,7 @@ import org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCodec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -88,7 +89,7 @@ public class OTelTraceGrpcService extends TraceServiceGrpc.TraceServiceImplBase 
         final Collection<Span> spans;
 
         try {
-            spans = oTelProtoDecoder.parseExportTraceServiceRequest(request);
+            spans = oTelProtoDecoder.parseExportTraceServiceRequest(request, Instant.now());
         } catch (final Exception e) {
             LOG.warn(DataPrepperMarkers.SENSITIVE, "Failed to parse request with error '{}'. Request body: {}.", e.getMessage(), request);
             throw new BadRequestException(e.getMessage(), e);

--- a/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcServiceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/org/opensearch/dataprepper/plugins/source/oteltrace/OTelTraceGrpcServiceTest.java
@@ -36,6 +36,7 @@ import org.opensearch.dataprepper.model.trace.Span;
 import org.opensearch.dataprepper.plugins.otel.codec.OTelProtoCodec;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -198,7 +199,7 @@ public class OTelTraceGrpcServiceTest {
     public void export_BadRequest_responseObserverOnError() throws Exception {
         final String testMessage = "test message";
         final RuntimeException testException = new RuntimeException(testMessage);
-        when(mockOTelProtoDecoder.parseExportTraceServiceRequest(any())).thenThrow(testException);
+        when(mockOTelProtoDecoder.parseExportTraceServiceRequest(any(), any(Instant.class))).thenThrow(testException);
         objectUnderTest = generateOTelTraceGrpcService(mockOTelProtoDecoder);
 
         try (MockedStatic<ServiceRequestContext> mockedStatic = mockStatic(ServiceRequestContext.class)) {

--- a/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodec.java
+++ b/data-prepper-plugins/parse-json-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/json/JsonInputCodec.java
@@ -8,11 +8,20 @@ package org.opensearch.dataprepper.plugins.codec.json;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.codec.JsonDecoder;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Consumer;
 
 /**
  * An implementation of {@link InputCodec} which parses JSON Objects for arrays.
  */
 @DataPrepperPlugin(name = "json", pluginType = InputCodec.class)
 public class JsonInputCodec extends JsonDecoder implements InputCodec {
+    public void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException {
+        parse(inputStream, null, eventConsumer);
+    }
 
 }


### PR DESCRIPTION
### Description
Fix pipeline latency to calculate correct latency when persistent buffer is used.
Modified the code to obtain time at which data is written to the kafka buffer and use it as the internal origination time. This internal origination time is used to calculate the pipeline latency
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
