### PR TITLE
Modify shutdown listeners to support a List of listeners

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/AbstractContextManager.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/AbstractContextManager.java
@@ -9,6 +9,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
+import java.util.List;
+
 /**
  * Base class for managing context. It provides hooks for inheritors to control the context to some degree.
  * <p>Creates Spring {@link org.springframework.context.ApplicationContext} hierarchy for Dependency Injection with limited visibility.</p>
@@ -59,7 +61,7 @@ public abstract class AbstractContextManager {
         coreApplicationContext.refresh();
 
         dataPrepper = coreApplicationContext.getBean(DataPrepper.class);
-        dataPrepper.registerShutdownHandler(new ContextShutdownListener());
+        dataPrepper.registerShutdownHandlers(List.of(new ContextShutdownListener()));
 
         LOG.trace("Data Prepper context is fully refreshed.");
     }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/AbstractContextManager.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/AbstractContextManager.java
@@ -9,8 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
-import java.util.List;
-
 /**
  * Base class for managing context. It provides hooks for inheritors to control the context to some degree.
  * <p>Creates Spring {@link org.springframework.context.ApplicationContext} hierarchy for Dependency Injection with limited visibility.</p>
@@ -61,7 +59,7 @@ public abstract class AbstractContextManager {
         coreApplicationContext.refresh();
 
         dataPrepper = coreApplicationContext.getBean(DataPrepper.class);
-        dataPrepper.registerShutdownHandlers(List.of(new ContextShutdownListener()));
+        dataPrepper.registerShutdownHandler(new ContextShutdownListener());
 
         LOG.trace("Data Prepper context is fully refreshed.");
     }

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/DataPrepper.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Lazy;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -46,7 +47,7 @@ public class DataPrepper implements PipelinesProvider {
     @Inject
     @Lazy
     private DataPrepperServer dataPrepperServer;
-    private List<DataPrepperShutdownListener> shutdownListeners;
+    private List<DataPrepperShutdownListener> shutdownListeners = new LinkedList<>();
 
     /**
      * returns serviceName if exists or default serviceName
@@ -139,8 +140,8 @@ public class DataPrepper implements PipelinesProvider {
         return transformationPipelines;
     }
 
-    public void registerShutdownHandlers(final List<DataPrepperShutdownListener> shutdownListeners) {
-        this.shutdownListeners = shutdownListeners;
+    public void registerShutdownHandler(final DataPrepperShutdownListener shutdownListener) {
+        this.shutdownListeners.add(shutdownListener);
     }
 
     private class PipelinesObserver implements PipelineObserver {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/DataPrepper.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Lazy;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -45,7 +46,7 @@ public class DataPrepper implements PipelinesProvider {
     @Inject
     @Lazy
     private DataPrepperServer dataPrepperServer;
-    private DataPrepperShutdownListener shutdownListener;
+    private List<DataPrepperShutdownListener> shutdownListeners;
 
     /**
      * returns serviceName if exists or default serviceName
@@ -115,8 +116,8 @@ public class DataPrepper implements PipelinesProvider {
     public void shutdownServers() {
         dataPrepperServer.stop();
         peerForwarderServer.stop();
-        if(shutdownListener != null) {
-            shutdownListener.handleShutdown();
+        if(shutdownListeners != null) {
+            shutdownListeners.forEach(DataPrepperShutdownListener::handleShutdown);
         }
     }
 
@@ -138,8 +139,8 @@ public class DataPrepper implements PipelinesProvider {
         return transformationPipelines;
     }
 
-    public void registerShutdownHandler(final DataPrepperShutdownListener shutdownListener) {
-        this.shutdownListener = shutdownListener;
+    public void registerShutdownHandlers(final List<DataPrepperShutdownListener> shutdownListeners) {
+        this.shutdownListeners = shutdownListeners;
     }
 
     private class PipelinesObserver implements PipelineObserver {

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/DataPrepperShutdownListener.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/DataPrepperShutdownListener.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper;
 
-interface DataPrepperShutdownListener {
+@FunctionalInterface
+public interface DataPrepperShutdownListener {
     void handleShutdown();
 }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/AbstractContextManagerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/AbstractContextManagerTest.java
@@ -16,7 +16,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -93,16 +92,12 @@ class AbstractContextManagerTest {
 
         objectUnderTest.getDataPrepperBean();
 
-        ArgumentCaptor<List<DataPrepperShutdownListener>> dataPrepperShutdownListenerArgumentCaptor = ArgumentCaptor.forClass(List.class);
-        verify(dataPrepper).registerShutdownHandlers(dataPrepperShutdownListenerArgumentCaptor.capture());
+        final ArgumentCaptor<DataPrepperShutdownListener> dataPrepperShutdownListenerArgumentCaptor = ArgumentCaptor.forClass(DataPrepperShutdownListener.class);
+        verify(dataPrepper).registerShutdownHandler(dataPrepperShutdownListenerArgumentCaptor.capture());
 
-        final List<DataPrepperShutdownListener> shutdownListeners = dataPrepperShutdownListenerArgumentCaptor.getValue();
+        final DataPrepperShutdownListener shutdownListener = dataPrepperShutdownListenerArgumentCaptor.getValue();
 
-        assertThat(shutdownListeners, notNullValue());
-        assertThat(shutdownListeners.size(), equalTo(1));
-        assertThat(shutdownListeners.get(0), notNullValue());
-
-        shutdownListeners.get(0).handleShutdown();
+        shutdownListener.handleShutdown();
 
         final InOrder inOrder = inOrder(applicationContexts.toArray());
         final List<AnnotationConfigApplicationContext> reversedContexts = Lists.reverse(applicationContexts);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/AbstractContextManagerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/AbstractContextManagerTest.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -92,12 +93,16 @@ class AbstractContextManagerTest {
 
         objectUnderTest.getDataPrepperBean();
 
-        ArgumentCaptor<DataPrepperShutdownListener> dataPrepperShutdownListenerArgumentCaptor = ArgumentCaptor.forClass(DataPrepperShutdownListener.class);
-        verify(dataPrepper).registerShutdownHandler(dataPrepperShutdownListenerArgumentCaptor.capture());
+        ArgumentCaptor<List<DataPrepperShutdownListener>> dataPrepperShutdownListenerArgumentCaptor = ArgumentCaptor.forClass(List.class);
+        verify(dataPrepper).registerShutdownHandlers(dataPrepperShutdownListenerArgumentCaptor.capture());
 
-        final DataPrepperShutdownListener shutdownListener = dataPrepperShutdownListenerArgumentCaptor.getValue();
+        final List<DataPrepperShutdownListener> shutdownListeners = dataPrepperShutdownListenerArgumentCaptor.getValue();
 
-        shutdownListener.handleShutdown();
+        assertThat(shutdownListeners, notNullValue());
+        assertThat(shutdownListeners.size(), equalTo(1));
+        assertThat(shutdownListeners.get(0), notNullValue());
+
+        shutdownListeners.get(0).handleShutdown();
 
         final InOrder inOrder = inOrder(applicationContexts.toArray());
         final List<AnnotationConfigApplicationContext> reversedContexts = Lists.reverse(applicationContexts);


### PR DESCRIPTION
### Description
* Modify data prepper core to accept a List of shutdownListeners that will all be run after shutdown.
 
### Issues Resolved
Following from https://github.com/opensearch-project/data-prepper/pull/4185
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
