### PR TITLE
Set default value of flattenAttributes to true in Otel metrics source

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
@@ -32,10 +32,14 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
     protected static final String SCHEMA_URL_KEY = "schemaUrl";
     protected static final String EXEMPLARS_KEY = "exemplars";
     protected static final String FLAGS_KEY = "flags";
-    private final boolean flattenAttributes;
+    private boolean flattenAttributes;
 
     protected JacksonMetric(Builder builder, boolean flattenAttributes) {
         super(builder);
+        this.flattenAttributes = flattenAttributes;
+    }
+
+    public void setFlattenAttributes(boolean flattenAttributes) {
         this.flattenAttributes = flattenAttributes;
     }
 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/metric/JacksonMetric.java
@@ -43,6 +43,10 @@ public abstract class JacksonMetric extends JacksonEvent implements Metric {
         this.flattenAttributes = flattenAttributes;
     }
 
+    boolean getFlattenAttributes() {
+        return flattenAttributes;
+    }
+
     @Override
     public String toJsonString() {
         if (!flattenAttributes) {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogramTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/metric/JacksonExponentialHistogramTest.java
@@ -156,6 +156,9 @@ public class JacksonExponentialHistogramTest {
     public void testZeroCount() {
         Long zeroCount = histogram.getZeroCount();
         assertThat(zeroCount, is(equalTo(TEST_ZERO_COUNT)));
+        assertThat(((JacksonMetric)histogram).getFlattenAttributes(), equalTo(true));
+        ((JacksonMetric)histogram).setFlattenAttributes(false);
+        assertThat(((JacksonMetric)histogram).getFlattenAttributes(), equalTo(false));
     }
 
     @Test

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OTelMetricsRawProcessor.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OTelMetricsRawProcessor.java
@@ -14,7 +14,6 @@ import static org.opensearch.dataprepper.model.metric.JacksonExponentialHistogra
 import static org.opensearch.dataprepper.model.metric.JacksonHistogram.BUCKETS_KEY;
 import org.opensearch.dataprepper.model.metric.JacksonMetric;
 import org.opensearch.dataprepper.model.metric.Metric;
-import static org.opensearch.dataprepper.model.metric.JacksonMetric.ATTRIBUTES_KEY;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.record.Record;
@@ -26,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OTelMetricsRawProcessor.java
+++ b/data-prepper-plugins/otel-metrics-raw-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/otelmetrics/OTelMetricsRawProcessor.java
@@ -12,6 +12,7 @@ import org.opensearch.dataprepper.model.configuration.PluginSetting;
 import static org.opensearch.dataprepper.model.metric.JacksonExponentialHistogram.POSITIVE_BUCKETS_KEY;
 import static org.opensearch.dataprepper.model.metric.JacksonExponentialHistogram.NEGATIVE_BUCKETS_KEY;
 import static org.opensearch.dataprepper.model.metric.JacksonHistogram.BUCKETS_KEY;
+import org.opensearch.dataprepper.model.metric.JacksonMetric;
 import org.opensearch.dataprepper.model.metric.Metric;
 import static org.opensearch.dataprepper.model.metric.JacksonMetric.ATTRIBUTES_KEY;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
@@ -55,13 +56,8 @@ public class OTelMetricsRawProcessor extends AbstractProcessor<Record<?>, Record
                               boolean calcualteExponentialHistogramBuckets) {
         Event event = (Event)record.getData();
 
-        if (flattenAttributes) {
-            Map<String, Object> attributes = event.get(ATTRIBUTES_KEY, Map.class);
-
-            for (Map.Entry<String, Object> entry : attributes.entrySet()) {
-                event.put(entry.getKey(), entry.getValue());
-            }
-            event.delete(ATTRIBUTES_KEY);
+        if (!flattenAttributes) {
+            ((JacksonMetric)record.getData()).setFlattenAttributes(false);
         }
         if (!calcualteHistogramBuckets && event.get(BUCKETS_KEY, List.class) != null) {
             event.delete(BUCKETS_KEY);
@@ -85,7 +81,7 @@ public class OTelMetricsRawProcessor extends AbstractProcessor<Record<?>, Record
         for (Record<?> rec : records) {
             if ((rec.getData() instanceof Event)) {
                 Record<? extends Metric> newRecord = (Record<? extends Metric>)rec;
-                if (otelMetricsRawProcessorConfig.getFlattenAttributesFlag() ||
+                if (!otelMetricsRawProcessorConfig.getFlattenAttributesFlag() ||
                     !otelMetricsRawProcessorConfig.getCalculateHistogramBuckets() ||
                     !otelMetricsRawProcessorConfig.getCalculateExponentialHistogramBuckets()) {
                     modifyRecord(newRecord, otelMetricsRawProcessorConfig.getFlattenAttributesFlag(), otelMetricsRawProcessorConfig.getCalculateHistogramBuckets(), otelMetricsRawProcessorConfig.getCalculateExponentialHistogramBuckets());


### PR DESCRIPTION
### Description
Set default value of flattenAttributes to true in Otel metrics source.
Modify the OTEL metrics source to create events/records with flatten attributes set to true.
If OTEL processor config changes the flatten attributes to flase, then change it false in the processor.

OTEL metrics always have been implemented with flattening the attributes(ie fields inside "attributes" field are moved to the root). We have added option to not flatten some time back. But that's not used by anyone (that I know of). When the previous PR which moved the creation of OTEL metrics records to OTEL source (instead of otel processor) I picked the default to false and it is changed to true in the processor. But that was unnecessary also hit a bug due to valid characters in a key. This new approach will avoid it.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
