### PR TITLE
Add include_performance_metadata parameter and track total grok patterns attempted in the grok processor

### DIFF
--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
@@ -269,12 +269,12 @@ public class GrokProcessor extends AbstractProcessor<Record<Event>, Record<Event
         }
 
         if (grokProcessorConfig.getIncludePerformanceMetadata()) {
-            final Integer totalPatternsAttemptedForEvent = (Integer) event.getMetadata().getAttribute(TOTAL_PATTERNS_ATTEMPTED_METADATA_KEY);
+            Integer totalPatternsAttemptedForEvent = (Integer) event.getMetadata().getAttribute(TOTAL_PATTERNS_ATTEMPTED_METADATA_KEY);
             if (totalPatternsAttemptedForEvent == null) {
-                event.getMetadata().setAttribute(TOTAL_PATTERNS_ATTEMPTED_METADATA_KEY, patternsAttempted);
-            } else {
-                event.getMetadata().setAttribute(TOTAL_PATTERNS_ATTEMPTED_METADATA_KEY, totalPatternsAttemptedForEvent + patternsAttempted);
+                totalPatternsAttemptedForEvent = 0;
             }
+
+            event.getMetadata().setAttribute(TOTAL_PATTERNS_ATTEMPTED_METADATA_KEY, totalPatternsAttemptedForEvent + patternsAttempted);
         }
     }
 

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -98,7 +98,7 @@ public class GrokProcessorConfig {
                 pluginSetting.getStringOrDefault(GROK_WHEN, null),
                 pluginSetting.getTypedList(TAGS_ON_MATCH_FAILURE, String.class),
                 pluginSetting.getTypedList(TAGS_ON_TIMEOUT, String.class),
-                pluginSetting.getBooleanOrDefault(INCLUDE_PERFORMANCE_METADATA, false));
+                pluginSetting.getBooleanOrDefault(INCLUDE_PERFORMANCE_METADATA, true));
     }
 
     public boolean isBreakOnMatch() {

--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -11,6 +11,9 @@ import java.util.List;
 import java.util.Map;
 
 public class GrokProcessorConfig {
+
+    static final String TOTAL_PATTERNS_ATTEMPTED_METADATA_KEY = "_total_grok_patterns_attempted";
+
     static final String BREAK_ON_MATCH = "break_on_match";
     static final String KEEP_EMPTY_CAPTURES = "keep_empty_captures";
     static final String MATCH = "match";
@@ -24,6 +27,8 @@ public class GrokProcessorConfig {
     static final String GROK_WHEN = "grok_when";
     static final String TAGS_ON_MATCH_FAILURE = "tags_on_match_failure";
     static final String TAGS_ON_TIMEOUT = "tags_on_timeout";
+
+    static final String INCLUDE_PERFORMANCE_METADATA = "include_performance_metadata";
 
     static final boolean DEFAULT_BREAK_ON_MATCH = true;
     static final boolean DEFAULT_KEEP_EMPTY_CAPTURES = false;
@@ -46,6 +51,8 @@ public class GrokProcessorConfig {
     private final List<String> tagsOnMatchFailure;
     private final List<String> tagsOnTimeout;
 
+    private final boolean includePerformanceMetadata;
+
     private GrokProcessorConfig(final boolean breakOnMatch,
                                 final boolean keepEmptyCaptures,
                                 final Map<String, List<String>> match,
@@ -58,7 +65,8 @@ public class GrokProcessorConfig {
                                 final String targetKey,
                                 final String grokWhen,
                                 final List<String> tagsOnMatchFailure,
-                                final List<String> tagsOnTimeout) {
+                                final List<String> tagsOnTimeout,
+                                final boolean includePerformanceMetadata) {
 
         this.breakOnMatch = breakOnMatch;
         this.keepEmptyCaptures = keepEmptyCaptures;
@@ -73,6 +81,7 @@ public class GrokProcessorConfig {
         this.grokWhen = grokWhen;
         this.tagsOnMatchFailure = tagsOnMatchFailure;
         this.tagsOnTimeout = tagsOnTimeout.isEmpty() ? tagsOnMatchFailure : tagsOnTimeout;
+        this.includePerformanceMetadata = includePerformanceMetadata;
     }
 
     public static GrokProcessorConfig buildConfig(final PluginSetting pluginSetting) {
@@ -88,7 +97,8 @@ public class GrokProcessorConfig {
                 pluginSetting.getStringOrDefault(TARGET_KEY, DEFAULT_TARGET_KEY),
                 pluginSetting.getStringOrDefault(GROK_WHEN, null),
                 pluginSetting.getTypedList(TAGS_ON_MATCH_FAILURE, String.class),
-                pluginSetting.getTypedList(TAGS_ON_TIMEOUT, String.class));
+                pluginSetting.getTypedList(TAGS_ON_TIMEOUT, String.class),
+                pluginSetting.getBooleanOrDefault(INCLUDE_PERFORMANCE_METADATA, false));
     }
 
     public boolean isBreakOnMatch() {
@@ -140,4 +150,6 @@ public class GrokProcessorConfig {
     public List<String> getTagsOnTimeout() {
         return tagsOnTimeout;
     }
+
+    public boolean getIncludePerformanceMetadata() { return includePerformanceMetadata; }
 }

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfigTests.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfigTests.java
@@ -77,7 +77,7 @@ public class GrokProcessorConfigTests {
         assertThat(grokProcessorConfig.getGrokWhen(), equalTo(null));
         assertThat(grokProcessorConfig.getTagsOnMatchFailure(), equalTo(Collections.emptyList()));
         assertThat(grokProcessorConfig.getTagsOnTimeout(), equalTo(Collections.emptyList()));
-        assertThat(grokProcessorConfig.getIncludePerformanceMetadata(), equalTo(false));
+        assertThat(grokProcessorConfig.getIncludePerformanceMetadata(), equalTo(true));
     }
 
     @Test
@@ -93,7 +93,7 @@ public class GrokProcessorConfigTests {
                 TEST_PATTERN_DEFINITIONS,
                 TEST_TIMEOUT_MILLIS,
                 TEST_TARGET_KEY,
-                true);
+                false);
 
         final GrokProcessorConfig grokProcessorConfig = GrokProcessorConfig.buildConfig(validPluginSetting);
 
@@ -107,7 +107,7 @@ public class GrokProcessorConfigTests {
         assertThat(grokProcessorConfig.getTargetKey(), equalTo(TEST_TARGET_KEY));
         assertThat(grokProcessorConfig.isNamedCapturesOnly(), equalTo(false));
         assertThat(grokProcessorConfig.getTimeoutMillis(), equalTo(TEST_TIMEOUT_MILLIS));
-        assertThat(grokProcessorConfig.getIncludePerformanceMetadata(), equalTo(true));
+        assertThat(grokProcessorConfig.getIncludePerformanceMetadata(), equalTo(false));
     }
 
     @Test

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfigTests.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfigTests.java
@@ -77,6 +77,7 @@ public class GrokProcessorConfigTests {
         assertThat(grokProcessorConfig.getGrokWhen(), equalTo(null));
         assertThat(grokProcessorConfig.getTagsOnMatchFailure(), equalTo(Collections.emptyList()));
         assertThat(grokProcessorConfig.getTagsOnTimeout(), equalTo(Collections.emptyList()));
+        assertThat(grokProcessorConfig.getIncludePerformanceMetadata(), equalTo(false));
     }
 
     @Test
@@ -91,7 +92,8 @@ public class GrokProcessorConfigTests {
                 TEST_PATTERNS_FILES_GLOB,
                 TEST_PATTERN_DEFINITIONS,
                 TEST_TIMEOUT_MILLIS,
-                TEST_TARGET_KEY);
+                TEST_TARGET_KEY,
+                true);
 
         final GrokProcessorConfig grokProcessorConfig = GrokProcessorConfig.buildConfig(validPluginSetting);
 
@@ -105,6 +107,7 @@ public class GrokProcessorConfigTests {
         assertThat(grokProcessorConfig.getTargetKey(), equalTo(TEST_TARGET_KEY));
         assertThat(grokProcessorConfig.isNamedCapturesOnly(), equalTo(false));
         assertThat(grokProcessorConfig.getTimeoutMillis(), equalTo(TEST_TIMEOUT_MILLIS));
+        assertThat(grokProcessorConfig.getIncludePerformanceMetadata(), equalTo(true));
     }
 
     @Test
@@ -119,7 +122,8 @@ public class GrokProcessorConfigTests {
                 TEST_PATTERNS_FILES_GLOB,
                 TEST_PATTERN_DEFINITIONS,
                 TEST_TIMEOUT_MILLIS,
-                TEST_TARGET_KEY);
+                TEST_TARGET_KEY,
+                false);
 
         invalidPluginSetting.getSettings().put(GrokProcessorConfig.MATCH, TEST_INVALID_MATCH);
 
@@ -135,7 +139,8 @@ public class GrokProcessorConfigTests {
                                                               final String patternsFilesGlob,
                                                               final Map<String, String> patternDefinitions,
                                                               final int timeoutMillis,
-                                                              final String targetKey) {
+                                                              final String targetKey,
+                                                              final boolean includePerformanceMetadata) {
         final Map<String, Object> settings = new HashMap<>();
         settings.put(GrokProcessorConfig.BREAK_ON_MATCH, breakOnMatch);
         settings.put(GrokProcessorConfig.NAMED_CAPTURES_ONLY, namedCapturesOnly);
@@ -147,6 +152,7 @@ public class GrokProcessorConfigTests {
         settings.put(GrokProcessorConfig.PATTERNS_FILES_GLOB, patternsFilesGlob);
         settings.put(GrokProcessorConfig.TIMEOUT_MILLIS, timeoutMillis);
         settings.put(GrokProcessorConfig.TARGET_KEY, targetKey);
+        settings.put(GrokProcessorConfig.INCLUDE_PERFORMANCE_METADATA, includePerformanceMetadata);
 
         return new PluginSetting(PLUGIN_NAME, settings);
     }

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorTests.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorTests.java
@@ -161,6 +161,8 @@ public class GrokProcessorTests {
 
     @Test
     public void testMatchMerge() throws JsonProcessingException, ExecutionException, InterruptedException, TimeoutException {
+        pluginSetting.getSettings().put(GrokProcessorConfig.INCLUDE_PERFORMANCE_METADATA, false);
+
         grokProcessor = createObjectUnderTest();
 
         capture.put("key_capture_1", "value_capture_1");

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorTests.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorTests.java
@@ -58,6 +58,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.processor.grok.GrokProcessor.EXECUTOR_SERVICE_SHUTDOWN_TIMEOUT;
+import static org.opensearch.dataprepper.plugins.processor.grok.GrokProcessorConfig.TOTAL_PATTERNS_ATTEMPTED_METADATA_KEY;
 import static org.opensearch.dataprepper.test.matcher.MapEquals.isEqualWithoutTimestamp;
 
 
@@ -182,7 +183,11 @@ public class GrokProcessorTests {
 
         assertThat(grokkedRecords.size(), equalTo(1));
         assertThat(grokkedRecords.get(0), notNullValue());
+        assertThat(grokkedRecords.get(0).getData(), notNullValue());
+        assertThat(grokkedRecords.get(0).getData().getMetadata(), notNullValue());
+        assertThat(grokkedRecords.get(0).getData().getMetadata().getAttribute(TOTAL_PATTERNS_ATTEMPTED_METADATA_KEY), equalTo(null));
         assertRecordsAreEqual(grokkedRecords.get(0), resultRecord);
+
         verify(grokProcessingMatchCounter, times(1)).increment();
         verify(grokProcessingTime, times(1)).record(any(Runnable.class));
         verifyNoInteractions(grokProcessingErrorsCounter, grokProcessingMismatchCounter, grokProcessingTimeoutsCounter);
@@ -510,6 +515,62 @@ public class GrokProcessorTests {
 
             assertThat(grokkedRecords.size(), equalTo(1));
             assertThat(grokkedRecords.get(0), notNullValue());
+            assertRecordsAreEqual(grokkedRecords.get(0), record);
+            verify(grokProcessingMismatchCounter, times(1)).increment();
+            verify(grokProcessingTime, times(1)).record(any(Runnable.class));
+            verifyNoInteractions(grokProcessingErrorsCounter, grokProcessingMatchCounter, grokProcessingTimeoutsCounter);
+        }
+
+        @Test
+        public void testMatchOnSecondPattern() throws JsonProcessingException {
+            pluginSetting.getSettings().put(GrokProcessorConfig.INCLUDE_PERFORMANCE_METADATA, true);
+
+            when(match.capture()).thenReturn(Collections.emptyMap());
+            when(grokSecondMatch.match(messageInput)).thenReturn(secondMatch);
+            when(secondMatch.capture()).thenReturn(capture);
+
+            grokProcessor = createObjectUnderTest();
+
+            final Map<String, Object> testData = new HashMap();
+            testData.put("message", messageInput);
+            final Record<Event> record = buildRecordWithEvent(testData);
+
+            final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+
+            assertThat(grokkedRecords.size(), equalTo(1));
+            assertThat(grokkedRecords.get(0), notNullValue());
+            assertThat(grokkedRecords.get(0).getData(), notNullValue());
+            assertThat(grokkedRecords.get(0).getData().getMetadata(), notNullValue());
+            assertThat(grokkedRecords.get(0).getData().getMetadata().getAttribute(TOTAL_PATTERNS_ATTEMPTED_METADATA_KEY), equalTo(2));
+            assertRecordsAreEqual(grokkedRecords.get(0), record);
+            verify(grokProcessingMismatchCounter, times(1)).increment();
+            verify(grokProcessingTime, times(1)).record(any(Runnable.class));
+            verifyNoInteractions(grokProcessingErrorsCounter, grokProcessingMatchCounter, grokProcessingTimeoutsCounter);
+        }
+
+        @Test
+        public void testMatchOnSecondPatternWithExistingMetadataForTotalPatternMatches() throws JsonProcessingException {
+            pluginSetting.getSettings().put(GrokProcessorConfig.INCLUDE_PERFORMANCE_METADATA, true);
+
+            when(match.capture()).thenReturn(Collections.emptyMap());
+            when(grokSecondMatch.match(messageInput)).thenReturn(secondMatch);
+            when(secondMatch.capture()).thenReturn(capture);
+
+            grokProcessor = createObjectUnderTest();
+
+            final Map<String, Object> testData = new HashMap();
+            testData.put("message", messageInput);
+            final Record<Event> record = buildRecordWithEvent(testData);
+
+            record.getData().getMetadata().setAttribute(TOTAL_PATTERNS_ATTEMPTED_METADATA_KEY, 1);
+
+            final List<Record<Event>> grokkedRecords = (List<Record<Event>>) grokProcessor.doExecute(Collections.singletonList(record));
+
+            assertThat(grokkedRecords.size(), equalTo(1));
+            assertThat(grokkedRecords.get(0), notNullValue());
+            assertThat(grokkedRecords.get(0).getData(), notNullValue());
+            assertThat(grokkedRecords.get(0).getData().getMetadata(), notNullValue());
+            assertThat(grokkedRecords.get(0).getData().getMetadata().getAttribute(TOTAL_PATTERNS_ATTEMPTED_METADATA_KEY), equalTo(3));
             assertRecordsAreEqual(grokkedRecords.get(0), record);
             verify(grokProcessingMismatchCounter, times(1)).increment();
             verify(grokProcessingTime, times(1)).record(any(Runnable.class));


### PR DESCRIPTION
### Description
This change adds an `include_performance_metadata` flag to the grok processor, which defaults to true. When enabled, static metadata fields will be added to Events to track the total number of patterns this Event has attempted to match on.

### Issues Resolved
Partially resolves #4196. Tracking the total time spent in grok is still needed.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
