### PR TITLE
Fix KafkaBuffer isEmpty

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/AbstractBuffer.java
@@ -145,12 +145,14 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
     @Override
     public void checkpoint(final CheckpointState checkpointState) {
         checkpointTimer.record(() -> doCheckpoint(checkpointState));
-        final int numRecordsToBeChecked = checkpointState.getNumRecordsToBeChecked();
-        recordsInFlight.addAndGet(-numRecordsToBeChecked);
-        recordsProcessedCounter.increment(numRecordsToBeChecked);
+        if (!isByteBuffer()) {
+            final int numRecordsToBeChecked = checkpointState.getNumRecordsToBeChecked();
+            recordsInFlight.addAndGet(-numRecordsToBeChecked);
+            recordsProcessedCounter.increment(numRecordsToBeChecked);
+        }
     }
 
-    protected int getRecordsInFlight() {
+    public int getRecordsInFlight() {
         return recordsInFlight.intValue();
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferIT.java
@@ -150,6 +150,11 @@ public class KafkaBufferIT {
         // TODO: The metadata is not included. It needs to be included in the Buffer, though not in the Sink. This may be something we make configurable in the consumer/producer - whether to serialize the metadata or not.
         //assertThat(onlyResult.getData().getMetadata(), equalTo(record.getData().getMetadata()));
         assertThat(onlyResult.getData().toMap(), equalTo(record.getData().toMap()));
+        assertThat(objectUnderTest.getRecordsInFlight(), equalTo(0));
+        assertThat(objectUnderTest.getInnerBufferRecordsInFlight(), equalTo(1));
+        objectUnderTest.checkpoint(readResult.getValue());
+        assertThat(objectUnderTest.getRecordsInFlight(), equalTo(0));
+        assertThat(objectUnderTest.getInnerBufferRecordsInFlight(), equalTo(0));
     }
 
     @Test

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
@@ -162,7 +162,7 @@ public class KafkaBuffer extends AbstractBuffer<Record<Event>> {
     public void doCheckpoint(CheckpointState checkpointState) {
         try {
             setMdc();
-            innerBuffer.doCheckpoint(checkpointState);
+            innerBuffer.checkpoint(checkpointState);
         } finally {
             resetMdc();
         }
@@ -186,6 +186,10 @@ public class KafkaBuffer extends AbstractBuffer<Record<Event>> {
     @Override
     public boolean isWrittenOffHeapOnly() {
         return true;
+    }
+
+    int getInnerBufferRecordsInFlight() {
+        return innerBuffer.getRecordsInFlight();
     }
 
     @Override

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBufferTest.java
@@ -297,7 +297,7 @@ class KafkaBufferTest {
     void test_kafkaBuffer_doCheckpoint() {
         kafkaBuffer = createObjectUnderTest();
         kafkaBuffer.doCheckpoint(mock(CheckpointState.class));
-        verify(blockingBuffer).doCheckpoint(any());
+        verify(blockingBuffer).checkpoint(any());
     }
 
     @Test


### PR DESCRIPTION
### Description
Fix KafkaBuffer isEmpty.
KafkaBuffer isEmpty depends on innerBuffer recordsInFlight to be zero. But innerBuffer recordsInFlight is not zero because when `checkpoint` is done on KafkaBuffer, it is directly invoking `doCheckpoint` on the innerBuffer instead of invoking `checkpoint` which actually updates the metrics.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
