### PR TITLE
Add exclude_keys option to flatten processor

### DIFF
--- a/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
+++ b/data-prepper-plugins/flatten-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfig.java
@@ -8,9 +8,12 @@ package org.opensearch.dataprepper.plugins.processor.flatten;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class FlattenProcessorConfig {
+
+    private static final List<String> DEFAULT_EXCLUDE_KEYS = new ArrayList<>();
 
     @NotNull
     @JsonProperty("source")
@@ -25,6 +28,9 @@ public class FlattenProcessorConfig {
 
     @JsonProperty("remove_list_indices")
     private boolean removeListIndices = false;
+
+    @JsonProperty("exclude_keys")
+    private List<String> excludeKeys = DEFAULT_EXCLUDE_KEYS;
 
     @JsonProperty("flatten_when")
     private String flattenWhen;
@@ -46,6 +52,10 @@ public class FlattenProcessorConfig {
 
     public boolean isRemoveListIndices() {
         return removeListIndices;
+    }
+
+    public List<String> getExcludeKeys() {
+        return excludeKeys;
     }
 
     public String getFlattenWhen() {

--- a/data-prepper-plugins/flatten-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfigTest.java
+++ b/data-prepper-plugins/flatten-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/flatten/FlattenProcessorConfigTest.java
@@ -7,6 +7,8 @@ package org.opensearch.dataprepper.plugins.processor.flatten;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -21,5 +23,6 @@ class FlattenProcessorConfigTest {
         assertThat(FlattenProcessorConfig.isRemoveListIndices(), equalTo(false));
         assertThat(FlattenProcessorConfig.getFlattenWhen(), equalTo(null));
         assertThat(FlattenProcessorConfig.getTagsOnFailure(), equalTo(null));
+        assertThat(FlattenProcessorConfig.getExcludeKeys(), equalTo(List.of()));
     }
 }


### PR DESCRIPTION
### Description
Add exclude_keys option to flatten processor, those keys will be excluded from the flattening operation.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
