### PR TITLE
Change grok performance_metadata to be disabled by default

### DIFF
--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfig.java
@@ -100,7 +100,7 @@ public class GrokProcessorConfig {
                 pluginSetting.getStringOrDefault(GROK_WHEN, null),
                 pluginSetting.getTypedList(TAGS_ON_MATCH_FAILURE, String.class),
                 pluginSetting.getTypedList(TAGS_ON_TIMEOUT, String.class),
-                pluginSetting.getBooleanOrDefault(INCLUDE_PERFORMANCE_METADATA, true));
+                pluginSetting.getBooleanOrDefault(INCLUDE_PERFORMANCE_METADATA, false));
     }
 
     public boolean isBreakOnMatch() {

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfigTests.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorConfigTests.java
@@ -77,7 +77,7 @@ public class GrokProcessorConfigTests {
         assertThat(grokProcessorConfig.getGrokWhen(), equalTo(null));
         assertThat(grokProcessorConfig.getTagsOnMatchFailure(), equalTo(Collections.emptyList()));
         assertThat(grokProcessorConfig.getTagsOnTimeout(), equalTo(Collections.emptyList()));
-        assertThat(grokProcessorConfig.getIncludePerformanceMetadata(), equalTo(true));
+        assertThat(grokProcessorConfig.getIncludePerformanceMetadata(), equalTo(false));
     }
 
     @Test
@@ -93,7 +93,7 @@ public class GrokProcessorConfigTests {
                 TEST_PATTERN_DEFINITIONS,
                 TEST_TIMEOUT_MILLIS,
                 TEST_TARGET_KEY,
-                false);
+                true);
 
         final GrokProcessorConfig grokProcessorConfig = GrokProcessorConfig.buildConfig(validPluginSetting);
 
@@ -107,7 +107,7 @@ public class GrokProcessorConfigTests {
         assertThat(grokProcessorConfig.getTargetKey(), equalTo(TEST_TARGET_KEY));
         assertThat(grokProcessorConfig.isNamedCapturesOnly(), equalTo(false));
         assertThat(grokProcessorConfig.getTimeoutMillis(), equalTo(TEST_TIMEOUT_MILLIS));
-        assertThat(grokProcessorConfig.getIncludePerformanceMetadata(), equalTo(false));
+        assertThat(grokProcessorConfig.getIncludePerformanceMetadata(), equalTo(true));
     }
 
     @Test


### PR DESCRIPTION
### Description
Changes the default value of `performance_metadata` to false
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
