### PR TITLE
Add check for if performance_metadata is enabled before adding metadata for grok processing time to Events

### DIFF
--- a/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
+++ b/data-prepper-plugins/grok-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessor.java
@@ -149,13 +149,15 @@ public class GrokProcessor extends AbstractProcessor<Record<Event>, Record<Event
 
             final Instant endTime = Instant.now();
 
-            Long totalEventTimeInGrok = (Long) event.getMetadata().getAttribute(TOTAL_TIME_SPENT_IN_GROK_METADATA_KEY);
-            if (totalEventTimeInGrok == null) {
-                totalEventTimeInGrok = 0L;
-            }
+            if (grokProcessorConfig.getIncludePerformanceMetadata()) {
+                Long totalEventTimeInGrok = (Long) event.getMetadata().getAttribute(TOTAL_TIME_SPENT_IN_GROK_METADATA_KEY);
+                if (totalEventTimeInGrok == null) {
+                    totalEventTimeInGrok = 0L;
+                }
 
-            final long timeSpentInThisGrok = endTime.toEpochMilli() - startTime.toEpochMilli();
-            event.getMetadata().setAttribute(TOTAL_TIME_SPENT_IN_GROK_METADATA_KEY, totalEventTimeInGrok + timeSpentInThisGrok);
+                final long timeSpentInThisGrok = endTime.toEpochMilli() - startTime.toEpochMilli();
+                event.getMetadata().setAttribute(TOTAL_TIME_SPENT_IN_GROK_METADATA_KEY, totalEventTimeInGrok + timeSpentInThisGrok);
+            }
          }
         return records;
     }

--- a/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorTests.java
+++ b/data-prepper-plugins/grok-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/grok/GrokProcessorTests.java
@@ -190,6 +190,7 @@ public class GrokProcessorTests {
         assertThat(grokkedRecords.get(0).getData(), notNullValue());
         assertThat(grokkedRecords.get(0).getData().getMetadata(), notNullValue());
         assertThat(grokkedRecords.get(0).getData().getMetadata().getAttribute(TOTAL_PATTERNS_ATTEMPTED_METADATA_KEY), equalTo(null));
+        assertThat(grokkedRecords.get(0).getData().getMetadata().getAttribute(TOTAL_TIME_SPENT_IN_GROK_METADATA_KEY), equalTo(null));
         assertRecordsAreEqual(grokkedRecords.get(0), resultRecord);
 
         verify(grokProcessingMatchCounter, times(1)).increment();


### PR DESCRIPTION


### Description
This was a miss from the previous PR (https://github.com/opensearch-project/data-prepper/commit/ebd2d470a84228170f2a4f6978e88419a8f653da) which did not consider the flag before writing the metadata for the total time spent in grok
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
