### PR TITLE
Modify S3 Source to create multiple SqsWorkers

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3SourceConfig.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 public class S3SourceConfig {
     static final Duration DEFAULT_BUFFER_TIMEOUT = Duration.ofSeconds(10);
+    static final Duration DEFAULT_NUMBER_OF_WORKERS = 5;
     static final int DEFAULT_NUMBER_OF_RECORDS_TO_ACCUMULATE = 100;
     static final String DEFAULT_METADATA_ROOT_KEY = "s3/";
 
@@ -42,6 +43,10 @@ public class S3SourceConfig {
     @JsonProperty("sqs")
     @Valid
     private SqsOptions sqsOptions;
+
+    @JsonProperty("workers")
+    @Valid
+    private int numWorkers = DEFAULT_NUMBER_OF_WORKERS;
 
     @JsonProperty("aws")
     @NotNull
@@ -99,6 +104,10 @@ public class S3SourceConfig {
 
     boolean getAcknowledgements() {
         return acknowledgments;
+    }
+
+    public int getNumWorkers() {
+        return numWorkers;
     }
 
     public CompressionOption getCompression() {


### PR DESCRIPTION
### Description
Modify S3 Source to create multiple SqsWorkers to process SQS messages in parallel.
Provided configuration option to change the number of workers.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
