### PR TITLE
Add key_value_when conditional to key_value processor

### DIFF
--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -101,6 +101,9 @@ public class KeyValueProcessorConfig {
     @JsonProperty("overwrite_if_destination_exists")
     private boolean overwriteIfDestinationExists = true;
 
+    @JsonProperty("key_value_when")
+    private String keyValueWhen;
+
     public String getSource() {
         return source;
     }
@@ -180,4 +183,6 @@ public class KeyValueProcessorConfig {
     public boolean getOverwriteIfDestinationExists() {
         return overwriteIfDestinationExists;
     }
+
+    public String getKeyValueWhen() { return keyValueWhen; }
 }


### PR DESCRIPTION
### Description
This adds a `key_value_when` condition to the `key_value` processor
 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR. (https://github.com/opensearch-project/documentation-website/issues/6503)
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
