### PR TITLE
Rename first and second database directories to blue and green

### DIFF
--- a/data-prepper-plugins/geoip-processor/src/integrationTest/java/org/opensearch/dataprepper/plugins/processor/GeoIPProcessorUrlServiceIT.java
+++ b/data-prepper-plugins/geoip-processor/src/integrationTest/java/org/opensearch/dataprepper/plugins/processor/GeoIPProcessorUrlServiceIT.java
@@ -37,7 +37,7 @@ public class GeoIPProcessorUrlServiceIT {
     private GeoIPInputJson geoIPInputJson;
     private String jsonInput;
     private static final String TEMP_PATH_FOLDER = "GeoIP";
-    public static final String DATABASE_1 = "first_database";
+    public static final String DATABASE_1 = "blue_database";
     public static final String URL_SUFFIX = "&suffix=tar.gz";
 
     @BeforeEach

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/databasedownload/GeoIPDatabaseManager.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/databasedownload/GeoIPDatabaseManager.java
@@ -29,8 +29,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
 public class GeoIPDatabaseManager {
     private static final Logger LOG = LoggerFactory.getLogger(GeoIPDatabaseManager.class);
-    public static final String FIRST_DATABASE_DIR = "first_database";
-    public static final String SECOND_DATABASE_DIR = "second_database";
+    public static final String BLUE_DATABASE_DIR = "blue_database";
+    public static final String GREEN_DATABASE_DIR = "green_database";
     private static final long INITIAL_DELAY = Duration.ofMinutes(1).toMillis();
     private static final long MAXIMUM_DELAY = Duration.ofHours(1).toMillis();
     private static final double JITTER_RATE = 0.15;
@@ -168,9 +168,9 @@ public class GeoIPDatabaseManager {
     private void switchDirectory() {
         databaseDirToggle = !databaseDirToggle;
         if (databaseDirToggle) {
-            currentDatabaseDir = FIRST_DATABASE_DIR;
+            currentDatabaseDir = BLUE_DATABASE_DIR;
         } else {
-            currentDatabaseDir = SECOND_DATABASE_DIR;
+            currentDatabaseDir = GREEN_DATABASE_DIR;
         }
     }
 
@@ -198,8 +198,8 @@ public class GeoIPDatabaseManager {
     }
 
     public void deleteDatabasesOnShutdown() {
-        geoIPFileManager.deleteDirectory(new File(maxMindConfig.getDatabaseDestination() + File.separator + FIRST_DATABASE_DIR));
-        geoIPFileManager.deleteDirectory(new File(maxMindConfig.getDatabaseDestination() + File.separator + SECOND_DATABASE_DIR));
+        geoIPFileManager.deleteDirectory(new File(maxMindConfig.getDatabaseDestination() + File.separator + BLUE_DATABASE_DIR));
+        geoIPFileManager.deleteDirectory(new File(maxMindConfig.getDatabaseDestination() + File.separator + GREEN_DATABASE_DIR));
     }
 
     public void deleteDirectory(final File file) {

--- a/data-prepper-plugins/geoip-processor/src/test/java/org/opensearch/dataprepper/plugins/geoip/extension/databasedownload/HttpDBDownloadServiceTest.java
+++ b/data-prepper-plugins/geoip-processor/src/test/java/org/opensearch/dataprepper/plugins/geoip/extension/databasedownload/HttpDBDownloadServiceTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 @ExtendWith(MockitoExtension.class)
 class HttpDBDownloadServiceTest {
 
-    private static final String PREFIX_DIR = "first_database";
+    private static final String PREFIX_DIR = "blue_database";
     private HttpDBDownloadService downloadThroughUrl;
     @Mock
     private GeoIPFileManager geoIPFileManager;

--- a/data-prepper-plugins/geoip-processor/src/test/java/org/opensearch/dataprepper/plugins/geoip/extension/databasedownload/S3DBServiceTest.java
+++ b/data-prepper-plugins/geoip-processor/src/test/java/org/opensearch/dataprepper/plugins/geoip/extension/databasedownload/S3DBServiceTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 class S3DBServiceTest {
 
     private static final String S3_URI = "s3://mybucket10012023/GeoLite2/";
-    private static final String DATABASE_DIR = "first_database";
+    private static final String DATABASE_DIR = "blue_database";
     @Mock
     private MaxMindDatabaseConfig maxMindDatabaseConfig;
     @Mock


### PR DESCRIPTION
### Description

The `geoip` processors creates directories named `first_database` and `second_database`. This can be confusing over time. So I renamed them to `blue_database` and `green_database`.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
