### PR TITLE
Set up serverless network policy before setting up index

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -228,6 +228,10 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
           .add(pluginSetting.getName()).toString());
       dlqWriter = potentialDlq.isPresent() ? potentialDlq.get() : null;
     }
+
+    // Attempt to update the serverless network policy if required argument are given.
+    maybeUpdateServerlessNetworkPolicy();
+
     indexManager.setupIndex();
 
     final Boolean requireAlias = indexManager.isIndexAlias(configuredIndexAlias);
@@ -256,9 +260,6 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
             maxRetries,
             bulkRequestSupplier,
             pluginSetting);
-
-    // Attempt to update the serverless network policy if required argument are given.
-    maybeUpdateServerlessNetworkPolicy();
 
     objectMapper = new ObjectMapper();
     this.initialized = true;


### PR DESCRIPTION
### Description
Fixes an issue that prevents users from using custom index type in vpc AOSS collection sink due to 401 errors.

Tests done:
- Existing OpenSearchSinkIT tests still pass
- Manually tested with a vpc collection with the following config to reproduce the issue and confirm the fix:
```yaml
log-pipeline:
  source:
    http:
      path: "/log/ingest"
  processor:
    - date:
        from_time_received: true
  sink:
    - stdout:
    - opensearch:
        hosts: [ "https://xxxx.us-east-1.aoss.amazonaws.com" ]
        aws:
          sts_role_arn: "arn:aws:iam::123456789012:role/OpenSearchServerlessPipelineRole"
          region: "us-east-1"
          serverless: true
          serverless_options:
            network_policy_name: auto-my-vpc-collection
            collection_name: my-vpc-collection
            vpce_id: vpce-01bd2921c3bcc0423
        index: vpc-aoss-test-000001
        index_type: custom
        template_type: index-template
        template_content: '{"template":{"mappings":{"date_detection":false}}}'
```

 
### Issues Resolved
Resolves #4188 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
