### PR TITLE
Fix release task after broken by #4247.

### DIFF
--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -9,6 +9,7 @@ ext.coreProjects = [
         project(':data-prepper-expression'),
         project(':data-prepper-logstash-configuration'),
         project(':data-prepper-main'),
+        project(':data-prepper-pipeline-parser'),
         project(':data-prepper-plugins'),
         project(':data-prepper-test-common')
 ]


### PR DESCRIPTION
### Description
Fixes the release task to build all jars since https://github.com/opensearch-project/data-prepper/pull/4247 broke the task by adding a new top level subproject but not registering in core projects
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
