### PR TITLE
Support large files in file source by using a thread

### DIFF
--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/source/file/FileSource.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/source/file/FileSource.java
@@ -44,6 +44,7 @@ public class FileSource implements Source<Record<Object>> {
     private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() { };
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final long STOP_WAIT_MILLIS = 200;
     private final FileSourceConfig fileSourceConfig;
     private final FileStrategy fileStrategy;
     private final EventFactory eventFactory;
@@ -88,6 +89,12 @@ public class FileSource implements Source<Record<Object>> {
     @Override
     public void stop() {
         isStopRequested = true;
+
+        try {
+            readThread.join(STOP_WAIT_MILLIS);
+        } catch (final InterruptedException e) {
+            readThread.interrupt();
+        }
     }
 
     private interface FileStrategy {

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/source/RandomStringSourceTests.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/source/RandomStringSourceTests.java
@@ -43,6 +43,8 @@ class RandomStringSourceTests {
         await().atMost(3, TimeUnit.SECONDS)
                 .pollDelay(200, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> verify(buffer).write(any(), anyInt()));
+
+        randomStringSource.stop();
     }
 
     @Test
@@ -55,6 +57,8 @@ class RandomStringSourceTests {
         await().atMost(3, TimeUnit.SECONDS)
                 .pollDelay(200, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> verify(buffer, atLeast(2)).write(any(), anyInt()));
+
+        randomStringSource.stop();
     }
 
     @Test
@@ -81,5 +85,7 @@ class RandomStringSourceTests {
         objectUnderTest.start(buffer);
 
         assertThrows(IllegalStateException.class, () -> objectUnderTest.start(buffer));
+
+        objectUnderTest.stop();
     }
 }

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/source/file/FileSourceTests.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/source/file/FileSourceTests.java
@@ -313,6 +313,9 @@ public class FileSourceTests {
 
             final ArgumentCaptor<Consumer> consumerArgumentCaptor = ArgumentCaptor.forClass(Consumer.class);
 
+            await().atMost(2, TimeUnit.SECONDS)
+                    .untilAsserted(() -> verify(inputCodec).parse(any(InputStream.class), any(Consumer.class)));
+
             verify(inputCodec).parse(any(InputStream.class), consumerArgumentCaptor.capture());
 
             final Consumer<Record<Event>> actualConsumer = consumerArgumentCaptor.getValue();

--- a/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/source/file/FileSourceTests.java
+++ b/data-prepper-plugins/common/src/test/java/org/opensearch/dataprepper/plugins/source/file/FileSourceTests.java
@@ -49,6 +49,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -146,17 +147,23 @@ public class FileSourceTests {
         }
 
         @Test
-        public void testFileSourceWithEmptyFilePathThrowsRuntimeException() {
+        public void testFileSourceWithEmptyFilePathDoesNotWriteToBuffer() throws InterruptedException {
+            buffer = mock(Buffer.class);
             pluginSettings.put(FileSourceConfig.ATTRIBUTE_PATH, "");
             fileSource = createObjectUnderTest();
-            assertThrows(RuntimeException.class, () -> fileSource.start(buffer));
+            fileSource.start(buffer);
+            Thread.sleep(500);
+            verifyNoInteractions(buffer);
         }
 
         @Test
-        public void testFileSourceWithNonexistentFilePathThrowsRuntimeException() {
+        public void testFileSourceWithNonexistentFilePathDoesNotWriteToBuffer() throws InterruptedException {
+            buffer = mock(Buffer.class);
             pluginSettings.put(FileSourceConfig.ATTRIBUTE_PATH, FILE_DOES_NOT_EXIST);
             fileSource = createObjectUnderTest();
-            assertThrows(RuntimeException.class, () -> fileSource.start(buffer));
+            fileSource.start(buffer);
+            Thread.sleep(500);
+            verifyNoInteractions(buffer);
         }
 
         @Test


### PR DESCRIPTION
### Description

Data Prepper currently fails when reading large files that exhaust the buffer. This is because the file is read in the start-up thread. If the buffer fills, the processors are not running and the buffer is stuck.

The fix is to start a new thread for reading from files. Now I've been able to read a 160MB file that did previously exhaust the buffer.
 
### Issues Resolved

Resolves #707
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
