### PR TITLE
Remove the S3 transfer manager in favor of using the S3 client directly

### DIFF
--- a/data-prepper-plugins/geoip-processor/build.gradle
+++ b/data-prepper-plugins/geoip-processor/build.gradle
@@ -19,8 +19,7 @@ dependencies {
     implementation libs.commons.compress
     implementation libs.commons.io
     implementation 'software.amazon.awssdk:sts'
-    implementation 'software.amazon.awssdk:s3-transfer-manager'
-    implementation 'software.amazon.awssdk.crt:aws-crt:0.29.9'
+    implementation 'software.amazon.awssdk:s3'
     implementation 'com.maxmind.geoip2:geoip2:4.2.0'
     implementation 'com.maxmind.db:maxmind-db:3.1.0'
     implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'

--- a/data-prepper-plugins/s3-sink/build.gradle
+++ b/data-prepper-plugins/s3-sink/build.gradle
@@ -29,8 +29,6 @@ dependencies {
     testImplementation project(':data-prepper-plugins:parse-json-processor')
     testImplementation project(':data-prepper-plugins:csv-processor')
     testImplementation testLibs.slf4j.simple
-    testImplementation 'software.amazon.awssdk:s3-transfer-manager'
-    testImplementation 'software.amazon.awssdk.crt:aws-crt:0.25.0'
 
     constraints {
         implementation('com.nimbusds:nimbus-jose-jwt') {


### PR DESCRIPTION
### Description

A couple of projects use the AWS Transfer Manager for some simple download scenarios. This project requires `aws-crt` which adds 11MB. The downloads from S3 are straightforward, so we can use the S3 client directly.

 
### Issues Resolved

Contributes toward #3356
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
