### PR TITLE
GitHub Action to verify the aws-testing-cdk project

### DIFF
--- a/.github/workflows/testing-resources-cdk-check.yml
+++ b/.github/workflows/testing-resources-cdk-check.yml
@@ -1,0 +1,34 @@
+name: Testing Resources CDK App Check
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'testing/aws-testing-cdk/**'
+  pull_request:
+    paths:
+      - 'testing/aws-testing-cdk/**'
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./testing/aws-testing-cdk
+    steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '18'
+
+    - name: Checkout Data Prepper
+      uses: actions/checkout@v2
+
+    - name: Install NPM Dependencies
+      run: npm install
+    - name: Test
+      run: npm run test
+    - name: Lint
+      run: npm run lint

--- a/testing/aws-testing-cdk/bin/aws-testing-cdk.ts
+++ b/testing/aws-testing-cdk/bin/aws-testing-cdk.ts
@@ -3,7 +3,7 @@ import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import {GitHubAccessStack} from '../lib/common/GitHubAccessStack';
 import {SecretsManagerStack} from '../lib/aws-secrets-manager/SecretsManagerStack';
-import {KmsStack} from "../lib/common/KmsStack";
+import {KmsStack} from '../lib/common/KmsStack';
 
 const app = new cdk.App();
 

--- a/testing/aws-testing-cdk/lib/common/GitHubAccessStack.ts
+++ b/testing/aws-testing-cdk/lib/common/GitHubAccessStack.ts
@@ -29,15 +29,15 @@ export class GitHubAccessStack extends Stack {
     const oidcProviderExists: boolean = scope.node.tryGetContext('gitHubOidcProviderExists');
 
     const gitHubOidcProvider =
-        oidcProviderExists ?
-            OpenIdConnectProvider.fromOpenIdConnectProviderArn(this, 'GitHubOidcProvider', `arn:aws:iam::${this.account}:oidc-provider/${GITHUB_TOKEN_URL}`) :
-            new OpenIdConnectProvider(this, 'GitHubOidcProvider', {
-                url: `https://${GITHUB_TOKEN_URL}`,
-                thumbprints: [
-                    '6938fd4d98bab03faadb97b34396831e3780aea1'
-                ],
-                clientIds: ['sts.amazonaws.com']
-            });
+      oidcProviderExists ?
+        OpenIdConnectProvider.fromOpenIdConnectProviderArn(this, 'GitHubOidcProvider', `arn:aws:iam::${this.account}:oidc-provider/${GITHUB_TOKEN_URL}`) :
+        new OpenIdConnectProvider(this, 'GitHubOidcProvider', {
+          url: `https://${GITHUB_TOKEN_URL}`,
+          thumbprints: [
+            '6938fd4d98bab03faadb97b34396831e3780aea1'
+          ],
+          clientIds: ['sts.amazonaws.com']
+        });
 
     const dataPrepperOrganization: string = scope.node.tryGetContext('dataPrepperOrganization') || DEFAULT_ORGANIZATION;
 
@@ -53,8 +53,8 @@ export class GitHubAccessStack extends Stack {
     this.gitHubActionsTestingRole = new Role(this, 'GitHubActionsTestingRole', {
       roleName: 'GitHubActionsTesting',
       assumedBy: new CompositePrincipal(
-          gitHubPrincipal,
-          currentAccountPrincipal
+        gitHubPrincipal,
+        currentAccountPrincipal
       )
     });
   }

--- a/testing/aws-testing-cdk/lib/common/KmsStack.ts
+++ b/testing/aws-testing-cdk/lib/common/KmsStack.ts
@@ -5,28 +5,28 @@
 
 import {Stack, StackProps} from 'aws-cdk-lib';
 import {Construct} from 'constructs';
-import {Role} from "aws-cdk-lib/aws-iam";
-import {Key} from "aws-cdk-lib/aws-kms";
+import {Role} from 'aws-cdk-lib/aws-iam';
+import {Key} from 'aws-cdk-lib/aws-kms';
 
 export interface KmsStackProps extends StackProps {
-    readonly testingRole: Role;
+  readonly testingRole: Role;
 }
 
 /**
  * CDK stack that creates a common KMS key.
  */
 export class KmsStack extends Stack {
-    readonly kmsKey: Key;
+  readonly kmsKey: Key;
 
-    constructor(scope: Construct, id: string, props: KmsStackProps) {
-        super(scope, id, props);
+  constructor(scope: Construct, id: string, props: KmsStackProps) {
+    super(scope, id, props);
 
-        this.kmsKey = new Key(this, 'DataPrepperTestingKey', {
-            alias: 'DataPrepperTesting',
-            description: 'Shared KMS key for testing any Data Prepper features that use KMS.'
-        });
+    this.kmsKey = new Key(this, 'DataPrepperTestingKey', {
+      alias: 'DataPrepperTesting',
+      description: 'Shared KMS key for testing any Data Prepper features that use KMS.'
+    });
 
-        this.kmsKey.grantEncryptDecrypt(props.testingRole)
-    }
+    this.kmsKey.grantEncryptDecrypt(props.testingRole)
+  }
 }
 

--- a/testing/aws-testing-cdk/lib/s3/S3SinkStack.ts
+++ b/testing/aws-testing-cdk/lib/s3/S3SinkStack.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Duration, RemovalPolicy, Stack, StackProps} from 'aws-cdk-lib';
+import {Construct} from 'constructs';
+import {Role} from 'aws-cdk-lib/aws-iam';
+import {Bucket} from 'aws-cdk-lib/aws-s3';
+
+export interface S3SinkStackProps extends StackProps {
+  readonly testingRole: Role;
+}
+
+/**
+ * CDK stack that creates a common KMS key.
+ */
+export class S3SinkStack extends Stack {
+  readonly bucket: Bucket;
+
+  constructor(scope: Construct, id: string, props: S3SinkStackProps) {
+    super(scope, id, props);
+
+    new Bucket(this, 'MyBucket', {
+      removalPolicy: RemovalPolicy.DESTROY,
+      lifecycleRules: [
+        {
+          expiration: Duration.days(10)
+        }
+      ]
+    });
+
+    this.bucket.grantWrite(props.testingRole)
+  }
+}
+

--- a/testing/aws-testing-cdk/test/common/GitHubAccessStack.test.ts
+++ b/testing/aws-testing-cdk/test/common/GitHubAccessStack.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {App} from 'aws-cdk-lib';
+import {Template} from 'aws-cdk-lib/assertions';
+import {GitHubAccessStack} from '../../lib/common/GitHubAccessStack';
+
+test('Creates OpenId Connect provider for GitHub', () => {
+  const app = new App();
+
+  const stackUnderTest = new GitHubAccessStack(app, 'TestStack');
+
+  const template = Template.fromStack(stackUnderTest);
+
+  template.hasResourceProperties('Custom::AWSCDKOpenIdConnectProvider', {
+    Url: 'https://token.actions.githubusercontent.com',
+    ClientIDList: ['sts.amazonaws.com']
+  });
+
+  template.hasResourceProperties('AWS::IAM::Role', {
+    RoleName: 'GitHubActionsTesting',
+  });
+});
+
+test('Uses existing OpenId Connect provider for GitHub when gitHubOidcProviderExists', () => {
+  const app = new App();
+  app.node.setContext('gitHubOidcProviderExists', true)
+
+  const stackUnderTest = new GitHubAccessStack(app, 'TestStack');
+
+  const template = Template.fromStack(stackUnderTest);
+
+  template.resourceCountIs('Custom::AWSCDKOpenIdConnectProvider', 0)
+
+  template.hasResourceProperties('AWS::IAM::Role', {
+    RoleName: 'GitHubActionsTesting',
+  });
+});


### PR DESCRIPTION
### Description

The `aws-testing-cdk` project has no verification. This PR:

* Adds a GitHub Action to verify the project by running the tests and the linter.
* Corrects the formatting to match the linter so that it passes.
* Adds a unit test for one of the stacks.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
