### PR TITLE
Add support for creating SSLContext for trustStore file path

### DIFF
--- a/data-prepper-plugins/http-common/build.gradle
+++ b/data-prepper-plugins/http-common/build.gradle
@@ -6,6 +6,7 @@
 dependencies {
     implementation 'org.apache.httpcomponents:httpcore:4.4.16'
     testImplementation testLibs.bundles.junit
+    testImplementation testLibs.mockito.inline
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/http-common/src/test/java/org/opensearch/dataprepper/plugins/truststore/TrustStoreProviderTest.java
+++ b/data-prepper-plugins/http-common/src/test/java/org/opensearch/dataprepper/plugins/truststore/TrustStoreProviderTest.java
@@ -1,15 +1,18 @@
 package org.opensearch.dataprepper.plugins.truststore;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -17,46 +20,41 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
 @ExtendWith(MockitoExtension.class)
 class TrustStoreProviderTest {
 
-    private TrustStoreProvider trustStoreProvider;
-
-    @BeforeEach
-    void setUp() {
-        trustStoreProvider = new TrustStoreProvider();
-    }
-
     @Test
     void createTrustManagerWithCertificatePath() {
         final Path certFilePath = Path.of("data/certificate/test_cert.crt");
-        final TrustManager[] trustManagers = trustStoreProvider.createTrustManager(certFilePath);
+        final TrustManager[] trustManagers = TrustStoreProvider.createTrustManager(certFilePath);
         assertThat(trustManagers, is(notNullValue()));
     }
 
     @Test
     void createTrustManagerWithInvalidCertificatePath() {
         final Path certFilePath = Path.of("data/certificate/cert_doesnt_exist.crt");
-        assertThrows(RuntimeException.class, () -> trustStoreProvider.createTrustManager(certFilePath));
+        assertThrows(RuntimeException.class, () -> TrustStoreProvider.createTrustManager(certFilePath));
     }
 
     @Test
     void createTrustManagerWithCertificateContent() throws IOException {
         final Path certFilePath = Path.of("data/certificate/test_cert.crt");
         final String certificateContent = Files.readString(certFilePath);
-        final TrustManager[] trustManagers = trustStoreProvider.createTrustManager(certificateContent);
+        final TrustManager[] trustManagers = TrustStoreProvider.createTrustManager(certificateContent);
         assertThat(trustManagers, is(notNullValue()));
     }
 
     @Test
     void createTrustManagerWithInvalidCertificateContent() {
-        assertThrows(RuntimeException.class, () -> trustStoreProvider.createTrustManager("invalid certificate content"));
+        assertThrows(RuntimeException.class, () -> TrustStoreProvider.createTrustManager("invalid certificate content"));
     }
 
     @Test
     void createTrustAllManager() {
-        final TrustManager[] trustManagers = trustStoreProvider.createTrustAllManager();
+        final TrustManager[] trustManagers = TrustStoreProvider.createTrustAllManager();
         assertThat(trustManagers, is(notNullValue()));
         assertThat(trustManagers, is(arrayWithSize(1)));
         assertThat(trustManagers[0], is(instanceOf(X509TrustAllManager.class)));
@@ -65,21 +63,36 @@ class TrustStoreProviderTest {
     @Test
     void createSSLContextWithCertificatePath() {
         final Path certFilePath = Path.of("data/certificate/test_cert.crt");
-        final SSLContext sslContext = trustStoreProvider.createSSLContext(certFilePath);
+        final SSLContext sslContext = TrustStoreProvider.createSSLContext(certFilePath);
         assertThat(sslContext, is(notNullValue()));
+    }
+
+    @Test
+    void createSSLContextWithTrustStorePathAndPassword() throws Exception {
+        final Path certFilePath = Path.of("data/certificate/test_cert.crt");
+        final KeyStore trustStore = mock(KeyStore.class);
+        final TrustManagerFactory trustManagerFactory = mock(TrustManagerFactory.class);
+        try (MockedStatic<KeyStore> keyStoreMockedStatic = mockStatic(KeyStore.class);
+             MockedStatic<TrustManagerFactory> trustManagerFactoryMockedStatic = mockStatic(TrustManagerFactory.class)) {
+            keyStoreMockedStatic.when(() -> KeyStore.getInstance("JKS")).thenReturn(trustStore);
+            trustManagerFactoryMockedStatic.when(() ->
+                    TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())).thenReturn(trustManagerFactory);
+            final SSLContext sslContext = TrustStoreProvider.createSSLContext(certFilePath, UUID.randomUUID().toString());
+            assertThat(sslContext, is(notNullValue()));
+        }
     }
 
     @Test
     void createSSLContextWithCertificateContent() throws IOException {
         final Path certFilePath = Path.of("data/certificate/test_cert.crt");
         final String certificateContent = Files.readString(certFilePath);
-        final SSLContext sslContext = trustStoreProvider.createSSLContext(certificateContent);
+        final SSLContext sslContext = TrustStoreProvider.createSSLContext(certificateContent);
         assertThat(sslContext, is(notNullValue()));
     }
 
     @Test
     void createSSLContextWithTrustAllStrategy() {
-        final SSLContext sslContext = trustStoreProvider.createSSLContextWithTrustAllStrategy();
+        final SSLContext sslContext = TrustStoreProvider.createSSLContextWithTrustAllStrategy();
         assertThat(sslContext, is(notNullValue()));
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -168,6 +168,3 @@ include 'data-prepper-plugins:decompress-processor'
 include 'data-prepper-plugins:split-event-processor'
 include 'data-prepper-plugins:http-common'
 include 'data-prepper-plugins:flatten-processor'
-
-
-include 'data-prepper-plugins:mongo-source'

--- a/settings.gradle
+++ b/settings.gradle
@@ -169,3 +169,5 @@ include 'data-prepper-plugins:split-event-processor'
 include 'data-prepper-plugins:http-common'
 include 'data-prepper-plugins:flatten-processor'
 
+
+include 'data-prepper-plugins:mongo-source'


### PR DESCRIPTION
### Description
Add support for creating SSLContext for trustStore file path
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
