### PR TITLE
Add support to use old ddb stream image for REMOVE events

### DIFF
--- a/data-prepper-plugins/dynamodb-source/build.gradle
+++ b/data-prepper-plugins/dynamodb-source/build.gradle
@@ -28,7 +28,3 @@ dependencies {
     testImplementation testLibs.mockito.inline
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 }
-
-test {
-    useJUnitPlatform()
-}

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfig.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfig.java
@@ -12,8 +12,15 @@ public class StreamConfig {
     @JsonProperty(value = "start_position")
     private StreamStartPosition startPosition = StreamStartPosition.LATEST;
 
+    @JsonProperty("use_old_image_for_deletes")
+    private boolean useOldImageForDeletes = false;
+
     public StreamStartPosition getStartPosition() {
         return startPosition;
+    }
+
+    public boolean shouldUseOldImageForDeletes() {
+        return useOldImageForDeletes;
     }
 
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfig.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/configuration/StreamConfig.java
@@ -6,21 +6,22 @@
 package org.opensearch.dataprepper.plugins.source.dynamodb.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.awssdk.services.dynamodb.model.StreamViewType;
 
 public class StreamConfig {
     
     @JsonProperty(value = "start_position")
     private StreamStartPosition startPosition = StreamStartPosition.LATEST;
 
-    @JsonProperty("use_old_image_for_deletes")
-    private boolean useOldImageForDeletes = false;
+    @JsonProperty("view_on_remove")
+    private StreamViewType viewForRemoves = StreamViewType.NEW_IMAGE;
 
     public StreamStartPosition getStartPosition() {
         return startPosition;
     }
 
-    public boolean shouldUseOldImageForDeletes() {
-        return useOldImageForDeletes;
+    public StreamViewType getStreamViewForRemoves() {
+        return viewForRemoves;
     }
 
 }

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverter.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.enhanced.dynamodb.document.EnhancedDocument;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.OperationType;
 import software.amazon.awssdk.services.dynamodb.model.Record;
+import software.amazon.awssdk.services.dynamodb.model.StreamViewType;
 
 import java.time.Instant;
 import java.util.HashMap;
@@ -167,9 +168,9 @@ public class StreamRecordConverter extends RecordConverter {
             return record.dynamodb().newImage();
         }
 
-        if (streamConfig.shouldUseOldImageForDeletes()) {
+        if (StreamViewType.OLD_IMAGE.equals(streamConfig.getStreamViewForRemoves())) {
             if (!record.dynamodb().hasOldImage()) {
-                LOG.warn("use_old_image_for_deletes is enabled, but no old image can be found on the stream record, using new image");
+                LOG.warn("view_on_remove with OLD_IMAGE is enabled, but no old image can be found on the stream record, using NEW_IMAGE");
                 return record.dynamodb().newImage();
             } else {
                 return record.dynamodb().oldImage();

--- a/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactory.java
+++ b/data-prepper-plugins/dynamodb-source/src/main/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactory.java
@@ -11,6 +11,7 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.StreamConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.GlobalState;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.StreamPartition;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.state.StreamProgressState;
@@ -45,18 +46,21 @@ public class ShardConsumerFactory {
     private final DynamoDBSourceAggregateMetrics dynamoDBSourceAggregateMetrics;
     private final Buffer<Record<Event>> buffer;
 
+    private final StreamConfig streamConfig;
+
 
     public ShardConsumerFactory(final EnhancedSourceCoordinator enhancedSourceCoordinator,
                                 final DynamoDbStreamsClient streamsClient,
                                 final PluginMetrics pluginMetrics,
                                 final DynamoDBSourceAggregateMetrics dynamoDBSourceAggregateMetrics,
-                                final Buffer<Record<Event>> buffer) {
+                                final Buffer<Record<Event>> buffer,
+                                final StreamConfig streamConfig) {
         this.streamsClient = streamsClient;
         this.enhancedSourceCoordinator = enhancedSourceCoordinator;
         this.pluginMetrics = pluginMetrics;
         this.dynamoDBSourceAggregateMetrics = dynamoDBSourceAggregateMetrics;
         this.buffer = buffer;
-
+        this.streamConfig = streamConfig;
     }
 
     public Runnable createConsumer(final StreamPartition streamPartition,
@@ -97,7 +101,7 @@ public class ShardConsumerFactory {
 
         LOG.debug("Create shard consumer for {} with shardIter {}", streamPartition.getShardId(), shardIterator);
         LOG.debug("Create shard consumer for {} with lastShardIter {}", streamPartition.getShardId(), lastShardIterator);
-        ShardConsumer shardConsumer = ShardConsumer.builder(streamsClient, pluginMetrics, dynamoDBSourceAggregateMetrics, buffer)
+        ShardConsumer shardConsumer = ShardConsumer.builder(streamsClient, pluginMetrics, dynamoDBSourceAggregateMetrics, buffer, streamConfig)
                 .tableInfo(tableInfo)
                 .checkpointer(checkpointer)
                 .shardIterator(shardIterator)

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBServiceTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/DynamoDBServiceTest.java
@@ -8,7 +8,9 @@ package org.opensearch.dataprepper.plugins.source.dynamodb;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -16,16 +18,26 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.StreamConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.TableConfig;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DynamoDBServiceTest {
@@ -52,6 +64,9 @@ class DynamoDBServiceTest {
     private TableConfig tableConfig;
 
     @Mock
+    private StreamConfig streamConfig;
+
+    @Mock
     private PluginMetrics pluginMetrics;
 
     @Mock
@@ -59,6 +74,9 @@ class DynamoDBServiceTest {
 
     @Mock
     private AcknowledgementSetManager acknowledgementSetManager;
+
+    @Mock
+    private ExecutorService executorService;
 
     private DynamoDBService dynamoDBService;
 
@@ -73,16 +91,45 @@ class DynamoDBServiceTest {
     }
 
     private DynamoDBService createObjectUnderTest() {
-        DynamoDBService objectUnderTest = new DynamoDBService(coordinator, clientFactory, sourceConfig, pluginMetrics, acknowledgementSetManager);
-        return objectUnderTest;
+
+        try (final MockedStatic<Executors> executorsMockedStatic = mockStatic(Executors.class)) {
+            executorsMockedStatic.when(() -> Executors.newFixedThreadPool(eq(4))).thenReturn(executorService);
+
+            return new DynamoDBService(coordinator, clientFactory, sourceConfig, pluginMetrics, acknowledgementSetManager);
+        }
     }
 
     @Test
-    void test_normal_start() {
+    void test_normal_start_with_stream_config() {
+        when(tableConfig.getStreamConfig()).thenReturn(streamConfig);
         dynamoDBService = createObjectUnderTest();
         assertThat(dynamoDBService, notNullValue());
+
+        final ArgumentCaptor<Runnable> runnableArgumentCaptor = ArgumentCaptor.forClass(Runnable.class);
+
         dynamoDBService.start(buffer);
 
+        verify(executorService, times(4)).submit(runnableArgumentCaptor.capture());
+
+        assertThat(runnableArgumentCaptor.getAllValues(), notNullValue());
+        assertThat(runnableArgumentCaptor.getAllValues().size(), equalTo(4));
+    }
+
+    @Test
+    void test_normal_start_without_stream_config() {
+        when(tableConfig.getStreamConfig()).thenReturn(null);
+
+        dynamoDBService = createObjectUnderTest();
+        assertThat(dynamoDBService, notNullValue());
+
+        final ArgumentCaptor<Runnable> runnableArgumentCaptor = ArgumentCaptor.forClass(Runnable.class);
+
+        dynamoDBService.start(buffer);
+
+        verify(executorService, times(3)).submit(runnableArgumentCaptor.capture());
+
+        assertThat(runnableArgumentCaptor.getAllValues(), notNullValue());
+        assertThat(runnableArgumentCaptor.getAllValues().size(), equalTo(3));
     }
 
 
@@ -90,6 +137,8 @@ class DynamoDBServiceTest {
     void test_normal_shutdown() {
         dynamoDBService = createObjectUnderTest();
         assertThat(dynamoDBService, notNullValue());
+
+        when(executorService.shutdownNow()).thenReturn(Collections.emptyList());
         dynamoDBService.shutdown();
     }
 

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
@@ -27,6 +27,7 @@ import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableMetadata;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.OperationType;
 import software.amazon.awssdk.services.dynamodb.model.StreamRecord;
+import software.amazon.awssdk.services.dynamodb.model.StreamViewType;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -344,7 +345,7 @@ class StreamRecordConverterTest {
 
     @Test
     void remove_record_with_use_old_image_on_delete_uses_old_image() throws Exception {
-        when(streamConfig.shouldUseOldImageForDeletes()).thenReturn(true);
+        when(streamConfig.getStreamViewForRemoves()).thenReturn(StreamViewType.OLD_IMAGE);
 
         final String newImageKey = UUID.randomUUID().toString();
         final String newImageValue = UUID.randomUUID().toString();
@@ -390,7 +391,7 @@ class StreamRecordConverterTest {
 
     @Test
     void remove_record_with_use_old_image_on_delete_with_no_new_image_found_uses_new_image() throws Exception {
-        when(streamConfig.shouldUseOldImageForDeletes()).thenReturn(true);
+        when(streamConfig.getStreamViewForRemoves()).thenReturn(StreamViewType.OLD_IMAGE);
 
         final String newImageKey = UUID.randomUUID().toString();
         final String newImageValue = UUID.randomUUID().toString();
@@ -431,7 +432,7 @@ class StreamRecordConverterTest {
 
     @Test
     void remove_record_without_use_old_image_on_delete_uses_new_image() throws Exception {
-        when(streamConfig.shouldUseOldImageForDeletes()).thenReturn(false);
+        when(streamConfig.getStreamViewForRemoves()).thenReturn(StreamViewType.NEW_IMAGE);
 
         final String newImageKey = UUID.randomUUID().toString();
         final String newImageValue = UUID.randomUUID().toString();

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/converter/StreamRecordConverterTest.java
@@ -21,6 +21,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.StreamConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableInfo;
 import org.opensearch.dataprepper.plugins.source.dynamodb.model.TableMetadata;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -47,6 +48,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP;
 import static org.opensearch.dataprepper.plugins.source.dynamodb.converter.MetadataKeyAttributes.EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE;
@@ -82,6 +84,9 @@ class StreamRecordConverterTest {
 
     @Mock
     private DistributionSummary bytesProcessedSummary;
+
+    @Mock
+    private StreamConfig streamConfig;
 
 
     private final String tableName = UUID.randomUUID().toString();
@@ -120,7 +125,7 @@ class StreamRecordConverterTest {
 
         List<software.amazon.awssdk.services.dynamodb.model.Record> records = buildRecords(numberOfRecords, Instant.now());
 
-        StreamRecordConverter recordConverter = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics);
+        StreamRecordConverter recordConverter = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics, streamConfig);
 
         recordConverter.writeToBuffer(null, records);
         verify(bufferAccumulator, times(numberOfRecords)).add(any(Record.class));
@@ -139,7 +144,7 @@ class StreamRecordConverterTest {
         List<software.amazon.awssdk.services.dynamodb.model.Record> records = buildRecords(1, Instant.now());
         final ArgumentCaptor<Record> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
         software.amazon.awssdk.services.dynamodb.model.Record record = records.get(0);
-        StreamRecordConverter recordConverter = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics);
+        StreamRecordConverter recordConverter = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics, streamConfig);
         doNothing().when(bufferAccumulator).add(recordArgumentCaptor.capture());
 
         recordConverter.writeToBuffer(null, records);
@@ -185,7 +190,7 @@ class StreamRecordConverterTest {
         List<software.amazon.awssdk.services.dynamodb.model.Record> records = buildRecords(1, Instant.now(), additionalData);
         final ArgumentCaptor<Record> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
         software.amazon.awssdk.services.dynamodb.model.Record record = records.get(0);
-        final StreamRecordConverter objectUnderTest = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics);
+        final StreamRecordConverter objectUnderTest = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics, streamConfig);
         doNothing().when(bufferAccumulator).add(recordArgumentCaptor.capture());
 
         objectUnderTest.writeToBuffer(null, records);
@@ -221,7 +226,7 @@ class StreamRecordConverterTest {
         final Map<String, AttributeValue> badData = Map.of("otherData", AttributeValue.builder().build());
         List<software.amazon.awssdk.services.dynamodb.model.Record> badRecords = buildRecords(2, Instant.now(), badData);
 
-        final StreamRecordConverter objectUnderTest = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics);
+        final StreamRecordConverter objectUnderTest = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics, streamConfig);
 
         objectUnderTest.writeToBuffer(null, badRecords);
 
@@ -235,7 +240,7 @@ class StreamRecordConverterTest {
         List<software.amazon.awssdk.services.dynamodb.model.Record> badRecords = buildRecords(2, Instant.now(), badData);
         List<software.amazon.awssdk.services.dynamodb.model.Record> goodRecords = buildRecords(5, Instant.now());
 
-        final StreamRecordConverter objectUnderTest = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics);
+        final StreamRecordConverter objectUnderTest = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics, streamConfig);
 
         List<software.amazon.awssdk.services.dynamodb.model.Record> mixedRecords = new ArrayList<>();
         mixedRecords.addAll(badRecords);
@@ -258,7 +263,7 @@ class StreamRecordConverterTest {
         records.add(buildRecord(newerSecond));
 
         final ArgumentCaptor<Record> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
-        StreamRecordConverter recordConverter = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics);
+        StreamRecordConverter recordConverter = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics, streamConfig);
         doNothing().when(bufferAccumulator).add(recordArgumentCaptor.capture());
 
         recordConverter.writeToBuffer(null, records);
@@ -337,6 +342,139 @@ class StreamRecordConverterTest {
         verify(bytesProcessedSummary, times(4)).record(anyDouble());
     }
 
+    @Test
+    void remove_record_with_use_old_image_on_delete_uses_old_image() throws Exception {
+        when(streamConfig.shouldUseOldImageForDeletes()).thenReturn(true);
+
+        final String newImageKey = UUID.randomUUID().toString();
+        final String newImageValue = UUID.randomUUID().toString();
+
+        final String oldImageKey = UUID.randomUUID().toString();
+        final String oldImageValue = UUID.randomUUID().toString();
+
+        final Map<String, AttributeValue> newImage = Map.of(newImageKey, AttributeValue.builder().s(newImageValue).build());
+        final Map<String, AttributeValue> oldImage = Map.of(oldImageKey, AttributeValue.builder().s(oldImageValue).build());
+        List<software.amazon.awssdk.services.dynamodb.model.Record> records = Collections.singletonList(buildRecord(Instant.now(), newImage, oldImage, OperationType.REMOVE));
+        final ArgumentCaptor<Record> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
+        software.amazon.awssdk.services.dynamodb.model.Record record = records.get(0);
+        final StreamRecordConverter objectUnderTest = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics, streamConfig);
+        doNothing().when(bufferAccumulator).add(recordArgumentCaptor.capture());
+
+        objectUnderTest.writeToBuffer(null, records);
+
+        verify(bufferAccumulator).add(any(Record.class));
+        verify(bufferAccumulator).flush();
+        verify(changeEventSuccessCounter).increment(anyDouble());
+        assertThat(recordArgumentCaptor.getValue().getData(), notNullValue());
+        JacksonEvent event = (JacksonEvent) recordArgumentCaptor.getValue().getData();
+
+        assertThat(event.getMetadata(), notNullValue());
+        String partitionKey = record.dynamodb().keys().get(partitionKeyAttrName).s();
+        String sortKey = record.dynamodb().keys().get(sortKeyAttrName).s();
+        assertThat(event.getMetadata().getAttribute(PARTITION_KEY_METADATA_ATTRIBUTE), equalTo(partitionKey));
+        assertThat(event.getMetadata().getAttribute(SORT_KEY_METADATA_ATTRIBUTE), equalTo(sortKey));
+        assertThat(event.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), equalTo(partitionKey + "|" + sortKey));
+        assertThat(event.getMetadata().getAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE), equalTo(OpenSearchBulkActions.DELETE.toString()));
+        assertThat(event.getMetadata().getAttribute(DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE), equalTo(OperationType.REMOVE.toString()));
+        assertThat(event.getMetadata().getAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE), equalTo(record.dynamodb().approximateCreationDateTime().toEpochMilli()));
+
+        assertThat(event.get(partitionKeyAttrName, String.class), notNullValue());
+        assertThat(event.get(sortKeyAttrName, String.class), notNullValue());
+        assertThat(event.get(newImageKey, String.class), equalTo(null));
+        assertThat(event.get(oldImageKey, String.class), equalTo(oldImageValue));
+
+        verifyNoInteractions(changeEventErrorCounter);
+        verify(bytesReceivedSummary).record(record.dynamodb().sizeBytes());
+        verify(bytesProcessedSummary).record(record.dynamodb().sizeBytes());
+    }
+
+    @Test
+    void remove_record_with_use_old_image_on_delete_with_no_new_image_found_uses_new_image() throws Exception {
+        when(streamConfig.shouldUseOldImageForDeletes()).thenReturn(true);
+
+        final String newImageKey = UUID.randomUUID().toString();
+        final String newImageValue = UUID.randomUUID().toString();
+
+        final Map<String, AttributeValue> newImage = Map.of(newImageKey, AttributeValue.builder().s(newImageValue).build());
+        List<software.amazon.awssdk.services.dynamodb.model.Record> records = Collections.singletonList(buildRecord(Instant.now(), newImage, null, OperationType.REMOVE));
+        final ArgumentCaptor<Record> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
+        software.amazon.awssdk.services.dynamodb.model.Record record = records.get(0);
+        final StreamRecordConverter objectUnderTest = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics, streamConfig);
+        doNothing().when(bufferAccumulator).add(recordArgumentCaptor.capture());
+
+        objectUnderTest.writeToBuffer(null, records);
+
+        verify(bufferAccumulator).add(any(Record.class));
+        verify(bufferAccumulator).flush();
+        verify(changeEventSuccessCounter).increment(anyDouble());
+        assertThat(recordArgumentCaptor.getValue().getData(), notNullValue());
+        JacksonEvent event = (JacksonEvent) recordArgumentCaptor.getValue().getData();
+
+        assertThat(event.getMetadata(), notNullValue());
+        String partitionKey = record.dynamodb().keys().get(partitionKeyAttrName).s();
+        String sortKey = record.dynamodb().keys().get(sortKeyAttrName).s();
+        assertThat(event.getMetadata().getAttribute(PARTITION_KEY_METADATA_ATTRIBUTE), equalTo(partitionKey));
+        assertThat(event.getMetadata().getAttribute(SORT_KEY_METADATA_ATTRIBUTE), equalTo(sortKey));
+        assertThat(event.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), equalTo(partitionKey + "|" + sortKey));
+        assertThat(event.getMetadata().getAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE), equalTo(OpenSearchBulkActions.DELETE.toString()));
+        assertThat(event.getMetadata().getAttribute(DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE), equalTo(OperationType.REMOVE.toString()));
+        assertThat(event.getMetadata().getAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE), equalTo(record.dynamodb().approximateCreationDateTime().toEpochMilli()));
+
+        assertThat(event.get(partitionKeyAttrName, String.class), notNullValue());
+        assertThat(event.get(sortKeyAttrName, String.class), notNullValue());
+        assertThat(event.get(newImageKey, String.class), equalTo(newImageValue));
+
+        verifyNoInteractions(changeEventErrorCounter);
+        verify(bytesReceivedSummary).record(record.dynamodb().sizeBytes());
+        verify(bytesProcessedSummary).record(record.dynamodb().sizeBytes());
+    }
+
+    @Test
+    void remove_record_without_use_old_image_on_delete_uses_new_image() throws Exception {
+        when(streamConfig.shouldUseOldImageForDeletes()).thenReturn(false);
+
+        final String newImageKey = UUID.randomUUID().toString();
+        final String newImageValue = UUID.randomUUID().toString();
+
+        final String oldImageKey = UUID.randomUUID().toString();
+        final String oldImageValue = UUID.randomUUID().toString();
+
+        final Map<String, AttributeValue> newImage = Map.of(newImageKey, AttributeValue.builder().s(newImageValue).build());
+        final Map<String, AttributeValue> oldImage = Map.of(oldImageKey, AttributeValue.builder().s(oldImageValue).build());
+        List<software.amazon.awssdk.services.dynamodb.model.Record> records = Collections.singletonList(buildRecord(Instant.now(), newImage, oldImage, OperationType.REMOVE));
+        final ArgumentCaptor<Record> recordArgumentCaptor = ArgumentCaptor.forClass(Record.class);
+        software.amazon.awssdk.services.dynamodb.model.Record record = records.get(0);
+        final StreamRecordConverter objectUnderTest = new StreamRecordConverter(bufferAccumulator, tableInfo, pluginMetrics, streamConfig);
+        doNothing().when(bufferAccumulator).add(recordArgumentCaptor.capture());
+
+        objectUnderTest.writeToBuffer(null, records);
+
+        verify(bufferAccumulator).add(any(Record.class));
+        verify(bufferAccumulator).flush();
+        verify(changeEventSuccessCounter).increment(anyDouble());
+        assertThat(recordArgumentCaptor.getValue().getData(), notNullValue());
+        JacksonEvent event = (JacksonEvent) recordArgumentCaptor.getValue().getData();
+
+        assertThat(event.getMetadata(), notNullValue());
+        String partitionKey = record.dynamodb().keys().get(partitionKeyAttrName).s();
+        String sortKey = record.dynamodb().keys().get(sortKeyAttrName).s();
+        assertThat(event.getMetadata().getAttribute(PARTITION_KEY_METADATA_ATTRIBUTE), equalTo(partitionKey));
+        assertThat(event.getMetadata().getAttribute(SORT_KEY_METADATA_ATTRIBUTE), equalTo(sortKey));
+        assertThat(event.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), equalTo(partitionKey + "|" + sortKey));
+        assertThat(event.getMetadata().getAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE), equalTo(OpenSearchBulkActions.DELETE.toString()));
+        assertThat(event.getMetadata().getAttribute(DDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE), equalTo(OperationType.REMOVE.toString()));
+        assertThat(event.getMetadata().getAttribute(EVENT_TIMESTAMP_METADATA_ATTRIBUTE), equalTo(record.dynamodb().approximateCreationDateTime().toEpochMilli()));
+
+        assertThat(event.get(partitionKeyAttrName, String.class), notNullValue());
+        assertThat(event.get(sortKeyAttrName, String.class), notNullValue());
+        assertThat(event.get(oldImageKey, String.class), equalTo(null));
+        assertThat(event.get(newImageKey, String.class), equalTo(newImageValue));
+
+        verifyNoInteractions(changeEventErrorCounter);
+        verify(bytesReceivedSummary).record(record.dynamodb().sizeBytes());
+        verify(bytesProcessedSummary).record(record.dynamodb().sizeBytes());
+    }
+
     private List<software.amazon.awssdk.services.dynamodb.model.Record> buildRecords(int count, final Instant creationTime) {
         return buildRecords(count, creationTime, Collections.emptyMap());
     }
@@ -347,18 +485,20 @@ class StreamRecordConverterTest {
             final Map<String, AttributeValue> additionalData) {
         List<software.amazon.awssdk.services.dynamodb.model.Record> records = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            records.add(buildRecord(creationTime, additionalData));
+            records.add(buildRecord(creationTime, additionalData, null, OperationType.INSERT));
         }
 
         return records;
     }
 
     private software.amazon.awssdk.services.dynamodb.model.Record buildRecord(final Instant creationTime) {
-        return buildRecord(creationTime, Collections.emptyMap());
+        return buildRecord(creationTime, Collections.emptyMap(), null, OperationType.INSERT);
     }
 
     private software.amazon.awssdk.services.dynamodb.model.Record buildRecord(final Instant creationTime,
-                                                                              Map<String, AttributeValue> additionalData) {
+                                                                              Map<String, AttributeValue> additionalData,
+                                                                              Map<String, AttributeValue> oldImage,
+                                                                              final OperationType operationType) {
         Map<String, AttributeValue> keysData = Map.of(
                 partitionKeyAttrName, AttributeValue.builder().s(UUID.randomUUID().toString()).build(),
                 sortKeyAttrName, AttributeValue.builder().s(UUID.randomUUID().toString()).build());
@@ -367,16 +507,24 @@ class StreamRecordConverterTest {
         data.putAll(keysData);
         data.putAll(additionalData);
 
+        Map<String, AttributeValue> oldImageData = new HashMap<>();
+        if (oldImage != null) {
+            oldImageData.putAll(keysData);
+            oldImageData.putAll(oldImage);
+        }
+
+
         StreamRecord streamRecord = StreamRecord.builder()
                 .sizeBytes(RANDOM.nextLong())
                 .newImage(data)
+                .oldImage(oldImageData.isEmpty() ? null : oldImageData)
                 .keys(keysData)
                 .sequenceNumber(UUID.randomUUID().toString())
                 .approximateCreationDateTime(creationTime)
                 .build();
         software.amazon.awssdk.services.dynamodb.model.Record record = software.amazon.awssdk.services.dynamodb.model.Record.builder()
                 .dynamodb(streamRecord)
-                .eventName(OperationType.INSERT)
+                .eventName(operationType)
                 .build();
         return record;
     }

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactoryTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerFactoryTest.java
@@ -16,6 +16,7 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.StreamConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.GlobalState;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.StreamPartition;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.state.StreamProgressState;
@@ -67,6 +68,9 @@ class ShardConsumerFactoryTest {
     @Mock
     private GlobalState tableInfoGlobalState;
 
+    @Mock
+    private StreamConfig streamConfig;
+
 
     private final String tableName = UUID.randomUUID().toString();
     private final String tableArn = "arn:aws:dynamodb:us-west-2:123456789012:table/" + tableName;
@@ -111,7 +115,7 @@ class ShardConsumerFactoryTest {
         state.setStartTime(Instant.now().toEpochMilli());
         streamPartition = new StreamPartition(streamArn, shardId, Optional.of(state));
 
-        ShardConsumerFactory consumerFactory = new ShardConsumerFactory(coordinator, dynamoDbStreamsClient, pluginMetrics, dynamoDBSourceAggregateMetrics, buffer);
+        ShardConsumerFactory consumerFactory = new ShardConsumerFactory(coordinator, dynamoDbStreamsClient, pluginMetrics, dynamoDBSourceAggregateMetrics, buffer, streamConfig);
         Runnable consumer = consumerFactory.createConsumer(streamPartition, null, null);
         assertThat(consumer, notNullValue());
         verify(dynamoDbStreamsClient).getShardIterator(any(GetShardIteratorRequest.class));
@@ -128,7 +132,7 @@ class ShardConsumerFactoryTest {
         state.setEndingSequenceNumber(UUID.randomUUID().toString());
         streamPartition = new StreamPartition(streamArn, shardId, Optional.of(state));
 
-        ShardConsumerFactory consumerFactory = new ShardConsumerFactory(coordinator, dynamoDbStreamsClient, pluginMetrics, dynamoDBSourceAggregateMetrics, buffer);
+        ShardConsumerFactory consumerFactory = new ShardConsumerFactory(coordinator, dynamoDbStreamsClient, pluginMetrics, dynamoDBSourceAggregateMetrics, buffer, streamConfig);
         Runnable consumer = consumerFactory.createConsumer(streamPartition, null, null);
         assertThat(consumer, notNullValue());
         // Should get iterators twice
@@ -149,7 +153,7 @@ class ShardConsumerFactoryTest {
         final Counter stream5xxErrors = mock(Counter.class);
         when(dynamoDBSourceAggregateMetrics.getStream5xxErrors()).thenReturn(stream5xxErrors);
 
-        ShardConsumerFactory consumerFactory = new ShardConsumerFactory(coordinator, dynamoDbStreamsClient, pluginMetrics, dynamoDBSourceAggregateMetrics, buffer);
+        ShardConsumerFactory consumerFactory = new ShardConsumerFactory(coordinator, dynamoDbStreamsClient, pluginMetrics, dynamoDBSourceAggregateMetrics, buffer, streamConfig);
         Runnable consumer = consumerFactory.createConsumer(streamPartition, null, null);
         assertThat(consumer, nullValue());
         verify(stream5xxErrors).increment();
@@ -167,7 +171,7 @@ class ShardConsumerFactoryTest {
         final Counter stream4xxErrors = mock(Counter.class);
         when(dynamoDBSourceAggregateMetrics.getStream4xxErrors()).thenReturn(stream4xxErrors);
 
-        ShardConsumerFactory consumerFactory = new ShardConsumerFactory(coordinator, dynamoDbStreamsClient, pluginMetrics, dynamoDBSourceAggregateMetrics, buffer);
+        ShardConsumerFactory consumerFactory = new ShardConsumerFactory(coordinator, dynamoDbStreamsClient, pluginMetrics, dynamoDBSourceAggregateMetrics, buffer, streamConfig);
         Runnable consumer = consumerFactory.createConsumer(streamPartition, null, null);
         assertThat(consumer, nullValue());
         verify(stream4xxErrors).increment();

--- a/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerTest.java
+++ b/data-prepper-plugins/dynamodb-source/src/test/java/org/opensearch/dataprepper/plugins/source/dynamodb/stream/ShardConsumerTest.java
@@ -20,6 +20,7 @@ import org.opensearch.dataprepper.model.buffer.Buffer;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
 import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.source.dynamodb.configuration.StreamConfig;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.GlobalState;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.partition.StreamPartition;
 import org.opensearch.dataprepper.plugins.source.dynamodb.coordination.state.StreamProgressState;
@@ -103,6 +104,9 @@ class ShardConsumerTest {
     @Mock
     private DistributionSummary testSummary;
 
+    @Mock
+    private StreamConfig streamConfig;
+
 
     private StreamCheckpointer checkpointer;
 
@@ -181,7 +185,7 @@ class ShardConsumerTest {
                 final MockedStatic<BufferAccumulator> bufferAccumulatorMockedStatic = mockStatic(BufferAccumulator.class)
         ) {
             bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(buffer, DEFAULT_BUFFER_BATCH_SIZE, BUFFER_TIMEOUT)).thenReturn(bufferAccumulator);
-            shardConsumer = ShardConsumer.builder(dynamoDbStreamsClient, pluginMetrics, aggregateMetrics, buffer)
+            shardConsumer = ShardConsumer.builder(dynamoDbStreamsClient, pluginMetrics, aggregateMetrics, buffer, streamConfig)
                     .shardIterator(shardIterator)
                     .checkpointer(checkpointer)
                     .tableInfo(tableInfo)
@@ -215,7 +219,7 @@ class ShardConsumerTest {
                 final MockedStatic<BufferAccumulator> bufferAccumulatorMockedStatic = mockStatic(BufferAccumulator.class)
         ) {
             bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(buffer, DEFAULT_BUFFER_BATCH_SIZE, BUFFER_TIMEOUT)).thenReturn(bufferAccumulator);
-            shardConsumer = ShardConsumer.builder(dynamoDbStreamsClient, pluginMetrics, aggregateMetrics, buffer)
+            shardConsumer = ShardConsumer.builder(dynamoDbStreamsClient, pluginMetrics, aggregateMetrics, buffer, streamConfig)
                     .shardIterator(shardIterator)
                     .checkpointer(checkpointer)
                     .tableInfo(tableInfo)
@@ -251,7 +255,7 @@ class ShardConsumerTest {
         try (
                 final MockedStatic<BufferAccumulator> bufferAccumulatorMockedStatic = mockStatic(BufferAccumulator.class)) {
             bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(buffer, DEFAULT_BUFFER_BATCH_SIZE, BUFFER_TIMEOUT)).thenReturn(bufferAccumulator);
-            shardConsumer = ShardConsumer.builder(dynamoDbStreamsClient, pluginMetrics, aggregateMetrics, buffer)
+            shardConsumer = ShardConsumer.builder(dynamoDbStreamsClient, pluginMetrics, aggregateMetrics, buffer, streamConfig)
                     .shardIterator(shardIterator)
                     .checkpointer(checkpointer)
                     .tableInfo(tableInfo)
@@ -275,7 +279,7 @@ class ShardConsumerTest {
         try (
                 final MockedStatic<BufferAccumulator> bufferAccumulatorMockedStatic = mockStatic(BufferAccumulator.class)) {
             bufferAccumulatorMockedStatic.when(() -> BufferAccumulator.create(buffer, DEFAULT_BUFFER_BATCH_SIZE, BUFFER_TIMEOUT)).thenReturn(bufferAccumulator);
-            shardConsumer = ShardConsumer.builder(dynamoDbStreamsClient, pluginMetrics, aggregateMetrics, buffer)
+            shardConsumer = ShardConsumer.builder(dynamoDbStreamsClient, pluginMetrics, aggregateMetrics, buffer, streamConfig)
                     .shardIterator(shardIterator)
                     .checkpointer(checkpointer)
                     .tableInfo(tableInfo)

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationConverter.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/dlq/FailedBulkOperationConverter.java
@@ -61,6 +61,11 @@ public class FailedBulkOperationConverter {
 
     private Object convertDocumentToGenericMap(final BulkOperationWrapper bulkOperation) {
         final SerializedJson document = (SerializedJson) bulkOperation.getDocument();
+
+        if (document == null) {
+            return ImmutableMap.of();
+        }
+
         final byte[] documentBytes = document.getSerializedJson();
         final String jsonString = new String(documentBytes, StandardCharsets.UTF_8);
 


### PR DESCRIPTION
### Description
  Adds an option in the to `view_on_remove: OLD_IMAGE` (defaults to NEW_IMAGE), which will construct an Event from the view type for REMOVE stream events, if old image exists. If it does not exist, the new image will still be used for the Event. 

This follows from DynamoDB streams documentation 

```
StreamViewType — Specifies the information that will be written to the stream whenever data in the table is modified:

    KEYS_ONLY — Only the key attributes of the modified item.

    NEW_IMAGE — The entire item, as it appears after it was modified.

    OLD_IMAGE — The entire item, as it appeared before it was modified.

    NEW_AND_OLD_IMAGES — Both the new and the old images of the item
```
 
### Issues Resolved
Resolves #4261 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
