### PR TITLE
Add ExportScheduler and LeaderScheduler for MongoDB/DocumentDB source

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/coordination/partition/ExportPartition.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/coordination/partition/ExportPartition.java
@@ -39,11 +39,11 @@ public class ExportPartition extends EnhancedSourcePartition<ExportProgressState
     }
 
     public ExportPartition(final String collection, final int partitionSize, final Instant exportTime,
-                           final Optional<ExportProgressState> state) {
+                           final ExportProgressState state) {
         this.collection = collection;
         this.partitionSize = partitionSize;
         this.exportTime = exportTime;
-        this.state = state.orElse(null);
+        this.state = state;
 
     }
     

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/coordination/partition/GlobalState.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/coordination/partition/GlobalState.java
@@ -29,9 +29,9 @@ public class GlobalState extends EnhancedSourcePartition<Map<String, Object>> {
         this.state = convertStringToPartitionProgressState(null, sourcePartitionStoreItem.getPartitionProgressState());
     }
 
-    public GlobalState(String stateName, Optional<Map<String, Object>> state) {
+    public GlobalState(String stateName, Map<String, Object> state) {
         this.stateName = stateName;
-        this.state = state.orElse(null);
+        this.state = state;
 
     }
 

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/export/ExportScheduler.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/export/ExportScheduler.java
@@ -1,0 +1,116 @@
+package org.opensearch.dataprepper.plugins.mongo.export;
+
+import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.source.coordinator.PartitionIdentifier;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.mongo.export.partition.MongoDBExportPartitionSupplier;
+import org.opensearch.dataprepper.plugins.mongo.coordination.partition.DataQueryPartition;
+import org.opensearch.dataprepper.plugins.mongo.coordination.partition.ExportPartition;
+import org.opensearch.dataprepper.plugins.mongo.coordination.partition.GlobalState;
+import org.opensearch.dataprepper.plugins.mongo.coordination.state.DataQueryProgressState;
+import org.opensearch.dataprepper.plugins.mongo.model.LoadStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ExportScheduler implements Runnable {
+    public static final String EXPORT_PREFIX = "EXPORT-";
+    private static final Logger LOG = LoggerFactory.getLogger(ExportScheduler.class);
+    private static final int DEFAULT_TAKE_LEASE_INTERVAL_MILLIS = 60_000;
+    static final String EXPORT_JOB_SUCCESS_COUNT = "exportJobSuccess";
+    static final String EXPORT_JOB_FAILURE_COUNT = "exportJobFailure";
+    static final String EXPORT_PARTITION_QUERY_TOTAL_COUNT = "exportPartitionQueryTotal";
+    static final String EXPORT_RECORDS_TOTAL_COUNT = "exportRecordsTotal";
+    private final PluginMetrics pluginMetrics;
+    private final EnhancedSourceCoordinator enhancedSourceCoordinator;
+    private final MongoDBExportPartitionSupplier mongoDBExportPartitionSupplier;
+    private final ExecutorService executor;
+
+    private final Counter exportJobSuccessCounter;
+    private final Counter exportJobFailureCounter;
+
+    private final Counter exportPartitionTotalCounter;
+    private final Counter exportRecordsTotalCounter;
+
+    public ExportScheduler(final EnhancedSourceCoordinator enhancedSourceCoordinator,
+                           final MongoDBExportPartitionSupplier mongoDBExportPartitionSupplier,
+                           final PluginMetrics pluginMetrics) {
+        this.enhancedSourceCoordinator = enhancedSourceCoordinator;
+        this.mongoDBExportPartitionSupplier = mongoDBExportPartitionSupplier;
+        this.pluginMetrics = pluginMetrics;
+
+        executor = Executors.newCachedThreadPool();
+
+        exportJobSuccessCounter = pluginMetrics.counter(EXPORT_JOB_SUCCESS_COUNT);
+        exportJobFailureCounter = pluginMetrics.counter(EXPORT_JOB_FAILURE_COUNT);
+        exportPartitionTotalCounter = pluginMetrics.counter(EXPORT_PARTITION_QUERY_TOTAL_COUNT);
+        exportRecordsTotalCounter = pluginMetrics.counter(EXPORT_RECORDS_TOTAL_COUNT);
+    }
+
+    @Override
+    public void run() {
+        LOG.info("Start running Export Scheduler");
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                final Optional<EnhancedSourcePartition> sourcePartition = enhancedSourceCoordinator.acquireAvailablePartition(ExportPartition.PARTITION_TYPE);
+                if (sourcePartition.isPresent()) {
+                    final ExportPartition exportPartition = (ExportPartition) sourcePartition.get();
+                    LOG.info("Acquired an export partition: " + exportPartition.getPartitionKey());
+
+                    final List<PartitionIdentifier> partitionIdentifiers = mongoDBExportPartitionSupplier.apply(exportPartition);
+
+                    createDataQueryPartitions(exportPartition.getPartitionKey(), Instant.now(), partitionIdentifiers);
+                }
+                try {
+                    Thread.sleep(DEFAULT_TAKE_LEASE_INTERVAL_MILLIS);
+                } catch (final InterruptedException e) {
+                    LOG.info("The ExportScheduler was interrupted while waiting to retry, stopping processing");
+                    break;
+                }
+            } catch (final Exception e) {
+                LOG.error("Received an exception during export from DocumentDB, backing off and retrying", e);
+                try {
+                    Thread.sleep(DEFAULT_TAKE_LEASE_INTERVAL_MILLIS);
+                } catch (final InterruptedException ex) {
+                    LOG.info("The ExportScheduler was interrupted while waiting to retry, stopping processing");
+                    break;
+                }
+            }
+        }
+        LOG.warn("Export scheduler interrupted, looks like shutdown has triggered");
+        executor.shutdownNow();
+
+    }
+
+    private void createDataQueryPartitions(final String collection,
+                                           final Instant exportTime,
+                                           final List<PartitionIdentifier> partitionIdentifiers) {
+        final AtomicInteger totalQueries = new AtomicInteger();
+        partitionIdentifiers.forEach(partitionIdentifier -> {
+            final DataQueryProgressState progressState = new DataQueryProgressState();
+            progressState.setExecutedQueries(0);
+            progressState.setLoadedRecords(0);
+            progressState.setStartTime(exportTime.toEpochMilli());
+
+            totalQueries.addAndGet(1);
+            final DataQueryPartition partition = new DataQueryPartition(partitionIdentifier.getPartitionKey(), progressState);
+            enhancedSourceCoordinator.createPartition(partition);
+        });
+
+        exportPartitionTotalCounter.increment(totalQueries.get());
+
+        // Currently, we need to maintain a global state to track the overall progress.
+        // So that we can easily tell if all the export files are loaded
+        final LoadStatus loadStatus = new LoadStatus(totalQueries.get(), 0);
+        enhancedSourceCoordinator.createPartition(new GlobalState(EXPORT_PREFIX + collection, loadStatus.toMap()));
+    }
+
+}

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderScheduler.java
@@ -1,0 +1,172 @@
+package org.opensearch.dataprepper.plugins.mongo.leader;
+
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.mongo.coordination.partition.ExportPartition;
+import org.opensearch.dataprepper.plugins.mongo.coordination.partition.GlobalState;
+import org.opensearch.dataprepper.plugins.mongo.coordination.partition.LeaderPartition;
+import org.opensearch.dataprepper.plugins.mongo.coordination.partition.StreamPartition;
+import org.opensearch.dataprepper.plugins.mongo.coordination.state.ExportProgressState;
+import org.opensearch.dataprepper.plugins.mongo.coordination.state.LeaderProgressState;
+import org.opensearch.dataprepper.plugins.mongo.coordination.state.StreamProgressState;
+import org.opensearch.dataprepper.plugins.mongo.configuration.CollectionConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public class LeaderScheduler implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LeaderScheduler.class);
+
+    /**
+     * Default duration to extend the timeout of lease
+     */
+    private static final int DEFAULT_EXTEND_LEASE_MINUTES = 3;
+
+    /**
+     * Default interval to run lease check and shard discovery
+     */
+    private static final Duration DEFAULT_LEASE_INTERVAL = Duration.ofMinutes(1);
+
+    private final List<CollectionConfig> collectionConfigs;
+
+    private final EnhancedSourceCoordinator coordinator;
+
+    private final Duration leaseInterval;
+
+    private LeaderPartition leaderPartition;
+
+    public LeaderScheduler(EnhancedSourceCoordinator coordinator, List<CollectionConfig> collectionConfigs) {
+        this(coordinator, collectionConfigs, DEFAULT_LEASE_INTERVAL);
+    }
+
+    LeaderScheduler(EnhancedSourceCoordinator coordinator,
+                    List<CollectionConfig> collectionConfigs,
+                    Duration leaseInterval) {
+        this.collectionConfigs = collectionConfigs;
+        this.coordinator = coordinator;
+        this.leaseInterval = leaseInterval;
+    }
+
+    @Override
+    public void run() {
+        LOG.info("Starting Leader Scheduler for initialization and stream discovery");
+
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                // Try to acquire the lease if not owned.
+                if (leaderPartition == null) {
+                    final Optional<EnhancedSourcePartition> sourcePartition = coordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE);
+                    LOG.info("Leader partition {}", sourcePartition);
+                    if (sourcePartition.isPresent()) {
+                        LOG.info("Running as a LEADER node");
+                        leaderPartition = (LeaderPartition) sourcePartition.get();
+                    }
+                }
+                // Once owned, run Normal LEADER node process.
+                // May want to quit this scheduler if streaming is not required
+                if (leaderPartition != null) {
+                    LeaderProgressState leaderProgressState = leaderPartition.getProgressState().get();
+                    if (!leaderProgressState.isInitialized()) {
+                        LOG.info("The service is not been initialized");
+                        init();
+                    }
+
+                }
+
+            } catch (Exception e) {
+                LOG.error("Exception occurred in primary scheduling loop", e);
+            } finally {
+                if(leaderPartition != null) {
+                    // Extend the timeout
+                    // will always be a leader until shutdown
+                    coordinator.saveProgressStateForPartition(leaderPartition, Duration.ofMinutes(DEFAULT_EXTEND_LEASE_MINUTES));
+                }
+                try {
+                    Thread.sleep(leaseInterval.toMillis());
+                } catch (final InterruptedException e) {
+                    LOG.info("InterruptedException occurred");
+                    break;
+                }
+            }
+        }
+        // Should Stop
+        LOG.warn("Quitting Leader Scheduler");
+        if (leaderPartition != null) {
+            coordinator.giveUpPartition(leaderPartition);
+        }
+    }
+
+    private boolean isExportRequired(final CollectionConfig.IngestionMode ingestionMode) {
+        return ingestionMode.equals(CollectionConfig.IngestionMode.EXPORT_STREAM) ||
+                ingestionMode.equals(CollectionConfig.IngestionMode.EXPORT);
+    }
+
+    private boolean isStreamRequired(final CollectionConfig.IngestionMode ingestionMode) {
+        return ingestionMode.equals(CollectionConfig.IngestionMode.EXPORT_STREAM) ||
+                ingestionMode.equals(CollectionConfig.IngestionMode.STREAM);
+    }
+    private void init() {
+        LOG.info("Try to initialize DocumentDB Leader Partition");
+
+        collectionConfigs.forEach(collectionConfig -> {
+            // Create a Global state in the coordination table for the configuration.
+            // Global State here is designed to be able to read whenever needed
+            // So that the jobs can refer to the configuration.
+            coordinator.createPartition(new GlobalState(collectionConfig.getCollection(), null));
+
+            final Instant startTime = Instant.now();
+            final boolean exportRequired = isExportRequired(collectionConfig.getIngestionMode());
+            LOG.info("Ingestion mode {} for Collection {}", collectionConfig.getIngestionMode(), collectionConfig.getCollection());
+            if (exportRequired) {
+                createExportPartition(collectionConfig, startTime);
+            }
+
+            if (isStreamRequired(collectionConfig.getIngestionMode())) {
+                createStreamPartition(collectionConfig, startTime, exportRequired);
+            }
+
+        });
+
+        LOG.debug("Update initialization state");
+        LeaderProgressState leaderProgressState = leaderPartition.getProgressState().get();
+        leaderProgressState.setInitialized(true);
+    }
+
+
+    /**
+     * Create a partition for a stream job in the coordination table.
+     *
+     * @param collectionConfig  collection configuration object containing collection details
+     * @param streamTime the start time for change events, any change events with creation datetime before this should be ignored.
+     */
+    private void createStreamPartition(final CollectionConfig collectionConfig, final Instant streamTime, final boolean waitForExport) {
+        LOG.info("Creating stream global partition");
+        final StreamProgressState streamProgressState = new StreamProgressState();
+        streamProgressState.setWaitForExport(waitForExport);
+        streamProgressState.setStartTime(streamTime.toEpochMilli());
+        coordinator.createPartition(new StreamPartition(collectionConfig.getCollection(), Optional.of(streamProgressState)));
+    }
+
+    /**
+     * Create a partition for an export job in the coordination table.
+     *
+     * @param collectionConfig  collection configuration object containing collection details
+     * @param exportTime the start time for Export
+     */
+    private void createExportPartition(final CollectionConfig collectionConfig, final Instant exportTime) {
+        LOG.info("Creating export global partition");
+        final ExportProgressState exportProgressState = new ExportProgressState();
+        exportProgressState.setCollectionName(collectionConfig.getCollectionName());
+        exportProgressState.setDatabaseName(collectionConfig.getDatabaseName());
+        exportProgressState.setExportTime(exportTime.toString()); // information purpose
+        final ExportPartition exportPartition = new ExportPartition(collectionConfig.getCollection(),
+                collectionConfig.getExportConfig().getItemsPerPartition(), exportTime, exportProgressState);
+        coordinator.createPartition(exportPartition);
+    }
+
+}

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/model/LoadStatus.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/model/LoadStatus.java
@@ -1,0 +1,58 @@
+package org.opensearch.dataprepper.plugins.mongo.model;
+
+import java.util.Map;
+
+public class LoadStatus {
+
+    static final String TOTAL_PARTITIONS = "totalPartitions";
+    private static final String LOADED_PARTITIONS = "loadedPartitions";
+    private static final String LOADED_RECORDS = "loadedRecords";
+
+    private long totalPartitions;
+    private long loadedPartitions;
+    private long loadedRecords;
+
+    public LoadStatus(int totalPartitions, long loadedRecords) {
+        this.totalPartitions = totalPartitions;
+        this.loadedRecords = loadedRecords;
+    }
+
+    public long getTotalPartitions() {
+        return totalPartitions;
+    }
+
+    public void setLoadedPartitions(long loadedPartitions) {
+        this.loadedPartitions = loadedPartitions;
+    }
+
+    public long getLoadedPartitions() {
+        return loadedPartitions;
+    }
+
+    public void setTotalPartitions(long totalPartitions) {
+        this.totalPartitions = totalPartitions;
+    }
+
+    public long getLoadedRecords() {
+        return loadedRecords;
+    }
+
+    public void setLoadedRecords(long loadedRecords) {
+        this.loadedRecords = loadedRecords;
+    }
+
+    public Map<String, Object> toMap() {
+        return Map.of(
+                TOTAL_PARTITIONS, totalPartitions,
+                LOADED_PARTITIONS, loadedPartitions,
+                LOADED_RECORDS, loadedRecords
+        );
+    }
+
+    public static LoadStatus fromMap(Map<String, Object> map) {
+        return new LoadStatus(
+                ((Number) map.get(TOTAL_PARTITIONS)).intValue(),
+                ((Number) map.get(LOADED_RECORDS)).longValue()
+        );
+    }
+}

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/ExportSchedulerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/ExportSchedulerTest.java
@@ -1,0 +1,193 @@
+package org.opensearch.dataprepper.plugins.mongo.export;
+
+import io.micrometer.core.instrument.Counter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.source.coordinator.PartitionIdentifier;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.mongo.coordination.partition.DataQueryPartition;
+import org.opensearch.dataprepper.plugins.mongo.coordination.partition.ExportPartition;
+import org.opensearch.dataprepper.plugins.mongo.coordination.partition.GlobalState;
+import org.opensearch.dataprepper.plugins.mongo.export.partition.MongoDBExportPartitionSupplier;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.opensearch.dataprepper.plugins.mongo.export.ExportScheduler.EXPORT_JOB_FAILURE_COUNT;
+import static org.opensearch.dataprepper.plugins.mongo.export.ExportScheduler.EXPORT_JOB_SUCCESS_COUNT;
+import static org.opensearch.dataprepper.plugins.mongo.export.ExportScheduler.EXPORT_PARTITION_QUERY_TOTAL_COUNT;
+import static org.opensearch.dataprepper.plugins.mongo.export.ExportScheduler.EXPORT_PREFIX;
+import static org.opensearch.dataprepper.plugins.mongo.export.ExportScheduler.EXPORT_RECORDS_TOTAL_COUNT;
+
+@ExtendWith(MockitoExtension.class)
+public class ExportSchedulerTest {
+    @Mock
+    private EnhancedSourceCoordinator coordinator;
+
+    @Mock
+    private MongoDBExportPartitionSupplier mongoDBExportPartitionSupplier;
+
+    @Mock
+    private PartitionIdentifier partitionIdentifier;
+
+    @Mock
+    private PluginMetrics pluginMetrics;
+
+    @Mock
+    private Counter exportJobSuccessCounter;
+
+    @Mock
+    private Counter exportJobFailureCounter;
+
+    @Mock
+    private Counter exportPartitionTotalCounter;
+
+    @Mock
+    private Counter exportRecordsTotalCounter;
+
+    private ExportScheduler exportScheduler;
+    private ExportPartition exportPartition;
+
+    @BeforeEach
+    void setup() throws Exception {
+        given(pluginMetrics.counter(EXPORT_JOB_SUCCESS_COUNT)).willReturn(exportJobSuccessCounter);
+        given(pluginMetrics.counter(EXPORT_JOB_FAILURE_COUNT)).willReturn(exportJobFailureCounter);
+        given(pluginMetrics.counter(EXPORT_PARTITION_QUERY_TOTAL_COUNT)).willReturn(exportPartitionTotalCounter);
+        given(pluginMetrics.counter(EXPORT_RECORDS_TOTAL_COUNT)).willReturn(exportRecordsTotalCounter);
+
+    }
+
+    @Test
+    void test_no_export_run() throws InterruptedException {
+        exportScheduler = new ExportScheduler(coordinator, mongoDBExportPartitionSupplier, pluginMetrics);
+        given(coordinator.acquireAvailablePartition(ExportPartition.PARTITION_TYPE)).willReturn(Optional.empty());
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> exportScheduler.run());
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+        verifyNoInteractions(mongoDBExportPartitionSupplier);
+        verify(coordinator, never()).createPartition(any());
+    }
+
+    @Test
+    void test_export_run() throws InterruptedException {
+        exportScheduler = new ExportScheduler(coordinator, mongoDBExportPartitionSupplier, pluginMetrics);
+        final String collection = UUID.randomUUID().toString();
+        final int partitionSize = new Random().nextInt();
+        final Instant exportTime = Instant.now();
+        final String partitionKey = collection + "|" + UUID.randomUUID();
+        final String globalPartitionKey = collection + "|" + partitionSize + "|" + exportTime.toEpochMilli();
+
+        exportPartition = new ExportPartition(collection, partitionSize, exportTime, null);
+        given(partitionIdentifier.getPartitionKey()).willReturn(partitionKey);
+        given(mongoDBExportPartitionSupplier.apply(exportPartition)).willReturn(List.of(partitionIdentifier));
+        given(coordinator.acquireAvailablePartition(ExportPartition.PARTITION_TYPE)).willReturn(Optional.of(exportPartition));
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> exportScheduler.run());
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+
+        // Acquire the init partition
+        verify(coordinator).acquireAvailablePartition(eq(ExportPartition.PARTITION_TYPE));
+
+        final ArgumentCaptor<EnhancedSourcePartition> argumentCaptor = ArgumentCaptor.forClass(EnhancedSourcePartition.class);
+        // Should create 1 export partition + 1 stream partitions + 1 global table state
+        verify(coordinator, times(2)).createPartition(argumentCaptor.capture());
+        final List<EnhancedSourcePartition> partitions = argumentCaptor.getAllValues();
+        partitions.forEach(partition -> {
+            if (partition instanceof DataQueryPartition) {
+                final DataQueryPartition dataQueryPartition = (DataQueryPartition) partition;
+                assertThat(dataQueryPartition.getCollection(), equalTo(collection));
+                assertThat(dataQueryPartition.getPartitionKey(), equalTo(partitionKey));
+                assertThat(dataQueryPartition.getQuery(), equalTo(partitionKey));
+                assertThat(partitions.get(0).getPartitionType(), equalTo(DataQueryPartition.PARTITION_TYPE));
+            } else {
+                final GlobalState globalState = (GlobalState) partition;
+                assertThat(globalState.getPartitionKey(), equalTo(EXPORT_PREFIX + globalPartitionKey));
+                assertThat(globalState.getProgressState().get().toString(), is(Map.of(
+                        "totalPartitions", 1,
+                        "loadedPartitions", 0,
+                        "loadedRecords", 0
+                ).toString()));
+                assertThat(globalState.getPartitionType(), equalTo(null));
+            }
+        });
+
+        verify(exportPartitionTotalCounter).increment(1);
+    }
+
+    @Test
+    void test_export_run_multiple_partitions() throws InterruptedException {
+        exportScheduler = new ExportScheduler(coordinator, mongoDBExportPartitionSupplier, pluginMetrics);
+        final String collection = UUID.randomUUID().toString();
+        final int partitionSize = new Random().nextInt();
+        final Instant exportTime = Instant.now();
+        final String partitionKey = collection + "|" + UUID.randomUUID();
+        final String globalPartitionKey = collection + "|" + partitionSize + "|" + exportTime.toEpochMilli();
+
+        exportPartition = new ExportPartition(collection, partitionSize, exportTime, null);
+        given(partitionIdentifier.getPartitionKey()).willReturn(partitionKey);
+        given(mongoDBExportPartitionSupplier.apply(exportPartition)).willReturn(List.of(partitionIdentifier, partitionIdentifier, partitionIdentifier));
+        given(coordinator.acquireAvailablePartition(ExportPartition.PARTITION_TYPE)).willReturn(Optional.of(exportPartition));
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> exportScheduler.run());
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+
+        // Acquire the init partition
+        verify(coordinator).acquireAvailablePartition(eq(ExportPartition.PARTITION_TYPE));
+
+        final ArgumentCaptor<EnhancedSourcePartition> argumentCaptor = ArgumentCaptor.forClass(EnhancedSourcePartition.class);
+        // Should create 1 export partition + 1 stream partitions + 1 global table state
+        verify(coordinator, times(4)).createPartition(argumentCaptor.capture());
+        final List<EnhancedSourcePartition> partitions = argumentCaptor.getAllValues();
+        partitions.forEach(partition -> {
+            if (partition instanceof DataQueryPartition) {
+                final DataQueryPartition dataQueryPartition = (DataQueryPartition) partition;
+                assertThat(dataQueryPartition.getCollection(), equalTo(collection));
+                assertThat(dataQueryPartition.getPartitionKey(), equalTo(partitionKey));
+                assertThat(dataQueryPartition.getQuery(), equalTo(partitionKey));
+                assertThat(partitions.get(0).getPartitionType(), equalTo(DataQueryPartition.PARTITION_TYPE));
+            } else {
+                final GlobalState globalState = (GlobalState) partition;
+                assertThat(globalState.getPartitionKey(), equalTo(EXPORT_PREFIX + globalPartitionKey));
+                assertThat(globalState.getProgressState().get().toString(), is(Map.of(
+                        "totalPartitions", 3,
+                        "loadedPartitions", 0,
+                        "loadedRecords", 0
+                ).toString()));
+                assertThat(globalState.getPartitionType(), equalTo(null));
+            }
+        });
+
+        verify(exportPartitionTotalCounter).increment(3);
+    }
+}

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderSchedulerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderSchedulerTest.java
@@ -1,0 +1,133 @@
+package org.opensearch.dataprepper.plugins.mongo.leader;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.mongo.configuration.CollectionConfig;
+import org.opensearch.dataprepper.plugins.mongo.coordination.partition.LeaderPartition;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+public class LeaderSchedulerTest {
+    @Mock
+    private EnhancedSourceCoordinator coordinator;
+
+    @Mock
+    private CollectionConfig collectionConfig;
+
+    @Mock
+    private CollectionConfig.ExportConfig exportConfig;
+
+    private LeaderScheduler leaderScheduler;
+    private LeaderPartition leaderPartition;
+
+    @Test
+    void test_non_leader_run() throws InterruptedException {
+        leaderScheduler = new LeaderScheduler(coordinator, List.of(collectionConfig));
+        given(coordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).willReturn(Optional.empty());
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> leaderScheduler.run());
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+        verifyNoInteractions(collectionConfig);
+    }
+
+    @Test
+    void test_should_init() throws InterruptedException {
+
+        leaderScheduler = new LeaderScheduler(coordinator, List.of(collectionConfig));
+        leaderPartition = new LeaderPartition();
+        given(coordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).willReturn(Optional.of(leaderPartition));
+        given(collectionConfig.getIngestionMode()).willReturn(CollectionConfig.IngestionMode.EXPORT_STREAM);
+        given(collectionConfig.getExportConfig()).willReturn(exportConfig);
+        given(exportConfig.getItemsPerPartition()).willReturn(new Random().nextInt());
+        given(collectionConfig.getCollection()).willReturn(UUID.randomUUID().toString());
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> leaderScheduler.run());
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+
+        // Acquire the init partition
+        verify(coordinator).acquireAvailablePartition(eq(LeaderPartition.PARTITION_TYPE));
+
+        // Should create 1 export partition + 1 stream partitions + 1 global table state
+        verify(coordinator, times(3)).createPartition(any(EnhancedSourcePartition.class));
+        verify(coordinator).giveUpPartition(leaderPartition);
+
+        assertThat(leaderPartition.getProgressState().get().isInitialized(), equalTo(true));
+    }
+
+    @Test
+    void test_should_init_export() throws InterruptedException {
+
+        leaderScheduler = new LeaderScheduler(coordinator, List.of(collectionConfig));
+        leaderPartition = new LeaderPartition();
+        given(coordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).willReturn(Optional.of(leaderPartition));
+        given(collectionConfig.getIngestionMode()).willReturn(CollectionConfig.IngestionMode.EXPORT);
+        given(collectionConfig.getExportConfig()).willReturn(exportConfig);
+        given(exportConfig.getItemsPerPartition()).willReturn(new Random().nextInt());
+        given(collectionConfig.getCollection()).willReturn(UUID.randomUUID().toString());
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> leaderScheduler.run());
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+
+        // Acquire the init partition
+        verify(coordinator).acquireAvailablePartition(eq(LeaderPartition.PARTITION_TYPE));
+
+        // Should create 1 export partition + 1 stream partitions + 1 global table state
+        verify(coordinator, times(2)).createPartition(any(EnhancedSourcePartition.class));
+        verify(coordinator).giveUpPartition(leaderPartition);
+
+        assertThat(leaderPartition.getProgressState().get().isInitialized(), equalTo(true));
+    }
+
+    @Test
+    void test_should_init_stream() throws InterruptedException {
+
+        leaderScheduler = new LeaderScheduler(coordinator, List.of(collectionConfig));
+        leaderPartition = new LeaderPartition();
+        given(coordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).willReturn(Optional.of(leaderPartition));
+        given(collectionConfig.getIngestionMode()).willReturn(CollectionConfig.IngestionMode.STREAM);
+        given(collectionConfig.getCollection()).willReturn(UUID.randomUUID().toString());
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> leaderScheduler.run());
+        Thread.sleep(100);
+        executorService.shutdownNow();
+
+
+        // Acquire the init partition
+        verify(coordinator).acquireAvailablePartition(eq(LeaderPartition.PARTITION_TYPE));
+
+        // Should create 1 export partition + 1 stream partitions + 1 global table state
+        verify(coordinator, times(2)).createPartition(any(EnhancedSourcePartition.class));
+        verify(coordinator).giveUpPartition(leaderPartition);
+
+        assertThat(leaderPartition.getProgressState().get().isInitialized(), equalTo(true));
+    }
+}


### PR DESCRIPTION
### Description
Add ExportScheduler and LeaderScheduler for MongoDB/DocumentDB source
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
