### PR TITLE
Fixes the S3 source tests when running together

### DIFF
--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/SqsServiceIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/SqsServiceIT.java
@@ -90,6 +90,8 @@ class SqsServiceIT {
         numMessagesCounter = mock(Counter.class);
         lenient().when(pluginMetrics.counter(SqsWorker.SQS_MESSAGES_RECEIVED_METRIC_NAME)).thenReturn(numMessagesCounter);
         lenient().when(pluginMetrics.counter(SqsWorker.SQS_MESSAGES_DELETED_METRIC_NAME)).thenReturn(deletedCounter);
+        lenient().when(pluginMetrics.counter(SqsWorker.SQS_MESSAGES_DELETED_METRIC_NAME)).thenReturn(deletedCounter);
+        lenient().when(pluginMetrics.counter(SqsWorker.S3_OBJECTS_EMPTY_METRIC_NAME)).thenReturn(mock(Counter.class));
         lenient().when(pluginMetrics.summary(anyString())).thenReturn(distributionSummary);
         when(pluginMetrics.timer(anyString())).thenReturn(sqsMessageDelayTimer);
         lenient().doAnswer((val) -> {


### PR DESCRIPTION
### Description

When running all the `s3` source integration tests on the command line, I would get a NullPointerException on the following line.

https://github.com/opensearch-project/data-prepper/blob/878c4437e4c2cbfef30dc632f1b3afc09bd30ea2/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/SqsWorker.java#L221

This adds a mocked Counter for that metric to avoid the NPE.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
