### PR TITLE
ENH: automatic credential refresher opensearch sink

### DIFF
--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -43,6 +43,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventType;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.opensearch.OpenSearchBulkActions;
+import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.SinkContext;
@@ -92,6 +93,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchIntegrationHelper.createContentParser;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchIntegrationHelper.createOpenSearchClient;
@@ -131,8 +133,12 @@ public class OpenSearchSinkIT {
     @Mock
     private ExpressionEvaluator expressionEvaluator;
 
+    @Mock
+    private PluginConfigObservable pluginConfigObservable;
+
     public OpenSearchSink createObjectUnderTest(PluginSetting pluginSetting, boolean doInitialize) {
-        OpenSearchSink sink = new OpenSearchSink(pluginSetting, pluginFactory, null, expressionEvaluator, awsCredentialsSupplier);
+        OpenSearchSink sink = new OpenSearchSink(
+                pluginSetting, pluginFactory, null, expressionEvaluator, awsCredentialsSupplier, pluginConfigObservable);
         if (doInitialize) {
             sink.doInitialize();
         }
@@ -143,7 +149,8 @@ public class OpenSearchSinkIT {
         sinkContext = mock(SinkContext.class);
         testTagsTargetKey = RandomStringUtils.randomAlphabetic(5);
         when(sinkContext.getTagsTargetKey()).thenReturn(testTagsTargetKey);
-        OpenSearchSink sink = new OpenSearchSink(pluginSetting, pluginFactory, sinkContext, expressionEvaluator, awsCredentialsSupplier);
+        OpenSearchSink sink = new OpenSearchSink(
+                pluginSetting, pluginFactory, sinkContext, expressionEvaluator, awsCredentialsSupplier, pluginConfigObservable);
         if (doInitialize) {
             sink.doInitialize();
         }
@@ -152,7 +159,7 @@ public class OpenSearchSinkIT {
 
     @BeforeEach
     public void setup() {
-
+        pluginConfigObservable = mock(PluginConfigObservable.class);
         expressionEvaluator = mock(ExpressionEvaluator.class);
         when(expressionEvaluator.isValidExpressionStatement(any(String.class))).thenReturn(false);
 
@@ -1140,6 +1147,7 @@ public class OpenSearchSinkIT {
 
         final PluginSetting pluginSetting = generatePluginSetting(IndexType.TRACE_ANALYTICS_RAW.getValue(), null, null);
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
+        verify(pluginConfigObservable).addPluginConfigObserver(any());
         sink.output(testRecords);
 
         final String expIndexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexType.TRACE_ANALYTICS_RAW);

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchClientRefresher.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchClientRefresher.java
@@ -26,12 +26,11 @@ public class OpenSearchClientRefresher implements PluginComponentRefresher<OpenS
     private final Counter clientRefreshErrorsCounter;
 
     public OpenSearchClientRefresher(final PluginMetrics pluginMetrics,
-                                     final OpenSearchClient openSearchClient,
                                      final ConnectionConfiguration connectionConfiguration,
                                      final Function<ConnectionConfiguration, OpenSearchClient> clientFunction) {
         this.clientFunction = clientFunction;
         this.currentConfig = connectionConfiguration;
-        this.currentClient = openSearchClient;
+        this.currentClient = clientFunction.apply(connectionConfiguration);
         credentialsChangeCounter = pluginMetrics.counter(CREDENTIALS_CHANGED);
         clientRefreshErrorsCounter = pluginMetrics.counter(CLIENT_REFRESH_ERRORS);
     }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchClientRefresher.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchClientRefresher.java
@@ -1,0 +1,69 @@
+package org.opensearch.dataprepper.plugins.sink.opensearch;
+
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.plugin.PluginComponentRefresher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BiFunction;
+
+public class OpenSearchClientRefresher implements PluginComponentRefresher<OpenSearchClient, PluginSetting> {
+    private static final Logger LOG = LoggerFactory.getLogger(OpenSearchClientRefresher.class);
+    private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+    private final AwsCredentialsSupplier awsCredentialsSupplier;
+    private final BiFunction<AwsCredentialsSupplier, ConnectionConfiguration, OpenSearchClient> clientBiFunction;
+    private OpenSearchClient currentClient;
+    private ConnectionConfiguration currentConfig;
+
+    public OpenSearchClientRefresher(final AwsCredentialsSupplier awsCredentialsSupplier,
+                                     final OpenSearchClient openSearchClient,
+                                     final ConnectionConfiguration connectionConfiguration,
+                                     final BiFunction<AwsCredentialsSupplier, ConnectionConfiguration, OpenSearchClient>
+                                             clientBiFunction) {
+        this.awsCredentialsSupplier = awsCredentialsSupplier;
+        this.clientBiFunction = clientBiFunction;
+        this.currentConfig = connectionConfiguration;
+        this.currentClient = openSearchClient;
+    }
+
+    @Override
+    public Class<OpenSearchClient> getComponentClass() {
+        return OpenSearchClient.class;
+    }
+
+    @Override
+    public OpenSearchClient get() {
+        readWriteLock.readLock().lock();
+        try {
+            return currentClient;
+        } finally {
+            readWriteLock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void update(PluginSetting pluginSetting) {
+        final ConnectionConfiguration newConfig = ConnectionConfiguration.readConnectionConfiguration(pluginSetting);
+        if (basicAuthChanged(newConfig)) {
+            readWriteLock.writeLock().lock();
+            try {
+                currentClient = clientBiFunction.apply(awsCredentialsSupplier, newConfig);
+                currentConfig = newConfig;
+            } catch (Exception e) {
+                LOG.error("Refreshing {} failed.", getComponentClass(), e);
+            } finally {
+                readWriteLock.writeLock().unlock();
+            }
+        }
+    }
+
+    private boolean basicAuthChanged(final ConnectionConfiguration newConfig) {
+        return !Objects.equals(currentConfig.getUsername(), newConfig.getUsername()) ||
+                !Objects.equals(currentConfig.getPassword(), newConfig.getPassword());
+    }
+}

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSink.java
@@ -228,7 +228,7 @@ public class OpenSearchSink extends AbstractSink<Record<Event>> {
                       .build());
     };
     openSearchClientRefresher = new OpenSearchClientRefresher(
-            pluginMetrics, openSearchClient, connectionConfiguration, clientFunction);
+            pluginMetrics, connectionConfiguration, clientFunction);
     pluginConfigObservable.addPluginConfigObserver(
             newPluginSetting -> openSearchClientRefresher.update((PluginSetting) newPluginSetting));
     configuredIndexAlias = openSearchSinkConfig.getIndexConfiguration().getIndexAlias();

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/BulkApiWrapperFactory.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/BulkApiWrapperFactory.java
@@ -4,13 +4,15 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.dataprepper.plugins.sink.opensearch.DistributionVersion;
 import org.opensearch.dataprepper.plugins.sink.opensearch.index.IndexConfiguration;
 
+import java.util.function.Supplier;
+
 public class BulkApiWrapperFactory {
     public static BulkApiWrapper getWrapper(final IndexConfiguration indexConfiguration,
-                                            final OpenSearchClient openSearchClient) {
+                                            final Supplier<OpenSearchClient> openSearchClientSupplier) {
         if (DistributionVersion.ES6.equals(indexConfiguration.getDistributionVersion())) {
-            return new Es6BulkApiWrapper(openSearchClient);
+            return new Es6BulkApiWrapper(openSearchClientSupplier);
         } else {
-            return new OpenSearchDefaultBulkApiWrapper(openSearchClient);
+            return new OpenSearchDefaultBulkApiWrapper(openSearchClientSupplier);
         }
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/Es6BulkApiWrapper.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/Es6BulkApiWrapper.java
@@ -14,18 +14,20 @@ import javax.ws.rs.HttpMethod;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class Es6BulkApiWrapper implements BulkApiWrapper {
-    private final OpenSearchClient openSearchClient;
+    private final Supplier<OpenSearchClient> openSearchClientSupplier;
 
-    public Es6BulkApiWrapper(final OpenSearchClient openSearchClient) {
-        this.openSearchClient = openSearchClient;
+    public Es6BulkApiWrapper(final Supplier<OpenSearchClient> openSearchClientSupplier) {
+        this.openSearchClientSupplier = openSearchClientSupplier;
     }
 
     @Override
     public BulkResponse bulk(BulkRequest request) throws IOException, OpenSearchException {
         final JsonEndpoint<BulkRequest, BulkResponse, ErrorResponse> endpoint = es6BulkEndpoint(request);
+        final OpenSearchClient openSearchClient = openSearchClientSupplier.get();
         return openSearchClient._transport().performRequest(request, endpoint, openSearchClient._transportOptions());
     }
 

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/OpenSearchDefaultBulkApiWrapper.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/OpenSearchDefaultBulkApiWrapper.java
@@ -5,16 +5,17 @@ import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
 public class OpenSearchDefaultBulkApiWrapper implements BulkApiWrapper {
-    private final OpenSearchClient openSearchClient;
+    private final Supplier<OpenSearchClient> openSearchClientSupplier;
 
-    public OpenSearchDefaultBulkApiWrapper(final OpenSearchClient openSearchClient) {
-        this.openSearchClient = openSearchClient;
+    public OpenSearchDefaultBulkApiWrapper(final Supplier<OpenSearchClient> openSearchClientSupplier) {
+        this.openSearchClientSupplier = openSearchClientSupplier;
     }
 
     @Override
     public BulkResponse bulk(BulkRequest request) throws IOException {
-        return openSearchClient.bulk(request);
+        return openSearchClientSupplier.get().bulk(request);
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchClientRefresherTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchClientRefresherTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchClientRefresher.CLIENT_REFRESH_ERRORS;

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchClientRefresherTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchClientRefresherTest.java
@@ -1,0 +1,109 @@
+package org.opensearch.dataprepper.plugins.sink.opensearch;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+
+import java.util.function.BiFunction;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OpenSearchClientRefresherTest {
+    private static final String TEST_USERNAME = "test_user";
+    private static final String TEST_PASSWORD = "test_password";
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
+
+    @Mock
+    private BiFunction<AwsCredentialsSupplier, ConnectionConfiguration, OpenSearchClient> clientBiFunction;
+
+    @Mock
+    private ConnectionConfiguration connectionConfiguration;
+
+    @Mock
+    private OpenSearchClient openSearchClient;
+
+    private OpenSearchClientRefresher createObjectUnderTest() {
+        return new OpenSearchClientRefresher(
+                awsCredentialsSupplier, openSearchClient, connectionConfiguration, clientBiFunction);
+    }
+
+    @Test
+    void testGet() {
+        final OpenSearchClientRefresher objectUnderTest = createObjectUnderTest();
+        assertThat(objectUnderTest.get(), equalTo(openSearchClient));
+    }
+
+    @Test
+    void testGetAfterUpdateWithBasicAuthUnchanged() {
+        final OpenSearchClientRefresher objectUnderTest = createObjectUnderTest();
+        when(connectionConfiguration.getUsername()).thenReturn(TEST_USERNAME);
+        when(connectionConfiguration.getPassword()).thenReturn(TEST_PASSWORD);
+        final PluginSetting newConfig = mock(PluginSetting.class);
+        final ConnectionConfiguration newConnectionConfiguration = mock(ConnectionConfiguration.class);
+        when(newConnectionConfiguration.getUsername()).thenReturn(TEST_USERNAME);
+        when(newConnectionConfiguration.getPassword()).thenReturn(TEST_PASSWORD);
+        try (MockedStatic<ConnectionConfiguration> configurationMockedStatic = mockStatic(
+                ConnectionConfiguration.class)) {
+            configurationMockedStatic.when(() -> ConnectionConfiguration.readConnectionConfiguration(eq(newConfig)))
+                    .thenReturn(newConnectionConfiguration);
+            objectUnderTest.update(newConfig);
+        }
+        assertThat(objectUnderTest.get(), equalTo(openSearchClient));
+        verifyNoInteractions(clientBiFunction);
+    }
+
+    @Test
+    void testGetAfterUpdateWithUsernameChanged() {
+        final OpenSearchClientRefresher objectUnderTest = createObjectUnderTest();
+        assertThat(objectUnderTest.get(), equalTo(openSearchClient));
+        when(connectionConfiguration.getUsername()).thenReturn(TEST_USERNAME);
+        final PluginSetting newConfig = mock(PluginSetting.class);
+        final ConnectionConfiguration newConnectionConfiguration = mock(ConnectionConfiguration.class);
+        when(newConnectionConfiguration.getUsername()).thenReturn(TEST_USERNAME + "_changed");
+        final OpenSearchClient newClient = mock(OpenSearchClient.class);
+        when(clientBiFunction.apply(eq(awsCredentialsSupplier), eq(newConnectionConfiguration)))
+                .thenReturn(newClient);
+        try (MockedStatic<ConnectionConfiguration> configurationMockedStatic = mockStatic(
+                ConnectionConfiguration.class)) {
+            configurationMockedStatic.when(() -> ConnectionConfiguration.readConnectionConfiguration(eq(newConfig)))
+                    .thenReturn(newConnectionConfiguration);
+            objectUnderTest.update(newConfig);
+        }
+        assertThat(objectUnderTest.get(), equalTo(newClient));
+    }
+
+    @Test
+    void testGetAfterUpdateWithPasswordChanged() {
+        final OpenSearchClientRefresher objectUnderTest = createObjectUnderTest();
+        assertThat(objectUnderTest.get(), equalTo(openSearchClient));
+        when(connectionConfiguration.getUsername()).thenReturn(TEST_USERNAME);
+        when(connectionConfiguration.getPassword()).thenReturn(TEST_PASSWORD);
+        final PluginSetting newConfig = mock(PluginSetting.class);
+        final ConnectionConfiguration newConnectionConfiguration = mock(ConnectionConfiguration.class);
+        when(newConnectionConfiguration.getUsername()).thenReturn(TEST_USERNAME);
+        when(newConnectionConfiguration.getPassword()).thenReturn(TEST_PASSWORD + "_changed");
+        final OpenSearchClient newClient = mock(OpenSearchClient.class);
+        when(clientBiFunction.apply(eq(awsCredentialsSupplier), eq(newConnectionConfiguration)))
+                .thenReturn(newClient);
+        try (MockedStatic<ConnectionConfiguration> configurationMockedStatic = mockStatic(
+                ConnectionConfiguration.class)) {
+            configurationMockedStatic.when(() -> ConnectionConfiguration.readConnectionConfiguration(eq(newConfig)))
+                    .thenReturn(newConnectionConfiguration);
+            objectUnderTest.update(newConfig);
+        }
+        assertThat(objectUnderTest.get(), equalTo(newClient));
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/BulkApiWrapperFactoryTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/BulkApiWrapperFactoryTest.java
@@ -23,14 +23,14 @@ class BulkApiWrapperFactoryTest {
     @Test
     void testGetEs6BulkApiWrapper() {
         when(indexConfiguration.getDistributionVersion()).thenReturn(DistributionVersion.ES6);
-        assertThat(BulkApiWrapperFactory.getWrapper(indexConfiguration, openSearchClient),
+        assertThat(BulkApiWrapperFactory.getWrapper(indexConfiguration, () -> openSearchClient),
                 instanceOf(Es6BulkApiWrapper.class));
     }
 
     @Test
     void testGetOpenSearchDefaultBulkApiWrapper() {
         when(indexConfiguration.getDistributionVersion()).thenReturn(DistributionVersion.DEFAULT);
-        assertThat(BulkApiWrapperFactory.getWrapper(indexConfiguration, openSearchClient),
+        assertThat(BulkApiWrapperFactory.getWrapper(indexConfiguration, () -> openSearchClient),
                 instanceOf(OpenSearchDefaultBulkApiWrapper.class));
     }
 }

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/Es6BulkApiWrapperTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/Es6BulkApiWrapperTest.java
@@ -75,7 +75,7 @@ class Es6BulkApiWrapperTest {
 
     @BeforeEach
     void setUp() {
-        objectUnderTest = new Es6BulkApiWrapper(openSearchClient);
+        objectUnderTest = new Es6BulkApiWrapper(() -> openSearchClient);
         testIndex = RandomStringUtils.randomAlphabetic(5);
         lenient().when(bulkOperation.index()).thenReturn(indexOperation);
         lenient().when(bulkOperation.create()).thenReturn(createOperation);

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/OpenSearchDefaultBulkApiWrapperTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/OpenSearchDefaultBulkApiWrapperTest.java
@@ -24,7 +24,7 @@ class OpenSearchDefaultBulkApiWrapperTest {
 
     @BeforeEach
     void setUp() {
-        objectUnderTest = new OpenSearchDefaultBulkApiWrapper(openSearchClient);
+        objectUnderTest = new OpenSearchDefaultBulkApiWrapper(() -> openSearchClient);
     }
 
     @Test


### PR DESCRIPTION
### Description
This PR adds automatic credential refresher for opensearch sink.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
