### PR TITLE
Improve geoip performance by reducing database lookups

### DIFF
--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/GeoIPDatabase.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/GeoIPDatabase.java
@@ -5,9 +5,45 @@
 
 package org.opensearch.dataprepper.plugins.geoip;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+
 public enum GeoIPDatabase {
-    CITY,
-    COUNTRY,
-    ASN,
-    ENTERPRISE;
+    CITY(),
+    COUNTRY(CITY),
+    ASN(),
+    ENTERPRISE();
+    private final Collection<GeoIPDatabase> isReplaceableBy;
+
+    GeoIPDatabase(final GeoIPDatabase... isReplaceableBy) {
+        this.isReplaceableBy = Arrays.asList(isReplaceableBy);
+    }
+
+    public static Collection<GeoIPDatabase> selectDatabasesForFields(final Collection<GeoIPField> geoIPFields) {
+        // TODO: With some additional refactoring we can also choose COUNTRY over CITY if no CITY fields are needed.
+        final Collection<GeoIPDatabase> geoIPDatabasesForFields = GeoIPField.getGeoIPDatabasesForFields(geoIPFields);
+        return GeoIPDatabase.selectDatabases(geoIPDatabasesForFields);
+    }
+
+    static Collection<GeoIPDatabase> selectDatabases(final Collection<GeoIPDatabase> databases) {
+        if(databases == null)
+            throw new NullPointerException("A null databases collection was provided to selectDatabases.");
+
+        final EnumSet<GeoIPDatabase> selectedDatabases = EnumSet.noneOf(GeoIPDatabase.class);
+        for (final GeoIPDatabase database : databases) {
+            boolean includeDatabase = true;
+            for (final GeoIPDatabase isReplacedBy : database.isReplaceableBy) {
+                if (databases.contains(isReplacedBy)) {
+                    includeDatabase = false;
+                    break;
+                }
+            }
+
+            if(includeDatabase)
+                selectedDatabases.add(database);
+        }
+
+        return selectedDatabases;
+    }
 }

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/GeoIPField.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/GeoIPField.java
@@ -74,17 +74,4 @@ public enum GeoIPField {
     Collection<GeoIPDatabase> getGeoIPDatabases() {
         return geoIPDatabases;
     }
-
-    static Collection<GeoIPDatabase> getGeoIPDatabasesForFields(final Collection<GeoIPField> fields) {
-        if(fields == null)
-            throw new NullPointerException("The fields parameter must be non-null.");
-
-        final EnumSet<GeoIPDatabase> databases = EnumSet.noneOf(GeoIPDatabase.class);
-
-        for (final GeoIPField field : fields) {
-            databases.addAll(field.geoIPDatabases);
-        }
-
-        return databases;
-    }
 }

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/GeoIPField.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/GeoIPField.java
@@ -5,50 +5,55 @@
 
 package org.opensearch.dataprepper.plugins.geoip;
 
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Collection;
+import java.util.EnumSet;
 import java.util.Set;
 
+/**
+ * GeoIP fields and their corresponding databases.
+ * The fields are available at
+ * <a href="https://dev.maxmind.com/geoip/docs/databases/city-and-country">GeoIP2 and GeoLite City and Country Databases</a>
+ *
+ */
 public enum GeoIPField {
-    CONTINENT_CODE("continent_code", GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE),
-    CONTINENT_NAME("continent_name", GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE),
-    COUNTRY_NAME("country_name", GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE),
-    IS_COUNTRY_IN_EUROPEAN_UNION("is_country_in_european_union", GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE),
-    COUNTRY_ISO_CODE("country_iso_code", GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE),
-    COUNTRY_CONFIDENCE("country_confidence", GeoIPDatabase.ENTERPRISE),
-    REGISTERED_COUNTRY_NAME("registered_country_name", GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE),
-    REGISTERED_COUNTRY_ISO_CODE("registered_country_iso_code", GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE),
-    REPRESENTED_COUNTRY_NAME("represented_country_name", GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE),
-    REPRESENTED_COUNTRY_ISO_CODE("represented_country_iso_code", GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE),
-    REPRESENTED_COUNTRY_TYPE("represented_country_type", GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE),
-    CITY_NAME("city_name", GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE),
-    CITY_CONFIDENCE("city_confidence", GeoIPDatabase.ENTERPRISE),
-    LOCATION("location", GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE),
-    LATITUDE("latitude", GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE),
-    LONGITUDE("longitude", GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE),
-    LOCATION_ACCURACY_RADIUS("location_accuracy_radius", GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE),
-    METRO_CODE("metro_code", GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE),
-    TIME_ZONE("time_zone", GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE),
-    POSTAL_CODE("postal_code", GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE),
-    POSTAL_CODE_CONFIDENCE("postal_code_confidence", GeoIPDatabase.ENTERPRISE),
-    MOST_SPECIFIED_SUBDIVISION_NAME("most_specified_subdivision_name", GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE),
-    MOST_SPECIFIED_SUBDIVISION_ISO_CODE("most_specified_subdivision_iso_code", GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE),
-    MOST_SPECIFIED_SUBDIVISION_CONFIDENCE("most_specified_subdivision_confidence", GeoIPDatabase.ENTERPRISE),
-    LEAST_SPECIFIED_SUBDIVISION_NAME("least_specified_subdivision_name", GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE),
-    LEAST_SPECIFIED_SUBDIVISION_ISO_CODE("least_specified_subdivision_iso_code", GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE),
-    LEAST_SPECIFIED_SUBDIVISION_CONFIDENCE("least_specified_subdivision_confidence", GeoIPDatabase.ENTERPRISE),
+    CONTINENT_CODE("continent_code", EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE)),
+    CONTINENT_NAME("continent_name", EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE)),
+    COUNTRY_NAME("country_name", EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE)),
+    IS_COUNTRY_IN_EUROPEAN_UNION("is_country_in_european_union", EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE)),
+    COUNTRY_ISO_CODE("country_iso_code", EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE)),
+    COUNTRY_CONFIDENCE("country_confidence", EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+    REGISTERED_COUNTRY_NAME("registered_country_name", EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+    REGISTERED_COUNTRY_ISO_CODE("registered_country_iso_code", EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+    REPRESENTED_COUNTRY_NAME("represented_country_name", EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+    REPRESENTED_COUNTRY_ISO_CODE("represented_country_iso_code", EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+    REPRESENTED_COUNTRY_TYPE("represented_country_type", EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+    CITY_NAME("city_name", EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE)),
+    CITY_CONFIDENCE("city_confidence", EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+    LOCATION("location", EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE)),
+    LATITUDE("latitude", EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE)),
+    LONGITUDE("longitude", EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE)),
+    LOCATION_ACCURACY_RADIUS("location_accuracy_radius", EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE)),
+    METRO_CODE("metro_code", EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE)),
+    TIME_ZONE("time_zone", EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE)),
+    POSTAL_CODE("postal_code", EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE)),
+    POSTAL_CODE_CONFIDENCE("postal_code_confidence", EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+    MOST_SPECIFIED_SUBDIVISION_NAME("most_specified_subdivision_name", EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+    MOST_SPECIFIED_SUBDIVISION_ISO_CODE("most_specified_subdivision_iso_code", EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+    MOST_SPECIFIED_SUBDIVISION_CONFIDENCE("most_specified_subdivision_confidence", EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+    LEAST_SPECIFIED_SUBDIVISION_NAME("least_specified_subdivision_name", EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+    LEAST_SPECIFIED_SUBDIVISION_ISO_CODE("least_specified_subdivision_iso_code", EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+    LEAST_SPECIFIED_SUBDIVISION_CONFIDENCE("least_specified_subdivision_confidence", EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+    ASN("asn", EnumSet.of(GeoIPDatabase.ASN)),
+    ASN_ORGANIZATION("asn_organization", EnumSet.of(GeoIPDatabase.ASN)),
+    NETWORK("network", EnumSet.of(GeoIPDatabase.ASN)),
+    IP("ip", EnumSet.of(GeoIPDatabase.ASN));
 
-    ASN("asn", GeoIPDatabase.ASN),
-    ASN_ORGANIZATION("asn_organization", GeoIPDatabase.ASN),
-    NETWORK("network", GeoIPDatabase.ASN),
-    IP("ip", GeoIPDatabase.ASN);
-
-    private final HashSet<GeoIPDatabase> geoIPDatabases;
+    private final Set<GeoIPDatabase> geoIPDatabases;
     private final String fieldName;
 
-    GeoIPField(final String fieldName, final GeoIPDatabase... geoIPDatabases) {
+    GeoIPField(final String fieldName, final EnumSet<GeoIPDatabase> geoIPDatabases) {
         this.fieldName = fieldName;
-        this.geoIPDatabases = new HashSet<>(Arrays.asList(geoIPDatabases));
+        this.geoIPDatabases = geoIPDatabases;
     }
 
     public static GeoIPField findByName(final String name) {
@@ -66,7 +71,20 @@ public enum GeoIPField {
         return fieldName;
     }
 
-    public Set<GeoIPDatabase> getGeoIPDatabases() {
+    Collection<GeoIPDatabase> getGeoIPDatabases() {
         return geoIPDatabases;
+    }
+
+    static Collection<GeoIPDatabase> getGeoIPDatabasesForFields(final Collection<GeoIPField> fields) {
+        if(fields == null)
+            throw new NullPointerException("The fields parameter must be non-null.");
+
+        final EnumSet<GeoIPDatabase> databases = EnumSet.noneOf(GeoIPDatabase.class);
+
+        for (final GeoIPField field : fields) {
+            databases.addAll(field.geoIPDatabases);
+        }
+
+        return databases;
     }
 }

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/AutoCountingDatabaseReader.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/AutoCountingDatabaseReader.java
@@ -12,9 +12,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 class AutoCountingDatabaseReader implements GeoIPDatabaseReader {
@@ -30,7 +30,7 @@ class AutoCountingDatabaseReader implements GeoIPDatabaseReader {
     @Override
     public Map<String, Object> getGeoData(final InetAddress inetAddress,
                                           final List<GeoIPField> fields,
-                                          final Set<GeoIPDatabase> geoIPDatabases) {
+                                          final Collection<GeoIPDatabase> geoIPDatabases) {
         return delegateDatabaseReader.getGeoData(inetAddress, fields, geoIPDatabases);
     }
 

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/GeoIP2DatabaseReader.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/GeoIP2DatabaseReader.java
@@ -32,11 +32,11 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -84,7 +84,7 @@ class GeoIP2DatabaseReader implements GeoIPDatabaseReader, AutoCloseable {
         }
     }
     @Override
-    public Map<String, Object> getGeoData(final InetAddress inetAddress, final List<GeoIPField> fields, final Set<GeoIPDatabase> geoIPDatabases) {
+    public Map<String, Object> getGeoData(final InetAddress inetAddress, final List<GeoIPField> fields, final Collection<GeoIPDatabase> geoIPDatabases) {
         Map<String, Object> geoData = new HashMap<>();
 
         try {

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/GeoLite2DatabaseReader.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/GeoLite2DatabaseReader.java
@@ -34,11 +34,11 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.opensearch.dataprepper.plugins.geoip.extension.MaxMindDatabaseConfig.GEOLITE2_ASN;
@@ -104,7 +104,7 @@ class GeoLite2DatabaseReader implements GeoIPDatabaseReader, AutoCloseable {
     }
 
     @Override
-    public Map<String, Object> getGeoData(final InetAddress inetAddress, final List<GeoIPField> fields, final Set<GeoIPDatabase> geoIPDatabases) {
+    public Map<String, Object> getGeoData(final InetAddress inetAddress, final List<GeoIPField> fields, final Collection<GeoIPDatabase> geoIPDatabases) {
         final Map<String, Object> geoData = new HashMap<>();
 
         try {
@@ -147,7 +147,7 @@ class GeoLite2DatabaseReader implements GeoIPDatabaseReader, AutoCloseable {
     private void processCityResponse(final CityResponse cityResponse,
                                      final Map<String, Object> geoData,
                                      final List<GeoIPField> fields,
-                                     final Set<GeoIPDatabase> geoIPDatabases) {
+                                     final Collection<GeoIPDatabase> geoIPDatabases) {
         // Continent and Country fields are added from City database only if they are not extracted from Country database
         if (!geoIPDatabases.contains(GeoIPDatabase.COUNTRY)) {
             final Continent continent = cityResponse.getContinent();

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/api/GeoIPDatabaseReader.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/api/GeoIPDatabaseReader.java
@@ -19,11 +19,11 @@ import org.opensearch.dataprepper.plugins.geoip.GeoIPField;
 import java.io.File;
 import java.net.InetAddress;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Interface for storing and maintaining MaxMind database readers
@@ -43,7 +43,7 @@ public interface GeoIPDatabaseReader extends AutoCloseable {
      *
      * @since 2.7
      */
-    Map<String, Object> getGeoData(InetAddress inetAddress, List<GeoIPField> fields, Set<GeoIPDatabase> geoIPDatabases);
+    Map<String, Object> getGeoData(InetAddress inetAddress, List<GeoIPField> fields, Collection<GeoIPDatabase> geoIPDatabases);
 
     /**
      * Gets if the database is expired from metadata or last updated timestamp

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/BatchGeoIPDatabaseReader.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/BatchGeoIPDatabaseReader.java
@@ -10,9 +10,9 @@ import org.opensearch.dataprepper.plugins.geoip.GeoIPField;
 import org.opensearch.dataprepper.plugins.geoip.extension.api.GeoIPDatabaseReader;
 
 import java.net.InetAddress;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A {@link GeoIPDatabaseReader} useful for a single batch of processing.
@@ -32,7 +32,7 @@ class BatchGeoIPDatabaseReader implements GeoIPDatabaseReader {
     }
 
     @Override
-    public Map<String, Object> getGeoData(final InetAddress inetAddress, final List<GeoIPField> fields, final Set<GeoIPDatabase> geoIPDatabases) {
+    public Map<String, Object> getGeoData(final InetAddress inetAddress, final List<GeoIPField> fields, final Collection<GeoIPDatabase> geoIPDatabases) {
         return delegate.getGeoData(inetAddress, fields, geoIPDatabases);
     }
 

--- a/data-prepper-plugins/geoip-processor/src/test/java/org/opensearch/dataprepper/plugins/geoip/GeoIPDatabaseTest.java
+++ b/data-prepper-plugins/geoip-processor/src/test/java/org/opensearch/dataprepper/plugins/geoip/GeoIPDatabaseTest.java
@@ -19,41 +19,27 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.opensearch.dataprepper.plugins.geoip.GeoIPDatabase.ASN;
 import static org.opensearch.dataprepper.plugins.geoip.GeoIPDatabase.CITY;
 import static org.opensearch.dataprepper.plugins.geoip.GeoIPDatabase.COUNTRY;
-import static org.opensearch.dataprepper.plugins.geoip.GeoIPDatabase.ENTERPRISE;
+import static org.opensearch.dataprepper.plugins.geoip.GeoIPField.ASN_ORGANIZATION;
+import static org.opensearch.dataprepper.plugins.geoip.GeoIPField.CITY_NAME;
+import static org.opensearch.dataprepper.plugins.geoip.GeoIPField.CONTINENT_CODE;
+import static org.opensearch.dataprepper.plugins.geoip.GeoIPField.COUNTRY_CONFIDENCE;
+import static org.opensearch.dataprepper.plugins.geoip.GeoIPField.LOCATION;
 
 class GeoIPDatabaseTest {
-
     @Test
-    void selectDatabases_throws_NullPointerException_for_null_databases() {
-        assertThrows(NullPointerException.class, () -> GeoIPDatabase.selectDatabases(null));
-    }
-
-    @Test
-    void selectDatabases_returns_empty_for_empty_databases() {
-        assertThat(GeoIPDatabase.selectDatabases(Collections.emptyList()),
-                equalTo(Collections.emptySet()));
-    }
-
-    @ParameterizedTest
-    @EnumSource(GeoIPDatabase.class)
-    void selectDatabases_returns_input_for_single_Database(final GeoIPDatabase database) {
-        assertThat(GeoIPDatabase.selectDatabases(Collections.singleton(database)),
-                equalTo(Collections.singleton(database)));
-    }
-
-    @ParameterizedTest
-    @ArgumentsSource(KnownSelectionsForDatabases.class)
-    void selectDatabases_returns_expected_databases(final Collection<GeoIPDatabase> inputDatabases,
-                                                    final Collection<GeoIPDatabase> expectedSelections) {
-        assertThat(GeoIPDatabase.selectDatabases(inputDatabases),
-                equalTo(expectedSelections));
+    void selectDatabasesForFields_throws_NullPointerException_for_null_databases() {
+        assertThrows(NullPointerException.class, () -> GeoIPDatabase.selectDatabasesForFields(null));
     }
 
     @Test
@@ -62,17 +48,36 @@ class GeoIPDatabaseTest {
                 equalTo(EnumSet.noneOf(GeoIPDatabase.class)));
     }
 
-    static class KnownSelectionsForDatabases implements ArgumentsProvider {
+    @ParameterizedTest
+    @EnumSource(GeoIPField.class)
+    void selectDatabasesForFields_never_returns_both_CITY_and_COUNTRY_for_any_single_field(final GeoIPField geoIPField) {
+        final Collection<GeoIPDatabase> actualSelected = GeoIPDatabase.selectDatabasesForFields(Collections.singleton(geoIPField));
+        assertThat(actualSelected, notNullValue());
+        assertThat(actualSelected, not(empty()));
+        assertThat(actualSelected, not(allOf(hasItem(CITY), hasItem(COUNTRY))));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(KnownSelectedDatabasesForFields.class)
+    void selectDatabasesForFields_returns_empty_for_empty_fields(
+            final Collection<GeoIPField> providedFields,
+            final Collection<GeoIPDatabase> expectedDatabases) {
+        assertThat(GeoIPDatabase.selectDatabasesForFields(providedFields),
+                equalTo(expectedDatabases));
+    }
+
+    static class KnownSelectedDatabasesForFields implements ArgumentsProvider {
         @Override
         public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
             return Stream.of(
-                    arguments(List.of(CITY, ASN), EnumSet.of(CITY, ASN)),
-                    arguments(List.of(CITY, ASN, ENTERPRISE), EnumSet.of(CITY, ASN, ENTERPRISE)),
-                    arguments(List.of(COUNTRY, ASN), EnumSet.of(COUNTRY, ASN)),
-                    arguments(List.of(COUNTRY, ASN, ENTERPRISE), EnumSet.of(COUNTRY, ASN, ENTERPRISE)),
-                    arguments(List.of(CITY, COUNTRY), EnumSet.of(CITY)),
-                    arguments(List.of(COUNTRY, CITY), EnumSet.of(CITY)),
-                    arguments(List.of(COUNTRY, CITY, ASN), EnumSet.of(CITY, ASN))
+                    arguments(List.of(CONTINENT_CODE), EnumSet.of(GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE)),
+                    arguments(List.of(COUNTRY_CONFIDENCE), EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+                    arguments(List.of(LOCATION), EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE)),
+                    arguments(List.of(LOCATION, CONTINENT_CODE), EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE)),
+                    arguments(List.of(ASN_ORGANIZATION), EnumSet.of(GeoIPDatabase.ASN)),
+                    arguments(List.of(ASN_ORGANIZATION, COUNTRY_CONFIDENCE), EnumSet.of(GeoIPDatabase.ASN, GeoIPDatabase.ENTERPRISE)),
+                    arguments(List.of(ASN_ORGANIZATION, CONTINENT_CODE), EnumSet.of(COUNTRY, GeoIPDatabase.ENTERPRISE, GeoIPDatabase.ASN)),
+                    arguments(List.of(ASN_ORGANIZATION, CITY_NAME), EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE, GeoIPDatabase.ASN))
             );
         }
     }

--- a/data-prepper-plugins/geoip-processor/src/test/java/org/opensearch/dataprepper/plugins/geoip/GeoIPDatabaseTest.java
+++ b/data-prepper-plugins/geoip-processor/src/test/java/org/opensearch/dataprepper/plugins/geoip/GeoIPDatabaseTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.geoip;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.opensearch.dataprepper.plugins.geoip.GeoIPDatabase.ASN;
+import static org.opensearch.dataprepper.plugins.geoip.GeoIPDatabase.CITY;
+import static org.opensearch.dataprepper.plugins.geoip.GeoIPDatabase.COUNTRY;
+import static org.opensearch.dataprepper.plugins.geoip.GeoIPDatabase.ENTERPRISE;
+
+class GeoIPDatabaseTest {
+
+    @Test
+    void selectDatabases_throws_NullPointerException_for_null_databases() {
+        assertThrows(NullPointerException.class, () -> GeoIPDatabase.selectDatabases(null));
+    }
+
+    @Test
+    void selectDatabases_returns_empty_for_empty_databases() {
+        assertThat(GeoIPDatabase.selectDatabases(Collections.emptyList()),
+                equalTo(Collections.emptySet()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(GeoIPDatabase.class)
+    void selectDatabases_returns_input_for_single_Database(final GeoIPDatabase database) {
+        assertThat(GeoIPDatabase.selectDatabases(Collections.singleton(database)),
+                equalTo(Collections.singleton(database)));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(KnownSelectionsForDatabases.class)
+    void selectDatabases_returns_expected_databases(final Collection<GeoIPDatabase> inputDatabases,
+                                                    final Collection<GeoIPDatabase> expectedSelections) {
+        assertThat(GeoIPDatabase.selectDatabases(inputDatabases),
+                equalTo(expectedSelections));
+    }
+
+    @Test
+    void selectDatabasesForFields_returns_empty_for_empty_fields() {
+        assertThat(GeoIPDatabase.selectDatabasesForFields(Collections.emptyList()),
+                equalTo(EnumSet.noneOf(GeoIPDatabase.class)));
+    }
+
+    static class KnownSelectionsForDatabases implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return Stream.of(
+                    arguments(List.of(CITY, ASN), EnumSet.of(CITY, ASN)),
+                    arguments(List.of(CITY, ASN, ENTERPRISE), EnumSet.of(CITY, ASN, ENTERPRISE)),
+                    arguments(List.of(COUNTRY, ASN), EnumSet.of(COUNTRY, ASN)),
+                    arguments(List.of(COUNTRY, ASN, ENTERPRISE), EnumSet.of(COUNTRY, ASN, ENTERPRISE)),
+                    arguments(List.of(CITY, COUNTRY), EnumSet.of(CITY)),
+                    arguments(List.of(COUNTRY, CITY), EnumSet.of(CITY)),
+                    arguments(List.of(COUNTRY, CITY, ASN), EnumSet.of(CITY, ASN))
+            );
+        }
+    }
+}

--- a/data-prepper-plugins/geoip-processor/src/test/java/org/opensearch/dataprepper/plugins/geoip/GeoIPFieldTest.java
+++ b/data-prepper-plugins/geoip-processor/src/test/java/org/opensearch/dataprepper/plugins/geoip/GeoIPFieldTest.java
@@ -6,9 +6,28 @@
 package org.opensearch.dataprepper.plugins.geoip;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.opensearch.dataprepper.plugins.geoip.GeoIPField.ASN_ORGANIZATION;
+import static org.opensearch.dataprepper.plugins.geoip.GeoIPField.CONTINENT_CODE;
+import static org.opensearch.dataprepper.plugins.geoip.GeoIPField.COUNTRY_CONFIDENCE;
+import static org.opensearch.dataprepper.plugins.geoip.GeoIPField.LOCATION;
 
 class GeoIPFieldTest {
 
@@ -22,5 +41,41 @@ class GeoIPFieldTest {
     void test_findByName_should_return_null_if_invalid() {
         final GeoIPField geoIPField = GeoIPField.findByName("coordinates");
         assertThat(geoIPField, equalTo(null));
+    }
+
+    @Test
+    void getGeoIPDatabasesForFields_throws_if_given_null_list() {
+        assertThrows(NullPointerException.class, () -> GeoIPField.getGeoIPDatabasesForFields(null));
+    }
+
+    @Test
+    void getGeoIPDatabasesForFields_returns_empty_collection_when_given_empty_collection() {
+        final Collection<GeoIPDatabase> actualDatabases = GeoIPField.getGeoIPDatabasesForFields(Collections.emptyList());
+        assertThat(actualDatabases, notNullValue());
+        assertThat(actualDatabases, empty());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(KnownDatabasesForFields.class)
+    void getGeoIPDatabasesForFields_returns_expected_results(final Collection<GeoIPField> providedFields, final Collection<GeoIPDatabase> expectedDatabases) {
+        final Collection<GeoIPDatabase> actualDatabases = GeoIPField.getGeoIPDatabasesForFields(providedFields);
+        assertThat(actualDatabases, notNullValue());
+        assertThat(actualDatabases.size(), equalTo(expectedDatabases.size()));
+        assertThat(actualDatabases, equalTo(expectedDatabases));
+    }
+
+    static class KnownDatabasesForFields implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return Stream.of(
+                    arguments(List.of(CONTINENT_CODE), EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE)),
+                    arguments(List.of(COUNTRY_CONFIDENCE), EnumSet.of(GeoIPDatabase.ENTERPRISE)),
+                    arguments(List.of(LOCATION), EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.ENTERPRISE)),
+                    arguments(List.of(LOCATION, CONTINENT_CODE), EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE)),
+                    arguments(List.of(ASN_ORGANIZATION), EnumSet.of(GeoIPDatabase.ASN)),
+                    arguments(List.of(ASN_ORGANIZATION, COUNTRY_CONFIDENCE), EnumSet.of(GeoIPDatabase.ASN, GeoIPDatabase.ENTERPRISE)),
+                    arguments(List.of(ASN_ORGANIZATION, CONTINENT_CODE), EnumSet.of(GeoIPDatabase.CITY, GeoIPDatabase.COUNTRY, GeoIPDatabase.ENTERPRISE, GeoIPDatabase.ASN))
+            );
+        }
     }
 }


### PR DESCRIPTION
### Description

The GeoLite2 Country database is a subset of the GeoLite2 City database. Prior to this change, the `geoip` processor was performing a lookup in both databases. These look ups are a substantial part of the processor time.

This PR makes a couple of significant changes.

1. If both city and country fields are needed, then only lookup the data in the city database. This prevents an unnecessary lookup in the country database.
2. If only country fields are needed, then lookup the data only in the country database. This database looks up data faster (presumably because it has less data). 

To accomplish these goals, I refactored the code to move this logic into the `GeoIPDatabase` enum and updated the `GeoIPField` to have the correct database associations.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
