### PR TITLE
Fix the default behavior of geoip such that all fields are included

### DIFF
--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/GeoIPField.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/GeoIPField.java
@@ -74,4 +74,8 @@ public enum GeoIPField {
     Collection<GeoIPDatabase> getGeoIPDatabases() {
         return geoIPDatabases;
     }
+
+    public static Collection<GeoIPField> allFields() {
+        return EnumSet.allOf(GeoIPField.class);
+    }
 }

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/AutoCountingDatabaseReader.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/AutoCountingDatabaseReader.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -29,7 +28,7 @@ class AutoCountingDatabaseReader implements GeoIPDatabaseReader {
 
     @Override
     public Map<String, Object> getGeoData(final InetAddress inetAddress,
-                                          final List<GeoIPField> fields,
+                                          final Collection<GeoIPField> fields,
                                           final Collection<GeoIPDatabase> geoIPDatabases) {
         return delegateDatabaseReader.getGeoData(inetAddress, fields, geoIPDatabases);
     }

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/GeoIP2DatabaseReader.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/GeoIP2DatabaseReader.java
@@ -34,7 +34,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -84,7 +83,7 @@ class GeoIP2DatabaseReader implements GeoIPDatabaseReader, AutoCloseable {
         }
     }
     @Override
-    public Map<String, Object> getGeoData(final InetAddress inetAddress, final List<GeoIPField> fields, final Collection<GeoIPDatabase> geoIPDatabases) {
+    public Map<String, Object> getGeoData(final InetAddress inetAddress, final Collection<GeoIPField> fields, final Collection<GeoIPDatabase> geoIPDatabases) {
         Map<String, Object> geoData = new HashMap<>();
 
         try {
@@ -106,7 +105,7 @@ class GeoIP2DatabaseReader implements GeoIPDatabaseReader, AutoCloseable {
         return geoData;
     }
 
-    private void processEnterpriseResponse(final EnterpriseResponse enterpriseResponse, final Map<String, Object> geoData, final List<GeoIPField> fields) {
+    private void processEnterpriseResponse(final EnterpriseResponse enterpriseResponse, final Map<String, Object> geoData, final Collection<GeoIPField> fields) {
         final Continent continent = enterpriseResponse.getContinent();
         final Country country = enterpriseResponse.getCountry();
         final Country registeredCountry = enterpriseResponse.getRegisteredCountry();
@@ -129,7 +128,7 @@ class GeoIP2DatabaseReader implements GeoIPDatabaseReader, AutoCloseable {
         extractLeastSpecifiedSubdivisionFields(leastSpecificSubdivision, geoData, fields, true);
     }
 
-    private void processAsnResponse(final AsnResponse asnResponse, final Map<String, Object> geoData, final List<GeoIPField> fields) {
+    private void processAsnResponse(final AsnResponse asnResponse, final Map<String, Object> geoData, final Collection<GeoIPField> fields) {
         extractAsnFields(asnResponse, geoData, fields);
     }
 

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/GeoLite2DatabaseReader.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/GeoLite2DatabaseReader.java
@@ -36,7 +36,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -104,7 +103,7 @@ class GeoLite2DatabaseReader implements GeoIPDatabaseReader, AutoCloseable {
     }
 
     @Override
-    public Map<String, Object> getGeoData(final InetAddress inetAddress, final List<GeoIPField> fields, final Collection<GeoIPDatabase> geoIPDatabases) {
+    public Map<String, Object> getGeoData(final InetAddress inetAddress, final Collection<GeoIPField> fields, final Collection<GeoIPDatabase> geoIPDatabases) {
         final Map<String, Object> geoData = new HashMap<>();
 
         try {
@@ -131,7 +130,7 @@ class GeoLite2DatabaseReader implements GeoIPDatabaseReader, AutoCloseable {
         return geoData;
     }
 
-    private void processCountryResponse(final CountryResponse countryResponse, final Map<String, Object> geoData, final List<GeoIPField> fields) {
+    private void processCountryResponse(final CountryResponse countryResponse, final Map<String, Object> geoData, final Collection<GeoIPField> fields) {
         final Continent continent = countryResponse.getContinent();
         final Country country = countryResponse.getCountry();
         final Country registeredCountry = countryResponse.getRegisteredCountry();
@@ -146,7 +145,7 @@ class GeoLite2DatabaseReader implements GeoIPDatabaseReader, AutoCloseable {
 
     private void processCityResponse(final CityResponse cityResponse,
                                      final Map<String, Object> geoData,
-                                     final List<GeoIPField> fields,
+                                     final Collection<GeoIPField> fields,
                                      final Collection<GeoIPDatabase> geoIPDatabases) {
         // Continent and Country fields are added from City database only if they are not extracted from Country database
         if (!geoIPDatabases.contains(GeoIPDatabase.COUNTRY)) {
@@ -174,7 +173,7 @@ class GeoLite2DatabaseReader implements GeoIPDatabaseReader, AutoCloseable {
         extractLeastSpecifiedSubdivisionFields(leastSpecificSubdivision, geoData, fields, false);
     }
 
-    private void processAsnResponse(final AsnResponse asnResponse, final Map<String, Object> geoData, final List<GeoIPField> fields) {
+    private void processAsnResponse(final AsnResponse asnResponse, final Map<String, Object> geoData, final Collection<GeoIPField> fields) {
         extractAsnFields(asnResponse, geoData, fields);
     }
 

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/api/GeoIPDatabaseReader.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/api/GeoIPDatabaseReader.java
@@ -21,7 +21,6 @@ import java.net.InetAddress;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -43,7 +42,7 @@ public interface GeoIPDatabaseReader extends AutoCloseable {
      *
      * @since 2.7
      */
-    Map<String, Object> getGeoData(InetAddress inetAddress, List<GeoIPField> fields, Collection<GeoIPDatabase> geoIPDatabases);
+    Map<String, Object> getGeoData(InetAddress inetAddress, Collection<GeoIPField> fields, Collection<GeoIPDatabase> geoIPDatabases);
 
     /**
      * Gets if the database is expired from metadata or last updated timestamp
@@ -91,7 +90,7 @@ public interface GeoIPDatabaseReader extends AutoCloseable {
 
     default void extractContinentFields(final Continent continent,
                                         final Map<String, Object> geoData,
-                                        final List<GeoIPField> fields) {
+                                        final Collection<GeoIPField> fields) {
         if (!fields.isEmpty()) {
             for (final GeoIPField field : fields) {
                 switch (field) {
@@ -112,7 +111,7 @@ public interface GeoIPDatabaseReader extends AutoCloseable {
 
     default void extractCountryFields(final Country country,
                                       final Map<String, Object> geoData,
-                                      final List<GeoIPField> fields,
+                                      final Collection<GeoIPField> fields,
                                       final boolean isEnterpriseDatabase) {
         if (!fields.isEmpty()) {
             for (final GeoIPField field : fields) {
@@ -144,7 +143,7 @@ public interface GeoIPDatabaseReader extends AutoCloseable {
 
     default void extractRegisteredCountryFields(final Country registeredCountry,
                                                 final Map<String, Object> geoData,
-                                                final List<GeoIPField> fields) {
+                                                final Collection<GeoIPField> fields) {
         if (!fields.isEmpty()) {
             for (final GeoIPField field : fields) {
                 switch (field) {
@@ -165,7 +164,7 @@ public interface GeoIPDatabaseReader extends AutoCloseable {
 
     default void extractRepresentedCountryFields(final RepresentedCountry representedCountry,
                                                      final Map<String, Object> geoData,
-                                                     final List<GeoIPField> fields) {
+                                                     final Collection<GeoIPField> fields) {
         if (!fields.isEmpty()) {
             for (final GeoIPField field : fields) {
                 switch (field) {
@@ -190,7 +189,7 @@ public interface GeoIPDatabaseReader extends AutoCloseable {
 
     default void extractCityFields(final City city,
                                    final Map<String, Object> geoData,
-                                   final List<GeoIPField> fields,
+                                   final Collection<GeoIPField> fields,
                                    final boolean isEnterpriseDatabase) {
         if (!fields.isEmpty()) {
             for (final GeoIPField field : fields) {
@@ -209,7 +208,7 @@ public interface GeoIPDatabaseReader extends AutoCloseable {
 
     default void extractLocationFields(final Location location,
                                        final Map<String, Object> geoData,
-                                       final List<GeoIPField> fields) {
+                                       final Collection<GeoIPField> fields) {
         final Map<String, Object> locationObject = new HashMap<>();
         locationObject.put(LAT, location.getLatitude());
         locationObject.put(LON, location.getLongitude());
@@ -248,7 +247,7 @@ public interface GeoIPDatabaseReader extends AutoCloseable {
 
     default void extractPostalFields(final Postal postal,
                                                     final Map<String, Object> geoData,
-                                                    final List<GeoIPField> fields,
+                                                    final Collection<GeoIPField> fields,
                                                     final boolean isEnterpriseDatabase) {
         if (!fields.isEmpty()) {
             for (final GeoIPField field : fields) {
@@ -267,7 +266,7 @@ public interface GeoIPDatabaseReader extends AutoCloseable {
 
     default void extractMostSpecifiedSubdivisionFields(final Subdivision subdivision,
                                                          final Map<String, Object> geoData,
-                                                         final List<GeoIPField> fields,
+                                                         final Collection<GeoIPField> fields,
                                                          final boolean isEnterpriseDatabase) {
         if (!fields.isEmpty()) {
             for (final GeoIPField field : fields) {
@@ -295,7 +294,7 @@ public interface GeoIPDatabaseReader extends AutoCloseable {
 
     default void extractLeastSpecifiedSubdivisionFields(final Subdivision subdivision,
                                           final Map<String, Object> geoData,
-                                          final List<GeoIPField> fields,
+                                          final Collection<GeoIPField> fields,
                                           final boolean isEnterpriseDatabase) {
         if (!fields.isEmpty()) {
             for (final GeoIPField field : fields) {
@@ -323,7 +322,7 @@ public interface GeoIPDatabaseReader extends AutoCloseable {
 
     default void extractAsnFields(final AsnResponse asnResponse,
                                   final Map<String, Object> geoData,
-                                  final List<GeoIPField> fields) {
+                                  final Collection<GeoIPField> fields) {
         if (!fields.isEmpty()) {
             for (final GeoIPField field : fields) {
                 switch (field) {

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/BatchGeoIPDatabaseReader.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/BatchGeoIPDatabaseReader.java
@@ -11,7 +11,6 @@ import org.opensearch.dataprepper.plugins.geoip.extension.api.GeoIPDatabaseReade
 
 import java.net.InetAddress;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -32,7 +31,7 @@ class BatchGeoIPDatabaseReader implements GeoIPDatabaseReader {
     }
 
     @Override
-    public Map<String, Object> getGeoData(final InetAddress inetAddress, final List<GeoIPField> fields, final Collection<GeoIPDatabase> geoIPDatabases) {
+    public Map<String, Object> getGeoData(final InetAddress inetAddress, final Collection<GeoIPField> fields, final Collection<GeoIPDatabase> geoIPDatabases) {
         return delegate.getGeoData(inetAddress, fields, geoIPDatabases);
     }
 

--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/EntryConfig.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/EntryConfig.java
@@ -8,7 +8,10 @@ package org.opensearch.dataprepper.plugins.geoip.processor;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
+import org.opensearch.dataprepper.plugins.geoip.GeoIPField;
 
+import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 
 public class EntryConfig {
@@ -34,11 +37,11 @@ public class EntryConfig {
         return target;
     }
 
-    public List<String> getIncludeFields() {
+    List<String> getIncludeFields() {
         return includeFields;
     }
 
-    public List<String> getExcludeFields() {
+    List<String> getExcludeFields() {
         return excludeFields;
     }
 
@@ -48,5 +51,35 @@ public class EntryConfig {
             return false;
         }
         return includeFields == null || excludeFields == null;
+    }
+
+    /**
+     * Gets the desired {@link GeoIPField} based on the configuration.
+     * @return A collection of {@link GeoIPField}
+     */
+    public Collection<GeoIPField> getGeoIPFields() {
+
+        if (includeFields != null && !includeFields.isEmpty()) {
+            final EnumSet<GeoIPField> geoIPFields = EnumSet.noneOf(GeoIPField.class);
+            for (final String field : includeFields) {
+                final GeoIPField geoIPField = GeoIPField.findByName(field);
+                if (geoIPField != null) {
+                    geoIPFields.add(geoIPField);
+                }
+            }
+            return geoIPFields;
+        } else if (excludeFields != null) {
+            final EnumSet<GeoIPField> geoIPFields = EnumSet.allOf(GeoIPField.class);
+            for (final String field : excludeFields) {
+                final GeoIPField geoIPField = GeoIPField.findByName(field);
+                if (geoIPField != null) {
+                    geoIPFields.remove(geoIPField);
+                }
+            }
+            return geoIPFields;
+        }
+
+        return GeoIPField.allFields();
+
     }
 }

--- a/data-prepper-plugins/geoip-processor/src/test/java/org/opensearch/dataprepper/plugins/geoip/GeoIPFieldTest.java
+++ b/data-prepper-plugins/geoip-processor/src/test/java/org/opensearch/dataprepper/plugins/geoip/GeoIPFieldTest.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.stream.Stream;
 
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -67,5 +68,14 @@ class GeoIPFieldTest {
                     arguments(ASN_ORGANIZATION, EnumSet.of(GeoIPDatabase.ASN))
             );
         }
+    }
+
+    @ParameterizedTest
+    @EnumSource(GeoIPField.class)
+    void allFields_includes_each_enum_value(final GeoIPField geoIPField) {
+        final Collection<GeoIPField> allFields = GeoIPField.allFields();
+        assertThat(allFields, notNullValue());
+        assertThat(allFields.size(), equalTo(GeoIPField.values().length));
+        assertThat(allFields, hasItem(geoIPField));
     }
 }


### PR DESCRIPTION
### Description

This PR fixes a bug where the default fields was not the entire set of GeoIP fields available in the databases. With this change, all available fields are used by default. This PR also includes some refactoring to prefer `Collection` over `List`.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
