### PR TITLE
Send acknowledgements to source when events are forwarded to remote peer

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/Buffer.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/Buffer.java
@@ -84,6 +84,15 @@ public interface Buffer<T extends Record<?>> {
     }
 
     /**
+     * Checks if the buffer enables acknowledgements for the pipeline
+     *
+     * @return true if the buffer supports raw bytes, false otherwise
+     */
+    default boolean areAcknowledgementsEnabled() {
+        return false;
+    }
+
+    /**
      * Returns buffer's drain timeout as duration
      *
      * @return buffers drain timeout

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/DelegatingBuffer.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/buffer/DelegatingBuffer.java
@@ -74,6 +74,11 @@ public abstract class DelegatingBuffer<T extends Record<?>> implements Buffer<T>
     }
 
     @Override
+    public boolean areAcknowledgementsEnabled() {
+        return delegateBuffer.areAcknowledgementsEnabled();
+    }
+
+    @Override
     public Duration getDrainTimeout() {
         return delegateBuffer.getDrainTimeout();
     }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/BufferTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/BufferTest.java
@@ -41,6 +41,7 @@ class BufferTest {
         final Buffer<Record<Event>> buffer = createObjectUnderTest();
 
         assertEquals(false, buffer.isByteBuffer());
+        assertEquals(false, buffer.areAcknowledgementsEnabled());
     }
 
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/DelegatingBufferTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/buffer/DelegatingBufferTest.java
@@ -184,6 +184,15 @@ class DelegatingBufferTest {
                 equalTo(isByteBuffer));
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void areAcksEnabled_returns_inner_areAcksEnabled(final boolean ackEnabled) {
+        when(innerBuffer.areAcknowledgementsEnabled()).thenReturn(ackEnabled);
+
+        assertThat(createObjectUnderTest().areAcknowledgementsEnabled(),
+                equalTo(ackEnabled));
+    }
+
     @Test
     void getDrainTimeout_returns_inner_getDrainTimeout() {
         final Duration drainTimeout = Duration.ofSeconds(random.nextInt(10_000) + 100);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineTransformer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineTransformer.java
@@ -59,7 +59,6 @@ public class PipelineTransformer {
     private final EventFactory eventFactory;
     private final AcknowledgementSetManager acknowledgementSetManager;
     private final SourceCoordinatorFactory sourceCoordinatorFactory;
-    private boolean acknowledgementsEnabled;
 
     public PipelineTransformer(final PipelinesDataFlowModel pipelinesDataFlowModel,
                                final PluginFactory pluginFactory,
@@ -79,7 +78,6 @@ public class PipelineTransformer {
         this.eventFactory = eventFactory;
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.sourceCoordinatorFactory = sourceCoordinatorFactory;
-        this.acknowledgementsEnabled = false;
     }
 
     public Map<String, Pipeline> transformConfiguration() {
@@ -119,11 +117,6 @@ public class PipelineTransformer {
             LOG.info("Building buffer for the pipeline [{}]", pipelineName);
             final Buffer pipelineDefinedBuffer = pluginFactory.loadPlugin(Buffer.class, pipelineConfiguration.getBufferPluginSetting(), source.getDecoder());
 
-            // If any buffer in the pipeline has acknowledgements enabled, then entire pipeline will have
-            // acknowledgements enabled. Usually, only the first pipeline's buffer can have acknowledgements enabled
-            // resulting in entire pipeline to be ack enabled
-            if (pipelineDefinedBuffer.areAcknowledgementsEnabled())
-                acknowledgementsEnabled = true;
             LOG.info("Building processors for the pipeline [{}]", pipelineName);
             final int processorThreads = pipelineConfiguration.getWorkers();
 
@@ -210,7 +203,7 @@ public class PipelineTransformer {
             Pipeline sourcePipeline = pipelineMap.get(connectedPipeline);
             final PipelineConnector pipelineConnector = sourceConnectorMap.get(sourcePipelineName);
             pipelineConnector.setSourcePipelineName(pipelineNameOptional.get());
-            if (sourcePipeline.getSource().areAcknowledgementsEnabled() || acknowledgementsEnabled) {
+            if (sourcePipeline.getSource().areAcknowledgementsEnabled() || sourcePipeline.getBuffer().areAcknowledgementsEnabled()) {
                 pipelineConnector.enableAcknowledgements();
             }
             return Optional.of(pipelineConnector);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineTransformer.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/parser/PipelineTransformer.java
@@ -119,7 +119,10 @@ public class PipelineTransformer {
             LOG.info("Building buffer for the pipeline [{}]", pipelineName);
             final Buffer pipelineDefinedBuffer = pluginFactory.loadPlugin(Buffer.class, pipelineConfiguration.getBufferPluginSetting(), source.getDecoder());
 
-            if (pipelineDefinedBuffer.isByteBuffer())
+            // If any buffer in the pipeline has acknowledgements enabled, then entire pipeline will have
+            // acknowledgements enabled. Usually, only the first pipeline's buffer can have acknowledgements enabled
+            // resulting in entire pipeline to be ack enabled
+            if (pipelineDefinedBuffer.areAcknowledgementsEnabled())
                 acknowledgementsEnabled = true;
             LOG.info("Building processors for the pipeline [{}]", pipelineName);
             final int processorThreads = pipelineConfiguration.getWorkers();

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/RemotePeerForwarder.java
@@ -266,6 +266,10 @@ class RemotePeerForwarder implements PeerForwarder {
                 final CompletableFuture<AggregatedHttpResponse> responseFuture =
                         peerForwarderClient.serializeRecordsAndSendHttpRequest(recordsToForward, destinationIp, pluginId, pipelineName);
                 forwardingRequestsMap.put(responseFuture, recordsToForward);
+                for (Record<Event> record: recordsToForward) {
+                    Event event = record.getData();
+                    event.getEventHandle().release(true);
+                }
             } catch (final Exception e) {
                 LOG.warn("Unable to submit request for forwarding, processing locally.", e);
                 processFailedRequestsLocally(null, recordsToForward);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/Pipeline.java
@@ -339,7 +339,7 @@ public class Pipeline {
 
         final RouterGetRecordStrategy getRecordStrategy =
                 new RouterCopyRecordStrategy(eventFactory,
-                (source.areAcknowledgementsEnabled() || buffer.isByteBuffer()) ?
+                (source.areAcknowledgementsEnabled() || buffer.areAcknowledgementsEnabled()) ?
                     acknowledgementSetManager :
                     InactiveAcknowledgementSetManager.getInstance(),
                 sinks);

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/ProcessWorker.java
@@ -50,7 +50,7 @@ public class ProcessWorker implements Runnable {
         this.pipeline = pipeline;
         this.pluginMetrics = PluginMetrics.fromNames("ProcessWorker", pipeline.getName());
         this.invalidEventHandlesCounter = pluginMetrics.counter(INVALID_EVENT_HANDLES);
-        this.acknowledgementsEnabled = pipeline.getSource().areAcknowledgementsEnabled();
+        this.acknowledgementsEnabled = pipeline.getSource().areAcknowledgementsEnabled() || readBuffer.isByteBuffer();
     }
 
     @Override

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/ProcessWorker.java
@@ -50,7 +50,7 @@ public class ProcessWorker implements Runnable {
         this.pipeline = pipeline;
         this.pluginMetrics = PluginMetrics.fromNames("ProcessWorker", pipeline.getName());
         this.invalidEventHandlesCounter = pluginMetrics.counter(INVALID_EVENT_HANDLES);
-        this.acknowledgementsEnabled = pipeline.getSource().areAcknowledgementsEnabled() || readBuffer.isByteBuffer();
+        this.acknowledgementsEnabled = pipeline.getSource().areAcknowledgementsEnabled() || readBuffer.areAcknowledgementsEnabled();
     }
 
     @Override

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
@@ -13,6 +13,7 @@ public class TestDataProvider {
     public static final String VALID_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/valid_multiple_pipeline_configuration.yml";
     public static final String VALID_SINGLE_PIPELINE_EMPTY_SOURCE_PLUGIN_FILE = "src/test/resources/single_pipeline_valid_empty_source_plugin_settings.yml";
     public static final String VALID_OFF_HEAP_FILE = "src/test/resources/single_pipeline_valid_off_heap_buffer.yml";
+    public static final String VALID_OFF_HEAP_FILE_WITH_ACKS = "src/test/resources/multiple_pipeline_valid_off_heap_buffer_with_acks.yml";
     public static final String CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT = "src/test/resources/connected_pipeline_incorrect_root_source.yml";
     public static final String CONNECTED_PIPELINE_CHILD_PIPELINE_INCORRECT = "src/test/resources/connected_pipeline_incorrect_child_pipeline.yml";
     public static final String CYCLE_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/cyclic_multiple_pipeline_configuration.yml";

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/TestDataProvider.java
@@ -14,6 +14,7 @@ public class TestDataProvider {
     public static final String VALID_SINGLE_PIPELINE_EMPTY_SOURCE_PLUGIN_FILE = "src/test/resources/single_pipeline_valid_empty_source_plugin_settings.yml";
     public static final String VALID_OFF_HEAP_FILE = "src/test/resources/single_pipeline_valid_off_heap_buffer.yml";
     public static final String VALID_OFF_HEAP_FILE_WITH_ACKS = "src/test/resources/multiple_pipeline_valid_off_heap_buffer_with_acks.yml";
+    public static final String DISCONNECTED_VALID_OFF_HEAP_FILE_WITH_ACKS = "src/test/resources/multiple_disconnected_pipeline_valid_off_heap_buffer_with_acks.yml";
     public static final String CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT = "src/test/resources/connected_pipeline_incorrect_root_source.yml";
     public static final String CONNECTED_PIPELINE_CHILD_PIPELINE_INCORRECT = "src/test/resources/connected_pipeline_incorrect_child_pipeline.yml";
     public static final String CYCLE_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/cyclic_multiple_pipeline_configuration.yml";

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/CircuitBreakingBufferTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/CircuitBreakingBufferTest.java
@@ -90,6 +90,14 @@ class CircuitBreakingBufferTest {
         assertThat(createObjectUnderTest().isByteBuffer(), equalTo(innerIsByteBuffer));
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void areAcknowledgementsEnabled_returns_value_of_inner_buffer(boolean ackEnabled) {
+        when(buffer.areAcknowledgementsEnabled()).thenReturn(ackEnabled);
+
+        assertThat(createObjectUnderTest().areAcknowledgementsEnabled(), equalTo(ackEnabled));
+    }
+
     @Nested
     class NoCircuitBreakerChecks {
         @AfterEach

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineTransformerTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineTransformerTests.java
@@ -136,6 +136,31 @@ class PipelineTransformerTests {
     }
 
     @Test
+    void parseConfiguration_with_multiple_valid_pipelines_creates_the_correct_pipelineMap_with_acks() {
+        mockDataPrepperConfigurationAccesses();
+        final PipelineTransformer pipelineTransformer =
+                createObjectUnderTest(TestDataProvider.VALID_OFF_HEAP_FILE_WITH_ACKS);
+        final Map<String, Pipeline> actualPipelineMap = pipelineTransformer.transformConfiguration();
+        assertThat(actualPipelineMap.keySet(), equalTo(TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES));
+        verifyDataPrepperConfigurationAccesses(actualPipelineMap.keySet().size());
+        verify(dataPrepperConfiguration).getPipelineExtensions();
+
+        assertThat(actualPipelineMap, hasKey("test-pipeline-1"));
+        assertThat(actualPipelineMap, hasKey("test-pipeline-2"));
+        assertThat(actualPipelineMap, hasKey("test-pipeline-3"));
+        Pipeline pipeline = actualPipelineMap.get("test-pipeline-1");
+        assertThat(pipeline, notNullValue());
+        assertThat(pipeline.getBuffer(), CoreMatchers.not(instanceOf(CircuitBreakingBuffer.class)));
+        assertThat(pipeline.getBuffer().areAcknowledgementsEnabled(),equalTo(true));
+        pipeline = actualPipelineMap.get("test-pipeline-2");
+        assertThat(pipeline, notNullValue());
+        assertThat(pipeline.getSource().areAcknowledgementsEnabled(),equalTo(true));
+        pipeline = actualPipelineMap.get("test-pipeline-3");
+        assertThat(pipeline, notNullValue());
+        assertThat(pipeline.getSource().areAcknowledgementsEnabled(),equalTo(true));
+    }
+
+    @Test
     void parseConfiguration_with_invalid_root_pipeline_creates_empty_pipelinesMap() {
         final PipelineTransformer pipelineTransformer =
                 createObjectUnderTest(TestDataProvider.CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineTransformerTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/parser/PipelineTransformerTests.java
@@ -161,6 +161,32 @@ class PipelineTransformerTests {
     }
 
     @Test
+    void parseConfiguration_with_multiple_disconnected_valid_pipelines_creates_the_correct_pipelineMap_with_acks() {
+        mockDataPrepperConfigurationAccesses();
+        final PipelineTransformer pipelineTransformer =
+                createObjectUnderTest(TestDataProvider.DISCONNECTED_VALID_OFF_HEAP_FILE_WITH_ACKS);
+        final Map<String, Pipeline> actualPipelineMap = pipelineTransformer.transformConfiguration();
+        assertThat(actualPipelineMap.keySet(), equalTo(TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES));
+        verifyDataPrepperConfigurationAccesses(actualPipelineMap.keySet().size());
+        verify(dataPrepperConfiguration).getPipelineExtensions();
+
+        assertThat(actualPipelineMap, hasKey("test-pipeline-1"));
+        assertThat(actualPipelineMap, hasKey("test-pipeline-2"));
+        assertThat(actualPipelineMap, hasKey("test-pipeline-3"));
+        Pipeline pipeline = actualPipelineMap.get("test-pipeline-1");
+        assertThat(pipeline, notNullValue());
+        assertThat(pipeline.getBuffer(), CoreMatchers.not(instanceOf(CircuitBreakingBuffer.class)));
+        assertThat(pipeline.getBuffer().areAcknowledgementsEnabled(),equalTo(true));
+        pipeline = actualPipelineMap.get("test-pipeline-2");
+        assertThat(pipeline, notNullValue());
+        assertThat(pipeline.getSource().areAcknowledgementsEnabled(),equalTo(true));
+        pipeline = actualPipelineMap.get("test-pipeline-3");
+        assertThat(pipeline, notNullValue());
+        assertThat(pipeline.getSource().areAcknowledgementsEnabled(),equalTo(false));
+    }
+
+
+    @Test
     void parseConfiguration_with_invalid_root_pipeline_creates_empty_pipelinesMap() {
         final PipelineTransformer pipelineTransformer =
                 createObjectUnderTest(TestDataProvider.CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugins/TestOffHeapBuffer.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/plugins/TestOffHeapBuffer.java
@@ -42,6 +42,11 @@ public class TestOffHeapBuffer implements Buffer {
     }
 
     @Override
+    public boolean areAcknowledgementsEnabled() {
+        return true;
+    }
+
+    @Override
     public boolean isEmpty() {
         return false;
     }

--- a/data-prepper-core/src/test/resources/multiple_disconnected_pipeline_valid_off_heap_buffer_with_acks.yml
+++ b/data-prepper-core/src/test/resources/multiple_disconnected_pipeline_valid_off_heap_buffer_with_acks.yml
@@ -1,0 +1,25 @@
+# this configuration file is solely for testing formatting
+test-pipeline-1:
+  source:
+    file:
+      path: "/tmp/file-source.tmp"
+  buffer:
+    test_off_heap: 
+  sink:
+    - pipeline:
+       name: "test-pipeline-2"
+test-pipeline-2:
+  source:
+    pipeline:
+      name: "test-pipeline-1"
+  sink:
+    - file:
+       path: "/tmp/todelete2.txt"
+test-pipeline-3:
+  source:
+    file:
+      path: "/tmp/file-source2.tmp"
+  sink:
+    - file:
+       path: "/tmp/todelete.txt"
+

--- a/data-prepper-core/src/test/resources/multiple_pipeline_valid_off_heap_buffer_with_acks.yml
+++ b/data-prepper-core/src/test/resources/multiple_pipeline_valid_off_heap_buffer_with_acks.yml
@@ -1,0 +1,24 @@
+# this configuration file is solely for testing formatting
+test-pipeline-1:
+  source:
+    file:
+      path: "/tmp/file-source.tmp"
+  buffer:
+    test_off_heap: 
+  sink:
+    - pipeline:
+       name: "test-pipeline-2"
+test-pipeline-2:
+  source:
+    pipeline:
+      name: "test-pipeline-1"
+  sink:
+    - pipeline:
+       name: "test-pipeline-3"
+test-pipeline-3:
+  source:
+    pipeline:
+      name: "test-pipeline-2"
+  sink:
+    - file:
+       path: "/tmp/todelete.txt"

--- a/data-prepper-plugins/aggregate-processor/README.md
+++ b/data-prepper-plugins/aggregate-processor/README.md
@@ -51,8 +51,8 @@ While not necessary, a great way to set up the Aggregate Processor [identificati
 ### <a name="when"></a>
 * `when` (Optional): A `String` that represents a condition that must be evaluated to true for the aggregation to be applied on the event. Events that do not evaluate to true on the condition are skipped. Default is no condition which means all events are included in the aggregation.
 
-### <a name="local_only"></a>
-* `local_only` (Optional): A `Boolean` indicating if the aggregation should be done local to node instead of forwarding to remote peers.
+### <a name="local_mode"></a>
+* `local_mode` (Optional): A `Boolean` indicating if the aggregation should be done local to node instead of forwarding to remote peers.
 
 ## Available Aggregate Actions
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer.java
@@ -131,6 +131,11 @@ public class KafkaBuffer extends AbstractBuffer<Record<Event>> {
     }
 
     @Override
+    public boolean areAcknowledgementsEnabled() {
+        return true;
+    }
+
+    @Override
     public void doWriteAll(Collection<Record<Event>> records, int timeoutInMillis) throws Exception {
         for (Record<Event> record : records) {
             doWrite(record, timeoutInMillis);


### PR DESCRIPTION
### Description
Send acknowledgements to source when events are forwarded to remote peer
Also, propagate the acknowledgements enabled flag in pipeline correctly when ByteBuffer is used.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
