### PR TITLE
Provide a config option to do node local aggregation

### DIFF
--- a/data-prepper-plugins/aggregate-processor/README.md
+++ b/data-prepper-plugins/aggregate-processor/README.md
@@ -51,6 +51,9 @@ While not necessary, a great way to set up the Aggregate Processor [identificati
 ### <a name="when"></a>
 * `when` (Optional): A `String` that represents a condition that must be evaluated to true for the aggregation to be applied on the event. Events that do not evaluate to true on the condition are skipped. Default is no condition which means all events are included in the aggregation.
 
+### <a name="local_only"></a>
+* `local_only` (Optional): A `Boolean` indicating if the aggregation should be done local to node instead of forwarding to remote peers.
+
 ## Available Aggregate Actions
 
 ### <a name="remove_duplicates"></a>

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -46,7 +46,7 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
     private final AggregateAction aggregateAction;
 
     private boolean forceConclude = false;
-    private boolean localOnly = false;
+    private boolean localMode = false;
     private final String whenCondition;
     private final ExpressionEvaluator expressionEvaluator;
 
@@ -70,7 +70,7 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
         this.actionHandleEventsOutCounter = pluginMetrics.counter(ACTION_HANDLE_EVENTS_OUT);
         this.actionHandleEventsDroppedCounter = pluginMetrics.counter(ACTION_HANDLE_EVENTS_DROPPED);
         this.whenCondition = aggregateProcessorConfig.getWhenCondition();
-        this.localOnly = aggregateProcessorConfig.getLocalOnly();
+        this.localMode = aggregateProcessorConfig.getLocalMode();
 
         pluginMetrics.gauge(CURRENT_AGGREGATE_GROUPS, aggregateGroupManager, AggregateGroupManager::getAllGroupsSize);
     }
@@ -155,7 +155,7 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
         if (whenCondition == null) {
             return true;
         }
-        if (localOnly) {
+        if (localMode) {
             return false;
         }
         return expressionEvaluator.evaluateConditional(whenCondition, event);

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -46,6 +46,7 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
     private final AggregateAction aggregateAction;
 
     private boolean forceConclude = false;
+    private boolean localOnly = false;
     private final String whenCondition;
     private final ExpressionEvaluator expressionEvaluator;
 
@@ -69,6 +70,7 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
         this.actionHandleEventsOutCounter = pluginMetrics.counter(ACTION_HANDLE_EVENTS_OUT);
         this.actionHandleEventsDroppedCounter = pluginMetrics.counter(ACTION_HANDLE_EVENTS_DROPPED);
         this.whenCondition = aggregateProcessorConfig.getWhenCondition();
+        this.localOnly = aggregateProcessorConfig.getLocalOnly();
 
         pluginMetrics.gauge(CURRENT_AGGREGATE_GROUPS, aggregateGroupManager, AggregateGroupManager::getAllGroupsSize);
     }
@@ -152,6 +154,9 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
     public boolean isApplicableEventForPeerForwarding(Event event) {
         if (whenCondition == null) {
             return true;
+        }
+        if (localOnly) {
+            return false;
         }
         return expressionEvaluator.evaluateConditional(whenCondition, event);
     }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
@@ -28,6 +28,10 @@ public class AggregateProcessorConfig {
     @NotNull
     private PluginModel aggregateAction;
 
+    @JsonProperty("local_only")
+    @NotNull
+    private Boolean localOnly = false;
+
     @JsonProperty("aggregate_when")
     private String whenCondition;
 
@@ -41,6 +45,10 @@ public class AggregateProcessorConfig {
 
     public String getWhenCondition() {
         return whenCondition;
+    }
+
+    public Boolean getLocalOnly() {
+        return localOnly;
     }
 
     public PluginModel getAggregateAction() { return aggregateAction; }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
@@ -28,9 +28,9 @@ public class AggregateProcessorConfig {
     @NotNull
     private PluginModel aggregateAction;
 
-    @JsonProperty("local_only")
+    @JsonProperty("local_mode")
     @NotNull
-    private Boolean localOnly = false;
+    private Boolean localMode = false;
 
     @JsonProperty("aggregate_when")
     private String whenCondition;
@@ -47,8 +47,8 @@ public class AggregateProcessorConfig {
         return whenCondition;
     }
 
-    public Boolean getLocalOnly() {
-        return localOnly;
+    public Boolean getLocalMode() {
+        return localMode;
     }
 
     public PluginModel getAggregateAction() { return aggregateAction; }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfigTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfigTest.java
@@ -18,6 +18,6 @@ public class AggregateProcessorConfigTest {
         final AggregateProcessorConfig aggregateConfig = new AggregateProcessorConfig();
 
         assertThat(aggregateConfig.getGroupDuration(), equalTo(Duration.ofSeconds(AggregateProcessorConfig.DEFAULT_GROUP_DURATION_SECONDS)));
-        assertThat(aggregateConfig.getLocalOnly(), equalTo(false));
+        assertThat(aggregateConfig.getLocalMode(), equalTo(false));
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfigTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfigTest.java
@@ -18,5 +18,6 @@ public class AggregateProcessorConfigTest {
         final AggregateProcessorConfig aggregateConfig = new AggregateProcessorConfig();
 
         assertThat(aggregateConfig.getGroupDuration(), equalTo(Duration.ofSeconds(AggregateProcessorConfig.DEFAULT_GROUP_DURATION_SECONDS)));
+        assertThat(aggregateConfig.getLocalOnly(), equalTo(false));
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -122,7 +122,7 @@ public class AggregateProcessorTest {
     @BeforeEach
     void setUp() {
         when(aggregateProcessorConfig.getAggregateAction()).thenReturn(actionConfiguration);
-        when(aggregateProcessorConfig.getLocalOnly()).thenReturn(false);
+        when(aggregateProcessorConfig.getLocalMode()).thenReturn(false);
         when(actionConfiguration.getPluginName()).thenReturn(UUID.randomUUID().toString());
         when(actionConfiguration.getPluginSettings()).thenReturn(Collections.emptyMap());
         when(pluginFactory.loadPlugin(eq(AggregateAction.class), any(PluginSetting.class)))
@@ -280,7 +280,7 @@ public class AggregateProcessorTest {
             when(expressionEvaluator.evaluateConditional(condition, firstEvent)).thenReturn(true);
             when(expressionEvaluator.evaluateConditional(condition, secondEvent)).thenReturn(false);
             when(aggregateProcessorConfig.getWhenCondition()).thenReturn(condition);
-            when(aggregateProcessorConfig.getLocalOnly()).thenReturn(true);
+            when(aggregateProcessorConfig.getLocalMode()).thenReturn(true);
             final AggregateProcessor objectUnderTest = createObjectUnderTest();
             when(aggregateGroupManager.getGroupsToConclude(eq(false))).thenReturn(Collections.emptyList());
             when(aggregateActionResponse.getEvent()).thenReturn(event);


### PR DESCRIPTION
### Description
Provide a config option to do node local aggregation

Added new `local_only` config option to `aggregate` processor to do local aggregation. No events are forwarded to remote peers when this option is used.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
