### PR TITLE
Adds a new tags_on_no_valid_ip configuration to geoip

### DIFF
--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/GeoIPProcessorConfig.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/GeoIPProcessorConfig.java
@@ -29,6 +29,9 @@ public class GeoIPProcessorConfig {
     @JsonProperty("tags_on_ip_not_found")
     private List<String> tagsOnIPNotFound;
 
+    @JsonProperty("tags_on_no_valid_ip")
+    private List<String> tagsOnNoValidIp;
+
     @JsonProperty("geoip_when")
     private String whenCondition;
 
@@ -49,11 +52,19 @@ public class GeoIPProcessorConfig {
     }
 
     /**
-     * Get the List of invalid IP / IP not found in database tags
-     * @return List of invalid IP / IP not found in database tags
+     * Get the List of IP not found in database tags
+     * @return List of IP not found in database tags
      */
     public List<String> getTagsOnIPNotFound() {
         return tagsOnIPNotFound;
+    }
+
+    /**
+     * Gets the list of tags to apply when a field is not a valid IP address.
+     * @return List of tags
+     */
+    public List<String> getTagsOnNoValidIp() {
+        return tagsOnNoValidIp;
     }
 
     /**


### PR DESCRIPTION
### Description

This PR changes the behavior of `tags_on_ip_not_found`. This configuration now only tags when the source has an IP address, but it is not found in the database.

It also adds the `tags_on_no_valid_ip` configuration. This will tag events that do not have any IP address at all.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
