### PR TITLE
Resolves transitive dependencies for 2.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,6 +146,12 @@ subprojects {
                 }
                 because 'the build fails if the Log4j API is not update along with log4j-core'
             }
+            implementation('org.apache.zookeeper:zookeeper') {
+                version {
+                    require '3.8.4'
+                }
+                because 'Fixes CVE-2024-23944, CVE-2023-44981'
+            }
             implementation('com.google.code.gson:gson') {
                 version {
                     require '2.8.9'

--- a/build.gradle
+++ b/build.gradle
@@ -146,12 +146,6 @@ subprojects {
                 }
                 because 'the build fails if the Log4j API is not update along with log4j-core'
             }
-            implementation('org.apache.zookeeper:zookeeper') {
-                version {
-                    require '3.7.2'
-                }
-                because 'Fixes CVE-2023-44981'
-            }
             implementation('com.google.code.gson:gson') {
                 version {
                     require '2.8.9'
@@ -223,12 +217,6 @@ subprojects {
                     require '2.9.0'
                 }
                 because 'Fixes CVE-2023-51074 from transitive dependencies'
-            }
-            implementation('org.bitbucket.b_c:jose4j') {
-                version {
-                    require '0.9.3'
-                }
-                because 'CVE from transitive dependencies'
             }
             implementation('org.scala-lang:scala-library') {
                 version {

--- a/data-prepper-plugins/kafka-plugins/build.gradle
+++ b/data-prepper-plugins/kafka-plugins/build.gradle
@@ -88,6 +88,12 @@ dependencies {
             }
             because 'Fixes SNYK-JAVA-ORGMOZILLA-1314295.'
         }
+        implementation('org.bitbucket.b_c:jose4j') {
+            version {
+                require '0.9.4'
+            }
+            because 'Fixes CVE-2023-51775 and other CVEs from transitive dependencies'
+        }
     }
 }
 

--- a/data-prepper-plugins/parquet-codecs/build.gradle
+++ b/data-prepper-plugins/parquet-codecs/build.gradle
@@ -22,7 +22,13 @@ dependencies {
             version {
                 require '9.37.1'
             }
-            because 'Fixes CVE-2021-31684 and CVE-2023-1370 by using a newer shaded version of json-smart.'
+            because 'Fixes CVE-2023-52428, CVE-2021-31684 and CVE-2023-1370 by using a newer shaded version of json-smart.'
+        }
+        implementation('org.apache.zookeeper:zookeeper') {
+            version {
+                require '3.8.4'
+            }
+            because 'Fixes CVE-2024-23944, CVE-2023-44981'
         }
     }
 }

--- a/data-prepper-plugins/parquet-codecs/build.gradle
+++ b/data-prepper-plugins/parquet-codecs/build.gradle
@@ -24,12 +24,6 @@ dependencies {
             }
             because 'Fixes CVE-2023-52428, CVE-2021-31684 and CVE-2023-1370 by using a newer shaded version of json-smart.'
         }
-        implementation('org.apache.zookeeper:zookeeper') {
-            version {
-                require '3.8.4'
-            }
-            because 'Fixes CVE-2024-23944, CVE-2023-44981'
-        }
     }
 }
 

--- a/data-prepper-plugins/s3-sink/build.gradle
+++ b/data-prepper-plugins/s3-sink/build.gradle
@@ -33,9 +33,9 @@ dependencies {
     constraints {
         implementation('com.nimbusds:nimbus-jose-jwt') {
             version {
-                require '9.37.1'
+                require '9.37.2'
             }
-            because 'Fixes CVE-2021-31684 and CVE-2023-1370 by using a newer shaded version of json-smart.'
+            because 'Fixes CVE-2023-52428, CVE-2021-31684 and CVE-2023-1370 by using a newer shaded version of json-smart.'
         }
     }
 }


### PR DESCRIPTION
### Description

This PR updates some transitive dependencies to resolve some CVEs:

* CVE-2023-51775
* CVE-2024-23944
* CVE-2023-52428

I also moved some of the dependency constraints such that they are only in the projects needing them. 

This is the last set of CVEs known to resolve for releasing 2.7.0.
 
### Issues Resolved

Resolves #4282, #4290, #4296.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
