### PR TITLE
Configure the MaxMind database by default and use correct defaults

### DIFF
--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/GeoIpServiceConfig.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/extension/GeoIpServiceConfig.java
@@ -6,6 +6,8 @@
 package org.opensearch.dataprepper.plugins.geoip.extension;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import jakarta.validation.Valid;
 
 public class GeoIpServiceConfig {
@@ -13,6 +15,7 @@ public class GeoIpServiceConfig {
 
     @Valid
     @JsonProperty("maxmind")
+    @JsonSetter(nulls = Nulls.SKIP)
     private MaxMindConfig maxMindConfig = DEFAULT_MAXMIND_CONFIG;
 
     /**

--- a/examples/config/example-data-prepper-config.yaml
+++ b/examples/config/example-data-prepper-config.yaml
@@ -1,1 +1,5 @@
 ssl: false
+
+extensions:
+  geoip_service:
+    maxmind:


### PR DESCRIPTION
### Description

This configures Data Prepper with the default `geoip_service` configuration. Additionally, it allows the user to configure this minimal and still get the default value by skipping explicit null values.
 
### Issues Resolved

Resolves #3942
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
