### PR TITLE
Truncate Processor: Add support to truncate all fields in an event

### DIFF
--- a/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessor.java
+++ b/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessor.java
@@ -89,14 +89,7 @@ public class TruncateProcessor extends AbstractProcessor<Record<Event>, Record<E
                     if (truncateWhen != null && !expressionEvaluator.evaluateConditional(truncateWhen, recordEvent)) {
                         continue;
                     }
-                    boolean truncateAll = false;
-                    for (String sourceKey : sourceKeys) {
-                        if (sourceKey.equals("*")) {
-                            truncateAll = true;
-                            break;
-                        }
-                    }
-                    if (truncateAll) {
+                    if (sourceKeys == null) {
                         for (Map.Entry<String, Object> mapEntry: recordEvent.toMap().entrySet()) {
                             truncateKey(recordEvent, mapEntry.getKey(), mapEntry.getValue(), entry);
                         }

--- a/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
+++ b/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
@@ -15,8 +15,6 @@ import java.util.List;
 
 public class TruncateProcessorConfig {
     public static class Entry {
-        @NotEmpty
-        @NotNull
         @JsonProperty("source_keys")
         private List<String> sourceKeys;
 
@@ -62,7 +60,7 @@ public class TruncateProcessorConfig {
             return truncateWhen;
         }
 
-        @AssertTrue(message = "source_keys must be specified and at least one of start_at or length or both must be specified and the values must be positive integers")
+        @AssertTrue(message = "At least one of start_at or length or both must be specified and the values must be positive integers")
         public boolean isValidConfig() {
             if (length == null && startAt == null) {
                 return false;

--- a/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
+++ b/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
@@ -26,14 +26,18 @@ public class TruncateProcessorConfig {
         @JsonProperty("length")
         private Integer length;
 
+        @JsonProperty("do_recursively")
+        private Boolean recurse = false;
+
         @JsonProperty("truncate_when")
         private String truncateWhen;
 
-        public Entry(final List<String> sourceKeys, final Integer startAt, final Integer length, final String truncateWhen) {
+        public Entry(final List<String> sourceKeys, final Integer startAt, final Integer length, final String truncateWhen, final Boolean recurse) {
             this.sourceKeys = sourceKeys;
             this.startAt = startAt;
             this.length = length;
             this.truncateWhen = truncateWhen;
+            this.recurse = recurse;
         }
 
         public Entry() {}
@@ -44,6 +48,10 @@ public class TruncateProcessorConfig {
 
         public Integer getStartAt() {
             return startAt;
+        }
+
+        public Boolean getRecurse() {
+            return recurse;
         }
 
         public Integer getLength() {

--- a/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
+++ b/data-prepper-plugins/truncate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorConfig.java
@@ -24,7 +24,7 @@ public class TruncateProcessorConfig {
         @JsonProperty("length")
         private Integer length;
 
-        @JsonProperty("do_recursively")
+        @JsonProperty("recursive")
         private Boolean recurse = false;
 
         @JsonProperty("truncate_when")

--- a/data-prepper-plugins/truncate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorTests.java
+++ b/data-prepper-plugins/truncate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -53,7 +54,7 @@ class TruncateProcessorTests {
     @ArgumentsSource(TruncateArgumentsProvider.class)
     void testTruncateProcessor(final Object messageValue, final Integer startAt, final Integer truncateLength, final Object truncatedMessage) {
 
-        when(config.getEntries()).thenReturn(Collections.singletonList(createEntry(List.of("message"), startAt, truncateLength, null)));
+        when(config.getEntries()).thenReturn(Collections.singletonList(createEntry(List.of("message"), startAt, truncateLength, null, false)));
         final TruncateProcessor truncateProcessor = createObjectUnderTest();
         final Record<Event> record = createEvent("message", messageValue);
         final List<Record<Event>> truncatedRecords = (List<Record<Event>>) truncateProcessor.doExecute(Collections.singletonList(record));
@@ -64,8 +65,8 @@ class TruncateProcessorTests {
     @ParameterizedTest
     @ArgumentsSource(MultipleTruncateArgumentsProvider.class)
     void testTruncateProcessorMultipleEntries(final Object messageValue, final Integer startAt1, final Integer truncateLength1, final Integer startAt2, final Integer truncateLength2, final Object truncatedMessage1, final Object truncatedMessage2) {
-        TruncateProcessorConfig.Entry entry1 = createEntry(List.of("message1"), startAt1, truncateLength1, null);
-        TruncateProcessorConfig.Entry entry2 = createEntry(List.of("message2"), startAt2, truncateLength2, null);
+        TruncateProcessorConfig.Entry entry1 = createEntry(List.of("message1"), startAt1, truncateLength1, null, false);
+        TruncateProcessorConfig.Entry entry2 = createEntry(List.of("message2"), startAt2, truncateLength2, null, false);
         when(config.getEntries()).thenReturn(List.of(entry1, entry2));
         final Record<Event> record1 = createEvent("message1", messageValue);
         final Record<Event> record2 = createEvent("message2", messageValue);
@@ -82,7 +83,7 @@ class TruncateProcessorTests {
         final String truncateWhen = UUID.randomUUID().toString();
         final String message = UUID.randomUUID().toString();
 
-        when(config.getEntries()).thenReturn(Collections.singletonList(createEntry(List.of("message"), null, 5, truncateWhen)));
+        when(config.getEntries()).thenReturn(Collections.singletonList(createEntry(List.of("message"), null, 5, truncateWhen, false)));
 
         final TruncateProcessor truncateProcessor = createObjectUnderTest();
         final Record<Event> record = createEvent("message", message);
@@ -92,8 +93,32 @@ class TruncateProcessorTests {
         assertThat(truncatedRecords.get(0).getData().toMap(), equalTo(record.getData().toMap()));
     }
 
-    private TruncateProcessorConfig.Entry createEntry(final List<String> sourceKeys, final Integer startAt, final Integer length, final String truncateWhen) {
-        return new TruncateProcessorConfig.Entry(sourceKeys, startAt, length, truncateWhen);
+    @Test
+    void test_event_with_all_fields_truncated() {
+        when(config.getEntries()).thenReturn(Collections.singletonList(createEntry(List.of("*"), null, 5, null, false)));
+        final TruncateProcessor truncateProcessor = createObjectUnderTest();
+        final Record<Event> record = createEventWithMultipleKeys(Map.of("key1", "aaaaa12345", "key2", "bbbbb12345", "key3", "ccccccc12345"));
+        final List<Record<Event>> truncatedRecords = (List<Record<Event>>) truncateProcessor.doExecute(Collections.singletonList(record));
+        Event event = truncatedRecords.get(0).getData();
+        assertThat(event.get("key1", String.class), equalTo("aaaaa"));
+        assertThat(event.get("key2", String.class), equalTo("bbbbb"));
+        assertThat(event.get("key3", String.class), equalTo("ccccc"));
+    }
+
+    @Test
+    void test_event_with_all_fields_truncated_recursively() {
+        when(config.getEntries()).thenReturn(Collections.singletonList(createEntry(List.of("*"), null, 5, null, true)));
+        final TruncateProcessor truncateProcessor = createObjectUnderTest();
+        final Record<Event> record = createEventWithMultipleKeys(ImmutableMap.of("key1", "aaaaa12345", "key2", ImmutableMap.of("key3", "bbbbb12345", "key4", ImmutableMap.of("key5", "ccccccc12345"))));
+        final List<Record<Event>> truncatedRecords = (List<Record<Event>>) truncateProcessor.doExecute(Collections.singletonList(record));
+        Event event = truncatedRecords.get(0).getData();
+        assertThat(event.get("key1", String.class), equalTo("aaaaa"));
+        assertThat(event.get("key2/key3", String.class), equalTo("bbbbb"));
+        assertThat(event.get("key2/key4/key5", String.class), equalTo("ccccc"));
+    }
+
+    private TruncateProcessorConfig.Entry createEntry(final List<String> sourceKeys, final Integer startAt, final Integer length, final String truncateWhen, final boolean recurse) {
+        return new TruncateProcessorConfig.Entry(sourceKeys, startAt, length, truncateWhen, recurse);
     }
 
     private Record<Event> createEvent(final String key, final Object value) {
@@ -102,6 +127,13 @@ class TruncateProcessorTests {
         return new Record<>(JacksonEvent.builder()
                 .withEventType("event")
                 .withData(eventData)
+                .build());
+    }
+
+    private Record<Event> createEventWithMultipleKeys(final Map<String, Object> data) {
+        return new Record<>(JacksonEvent.builder()
+                .withEventType("event")
+                .withData(data)
                 .build());
     }
 

--- a/data-prepper-plugins/truncate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorTests.java
+++ b/data-prepper-plugins/truncate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/truncate/TruncateProcessorTests.java
@@ -95,7 +95,7 @@ class TruncateProcessorTests {
 
     @Test
     void test_event_with_all_fields_truncated() {
-        when(config.getEntries()).thenReturn(Collections.singletonList(createEntry(List.of("*"), null, 5, null, false)));
+        when(config.getEntries()).thenReturn(Collections.singletonList(createEntry(null, null, 5, null, false)));
         final TruncateProcessor truncateProcessor = createObjectUnderTest();
         final Record<Event> record = createEventWithMultipleKeys(Map.of("key1", "aaaaa12345", "key2", "bbbbb12345", "key3", "ccccccc12345"));
         final List<Record<Event>> truncatedRecords = (List<Record<Event>>) truncateProcessor.doExecute(Collections.singletonList(record));
@@ -107,7 +107,7 @@ class TruncateProcessorTests {
 
     @Test
     void test_event_with_all_fields_truncated_recursively() {
-        when(config.getEntries()).thenReturn(Collections.singletonList(createEntry(List.of("*"), null, 5, null, true)));
+        when(config.getEntries()).thenReturn(Collections.singletonList(createEntry(null, null, 5, null, true)));
         final TruncateProcessor truncateProcessor = createObjectUnderTest();
         final Record<Event> record = createEventWithMultipleKeys(ImmutableMap.of("key1", "aaaaa12345", "key2", ImmutableMap.of("key3", "bbbbb12345", "key4", ImmutableMap.of("key5", "ccccccc12345"))));
         final List<Record<Event>> truncatedRecords = (List<Record<Event>>) truncateProcessor.doExecute(Collections.singletonList(record));


### PR DESCRIPTION
### Description
Supports truncating all fields in an event when `source_keys` is not specified or null. 
The config would look like this to truncate all fields to a length of 5 characters.
```
processor:
   - truncate:
        entries:
           - length: 5
```

Also, added support to do truncation recursively in case of nested objects with config option
```
do_recursively: true
```
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
