### PR TITLE
Updates the next Data Prepper version to 2.8.

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersion.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersion.java
@@ -6,7 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class DataPrepperVersion {
-    private static final String CURRENT_VERSION = "2.7";
+    private static final String CURRENT_VERSION = "2.8";
 
     private static final String FULL_FORMAT = "%d.%d";
     private static final String SHORTHAND_FORMAT = "%d";

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@
 
 # ATTENTION: If you are changing the version, please change the DataPrepperVersion whenever the major or minor version changes.
 # See: https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/DataPrepperVersion.java#L9
-version=2.7.0-SNAPSHOT
+version=2.8.0-SNAPSHOT
 org.gradle.jvmargs=-Xmx2048M


### PR DESCRIPTION
### Description

Updates the next Data Prepper version to 2.8.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
