### PR TITLE
Split up the Maven groupIds for core, plugins, and test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,39 +48,41 @@ allprojects {
             withSourcesJar()
         }
 
-        project.publishing {
-            repositories {
-                maven {
-                    url "file://${mavenPublicationRootFile.absolutePath}"
+        afterEvaluate {
+            project.publishing {
+                repositories {
+                    maven {
+                        url "file://${mavenPublicationRootFile.absolutePath}"
+                    }
                 }
-            }
-            publications {
-                mavenJava(MavenPublication) {
-                    from project.components.findByName("java") ?: project.components.findByName("javaLibrary")
+                publications {
+                    mavenJava(MavenPublication) {
+                        from project.components.findByName("java") ?: project.components.findByName("javaLibrary")
 
-                    groupId = project.group
-                    artifactId = project.name
-                    version = project.version
+                        groupId = project.group
+                        artifactId = project.name
+                        version = project.version
 
-                    pom {
-                        name = project.name
-                        description = "Data Prepper project: ${project.name}"
-                        url = 'https://github.com/opensearch-project/data-prepper'
-                        licenses {
-                            license {
-                                name = 'The Apache Software License, Version 2.0'
-                                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                                distribution = 'repo'
-                            }
-                        }
-                        developers {
-                            developer {
-                                name = 'OpenSearch'
-                                url = 'https://github.com/opensearch-project'
-                            }
-                        }
-                        scm {
+                        pom {
+                            name = project.name
+                            description = "Data Prepper project: ${project.name}"
                             url = 'https://github.com/opensearch-project/data-prepper'
+                            licenses {
+                                license {
+                                    name = 'The Apache Software License, Version 2.0'
+                                    url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                                    distribution = 'repo'
+                                }
+                            }
+                            developers {
+                                developer {
+                                    name = 'OpenSearch'
+                                    url = 'https://github.com/opensearch-project'
+                                }
+                            }
+                            scm {
+                                url = 'https://github.com/opensearch-project/data-prepper'
+                            }
                         }
                     }
                 }

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -11,6 +11,8 @@ sourceSets {
     }
 }
 
+group = 'org.opensearch.dataprepper.core'
+
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-expression')

--- a/data-prepper-event/build.gradle
+++ b/data-prepper-event/build.gradle
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+group = 'org.opensearch.dataprepper.core'
+
 dependencies {
     implementation project(':data-prepper-api')
     implementation 'javax.inject:javax.inject:1'

--- a/data-prepper-expression/build.gradle
+++ b/data-prepper-expression/build.gradle
@@ -8,6 +8,8 @@ plugins {
     id 'idea'
 }
 
+group = 'org.opensearch.dataprepper.core'
+
 ext {
     antlrGeneratedPackageDirectory = "org/opensearch/dataprepper/expression/antlr/"
 }

--- a/data-prepper-logstash-configuration/build.gradle
+++ b/data-prepper-logstash-configuration/build.gradle
@@ -8,6 +8,8 @@ plugins {
     id 'idea'
 }
 
+group = 'org.opensearch.dataprepper.core'
+
 ext {
     antlrGeneratedPackageDirectory = "org/opensearch/dataprepper/logstash/"
 }

--- a/data-prepper-main/build.gradle
+++ b/data-prepper-main/build.gradle
@@ -11,6 +11,8 @@ sourceSets {
     }
 }
 
+group = 'org.opensearch.dataprepper.core'
+
 dependencies {
     implementation project(':data-prepper-core')
     implementation project(':data-prepper-plugins')

--- a/data-prepper-pipeline-parser/build.gradle
+++ b/data-prepper-pipeline-parser/build.gradle
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+group = 'org.opensearch.dataprepper.core'
+
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:blocking-buffer')

--- a/data-prepper-plugin-framework/build.gradle
+++ b/data-prepper-plugin-framework/build.gradle
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+group = 'org.opensearch.dataprepper.core'
+
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-pipeline-parser')

--- a/data-prepper-plugins/build.gradle
+++ b/data-prepper-plugins/build.gradle
@@ -7,6 +7,10 @@ plugins {
     id 'java-library'
 }
 
+allprojects {
+    group = 'org.opensearch.dataprepper.plugins'
+}
+
 dependencies {
     subprojects.forEach { api project(':data-prepper-plugins:' + it.name) }
 }

--- a/data-prepper-test-common/build.gradle
+++ b/data-prepper-test-common/build.gradle
@@ -7,6 +7,8 @@ plugins {
     id 'java'
 }
 
+group = 'org.opensearch.dataprepper.test'
+
 dependencies {
     implementation testLibs.hamcrest
     testRuntimeOnly testLibs.junit.engine

--- a/data-prepper-test-event/build.gradle
+++ b/data-prepper-test-event/build.gradle
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+group = 'org.opensearch.dataprepper.test'
+
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-event')


### PR DESCRIPTION
### Description

Starting in Data Prepper 2.7.0, Data Prepper will deploy all artifacts to Maven. This PR splits those groupIds:

* `org.opensearch.dataprepper.core`
* `org.opensearch.dataprepper.plugins`
* `org.opensearch.dataprepper.test`
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
