### PR TITLE
Fix Router performance issue

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/Router.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/router/Router.java
@@ -24,13 +24,11 @@ public class Router {
     private final RouteEventEvaluator routeEventEvaluator;
     private final DataFlowComponentRouter dataFlowComponentRouter;
     private final Consumer<Event> noRouteHandler;
-    private Set<Record> recordsUnRouted;
 
     Router(final RouteEventEvaluator routeEventEvaluator, final DataFlowComponentRouter dataFlowComponentRouter, final Consumer<Event> noRouteHandler) {
         this.routeEventEvaluator = Objects.requireNonNull(routeEventEvaluator);
         this.dataFlowComponentRouter = dataFlowComponentRouter;
         this.noRouteHandler = noRouteHandler;
-        this.recordsUnRouted = null;
     }
 
     public <C> void route(
@@ -44,7 +42,6 @@ public class Router {
         Objects.requireNonNull(componentRecordsConsumer);
 
         final Map<Record, Set<String>> recordsToRoutes = routeEventEvaluator.evaluateEventRoutes(allRecords);
-        recordsUnRouted = null;
 
         boolean allRecordsRouted = false;
 
@@ -55,9 +52,7 @@ public class Router {
             }
         }
 
-        if (!allRecordsRouted) {
-            recordsUnRouted = new HashSet<>(allRecords);
-        }
+        final Set<Record> recordsUnRouted = (allRecordsRouted) ? null : new HashSet<>(allRecords);
 
         for (DataFlowComponent<C> dataFlowComponent : dataFlowComponents) {
             dataFlowComponentRouter.route(allRecords, dataFlowComponent, recordsToRoutes, getRecordStrategy, (component, records) -> { 


### PR DESCRIPTION
### Description
Fix Router performance issue.
PR #3959 added `removeAll` to Router code. This method is very expensive in cases with ArrayLists(). Replacing it with for loop that removes individual records.

Also, added a performance optimization to avoid populating `recordsUnRouted` if there is at least one sink to which all records are routed.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
