### PR TITLE
Revert HTTP data chunking changes for kafka buffer done in PR 4266

### DIFF
--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/HTTPSource.java
@@ -20,7 +20,7 @@ import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.source.Source;
 import org.opensearch.dataprepper.model.codec.ByteDecoder;
-import org.opensearch.dataprepper.model.codec.JsonObjectDecoder;
+import org.opensearch.dataprepper.model.codec.JsonDecoder;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -64,7 +64,7 @@ public class HTTPSource implements Source<Record<Log>> {
         this.sourceConfig = sourceConfig;
         this.pluginMetrics = pluginMetrics;
         this.pipelineName = pipelineDescription.getPipelineName();
-        this.byteDecoder = new JsonObjectDecoder();
+        this.byteDecoder = new JsonDecoder();
         this.certificateProviderFactory = new CertificateProviderFactory(sourceConfig);
         final PluginModel authenticationConfiguration = sourceConfig.getAuthentication();
         final PluginSetting authenticationPluginSetting;

--- a/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPService.java
+++ b/data-prepper-plugins/http-source/src/main/java/org/opensearch/dataprepper/plugins/source/loghttp/LogHTTPService.java
@@ -87,9 +87,9 @@ public class LogHTTPService {
         }
         try {
             if (buffer.isByteBuffer()) {
-                for (final String json: jsonList) {
-                    buffer.writeBytes(json.getBytes(), null, bufferWriteTimeoutInMillis);
-                }
+                // jsonList is ignored in this path but parse() was done to make 
+                // sure that the data is in the expected json format
+                buffer.writeBytes(content.array(), null, bufferWriteTimeoutInMillis);
             } else {
                 final List<Record<Log>> records = jsonList.stream()
                         .map(this::buildRecordLog)


### PR DESCRIPTION
### Description
Revert HTTP data chunking changes for kafka buffer done in PR 4266

Only the relevant changes are reverted, The JsonObjectDecoder added in that PR is not removed as it be useful in future.
HTTP source is modified to use `JsonDecoder` like it was before and LogHTTPService is modified to send the entire data (without chunking) to Kafka.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
