### PR TITLE
Add developer guide/integration test section

### DIFF
--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -596,3 +596,20 @@ The default behavior is to process all indices.
 #### <a name="index_configuration">Index Configuration</a>
 
 * `index_name_regex`: A regex pattern to represent the index names for filtering
+
+## Developer guide
+
+### Integration tests
+
+#### Run OpenSearch
+
+Start an instance of OpenSearch that listens to opens port 9200 with default user admin:admin.
+```
+docker run -p 9200:9200 -e "discovery.type=single-node" opensearchproject/opensearch:1.0.0
+```
+
+#### Run tests
+
+```
+./gradlew data-prepper-plugins:opensearch:integrationTest -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=admin
+```

--- a/data-prepper-plugins/opensearch/README.md
+++ b/data-prepper-plugins/opensearch/README.md
@@ -605,11 +605,11 @@ The default behavior is to process all indices.
 
 Start an instance of OpenSearch that listens to opens port 9200 with default user admin:admin.
 ```
-docker run -p 9200:9200 -e "discovery.type=single-node" opensearchproject/opensearch:1.0.0
+docker run -p 9200:9200 -e "discovery.type=single-node" -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=yourStrongPassword123!" opensearchproject/opensearch:latest
 ```
 
 #### Run tests
 
 ```
-./gradlew data-prepper-plugins:opensearch:integrationTest -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=admin
+./gradlew data-prepper-plugins:opensearch:integrationTest -Dtests.opensearch.host=localhost:9200 -Dtests.opensearch.user=admin -Dtests.opensearch.password=yourStrongPassword123!
 ```


### PR DESCRIPTION
### Description
Document how to perform integration tests for the opensearch-plugin.
This is only documentation

Aligned with Kafka example
https://github.com/opensearch-project/data-prepper/blob/51ee0df595aaad1b921c888394bf3e110ffc74e9/data-prepper-plugins/kafka-plugins/README.md#developer-guide
 
### Issues Resolved

I am not aware of an issue, but it would have saved time for https://github.com/opensearch-project/data-prepper/pull/3929 and future contributions
 
### Check List
- [ ] New functionality includes testing. **[not applicable]**
- [ ] New functionality has a documentation issue. Please link to it in this PR. **[not applicable]**
  - [ ] New functionality has javadoc added **[not applicable]**
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
