### PR TITLE
Removes the release flag from the release GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,19 +42,19 @@ jobs:
         aws-region: us-east-1
 
     - name: Build Archives
-      run: ./gradlew --parallel --max-workers 2 :release:archives:buildArchives -Prelease
+      run: ./gradlew --parallel --max-workers 2 :release:archives:buildArchives
 
     - name: Build Maven Artifacts
       run: ./gradlew publish
 
     - name: Build Docker Image
-      run: ./gradlew :release:docker:docker -Prelease
+      run: ./gradlew :release:docker:docker
 
     - name: Upload Archives to Archives Bucket
-      run: ./gradlew :release:archives:uploadArchives -Prelease -Pregion=us-east-1 -Pbucket=${{ secrets.ARCHIVES_BUCKET_NAME }} -Pprofile=default -PbuildNumber=${{ github.run_number }}
+      run: ./gradlew :release:archives:uploadArchives -Pregion=us-east-1 -Pbucket=${{ secrets.ARCHIVES_BUCKET_NAME }} -Pprofile=default -PbuildNumber=${{ github.run_number }}
 
     - name: Upload Maven Artifacts to Archives Bucket
-      run: ./gradlew :release:maven:uploadArtifacts -Prelease -Pregion=us-east-1 -Pbucket=${{ secrets.ARCHIVES_BUCKET_NAME }} -Pprofile=default -PbuildNumber=${{ github.run_number }}
+      run: ./gradlew :release:maven:uploadArtifact -Pregion=us-east-1 -Pbucket=${{ secrets.ARCHIVES_BUCKET_NAME }} -Pprofile=default -PbuildNumber=${{ github.run_number }}
 
     - name: Log into Amazon ECR Public
       id: login-ecr


### PR DESCRIPTION
### Description

The release flag has not been needed for a while and now conflicts with the `release` task. This PR removes it from our release GitHub Actions workflow.

We need this to release 2.7.0.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
