### PR TITLE
Fix the release build by only applying the Maven publish task to our actual Java artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,46 +42,48 @@ allprojects {
         }
     }
 
-    project.plugins.withType(JavaPlugin).configureEach {
-        java {
-            withJavadocJar()
-            withSourcesJar()
-        }
+    if(project.name.startsWith('data-prepper') || project.parent != null && project.parent.name.equals('data-prepper-plugins')) {
+        project.plugins.withType(JavaPlugin).configureEach {
+            java {
+                withJavadocJar()
+                withSourcesJar()
+            }
 
-        afterEvaluate {
-            project.publishing {
-                repositories {
-                    maven {
-                        url "file://${mavenPublicationRootFile.absolutePath}"
+            afterEvaluate {
+                project.publishing {
+                    repositories {
+                        maven {
+                            url "file://${mavenPublicationRootFile.absolutePath}"
+                        }
                     }
-                }
-                publications {
-                    mavenJava(MavenPublication) {
-                        from project.components.findByName("java") ?: project.components.findByName("javaLibrary")
+                    publications {
+                        mavenJava(MavenPublication) {
+                            from project.components.findByName("java") ?: project.components.findByName("javaLibrary")
 
-                        groupId = project.group
-                        artifactId = project.name
-                        version = project.version
+                            groupId = project.group
+                            artifactId = project.name
+                            version = project.version
 
-                        pom {
-                            name = project.name
-                            description = "Data Prepper project: ${project.name}"
-                            url = 'https://github.com/opensearch-project/data-prepper'
-                            licenses {
-                                license {
-                                    name = 'The Apache Software License, Version 2.0'
-                                    url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                                    distribution = 'repo'
-                                }
-                            }
-                            developers {
-                                developer {
-                                    name = 'OpenSearch'
-                                    url = 'https://github.com/opensearch-project'
-                                }
-                            }
-                            scm {
+                            pom {
+                                name = project.name
+                                description = "Data Prepper project: ${project.name}"
                                 url = 'https://github.com/opensearch-project/data-prepper'
+                                licenses {
+                                    license {
+                                        name = 'The Apache Software License, Version 2.0'
+                                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                                        distribution = 'repo'
+                                    }
+                                }
+                                developers {
+                                    developer {
+                                        name = 'OpenSearch'
+                                        url = 'https://github.com/opensearch-project'
+                                    }
+                                }
+                                scm {
+                                    url = 'https://github.com/opensearch-project/data-prepper'
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
### Description

The release build is failing on the `publish` step:

```
> Task :release:docker:processResources NO-SOURCE
   > Invalid publication 'mavenJava': version cannot be empty.
```

The reason is that the current Gradle configuration is trying to publish all projects. This includes projects such as performance-test, e2e-test, and the release projects. 

The current fix for now is to look for projects by name. Either:

* The name starts with `data-prepper` - this covers core projects; or
* The parent project is `data-prepper-plugins` - this covers all plugins

This is needed for the 2.7.0 release.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
