### PR TITLE
Add creation and aggregation of dynamic S3 groups based on events

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/expression/ExpressionEvaluator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/expression/ExpressionEvaluator.java
@@ -7,6 +7,8 @@ package org.opensearch.dataprepper.expression;
 
 import org.opensearch.dataprepper.model.event.Event;
 
+import java.util.List;
+
 /**
  * @since 1.3
  * ExpressionEvaluator interface to abstract the parse and evaluate implementations.
@@ -36,4 +38,8 @@ public interface ExpressionEvaluator {
     Boolean isValidExpressionStatement(final String statement);
 
     Boolean isValidFormatExpression(final String format);
+
+    List<String> extractDynamicKeysFromFormatExpression(final String format);
+
+    List<String> extractDynamicExpressionsFromFormatExpression(final String format);
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/expression/ExpressionEvaluatorTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/expression/ExpressionEvaluatorTest.java
@@ -5,12 +5,16 @@
 
 package org.opensearch.dataprepper.expression;
 
+import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
-import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.hamcrest.CoreMatchers.equalTo;
 
 public class ExpressionEvaluatorTest {
     private ExpressionEvaluator expressionEvaluator;
@@ -27,6 +31,16 @@ public class ExpressionEvaluatorTest {
         @Override
         public Boolean isValidFormatExpression(String format) {
             return true;
+        }
+
+        @Override
+        public List<String> extractDynamicKeysFromFormatExpression(String format) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<String> extractDynamicExpressionsFromFormatExpression(String format) {
+            return Collections.emptyList();
         }
     }
 

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluator.java
@@ -11,6 +11,8 @@ import org.opensearch.dataprepper.model.event.JacksonEvent;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Public class that {@link org.opensearch.dataprepper.model.processor.Processor},
@@ -73,5 +75,58 @@ class GenericExpressionEvaluator implements ExpressionEvaluator {
             fromIndex = endPosition + 1;
         }
         return true;
+    }
+
+    @Override
+    public List<String> extractDynamicKeysFromFormatExpression(final String format) {
+        final List<String> formatExpressionKeys = new ArrayList<>();
+
+        if (format == null) {
+            return formatExpressionKeys;
+        }
+
+        int fromIndex = 0;
+        int position = 0;
+        while ((position = format.indexOf("${", fromIndex)) != -1) {
+            int endPosition = format.indexOf("}", position + 1);
+            if (endPosition == -1) {
+                return formatExpressionKeys;
+            }
+            String name = format.substring(position + 2, endPosition);
+
+            if (JacksonEvent.isValidEventKey(name)) {
+                if (!name.startsWith("/")) {
+                    name = "/" + name;
+                }
+                formatExpressionKeys.add(name);
+            }
+            fromIndex = endPosition + 1;
+        }
+        return formatExpressionKeys;
+    }
+
+    @Override
+    public List<String> extractDynamicExpressionsFromFormatExpression(final String format) {
+        final List<String> dynamicExpressionStatements = new ArrayList<>();
+
+        if (format == null) {
+            return dynamicExpressionStatements;
+        }
+
+        int fromIndex = 0;
+        int position = 0;
+        while ((position = format.indexOf("${", fromIndex)) != -1) {
+            int endPosition = format.indexOf("}", position + 1);
+            if (endPosition == -1) {
+                return dynamicExpressionStatements;
+            }
+            String name = format.substring(position + 2, endPosition);
+
+            if (!JacksonEvent.isValidEventKey(name) && isValidExpressionStatement(name)) {
+                dynamicExpressionStatements.add(name);
+            }
+            fromIndex = endPosition + 1;
+        }
+        return dynamicExpressionStatements;
     }
 }

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/GenericExpressionEvaluatorTest.java
@@ -20,13 +20,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.event.Event;
 
-import java.util.Calendar;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -178,7 +174,9 @@ class GenericExpressionEvaluatorTest {
             return Stream.of(
                     arguments("test-${foo}-${bar}", List.of("/foo", "/bar")),
                     arguments("test-${getMetadata(\"key\"}-${/test}", List.of("/test")),
-                    arguments("test-format", List.of())
+                    arguments("test-format", List.of()),
+                    arguments("test-${/test", List.of()),
+                    arguments(null, List.of())
             );
         }
     }
@@ -188,7 +186,9 @@ class GenericExpressionEvaluatorTest {
         public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
             return Stream.of(
                     arguments("test-${foo}-${bar}", List.of()),
-                    arguments("test-${getMetadata(\"key\")}-${/test}", List.of("getMetadata(\"key\")"))
+                    arguments("test-${getMetadata(\"key\")}-${/test}", List.of("getMetadata(\"key\")")),
+                    arguments("test-${/test", List.of()),
+                    arguments(null, List.of())
             );
         }
     }

--- a/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/s3keyindex/S3ObjectIndexUtility.java
+++ b/data-prepper-plugins/common/src/main/java/org/opensearch/dataprepper/plugins/s3keyindex/S3ObjectIndexUtility.java
@@ -31,6 +31,8 @@ public class S3ObjectIndexUtility {
     // For a string like "data-prepper-%{yyyy-MM}", "yyyy-MM" is matched.
     private static final String TIME_PATTERN_INTERNAL_EXTRACTOR_REGULAR_EXPRESSION = "\\%\\{(.*?)\\}";
 
+    private static final Pattern DATE_TIME_PATTERN = Pattern.compile(TIME_PATTERN_INTERNAL_EXTRACTOR_REGULAR_EXPRESSION);
+
     private static final ZoneId UTC_ZONE_ID = ZoneId.of(TimeZone.getTimeZone("UTC").getID());
 
     S3ObjectIndexUtility() {
@@ -76,8 +78,7 @@ public class S3ObjectIndexUtility {
      * @return returns date time formatter
      */
     public static DateTimeFormatter validateAndGetDateTimeFormatter(final String indexAlias) {
-        final Pattern pattern = Pattern.compile(TIME_PATTERN_INTERNAL_EXTRACTOR_REGULAR_EXPRESSION);
-        final Matcher timePatternMatcher = pattern.matcher(indexAlias);
+        final Matcher timePatternMatcher = DATE_TIME_PATTERN.matcher(indexAlias);
         if (timePatternMatcher.find()) {
             final String timePattern = timePatternMatcher.group(1);
             if (timePatternMatcher.find()) { // check if there is a one more match.

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/NdjsonOutputScenario.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/NdjsonOutputScenario.java
@@ -56,6 +56,25 @@ public class NdjsonOutputScenario implements OutputScenario {
         assertThat(sampledData, equalTo(sampleEventData.size()));
     }
 
+    public void validateDynamicPartition(int expectedRecords, int partitionNumber, final File actualContentFile, final CompressionScenario compressionScenario) throws IOException {
+        final InputStream inputStream = new BufferedInputStream(new FileInputStream(actualContentFile), 64 * 1024);
+
+        final Scanner scanner = new Scanner(inputStream);
+
+        int count = 0;
+        while (scanner.hasNext()) {
+
+            final String actualJsonString = scanner.next();
+
+            final Map<String, Object> actualData = OBJECT_MAPPER.readValue(actualJsonString, Map.class);
+            assertThat(actualData.get("sequence"), equalTo(partitionNumber));
+
+            count++;
+        }
+
+        assertThat(count, equalTo(expectedRecords));
+    }
+
     @Override
     public String toString() {
         return "NDJSON";

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkIT.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkIT.java
@@ -45,6 +45,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.S3Object;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -71,6 +72,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -97,6 +99,9 @@ public class S3SinkIT {
     private ThresholdOptions thresholdOptions;
     @Mock
     private ObjectKeyOptions objectKeyOptions;
+
+    @Mock
+    private ExpressionEvaluator expressionEvaluator;
     private String s3region;
     private String bucketName;
     private S3Client s3Client;
@@ -154,10 +159,12 @@ public class S3SinkIT {
                 .credentialsProvider(awsCredentialsProvider)
                 .region(region)
                 .build();
+
+        when(expressionEvaluator.isValidFormatExpression(anyString())).thenReturn(true);
     }
 
     private S3Sink createObjectUnderTest() {
-        return new S3Sink(pluginSetting, s3SinkConfig, pluginFactory, sinkContext, awsCredentialsSupplier);
+        return new S3Sink(pluginSetting, s3SinkConfig, pluginFactory, sinkContext, awsCredentialsSupplier, expressionEvaluator);
     }
 
     @ParameterizedTest

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/KeyGenerator.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/KeyGenerator.java
@@ -28,10 +28,9 @@ public class KeyGenerator {
      *
      * @return object key path.
      */
-    public String generateKeyForEvent(final Event event, final boolean includeDateAndCodec) {
+    public String generateKeyForEvent(final Event event) {
         final String pathPrefix = ObjectKey.buildingPathPrefix(s3SinkConfig, event, expressionEvaluator);
-        final String namePattern = includeDateAndCodec ? ObjectKey.objectFileName(s3SinkConfig, extensionProvider.getExtension(), event, expressionEvaluator) :
-                ObjectKey.objectFileNameWithoutDateTimeAndCodecInjection(s3SinkConfig, event, expressionEvaluator);
+        final String namePattern = ObjectKey.objectFileName(s3SinkConfig, extensionProvider.getExtension(), event, expressionEvaluator);
         return (!pathPrefix.isEmpty()) ? pathPrefix + namePattern : namePattern;
     }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/KeyGenerator.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/KeyGenerator.java
@@ -5,15 +5,22 @@
 
 package org.opensearch.dataprepper.plugins.sink.s3;
 
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.ObjectKey;
 
 public class KeyGenerator {
     private final S3SinkConfig s3SinkConfig;
     private final ExtensionProvider extensionProvider;
 
-    public KeyGenerator(S3SinkConfig s3SinkConfig, ExtensionProvider extensionProvider) {
+    private final ExpressionEvaluator expressionEvaluator;
+
+    public KeyGenerator(final S3SinkConfig s3SinkConfig,
+                        final ExtensionProvider extensionProvider,
+                        final ExpressionEvaluator expressionEvaluator) {
         this.s3SinkConfig = s3SinkConfig;
         this.extensionProvider = extensionProvider;
+        this.expressionEvaluator = expressionEvaluator;
     }
 
     /**
@@ -21,9 +28,10 @@ public class KeyGenerator {
      *
      * @return object key path.
      */
-    String generateKey() {
-        final String pathPrefix = ObjectKey.buildingPathPrefix(s3SinkConfig);
-        final String namePattern = ObjectKey.objectFileName(s3SinkConfig, extensionProvider.getExtension());
+    public String generateKeyForEvent(final Event event, final boolean includeDateAndCodec) {
+        final String pathPrefix = ObjectKey.buildingPathPrefix(s3SinkConfig, event, expressionEvaluator);
+        final String namePattern = includeDateAndCodec ? ObjectKey.objectFileName(s3SinkConfig, extensionProvider.getExtension(), event, expressionEvaluator) :
+                ObjectKey.objectFileNameWithoutDateTimeAndCodecInjection(s3SinkConfig, event, expressionEvaluator);
         return (!pathPrefix.isEmpty()) ? pathPrefix + namePattern : namePattern;
     }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
@@ -45,6 +45,8 @@ import java.util.Collection;
 public class S3Sink extends AbstractSink<Record<Event>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(S3Sink.class);
+
+    private static final Duration RETRY_FLUSH_BACKOFF = Duration.ofSeconds(5);
     private final S3SinkConfig s3SinkConfig;
     private final OutputCodec codec;
     private volatile boolean sinkInitialized;
@@ -102,11 +104,11 @@ public class S3Sink extends AbstractSink<Record<Event>> {
 
         codec.validateAgainstCodecContext(s3OutputCodecContext);
 
-        final S3GroupIdentifierFactory s3GroupIdentifierFactory = new S3GroupIdentifierFactory(keyGenerator);
+        final S3GroupIdentifierFactory s3GroupIdentifierFactory = new S3GroupIdentifierFactory(keyGenerator, expressionEvaluator, s3SinkConfig);
         final S3GroupManager s3GroupManager = new S3GroupManager(s3SinkConfig, s3GroupIdentifierFactory, bufferFactory, s3Client);
 
 
-        s3SinkService = new S3SinkService(s3SinkConfig, codec, s3OutputCodecContext, s3Client, keyGenerator, Duration.ofSeconds(5), pluginMetrics, s3GroupManager);
+        s3SinkService = new S3SinkService(s3SinkConfig, codec, s3OutputCodecContext, s3Client, keyGenerator, RETRY_FLUSH_BACKOFF, pluginMetrics, s3GroupManager);
     }
 
     @Override

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.sink.s3;
 
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
@@ -27,6 +28,8 @@ import org.opensearch.dataprepper.plugins.sink.s3.accumulator.CompressionBufferF
 import org.opensearch.dataprepper.plugins.sink.s3.codec.BufferedCodec;
 import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionEngine;
 import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionOption;
+import org.opensearch.dataprepper.plugins.sink.s3.grouping.S3GroupIdentifierFactory;
+import org.opensearch.dataprepper.plugins.sink.s3.grouping.S3GroupManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -59,7 +62,8 @@ public class S3Sink extends AbstractSink<Record<Event>> {
                   final S3SinkConfig s3SinkConfig,
                   final PluginFactory pluginFactory,
                   final SinkContext sinkContext,
-                  final AwsCredentialsSupplier awsCredentialsSupplier) {
+                  final AwsCredentialsSupplier awsCredentialsSupplier,
+                  final ExpressionEvaluator expressionEvaluator) {
         super(pluginSetting);
         this.s3SinkConfig = s3SinkConfig;
         this.sinkContext = sinkContext;
@@ -82,13 +86,27 @@ public class S3Sink extends AbstractSink<Record<Event>> {
         bufferFactory = new CompressionBufferFactory(innerBufferFactory, compressionEngine, codec);
 
         ExtensionProvider extensionProvider = StandardExtensionProvider.create(codec, compressionOption);
-        KeyGenerator keyGenerator = new KeyGenerator(s3SinkConfig, extensionProvider);
+        KeyGenerator keyGenerator = new KeyGenerator(s3SinkConfig, extensionProvider, expressionEvaluator);
+
+        if (s3SinkConfig.getObjectKeyOptions().getPathPrefix() != null &&
+            !expressionEvaluator.isValidFormatExpression(s3SinkConfig.getObjectKeyOptions().getPathPrefix())) {
+            throw new InvalidPluginConfigurationException("path_prefix is not a valid format expression");
+        }
+
+        if (s3SinkConfig.getObjectKeyOptions().getNamePattern() != null &&
+                !expressionEvaluator.isValidFormatExpression(s3SinkConfig.getObjectKeyOptions().getNamePattern())) {
+            throw new InvalidPluginConfigurationException("name_pattern is not a valid format expression");
+        }
 
         S3OutputCodecContext s3OutputCodecContext = new S3OutputCodecContext(OutputCodecContext.fromSinkContext(sinkContext), compressionOption);
 
         codec.validateAgainstCodecContext(s3OutputCodecContext);
 
-        s3SinkService = new S3SinkService(s3SinkConfig, bufferFactory, codec, s3OutputCodecContext, s3Client, keyGenerator, Duration.ofSeconds(5), pluginMetrics);
+        final S3GroupIdentifierFactory s3GroupIdentifierFactory = new S3GroupIdentifierFactory(keyGenerator);
+        final S3GroupManager s3GroupManager = new S3GroupManager(s3SinkConfig, s3GroupIdentifierFactory, bufferFactory, s3Client);
+
+
+        s3SinkService = new S3SinkService(s3SinkConfig, codec, s3OutputCodecContext, s3Client, keyGenerator, Duration.ofSeconds(5), pluginMetrics, s3GroupManager);
     }
 
     @Override

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkConfig.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkConfig.java
@@ -37,7 +37,7 @@ public class S3SinkConfig {
     private String bucketName;
 
     @JsonProperty("object_key")
-    private ObjectKeyOptions objectKeyOptions;
+    private ObjectKeyOptions objectKeyOptions = new ObjectKeyOptions();
 
     @JsonProperty("compression")
     private CompressionOption compression = CompressionOption.NONE;

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkService.java
@@ -10,7 +10,6 @@ import io.micrometer.core.instrument.DistributionSummary;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 import org.opensearch.dataprepper.model.types.ByteCount;
@@ -27,7 +26,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -46,7 +44,6 @@ public class S3SinkService {
     static final String S3_OBJECTS_SIZE = "s3SinkObjectSizeBytes";
     private final S3SinkConfig s3SinkConfig;
     private final Lock reentrantLock;
-    private final Collection<EventHandle> bufferedEventHandles;
     private final OutputCodec codec;
     private final S3Client s3Client;
     private final int maxEvents;
@@ -81,8 +78,6 @@ public class S3SinkService {
         this.keyGenerator = keyGenerator;
         this.retrySleepTime = retrySleepTime;
         reentrantLock = new ReentrantLock();
-
-        bufferedEventHandles = new LinkedList<>();
 
         maxEvents = s3SinkConfig.getThresholdOptions().getEventCount();
         maxBytes = s3SinkConfig.getThresholdOptions().getMaximumSize();
@@ -126,8 +121,7 @@ public class S3SinkService {
                     codec.writeEvent(event, currentBuffer.getOutputStream());
                     int count = currentBuffer.getEventCount() + 1;
                     currentBuffer.setEventCount(count);
-
-                    bufferedEventHandles.add(event.getEventHandle());
+                    s3Group.addEventHandle(event.getEventHandle());
                 } catch (Exception ex) {
                     if(sampleException == null) {
                         sampleException = ex;
@@ -136,7 +130,7 @@ public class S3SinkService {
                     failedEvents.add(event);
                 }
 
-                final boolean flushed = flushToS3IfNeeded(currentBuffer);
+                final boolean flushed = flushToS3IfNeeded(s3Group);
 
                 if (flushed) {
                     s3GroupManager.removeGroup(s3Group);
@@ -144,7 +138,7 @@ public class S3SinkService {
             }
 
             for (final S3Group s3Group : s3GroupManager.getS3GroupEntries()) {
-                final boolean flushed = flushToS3IfNeeded(s3Group.getBuffer());
+                final boolean flushed = flushToS3IfNeeded(s3Group);
 
                 if (flushed) {
                     s3GroupManager.removeGroup(s3Group);
@@ -163,38 +157,30 @@ public class S3SinkService {
         }
     }
 
-    private void releaseEventHandles(final boolean result) {
-        for (EventHandle eventHandle : bufferedEventHandles) {
-            eventHandle.release(result);
-        }
-
-        bufferedEventHandles.clear();
-    }
-
     /**
      * @return whether the flush was attempted
      */
-    private boolean flushToS3IfNeeded(final Buffer currentBuffer) {
+    private boolean flushToS3IfNeeded(final S3Group s3Group) {
         LOG.trace("Flush to S3 check: currentBuffer.size={}, currentBuffer.events={}, currentBuffer.duration={}",
-                currentBuffer.getSize(), currentBuffer.getEventCount(), currentBuffer.getDuration());
-        if (ThresholdCheck.checkThresholdExceed(currentBuffer, maxEvents, maxBytes, maxCollectionDuration)) {
+                s3Group.getBuffer().getSize(), s3Group.getBuffer().getEventCount(), s3Group.getBuffer().getDuration());
+        if (ThresholdCheck.checkThresholdExceed(s3Group.getBuffer(), maxEvents, maxBytes, maxCollectionDuration)) {
             try {
-                codec.complete(currentBuffer.getOutputStream());
-                String s3Key = currentBuffer.getKey();
+                codec.complete(s3Group.getBuffer().getOutputStream());
+                String s3Key = s3Group.getBuffer().getKey();
                 LOG.info("Writing {} to S3 with {} events and size of {} bytes.",
-                        s3Key, currentBuffer.getEventCount(), currentBuffer.getSize());
-                final boolean isFlushToS3 = retryFlushToS3(currentBuffer, s3Key);
+                        s3Key, s3Group.getBuffer().getEventCount(), s3Group.getBuffer().getSize());
+                final boolean isFlushToS3 = retryFlushToS3(s3Group.getBuffer(), s3Key);
                 if (isFlushToS3) {
                     LOG.info("Successfully saved {} to S3.", s3Key);
-                    numberOfRecordsSuccessCounter.increment(currentBuffer.getEventCount());
+                    numberOfRecordsSuccessCounter.increment(s3Group.getBuffer().getEventCount());
                     objectsSucceededCounter.increment();
-                    s3ObjectSizeSummary.record(currentBuffer.getSize());
-                    releaseEventHandles(true);
+                    s3ObjectSizeSummary.record(s3Group.getBuffer().getSize());
+                    s3Group.releaseEventHandles(true);
                 } else {
                     LOG.error("Failed to save {} to S3.", s3Key);
-                    numberOfRecordsFailedCounter.increment(currentBuffer.getEventCount());
+                    numberOfRecordsFailedCounter.increment(s3Group.getBuffer().getEventCount());
                     objectsFailedCounter.increment();
-                    releaseEventHandles(false);
+                    s3Group.releaseEventHandles(false);
                 }
 
                 return true;

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/InMemoryBuffer.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/InMemoryBuffer.java
@@ -20,8 +20,8 @@ import java.util.function.Supplier;
  */
 public class InMemoryBuffer implements Buffer {
 
-    private static final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    private static final ByteArrayPositionOutputStream byteArrayPositionOutputStream = new ByteArrayPositionOutputStream(byteArrayOutputStream);
+    private final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    private final ByteArrayPositionOutputStream byteArrayPositionOutputStream = new ByteArrayPositionOutputStream(byteArrayOutputStream);
     private final S3Client s3Client;
     private final Supplier<String> bucketSupplier;
     private final Supplier<String> keySupplier;

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ObjectKey.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ObjectKey.java
@@ -6,6 +6,9 @@
 package org.opensearch.dataprepper.plugins.sink.s3.accumulator;
 
 import java.util.regex.Pattern;
+
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.s3keyindex.S3ObjectIndexUtility;
 import org.opensearch.dataprepper.plugins.sink.s3.S3SinkConfig;
 import org.slf4j.Logger;
@@ -31,10 +34,23 @@ public class ObjectKey {
      * @return s3 object path
      */
     public static String buildingPathPrefix(final S3SinkConfig s3SinkConfig) {
+        return buildingPathPrefixInternal(s3SinkConfig, null, null);
+    }
+
+    public static String buildingPathPrefix(final S3SinkConfig s3SinkConfig,
+                                            final Event event,
+                                            final ExpressionEvaluator expressionEvaluator) {
+        return buildingPathPrefixInternal(s3SinkConfig, event, expressionEvaluator);
+    }
+
+    private static String buildingPathPrefixInternal(final S3SinkConfig s3SinkConfig,
+                                                     final Event event,
+                                                     final ExpressionEvaluator expressionEvaluator) {
         String pathPrefix = s3SinkConfig.getObjectKeyOptions().getPathPrefix();
+        String pathPrefixExpressionResult = expressionEvaluator != null ? event.formatString(pathPrefix, expressionEvaluator) : pathPrefix;
         StringBuilder s3ObjectPath = new StringBuilder();
-        if (pathPrefix != null && !pathPrefix.isEmpty()) {
-            String[] pathPrefixList = pathPrefix.split("\\/");
+        if (pathPrefixExpressionResult != null && !pathPrefixExpressionResult.isEmpty()) {
+            String[] pathPrefixList = pathPrefixExpressionResult.split("\\/");
             for (String prefixPath : pathPrefixList) {
                 if (SIMPLE_DURATION_PATTERN.matcher(prefixPath).find()) {
                     s3ObjectPath.append(S3ObjectIndexUtility.getObjectPathPrefix(prefixPath)).append("/");
@@ -53,15 +69,26 @@ public class ObjectKey {
      * @param codecExtension extension
      * @return s3 object name with prefix
      */
-    public static String objectFileName(S3SinkConfig s3SinkConfig, String codecExtension) {
+    public static String objectFileName(final S3SinkConfig s3SinkConfig,
+                                        final String codecExtension,
+                                        final Event event,
+                                        final ExpressionEvaluator expressionEvaluator) {
         String configNamePattern = s3SinkConfig.getObjectKeyOptions().getNamePattern();
-        int extensionIndex = configNamePattern.lastIndexOf('.');
+        String configNamePatternExpressionResult = event.formatString(configNamePattern, expressionEvaluator);
+        int extensionIndex = configNamePatternExpressionResult.lastIndexOf('.');
         if (extensionIndex > 0) {
-            return S3ObjectIndexUtility.getObjectNameWithDateTimeId(configNamePattern.substring(0, extensionIndex)) + "."
-                    + (codecExtension!=null? codecExtension :configNamePattern.substring(extensionIndex + 1));
+            return S3ObjectIndexUtility.getObjectNameWithDateTimeId(configNamePatternExpressionResult.substring(0, extensionIndex)) + "."
+                    + (codecExtension!=null? codecExtension :configNamePatternExpressionResult.substring(extensionIndex + 1));
         } else {
-            return S3ObjectIndexUtility.getObjectNameWithDateTimeId(configNamePattern) + "." +
+            return S3ObjectIndexUtility.getObjectNameWithDateTimeId(configNamePatternExpressionResult) + "." +
                     (codecExtension!=null? codecExtension : DEFAULT_CODEC_FILE_EXTENSION);
         }
+    }
+
+    public static String objectFileNameWithoutDateTimeAndCodecInjection(final S3SinkConfig s3SinkConfig,
+                                                                final Event event,
+                                                                final ExpressionEvaluator expressionEvaluator) {
+        String configNamePattern = s3SinkConfig.getObjectKeyOptions().getNamePattern();
+        return event.formatString(configNamePattern, expressionEvaluator);
     }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ObjectKey.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ObjectKey.java
@@ -84,11 +84,4 @@ public class ObjectKey {
                     (codecExtension!=null? codecExtension : DEFAULT_CODEC_FILE_EXTENSION);
         }
     }
-
-    public static String objectFileNameWithoutDateTimeAndCodecInjection(final S3SinkConfig s3SinkConfig,
-                                                                final Event event,
-                                                                final ExpressionEvaluator expressionEvaluator) {
-        String configNamePattern = s3SinkConfig.getObjectKeyOptions().getNamePattern();
-        return event.formatString(configNamePattern, expressionEvaluator);
-    }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3Group.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3Group.java
@@ -11,11 +11,17 @@ public class S3Group {
 
     private final Buffer buffer;
 
-    public S3Group(final Buffer buffer) {
+    private final S3GroupIdentifier s3GroupIdentifier;
+
+    public S3Group(final S3GroupIdentifier s3GroupIdentifier,
+                   final Buffer buffer) {
         this.buffer = buffer;
+        this.s3GroupIdentifier = s3GroupIdentifier;
     }
 
     public Buffer getBuffer() {
         return buffer;
     }
+
+    S3GroupIdentifier getS3GroupIdentifier() { return s3GroupIdentifier; }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3Group.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3Group.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3.grouping;
+
+import org.opensearch.dataprepper.plugins.sink.s3.accumulator.Buffer;
+
+public class S3Group {
+
+    private final Buffer buffer;
+
+    public S3Group(final Buffer buffer) {
+        this.buffer = buffer;
+    }
+
+    public Buffer getBuffer() {
+        return buffer;
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3Group.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3Group.java
@@ -5,7 +5,11 @@
 
 package org.opensearch.dataprepper.plugins.sink.s3.grouping;
 
+import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.Buffer;
+
+import java.util.Collection;
+import java.util.LinkedList;
 
 public class S3Group {
 
@@ -13,10 +17,13 @@ public class S3Group {
 
     private final S3GroupIdentifier s3GroupIdentifier;
 
+    private final Collection<EventHandle> groupEventHandles;
+
     public S3Group(final S3GroupIdentifier s3GroupIdentifier,
                    final Buffer buffer) {
         this.buffer = buffer;
         this.s3GroupIdentifier = s3GroupIdentifier;
+        this.groupEventHandles = new LinkedList<>();
     }
 
     public Buffer getBuffer() {
@@ -24,4 +31,20 @@ public class S3Group {
     }
 
     S3GroupIdentifier getS3GroupIdentifier() { return s3GroupIdentifier; }
+
+    public void addEventHandle(final EventHandle eventHandle) {
+        groupEventHandles.add(eventHandle);
+    }
+
+    public void releaseEventHandles(final boolean result) {
+        for (EventHandle eventHandle : groupEventHandles) {
+            eventHandle.release(result);
+        }
+
+        groupEventHandles.clear();
+    }
+
+    Collection<EventHandle> getGroupEventHandles() {
+        return groupEventHandles;
+    }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifier.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3.grouping;
+
+import java.util.Objects;
+
+public class S3GroupIdentifier {
+    private final String groupIdentifierHash;
+    private final String groupIdentifierFullObjectKey;
+
+    public S3GroupIdentifier(final String groupIdentifierHash,
+                             final String groupIdentifierFullObjectKey) {
+        this.groupIdentifierHash = groupIdentifierHash;
+        this.groupIdentifierFullObjectKey = groupIdentifierFullObjectKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        S3GroupIdentifier that = (S3GroupIdentifier) o;
+        return Objects.equals(groupIdentifierHash, that.groupIdentifierHash);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupIdentifierHash);
+    }
+
+    public String getGroupIdentifierFullObjectKey() { return groupIdentifierFullObjectKey; }
+
+    public String getGroupIdentifierHash() { return groupIdentifierHash; }
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifier.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifier.java
@@ -5,13 +5,14 @@
 
 package org.opensearch.dataprepper.plugins.sink.s3.grouping;
 
+import java.util.Map;
 import java.util.Objects;
 
-public class S3GroupIdentifier {
-    private final String groupIdentifierHash;
+class S3GroupIdentifier {
+    private final Map<String, Object> groupIdentifierHash;
     private final String groupIdentifierFullObjectKey;
 
-    public S3GroupIdentifier(final String groupIdentifierHash,
+    public S3GroupIdentifier(final Map<String, Object> groupIdentifierHash,
                              final String groupIdentifierFullObjectKey) {
         this.groupIdentifierHash = groupIdentifierHash;
         this.groupIdentifierFullObjectKey = groupIdentifierFullObjectKey;
@@ -32,5 +33,5 @@ public class S3GroupIdentifier {
 
     public String getGroupIdentifierFullObjectKey() { return groupIdentifierFullObjectKey; }
 
-    public String getGroupIdentifierHash() { return groupIdentifierHash; }
+    public Map<String, Object> getGroupIdentifierHash() { return groupIdentifierHash; }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifierFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifierFactory.java
@@ -5,22 +5,56 @@
 
 package org.opensearch.dataprepper.plugins.sink.s3.grouping;
 
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.sink.s3.KeyGenerator;
+import org.opensearch.dataprepper.plugins.sink.s3.S3SinkConfig;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class S3GroupIdentifierFactory {
 
     private final KeyGenerator keyGenerator;
 
-    public S3GroupIdentifierFactory(final KeyGenerator keyGenerator) {
+    private final List<String> dynamicEventsKeys;
+
+    private final List<String> dynamicExpressions;
+
+    private final ExpressionEvaluator expressionEvaluator;
+
+    private final S3SinkConfig s3SinkConfig;
+
+    public S3GroupIdentifierFactory(final KeyGenerator keyGenerator,
+                                    final ExpressionEvaluator expressionEvaluator,
+                                    final S3SinkConfig s3SinkConfig) {
         this.keyGenerator = keyGenerator;
+        this.expressionEvaluator = expressionEvaluator;
+        this.s3SinkConfig = s3SinkConfig;
+
+        dynamicExpressions = expressionEvaluator.extractDynamicExpressionsFromFormatExpression(s3SinkConfig.getObjectKeyOptions().getPathPrefix());
+        dynamicExpressions.addAll(expressionEvaluator.extractDynamicExpressionsFromFormatExpression(s3SinkConfig.getObjectKeyOptions().getNamePattern()));
+
+        dynamicEventsKeys = expressionEvaluator.extractDynamicKeysFromFormatExpression(s3SinkConfig.getObjectKeyOptions().getPathPrefix());
+        dynamicEventsKeys.addAll(expressionEvaluator.extractDynamicKeysFromFormatExpression(s3SinkConfig.getObjectKeyOptions().getNamePattern()));
      }
 
 
     public S3GroupIdentifier getS3GroupIdentifierForEvent(final Event event) {
 
-        final String groupIdentificationHash = keyGenerator.generateKeyForEvent(event, false);
-        final String fullObjectKey = keyGenerator.generateKeyForEvent(event, true);
+        final String fullObjectKey = keyGenerator.generateKeyForEvent(event);
+        final Map<String, Object> groupIdentificationHash = new HashMap<>();
+
+        for (final String key : dynamicEventsKeys) {
+            final Object value = event.get(key, Object.class);
+            groupIdentificationHash.put(key, value);
+        }
+
+        for (final String expression : dynamicExpressions) {
+            final Object value = expressionEvaluator.evaluate(expression, event);
+            groupIdentificationHash.put(expression, value);
+        }
 
         return new S3GroupIdentifier(groupIdentificationHash, fullObjectKey);
     }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifierFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifierFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3.grouping;
+
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.plugins.sink.s3.KeyGenerator;
+
+public class S3GroupIdentifierFactory {
+
+    private final KeyGenerator keyGenerator;
+
+    public S3GroupIdentifierFactory(final KeyGenerator keyGenerator) {
+        this.keyGenerator = keyGenerator;
+     }
+
+
+    public S3GroupIdentifier getS3GroupIdentifierForEvent(final Event event) {
+
+        final String groupIdentificationHash = keyGenerator.generateKeyForEvent(event, false);
+        final String fullObjectKey = keyGenerator.generateKeyForEvent(event, true);
+
+        return new S3GroupIdentifier(groupIdentificationHash, fullObjectKey);
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManager.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManager.java
@@ -38,25 +38,25 @@ public class S3GroupManager {
         return allGroups.isEmpty();
     }
 
-    public void removeGroup(final S3GroupIdentifier s3GroupIdentifier) {
-        allGroups.remove(s3GroupIdentifier);
+    public void removeGroup(final S3Group s3Group) {
+        allGroups.remove(s3Group.getS3GroupIdentifier());
     }
 
-    public Collection<Map.Entry<S3GroupIdentifier, S3Group>> getS3GroupEntries() {
-        return allGroups.entrySet();
+    public Collection<S3Group> getS3GroupEntries() {
+        return allGroups.values();
     }
 
-    public Map.Entry<S3GroupIdentifier, S3Group> getOrCreateGroupForEvent(final Event event) {
+    public S3Group getOrCreateGroupForEvent(final Event event) {
 
         final S3GroupIdentifier s3GroupIdentifier = s3GroupIdentifierFactory.getS3GroupIdentifierForEvent(event);
 
         if (allGroups.containsKey(s3GroupIdentifier)) {
-            return Map.entry(s3GroupIdentifier, allGroups.get(s3GroupIdentifier));
+            return allGroups.get(s3GroupIdentifier);
         } else {
             final Buffer bufferForNewGroup =  bufferFactory.getBuffer(s3Client, s3SinkConfig::getBucketName, s3GroupIdentifier::getGroupIdentifierFullObjectKey);
-            final S3Group s3Group = new S3Group(bufferForNewGroup);
+            final S3Group s3Group = new S3Group(s3GroupIdentifier, bufferForNewGroup);
             allGroups.put(s3GroupIdentifier, s3Group);
-            return Map.entry(s3GroupIdentifier, s3Group);
+            return s3Group;
         }
     }
 

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManager.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManager.java
@@ -10,12 +10,16 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.sink.s3.S3SinkConfig;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.Buffer;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.Collection;
 import java.util.Map;
 
 public class S3GroupManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(S3GroupManager.class);
 
     private final Map<S3GroupIdentifier, S3Group> allGroups = Maps.newConcurrentMap();
     private final S3SinkConfig s3SinkConfig;
@@ -56,6 +60,7 @@ public class S3GroupManager {
             final Buffer bufferForNewGroup =  bufferFactory.getBuffer(s3Client, s3SinkConfig::getBucketName, s3GroupIdentifier::getGroupIdentifierFullObjectKey);
             final S3Group s3Group = new S3Group(s3GroupIdentifier, bufferForNewGroup);
             allGroups.put(s3GroupIdentifier, s3Group);
+            LOG.debug("Created a new S3 group. Total number of groups: {}", allGroups.size());
             return s3Group;
         }
     }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManager.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManager.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3.grouping;
+
+import com.google.common.collect.Maps;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.plugins.sink.s3.S3SinkConfig;
+import org.opensearch.dataprepper.plugins.sink.s3.accumulator.Buffer;
+import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferFactory;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class S3GroupManager {
+
+    private final Map<S3GroupIdentifier, S3Group> allGroups = Maps.newConcurrentMap();
+    private final S3SinkConfig s3SinkConfig;
+    private final S3GroupIdentifierFactory s3GroupIdentifierFactory;
+    private final BufferFactory bufferFactory;
+
+    private final S3Client s3Client;
+
+    public S3GroupManager(final S3SinkConfig s3SinkConfig,
+                          final S3GroupIdentifierFactory s3GroupIdentifierFactory,
+                          final BufferFactory bufferFactory,
+                          final S3Client s3Client) {
+        this.s3SinkConfig = s3SinkConfig;
+        this.s3GroupIdentifierFactory = s3GroupIdentifierFactory;
+        this.bufferFactory = bufferFactory;
+        this.s3Client = s3Client;
+    }
+
+    public boolean hasNoGroups() {
+        return allGroups.isEmpty();
+    }
+
+    public void removeGroup(final S3GroupIdentifier s3GroupIdentifier) {
+        allGroups.remove(s3GroupIdentifier);
+    }
+
+    public Collection<Map.Entry<S3GroupIdentifier, S3Group>> getS3GroupEntries() {
+        return allGroups.entrySet();
+    }
+
+    public Map.Entry<S3GroupIdentifier, S3Group> getOrCreateGroupForEvent(final Event event) {
+
+        final S3GroupIdentifier s3GroupIdentifier = s3GroupIdentifierFactory.getS3GroupIdentifierForEvent(event);
+
+        if (allGroups.containsKey(s3GroupIdentifier)) {
+            return Map.entry(s3GroupIdentifier, allGroups.get(s3GroupIdentifier));
+        } else {
+            final Buffer bufferForNewGroup =  bufferFactory.getBuffer(s3Client, s3SinkConfig::getBucketName, s3GroupIdentifier::getGroupIdentifierFullObjectKey);
+            final S3Group s3Group = new S3Group(bufferForNewGroup);
+            allGroups.put(s3GroupIdentifier, s3Group);
+            return Map.entry(s3GroupIdentifier, s3Group);
+        }
+    }
+
+
+}

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/KeyGeneratorTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/KeyGeneratorTest.java
@@ -27,9 +27,6 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class KeyGeneratorTest {
-    public static final String OBJECT_KEY_NAME_PATTERN_START = "events-";
-    public static final String OBJECT_KEY_NAME_PATTERN = OBJECT_KEY_NAME_PATTERN_START + "%{yyyy-MM-dd'T'hh-mm-ss}";
-
     @Mock
     private S3SinkConfig s3SinkConfig;
 
@@ -49,30 +46,6 @@ class KeyGeneratorTest {
     }
 
     @Test
-    void test_generateKey_with_general_prefix() {
-        String pathPrefix = "events/";
-        final String objectName = UUID.randomUUID().toString();
-        final Event event = mock(Event.class);
-
-        final KeyGenerator objectUnderTest = createObjectUnderTest();
-
-        try (final MockedStatic<ObjectKey> objectKeyMockedStatic = mockStatic(ObjectKey.class)) {
-
-            objectKeyMockedStatic.when(() -> ObjectKey.buildingPathPrefix(s3SinkConfig, event, expressionEvaluator))
-                    .thenReturn(pathPrefix);
-            objectKeyMockedStatic.when(() -> ObjectKey.objectFileNameWithoutDateTimeAndCodecInjection(s3SinkConfig, event, expressionEvaluator))
-                    .thenReturn(objectName);
-
-            String key = objectUnderTest.generateKeyForEvent(event, false);
-
-            assertNotNull(key);
-            assertThat(key, true);
-            assertThat(key, key.contains(pathPrefix));
-            assertThat(key.contains(objectName), equalTo(true));
-        }
-    }
-
-    @Test
     void test_generateKey_with_date_prefix() {
         String pathPrefix = "logdata/";
         final String objectName = UUID.randomUUID().toString();
@@ -89,7 +62,7 @@ class KeyGeneratorTest {
             objectKeyMockedStatic.when(() -> ObjectKey.objectFileName(s3SinkConfig, null, event, expressionEvaluator))
                     .thenReturn(objectName);
 
-            String key = objectUnderTest.generateKeyForEvent(event, true);
+            String key = objectUnderTest.generateKeyForEvent(event);
             assertNotNull(key);
             assertThat(key, true);
             assertThat(key.contains(pathPrefix), equalTo(true));
@@ -113,7 +86,7 @@ class KeyGeneratorTest {
             objectKeyMockedStatic.when(() -> ObjectKey.objectFileName(s3SinkConfig, extension, event, expressionEvaluator))
                     .thenReturn(objectName);
 
-            String key = objectUnderTest.generateKeyForEvent(event, true);
+            String key = objectUnderTest.generateKeyForEvent(event);
             assertThat(key, notNullValue());
             assertThat(key.contains(pathPrefix), equalTo(true));
             assertThat(key.contains(objectName), equalTo(true));

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceTest.java
@@ -31,7 +31,6 @@ import org.opensearch.dataprepper.plugins.sink.s3.configuration.AwsAuthenticatio
 import org.opensearch.dataprepper.plugins.sink.s3.configuration.ObjectKeyOptions;
 import org.opensearch.dataprepper.plugins.sink.s3.configuration.ThresholdOptions;
 import org.opensearch.dataprepper.plugins.sink.s3.grouping.S3Group;
-import org.opensearch.dataprepper.plugins.sink.s3.grouping.S3GroupIdentifier;
 import org.opensearch.dataprepper.plugins.sink.s3.grouping.S3GroupManager;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.regions.Region;
@@ -44,7 +43,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -166,12 +164,11 @@ class S3SinkServiceTest {
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
 
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
-        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
         doNothing().when(codec).writeEvent(event, outputStream);
         S3SinkService s3SinkService = createObjectUnderTest();
         assertNotNull(s3SinkService);
@@ -193,12 +190,11 @@ class S3SinkServiceTest {
         when(s3SinkConfig.getThresholdOptions().getMaximumSize()).thenReturn(ByteCount.parse("2kb"));
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
-        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
         doNothing().when(codec).writeEvent(event, outputStream);
         S3SinkService s3SinkService = createObjectUnderTest();
         assertNotNull(s3SinkService);
@@ -215,12 +211,11 @@ class S3SinkServiceTest {
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
-        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
 
         doNothing().when(codec).writeEvent(event, outputStream);
         S3SinkService s3SinkService = createObjectUnderTest();
@@ -240,12 +235,11 @@ class S3SinkServiceTest {
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
-        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
 
         doNothing().when(codec).writeEvent(event, outputStream);
         final S3SinkService s3SinkService = createObjectUnderTest();
@@ -266,12 +260,11 @@ class S3SinkServiceTest {
                 .thenReturn(outputStream1)
                 .thenReturn(outputStream2);
 
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
-        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
 
         doNothing().when(codec).writeEvent(any(), eq(outputStream1));
         doNothing().when(codec).writeEvent(any(), eq(outputStream2));
@@ -295,13 +288,12 @@ class S3SinkServiceTest {
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
         doNothing().when(codec).writeEvent(event, outputStream);
 
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         Buffer buffer = mock(Buffer.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
-        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
 
         S3SinkService s3SinkService = createObjectUnderTest();
         assertNotNull(s3SinkService);
@@ -322,12 +314,11 @@ class S3SinkServiceTest {
 
         final S3SinkService s3SinkService = createObjectUnderTest();
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
-        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
 
         final OutputStream outputStream = mock(OutputStream.class);
         doNothing().when(codec).writeEvent(event, outputStream);
@@ -346,12 +337,11 @@ class S3SinkServiceTest {
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
 
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(event)).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
-        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+        when(s3GroupManager.getOrCreateGroupForEvent(event)).thenReturn(s3Group);
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
 
         doNothing().when(codec).writeEvent(event, outputStream);
         final S3SinkService s3SinkService = createObjectUnderTest();
@@ -380,12 +370,11 @@ class S3SinkServiceTest {
         assertNotNull(buffer);
         OutputStream outputStream = buffer.getOutputStream();
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(event)).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
-        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+        when(s3GroupManager.getOrCreateGroupForEvent(event)).thenReturn(s3Group);
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
 
         codec.writeEvent(event, outputStream);
         final String s3Key = UUID.randomUUID().toString();
@@ -401,12 +390,11 @@ class S3SinkServiceTest {
         assertNotNull(s3SinkService);
         OutputStream outputStream = buffer.getOutputStream();
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(event)).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
-        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+        when(s3GroupManager.getOrCreateGroupForEvent(event)).thenReturn(s3Group);
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
 
         codec.writeEvent(event, outputStream);
         final String s3Key = UUID.randomUUID().toString();
@@ -425,12 +413,11 @@ class S3SinkServiceTest {
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
-        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
 
         doNothing().when(codec).writeEvent(event, outputStream);
         final S3SinkService s3SinkService = createObjectUnderTest();
@@ -455,11 +442,10 @@ class S3SinkServiceTest {
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event1 = JacksonEvent.fromMessage(UUID.randomUUID().toString());
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
 
         doNothing().when(codec).writeEvent(event1, outputStream);
         final S3SinkService s3SinkService = createObjectUnderTest();
@@ -500,11 +486,10 @@ class S3SinkServiceTest {
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
 
         doNothing().when(codec).writeEvent(event, outputStream);
         final S3SinkService s3SinkService = createObjectUnderTest();
@@ -530,11 +515,10 @@ class S3SinkServiceTest {
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
 
         doNothing().when(codec).writeEvent(event, outputStream);
         final S3SinkService s3SinkService = createObjectUnderTest();
@@ -573,11 +557,10 @@ class S3SinkServiceTest {
         List<Record<Event>> records = generateEventRecords(2);
         Event event1 = records.get(0).getData();
         Event event2 = records.get(1).getData();
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
 
         DefaultEventHandle eventHandle1 = (DefaultEventHandle)event1.getEventHandle();
         DefaultEventHandle eventHandle2 = (DefaultEventHandle)event2.getEventHandle();
@@ -610,11 +593,10 @@ class S3SinkServiceTest {
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
-        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
-        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
 
         doNothing().when(codec).writeEvent(event, outputStream);
         final S3SinkService s3SinkService = createObjectUnderTest();

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceTest.java
@@ -12,26 +12,27 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventHandle;
-import org.opensearch.dataprepper.model.event.DefaultEventHandle;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.plugin.PluginFactory;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 import org.opensearch.dataprepper.model.types.ByteCount;
-import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.Buffer;
-import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferFactory;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferTypeOptions;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.InMemoryBuffer;
-import org.opensearch.dataprepper.plugins.sink.s3.accumulator.InMemoryBufferFactory;
 import org.opensearch.dataprepper.plugins.sink.s3.configuration.AwsAuthenticationOptions;
 import org.opensearch.dataprepper.plugins.sink.s3.configuration.ObjectKeyOptions;
 import org.opensearch.dataprepper.plugins.sink.s3.configuration.ThresholdOptions;
+import org.opensearch.dataprepper.plugins.sink.s3.grouping.S3Group;
+import org.opensearch.dataprepper.plugins.sink.s3.grouping.S3GroupIdentifier;
+import org.opensearch.dataprepper.plugins.sink.s3.grouping.S3GroupManager;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -43,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -81,12 +83,13 @@ class S3SinkServiceTest {
     private OutputCodecContext codecContext;
     private KeyGenerator keyGenerator = mock(KeyGenerator.class);
     private PluginMetrics pluginMetrics;
-    private BufferFactory bufferFactory;
     private Counter snapshotSuccessCounter;
     private DistributionSummary s3ObjectSizeSummary;
     private Random random;
     private String tagsTargetKey;
     private AcknowledgementSet acknowledgementSet;
+
+    private S3GroupManager s3GroupManager;
 
     @BeforeEach
     void setUp() {
@@ -111,7 +114,7 @@ class S3SinkServiceTest {
         Counter numberOfRecordsFailedCounter = mock(Counter.class);
         s3ObjectSizeSummary = mock(DistributionSummary.class);
 
-        bufferFactory = new InMemoryBufferFactory();
+        s3GroupManager = mock(S3GroupManager.class);
 
         when(objectKeyOptions.getNamePattern()).thenReturn(OBJECT_KEY_NAME_PATTERN);
         when(s3SinkConfig.getMaxUploadRetries()).thenReturn(MAX_RETRIES);
@@ -143,7 +146,7 @@ class S3SinkServiceTest {
     }
 
     private S3SinkService createObjectUnderTest() {
-        return new S3SinkService(s3SinkConfig, bufferFactory, codec, codecContext, s3Client, keyGenerator, Duration.ofMillis(100), pluginMetrics);
+        return new S3SinkService(s3SinkConfig, codec, codecContext, s3Client, keyGenerator, Duration.ofMillis(100), pluginMetrics, s3GroupManager);
     }
 
     @Test
@@ -155,15 +158,20 @@ class S3SinkServiceTest {
 
     @Test
     void test_output_with_threshold_set_as_more_then_zero_event_count() throws IOException {
-        bufferFactory = mock(BufferFactory.class);
         InMemoryBuffer buffer = mock(InMemoryBuffer.class);
         when(buffer.getEventCount()).thenReturn(10);
         doNothing().when(buffer).flushToS3();
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
 
         when(s3SinkConfig.getThresholdOptions().getEventCount()).thenReturn(5);
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
         doNothing().when(codec).writeEvent(event, outputStream);
         S3SinkService s3SinkService = createObjectUnderTest();
         assertNotNull(s3SinkService);
@@ -177,16 +185,20 @@ class S3SinkServiceTest {
     @Test
     void test_output_with_threshold_set_as_zero_event_count() throws IOException {
 
-        bufferFactory = mock(BufferFactory.class);
         InMemoryBuffer buffer = mock(InMemoryBuffer.class);
         when(buffer.getSize()).thenReturn(25500L);
         doNothing().when(buffer).flushToS3();
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
 
         when(s3SinkConfig.getThresholdOptions().getEventCount()).thenReturn(0);
         when(s3SinkConfig.getThresholdOptions().getMaximumSize()).thenReturn(ByteCount.parse("2kb"));
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
         doNothing().when(codec).writeEvent(event, outputStream);
         S3SinkService s3SinkService = createObjectUnderTest();
         assertNotNull(s3SinkService);
@@ -197,14 +209,19 @@ class S3SinkServiceTest {
     @Test
     void test_output_with_uploadedToS3_success() throws IOException {
 
-        bufferFactory = mock(BufferFactory.class);
         InMemoryBuffer buffer = mock(InMemoryBuffer.class);
         when(buffer.getEventCount()).thenReturn(10);
         doNothing().when(buffer).flushToS3();
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+
         doNothing().when(codec).writeEvent(event, outputStream);
         S3SinkService s3SinkService = createObjectUnderTest();
         assertNotNull(s3SinkService);
@@ -216,15 +233,20 @@ class S3SinkServiceTest {
     @Test
     void test_output_with_uploadedToS3_success_records_byte_count() throws IOException {
 
-        bufferFactory = mock(BufferFactory.class);
         Buffer buffer = mock(Buffer.class);
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
 
         final long objectSize = random.nextInt(1_000_000) + 10_000;
         when(buffer.getSize()).thenReturn(objectSize);
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+
         doNothing().when(codec).writeEvent(event, outputStream);
         final S3SinkService s3SinkService = createObjectUnderTest();
         s3SinkService.output(generateRandomStringEventRecord());
@@ -235,16 +257,21 @@ class S3SinkServiceTest {
     @Test
     void test_output_with_uploadedToS3_midBatch_generatesNewOutputStream() throws IOException {
 
-        bufferFactory = mock(BufferFactory.class);
         InMemoryBuffer buffer = mock(InMemoryBuffer.class);
         when(buffer.getEventCount()).thenReturn(10);
         doNothing().when(buffer).flushToS3();
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
         final OutputStream outputStream1 = mock(OutputStream.class);
         final OutputStream outputStream2 = mock(OutputStream.class);
         when(buffer.getOutputStream())
                 .thenReturn(outputStream1)
                 .thenReturn(outputStream2);
+
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
 
         doNothing().when(codec).writeEvent(any(), eq(outputStream1));
         doNothing().when(codec).writeEvent(any(), eq(outputStream2));
@@ -267,6 +294,15 @@ class S3SinkServiceTest {
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
         doNothing().when(codec).writeEvent(event, outputStream);
+
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        Buffer buffer = mock(Buffer.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+
         S3SinkService s3SinkService = createObjectUnderTest();
         assertNotNull(s3SinkService);
         assertThat(s3SinkService, instanceOf(S3SinkService.class));
@@ -277,9 +313,7 @@ class S3SinkServiceTest {
     @Test
     void test_output_with_uploadedToS3_failure_does_not_record_byte_count() throws IOException {
 
-        bufferFactory = mock(BufferFactory.class);
         Buffer buffer = mock(Buffer.class);
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
 
         doThrow(AwsServiceException.class).when(buffer).flushToS3();
 
@@ -288,6 +322,13 @@ class S3SinkServiceTest {
 
         final S3SinkService s3SinkService = createObjectUnderTest();
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+
         final OutputStream outputStream = mock(OutputStream.class);
         doNothing().when(codec).writeEvent(event, outputStream);
         s3SinkService.output(Collections.singletonList(new Record<>(event)));
@@ -299,13 +340,19 @@ class S3SinkServiceTest {
     @Test
     void test_output_with_no_incoming_records_flushes_batch() throws IOException {
 
-        bufferFactory = mock(BufferFactory.class);
         Buffer buffer = mock(Buffer.class);
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
         when(buffer.getEventCount()).thenReturn(10);
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(event)).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+
         doNothing().when(codec).writeEvent(event, outputStream);
         final S3SinkService s3SinkService = createObjectUnderTest();
         s3SinkService.output(Collections.emptyList());
@@ -316,37 +363,30 @@ class S3SinkServiceTest {
 
     @Test
     void test_output_with_no_incoming_records_or_buffered_records_short_circuits() throws IOException {
-
-        bufferFactory = mock(BufferFactory.class);
-        Buffer buffer = mock(Buffer.class);
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
-        when(buffer.getEventCount()).thenReturn(0);
-        final long objectSize = random.nextInt(1_000_000) + 10_000;
-        when(buffer.getSize()).thenReturn(objectSize);
-
-        final OutputStream outputStream = mock(OutputStream.class);
-        final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
-        doNothing().when(codec).writeEvent(event, outputStream);
+        when(s3GroupManager.hasNoGroups()).thenReturn(true);
         final S3SinkService s3SinkService = createObjectUnderTest();
         s3SinkService.output(Collections.emptyList());
 
         verify(snapshotSuccessCounter, times(0)).increment();
-        verify(buffer, times(0)).flushToS3();
     }
 
     @Test
     void test_retryFlushToS3_positive() throws InterruptedException, IOException {
-
-        bufferFactory = mock(BufferFactory.class);
         InMemoryBuffer buffer = mock(InMemoryBuffer.class);
         doNothing().when(buffer).flushToS3();
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
 
         S3SinkService s3SinkService = createObjectUnderTest();
         assertNotNull(s3SinkService);
         assertNotNull(buffer);
         OutputStream outputStream = buffer.getOutputStream();
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(event)).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+
         codec.writeEvent(event, outputStream);
         final String s3Key = UUID.randomUUID().toString();
         boolean isUploadedToS3 = s3SinkService.retryFlushToS3(buffer, s3Key);
@@ -355,14 +395,19 @@ class S3SinkServiceTest {
 
     @Test
     void test_retryFlushToS3_negative() throws InterruptedException, IOException {
-        bufferFactory = mock(BufferFactory.class);
         InMemoryBuffer buffer = mock(InMemoryBuffer.class);
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
         when(s3SinkConfig.getBucketName()).thenReturn("");
         S3SinkService s3SinkService = createObjectUnderTest();
         assertNotNull(s3SinkService);
         OutputStream outputStream = buffer.getOutputStream();
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(event)).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+
         codec.writeEvent(event, outputStream);
         final String s3Key = UUID.randomUUID().toString();
         doThrow(AwsServiceException.class).when(buffer).flushToS3();
@@ -373,15 +418,20 @@ class S3SinkServiceTest {
 
     @Test
     void output_will_release_all_handles_since_a_flush() throws IOException {
-        bufferFactory = mock(BufferFactory.class);
         final Buffer buffer = mock(Buffer.class);
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
 
         final long objectSize = random.nextInt(1_000_000) + 10_000;
         when(buffer.getSize()).thenReturn(objectSize);
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+        when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(Map.entry(s3GroupIdentifier, s3Group)));
+
         doNothing().when(codec).writeEvent(event, outputStream);
         final S3SinkService s3SinkService = createObjectUnderTest();
         final Collection<Record<Event>> records = generateRandomStringEventRecord();
@@ -399,15 +449,18 @@ class S3SinkServiceTest {
 
     @Test
     void output_will_skip_releasing_events_without_EventHandle_objects() throws IOException {
-        bufferFactory = mock(BufferFactory.class);
         final Buffer buffer = mock(Buffer.class);
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
-
         final long objectSize = random.nextInt(1_000_000) + 10_000;
         when(buffer.getSize()).thenReturn(objectSize);
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event1 = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+
         doNothing().when(codec).writeEvent(event1, outputStream);
         final S3SinkService s3SinkService = createObjectUnderTest();
         final Collection<Record<Event>> records = generateRandomStringEventRecord();
@@ -438,9 +491,7 @@ class S3SinkServiceTest {
 
     @Test
     void output_will_release_all_handles_since_a_flush_when_S3_fails() throws IOException {
-        bufferFactory = mock(BufferFactory.class);
         final Buffer buffer = mock(Buffer.class);
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
 
         doThrow(AwsServiceException.class).when(buffer).flushToS3();
 
@@ -449,6 +500,12 @@ class S3SinkServiceTest {
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+
         doNothing().when(codec).writeEvent(event, outputStream);
         final S3SinkService s3SinkService = createObjectUnderTest();
         final List<Record<Event>> records = generateEventRecords(1);
@@ -466,15 +523,19 @@ class S3SinkServiceTest {
 
     @Test
     void output_will_release_only_new_handles_since_a_flush() throws IOException {
-        bufferFactory = mock(BufferFactory.class);
         final Buffer buffer = mock(Buffer.class);
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
 
         final long objectSize = random.nextInt(1_000_000) + 10_000;
         when(buffer.getSize()).thenReturn(objectSize);
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+
         doNothing().when(codec).writeEvent(event, outputStream);
         final S3SinkService s3SinkService = createObjectUnderTest();
         final Collection<Record<Event>> records = generateRandomStringEventRecord();
@@ -500,9 +561,7 @@ class S3SinkServiceTest {
 
     @Test
     void output_will_skip_and_drop_failed_records() throws IOException {
-        bufferFactory = mock(BufferFactory.class);
         final Buffer buffer = mock(Buffer.class);
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
 
         final long objectSize = random.nextInt(1_000_000) + 10_000;
         when(buffer.getSize()).thenReturn(objectSize);
@@ -514,6 +573,12 @@ class S3SinkServiceTest {
         List<Record<Event>> records = generateEventRecords(2);
         Event event1 = records.get(0).getData();
         Event event2 = records.get(1).getData();
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+
         DefaultEventHandle eventHandle1 = (DefaultEventHandle)event1.getEventHandle();
         DefaultEventHandle eventHandle2 = (DefaultEventHandle)event2.getEventHandle();
         eventHandle1.setAcknowledgementSet(acknowledgementSet);
@@ -536,9 +601,7 @@ class S3SinkServiceTest {
 
     @Test
     void output_will_release_only_new_handles_since_a_flush_when_S3_fails() throws IOException {
-        bufferFactory = mock(BufferFactory.class);
         final Buffer buffer = mock(Buffer.class);
-        when(bufferFactory.getBuffer(any(S3Client.class), any(), any())).thenReturn(buffer);
 
         doThrow(AwsServiceException.class).when(buffer).flushToS3();
 
@@ -547,6 +610,12 @@ class S3SinkServiceTest {
 
         final OutputStream outputStream = mock(OutputStream.class);
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getBuffer()).thenReturn(buffer);
+
+        when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(Map.entry(s3GroupIdentifier, s3Group));
+
         doNothing().when(codec).writeEvent(event, outputStream);
         final S3SinkService s3SinkService = createObjectUnderTest();
         final List<Record<Event>> records = generateEventRecords(1);

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
@@ -37,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -58,6 +60,7 @@ class S3SinkTest {
     private PluginFactory pluginFactory;
     private AwsCredentialsSupplier awsCredentialsSupplier;
     private SinkContext sinkContext;
+    private ExpressionEvaluator expressionEvaluator;
     private OutputCodec codec;
 
     @BeforeEach
@@ -73,6 +76,7 @@ class S3SinkTest {
         PluginModel pluginModel = mock(PluginModel.class);
         pluginFactory = mock(PluginFactory.class);
         awsCredentialsSupplier = mock(AwsCredentialsSupplier.class);
+        expressionEvaluator = mock(ExpressionEvaluator.class);
 
         when(s3SinkConfig.getBufferType()).thenReturn(BufferTypeOptions.INMEMORY);
         when(s3SinkConfig.getThresholdOptions()).thenReturn(thresholdOptions);
@@ -89,10 +93,12 @@ class S3SinkTest {
         when(pluginSetting.getName()).thenReturn(SINK_PLUGIN_NAME);
         when(pluginSetting.getPipelineName()).thenReturn(SINK_PIPELINE_NAME);
         when(s3SinkConfig.getBucketName()).thenReturn(BUCKET_NAME);
+        when(s3SinkConfig.getObjectKeyOptions()).thenReturn(objectKeyOptions);
+        when(expressionEvaluator.isValidFormatExpression(anyString())).thenReturn(true);
     }
 
     private S3Sink createObjectUnderTest() {
-        return new S3Sink(pluginSetting, s3SinkConfig, pluginFactory, sinkContext, awsCredentialsSupplier);
+        return new S3Sink(pluginSetting, s3SinkConfig, pluginFactory, sinkContext, awsCredentialsSupplier, expressionEvaluator);
     }
 
     @Test

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ObjectKeyTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ObjectKeyTest.java
@@ -16,7 +16,6 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.sink.s3.S3SinkConfig;
 import org.opensearch.dataprepper.plugins.sink.s3.configuration.ObjectKeyOptions;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
@@ -84,17 +83,5 @@ class ObjectKeyTest {
         String objectFileName = ObjectKey.objectFileName(s3SinkConfig, null, event, expressionEvaluator);
         Assertions.assertNotNull(objectFileName);
         Assertions.assertTrue(objectFileName.contains(".json"));
-    }
-
-    @Test
-    void test_objectFileName_without_date_time_and_codec_injection() {
-        final String namePattern = "events-%{yyyy-MM-dd'T'hh-mm-ss}";
-
-        when(s3SinkConfig.getObjectKeyOptions().getNamePattern())
-                .thenReturn(namePattern);
-        when(event.formatString(namePattern, expressionEvaluator)).thenReturn(namePattern);
-        String objectFileName = ObjectKey.objectFileNameWithoutDateTimeAndCodecInjection(s3SinkConfig, event, expressionEvaluator);
-        Assertions.assertNotNull(objectFileName);
-        assertThat(objectFileName, equalTo(namePattern));
     }
 }

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ObjectKeyTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/ObjectKeyTest.java
@@ -11,12 +11,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.opensearch.dataprepper.model.configuration.PluginModel;
-import org.opensearch.dataprepper.model.configuration.PluginSetting;
-import org.opensearch.dataprepper.model.plugin.PluginFactory;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.sink.s3.S3SinkConfig;
 import org.opensearch.dataprepper.plugins.sink.s3.configuration.ObjectKeyOptions;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
@@ -25,17 +25,15 @@ import static org.mockito.Mockito.when;
 class ObjectKeyTest {
 
     @Mock
-    private ObjectKey objectKey;
-    @Mock
     private S3SinkConfig s3SinkConfig;
     @Mock
-    private PluginModel pluginModel;
-    @Mock
-    private PluginSetting pluginSetting;
-    @Mock
-    private PluginFactory pluginFactory;
-    @Mock
     private ObjectKeyOptions objectKeyOptions;
+
+    @Mock
+    private ExpressionEvaluator expressionEvaluator;
+
+    @Mock
+    private Event event;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -44,39 +42,59 @@ class ObjectKeyTest {
 
     @Test
     void test_buildingPathPrefix() {
+        final String pathPrefix = "events/%{yyyy}/%{MM}/%{dd}/";
 
-        when(objectKeyOptions.getPathPrefix()).thenReturn("events/%{yyyy}/%{MM}/%{dd}/");
-        String pathPrefix = ObjectKey.buildingPathPrefix(s3SinkConfig);
-        Assertions.assertNotNull(pathPrefix);
-        assertThat(pathPrefix, startsWith("events"));
+        when(objectKeyOptions.getPathPrefix()).thenReturn(pathPrefix);
+        when(event.formatString(pathPrefix, expressionEvaluator)).thenReturn(pathPrefix);
+        String pathPrefixResult = ObjectKey.buildingPathPrefix(s3SinkConfig, event, expressionEvaluator);
+        Assertions.assertNotNull(pathPrefixResult);
+        assertThat(pathPrefixResult, startsWith("events"));
     }
 
     @Test
     void test_objectFileName() {
+        final String namePattern = "my-elb-%{yyyy-MM-dd'T'hh-mm-ss}";
 
-        when(objectKeyOptions.getNamePattern()).thenReturn("my-elb-%{yyyy-MM-dd'T'hh-mm-ss}");
-        String objectFileName = ObjectKey.objectFileName(s3SinkConfig, null);
+        when(objectKeyOptions.getNamePattern()).thenReturn(namePattern);
+        when(event.formatString(namePattern, expressionEvaluator)).thenReturn(namePattern);
+        String objectFileName = ObjectKey.objectFileName(s3SinkConfig, null, event, expressionEvaluator);
         Assertions.assertNotNull(objectFileName);
         assertThat(objectFileName, startsWith("my-elb"));
     }
 
     @Test
     void test_objectFileName_with_fileExtension() {
+        final String namePattern = "events-%{yyyy-MM-dd'T'hh-mm-ss}.pdf";
 
         when(s3SinkConfig.getObjectKeyOptions().getNamePattern())
-                .thenReturn("events-%{yyyy-MM-dd'T'hh-mm-ss}.pdf");
-        String objectFileName = ObjectKey.objectFileName(s3SinkConfig, null);
+                .thenReturn(namePattern);
+        when(event.formatString(namePattern, expressionEvaluator)).thenReturn(namePattern);
+        String objectFileName = ObjectKey.objectFileName(s3SinkConfig, null, event, expressionEvaluator);
         Assertions.assertNotNull(objectFileName);
         Assertions.assertTrue(objectFileName.contains(".pdf"));
     }
 
     @Test
     void test_objectFileName_default_fileExtension() {
+        final String namePattern = "events-%{yyyy-MM-dd'T'hh-mm-ss}";
 
         when(s3SinkConfig.getObjectKeyOptions().getNamePattern())
-                .thenReturn("events-%{yyyy-MM-dd'T'hh-mm-ss}");
-        String objectFileName = ObjectKey.objectFileName(s3SinkConfig, null);
+                .thenReturn(namePattern);
+        when(event.formatString(namePattern, expressionEvaluator)).thenReturn(namePattern);
+        String objectFileName = ObjectKey.objectFileName(s3SinkConfig, null, event, expressionEvaluator);
         Assertions.assertNotNull(objectFileName);
         Assertions.assertTrue(objectFileName.contains(".json"));
+    }
+
+    @Test
+    void test_objectFileName_without_date_time_and_codec_injection() {
+        final String namePattern = "events-%{yyyy-MM-dd'T'hh-mm-ss}";
+
+        when(s3SinkConfig.getObjectKeyOptions().getNamePattern())
+                .thenReturn(namePattern);
+        when(event.formatString(namePattern, expressionEvaluator)).thenReturn(namePattern);
+        String objectFileName = ObjectKey.objectFileNameWithoutDateTimeAndCodecInjection(s3SinkConfig, event, expressionEvaluator);
+        Assertions.assertNotNull(objectFileName);
+        assertThat(objectFileName, equalTo(namePattern));
     }
 }

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifierFactoryTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifierFactoryTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3.grouping;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.plugins.sink.s3.KeyGenerator;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class S3GroupIdentifierFactoryTest {
+
+    private KeyGenerator keyGenerator;
+
+    @BeforeEach
+    void setup() {
+        keyGenerator = mock(KeyGenerator.class);
+    }
+
+    private S3GroupIdentifierFactory createObjectUnderTest() {
+        return new S3GroupIdentifierFactory(keyGenerator);
+    }
+
+    @Test
+    void getS3GroupIdentifierForEvent_returns_expected_s3GroupIdentifier() {
+        final String expectedIdentificationHash = UUID.randomUUID().toString();
+        final String expectedFullObjectKey = UUID.randomUUID().toString();
+        final Event event = mock(Event.class);
+
+        when(keyGenerator.generateKeyForEvent(event, false)).thenReturn(expectedIdentificationHash);
+        when(keyGenerator.generateKeyForEvent(event, true)).thenReturn(expectedFullObjectKey);
+
+        final S3GroupIdentifierFactory objectUnderTest = createObjectUnderTest();
+
+        final S3GroupIdentifier result = objectUnderTest.getS3GroupIdentifierForEvent(event);
+
+        assertThat(result, notNullValue());
+        assertThat(result.getGroupIdentifierFullObjectKey(), equalTo(expectedFullObjectKey));
+        assertThat(result.getGroupIdentifierHash(), equalTo(expectedIdentificationHash));
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifierFactoryTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifierFactoryTest.java
@@ -7,9 +7,15 @@ package org.opensearch.dataprepper.plugins.sink.s3.grouping;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.sink.s3.KeyGenerator;
+import org.opensearch.dataprepper.plugins.sink.s3.S3SinkConfig;
+import org.opensearch.dataprepper.plugins.sink.s3.configuration.ObjectKeyOptions;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,23 +28,72 @@ public class S3GroupIdentifierFactoryTest {
 
     private KeyGenerator keyGenerator;
 
+    private S3SinkConfig s3SinkConfig;
+
+    private ExpressionEvaluator expressionEvaluator;
+
     @BeforeEach
     void setup() {
         keyGenerator = mock(KeyGenerator.class);
+        expressionEvaluator = mock(ExpressionEvaluator.class);
+        s3SinkConfig = mock(S3SinkConfig.class);
+
+        final String pathPrefix = UUID.randomUUID().toString();
+        final String objectName = UUID.randomUUID().toString();
+        final ObjectKeyOptions objectKeyOptions = mock(ObjectKeyOptions.class);
+        when(objectKeyOptions.getNamePattern()).thenReturn(objectName);
+        when(objectKeyOptions.getPathPrefix()).thenReturn(pathPrefix);
+
+        when(s3SinkConfig.getObjectKeyOptions()).thenReturn(objectKeyOptions);
     }
 
     private S3GroupIdentifierFactory createObjectUnderTest() {
-        return new S3GroupIdentifierFactory(keyGenerator);
+        return new S3GroupIdentifierFactory(keyGenerator, expressionEvaluator, s3SinkConfig);
     }
 
     @Test
     void getS3GroupIdentifierForEvent_returns_expected_s3GroupIdentifier() {
-        final String expectedIdentificationHash = UUID.randomUUID().toString();
+        final String dynamicKeyPathPrefix = UUID.randomUUID().toString();
+        final String dynamicValuePathPrefix = UUID.randomUUID().toString();
+        final String dynamicExpressionPathPrefix = UUID.randomUUID().toString();
+        final String dynamicExpressionResultPathPrefix = UUID.randomUUID().toString();
+        final String dynamicKeyObjectName = UUID.randomUUID().toString();
+        final String dynamicValueObjectName = UUID.randomUUID().toString();
+        final String dynamicExpressionObjectName = UUID.randomUUID().toString();
+        final String dynamicExpressionResultObjectName = UUID.randomUUID().toString();
+
+        final Map<String, Object> expectedIdentificationHash = Map.of(
+                dynamicKeyPathPrefix, dynamicValuePathPrefix,
+                dynamicExpressionPathPrefix, dynamicExpressionResultPathPrefix,
+                dynamicKeyObjectName, dynamicValueObjectName,
+                dynamicExpressionObjectName, dynamicExpressionResultObjectName
+        );
         final String expectedFullObjectKey = UUID.randomUUID().toString();
         final Event event = mock(Event.class);
 
-        when(keyGenerator.generateKeyForEvent(event, false)).thenReturn(expectedIdentificationHash);
-        when(keyGenerator.generateKeyForEvent(event, true)).thenReturn(expectedFullObjectKey);
+        final List<String> expectedDynamicKeysPathPrefix = new ArrayList<>();
+        expectedDynamicKeysPathPrefix.add(dynamicKeyPathPrefix);
+
+        final List<String> expectedDynamicExpressionsPathPrefix = new ArrayList<>();
+        expectedDynamicExpressionsPathPrefix.add(dynamicExpressionPathPrefix);
+
+        when(expressionEvaluator.extractDynamicExpressionsFromFormatExpression(s3SinkConfig.getObjectKeyOptions().getPathPrefix()))
+                .thenReturn(expectedDynamicExpressionsPathPrefix);
+        when(expressionEvaluator.extractDynamicKeysFromFormatExpression(s3SinkConfig.getObjectKeyOptions().getPathPrefix()))
+                .thenReturn(expectedDynamicKeysPathPrefix);
+        when(event.get(dynamicKeyPathPrefix, Object.class)).thenReturn(dynamicValuePathPrefix);
+        when(expressionEvaluator.evaluate(dynamicExpressionPathPrefix, event))
+                .thenReturn(dynamicExpressionResultPathPrefix);
+
+        when(expressionEvaluator.extractDynamicExpressionsFromFormatExpression(s3SinkConfig.getObjectKeyOptions().getNamePattern()))
+                .thenReturn(List.of(dynamicExpressionObjectName));
+        when(expressionEvaluator.extractDynamicKeysFromFormatExpression(s3SinkConfig.getObjectKeyOptions().getNamePattern()))
+                .thenReturn(List.of(dynamicKeyObjectName));
+        when(event.get(dynamicKeyObjectName, Object.class)).thenReturn(dynamicValueObjectName);
+        when(expressionEvaluator.evaluate(dynamicExpressionObjectName, event))
+                .thenReturn(dynamicExpressionResultObjectName);
+
+        when(keyGenerator.generateKeyForEvent(event)).thenReturn(expectedFullObjectKey);
 
         final S3GroupIdentifierFactory objectUnderTest = createObjectUnderTest();
 

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifierTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifierTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3.grouping;
+
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class S3GroupIdentifierTest {
+
+    @Test
+    void S3GroupIdentifier_with_the_same_identificationHash_and_different_fullObjectKey_are_considered_equal() {
+        final String identificationHash = UUID.randomUUID().toString();
+        final String groupOneFullObjectKey = UUID.randomUUID().toString();
+        final String groupTwoFullObjectKey = UUID.randomUUID().toString();
+
+        final S3GroupIdentifier s3GroupIdentifier = new S3GroupIdentifier(identificationHash, groupOneFullObjectKey);
+        final S3GroupIdentifier seconds3GroupIdentifier = new S3GroupIdentifier(identificationHash, groupTwoFullObjectKey);
+
+        assertThat(s3GroupIdentifier.equals(seconds3GroupIdentifier), equalTo(true));
+    }
+
+    @Test
+    void S3GroupIdentifier_with_different_identificationHash_is_not_considered_equal() {
+        final String identificationHashOne = UUID.randomUUID().toString();
+        final String identificationHashTwo = UUID.randomUUID().toString();
+        final String groupOneFullObjectKey = UUID.randomUUID().toString();
+        final String groupTwoFullObjectKey = UUID.randomUUID().toString();
+
+        final S3GroupIdentifier s3GroupIdentifier = new S3GroupIdentifier(identificationHashOne, groupOneFullObjectKey);
+        final S3GroupIdentifier seconds3GroupIdentifier = new S3GroupIdentifier(identificationHashTwo, groupTwoFullObjectKey);
+
+        assertThat(s3GroupIdentifier.equals(seconds3GroupIdentifier), equalTo(false));
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifierTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupIdentifierTest.java
@@ -8,16 +8,18 @@ package org.opensearch.dataprepper.plugins.sink.s3.grouping;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class S3GroupIdentifierTest {
 
     @Test
     void S3GroupIdentifier_with_the_same_identificationHash_and_different_fullObjectKey_are_considered_equal() {
-        final String identificationHash = UUID.randomUUID().toString();
+        final Map<String, Object> identificationHash = Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
         final String groupOneFullObjectKey = UUID.randomUUID().toString();
         final String groupTwoFullObjectKey = UUID.randomUUID().toString();
 
@@ -25,12 +27,13 @@ public class S3GroupIdentifierTest {
         final S3GroupIdentifier seconds3GroupIdentifier = new S3GroupIdentifier(identificationHash, groupTwoFullObjectKey);
 
         assertThat(s3GroupIdentifier.equals(seconds3GroupIdentifier), equalTo(true));
+        assertThat(s3GroupIdentifier.hashCode(), equalTo(seconds3GroupIdentifier.hashCode()));
     }
 
     @Test
     void S3GroupIdentifier_with_different_identificationHash_is_not_considered_equal() {
-        final String identificationHashOne = UUID.randomUUID().toString();
-        final String identificationHashTwo = UUID.randomUUID().toString();
+        final Map<String, Object> identificationHashOne = Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        final Map<String, Object> identificationHashTwo = Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
         final String groupOneFullObjectKey = UUID.randomUUID().toString();
         final String groupTwoFullObjectKey = UUID.randomUUID().toString();
 
@@ -38,5 +41,6 @@ public class S3GroupIdentifierTest {
         final S3GroupIdentifier seconds3GroupIdentifier = new S3GroupIdentifier(identificationHashTwo, groupTwoFullObjectKey);
 
         assertThat(s3GroupIdentifier.equals(seconds3GroupIdentifier), equalTo(false));
+        assertNotEquals(s3GroupIdentifier.hashCode(), seconds3GroupIdentifier.hashCode());
     }
 }

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManagerTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManagerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3.grouping;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.plugins.sink.s3.S3SinkConfig;
+import org.opensearch.dataprepper.plugins.sink.s3.accumulator.Buffer;
+import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferFactory;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class S3GroupManagerTest {
+
+    @Mock
+    private S3SinkConfig s3SinkConfig;
+
+    @Mock
+    private S3GroupIdentifierFactory s3GroupIdentifierFactory;
+
+    @Mock
+    private BufferFactory bufferFactory;
+
+    @Mock
+    private S3Client s3Client;
+
+    private S3GroupManager createObjectUnderTest() {
+        return new S3GroupManager(s3SinkConfig, s3GroupIdentifierFactory, bufferFactory, s3Client);
+    }
+
+    @Test
+    void hasNoGroups_returns_true_when_there_are_no_groups() {
+        final S3GroupManager objectUnderTest = createObjectUnderTest();
+
+        assertThat(objectUnderTest.hasNoGroups(), equalTo(true));
+    }
+
+    @Test
+    void getOrCreateGroupForEvent_creates_expected_group_when_it_does_not_exist() {
+        final Event event = mock(Event.class);
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        when(s3GroupIdentifierFactory.getS3GroupIdentifierForEvent(event)).thenReturn(s3GroupIdentifier);
+
+        final Buffer buffer = mock(Buffer.class);
+        when(bufferFactory.getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class)))
+                .thenReturn(buffer);
+
+        final S3GroupManager objectUnderTest = createObjectUnderTest();
+
+        final Map.Entry<S3GroupIdentifier, S3Group> result = objectUnderTest.getOrCreateGroupForEvent(event);
+
+        assertThat(result, notNullValue());
+        assertThat(result.getKey(), equalTo(s3GroupIdentifier));
+        assertThat(result.getValue(), notNullValue());
+        assertThat(result.getValue().getBuffer(), equalTo(buffer));
+
+        final Set<Map.Entry<S3GroupIdentifier, S3Group>> groups = (Set<Map.Entry<S3GroupIdentifier, S3Group>>) objectUnderTest.getS3GroupEntries();
+        assertThat(groups, notNullValue());
+        assertThat(groups.size(), equalTo(1));
+
+        assertThat(groups.contains(result), equalTo(true));
+        assertThat(objectUnderTest.hasNoGroups(), equalTo(false));
+    }
+
+    @Test
+    void getOrCreateGroupForEvent_returns_expected_group_when_it_exists() {
+        final Event event = mock(Event.class);
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        when(s3GroupIdentifierFactory.getS3GroupIdentifierForEvent(event)).thenReturn(s3GroupIdentifier);
+
+        final Buffer buffer = mock(Buffer.class);
+        when(bufferFactory.getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class)))
+                .thenReturn(buffer);
+
+        final S3GroupManager objectUnderTest = createObjectUnderTest();
+
+        final Map.Entry<S3GroupIdentifier, S3Group> result = objectUnderTest.getOrCreateGroupForEvent(event);
+
+        assertThat(result, notNullValue());
+        assertThat(result.getKey(), equalTo(s3GroupIdentifier));
+        assertThat(result.getValue(), notNullValue());
+        assertThat(result.getValue().getBuffer(), equalTo(buffer));
+
+        final Map.Entry<S3GroupIdentifier, S3Group> secondResult = objectUnderTest.getOrCreateGroupForEvent(event);
+
+        assertThat(secondResult,  notNullValue());
+        assertThat(secondResult, notNullValue());
+        assertThat(secondResult.getKey(), equalTo(s3GroupIdentifier));
+        assertThat(secondResult.getValue(), notNullValue());
+        assertThat(secondResult.getValue().getBuffer(), equalTo(buffer));
+
+        verify(s3GroupIdentifierFactory, times(2)).getS3GroupIdentifierForEvent(event);
+        verify(bufferFactory, times(1)).getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class));
+
+        final Set<Map.Entry<S3GroupIdentifier, S3Group>> groups = (Set<Map.Entry<S3GroupIdentifier, S3Group>>) objectUnderTest.getS3GroupEntries();
+        assertThat(groups, notNullValue());
+        assertThat(groups.size(), equalTo(1));
+
+        assertThat(groups.contains(result), equalTo(true));
+        assertThat(groups.contains(secondResult), equalTo(true));
+        assertThat(objectUnderTest.hasNoGroups(), equalTo(false));
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManagerTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManagerTest.java
@@ -15,8 +15,7 @@ import org.opensearch.dataprepper.plugins.sink.s3.accumulator.Buffer;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferFactory;
 import software.amazon.awssdk.services.s3.S3Client;
 
-import java.util.Map;
-import java.util.Set;
+import java.util.Collection;
 import java.util.function.Supplier;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -67,14 +66,13 @@ public class S3GroupManagerTest {
 
         final S3GroupManager objectUnderTest = createObjectUnderTest();
 
-        final Map.Entry<S3GroupIdentifier, S3Group> result = objectUnderTest.getOrCreateGroupForEvent(event);
+        final S3Group result = objectUnderTest.getOrCreateGroupForEvent(event);
 
         assertThat(result, notNullValue());
-        assertThat(result.getKey(), equalTo(s3GroupIdentifier));
-        assertThat(result.getValue(), notNullValue());
-        assertThat(result.getValue().getBuffer(), equalTo(buffer));
+        assertThat(result.getS3GroupIdentifier(), equalTo(s3GroupIdentifier));
+        assertThat(result.getBuffer(), equalTo(buffer));
 
-        final Set<Map.Entry<S3GroupIdentifier, S3Group>> groups = (Set<Map.Entry<S3GroupIdentifier, S3Group>>) objectUnderTest.getS3GroupEntries();
+        final Collection<S3Group> groups = objectUnderTest.getS3GroupEntries();
         assertThat(groups, notNullValue());
         assertThat(groups.size(), equalTo(1));
 
@@ -94,25 +92,23 @@ public class S3GroupManagerTest {
 
         final S3GroupManager objectUnderTest = createObjectUnderTest();
 
-        final Map.Entry<S3GroupIdentifier, S3Group> result = objectUnderTest.getOrCreateGroupForEvent(event);
+        final S3Group result = objectUnderTest.getOrCreateGroupForEvent(event);
 
         assertThat(result, notNullValue());
-        assertThat(result.getKey(), equalTo(s3GroupIdentifier));
-        assertThat(result.getValue(), notNullValue());
-        assertThat(result.getValue().getBuffer(), equalTo(buffer));
+        assertThat(result.getS3GroupIdentifier(), equalTo(s3GroupIdentifier));
+        assertThat(result.getBuffer(), equalTo(buffer));
 
-        final Map.Entry<S3GroupIdentifier, S3Group> secondResult = objectUnderTest.getOrCreateGroupForEvent(event);
+        final S3Group secondResult = objectUnderTest.getOrCreateGroupForEvent(event);
 
         assertThat(secondResult,  notNullValue());
         assertThat(secondResult, notNullValue());
-        assertThat(secondResult.getKey(), equalTo(s3GroupIdentifier));
-        assertThat(secondResult.getValue(), notNullValue());
-        assertThat(secondResult.getValue().getBuffer(), equalTo(buffer));
+        assertThat(secondResult.getS3GroupIdentifier(), equalTo(s3GroupIdentifier));
+        assertThat(secondResult.getBuffer(), equalTo(buffer));
 
         verify(s3GroupIdentifierFactory, times(2)).getS3GroupIdentifierForEvent(event);
         verify(bufferFactory, times(1)).getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class));
 
-        final Set<Map.Entry<S3GroupIdentifier, S3Group>> groups = (Set<Map.Entry<S3GroupIdentifier, S3Group>>) objectUnderTest.getS3GroupEntries();
+        final Collection<S3Group> groups = objectUnderTest.getS3GroupEntries();
         assertThat(groups, notNullValue());
         assertThat(groups.size(), equalTo(1));
 

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManagerTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManagerTest.java
@@ -98,14 +98,14 @@ public class S3GroupManagerTest {
         assertThat(result.getS3GroupIdentifier(), equalTo(s3GroupIdentifier));
         assertThat(result.getBuffer(), equalTo(buffer));
 
-        final S3Group secondResult = objectUnderTest.getOrCreateGroupForEvent(event);
+        final Event secondEvent = mock(Event.class);
+        when(s3GroupIdentifierFactory.getS3GroupIdentifierForEvent(secondEvent)).thenReturn(s3GroupIdentifier);
+        final S3Group secondResult = objectUnderTest.getOrCreateGroupForEvent(secondEvent);
 
         assertThat(secondResult,  notNullValue());
-        assertThat(secondResult, notNullValue());
         assertThat(secondResult.getS3GroupIdentifier(), equalTo(s3GroupIdentifier));
         assertThat(secondResult.getBuffer(), equalTo(buffer));
 
-        verify(s3GroupIdentifierFactory, times(2)).getS3GroupIdentifierForEvent(event);
         verify(bufferFactory, times(1)).getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class));
 
         final Collection<S3Group> groups = objectUnderTest.getS3GroupEntries();

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupTest.java
@@ -1,0 +1,35 @@
+package org.opensearch.dataprepper.plugins.sink.s3.grouping;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.model.event.EventHandle;
+import org.opensearch.dataprepper.plugins.sink.s3.accumulator.Buffer;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class S3GroupTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void releasingEventHandles_releases_all_event_handles(final boolean result) {
+        final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
+        final Buffer buffer = mock(Buffer.class);
+        final S3Group objectUnderTest = new S3Group(s3GroupIdentifier, buffer);
+        final Collection<EventHandle> eventHandles = List.of(mock(EventHandle.class), mock(EventHandle.class));
+
+        for (final EventHandle eventHandle : eventHandles) {
+            objectUnderTest.addEventHandle(eventHandle);
+        }
+
+        objectUnderTest.releaseEventHandles(result);
+
+        for (final EventHandle eventHandle : eventHandles) {
+            verify(eventHandle).release(result);
+        }
+
+    }
+}


### PR DESCRIPTION
### Description
This change adds a concept of `S3Groups` to the S3 Sink. Groups will be created dynamically based on the Events that come into the sink, and will be sent to S3 as a single object when the thresholds are reached for that group.

This PR only adds support for a dynamic `path_prefix`. The support for exposing `object_name` as a dynamic expression will be added in a future PR

Future Planned PRs

* Refactor the buffer tracking of thresholds to the S3Group tracking this to reduce deduplication
* Support `aggregate_threshold` for flushing the largest groups when the threshold is reached
* Support injection of `getEpochNanos()` and `getRandomUUID()` into the dynamic expressions
 
### Issues Resolved
Related to #4345 

Ran the s3 sink integration tests successfully
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
