### PR TITLE
Fixes a bug with lz4

### DIFF
--- a/data-prepper-plugins/mapdb-processor-state/build.gradle
+++ b/data-prepper-plugins/mapdb-processor-state/build.gradle
@@ -10,7 +10,10 @@ plugins {
 dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')
-    implementation 'org.mapdb:mapdb:3.1.0'
+    implementation('org.mapdb:mapdb:3.1.0') {
+        exclude group: 'net.jpountz.lz4', module: 'lz4'
+    }
+    implementation 'org.lz4:lz4-java:1.8.0'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.21'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22'
     testImplementation project(':data-prepper-plugins:common').sourceSets.test.output


### PR DESCRIPTION
### Description

We saw the following error log:

```
2024-03-27T05:05:32.331 [pool-10-thread-1] ERROR org.opensearch.dataprepper.plugins.kafka.consumer.KafkaCustomConsumer - Error while reading the records from the topic XYZ. Retry after 10 seconds
...
Caused by: org.apache.kafka.common.KafkaException: java.lang.RuntimeException: Kafka has detected detected a buggy lz4-java library (< 1.4.x) on the classpath. If you are using Kafka client libraries, make sure your application does not accidentally override the version provided by Kafka or include multiple versions of the library on the classpath. The lz4-java version on the classpath should match the version the Kafka client libraries depend on. Adding -verbose:class to your JVM arguments may help understand which lz4-java version is getting loaded.
```

This PR removes the `net.jpountz.lz4` dependency and makes the mapdb-processor-state use `org.lz4:lz4-java` instead.

 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
