### PR TITLE
Updates the S3/file codecs to use the EventFactory

### DIFF
--- a/data-prepper-event/src/main/java/org/opensearch/dataprepper/core/event/DefaultBaseEventBuilder.java
+++ b/data-prepper-event/src/main/java/org/opensearch/dataprepper/core/event/DefaultBaseEventBuilder.java
@@ -33,10 +33,12 @@ abstract class DefaultBaseEventBuilder<T extends Event> implements BaseEventBuil
         return this.eventType;
     }
 
+    abstract String getDefaultEventType();
+
     public EventMetadata getEventMetadata() {
         if (this.eventMetadata == null) {
             this.eventMetadata = new DefaultEventMetadata.Builder()
-                    .withEventType(eventType)
+                    .withEventType(eventType != null ? eventType : getDefaultEventType())
                     .withTimeReceived(timeReceived)
                     .withAttributes(attributes)
                     .build();

--- a/data-prepper-event/src/main/java/org/opensearch/dataprepper/core/event/DefaultEventBuilderFactory.java
+++ b/data-prepper-event/src/main/java/org/opensearch/dataprepper/core/event/DefaultEventBuilderFactory.java
@@ -23,14 +23,15 @@ class DefaultEventBuilderFactory extends EventBuilderFactory {
     }
 
     public static class DefaultEventBuilder extends DefaultBaseEventBuilder<Event> implements EventBuilder {
-        public String getEventType() {
+        @Override
+        String getDefaultEventType() {
             return EVENT_TYPE;
         }
 
         public Event build() {
             return (Event) JacksonEvent.builder()
+                    .withEventMetadata(getEventMetadata())
                     .withData(getData())
-                    .withEventType(EVENT_TYPE)
                     .build();
         }
     }

--- a/data-prepper-event/src/main/java/org/opensearch/dataprepper/core/event/DefaultLogEventBuilderFactory.java
+++ b/data-prepper-event/src/main/java/org/opensearch/dataprepper/core/event/DefaultLogEventBuilderFactory.java
@@ -27,6 +27,11 @@ class DefaultLogEventBuilderFactory extends DefaultEventBuilderFactory {
             return LOG_EVENT_TYPE;
         }
 
+        @Override
+        String getDefaultEventType() {
+            return LOG_EVENT_TYPE;
+        }
+
         public Log build() {
             return (Log) JacksonLog.builder()
                     .withData(getData())

--- a/data-prepper-event/src/test/java/org/opensearch/dataprepper/core/event/DefaultBaseEventBuilderTests.java
+++ b/data-prepper-event/src/test/java/org/opensearch/dataprepper/core/event/DefaultBaseEventBuilderTests.java
@@ -26,6 +26,11 @@ class DefaultBaseEventBuilderTests {
         public Event build() {
             return JacksonEvent.builder().build();
         }
+
+        @Override
+        String getDefaultEventType() {
+            return null;
+        }
     }
 
     private DefaultBaseEventBuilder createObjectUnderTest() {

--- a/data-prepper-event/src/test/java/org/opensearch/dataprepper/core/event/DefaultEventBuilderFactoryTests.java
+++ b/data-prepper-event/src/test/java/org/opensearch/dataprepper/core/event/DefaultEventBuilderFactoryTests.java
@@ -14,6 +14,7 @@ import org.opensearch.dataprepper.model.event.JacksonEvent;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -37,9 +38,14 @@ class DefaultEventBuilderFactoryTests {
     }
 
     @Test
+    void getDefaultEventType_returns_EVENT() {
+        DefaultBaseEventBuilder baseEventBuilder = defaultEventBuilderFactory.createNew();
+        assertThat(baseEventBuilder.getDefaultEventType(), equalTo(DefaultEventBuilderFactory.EVENT_TYPE));
+    }
+
+    @Test
     public void testBasic() {
         DefaultBaseEventBuilder baseEventBuilder = defaultEventBuilderFactory.createNew();
-        assertThat(baseEventBuilder.getEventType(), equalTo(DefaultEventBuilderFactory.EVENT_TYPE));
 
         String testKey = RandomStringUtils.randomAlphabetic(5);
         String testValue = RandomStringUtils.randomAlphabetic(10);
@@ -51,6 +57,25 @@ class DefaultEventBuilderFactoryTests {
         EventMetadata eventMetadata = event.getMetadata();
         assertThat(eventMetadata.getTimeReceived(), not(equalTo(null)));
         assertThat(eventMetadata.getEventType(), equalTo(DefaultEventBuilderFactory.EVENT_TYPE));
+        assertThat(eventMetadata.getAttributes(), equalTo(attributes));
+        assertThat(event.toMap(), equalTo(data));
+    }
+
+    @Test
+    public void build_uses_eventType_from_builder_if_supplied() {
+        DefaultBaseEventBuilder baseEventBuilder = defaultEventBuilderFactory.createNew();
+
+        String eventType = UUID.randomUUID().toString();
+        String testKey = RandomStringUtils.randomAlphabetic(5);
+        String testValue = RandomStringUtils.randomAlphabetic(10);
+        Map<String, Object> data = Map.of(testKey, testValue);
+        Map<String, Object> attributes = Collections.emptyMap();
+        EventBuilder eventBuilder = (EventBuilder) baseEventBuilder.withEventMetadataAttributes(attributes).withData(data).withEventType(eventType);
+
+        JacksonEvent event = (JacksonEvent) eventBuilder.build();
+        EventMetadata eventMetadata = event.getMetadata();
+        assertThat(eventMetadata.getTimeReceived(), not(equalTo(null)));
+        assertThat(eventMetadata.getEventType(), equalTo(eventType));
         assertThat(eventMetadata.getAttributes(), equalTo(attributes));
         assertThat(event.toMap(), equalTo(data));
     }

--- a/data-prepper-plugins/avro-codecs/build.gradle
+++ b/data-prepper-plugins/avro-codecs/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation 'software.amazon.awssdk:apache-client'
     testImplementation 'org.json:json:20240205'
     testImplementation project(':data-prepper-plugins:common')
+    testImplementation project(':data-prepper-test-event')
 }
 
 test {

--- a/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroInputCodec.java
+++ b/data-prepper-plugins/avro-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/avro/AvroInputCodec.java
@@ -5,17 +5,18 @@
 package org.opensearch.dataprepper.plugins.codec.avro;
 
 import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericEnumSymbol;
 import org.apache.avro.generic.GenericRecord;
-
-import org.apache.avro.file.DataFileStream;
 import org.apache.avro.util.Utf8;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.log.JacksonLog;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.LogEventBuilder;
 import org.opensearch.dataprepper.model.record.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +38,12 @@ import java.util.function.Consumer;
 public class AvroInputCodec implements InputCodec {
 
     private static final Logger LOG =  LoggerFactory.getLogger(AvroInputCodec.class);
+    private final EventFactory eventFactory;
+
+    @DataPrepperPluginConstructor
+    public AvroInputCodec(final EventFactory eventFactory) {
+        this.eventFactory = eventFactory;
+    }
 
     @Override
     public void parse(InputStream inputStream, Consumer<Record<Event>> eventConsumer) throws IOException {
@@ -60,7 +67,7 @@ public class AvroInputCodec implements InputCodec {
 
                 final Map<String, Object> eventData = convertRecordToMap(avroRecord, schema);
 
-                final Event event = JacksonLog.builder().withData(eventData).build();
+                final Event event = eventFactory.eventBuilder(LogEventBuilder.class).withData(eventData).build();
                 eventConsumer.accept(new Record<>(event));
             }
 

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroCodecsIT.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroCodecsIT.java
@@ -22,8 +22,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.log.JacksonLog;
+import org.opensearch.dataprepper.model.event.LogEventBuilder;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 
@@ -85,7 +86,7 @@ public class AvroCodecsIT {
             eventData.put(field.name(), record.get(field.name()));
 
         }
-        final Event event = JacksonLog.builder().withData(eventData).build();
+        final Event event = TestEventFactory.getTestEventFactory().eventBuilder(LogEventBuilder.class).withData(eventData).build();
         return event;
     }
 
@@ -155,7 +156,7 @@ public class AvroCodecsIT {
     }
 
     private AvroInputCodec createInputCodecObjectUnderTest() {
-        return new AvroInputCodec();
+        return new AvroInputCodec(TestEventFactory.getTestEventFactory());
     }
 
     private AvroOutputCodec createOutputCodecObjectUnderTest() {

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroInputCodecTest.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroInputCodecTest.java
@@ -18,34 +18,35 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventType;
+import org.opensearch.dataprepper.model.event.LogEventBuilder;
 import org.opensearch.dataprepper.model.io.InputFile;
-import org.opensearch.dataprepper.model.log.JacksonLog;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.codec.NoneDecompressionEngine;
 import org.opensearch.dataprepper.plugins.fs.LocalInputFile;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ByteArrayInputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
-import java.util.ArrayList;
 import java.util.function.Consumer;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 public class AvroInputCodecTest {
@@ -70,7 +71,7 @@ public class AvroInputCodecTest {
     private static File testDataFile;
 
     private AvroInputCodec createObjectUnderTest(){
-        return new AvroInputCodec();
+        return new AvroInputCodec(TestEventFactory.getTestEventFactory());
     }
 
     @BeforeAll
@@ -82,7 +83,7 @@ public class AvroInputCodecTest {
 
     @Test
     public void test_when_nullInputStream_then_throwsException(){
-        avroInputCodec=new AvroInputCodec();
+        avroInputCodec=new AvroInputCodec(TestEventFactory.getTestEventFactory());
         Consumer<Record<Event>> eventConsumer = mock(Consumer.class);
         assertThrows(NullPointerException.class,()->
                 avroInputCodec.parse((InputStream) null, eventConsumer));
@@ -93,7 +94,7 @@ public class AvroInputCodecTest {
 
     @Test
     public void test_when_nullInputFile_then_throwsException(){
-        avroInputCodec=new AvroInputCodec();
+        avroInputCodec=new AvroInputCodec(TestEventFactory.getTestEventFactory());
         Consumer<Record<Event>> eventConsumer = mock(Consumer.class);
         assertThrows(NullPointerException.class,()->
                 avroInputCodec.parse((InputFile) null, new NoneDecompressionEngine(), eventConsumer));
@@ -211,7 +212,7 @@ public class AvroInputCodecTest {
             eventData.put(field.name(), record.get(field.name()));
 
         }
-        final Event event = JacksonLog.builder().withData(eventData).build();
+        final Event event = TestEventFactory.getTestEventFactory().eventBuilder(LogEventBuilder.class).withData(eventData).build();
         return event;
     }
 

--- a/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodecTest.java
+++ b/data-prepper-plugins/avro-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/avro/AvroOutputCodecTest.java
@@ -16,8 +16,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.log.JacksonLog;
+import org.opensearch.dataprepper.model.event.LogEventBuilder;
 import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
 
@@ -389,7 +390,7 @@ public class AvroOutputCodecTest {
     }
 
     private static Event createEventRecord(final Map<String, Object> eventData) {
-        return JacksonLog.builder().withData(eventData).build();
+        return TestEventFactory.getTestEventFactory().eventBuilder(LogEventBuilder.class).withData(eventData).build();
     }
 
     private static List<Map<String, Object>> generateRecords(final int numberOfRecords) {

--- a/data-prepper-plugins/csv-processor/build.gradle
+++ b/data-prepper-plugins/csv-processor/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     testImplementation project(':data-prepper-plugins:log-generator-source')
     testImplementation project(':data-prepper-test-common')
     testImplementation project(':data-prepper-plugins:common')
+    testImplementation project(':data-prepper-test-event')
     implementation 'com.opencsv:opencsv:5.9'
 }
 

--- a/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/csv/CsvInputCodec.java
+++ b/data-prepper-plugins/csv-processor/src/main/java/org/opensearch/dataprepper/plugins/codec/csv/CsvInputCodec.java
@@ -14,7 +14,8 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.log.JacksonLog;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.LogEventBuilder;
 import org.opensearch.dataprepper.model.record.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,11 +37,13 @@ import java.util.function.Consumer;
 public class CsvInputCodec implements InputCodec {
     private static final Logger LOG = LoggerFactory.getLogger(CsvInputCodec.class);
     private final CsvInputCodecConfig config;
+    private final EventFactory eventFactory;
 
     @DataPrepperPluginConstructor
-    public CsvInputCodec(CsvInputCodecConfig config) {
+    public CsvInputCodec(final CsvInputCodecConfig config, final EventFactory eventFactory) {
         Objects.requireNonNull(config);
         this.config = config;
+        this.eventFactory = eventFactory;
     }
 
     @Override
@@ -93,7 +96,7 @@ public class CsvInputCodec implements InputCodec {
         try {
             final Map<String, String> parsedLine = parsingIterator.nextValue();
 
-            final Event event = JacksonLog.builder()
+            final Event event = eventFactory.eventBuilder(LogEventBuilder.class)
                     .withData(parsedLine)
                     .build();
             eventConsumer.accept(new Record<>(event));

--- a/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/csv/CsvCodecTest.java
+++ b/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/csv/CsvCodecTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventType;
 import org.opensearch.dataprepper.model.io.InputFile;
@@ -61,7 +62,7 @@ public class CsvCodecTest {
     private Consumer<Record<Event>> eventConsumer;
     private CsvInputCodec csvCodec;
     private CsvInputCodec createObjectUnderTest() {
-        return new CsvInputCodec(config);
+        return new CsvInputCodec(config, TestEventFactory.getTestEventFactory());
     }
 
     @BeforeEach

--- a/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/csv/CsvCodecsIT.java
+++ b/data-prepper-plugins/csv-processor/src/test/java/org/opensearch/dataprepper/plugins/codec/csv/CsvCodecsIT.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.model.sink.OutputCodecContext;
@@ -47,7 +48,7 @@ public class CsvCodecsIT {
     private CsvInputCodec csvCodec;
 
     private CsvInputCodec createObjectUnderTest() {
-        return new CsvInputCodec(config);
+        return new CsvInputCodec(config, TestEventFactory.getTestEventFactory());
     }
 
     @BeforeEach

--- a/data-prepper-plugins/newline-codecs/build.gradle
+++ b/data-prepper-plugins/newline-codecs/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'org.apache.parquet:parquet-common:1.13.1'
     testImplementation project(':data-prepper-plugins:common')
+    testImplementation project(':data-prepper-test-event')
 }
 
 test {

--- a/data-prepper-plugins/newline-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/newline/NewlineDelimitedInputCodec.java
+++ b/data-prepper-plugins/newline-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/newline/NewlineDelimitedInputCodec.java
@@ -9,6 +9,7 @@ import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.log.JacksonLog;
 import org.opensearch.dataprepper.model.record.Record;
 
@@ -28,7 +29,9 @@ public class NewlineDelimitedInputCodec implements InputCodec {
     private final String headerDestination;
 
     @DataPrepperPluginConstructor
-    public NewlineDelimitedInputCodec(final NewlineDelimitedInputConfig config) {
+    public NewlineDelimitedInputCodec(
+            final NewlineDelimitedInputConfig config,
+            final EventFactory eventFactory) {
         Objects.requireNonNull(config);
         skipLines = config.getSkipLines();
 

--- a/data-prepper-plugins/newline-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/newline/NewlineDelimitedCodecTest.java
+++ b/data-prepper-plugins/newline-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/newline/NewlineDelimitedCodecTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventType;
 import org.opensearch.dataprepper.model.io.InputFile;
@@ -38,8 +39,8 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -49,7 +50,7 @@ class NewlineDelimitedCodecTest {
     private NewlineDelimitedInputConfig config;
 
     private NewlineDelimitedInputCodec createObjectUnderTest() {
-        return new NewlineDelimitedInputCodec(config);
+        return new NewlineDelimitedInputCodec(config, TestEventFactory.getTestEventFactory());
     }
 
     @Test

--- a/data-prepper-plugins/parquet-codecs/build.gradle
+++ b/data-prepper-plugins/parquet-codecs/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.apache.parquet:parquet-common:1.13.1'
     implementation 'org.apache.parquet:parquet-hadoop:1.13.1'
     testImplementation project(':data-prepper-test-common')
+    testImplementation project(':data-prepper-test-event')
 
     constraints {
         implementation('com.nimbusds:nimbus-jose-jwt') {

--- a/data-prepper-plugins/parquet-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetInputCodec.java
+++ b/data-prepper-plugins/parquet-codecs/src/main/java/org/opensearch/dataprepper/plugins/codec/parquet/ParquetInputCodec.java
@@ -10,10 +10,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.codec.DecompressionEngine;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.event.EventBuilder;
+import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.io.InputFile;
 import org.opensearch.dataprepper.model.record.Record;
 import org.opensearch.dataprepper.plugins.fs.LocalInputFile;
@@ -45,8 +47,11 @@ public class ParquetInputCodec implements InputCodec {
     private static final Logger LOG = LoggerFactory.getLogger(ParquetInputCodec.class);
 
     private final Configuration configuration;
+    private final EventFactory eventFactory;
 
-    public ParquetInputCodec() {
+    @DataPrepperPluginConstructor
+    public ParquetInputCodec(final EventFactory eventFactory) {
+        this.eventFactory = eventFactory;
         configuration = new Configuration();
         configuration.setBoolean(READ_INT96_AS_FIXED, true);
     }
@@ -84,7 +89,7 @@ public class ParquetInputCodec implements InputCodec {
             while ((record = reader.read()) != null) {
                 final String json = encoder.serialize(record);
 
-                final JacksonEvent event = JacksonEvent.builder()
+                final Event event = eventFactory.eventBuilder(EventBuilder.class)
                         .withEventType(EVENT_TYPE)
                         .withData(json)
                         .build();

--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     testImplementation project(':data-prepper-plugins:in-memory-source-coordination-store')
     testImplementation project(':data-prepper-core')
     testImplementation project(':data-prepper-plugins:parquet-codecs')
+    testImplementation project(':data-prepper-test-event')
     testImplementation libs.avro.core
     testImplementation testLibs.hadoop.common
     testImplementation 'org.apache.parquet:parquet-avro:1.13.1'

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/AvroRecordsGenerator.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/AvroRecordsGenerator.java
@@ -7,6 +7,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.specific.SpecificDatumWriter;
+import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.codec.avro.AvroInputCodec;
@@ -52,7 +53,7 @@ public class AvroRecordsGenerator implements RecordsGenerator {
 
     @Override
     public InputCodec getCodec() {
-        return new AvroInputCodec();
+        return new AvroInputCodec(TestEventFactory.getTestEventFactory());
     }
 
     @Override

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/CsvRecordsGenerator.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/CsvRecordsGenerator.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.s3;
 
+import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.codec.csv.CsvInputCodec;
@@ -42,7 +43,7 @@ class CsvRecordsGenerator implements RecordsGenerator {
     @Override
     public InputCodec getCodec() {
         CsvInputCodecConfig config = csvCodecConfigWithAutogenerateHeader();
-        return new CsvInputCodec(config);
+        return new CsvInputCodec(config, TestEventFactory.getTestEventFactory());
     }
 
     /**

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/NewlineDelimitedRecordsGenerator.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/NewlineDelimitedRecordsGenerator.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.source.s3;
 
+import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.codec.newline.NewlineDelimitedInputCodec;
@@ -42,7 +43,7 @@ class NewlineDelimitedRecordsGenerator implements RecordsGenerator {
 
     @Override
     public InputCodec getCodec() {
-        return new NewlineDelimitedInputCodec(new NewlineDelimitedInputConfig());
+        return new NewlineDelimitedInputCodec(new NewlineDelimitedInputConfig(), TestEventFactory.getTestEventFactory());
     }
 
     @Override

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/ParquetRecordsGenerator.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/ParquetRecordsGenerator.java
@@ -5,6 +5,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
+import org.opensearch.dataprepper.event.TestEventFactory;
 import org.opensearch.dataprepper.model.codec.InputCodec;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.plugins.codec.parquet.ParquetInputCodec;
@@ -67,7 +68,7 @@ public class ParquetRecordsGenerator implements RecordsGenerator {
 
     @Override
     public InputCodec getCodec() {
-        return new ParquetInputCodec();
+        return new ParquetInputCodec(TestEventFactory.getTestEventFactory());
     }
 
     @Override


### PR DESCRIPTION
### Description

This PR continues some of the work from #2378 and #4110 by updating the codecs to use the `EventFactory`.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
