### PR TITLE
Cache geolocation data during a batch of events

### DIFF
--- a/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/BatchGeoIPDatabaseReader.java
+++ b/data-prepper-plugins/geoip-processor/src/main/java/org/opensearch/dataprepper/plugins/geoip/processor/BatchGeoIPDatabaseReader.java
@@ -11,13 +11,16 @@ import org.opensearch.dataprepper.plugins.geoip.extension.api.GeoIPDatabaseReade
 
 import java.net.InetAddress;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * A {@link GeoIPDatabaseReader} useful for a single batch of processing.
  */
 class BatchGeoIPDatabaseReader implements GeoIPDatabaseReader {
     private final GeoIPDatabaseReader delegate;
+    private final Map<GeoDataInput, Map<String, Object>> geoDataCache = new HashMap<>();
     private Boolean isExpired = null;
 
     BatchGeoIPDatabaseReader(final GeoIPDatabaseReader delegate) {
@@ -32,7 +35,8 @@ class BatchGeoIPDatabaseReader implements GeoIPDatabaseReader {
 
     @Override
     public Map<String, Object> getGeoData(final InetAddress inetAddress, final Collection<GeoIPField> fields, final Collection<GeoIPDatabase> geoIPDatabases) {
-        return delegate.getGeoData(inetAddress, fields, geoIPDatabases);
+        final GeoDataInput geoDataInput = new GeoDataInput(inetAddress, fields, geoIPDatabases);
+        return geoDataCache.computeIfAbsent(geoDataInput, unused -> delegate.getGeoData(inetAddress, fields, geoIPDatabases));
     }
 
     @Override
@@ -51,5 +55,30 @@ class BatchGeoIPDatabaseReader implements GeoIPDatabaseReader {
     @Override
     public void close() throws Exception {
         delegate.close();
+    }
+
+    private static class GeoDataInput {
+        final InetAddress inetAddress;
+        final Collection<GeoIPField> fields;
+        final Collection<GeoIPDatabase> geoIPDatabases;
+
+        private GeoDataInput(InetAddress inetAddress, Collection<GeoIPField> fields, Collection<GeoIPDatabase> geoIPDatabases) {
+            this.inetAddress = inetAddress;
+            this.fields = fields;
+            this.geoIPDatabases = geoIPDatabases;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            final GeoDataInput that = (GeoDataInput) o;
+            return Objects.equals(inetAddress, that.inetAddress) && Objects.equals(fields, that.fields) && Objects.equals(geoIPDatabases, that.geoIPDatabases);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(inetAddress, fields, geoIPDatabases);
+        }
     }
 }


### PR DESCRIPTION
### Description

This PR creates a batch-level cache for getting geolocation data. In some local testing I performed with a small processor, I found that this reduced the total memory allocations within the geoip processor from 29% to 25% of the total allocations.

As this cache works for only a given batch, it avoids holding data for a long period of time. And the data itself (IP address and geolocation data) would need to be in memory anyway. So the only overhead is the Map and the references therein.

 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
