### PR TITLE
Do not require field_split_characters to not be empty for key_value processor

### DIFF
--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -40,7 +40,6 @@ public class KeyValueProcessorConfig {
     private String fieldDelimiterRegex;
 
     @JsonProperty("field_split_characters")
-    @NotEmpty
     private String fieldSplitCharacters = DEFAULT_FIELD_SPLIT_CHARACTERS;
 
     @JsonProperty("include_keys")


### PR DESCRIPTION
### Description
Currently, one cannot configure both the `field_split_characters` and `field_delimiter_regex` for the key_value processor. However, the `field_split_characters` has a default. Even setting both like this fails because field_split_characters is required to not be empty, which means there is currently no way to set `field_delimiter_regex`

```
field_split_characters: null
field_delimiter_regex: ','
```

To allow this, this PR removes the `@NotEmpty` annotation from the `field_split_characters`
 
 Resolves #2946 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
