### PR TITLE
Aggregate Processor: local mode should work when there is no when condition

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -152,11 +152,11 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
 
     @Override
     public boolean isApplicableEventForPeerForwarding(Event event) {
-        if (whenCondition == null) {
-            return true;
-        }
         if (localMode) {
             return false;
+        }
+        if (whenCondition == null) {
+            return true;
         }
         return expressionEvaluator.evaluateConditional(whenCondition, event);
     }


### PR DESCRIPTION
### Description
Aggregate Processor: local mode should work when there is no when condition.
`local_mode` introduced in PR #4306 should do local aggregation when the condition is not specified too. 
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
