### PR TITLE
Fix flaky PipelineConfigurationFileReaderTest

### DIFF
--- a/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/PipelineConfigurationFileReaderTest.java
+++ b/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/PipelineConfigurationFileReaderTest.java
@@ -103,12 +103,12 @@ public class PipelineConfigurationFileReaderTest {
 
         try (final BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStreams.get(0), StandardCharsets.UTF_8))) {
             final String content = bufferedReader.lines().collect(Collectors.joining(System.lineSeparator()));
-            assertThat(content, equalTo(yamlContentPipelineOne));
+            assertThat(content.equals(yamlContentPipelineOne) || content.equals(yamlContentPipelineTwo), equalTo(true));
         }
 
         try (final BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStreams.get(1), StandardCharsets.UTF_8))) {
             final String content = bufferedReader.lines().collect(Collectors.joining(System.lineSeparator()));
-            assertThat(content, equalTo(yamlContentPipelineTwo));
+            assertThat(content.equals(yamlContentPipelineOne) || content.equals(yamlContentPipelineTwo), equalTo(true));
         }
     }
 }


### PR DESCRIPTION
### Description
I have noticed the builds failings sometimes in github actions with 

```
PipelineConfigurationFileReaderTest > getPipelineConfigurationInput_streams_from_existing_directory() FAILED
    java.lang.AssertionError at PipelineConfigurationFileReaderTest.java:106
```

This appears to be due to no guarantee that the List<InputStreams> is in a predictable order, which the test assumes. This makes it so that the order of the expected InputStreams does not matter in the test
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
