### PR TITLE
Remove unexpected event handle message

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSet.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSet.java
@@ -161,8 +161,6 @@ public class DefaultAcknowledgementSet implements AcknowledgementSet {
         try {
             if (!pendingAcknowledgments.containsKey(eventHandle) ||
                 pendingAcknowledgments.get(eventHandle).get() == 0) {
-                LOG.warn("Unexpected event handle release");
-                metrics.increment(DefaultAcknowledgementSetMetrics.INVALID_RELEASES_METRIC_NAME);
                 return false;
             }
             if (pendingAcknowledgments.get(eventHandle).decrementAndGet() == 0) {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetTests.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/acknowledgements/DefaultAcknowledgementSetTests.java
@@ -136,13 +136,11 @@ class DefaultAcknowledgementSetTests {
         assertThat(invalidAcquiresCounter, equalTo(1));
     }
 
-    @Test
     void testDefaultAcknowledgementInvalidRelease() {
         defaultAcknowledgementSet.add(event);
         defaultAcknowledgementSet.complete();
         DefaultAcknowledgementSet secondAcknowledgementSet = createObjectUnderTest();
         assertThat(defaultAcknowledgementSet.release(handle2, true), equalTo(false));
-        assertThat(invalidReleasesCounter, equalTo(1));
     }
 
     @Test
@@ -153,7 +151,6 @@ class DefaultAcknowledgementSetTests {
         assertThat(handle.getAcknowledgementSet(), equalTo(defaultAcknowledgementSet));
         assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(true));
         assertThat(defaultAcknowledgementSet.release(handle, true), equalTo(false));
-        assertThat(invalidReleasesCounter, equalTo(1));
     }
 
     @Test


### PR DESCRIPTION
### Description
Remove unexpected event handle message.

This message was added initially because duplicate release was not expected. But with remote peer and aggregate processor support, this can happen now. So, removing the message and the metric.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
