### PR TITLE
Adds KarstenSchnitter as a maintainer to the Data Prepper project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @chenqi0805 @engechas @graytaylor0 @dinujoh @kkondaka @asifsmohammed @dlvenable @oeyh
+*   @chenqi0805 @engechas @graytaylor0 @dinujoh @kkondaka @asifsmohammed @KarstenSchnitter @dlvenable @oeyh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,16 +4,17 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer           | GitHub ID                                             | Affiliation |
-| -------------------- | ----------------------------------------------------- | ----------- |
-| Qi Chen              | [chenqi0805](https://github.com/chenqi0805)           | Amazon      |
-| Chase Engelbrecht    | [engechas](https://github.com/engechas)               | Amazon      |
-| Taylor Gray          | [graytaylor0](https://github.com/graytaylor0)         | Amazon      |
-| Dinu John            | [dinujoh](https://github.com/dinujoh)                 | Amazon      |
-| Krishna Kondaka      | [kkondaka](https://github.com/kkondaka)               | Amazon      |
-| Asif Sohail Mohammed | [asifsmohammed](https://github.com/asifsmohammed)     | Amazon      |
-| David Venable        | [dlvenable](https://github.com/dlvenable)             | Amazon      |
-| Hai Yan              | [oeyh](https://github.com/oeyh)                       | Amazon      |
+| Maintainer           | GitHub ID                                                 | Affiliation |
+| -------------------- | --------------------------------------------------------- | ----------- |
+| Qi Chen              | [chenqi0805](https://github.com/chenqi0805)               | Amazon      |
+| Chase Engelbrecht    | [engechas](https://github.com/engechas)                   | Amazon      |
+| Taylor Gray          | [graytaylor0](https://github.com/graytaylor0)             | Amazon      |
+| Dinu John            | [dinujoh](https://github.com/dinujoh)                     | Amazon      |
+| Krishna Kondaka      | [kkondaka](https://github.com/kkondaka)                   | Amazon      |
+| Asif Sohail Mohammed | [asifsmohammed](https://github.com/asifsmohammed)         | Amazon      |
+| Karsten Schnitter    | [KarstenSchnitter](https://github.com/KarstenSchnitter)   | SAP         |
+| David Venable        | [dlvenable](https://github.com/dlvenable)                 | Amazon      |
+| Hai Yan              | [oeyh](https://github.com/oeyh)                           | Amazon      |
 
 
 ## Emeritus


### PR DESCRIPTION
### Description

Adding @KarstenSchnitter as voted upon by the existing Data Prepper maintainers per the [maintainer guidelines](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer).

Karsten has lead efforts at SAP to introduce new features into Data Prepper. In particular, his contributions provided support for OTel Metrics and OTel Logs.

Some PRs where he is listed as an author or co-author:
* #1507
* #1372
* #1335
* #1154
* #3560
* #3281


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
