### PR TITLE
Log the User-Agent when Data Prepper shuts down from POST /shutdown

### DIFF
--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandler.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandler.java
@@ -36,7 +36,10 @@ public class ShutdownHandler implements HttpHandler {
         }
 
         try {
-            LOG.info("Received HTTP shutdown request to shutdown Data Prepper. Shutdown pipelines and server.");
+            if(LOG.isInfoEnabled()) {
+                LOG.info("Received HTTP shutdown request to shutdown Data Prepper. Shutdown pipelines and server. User-Agent='{}'",
+                        exchange.getRequestHeaders().getFirst("User-Agent"));
+            }
             dataPrepper.shutdownPipelines();
             exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0);
         } catch (final Exception e) {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandlerTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/pipeline/server/ShutdownHandlerTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.pipeline.server;
 
+import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import java.net.HttpURLConnection;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,6 +47,8 @@ public class ShutdownHandlerTest {
     public void beforeEach() {
         when(exchange.getResponseBody())
                 .thenReturn(responseBody);
+        lenient().when(exchange.getRequestHeaders())
+                .thenReturn(new Headers());
     }
 
     @Test


### PR DESCRIPTION
### Description

To help track down the cause of a Data Prepper shutdown, log the `User-Agent` header. If it is not present, this will output `null`.

Example log from this PR:

```
2024-04-03T16:37:01,937 [pool-6-thread-2] INFO  org.opensearch.dataprepper.pipeline.server.ShutdownHandler - Received HTTP shutdown request to shutdown Data Prepper. Shutdown pipelines and server. User-Agent='curl/8.4.0'
```
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
