### PR TITLE
MAINT: float up exception from createPartition

### DIFF
--- a/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
+++ b/data-prepper-plugins/dynamodb-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/dynamodb/DynamoDbClientWrapper.java
@@ -145,7 +145,9 @@ public class DynamoDbClientWrapper {
             return false;
         } catch (final Exception e) {
             LOG.error("An exception occurred while attempting to create a DynamoDb partition item {}", dynamoDbSourcePartitionItem.getSourcePartitionKey());
-            return false;
+            throw new PartitionUpdateException(
+                    "Exception when trying to create partition item " + dynamoDbSourcePartitionItem.getSourcePartitionKey(),
+                    e);
         }
     }
 


### PR DESCRIPTION
### Description
Float up exception from sourceCoordinationStore createPartition as PartitionUpdateException as discussed offline. This will help fix the partition creation loop in DDB and DocumentDB.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
