### PR TITLE
Remove the duplicate key/value when ingesting log from opentelemetry-dotnet

### DIFF
--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodec.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodec.java
@@ -1086,7 +1086,7 @@ public class OTelProtoCodec {
      */
     public static Map<String, Object> convertKeysOfDataPointAttributes(final NumberDataPoint numberDataPoint) {
         return numberDataPoint.getAttributesList().stream()
-                .collect(Collectors.toMap(i -> PREFIX_AND_METRIC_ATTRIBUTES_REPLACE_DOT_WITH_AT.apply(i.getKey()), i -> convertAnyValue(i.getValue())));
+                .collect(Collectors.toMap(i -> PREFIX_AND_METRIC_ATTRIBUTES_REPLACE_DOT_WITH_AT.apply(i.getKey()), i -> convertAnyValue(i.getValue()), (existing, replacement) -> existing));
     }
 
     /**
@@ -1099,7 +1099,7 @@ public class OTelProtoCodec {
      */
     public static Map<String, Object> unpackKeyValueList(List<KeyValue> attributesList) {
         return attributesList.stream()
-                .collect(Collectors.toMap(i -> PREFIX_AND_METRIC_ATTRIBUTES_REPLACE_DOT_WITH_AT.apply(i.getKey()), i -> convertAnyValue(i.getValue())));
+                .collect(Collectors.toMap(i -> PREFIX_AND_METRIC_ATTRIBUTES_REPLACE_DOT_WITH_AT.apply(i.getKey()), i -> convertAnyValue(i.getValue()), (existing, replacement) -> existing));
     }
 
     /**
@@ -1112,7 +1112,7 @@ public class OTelProtoCodec {
      */
     public static Map<String, Object> unpackKeyValueListLog(List<KeyValue> attributesList) {
         return attributesList.stream()
-                .collect(Collectors.toMap(i -> PREFIX_AND_LOG_ATTRIBUTES_REPLACE_DOT_WITH_AT.apply(i.getKey()), i -> convertAnyValue(i.getValue())));
+                .collect(Collectors.toMap(i -> PREFIX_AND_LOG_ATTRIBUTES_REPLACE_DOT_WITH_AT.apply(i.getKey()), i -> convertAnyValue(i.getValue()), (existing, replacement) -> existing));
     }
 
 
@@ -1126,7 +1126,7 @@ public class OTelProtoCodec {
      */
     public static Map<String, Object> unpackExemplarValueList(List<KeyValue> attributesList) {
         return attributesList.stream()
-                .collect(Collectors.toMap(i -> PREFIX_AND_EXEMPLAR_ATTRIBUTES_REPLACE_DOT_WITH_AT.apply(i.getKey()), i -> convertAnyValue(i.getValue())));
+                .collect(Collectors.toMap(i -> PREFIX_AND_EXEMPLAR_ATTRIBUTES_REPLACE_DOT_WITH_AT.apply(i.getKey()), i -> convertAnyValue(i.getValue()), (existing, replacement) -> existing));
     }
 
 

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodecTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoCodecTest.java
@@ -1318,4 +1318,61 @@ public class OTelProtoCodecTest {
         assertNotEquals(k1, k2);
     }
 
+    @Test
+    void testConvertKeysOfDataPointAttributesRemoveDuplicatedKey() {
+        final String keyName = "duplicate_key_name";
+        final String keyValue = "duplicate_value";
+        final KeyValue duplicateAttribute1 = KeyValue.newBuilder().setKey(keyName).setValue(AnyValue.newBuilder()
+                .setStringValue(keyValue).build()).build();
+        final KeyValue duplicateAttribute2 = KeyValue.newBuilder().setKey(keyName).setValue(AnyValue.newBuilder()
+                .setStringValue(keyValue).build()).build();
+        final NumberDataPoint actual = NumberDataPoint.newBuilder()
+                .addAllAttributes(Arrays.asList(duplicateAttribute1, duplicateAttribute2)).build();
+        
+        Map<String, Object> map = OTelProtoCodec.convertKeysOfDataPointAttributes(actual);
+        assertThat(map.size(), is(equalTo(1)));
+    }
+
+    @Test
+    void testUnpackKeyValueListRemoveDuplicatedKey() {
+        final String keyName = "duplicate_key_name";
+        final String keyValue = "duplicate_value";
+        final KeyValue duplicateAttribute1 = KeyValue.newBuilder().setKey(keyName).setValue(AnyValue.newBuilder()
+                .setStringValue(keyValue).build()).build();
+        final KeyValue duplicateAttribute2 = KeyValue.newBuilder().setKey(keyName).setValue(AnyValue.newBuilder()
+                .setStringValue(keyValue).build()).build();
+        final List<KeyValue> actual = Arrays.asList(duplicateAttribute1, duplicateAttribute2);
+        
+        Map<String, Object> map = OTelProtoCodec.unpackKeyValueList(actual);
+        assertThat(map.size(), is(equalTo(1)));
+    }
+
+    @Test
+    void testUnpackKeyValueListLogRemoveDuplicatedKey() {
+        final String keyName = "duplicate_key_name";
+        final String keyValue = "duplicate_value";
+        final KeyValue duplicateAttribute1 = KeyValue.newBuilder().setKey(keyName).setValue(AnyValue.newBuilder()
+                .setStringValue(keyValue).build()).build();
+        final KeyValue duplicateAttribute2 = KeyValue.newBuilder().setKey(keyName).setValue(AnyValue.newBuilder()
+                .setStringValue(keyValue).build()).build();
+        final List<KeyValue> actual = Arrays.asList(duplicateAttribute1, duplicateAttribute2);        
+        
+        Map<String, Object> map = OTelProtoCodec.unpackKeyValueListLog(actual);
+        assertThat(map.size(), is(equalTo(1)));
+    }
+
+    @Test
+    void testUnpackExemplarValueListRemoveDuplicatedKey() {
+        final String keyName = "duplicate_key_name";
+        final String keyValue = "duplicate_value";
+        final KeyValue duplicateAttribute1 = KeyValue.newBuilder().setKey(keyName).setValue(AnyValue.newBuilder()
+                .setStringValue(keyValue).build()).build();
+        final KeyValue duplicateAttribute2 = KeyValue.newBuilder().setKey(keyName).setValue(AnyValue.newBuilder()
+                .setStringValue(keyValue).build()).build();
+        final List<KeyValue> actual = Arrays.asList(duplicateAttribute1, duplicateAttribute2);        
+        
+        Map<String, Object> map = OTelProtoCodec.unpackExemplarValueList(actual);
+        assertThat(map.size(), is(equalTo(1)));
+    }
+
 }


### PR DESCRIPTION
### Description
This PR is intended to resolve the duplicate key exception while ingesting the otel-dotnet log.
 
### Issues Resolved
Resolves #3868
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
