### PR TITLE
Fix bug where using upsert or update without routing parameter caused…

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/SerializedJsonNode.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/bulk/SerializedJsonNode.java
@@ -17,8 +17,8 @@ class SerializedJsonNode implements SerializedJson, Serializable {
 
     public SerializedJsonNode(final JsonNode jsonNode, SerializedJson doc) {
         this.jsonNode = jsonNode;
-        this.documentId = doc.getDocumentId().get();
-        this.routingField = doc.getRoutingField().get();
+        this.documentId = doc.getDocumentId().orElse(null);
+        this.routingField = doc.getRoutingField().orElse(null);
         this.document = jsonNode.toString().getBytes();
     }
 


### PR DESCRIPTION
… NoSuchElementException

### Description
If one uses `update` or `upsert` action will `document_id` and no `routing` or `routing_field`, then there is an exception for trying to access the Optional for routing 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
