### PR TITLE
Do not write empty lists of DlqObject to the DLQ

### DIFF
--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriter.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriter.java
@@ -84,6 +84,10 @@ public class S3DlqWriter implements DlqWriter {
 
     @Override
     public void write(final List<DlqObject> dlqObjects, final String pipelineName, final String pluginId) throws IOException {
+        if(dlqObjects.isEmpty()) {
+            return;
+        }
+
         try {
             doWrite(dlqObjects, pipelineName, pluginId);
             dlqS3RequestSuccessCounter.increment();

--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterTest.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
@@ -48,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.dlq.s3.S3DlqWriter.S3_DLQ_RECORDS_FAILED;
@@ -161,6 +163,24 @@ public class S3DlqWriterTest {
         assertThat(putObjectRequest.key(), endsWith(".json"));
         verify(dlqS3RequestSuccessCounter).increment();
         verify(dlqS3RecordsSuccessCounter).increment(dlqObjects.size());
+    }
+
+    @Test
+    void write_with_empty_list_does_not_write_to_S3() throws Exception {
+        when(config.getKeyPathPrefix()).thenReturn(keyPathPrefix);
+        when(config.getS3Client()).thenReturn(s3Client);
+        when(config.getBucket()).thenReturn(bucket);
+        s3DlqWriter = new S3DlqWriter(config, objectMapper, pluginMetrics);
+
+        dlqObjects = Collections.emptyList();
+
+        s3DlqWriter.write(dlqObjects, pipelineName, pluginId);
+
+        verifyNoInteractions(s3Client);
+        verifyNoInteractions(dlqS3RequestSuccessCounter);
+        verifyNoInteractions(dlqS3RecordsSuccessCounter);
+        verifyNoInteractions(dlqS3RequestFailedCounter);
+        verifyNoInteractions(dlqS3RecordsFailedCounter);
     }
 
     private static Stream<Arguments> validKeyPathPrefixes() {


### PR DESCRIPTION
### Description

The DLQ was writing empty objects for some scenarios. This PR does not write empty lists to S3.
 
### Issues Resolved

Resolves #4301
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
