### PR TITLE
Create new codec for each s3 group in s3 sink

### DIFF
--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
@@ -26,6 +26,7 @@ import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferTypeOptions;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.CodecBufferFactory;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.CompressionBufferFactory;
 import org.opensearch.dataprepper.plugins.sink.s3.codec.BufferedCodec;
+import org.opensearch.dataprepper.plugins.sink.s3.codec.CodecFactory;
 import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionEngine;
 import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionOption;
 import org.opensearch.dataprepper.plugins.sink.s3.grouping.S3GroupIdentifierFactory;
@@ -48,7 +49,6 @@ public class S3Sink extends AbstractSink<Record<Event>> {
 
     private static final Duration RETRY_FLUSH_BACKOFF = Duration.ofSeconds(5);
     private final S3SinkConfig s3SinkConfig;
-    private final OutputCodec codec;
     private volatile boolean sinkInitialized;
     private final S3SinkService s3SinkService;
     private final BufferFactory bufferFactory;
@@ -70,24 +70,26 @@ public class S3Sink extends AbstractSink<Record<Event>> {
         this.s3SinkConfig = s3SinkConfig;
         this.sinkContext = sinkContext;
         final PluginModel codecConfiguration = s3SinkConfig.getCodec();
+        final CodecFactory codecFactory = new CodecFactory(pluginFactory, codecConfiguration);
+
         final PluginSetting codecPluginSettings = new PluginSetting(codecConfiguration.getPluginName(),
                 codecConfiguration.getPluginSettings());
-        codec = pluginFactory.loadPlugin(OutputCodec.class, codecPluginSettings);
+        final OutputCodec testCodec = pluginFactory.loadPlugin(OutputCodec.class, codecPluginSettings);
         sinkInitialized = Boolean.FALSE;
 
         final S3Client s3Client = ClientFactory.createS3Client(s3SinkConfig, awsCredentialsSupplier);
         BufferFactory innerBufferFactory = s3SinkConfig.getBufferType().getBufferFactory();
-        if(codec instanceof ParquetOutputCodec && s3SinkConfig.getBufferType() != BufferTypeOptions.INMEMORY) {
+        if(testCodec instanceof ParquetOutputCodec && s3SinkConfig.getBufferType() != BufferTypeOptions.INMEMORY) {
             throw new InvalidPluginConfigurationException("The Parquet sink codec is an in_memory buffer only.");
         }
-        if(codec instanceof BufferedCodec) {
-            innerBufferFactory = new CodecBufferFactory(innerBufferFactory, (BufferedCodec) codec);
+        if(testCodec instanceof BufferedCodec) {
+            innerBufferFactory = new CodecBufferFactory(innerBufferFactory, (BufferedCodec) testCodec);
         }
         CompressionOption compressionOption = s3SinkConfig.getCompression();
         final CompressionEngine compressionEngine = compressionOption.getCompressionEngine();
-        bufferFactory = new CompressionBufferFactory(innerBufferFactory, compressionEngine, codec);
+        bufferFactory = new CompressionBufferFactory(innerBufferFactory, compressionEngine, testCodec);
 
-        ExtensionProvider extensionProvider = StandardExtensionProvider.create(codec, compressionOption);
+        ExtensionProvider extensionProvider = StandardExtensionProvider.create(testCodec, compressionOption);
         KeyGenerator keyGenerator = new KeyGenerator(s3SinkConfig, extensionProvider, expressionEvaluator);
 
         if (s3SinkConfig.getObjectKeyOptions().getPathPrefix() != null &&
@@ -102,13 +104,13 @@ public class S3Sink extends AbstractSink<Record<Event>> {
 
         S3OutputCodecContext s3OutputCodecContext = new S3OutputCodecContext(OutputCodecContext.fromSinkContext(sinkContext), compressionOption);
 
-        codec.validateAgainstCodecContext(s3OutputCodecContext);
+        testCodec.validateAgainstCodecContext(s3OutputCodecContext);
 
         final S3GroupIdentifierFactory s3GroupIdentifierFactory = new S3GroupIdentifierFactory(keyGenerator, expressionEvaluator, s3SinkConfig);
-        final S3GroupManager s3GroupManager = new S3GroupManager(s3SinkConfig, s3GroupIdentifierFactory, bufferFactory, s3Client);
+        final S3GroupManager s3GroupManager = new S3GroupManager(s3SinkConfig, s3GroupIdentifierFactory, bufferFactory, codecFactory, s3Client);
 
 
-        s3SinkService = new S3SinkService(s3SinkConfig, codec, s3OutputCodecContext, s3Client, keyGenerator, RETRY_FLUSH_BACKOFF, pluginMetrics, s3GroupManager);
+        s3SinkService = new S3SinkService(s3SinkConfig, s3OutputCodecContext, s3Client, keyGenerator, RETRY_FLUSH_BACKOFF, pluginMetrics, s3GroupManager);
     }
 
     @Override

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/codec/CodecFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/codec/CodecFactory.java
@@ -1,0 +1,23 @@
+package org.opensearch.dataprepper.plugins.sink.s3.codec;
+
+import org.opensearch.dataprepper.model.codec.OutputCodec;
+import org.opensearch.dataprepper.model.configuration.PluginModel;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.model.plugin.PluginFactory;
+
+public class CodecFactory {
+
+    private final PluginFactory pluginFactory;
+
+    private final PluginSetting codecPluginSetting;
+
+    public CodecFactory(final PluginFactory pluginFactory,
+                        final PluginModel codecConfiguration) {
+        this.pluginFactory = pluginFactory;
+        this.codecPluginSetting = new PluginSetting(codecConfiguration.getPluginName(), codecConfiguration.getPluginSettings());
+    }
+
+    public OutputCodec provideCodec() {
+        return pluginFactory.loadPlugin(OutputCodec.class, codecPluginSetting);
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3Group.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3Group.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.sink.s3.grouping;
 
+import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.Buffer;
 
@@ -15,19 +16,27 @@ public class S3Group implements Comparable<S3Group> {
 
     private final Buffer buffer;
 
+    private OutputCodec outputCodec;
+
     private final S3GroupIdentifier s3GroupIdentifier;
 
     private final Collection<EventHandle> groupEventHandles;
 
     public S3Group(final S3GroupIdentifier s3GroupIdentifier,
-                   final Buffer buffer) {
+                   final Buffer buffer,
+                   final OutputCodec outputCodec) {
         this.buffer = buffer;
         this.s3GroupIdentifier = s3GroupIdentifier;
+        this.outputCodec = outputCodec;
         this.groupEventHandles = new LinkedList<>();
     }
 
     public Buffer getBuffer() {
         return buffer;
+    }
+
+    public OutputCodec getOutputCodec() {
+        return outputCodec;
     }
 
     S3GroupIdentifier getS3GroupIdentifier() { return s3GroupIdentifier; }

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceTest.java
@@ -156,7 +156,7 @@ class S3SinkServiceTest {
     }
 
     private S3SinkService createObjectUnderTest() {
-        return new S3SinkService(s3SinkConfig, codec, codecContext, s3Client, keyGenerator, Duration.ofMillis(100), pluginMetrics, s3GroupManager);
+        return new S3SinkService(s3SinkConfig, codecContext, s3Client, keyGenerator, Duration.ofMillis(100), pluginMetrics, s3GroupManager);
     }
 
     @Test
@@ -178,6 +178,7 @@ class S3SinkServiceTest {
 
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
         when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
@@ -204,6 +205,7 @@ class S3SinkServiceTest {
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
         when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
@@ -225,6 +227,7 @@ class S3SinkServiceTest {
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
         when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
@@ -249,6 +252,7 @@ class S3SinkServiceTest {
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
         when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
@@ -274,6 +278,7 @@ class S3SinkServiceTest {
 
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
         when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
@@ -301,6 +306,7 @@ class S3SinkServiceTest {
         doNothing().when(codec).writeEvent(event, outputStream);
 
         final S3Group s3Group = mock(S3Group.class);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
         Buffer buffer = mock(Buffer.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
 
@@ -328,6 +334,7 @@ class S3SinkServiceTest {
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
         when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
@@ -351,6 +358,7 @@ class S3SinkServiceTest {
 
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(event)).thenReturn(s3Group);
         when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
@@ -384,6 +392,7 @@ class S3SinkServiceTest {
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(event)).thenReturn(s3Group);
         when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
@@ -404,6 +413,7 @@ class S3SinkServiceTest {
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(event)).thenReturn(s3Group);
         when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
@@ -427,6 +437,7 @@ class S3SinkServiceTest {
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
         when(s3GroupManager.getS3GroupEntries()).thenReturn(Collections.singletonList(s3Group));
@@ -455,6 +466,7 @@ class S3SinkServiceTest {
         final Event event1 = JacksonEvent.fromMessage(UUID.randomUUID().toString());
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
 
@@ -495,6 +507,7 @@ class S3SinkServiceTest {
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
 
@@ -523,6 +536,7 @@ class S3SinkServiceTest {
         final Event event = JacksonEvent.fromMessage(UUID.randomUUID().toString());
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
 
@@ -562,6 +576,7 @@ class S3SinkServiceTest {
         Event event2 = records.get(1).getData();
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
         when(s3GroupManager.getS3GroupEntries()).thenReturn(List.of(s3Group));
@@ -600,6 +615,7 @@ class S3SinkServiceTest {
         final OutputStream outputStream = mock(OutputStream.class);
         final S3Group s3Group = mock(S3Group.class);
         when(s3Group.getBuffer()).thenReturn(buffer);
+        when(s3Group.getOutputCodec()).thenReturn(codec);
 
         when(s3GroupManager.getOrCreateGroupForEvent(any(Event.class))).thenReturn(s3Group);
 
@@ -644,6 +660,7 @@ class S3SinkServiceTest {
         final Event firstGroupEvent = mock(Event.class);
         final S3Group firstGroup = mock(S3Group.class);
         final Buffer firstGroupBuffer = mock(Buffer.class);
+        when(firstGroup.getOutputCodec()).thenReturn(codec);
         when(firstGroupBuffer.getOutputStream()).thenReturn(mock(OutputStream.class));
         when(firstGroupBuffer.getSize()).thenReturn(bufferOneSize);
         when(firstGroup.getBuffer()).thenReturn(firstGroupBuffer);
@@ -652,6 +669,7 @@ class S3SinkServiceTest {
         final Event secondGroupEvent = mock(Event.class);
         final S3Group secondGroup = mock(S3Group.class);
         final Buffer secondGroupBuffer = mock(Buffer.class);
+        when(secondGroup.getOutputCodec()).thenReturn(codec);
         when(secondGroupBuffer.getSize()).thenReturn(bufferTwoSize);
         when(secondGroupBuffer.getOutputStream()).thenReturn(mock(OutputStream.class));
         when(secondGroup.getBuffer()).thenReturn(secondGroupBuffer);
@@ -659,6 +677,8 @@ class S3SinkServiceTest {
 
         final Event thirdGroupEvent = mock(Event.class);
         final S3Group thirdGroup = mock(S3Group.class);
+        when(thirdGroup.getOutputCodec()).thenReturn(codec);
+
         final Buffer thirdGroupBuffer = mock(Buffer.class);
         when(thirdGroupBuffer.getSize()).thenReturn(bufferThreeSize);
         when(thirdGroupBuffer.getOutputStream()).thenReturn(mock(OutputStream.class));

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupTest.java
@@ -3,6 +3,7 @@ package org.opensearch.dataprepper.plugins.sink.s3.grouping;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.model.event.EventHandle;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.Buffer;
 
@@ -22,7 +23,8 @@ public class S3GroupTest {
     void releasingEventHandles_releases_all_event_handles(final boolean result) {
         final S3GroupIdentifier s3GroupIdentifier = mock(S3GroupIdentifier.class);
         final Buffer buffer = mock(Buffer.class);
-        final S3Group objectUnderTest = new S3Group(s3GroupIdentifier, buffer);
+        final OutputCodec outputCodec = mock(OutputCodec.class);
+        final S3Group objectUnderTest = new S3Group(s3GroupIdentifier, buffer, outputCodec);
         final Collection<EventHandle> eventHandles = List.of(mock(EventHandle.class), mock(EventHandle.class));
 
         for (final EventHandle eventHandle : eventHandles) {
@@ -47,9 +49,9 @@ public class S3GroupTest {
         final Buffer equalBuffer = mock(Buffer.class);
         when(equalBuffer.getSize()).thenReturn(1000L);
 
-        final S3Group smallGroup = new S3Group(mock(S3GroupIdentifier.class), smallBuffer);
-        final S3Group largeGroup = new S3Group(mock(S3GroupIdentifier.class), largeBuffer);
-        final S3Group anotherLargeGroup = new S3Group(mock(S3GroupIdentifier.class), equalBuffer);
+        final S3Group smallGroup = new S3Group(mock(S3GroupIdentifier.class), smallBuffer, mock(OutputCodec.class));
+        final S3Group largeGroup = new S3Group(mock(S3GroupIdentifier.class), largeBuffer, mock(OutputCodec.class));
+        final S3Group anotherLargeGroup = new S3Group(mock(S3GroupIdentifier.class), equalBuffer, mock(OutputCodec.class));
 
         assertThat(smallGroup.compareTo(largeGroup), equalTo(1));
         assertThat(largeGroup.compareTo(smallGroup), equalTo(-1));


### PR DESCRIPTION
### Description
This change fixes a bug where with codecs in the s3 sink where each codec instantiation expects to only track a single output stream by moving the codec instantiation within each S3 group

This only occurs for the Json output codec, which I will add an integration test for in a follow up
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
