### PR TITLE
Add integration test for Json codec in S3 sink

### DIFF
--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/JsonOutputScenario.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/JsonOutputScenario.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opensearch.dataprepper.model.codec.OutputCodec;
+import org.opensearch.dataprepper.plugins.codec.json.JsonOutputCodec;
+import org.opensearch.dataprepper.plugins.codec.json.JsonOutputCodecConfig;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class JsonOutputScenario implements OutputScenario {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Override
+    public OutputCodec getCodec() {
+        return new JsonOutputCodec(new JsonOutputCodecConfig());
+    }
+
+    @Override
+    public void validate(int expectedRecords, List<Map<String, Object>> sampleEventData, File actualContentFile, CompressionScenario compressionScenario) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void validateDynamicPartition(int expectedRecords, int partitionNumber, File actualContentFile, CompressionScenario compressionScenario) throws IOException {
+        JsonNode jsonArray = OBJECT_MAPPER.readTree(actualContentFile).get("events");
+
+        int count = 0;
+        for (final JsonNode eventNode : jsonArray) {
+            final Integer sequence = eventNode.get("sequence").intValue();
+            assertThat(sequence, equalTo(partitionNumber));
+            count++;
+        }
+
+        if (expectedRecords != -1) {
+            assertThat(count, equalTo(expectedRecords));
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "JSON";
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/NdjsonOutputScenario.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/NdjsonOutputScenario.java
@@ -56,6 +56,7 @@ public class NdjsonOutputScenario implements OutputScenario {
         assertThat(sampledData, equalTo(sampleEventData.size()));
     }
 
+    @Override
     public void validateDynamicPartition(int expectedRecords, int partitionNumber, final File actualContentFile, final CompressionScenario compressionScenario) throws IOException {
         final InputStream inputStream = new BufferedInputStream(new FileInputStream(actualContentFile), 64 * 1024);
 

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/OutputScenario.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/OutputScenario.java
@@ -50,4 +50,6 @@ public interface OutputScenario {
      * @throws IOException Some IOException
      */
     void validate(int expectedRecords, List<Map<String, Object>> sampleEventData, File actualContentFile, CompressionScenario compressionScenario) throws IOException;
+
+    void validateDynamicPartition(int expectedRecords, int partitionNumber, File actualContentFile, CompressionScenario compressionScenario) throws IOException;
 }

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/ParquetOutputScenario.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/ParquetOutputScenario.java
@@ -100,6 +100,11 @@ public class ParquetOutputScenario implements OutputScenario {
         assertThat("Not all the sample data was validated.", validatedRecords, equalTo(sampleEventData.size()));
     }
 
+    @Override
+    public void validateDynamicPartition(int expectedRecords, int partitionNumber, File actualContentFile, CompressionScenario compressionScenario) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
     private static void validateParquetStructure(int expectedRecords, final List<Map<String, Object>> allEventData, final InputFile inputFile, CompressionCodecName expectedCompressionCodec) throws IOException {
         // This test assumes that the data all has the same keys.
         final Map<String, Object> sampleEvent = allEventData.iterator().next();

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkIT.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkIT.java
@@ -245,11 +245,11 @@ public class S3SinkIT {
         outputScenario.validate(expectedTotalSize, sampleEventData, actualContentFile, compressionScenario);
     }
 
-    @Test
-    void testWithDynamicGroups() throws IOException {
+    @ParameterizedTest
+    @ArgumentsSource(OutputScenarioArguments.class)
+    void testWithDynamicGroups(final OutputScenario outputScenario) throws IOException {
         final BufferScenario bufferScenario = new InMemoryBufferScenario();
         final CompressionScenario compressionScenario = new NoneCompressionScenario();
-        final NdjsonOutputScenario outputScenario = new NdjsonOutputScenario();
         final SizeCombination sizeCombination = SizeCombination.MEDIUM_SMALLER;
 
         BufferTypeOptions bufferTypeOptions = bufferScenario.getBufferType();
@@ -271,7 +271,7 @@ public class S3SinkIT {
         when(expressionEvaluator.extractDynamicExpressionsFromFormatExpression(objectKeyOptions.getNamePattern()))
                 .thenReturn(Collections.emptyList());
 
-        when(pluginFactory.loadPlugin(eq(OutputCodec.class), any())).thenReturn(outputScenario.getCodec());
+        when(pluginFactory.loadPlugin(eq(OutputCodec.class), any())).thenAnswer(invocation -> outputScenario.getCodec());
         when(s3SinkConfig.getBufferType()).thenReturn(bufferTypeOptions);
         when(s3SinkConfig.getCompression()).thenReturn(compressionScenario.getCompressionOption());
         int expectedTotalSize = sizeCombination.getTotalSize();
@@ -357,7 +357,7 @@ public class S3SinkIT {
         when(expressionEvaluator.extractDynamicExpressionsFromFormatExpression(objectKeyOptions.getNamePattern()))
                 .thenReturn(Collections.emptyList());
 
-        when(pluginFactory.loadPlugin(eq(OutputCodec.class), any())).thenReturn(outputScenario.getCodec());
+        when(pluginFactory.loadPlugin(eq(OutputCodec.class), any())).thenAnswer(invocation -> outputScenario.getCodec());
         when(s3SinkConfig.getBufferType()).thenReturn(bufferTypeOptions);
         when(s3SinkConfig.getCompression()).thenReturn(compressionScenario.getCompressionOption());
         int expectedTotalSize = sizeCombination.getTotalSize();
@@ -535,6 +535,16 @@ public class S3SinkIT {
             );
 
             return generateCombinedArguments(bufferScenarios, outputScenarios, compressionScenarios, sizeCombinations);
+        }
+    }
+
+    static class OutputScenarioArguments implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+            return Stream.of(
+                    arguments(new NdjsonOutputScenario()),
+                    arguments(new JsonOutputScenario()));
         }
     }
 


### PR DESCRIPTION
### Description
Adds an integration test for the json codec which was previously failing before this change (https://github.com/opensearch-project/data-prepper/pull/4410)
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
