### PR TITLE
Fix bug in s3 sink dynamic bucket and catch invalid bucket message

### DIFF
--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/BufferUtilities.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/BufferUtilities.java
@@ -18,6 +18,7 @@ class BufferUtilities {
     private static final Logger LOG = LoggerFactory.getLogger(BufferUtilities.class);
 
     static final String ACCESS_DENIED = "Access Denied";
+    static final String INVALID_BUCKET = "The specified bucket is not valid";
 
     static void putObjectOrSendToDefaultBucket(final S3Client s3Client,
                                                final RequestBody requestBody,
@@ -29,7 +30,8 @@ class BufferUtilities {
                     PutObjectRequest.builder().bucket(targetBucket).key(objectKey).build(),
                     requestBody);
         } catch (final S3Exception e) {
-            if (defaultBucket != null && (e instanceof NoSuchBucketException || e.getMessage().contains(ACCESS_DENIED))) {
+            if (defaultBucket != null &&
+                    (e instanceof NoSuchBucketException || e.getMessage().contains(ACCESS_DENIED) || e.getMessage().contains(INVALID_BUCKET))) {
                 LOG.warn("Bucket {} could not be accessed, attempting to send to default_bucket {}", targetBucket, defaultBucket);
                 s3Client.putObject(
                         PutObjectRequest.builder().bucket(defaultBucket).key(objectKey).build(),

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManager.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManager.java
@@ -74,7 +74,7 @@ public class S3GroupManager {
         if (allGroups.containsKey(s3GroupIdentifier)) {
             return allGroups.get(s3GroupIdentifier);
         } else {
-            final Buffer bufferForNewGroup =  bufferFactory.getBuffer(s3Client, s3SinkConfig::getBucketName, s3GroupIdentifier::getGroupIdentifierFullObjectKey, s3SinkConfig.getDefaultBucket());
+            final Buffer bufferForNewGroup =  bufferFactory.getBuffer(s3Client, s3GroupIdentifier::getFullBucketName, s3GroupIdentifier::getGroupIdentifierFullObjectKey, s3SinkConfig.getDefaultBucket());
             final OutputCodec outputCodec = codecFactory.provideCodec();
             final S3Group s3Group = new S3Group(s3GroupIdentifier, bufferForNewGroup, outputCodec);
             allGroups.put(s3GroupIdentifier, s3Group);

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/BufferUtilitiesTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/BufferUtilitiesTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferUtilities.ACCESS_DENIED;
+import static org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferUtilities.INVALID_BUCKET;
 
 @ExtendWith(MockitoExtension.class)
 public class BufferUtilitiesTest {
@@ -121,14 +122,18 @@ public class BufferUtilitiesTest {
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
-            final S3Exception s3Exception = mock(S3Exception.class);
-            when(s3Exception.getMessage()).thenReturn(UUID.randomUUID() + ACCESS_DENIED + UUID.randomUUID());
+            final S3Exception accessDeniedException = mock(S3Exception.class);
+            when(accessDeniedException.getMessage()).thenReturn(UUID.randomUUID() + ACCESS_DENIED + UUID.randomUUID());
+
+            final S3Exception invalidBucketException = mock(S3Exception.class);
+            when(invalidBucketException.getMessage()).thenReturn(UUID.randomUUID() + INVALID_BUCKET + UUID.randomUUID());
 
             final NoSuchBucketException noSuchBucketException = mock(NoSuchBucketException.class);
 
             return Stream.of(
                     Arguments.arguments(noSuchBucketException),
-                    Arguments.arguments(s3Exception)
+                    Arguments.arguments(accessDeniedException),
+                    Arguments.arguments(invalidBucketException)
             );
         }
     }

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManagerTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManagerTest.java
@@ -71,7 +71,13 @@ public class S3GroupManagerTest {
 
         final Buffer buffer = mock(Buffer.class);
         when(bufferFactory.getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class), eq(defaultBucket)))
-                .thenReturn(buffer);
+                .thenAnswer(invocation -> {
+                    Supplier<String> bucketSupplier = invocation.getArgument(1);
+                    Supplier<String> objectKeySupplier = invocation.getArgument(2);
+                    bucketSupplier.get();
+                    objectKeySupplier.get();
+                    return buffer;
+                });
         final OutputCodec outputCodec = mock(OutputCodec.class);
         when(codecFactory.provideCodec()).thenReturn(outputCodec);
 
@@ -90,6 +96,9 @@ public class S3GroupManagerTest {
 
         assertThat(groups.contains(result), equalTo(true));
         assertThat(objectUnderTest.hasNoGroups(), equalTo(false));
+
+        verify(s3GroupIdentifier).getFullBucketName();
+        verify(s3GroupIdentifier).getGroupIdentifierFullObjectKey();
     }
 
     @Test


### PR DESCRIPTION
### Description
This bug happened on rebase of the previous PR (https://github.com/opensearch-project/data-prepper/pull/4402) which passes static bucket name from config to the buffer rather than the dynamic bucket. This led to a finding that we should catch errors for invalid bucket message
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
