### PR TITLE
Fix an issue that exception messages are masked

### DIFF
--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriter.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriter.java
@@ -123,7 +123,7 @@ public class S3DlqWriter implements DlqWriter {
         } catch (final IOException ioException) {
             throw ioException;
         } catch (final Exception ex) {
-            LOG.error(SENSITIVE, "Failed timed write to S3 dlq: [{}]", content, ex);
+            LOG.error(SENSITIVE, "Failed timed write to S3 dlq with content: [{}]", content, ex);
             throw new IOException("Failed timed write to S3 dlq.", ex);
         }
     }
@@ -132,7 +132,7 @@ public class S3DlqWriter implements DlqWriter {
         try {
             return s3Client.putObject(request, RequestBody.fromString(content));
         } catch (Exception ex) {
-            LOG.error(SENSITIVE, "Failed to write to S3 dlq: [{}] to S3", content, ex);
+            LOG.error(SENSITIVE, "Failed to write content [{}] to S3 dlq", content, ex);
             throw new IOException("Failed to write to S3 dlq.", ex);
         }
     }

--- a/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriter.java
+++ b/data-prepper-plugins/failures-common/src/main/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriter.java
@@ -110,8 +110,8 @@ public class S3DlqWriter implements DlqWriter {
         final PutObjectResponse response = timedPutObject(putObjectRequest, content);
 
         if (!response.sdkHttpResponse().isSuccessful()) {
-            LOG.error(SENSITIVE, "Failed to write to S3 dlq: [{}] to S3 due to status code: [{}]",
-                content, response.sdkHttpResponse().statusCode());
+            LOG.error(SENSITIVE, "Failed to write content [{}] to S3 dlq", content);
+            LOG.error("Failed to write to S3 dlq due to status code: [{}]", response.sdkHttpResponse().statusCode());
             throw new IOException(String.format(
                 "Failed to write to S3 dlq due to status code: %d", response.sdkHttpResponse().statusCode()));
         }
@@ -123,8 +123,7 @@ public class S3DlqWriter implements DlqWriter {
         } catch (final IOException ioException) {
             throw ioException;
         } catch (final Exception ex) {
-            LOG.error(SENSITIVE, "Failed timed write to S3 dlq: [{}] to S3 due to error: [{}]",
-                content, ex.getMessage());
+            LOG.error(SENSITIVE, "Failed timed write to S3 dlq: [{}]", content, ex);
             throw new IOException("Failed timed write to S3 dlq.", ex);
         }
     }
@@ -133,8 +132,7 @@ public class S3DlqWriter implements DlqWriter {
         try {
             return s3Client.putObject(request, RequestBody.fromString(content));
         } catch (Exception ex) {
-            LOG.error(SENSITIVE, "Failed to write to S3 dlq: [{}] to S3 due to error: [{}]",
-                content, ex.getMessage());
+            LOG.error(SENSITIVE, "Failed to write to S3 dlq: [{}] to S3", content, ex);
             throw new IOException("Failed to write to S3 dlq.", ex);
         }
     }
@@ -149,8 +147,7 @@ public class S3DlqWriter implements DlqWriter {
 
             return content;
         } catch (JsonProcessingException e) {
-            LOG.error(SENSITIVE, "Failed to build valid S3 request body with dlqObjects: [{}] due to error: [{}]",
-                dlqObjects, e.getMessage());
+            LOG.error(SENSITIVE, "Failed to build valid S3 request body with dlqObjects: [{}]", dlqObjects, e);
             throw new IOException("Failed to build valid S3 request body", e);
         }
     }


### PR DESCRIPTION
### Description
Show exception messages instead of masking them through the SENSITIVE marker.

I checked all usages of SENSITIVE and EVENT in the repo and seems that all issues are in this S3DlqWriter.java file. 
 
### Issues Resolved
Resolves #3375 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
