### PR TITLE
Adds a Gradle convention plugin for Maven publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,6 @@ allprojects {
     apply plugin: 'checkstyle'
     apply plugin: 'com.diffplug.spotless'
     apply plugin: 'com.github.jk1.dependency-license-report'
-    apply plugin: 'maven-publish'
-
-    group = 'org.opensearch.dataprepper'
 
     ext {
         mavenPublicationRootFile = file("${rootProject.buildDir}/m2")
@@ -42,53 +39,10 @@ allprojects {
         }
     }
 
-    if(project.name.startsWith('data-prepper') || project.parent != null && project.parent.name.equals('data-prepper-plugins')) {
-        project.plugins.withType(JavaPlugin).configureEach {
-            java {
-                withJavadocJar()
-                withSourcesJar()
-            }
-
-            afterEvaluate {
-                project.publishing {
-                    repositories {
-                        maven {
-                            url "file://${mavenPublicationRootFile.absolutePath}"
-                        }
-                    }
-                    publications {
-                        mavenJava(MavenPublication) {
-                            from project.components.findByName("java") ?: project.components.findByName("javaLibrary")
-
-                            groupId = project.group
-                            artifactId = project.name
-                            version = project.version
-
-                            pom {
-                                name = project.name
-                                description = "Data Prepper project: ${project.name}"
-                                url = 'https://github.com/opensearch-project/data-prepper'
-                                licenses {
-                                    license {
-                                        name = 'The Apache Software License, Version 2.0'
-                                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                                        distribution = 'repo'
-                                    }
-                                }
-                                developers {
-                                    developer {
-                                        name = 'OpenSearch'
-                                        url = 'https://github.com/opensearch-project'
-                                    }
-                                }
-                                scm {
-                                    url = 'https://github.com/opensearch-project/data-prepper'
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+    project.plugins.withType(JavaPlugin).configureEach {
+        java {
+            withJavadocJar()
+            withSourcesJar()
         }
     }
 
@@ -99,7 +53,6 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
-    apply plugin: 'maven-publish'
     apply plugin: 'jacoco'
 
     java {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -6,4 +6,5 @@
 plugins {
     id 'java-gradle-plugin'
     id 'java'
+    id 'groovy-gradle-plugin'
 }

--- a/buildSrc/src/main/groovy/data-prepper.publish.gradle
+++ b/buildSrc/src/main/groovy/data-prepper.publish.gradle
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+    id 'maven-publish'
+}
+
+group = 'org.opensearch.dataprepper'
+
+afterEvaluate {
+    project.publishing {
+        repositories {
+            maven {
+                url "file://${mavenPublicationRootFile.absolutePath}"
+            }
+        }
+        publications {
+            mavenJava(MavenPublication) {
+                from project.components.findByName('java') ?: project.components.findByName('javaLibrary')
+
+                groupId = project.group
+                artifactId = project.name
+                version = project.version
+
+                pom {
+                    name = project.name
+                    description = "Data Prepper project: ${project.name}"
+                    url = 'https://github.com/opensearch-project/data-prepper'
+                    licenses {
+                        license {
+                            name = 'The Apache Software License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            distribution = 'repo'
+                        }
+                    }
+                    developers {
+                        developer {
+                            name = 'OpenSearch'
+                            url = 'https://github.com/opensearch-project'
+                        }
+                    }
+                    scm {
+                        url = 'https://github.com/opensearch-project/data-prepper'
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+plugins {
+    id 'data-prepper.publish'
+}
+
 dependencies {
     implementation 'io.micrometer:micrometer-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+plugins {
+    id 'data-prepper.publish'
+}
+
 sourceSets {
     main {
         resources {

--- a/data-prepper-event/build.gradle
+++ b/data-prepper-event/build.gradle
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+plugins {
+    id 'data-prepper.publish'
+}
+
 group = 'org.opensearch.dataprepper.core'
 
 dependencies {

--- a/data-prepper-main/build.gradle
+++ b/data-prepper-main/build.gradle
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+plugins {
+    id 'data-prepper.publish'
+}
+
 sourceSets {
     main {
         resources {

--- a/data-prepper-pipeline-parser/build.gradle
+++ b/data-prepper-pipeline-parser/build.gradle
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+plugins {
+    id 'data-prepper.publish'
+}
+
 group = 'org.opensearch.dataprepper.core'
 
 dependencies {

--- a/data-prepper-plugin-framework/build.gradle
+++ b/data-prepper-plugin-framework/build.gradle
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+plugins {
+    id 'data-prepper.publish'
+}
+
 group = 'org.opensearch.dataprepper.core'
 
 dependencies {

--- a/data-prepper-plugins/build.gradle
+++ b/data-prepper-plugins/build.gradle
@@ -7,7 +7,8 @@ plugins {
     id 'java-library'
 }
 
-allprojects {
+subprojects {
+    apply plugin: 'data-prepper.publish'
     group = 'org.opensearch.dataprepper.plugins'
 }
 

--- a/data-prepper-test-common/build.gradle
+++ b/data-prepper-test-common/build.gradle
@@ -5,6 +5,7 @@
 
 plugins {
     id 'java'
+    id 'data-prepper.publish'
 }
 
 group = 'org.opensearch.dataprepper.test'

--- a/data-prepper-test-event/build.gradle
+++ b/data-prepper-test-event/build.gradle
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+plugins {
+    id 'data-prepper.publish'
+}
+
 group = 'org.opensearch.dataprepper.test'
 
 dependencies {


### PR DESCRIPTION
### Description

This PR moves the Maven publication steps into a [Gradle convention plugin](https://docs.gradle.org/current/userguide/sharing_build_logic_between_subprojects.html#sec:convention_plugins).

There are a few of motivations for this.
1. The decision for which projects to publish was made in the root `build.gradle` rather than in the projects themselves. Now, projects decide by adding the plugin.
2. This is easier to change dynamically when running builds that are not part of the standard open-source release.
3. The projects would set the `group`, but it was not clear why from reading the project Gradle since the publication was inherited.
4. Gradle recommends using convention plugins over `subprojects`/`allprojects`. This may be a good thing to do going forward.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
