### PR TITLE
Encode MongoDB/DocumentDB username and password while constructing connection string

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/MongoDBConnection.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/MongoDBConnection.java
@@ -8,6 +8,8 @@ import org.opensearch.dataprepper.plugins.mongo.configuration.MongoDBSourceConfi
 import org.opensearch.dataprepper.plugins.truststore.TrustStoreProvider;
 
 import java.io.File;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 public class MongoDBConnection {
@@ -33,9 +35,23 @@ public class MongoDBConnection {
         return MongoClients.create(settingBuilder.build());
     }
 
+    private static String encodeString(final String input) {
+        return URLEncoder.encode(input, StandardCharsets.UTF_8);
+    }
+
     private static String getConnectionString(final MongoDBSourceConfig sourceConfig) {
-        final String username = sourceConfig.getCredentialsConfig().getUsername();
-        final String password = sourceConfig.getCredentialsConfig().getPassword();
+        final String username;
+        try {
+            username = encodeString(sourceConfig.getCredentialsConfig().getUsername());
+        } catch (final Exception e) {
+            throw new RuntimeException("Unsupported characters in username.");
+        }
+        final String password;
+        try {
+            password = encodeString(sourceConfig.getCredentialsConfig().getPassword());
+        } catch (final Exception e) {
+            throw new RuntimeException("Unsupported characters in password.");
+        }
         final String hostname = sourceConfig.getHostname();
         final int port = sourceConfig.getPort();
         final String tls = sourceConfig.getTls().toString();

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/client/MongoDBConnectionTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/client/MongoDBConnectionTest.java
@@ -35,8 +35,8 @@ public class MongoDBConnectionTest {
     @BeforeEach
     void setUp() {
         when(mongoDBSourceConfig.getCredentialsConfig()).thenReturn(credentialsConfig);
-        when(credentialsConfig.getUsername()).thenReturn(UUID.randomUUID().toString());
-        when(credentialsConfig.getPassword()).thenReturn(UUID.randomUUID().toString());
+        when(credentialsConfig.getUsername()).thenReturn("\uD800\uD800" + UUID.randomUUID());
+        when(credentialsConfig.getPassword()).thenReturn("aЯ ⾀sd?q=%%l€0£.lo" + UUID.randomUUID());
         when(mongoDBSourceConfig.getHostname()).thenReturn(UUID.randomUUID().toString());
         when(mongoDBSourceConfig.getPort()).thenReturn(getRandomInteger());
         when(mongoDBSourceConfig.getTls()).thenReturn(getRandomBoolean());


### PR DESCRIPTION
Encode MongoDB/DocumentDB username and password while constructing connection string

 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
