### PR TITLE
Maint/renaming kafka source plugin setting

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/SchemaConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/SchemaConfig.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.kafka.configuration;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
@@ -31,10 +32,12 @@ public class SchemaConfig {
   @JsonProperty("version")
   private int version;
 
-  @JsonProperty("schema_registry_api_key")
+  @JsonAlias("schema_registry_api_key")
+  @JsonProperty("api_key")
   private String schemaRegistryApiKey;
 
-  @JsonProperty("schema_registry_api_secret")
+  @JsonAlias("schema_registry_api_secret")
+  @JsonProperty("api_secret")
   private String schemaRegistryApiSecret;
 
   @JsonProperty("session_timeout_ms")

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/SchemaConfigTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/configuration/SchemaConfigTest.java
@@ -54,6 +54,8 @@ class SchemaConfigTest {
 		assertThat(schemaConfig, notNullValue());
 		assertThat(schemaConfig.getVersion(), notNullValue());
 		assertThat(schemaConfig.getRegistryURL(), notNullValue());
+		assertThat(schemaConfig.getSchemaRegistryApiKey(), notNullValue());
+		assertThat(schemaConfig.getSchemaRegistryApiSecret(), notNullValue());
 	}
 
 	@Test

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/sample-pipelines.yaml
@@ -25,8 +25,8 @@ log-pipeline:
       schema:
         registry_url: http://localhost:8081/
         version: 1
-        schema_registry_api_key: 7QV2UXHRVNOC6AJD
-        schema_registry_api_secret: 6M9xLZDIfmyBN9cqNm2n9GU23mleiaIHJWqQeA5P4JY/LyShaRqPuLJw0XhQQ1pD
+        api_key: 7QV2UXHRVNOC6AJD
+        api_secret: 6M9xLZDIfmyBN9cqNm2n9GU23mleiaIHJWqQeA5P4JY/LyShaRqPuLJw0XhQQ1pD
         basic_auth_credentials_source: USER_INFO
         session_timeout_ms: 45000
       aws:


### PR DESCRIPTION
### Description
This PR simplifies naming of settings in kafka schema

* schema_registry_api_key -> api_key
* schema_registry_api_secret -> api_secret
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
