### PR TITLE
MAINT: deprecate certificate_content with certificate_key

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/EncryptionConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/EncryptionConfig.java
@@ -5,13 +5,15 @@
 
 package org.opensearch.dataprepper.plugins.kafka.configuration;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class EncryptionConfig {
     @JsonProperty("type")
     private EncryptionType type = EncryptionType.SSL;
 
-    @JsonProperty("certificate_content")
+    @JsonAlias("certificate_content")
+    @JsonProperty("certificate_key")
     private String certificateContent;
 
     @JsonProperty("trust_store_file_path")

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-auth-insecure.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-auth-insecure.yaml
@@ -5,7 +5,7 @@ log-pipeline :
           - "localhost:9092"
         encryption:
           type: "NONE"
-          certificate_content: "CERTIFICATE_DATA"
+          certificate_key: "CERTIFICATE_DATA"
           insecure: "true"
         authentication:
           sasl:

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-no-auth-ssl-none.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-no-auth-ssl-none.yaml
@@ -5,7 +5,7 @@ log-pipeline :
           - "localhost:9092"
         encryption:
           type: "NONE"
-          certificate_content: "CERTIFICATE_DATA"
+          certificate_key: "CERTIFICATE_DATA"
         topics:
         - name: "quickstart-events"
           group_id: "groupdID1"

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-no-auth-ssl.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-no-auth-ssl.yaml
@@ -5,7 +5,7 @@ log-pipeline :
           - "localhost:9092"
         encryption:
           type: "SSL"
-          certificate_content: "CERTIFICATE_DATA"
+          certificate_key: "CERTIFICATE_DATA"
         topics:
         - name: "quickstart-events"
           group_id: "groupdID1"

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-sasl-ssl-certificate-content.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-sasl-ssl-certificate-content.yaml
@@ -5,7 +5,7 @@ log-pipeline :
           - "localhost:9092"
         encryption:
           type: "SSL"
-          certificate_content: "CERTIFICATE_DATA"
+          certificate_key: "CERTIFICATE_DATA"
         authentication:
           sasl:
             plaintext:

--- a/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-sasl-ssl.yaml
+++ b/data-prepper-plugins/kafka-plugins/src/test/resources/kafka-pipeline-sasl-ssl.yaml
@@ -5,7 +5,7 @@ log-pipeline :
           - "localhost:9092"
         encryption:
           type: "SSL"
-          certificate_content: "CERTIFICATE_DATA"
+          certificate_key: "CERTIFICATE_DATA"
         authentication:
           sasl:
             plaintext:

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfiguration.java
@@ -4,6 +4,7 @@
  */
 package org.opensearch.dataprepper.plugins.source.opensearch.configuration;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.AssertTrue;
 
@@ -15,7 +16,8 @@ public class ConnectionConfiguration {
   @JsonProperty("cert")
   private Path certPath;
 
-  @JsonProperty("certificate_content")
+  @JsonAlias("certiciate_content")
+  @JsonProperty("certificate_key")
   private String certificateContent;
 
   @JsonProperty("socket_timeout")

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfigurationTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfigurationTest.java
@@ -46,7 +46,7 @@ public class ConnectionConfigurationTest {
 
         final String connectionYaml =
                 "  cert: \"cert\"\n" +
-                "  certificate_content: \"certificate content\"\n" +
+                "  certificate_key: \"certificate content\"\n" +
                 "  insecure: true\n";
         final ConnectionConfiguration connectionConfig = objectMapper.readValue(connectionYaml, ConnectionConfiguration.class);
         assertThat(connectionConfig.getCertPath(),equalTo(Path.of("cert")));


### PR DESCRIPTION
### Description
This PR deprecates `certificate_content` with `certificate_key`
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
