### PR TITLE
Make s3 partition size configurable and add unit test for S3 partition creator classes

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/CollectionConfig.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/CollectionConfig.java
@@ -9,14 +9,16 @@ import java.util.stream.Collectors;
 public class CollectionConfig {
     private static final String COLLECTION_SPLITTER = "\\.";
     private static final int DEFAULT_STREAM_BATCH_SIZE = 1000;
+    private static final int DEFAULT_PARTITION_COUNT = 100;
+    private static final int DEFAULT_EXPORT_PARTITION_SIZE = 4000;
     @JsonProperty("collection")
     private @NotNull String collection;
 
-    @JsonProperty("export_config")
-    private ExportConfig exportConfig;
-
     @JsonProperty("export")
     private boolean export;
+
+    @JsonProperty("export_partition_size")
+    private int exportPartitionSize;
 
     @JsonProperty("stream")
     private boolean stream;
@@ -30,14 +32,18 @@ public class CollectionConfig {
     @JsonProperty("s3_region")
     private String s3Region;
 
+    @JsonProperty("partition_count")
+    private int partitionCount;
+
     @JsonProperty("stream_batch_size")
     private int streamBatchSize;
 
     public CollectionConfig() {
         this.export = true;
         this.stream = true;
-        this.exportConfig = new ExportConfig();
         this.streamBatchSize = DEFAULT_STREAM_BATCH_SIZE;
+        this.partitionCount = DEFAULT_PARTITION_COUNT;
+        this.exportPartitionSize = DEFAULT_EXPORT_PARTITION_SIZE;
     }
 
     public String getCollection() {
@@ -68,28 +74,18 @@ public class CollectionConfig {
         return this.s3PathPrefix;
     }
 
+    public int getPartitionCount() {
+        return this.partitionCount;
+    }
+
+    public int getExportPartitionSize() {
+        return this.exportPartitionSize;
+    }
+
     public int getStreamBatchSize() {
         return this.streamBatchSize;
     }
     public String getS3Region() {
         return this.s3Region;
-    }
-
-    public ExportConfig getExportConfig() {
-        return this.exportConfig;
-    }
-
-    public static class ExportConfig {
-        private static final int DEFAULT_ITEMS_PER_PARTITION = 4000;
-        @JsonProperty("items_per_partition")
-        private Integer itemsPerPartition;
-
-        public ExportConfig() {
-            this.itemsPerPartition = DEFAULT_ITEMS_PER_PARTITION;
-        }
-
-        public Integer getItemsPerPartition() {
-            return this.itemsPerPartition;
-        }
     }
 }

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/CollectionConfig.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/CollectionConfig.java
@@ -10,15 +10,12 @@ public class CollectionConfig {
     private static final String COLLECTION_SPLITTER = "\\.";
     private static final int DEFAULT_STREAM_BATCH_SIZE = 1000;
     private static final int DEFAULT_PARTITION_COUNT = 100;
-    private static final int DEFAULT_EXPORT_PARTITION_SIZE = 4000;
+    private static final int DEFAULT_EXPORT_BATCH_SIZE = 10_000;
     @JsonProperty("collection")
     private @NotNull String collection;
 
     @JsonProperty("export")
     private boolean export;
-
-    @JsonProperty("export_partition_size")
-    private int exportPartitionSize;
 
     @JsonProperty("stream")
     private boolean stream;
@@ -35,6 +32,8 @@ public class CollectionConfig {
     @JsonProperty("partition_count")
     private int partitionCount;
 
+    @JsonProperty("export_batch_size")
+    private int exportBatchSize;
     @JsonProperty("stream_batch_size")
     private int streamBatchSize;
 
@@ -43,7 +42,7 @@ public class CollectionConfig {
         this.stream = true;
         this.streamBatchSize = DEFAULT_STREAM_BATCH_SIZE;
         this.partitionCount = DEFAULT_PARTITION_COUNT;
-        this.exportPartitionSize = DEFAULT_EXPORT_PARTITION_SIZE;
+        this.exportBatchSize = DEFAULT_EXPORT_BATCH_SIZE;
     }
 
     public String getCollection() {
@@ -78,8 +77,8 @@ public class CollectionConfig {
         return this.partitionCount;
     }
 
-    public int getExportPartitionSize() {
-        return this.exportPartitionSize;
+    public int getExportBatchSize() {
+        return this.exportBatchSize;
     }
 
     public int getStreamBatchSize() {

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/coordination/partition/S3FolderPartition.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/coordination/partition/S3FolderPartition.java
@@ -11,31 +11,34 @@ import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSour
 import java.util.Optional;
 
 /**
- * A S3 partition represents an S3 partition job to create S3 path prefix/sub folder that will
+ * A S3 Folder partition represents an S3 partition job to create S3 path prefix/sub folder that will
  * be used to group records based on record key.
  */
 public class S3FolderPartition extends EnhancedSourcePartition<String> {
 
     public static final String PARTITION_TYPE = "S3_FOLDER";
     private final String bucketName;
-    private final String subFolder;
+    private final String pathPrefix;
     private final String region;
     private final String collection;
+    private final int partitionCount;
 
     public S3FolderPartition(final SourcePartitionStoreItem sourcePartitionStoreItem) {
         setSourcePartitionStoreItem(sourcePartitionStoreItem);
         String[] keySplits = sourcePartitionStoreItem.getSourcePartitionKey().split("\\|");
         collection = keySplits[0];
         bucketName = keySplits[1];
-        subFolder = keySplits[2];
-        region = keySplits[3];
+        pathPrefix = keySplits[2];
+        partitionCount = Integer.parseInt(keySplits[3]);
+        region = keySplits[4];
     }
 
-    public S3FolderPartition(final String bucketName, final String subFolder, final String region, final String collection) {
+    public S3FolderPartition(final String bucketName, final String pathPrefix, final String region, final String collection, final int partitionCount) {
         this.bucketName = bucketName;
-        this.subFolder = subFolder;
+        this.pathPrefix = pathPrefix;
         this.region = region;
         this.collection = collection;
+        this.partitionCount = partitionCount;
     }
     
     @Override
@@ -45,7 +48,7 @@ public class S3FolderPartition extends EnhancedSourcePartition<String> {
 
     @Override
     public String getPartitionKey() {
-        return collection + "|" + bucketName + "|" + subFolder + "|" + region;
+        return collection + "|" + bucketName + "|" + pathPrefix + "|" + partitionCount + "|" + region;
     }
 
     @Override
@@ -58,8 +61,8 @@ public class S3FolderPartition extends EnhancedSourcePartition<String> {
         return bucketName;
     }
 
-    public String getSubFolder() {
-        return subFolder;
+    public String getPathPrefix() {
+        return pathPrefix;
     }
 
     public String getRegion() {
@@ -68,5 +71,9 @@ public class S3FolderPartition extends EnhancedSourcePartition<String> {
 
     public String getCollection() {
         return collection;
+    }
+
+    public int getPartitionCount() {
+        return partitionCount;
     }
 }

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderScheduler.java
@@ -171,7 +171,7 @@ public class LeaderScheduler implements Runnable {
         exportProgressState.setDatabaseName(collectionConfig.getDatabaseName());
         exportProgressState.setExportTime(exportTime.toString()); // information purpose
         final ExportPartition exportPartition = new ExportPartition(collectionConfig.getCollection(),
-                collectionConfig.getExportPartitionSize(), exportTime, exportProgressState);
+                collectionConfig.getExportBatchSize(), exportTime, exportProgressState);
         coordinator.createPartition(exportPartition);
     }
 

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderScheduler.java
@@ -140,7 +140,7 @@ public class LeaderScheduler implements Runnable {
     private void createS3Partition(final CollectionConfig collectionConfig) {
         LOG.info("Creating s3 folder global partition: {}", collectionConfig.getCollection());
         coordinator.createPartition(new S3FolderPartition(collectionConfig.getS3Bucket(), collectionConfig.getS3PathPrefix(),
-                collectionConfig.getS3Region(), collectionConfig.getCollection()));
+                collectionConfig.getS3Region(), collectionConfig.getCollection(), collectionConfig.getPartitionCount()));
     }
 
     /**
@@ -171,7 +171,7 @@ public class LeaderScheduler implements Runnable {
         exportProgressState.setDatabaseName(collectionConfig.getDatabaseName());
         exportProgressState.setExportTime(exportTime.toString()); // information purpose
         final ExportPartition exportPartition = new ExportPartition(collectionConfig.getCollection(),
-                collectionConfig.getExportConfig().getItemsPerPartition(), exportTime, exportProgressState);
+                collectionConfig.getExportPartitionSize(), exportTime, exportProgressState);
         coordinator.createPartition(exportPartition);
     }
 

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/s3partition/S3PartitionCreator.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/s3partition/S3PartitionCreator.java
@@ -7,15 +7,15 @@ import java.util.List;
 
 public class S3PartitionCreator {
     private static final Logger LOG = LoggerFactory.getLogger(S3PartitionCreator.class);
-    private final int partitionSize;
+    private final int partitionCount;
 
-    S3PartitionCreator(final int partitionSize) {
-        this.partitionSize = partitionSize;
+    S3PartitionCreator(final int partitionCount) {
+        this.partitionCount = partitionCount;
     }
 
     List<String> createPartition() {
         final List<String> partitions = new ArrayList<>();
-        for (int i = 0; i < partitionSize; i++) {
+        for (int i = 0; i < partitionCount; i++) {
             String partitionName = String.format("%02x", i) + "/";
             partitions.add(partitionName);
         }

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/s3partition/S3PartitionCreatorScheduler.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/s3partition/S3PartitionCreatorScheduler.java
@@ -16,7 +16,6 @@ public class S3PartitionCreatorScheduler extends S3FolderPartitionCoordinator im
     private static final Logger LOG = LoggerFactory.getLogger(S3PartitionCreatorScheduler.class);
     public static final String S3_FOLDER_PREFIX = "S3-FOLDER-";
     private static final int DEFAULT_TAKE_LEASE_INTERVAL_MILLIS = 60_000;
-    private static final int DEFAULT_S3_PARTITION_SIZE = 50;
     private final EnhancedSourceCoordinator sourceCoordinator;
     private final List<String> collections;
     public S3PartitionCreatorScheduler(final EnhancedSourceCoordinator sourceCoordinator,
@@ -33,7 +32,7 @@ public class S3PartitionCreatorScheduler extends S3FolderPartitionCoordinator im
                 final Optional<EnhancedSourcePartition> sourcePartition = sourceCoordinator.acquireAvailablePartition(S3FolderPartition.PARTITION_TYPE);
                 if (sourcePartition.isPresent()) {
                     final S3FolderPartition s3FolderPartition = (S3FolderPartition) sourcePartition.get();
-                    final List<String> s3Folders = createS3BucketPartitions();
+                    final List<String> s3Folders = createS3BucketPartitions(s3FolderPartition.getPartitionCount());
                     sourceCoordinator.completePartition(s3FolderPartition);
                     final S3PartitionStatus s3PartitionStatus = new S3PartitionStatus(s3Folders);
                     sourceCoordinator.createPartition(new GlobalState(S3_FOLDER_PREFIX + s3FolderPartition.getCollection(), s3PartitionStatus.toMap()));
@@ -72,8 +71,8 @@ public class S3PartitionCreatorScheduler extends S3FolderPartitionCoordinator im
         LOG.warn("S3 partition creator scheduler interrupted, looks like shutdown has triggered");
     }
 
-    private List<String> createS3BucketPartitions() {
-        final S3PartitionCreator s3PartitionCreator = new S3PartitionCreator(DEFAULT_S3_PARTITION_SIZE);
+    private List<String> createS3BucketPartitions(int partitionCount) {
+        final S3PartitionCreator s3PartitionCreator = new S3PartitionCreator(partitionCount);
         return s3PartitionCreator.createPartition();
     }
 }

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderSchedulerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderSchedulerTest.java
@@ -38,9 +38,6 @@ public class LeaderSchedulerTest {
     @Mock
     private CollectionConfig collectionConfig;
 
-    @Mock
-    private CollectionConfig.ExportConfig exportConfig;
-
     private LeaderScheduler leaderScheduler;
     private LeaderPartition leaderPartition;
 
@@ -65,8 +62,7 @@ public class LeaderSchedulerTest {
         given(coordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).willReturn(Optional.of(leaderPartition));
         given(collectionConfig.isExport()).willReturn(true);
         given(collectionConfig.isStream()).willReturn(true);
-        given(collectionConfig.getExportConfig()).willReturn(exportConfig);
-        given(exportConfig.getItemsPerPartition()).willReturn(new Random().nextInt());
+        given(collectionConfig.getExportPartitionSize()).willReturn(Math.abs(new Random().nextInt()));
         given(collectionConfig.getCollection()).willReturn(UUID.randomUUID().toString());
 
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -98,8 +94,7 @@ public class LeaderSchedulerTest {
         leaderPartition = new LeaderPartition();
         given(coordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).willReturn(Optional.of(leaderPartition));
         given(collectionConfig.isExport()).willReturn(true);
-        given(collectionConfig.getExportConfig()).willReturn(exportConfig);
-        given(exportConfig.getItemsPerPartition()).willReturn(new Random().nextInt());
+        given(collectionConfig.getExportPartitionSize()).willReturn(Math.abs(new Random().nextInt()));
         given(collectionConfig.getCollection()).willReturn(UUID.randomUUID().toString());
 
         final ExecutorService executorService = Executors.newSingleThreadExecutor();

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderSchedulerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderSchedulerTest.java
@@ -62,7 +62,7 @@ public class LeaderSchedulerTest {
         given(coordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).willReturn(Optional.of(leaderPartition));
         given(collectionConfig.isExport()).willReturn(true);
         given(collectionConfig.isStream()).willReturn(true);
-        given(collectionConfig.getExportPartitionSize()).willReturn(Math.abs(new Random().nextInt()));
+        given(collectionConfig.getExportBatchSize()).willReturn(Math.abs(new Random().nextInt()));
         given(collectionConfig.getCollection()).willReturn(UUID.randomUUID().toString());
 
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -94,7 +94,7 @@ public class LeaderSchedulerTest {
         leaderPartition = new LeaderPartition();
         given(coordinator.acquireAvailablePartition(LeaderPartition.PARTITION_TYPE)).willReturn(Optional.of(leaderPartition));
         given(collectionConfig.isExport()).willReturn(true);
-        given(collectionConfig.getExportPartitionSize()).willReturn(Math.abs(new Random().nextInt()));
+        given(collectionConfig.getExportBatchSize()).willReturn(Math.abs(new Random().nextInt()));
         given(collectionConfig.getCollection()).willReturn(UUID.randomUUID().toString());
 
         final ExecutorService executorService = Executors.newSingleThreadExecutor();

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/s3partition/S3FolderPartitionCoordinatorTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/s3partition/S3FolderPartitionCoordinatorTest.java
@@ -1,0 +1,50 @@
+package org.opensearch.dataprepper.plugins.mongo.s3partition;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.plugins.mongo.coordination.partition.GlobalState;
+import org.opensearch.dataprepper.plugins.mongo.model.S3PartitionStatus;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class S3FolderPartitionCoordinatorTest {
+    @Mock
+    private EnhancedSourceCoordinator sourceCoordinator;
+
+    @InjectMocks
+    private S3FolderPartitionCoordinator s3FolderPartitionCoordinator;
+
+    @Test
+    public void getGlobalS3FolderCreationStatus_empty() {
+        final String collection = UUID.randomUUID().toString();
+        when(sourceCoordinator.getPartition(S3PartitionCreatorScheduler.S3_FOLDER_PREFIX + collection)).thenReturn(Optional.empty());
+        Optional<S3PartitionStatus>  partitionStatus = s3FolderPartitionCoordinator.getGlobalS3FolderCreationStatus(collection);
+        assertThat(partitionStatus.isEmpty(), is(true));
+    }
+
+    @Test
+    public void getGlobalS3FolderCreationStatus_nonEmpty() {
+        final String collection = UUID.randomUUID().toString();
+        final List<String> partitions = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        final GlobalState globalState = mock(GlobalState.class);
+        final Map<String, Object> props = Map.of("partitions", partitions);
+        when(globalState.getProgressState()).thenReturn(Optional.of(props));
+        when(sourceCoordinator.getPartition(S3PartitionCreatorScheduler.S3_FOLDER_PREFIX + collection)).thenReturn(Optional.of(globalState));
+        Optional<S3PartitionStatus> partitionStatus = s3FolderPartitionCoordinator.getGlobalS3FolderCreationStatus(collection);
+        assertThat(partitionStatus.isEmpty(), is(false));
+        assertThat(partitionStatus.get().getPartitions(), is(partitions));
+    }
+}

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/s3partition/S3PartitionCreatorSchedulerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/s3partition/S3PartitionCreatorSchedulerTest.java
@@ -1,0 +1,75 @@
+package org.opensearch.dataprepper.plugins.mongo.s3partition;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourceCoordinator;
+import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSourcePartition;
+import org.opensearch.dataprepper.plugins.mongo.coordination.partition.GlobalState;
+import org.opensearch.dataprepper.plugins.mongo.coordination.partition.S3FolderPartition;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.opensearch.dataprepper.plugins.mongo.s3partition.S3PartitionCreatorScheduler.S3_FOLDER_PREFIX;
+
+@ExtendWith(MockitoExtension.class)
+public class S3PartitionCreatorSchedulerTest {
+    @Mock
+    private EnhancedSourceCoordinator coordinator;
+    private S3PartitionCreatorScheduler s3PartitionCreatorScheduler;
+
+    @BeforeEach
+    public void setup() {
+        s3PartitionCreatorScheduler = new S3PartitionCreatorScheduler(coordinator, List.of(UUID.randomUUID().toString()));
+    }
+
+    @Test
+    void test_S3FolderPartition_empty() {
+        given(coordinator.acquireAvailablePartition(S3FolderPartition.PARTITION_TYPE)).willReturn(Optional.empty());
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> s3PartitionCreatorScheduler.run());
+        await()
+                .atMost(Duration.ofSeconds(2))
+                .untilAsserted(() -> verify(coordinator, never()).completePartition(any(EnhancedSourcePartition.class)));
+        await()
+                .atMost(Duration.ofSeconds(2))
+                .untilAsserted(() -> verify(coordinator, never()).createPartition(any(EnhancedSourcePartition.class)));
+        executorService.shutdownNow();
+    }
+
+    @Test
+    void test_S3FolderPartition_exist() {
+        final S3FolderPartition s3FolderPartition = mock(S3FolderPartition.class);
+        given(s3FolderPartition.getPartitionCount()).willReturn(Math.abs(new Random().nextInt(100)));
+        given(s3FolderPartition.getCollection()).willReturn(UUID.randomUUID().toString());
+        given(coordinator.acquireAvailablePartition(S3FolderPartition.PARTITION_TYPE)).willReturn(Optional.of(s3FolderPartition));
+        s3PartitionCreatorScheduler.run();
+        verify(coordinator).completePartition(s3FolderPartition);
+        final ArgumentCaptor<GlobalState> argumentCaptor = ArgumentCaptor.forClass(GlobalState.class);
+        verify(coordinator).createPartition(argumentCaptor.capture());
+        final GlobalState globalState = argumentCaptor.getValue();
+        assertThat(globalState.getPartitionKey(), is(S3_FOLDER_PREFIX + s3FolderPartition.getCollection()));
+        assertThat(globalState.getProgressState().get(), hasKey("partitions"));
+        final List<String> partitions = (List<String>) globalState.getProgressState().get().get("partitions");
+        assertThat(partitions, hasSize(s3FolderPartition.getPartitionCount()));
+    }
+}

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/s3partition/S3PartitionCreatorTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/s3partition/S3PartitionCreatorTest.java
@@ -1,0 +1,20 @@
+package org.opensearch.dataprepper.plugins.mongo.s3partition;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Random;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+public class S3PartitionCreatorTest {
+
+    @Test
+    public void createPartitionTest() {
+        final int partitionCount = Math.abs(new Random().nextInt(1000));
+        final S3PartitionCreator s3PartitionCreator = new S3PartitionCreator(partitionCount);
+        final List<String> partitions = s3PartitionCreator.createPartition();
+        assertThat(partitions, hasSize(partitionCount));
+    }
+}


### PR DESCRIPTION
Make s3 partition size configurable and add unit test for S3 partition creator classes

 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
