### PR TITLE
MAINT: use authentication block in opensearch sink

### DIFF
--- a/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
+++ b/data-prepper-plugins/opensearch/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchSinkIT.java
@@ -101,6 +101,9 @@ import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchInteg
 import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchIntegrationHelper.isOSBundle;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchIntegrationHelper.waitForClusterStateUpdatesToFinish;
 import static org.opensearch.dataprepper.plugins.sink.opensearch.OpenSearchIntegrationHelper.wipeAllTemplates;
+import static org.opensearch.dataprepper.plugins.source.opensearch.configuration.AuthConfig.AUTHENTICATION;
+import static org.opensearch.dataprepper.plugins.source.opensearch.configuration.AuthConfig.PASSWORD;
+import static org.opensearch.dataprepper.plugins.source.opensearch.configuration.AuthConfig.USERNAME;
 
 public class OpenSearchSinkIT {
     private static final int LUCENE_CHAR_LENGTH_LIMIT = 32_766;
@@ -1516,8 +1519,7 @@ public class OpenSearchSinkIT {
 
         final Map<String, Object> metadata = initializeConfigurationMetadata(null, testIndexAlias, null);
         metadata.put(IndexConfiguration.INDEX_TYPE, IndexType.MANAGEMENT_DISABLED.getValue());
-        metadata.put(ConnectionConfiguration.USERNAME, username);
-        metadata.put(ConnectionConfiguration.PASSWORD, password);
+        metadata.put(AUTHENTICATION, Map.of(USERNAME, username, PASSWORD, password));
         metadata.put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
         final PluginSetting pluginSetting = generatePluginSettingByMetadata(metadata);
         final OpenSearchSink sink = createObjectUnderTest(pluginSetting, true);
@@ -1553,8 +1555,7 @@ public class OpenSearchSinkIT {
         final String user = System.getProperty("tests.opensearch.user");
         final String password = System.getProperty("tests.opensearch.password");
         if (user != null) {
-            metadata.put(ConnectionConfiguration.USERNAME, user);
-            metadata.put(ConnectionConfiguration.PASSWORD, password);
+            metadata.put(AUTHENTICATION, Map.of(USERNAME, user, PASSWORD, password));
         }
         final String distributionVersion = DeclaredOpenSearchVersion.OPENDISTRO_0_10.compareTo(
                 OpenSearchIntegrationHelper.getVersion()) >= 0 ?

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchClientRefresher.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchClientRefresher.java
@@ -69,7 +69,27 @@ public class OpenSearchClientRefresher implements PluginComponentRefresher<OpenS
     }
 
     private boolean basicAuthChanged(final ConnectionConfiguration newConfig) {
-        return !Objects.equals(currentConfig.getUsername(), newConfig.getUsername()) ||
-                !Objects.equals(currentConfig.getPassword(), newConfig.getPassword());
+        final String existingUsername;
+        final String existingPassword;
+        if (currentConfig.getAuthConfig() != null) {
+            existingUsername = currentConfig.getAuthConfig().getUsername();
+            existingPassword = currentConfig.getAuthConfig().getPassword();
+        } else {
+            existingUsername = currentConfig.getUsername();
+            existingPassword = currentConfig.getPassword();
+        }
+
+        final String newUsername;
+        final String newPassword;
+        if (newConfig.getAuthConfig() != null) {
+            newUsername = newConfig.getAuthConfig().getUsername();
+            newPassword = newConfig.getAuthConfig().getPassword();
+        } else {
+            newUsername = newConfig.getUsername();
+            newPassword = newConfig.getPassword();
+        }
+
+        return !Objects.equals(existingUsername, newUsername) ||
+                !Objects.equals(existingPassword, newPassword);
     }
 }

--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/AuthConfig.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/AuthConfig.java
@@ -1,0 +1,30 @@
+package org.opensearch.dataprepper.plugins.source.opensearch.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opensearch.dataprepper.model.configuration.PluginSetting;
+
+import java.util.Map;
+
+public class AuthConfig {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    public static final String AUTHENTICATION = "authentication";
+    public static final String USERNAME = "username";
+    public static final String PASSWORD = "password";
+    private String username;
+
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public static AuthConfig readAuthConfig(final PluginSetting pluginSetting) {
+        final Map<String, Object> authConfigMap =
+                pluginSetting.getTypedMap(AUTHENTICATION, String.class, Object.class);
+        return authConfigMap.isEmpty() ? null : OBJECT_MAPPER.convertValue(authConfigMap, AuthConfig.class);
+    }
+}

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchClientRefresherTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/sink/opensearch/OpenSearchClientRefresherTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.configuration.PluginSetting;
+import org.opensearch.dataprepper.plugins.source.opensearch.configuration.AuthConfig;
 
 import java.util.function.Function;
 
@@ -41,6 +42,9 @@ class OpenSearchClientRefresherTest {
     private OpenSearchClient openSearchClient;
 
     @Mock
+    private AuthConfig authConfig;
+
+    @Mock
     private PluginMetrics pluginMetrics;
 
     @Mock
@@ -65,7 +69,7 @@ class OpenSearchClientRefresherTest {
     }
 
     @Test
-    void testGetAfterUpdateWithBasicAuthUnchanged() {
+    void testGetAfterUpdateWithDeprecatedBasicAuthUnchanged() {
         final OpenSearchClientRefresher objectUnderTest = createObjectUnderTest();
         verify(clientFunction, times(1)).apply(any());
         when(connectionConfiguration.getUsername()).thenReturn(TEST_USERNAME);
@@ -85,7 +89,30 @@ class OpenSearchClientRefresherTest {
     }
 
     @Test
-    void testGetAfterUpdateWithUsernameChanged() {
+    void testGetAfterUpdateWithBasicAuthUnchanged() {
+        final OpenSearchClientRefresher objectUnderTest = createObjectUnderTest();
+        verify(clientFunction, times(1)).apply(any());
+        when(connectionConfiguration.getAuthConfig()).thenReturn(authConfig);
+        when(authConfig.getUsername()).thenReturn(TEST_USERNAME);
+        when(authConfig.getPassword()).thenReturn(TEST_PASSWORD);
+        final PluginSetting newConfig = mock(PluginSetting.class);
+        final ConnectionConfiguration newConnectionConfiguration = mock(ConnectionConfiguration.class);
+        final AuthConfig newAuthConfig = mock(AuthConfig.class);
+        when(newConnectionConfiguration.getAuthConfig()).thenReturn(newAuthConfig);
+        when(newAuthConfig.getUsername()).thenReturn(TEST_USERNAME);
+        when(newAuthConfig.getPassword()).thenReturn(TEST_PASSWORD);
+        try (MockedStatic<ConnectionConfiguration> configurationMockedStatic = mockStatic(
+                ConnectionConfiguration.class)) {
+            configurationMockedStatic.when(() -> ConnectionConfiguration.readConnectionConfiguration(eq(newConfig)))
+                    .thenReturn(newConnectionConfiguration);
+            objectUnderTest.update(newConfig);
+        }
+        assertThat(objectUnderTest.get(), equalTo(openSearchClient));
+        verifyNoMoreInteractions(clientFunction);
+    }
+
+    @Test
+    void testGetAfterUpdateWithDeprecatedUsernameChanged() {
         when(pluginMetrics.counter(CREDENTIALS_CHANGED)).thenReturn(credentialsChangeCounter);
         final OpenSearchClientRefresher objectUnderTest = createObjectUnderTest();
         verify(clientFunction, times(1)).apply(any());
@@ -108,7 +135,34 @@ class OpenSearchClientRefresherTest {
     }
 
     @Test
-    void testGetAfterUpdateWithPasswordChanged() {
+    void testGetAfterUpdateWithUsernameChanged() {
+        when(pluginMetrics.counter(CREDENTIALS_CHANGED)).thenReturn(credentialsChangeCounter);
+        final OpenSearchClientRefresher objectUnderTest = createObjectUnderTest();
+        verify(clientFunction, times(1)).apply(any());
+        assertThat(objectUnderTest.get(), equalTo(openSearchClient));
+        when(connectionConfiguration.getAuthConfig()).thenReturn(authConfig);
+        when(authConfig.getUsername()).thenReturn(TEST_USERNAME);
+        when(authConfig.getPassword()).thenReturn(TEST_PASSWORD);
+        final PluginSetting newConfig = mock(PluginSetting.class);
+        final ConnectionConfiguration newConnectionConfiguration = mock(ConnectionConfiguration.class);
+        final AuthConfig newAuthConfig = mock(AuthConfig.class);
+        when(newConnectionConfiguration.getAuthConfig()).thenReturn(newAuthConfig);
+        when(newAuthConfig.getUsername()).thenReturn(TEST_USERNAME + "_changed");
+        final OpenSearchClient newClient = mock(OpenSearchClient.class);
+        when(clientFunction.apply(eq(newConnectionConfiguration))).thenReturn(newClient);
+        try (MockedStatic<ConnectionConfiguration> configurationMockedStatic = mockStatic(
+                ConnectionConfiguration.class)) {
+            configurationMockedStatic.when(() -> ConnectionConfiguration.readConnectionConfiguration(eq(newConfig)))
+                    .thenReturn(newConnectionConfiguration);
+            objectUnderTest.update(newConfig);
+        }
+        assertThat(objectUnderTest.get(), equalTo(newClient));
+        verify(credentialsChangeCounter).increment();
+        verify(clientFunction, times(2)).apply(any());
+    }
+
+    @Test
+    void testGetAfterUpdateWithDeprecatedPasswordChanged() {
         when(pluginMetrics.counter(CREDENTIALS_CHANGED)).thenReturn(credentialsChangeCounter);
         final OpenSearchClientRefresher objectUnderTest = createObjectUnderTest();
         verify(clientFunction, times(1)).apply(any());
@@ -119,6 +173,34 @@ class OpenSearchClientRefresherTest {
         final ConnectionConfiguration newConnectionConfiguration = mock(ConnectionConfiguration.class);
         when(newConnectionConfiguration.getUsername()).thenReturn(TEST_USERNAME);
         when(newConnectionConfiguration.getPassword()).thenReturn(TEST_PASSWORD + "_changed");
+        final OpenSearchClient newClient = mock(OpenSearchClient.class);
+        when(clientFunction.apply(eq(newConnectionConfiguration))).thenReturn(newClient);
+        try (MockedStatic<ConnectionConfiguration> configurationMockedStatic = mockStatic(
+                ConnectionConfiguration.class)) {
+            configurationMockedStatic.when(() -> ConnectionConfiguration.readConnectionConfiguration(eq(newConfig)))
+                    .thenReturn(newConnectionConfiguration);
+            objectUnderTest.update(newConfig);
+        }
+        assertThat(objectUnderTest.get(), equalTo(newClient));
+        verify(credentialsChangeCounter).increment();
+        verify(clientFunction, times(2)).apply(any());
+    }
+
+    @Test
+    void testGetAfterUpdateWithPasswordChanged() {
+        when(pluginMetrics.counter(CREDENTIALS_CHANGED)).thenReturn(credentialsChangeCounter);
+        final OpenSearchClientRefresher objectUnderTest = createObjectUnderTest();
+        verify(clientFunction, times(1)).apply(any());
+        assertThat(objectUnderTest.get(), equalTo(openSearchClient));
+        when(connectionConfiguration.getAuthConfig()).thenReturn(authConfig);
+        when(authConfig.getUsername()).thenReturn(TEST_USERNAME);
+        when(authConfig.getPassword()).thenReturn(TEST_PASSWORD);
+        final PluginSetting newConfig = mock(PluginSetting.class);
+        final ConnectionConfiguration newConnectionConfiguration = mock(ConnectionConfiguration.class);
+        final AuthConfig newAuthConfig = mock(AuthConfig.class);
+        when(newConnectionConfiguration.getAuthConfig()).thenReturn(newAuthConfig);
+        when(newAuthConfig.getUsername()).thenReturn(TEST_USERNAME);
+        when(newAuthConfig.getPassword()).thenReturn(TEST_PASSWORD + "_changed");
         final OpenSearchClient newClient = mock(OpenSearchClient.class);
         when(clientFunction.apply(eq(newConnectionConfiguration))).thenReturn(newClient);
         try (MockedStatic<ConnectionConfiguration> configurationMockedStatic = mockStatic(


### PR DESCRIPTION


### Description
This PR deprecates username and password with authentication in opensearch sink.

```
sink:
 - opensearch:
       authentication:
           username:
           password:
```
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
