### PR TITLE
Updates Ameria to 1.28.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,10 +212,10 @@ subprojects {
         resolutionStrategy.eachDependency { def details ->
             if (details.requested.group == 'io.netty') {
                 if (details.requested.name == 'netty') {
-                    details.useTarget group: 'io.netty', name: 'netty-all', version: '4.1.100.Final'
+                    details.useTarget group: 'io.netty', name: 'netty-all', version: '4.1.108.Final'
                     details.because 'Fixes CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
                 } else if (!details.requested.name.startsWith('netty-tcnative')) {
-                    details.useVersion '4.1.100.Final'
+                    details.useVersion '4.1.108.Final'
                     details.because 'Fixes CVE-2022-41881, CVE-2021-21290 and CVE-2022-41915.'
                 }
             } else if (details.requested.group == 'log4j' && details.requested.name == 'log4j') {

--- a/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/plugins/GrpcBasicAuthenticationProviderTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/plugins/GrpcBasicAuthenticationProviderTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.opensearch.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
 import org.opensearch.dataprepper.armeria.authentication.HttpBasicAuthenticationConfig;
 
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.UUID;
 
@@ -152,12 +154,12 @@ public class GrpcBasicAuthenticationProviderTest {
                     .method(HttpMethod.POST)
                     .path("/grpc.health.v1.Health/Check")
                     .contentType(MediaType.JSON_UTF_8)
-                    .build());
+                    .build(),
+                    HttpData.of(Charset.defaultCharset(), "{\"healthCheckConfig\":{\"serviceName\": \"test\"} }"));
 
             final AggregatedHttpResponse httpResponse = client.execute(request).aggregate().join();
 
-            // TODO: Figure out how to get SampleHealthGrpcService to return a status of 200
-            assertThat(httpResponse.status(), equalTo(HttpStatus.SERVICE_UNAVAILABLE));
+            assertThat(httpResponse.status(), equalTo(HttpStatus.OK));
         }
     }
 }

--- a/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/plugins/UnauthenticatedGrpcAuthenticationProviderTest.java
+++ b/data-prepper-plugins/armeria-common/src/test/java/org/opensearch/dataprepper/plugins/UnauthenticatedGrpcAuthenticationProviderTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.opensearch.dataprepper.armeria.authentication.GrpcAuthenticationProvider;
 
+import java.nio.charset.Charset;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -66,12 +68,12 @@ class UnauthenticatedGrpcAuthenticationProviderTest {
                 .method(HttpMethod.POST)
                 .path("/grpc.health.v1.Health/Check")
                 .contentType(MediaType.JSON_UTF_8)
-                .build());
+                .build(),
+                HttpData.of(Charset.defaultCharset(), "{\"healthCheckConfig\":{\"serviceName\": \"test\"} }"));
 
         final AggregatedHttpResponse httpResponse = client.execute(request).aggregate().join();
 
-        // TODO: Figure out how to get SampleHealthGrpcService to return a status of 200
-        assertThat(httpResponse.status(), equalTo(HttpStatus.SERVICE_UNAVAILABLE));
+        assertThat(httpResponse.status(), equalTo(HttpStatus.OK));
     }
 
     @Test
@@ -84,11 +86,12 @@ class UnauthenticatedGrpcAuthenticationProviderTest {
                 .method(HttpMethod.POST)
                 .path("/grpc.health.v1.Health/Check")
                 .contentType(MediaType.JSON_UTF_8)
-                .build());
+                .build(),
+                HttpData.of(Charset.defaultCharset(), "{\"healthCheckConfig\":{\"serviceName\": \"test\"} }"));
 
         final AggregatedHttpResponse httpResponse = client.execute(request).aggregate().join();
 
         // TODO: Figure out how to get SampleHealthGrpcService to return a status of 200
-        assertThat(httpResponse.status(), equalTo(HttpStatus.SERVICE_UNAVAILABLE));
+        assertThat(httpResponse.status(), equalTo(HttpStatus.OK));
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,11 +30,11 @@ dependencyResolutionManagement {
         libs {
             version('slf4j', '2.0.6')
             library('slf4j-api', 'org.slf4j', 'slf4j-api').versionRef('slf4j')
-            version('armeria', '1.26.4')
+            version('armeria', '1.28.2')
             library('armeria-core', 'com.linecorp.armeria', 'armeria').versionRef('armeria')
             library('armeria-grpc', 'com.linecorp.armeria', 'armeria-grpc').versionRef('armeria')
             library('armeria-junit', 'com.linecorp.armeria', 'armeria-junit5').versionRef('armeria')
-            version('grpc', '1.58.0')
+            version('grpc', '1.63.0')
             library('grpc-inprocess', 'io.grpc', 'grpc-inprocess').versionRef('grpc')
             version('protobuf', '3.24.3')
             library('protobuf-core', 'com.google.protobuf', 'protobuf-java').versionRef('protobuf')


### PR DESCRIPTION
### Description

The goal of this PR is to update Armeria to 1.28.2. This fixes a bug that affects Data Prepper - https://github.com/line/armeria/issues/5572.

This change also required updating a couple other dependencies: gRPC to 1.63.0 and Netty to 4.1.108.

Also, a couple unit tests started failing with this update. Armeria had fixed a bug to return Bad Request instead of Service Unavailable when the request was bad. The test was asserting for this failure because it was not sending the correct request body. I corrected this by sending the necessary body.
 
### Issues Resolved

N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
