### PR TITLE
Use positive numbers in S3DlqWriterTest for consistent test success.

### DIFF
--- a/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterTest.java
+++ b/data-prepper-plugins/failures-common/src/test/java/org/opensearch/dataprepper/plugins/dlq/s3/S3DlqWriterTest.java
@@ -116,7 +116,7 @@ public class S3DlqWriterTest {
             .sdkHttpResponse(mockHttpResponse)
             .build();
 
-        final int numberOfObjects = new Random().nextInt(20);
+        final int numberOfObjects = new Random().nextInt(18) + 2;
         dlqObjects = generateDlqData(numberOfObjects);
 
         objectMapper = new ObjectMapper();


### PR DESCRIPTION
### Description

With the recent change in #4403, the DLQ write does not write for empty objects. The unit tests use a random value which would sometimes generate 0 entries. This is causing test failures and flakiness.

This change always uses a value of at least 2. I chose 2 so that all tests run with multiple values.

### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
