### PR TITLE
MAINT: allow latest schema version if not specified in confluent schema

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/ConfluentKafkaProducerConsumerWithSchemaRegistryIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/ConfluentKafkaProducerConsumerWithSchemaRegistryIT.java
@@ -154,6 +154,7 @@ public class ConfluentKafkaProducerConsumerWithSchemaRegistryIT {
         jsonSourceConfig = mock(KafkaSourceConfig.class);
         avroSourceConfig = mock(KafkaSourceConfig.class);
         pluginMetrics = mock(PluginMetrics.class);
+        pluginConfigObservable = mock(PluginConfigObservable.class);
 	Random random = new Random();
 	testId = random.nextInt();
 	testValue = random.nextDouble();
@@ -251,12 +252,21 @@ public class ConfluentKafkaProducerConsumerWithSchemaRegistryIT {
     }
 
     @Test
-    public void KafkaJsonProducerConsumerTest() {
+    public void KafkaJsonProducerConsumerTestWithSpecifiedSchemaVersion() {
         when(schemaConfig.getVersion()).thenReturn(2);
-	produceJsonRecords(bootstrapServers,  numRecordsProduced);
-	consumeRecords(bootstrapServers, jsonSourceConfig);
-	await().atMost(Duration.ofSeconds(20)).
-	  untilAsserted(() -> assertThat(numRecordsReceived.get(), equalTo(numRecordsProduced)));
+        produceJsonRecords(bootstrapServers,  numRecordsProduced);
+        consumeRecords(bootstrapServers, jsonSourceConfig);
+        await().atMost(Duration.ofSeconds(20)).
+                untilAsserted(() -> assertThat(numRecordsReceived.get(), equalTo(numRecordsProduced)));
+    }
+
+    @Test
+    public void KafkaJsonProducerConsumerTestWithLatestSchemaVersion() {
+        when(schemaConfig.getVersion()).thenReturn(null);
+        produceJsonRecords(bootstrapServers,  numRecordsProduced);
+        consumeRecords(bootstrapServers, jsonSourceConfig);
+        await().atMost(Duration.ofSeconds(20)).
+                untilAsserted(() -> assertThat(numRecordsReceived.get(), equalTo(numRecordsProduced)));
     }
 
     public void consumeRecords(String servers, KafkaSourceConfig sourceConfig) {
@@ -293,12 +303,21 @@ public class ConfluentKafkaProducerConsumerWithSchemaRegistryIT {
 
 
     @Test
-    public void KafkaAvroProducerConsumerTest() {
+    public void KafkaAvroProducerConsumerTestWithSpecifiedSchemaVersion() {
         when(schemaConfig.getVersion()).thenReturn(1);
 	produceAvroRecords(bootstrapServers,  numRecordsProduced);
 	consumeRecords(bootstrapServers, avroSourceConfig);
 	await().atMost(Duration.ofSeconds(20)).
 	  untilAsserted(() -> assertThat(numRecordsReceived.get(), equalTo(numRecordsProduced)));
+    }
+
+    @Test
+    public void KafkaAvroProducerConsumerTestWithLatestSchemaVersion() {
+        when(schemaConfig.getVersion()).thenReturn(null);
+        produceAvroRecords(bootstrapServers,  numRecordsProduced);
+        consumeRecords(bootstrapServers, avroSourceConfig);
+        await().atMost(Duration.ofSeconds(20)).
+                untilAsserted(() -> assertThat(numRecordsReceived.get(), equalTo(numRecordsProduced)));
     }
 
     public void produceAvroRecords(String servers, int numRecords) throws SerializationException {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/SchemaConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/SchemaConfig.java
@@ -30,7 +30,7 @@ public class SchemaConfig {
   private String registryURL;
 
   @JsonProperty("version")
-  private int version;
+  private Integer version;
 
   @JsonAlias("schema_registry_api_key")
   @JsonProperty("api_key")
@@ -103,7 +103,7 @@ public class SchemaConfig {
     return registryURL;
   }
 
-  public int getVersion() {
+  public Integer getVersion() {
     return version;
   }
 

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
@@ -218,9 +218,15 @@ public class KafkaCustomConsumerFactory {
         properties.put(KafkaAvroDeserializerConfig.AUTO_REGISTER_SCHEMAS, false);
         final CachedSchemaRegistryClient schemaRegistryClient = new CachedSchemaRegistryClient(properties.getProperty(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG),
             100, propertyMap);
+        final SchemaConfig schemaConfig = kafkaConsumerConfig.getSchemaConfig();
         try {
-            schemaType = schemaRegistryClient.getSchemaMetadata(topic.getName() + "-value",
-                kafkaConsumerConfig.getSchemaConfig().getVersion()).getSchemaType();
+            final String subject = topic.getName() + "-value";
+            if (schemaConfig.getVersion() != null) {
+                schemaType = schemaRegistryClient.getSchemaMetadata(subject,
+                        kafkaConsumerConfig.getSchemaConfig().getVersion()).getSchemaType();
+            } else {
+                schemaType = schemaRegistryClient.getLatestSchemaMetadata(subject).getSchemaType();
+            }
         } catch (IOException | RestClientException e) {
             LOG.error("Failed to connect to the schema registry...");
             throw new RuntimeException(e);

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -293,9 +293,15 @@ public class KafkaSource implements Source<Record<Event>> {
         properties.put("auto.register.schemas", false);
         schemaRegistryClient = new CachedSchemaRegistryClient(getSchemaRegistryUrl(),
                 100, propertyMap);
+        final SchemaConfig schemaConfig = sourceConfig.getSchemaConfig();
         try {
-            schemaType = schemaRegistryClient.getSchemaMetadata(topic.getName() + "-value",
-                    sourceConfig.getSchemaConfig().getVersion()).getSchemaType();
+            final String subject = topic.getName() + "-value";
+            if (schemaConfig.getVersion() != null) {
+                schemaType = schemaRegistryClient.getSchemaMetadata(subject,
+                        schemaConfig.getVersion()).getSchemaType();
+            } else {
+                schemaType = schemaRegistryClient.getLatestSchemaMetadata(subject).getSchemaType();
+            }
         } catch (IOException | RestClientException e) {
             LOG.error("Failed to connect to the schema registry...");
             throw new RuntimeException(e);


### PR DESCRIPTION
### Description
This PR fixes the requirement to specify schema version in confluent schema type:

current
```
kafka:
      topics:
        - name: "topic_4"
          group_id: "groupdID1"
      bootstrap_servers:
        - ...
      schema:
        type: confluent
        registry_url: https://psrc-m5k9x.us-west-2.aws.confluent.cloud
        version: 1 # <- required previously
```
after this change:
```
kafka:
      topics:
        - name: "topic_4"
          group_id: "groupdID1"
      bootstrap_servers:
        - ...
      schema:
        type: confluent
        registry_url: https://psrc-m5k9x.us-west-2.aws.confluent.cloud
```
 
Run confluent integration tests manually to verify the change
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
