### PR TITLE
Add folder-based partitioning for s3 scan source

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/SourceCoordinationStore.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/SourceCoordinationStore.java
@@ -9,6 +9,7 @@ import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStatus
 import org.opensearch.dataprepper.model.source.coordinator.SourcePartitionStoreItem;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -64,4 +65,8 @@ public interface SourceCoordinationStore {
      * @throws org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionUpdateException when the partition was not updated successfully
      */
     void tryUpdateSourcePartitionItem(final SourcePartitionStoreItem updateItem);
+
+    void tryUpdateSourcePartitionItem(final SourcePartitionStoreItem updateItem, final Instant priorityForUnassignedPartitions);
+
+    void tryDeletePartitionItem(final SourcePartitionStoreItem deleteItem);
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/PartitionIdentifier.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/PartitionIdentifier.java
@@ -42,4 +42,17 @@ public class PartitionIdentifier {
             return new PartitionIdentifier(this);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PartitionIdentifier that = (PartitionIdentifier) o;
+        return Objects.equals(partitionKey, that.partitionKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partitionKey);
+    }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/PartitionIdentifierTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/source/coordinator/PartitionIdentifierTest.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class PartitionIdentifierTest {
 
@@ -21,5 +22,25 @@ public class PartitionIdentifierTest {
         final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(partitionKey).build();
 
         assertThat(partitionIdentifier.getPartitionKey(), equalTo(partitionKey));
+    }
+
+    @Test
+    void testPartitionIdentifierEquals_and_hashCode() {
+        final String partitionKey = UUID.randomUUID().toString();
+        final String differentPartitionKey = UUID.randomUUID().toString();
+
+        final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(partitionKey).build();
+        final PartitionIdentifier equalPartitionIdentifier = PartitionIdentifier.builder().withPartitionKey(partitionKey).build();
+
+        assertThat(partitionIdentifier.equals(equalPartitionIdentifier), equalTo(true));
+        assertThat(partitionIdentifier.hashCode(), equalTo(equalPartitionIdentifier.hashCode()));
+
+        final PartitionIdentifier notEqualPartitionIdentifier = PartitionIdentifier.builder().withPartitionKey(differentPartitionKey).build();
+        assertThat(partitionIdentifier.equals(notEqualPartitionIdentifier), equalTo(false));
+        assertNotEquals(partitionIdentifier.hashCode(), notEqualPartitionIdentifier.hashCode());
+
+        assertThat(partitionIdentifier.equals(partitionIdentifier), equalTo(true));
+        assertThat(partitionIdentifier.equals(null), equalTo(false));
+
     }
 }

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     testImplementation testLibs.mockito.inline
     testImplementation libs.commons.lang3
     testImplementation project(':data-prepper-test-event')
+    testImplementation project(':data-prepper-test-common')
     testImplementation project(':data-prepper-api').sourceSets.test.output
 }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinator.java
@@ -51,6 +51,8 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     static final String PARTITIONS_ACQUIRED_COUNT = "partitionsAcquired";
     static final String PARTITIONS_COMPLETED_COUNT = "partitionsCompleted";
     static final String PARTITIONS_CLOSED_COUNT = "partitionsClosed";
+
+    static final String PARTITIONS_DELETED = "partitionsDeleted";
     static final String SAVE_PROGRESS_STATE_INVOCATION_SUCCESS_COUNT = "savePartitionProgressStateInvocationsSuccess";
     static final String PARTITION_OWNERSHIP_GIVEN_UP_COUNT = "partitionsGivenUp";
 
@@ -89,11 +91,13 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
     private final Counter saveStatePartitionUpdateErrorCounter;
     private final Counter closePartitionUpdateErrorCounter;
     private final Counter completePartitionUpdateErrorCounter;
+
+    private final Counter partitionsDeleted;
     private final ReentrantLock lock;
 
     private Instant lastSupplierRunTime;
 
-    static final Duration FORCE_SUPPLIER_AFTER_DURATION = Duration.ofMinutes(15);
+    static final Duration FORCE_SUPPLIER_AFTER_DURATION = Duration.ofMinutes(5);
 
     static {
         try {
@@ -131,6 +135,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
         this.saveStatePartitionUpdateErrorCounter = pluginMetrics.counter(PARTITION_UPDATE_ERROR_COUNT, SAVE_STATE_ACTION);
         this.closePartitionUpdateErrorCounter = pluginMetrics.counter(PARTITION_UPDATE_ERROR_COUNT, CLOSE_ACTION);
         this.completePartitionUpdateErrorCounter = pluginMetrics.counter(PARTITION_UPDATE_ERROR_COUNT, COMPLETE_ACTION);
+        this.partitionsDeleted = pluginMetrics.counter(PARTITIONS_DELETED);
         this.lock = new ReentrantLock();
         this.lastSupplierRunTime = Instant.now();
     }
@@ -370,7 +375,7 @@ public class LeaseBasedSourceCoordinator<T> implements SourceCoordinator<T> {
                 return;
             }
 
-
+            partitionsDeleted.increment();
             LOG.info("Partition key {} was deleted by owner {}", deleteItem.getSourcePartitionKey(), ownerId);
         }
     }

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinatorTest.java
@@ -27,6 +27,7 @@ import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionN
 import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionUpdateException;
 import org.opensearch.dataprepper.model.source.coordinator.exceptions.UninitializedSourceCoordinatorException;
 import org.opensearch.dataprepper.parser.model.SourceCoordinationConfig;
+import org.opensearch.dataprepper.test.helper.ReflectivelySetField;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -54,7 +55,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.DEFAULT_LEASE_TIMEOUT;
+import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.FORCE_SUPPLIER_AFTER_DURATION;
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS;
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.GLOBAL_STATE_TYPE;
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.NO_PARTITIONS_ACQUIRED_COUNT;
@@ -831,7 +834,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
 
         if (updatedItemSuccessfully) {
-            doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);
+            doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(eq(sourcePartitionStoreItem), eq(null));
             createObjectUnderTest().giveUpPartition(sourcePartition.getPartitionKey());
 
             verify(sourcePartitionStoreItem).setSourcePartitionStatus(SourcePartitionStatus.UNASSIGNED);
@@ -839,7 +842,7 @@ public class LeaseBasedSourceCoordinatorTest {
             verify(sourcePartitionStoreItem).setPartitionOwnershipTimeout(null);
 
         } else {
-            doThrow(PartitionUpdateException.class).when(sourceCoordinationStore).tryUpdateSourcePartitionItem(sourcePartitionStoreItem);
+            doThrow(PartitionUpdateException.class).when(sourceCoordinationStore).tryUpdateSourcePartitionItem(eq(sourcePartitionStoreItem), eq(null));
             createObjectUnderTest().giveUpPartition(sourcePartition.getPartitionKey());
         }
 
@@ -859,6 +862,160 @@ public class LeaseBasedSourceCoordinatorTest {
                 closePartitionUpdateErrorCounter,
                 completePartitionUpdateErrorCounter);
 
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void giveUpPartitions_with_override_timestamp_and_existing_store_item_with_valid_owner_returns_expected_result(final boolean updatedItemSuccessfully) throws UnknownHostException {
+        final SourcePartition<String> sourcePartition = SourcePartition.builder(String.class)
+                .withPartitionKey(UUID.randomUUID().toString())
+                .withPartitionState(null)
+                .build();
+
+        final Instant now = Instant.now();
+
+        given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(sourceIdentifierWithPartitionPrefix + ":" + InetAddress.getLocalHost().getHostName());
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, sourcePartition.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+
+        if (updatedItemSuccessfully) {
+            doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(eq(sourcePartitionStoreItem), eq(now));
+            createObjectUnderTest().giveUpPartition(sourcePartition.getPartitionKey(), now);
+
+            verify(sourcePartitionStoreItem).setSourcePartitionStatus(SourcePartitionStatus.UNASSIGNED);
+            verify(sourcePartitionStoreItem).setPartitionOwner(null);
+            verify(sourcePartitionStoreItem).setPartitionOwnershipTimeout(null);
+
+        } else {
+            doThrow(PartitionUpdateException.class).when(sourceCoordinationStore).tryUpdateSourcePartitionItem(eq(sourcePartitionStoreItem), eq(now));
+            createObjectUnderTest().giveUpPartition(sourcePartition.getPartitionKey(), now);
+        }
+
+        verify(partitionsGivenUpCounter).increment();
+
+        verifyNoInteractions(
+                partitionCreationSupplierInvocationsCounter,
+                partitionsAcquiredCounter,
+                partitionsCreatedCounter,
+                noPartitionsAcquiredCounter,
+                partitionsCompletedCounter,
+                partitionsClosedCounter,
+                saveProgressStateInvocationSuccessCounter,
+                partitionNotOwnedErrorCounter,
+                partitionNotFoundErrorCounter,
+                saveStatePartitionUpdateErrorCounter,
+                closePartitionUpdateErrorCounter,
+                completePartitionUpdateErrorCounter);
+
+    }
+
+    @Test
+    void getNextPartition_with_supplier_force_will_run_supplier_if_it_has_not_been_run_for_duration() throws NoSuchFieldException, IllegalAccessException {
+        final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
+        final PartitionIdentifier partitionIdentifierToSkip = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
+        final Function<Map<String, Object>, List<PartitionIdentifier>> partitionCreationSupplier = (map) -> List.of(partitionIdentifierToSkip, partitionIdentifier);
+        given(sourcePartitionStoreItem.getSourcePartitionKey()).willReturn(UUID.randomUUID().toString());
+
+        given(sourcePartitionStoreItem.getPartitionProgressState()).willReturn(null);
+        given(sourcePartitionStoreItem.getClosedCount()).willReturn(1L);
+
+        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), anyString(), any())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(globalStateForPartitionCreationItem.getSourcePartitionStatus()).willReturn(SourcePartitionStatus.UNASSIGNED);
+        given(globalStateForPartitionCreationItem.getPartitionOwner()).willReturn(null);
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForGlobalState, GLOBAL_STATE_SOURCE_PARTITION_KEY_FOR_CREATING_PARTITIONS)).willReturn(Optional.of(globalStateForPartitionCreationItem));
+        doNothing().when(sourceCoordinationStore).tryUpdateSourcePartitionItem(globalStateForPartitionCreationItem);
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, partitionIdentifierToSkip.getPartitionKey())).willReturn(Optional.of(sourcePartitionStoreItem));
+        given(sourceCoordinationStore.getSourcePartitionItem(fullSourceIdentifierForPartition, partitionIdentifier.getPartitionKey())).willReturn(Optional.empty());
+        given(sourceCoordinationStore.tryCreatePartitionItem(fullSourceIdentifierForPartition, partitionIdentifier.getPartitionKey(), SourcePartitionStatus.UNASSIGNED, 0L, null, false)).willReturn(true);
+
+        final SourceCoordinator<String> objectUnderTest = createObjectUnderTest();
+
+        final Instant expiredSupplierRunTime = Instant.now().minus(FORCE_SUPPLIER_AFTER_DURATION).minus(Duration.ofMinutes(1));
+        ReflectivelySetField.setField(LeaseBasedSourceCoordinator.class, objectUnderTest, "lastSupplierRunTime", expiredSupplierRunTime);
+
+        final Optional<SourcePartition<String>> result = objectUnderTest.getNextPartition(partitionCreationSupplier, true);
+
+        assertThat(result.isPresent(), equalTo(true));
+        assertThat(result.get().getPartitionClosedCount(), equalTo(sourcePartitionStoreItem.getClosedCount()));
+        assertThat(result.get().getPartitionKey(), equalTo(sourcePartitionStoreItem.getSourcePartitionKey()));
+        assertThat(result.get().getPartitionState().isPresent(), equalTo(false));
+
+        verify(globalStateForPartitionCreationItem).setPartitionOwner(anyString());
+        verify(globalStateForPartitionCreationItem).setPartitionOwnershipTimeout(any(Instant.class));
+        verify(globalStateForPartitionCreationItem).setSourcePartitionStatus(SourcePartitionStatus.ASSIGNED);
+
+        verify(partitionCreationSupplierInvocationsCounter).increment();
+        verify(partitionsAcquiredCounter).increment();
+        verify(partitionsCreatedCounter).increment();
+
+        verifyNoInteractions(
+                noPartitionsAcquiredCounter,
+                partitionsCompletedCounter,
+                partitionsClosedCounter,
+                saveProgressStateInvocationSuccessCounter,
+                partitionsGivenUpCounter,
+                partitionNotFoundErrorCounter,
+                partitionNotOwnedErrorCounter,
+                saveStatePartitionUpdateErrorCounter,
+                closePartitionUpdateErrorCounter,
+                completePartitionUpdateErrorCounter);
+    }
+
+    @Test
+    void getNextPartition_with_supplier_force_will_not_run_supplier_if_it_has_not_reached_force_duration() throws NoSuchFieldException, IllegalAccessException {
+        final PartitionIdentifier partitionIdentifier = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
+        final PartitionIdentifier partitionIdentifierToSkip = PartitionIdentifier.builder().withPartitionKey(UUID.randomUUID().toString()).build();
+        final Function<Map<String, Object>, List<PartitionIdentifier>> partitionCreationSupplier = (map) -> List.of(partitionIdentifierToSkip, partitionIdentifier);
+        given(sourcePartitionStoreItem.getSourcePartitionKey()).willReturn(UUID.randomUUID().toString());
+
+        given(sourcePartitionStoreItem.getPartitionProgressState()).willReturn(null);
+        given(sourcePartitionStoreItem.getClosedCount()).willReturn(1L);
+
+        given(sourceCoordinationStore.tryAcquireAvailablePartition(anyString(), anyString(), any())).willReturn(Optional.of(sourcePartitionStoreItem));
+
+        final SourceCoordinator<String> objectUnderTest = createObjectUnderTest();
+
+        final Optional<SourcePartition<String>> result = objectUnderTest.getNextPartition(partitionCreationSupplier, true);
+
+        assertThat(result.isPresent(), equalTo(true));
+        assertThat(result.get().getPartitionClosedCount(), equalTo(sourcePartitionStoreItem.getClosedCount()));
+        assertThat(result.get().getPartitionKey(), equalTo(sourcePartitionStoreItem.getSourcePartitionKey()));
+        assertThat(result.get().getPartitionState().isPresent(), equalTo(false));
+
+        verify(partitionsAcquiredCounter).increment();
+
+
+        verifyNoInteractions(
+                partitionsCreatedCounter,
+                partitionCreationSupplierInvocationsCounter,
+                noPartitionsAcquiredCounter,
+                partitionsCompletedCounter,
+                partitionsClosedCounter,
+                saveProgressStateInvocationSuccessCounter,
+                partitionsGivenUpCounter,
+                partitionNotFoundErrorCounter,
+                partitionNotOwnedErrorCounter,
+                saveStatePartitionUpdateErrorCounter,
+                closePartitionUpdateErrorCounter,
+                completePartitionUpdateErrorCounter);
+    }
+
+    @Test
+    void deletePartition_will_call_delete_partition_on_the_coordination_store() throws UnknownHostException {
+
+        final String partitionKey = UUID.randomUUID().toString();
+        when(sourcePartitionStoreItem.getSourcePartitionKey()).thenReturn(partitionKey);
+        given(sourcePartitionStoreItem.getPartitionOwner()).willReturn(sourceIdentifierWithPartitionPrefix + ":" + InetAddress.getLocalHost().getHostName());
+
+
+        when(sourceCoordinationStore.getSourcePartitionItem(anyString(), eq(partitionKey))).thenReturn(Optional.of(sourcePartitionStoreItem));
+
+        doNothing().when(sourceCoordinationStore).tryDeletePartitionItem(sourcePartitionStoreItem);
+
+        final SourceCoordinator<String> objectUnderTest = createObjectUnderTest();
+
+        objectUnderTest.deletePartition(partitionKey);
+
+        verify(sourceCoordinationStore).tryDeletePartitionItem(sourcePartitionStoreItem);
     }
 
     static Stream<Object[]> getClosedCountArgs() {

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinatorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/sourcecoordination/LeaseBasedSourceCoordinatorTest.java
@@ -64,6 +64,7 @@ import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoor
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.PARTITIONS_ACQUIRED_COUNT;
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.PARTITIONS_CLOSED_COUNT;
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.PARTITIONS_COMPLETED_COUNT;
+import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.PARTITIONS_DELETED;
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.PARTITION_CREATED_COUNT;
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.PARTITION_CREATION_SUPPLIER_INVOCATION_COUNT;
 import static org.opensearch.dataprepper.sourcecoordination.LeaseBasedSourceCoordinator.PARTITION_NOT_FOUND_ERROR_COUNT;
@@ -128,6 +129,9 @@ public class LeaseBasedSourceCoordinatorTest {
     private Counter completePartitionUpdateErrorCounter;
 
     @Mock
+    private Counter partitionsDeletedCounter;
+
+    @Mock
     private SourcePartitionStoreItem globalStateForPartitionCreationItem;
 
     private String sourceIdentifier;
@@ -157,6 +161,7 @@ public class LeaseBasedSourceCoordinatorTest {
         given(pluginMetrics.counter(PARTITION_UPDATE_ERROR_COUNT, "saveState")).willReturn(saveStatePartitionUpdateErrorCounter);
         given(pluginMetrics.counter(PARTITION_UPDATE_ERROR_COUNT, "close")).willReturn(closePartitionUpdateErrorCounter);
         given(pluginMetrics.counter(PARTITION_UPDATE_ERROR_COUNT, "complete")).willReturn(completePartitionUpdateErrorCounter);
+        given(pluginMetrics.counter(PARTITIONS_DELETED)).willReturn(partitionsDeletedCounter);
     }
 
     private SourceCoordinator<String> createObjectUnderTest() {
@@ -1016,6 +1021,7 @@ public class LeaseBasedSourceCoordinatorTest {
         objectUnderTest.deletePartition(partitionKey);
 
         verify(sourceCoordinationStore).tryDeletePartitionItem(sourcePartitionStoreItem);
+        verify(partitionsDeletedCounter).increment();
     }
 
     static Stream<Object[]> getClosedCountArgs() {

--- a/data-prepper-plugins/in-memory-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/inmemory/InMemorySourceCoordinationStore.java
+++ b/data-prepper-plugins/in-memory-source-coordination-store/src/main/java/org/opensearch/dataprepper/plugins/sourcecoordinator/inmemory/InMemorySourceCoordinationStore.java
@@ -116,4 +116,14 @@ public class InMemorySourceCoordinationStore implements SourceCoordinationStore 
             inMemoryPartitionAccessor.updateItem((InMemorySourcePartitionStoreItem) updateItem);
         }
     }
+
+    @Override
+    public void tryUpdateSourcePartitionItem(final SourcePartitionStoreItem updateItem, final Instant priorityForUnassignedPartitions) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void tryDeletePartitionItem(SourcePartitionStoreItem deleteItem) {
+        throw new UnsupportedOperationException("deleting partitions is not currently supported by the in memory source coordination store");
+    }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectReference.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectReference.java
@@ -50,7 +50,6 @@ class S3ObjectReference {
     }
 
     public static final class Builder {
-
         private final String bucketName;
         private final String key;
         private String owner;

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3SourceConfig.java
@@ -104,6 +104,16 @@ public class S3SourceConfig {
         return true;
     }
 
+    @AssertTrue(message = "acknowledgments and delete_s3_objects_on_read must both be set to true when using PREFIX partition mode")
+    boolean isPrefixPartitionModeValid() {
+        if (s3ScanScanOptions != null &&
+                s3ScanScanOptions.getPartitioningOptions() != null) {
+            return acknowledgments && deleteS3ObjectsOnRead;
+        }
+
+        return true;
+    }
+
     public NotificationTypeOption getNotificationType() {
         return notificationType;
     }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3SourceConfig.java
@@ -104,7 +104,7 @@ public class S3SourceConfig {
         return true;
     }
 
-    @AssertTrue(message = "acknowledgments and delete_s3_objects_on_read must both be set to true when using PREFIX partition mode")
+    @AssertTrue(message = "acknowledgments and delete_s3_objects_on_read must both be set to true when using folder_partitions mode")
     boolean isPrefixPartitionModeValid() {
         if (s3ScanScanOptions != null &&
                 s3ScanScanOptions.getPartitioningOptions() != null) {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3SourceProgressState.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3SourceProgressState.java
@@ -6,11 +6,24 @@
 package org.opensearch.dataprepper.plugins.source.s3;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class S3SourceProgressState {
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Long lastTimeObjectsFound;
 
     @JsonCreator
-    S3SourceProgressState() {
+    public S3SourceProgressState(@JsonProperty("last_time_objects_found") final Long lastTimeObjectsFound) {
+        this.lastTimeObjectsFound = lastTimeObjectsFound;
+    }
+
+    public Long getLastTimeObjectsFound() {
+        return lastTimeObjectsFound;
+    }
+
+    public void setLastTimeObjectsFound(final Long lastTimeObjectsFound) {
+        this.lastTimeObjectsFound = lastTimeObjectsFound;
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ScanObjectWorker.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/ScanObjectWorker.java
@@ -14,21 +14,32 @@ import org.opensearch.dataprepper.model.source.coordinator.SourcePartition;
 import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionNotFoundException;
 import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionNotOwnedException;
 import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionUpdateException;
+import org.opensearch.dataprepper.plugins.source.s3.configuration.FolderPartitioningOptions;
 import org.opensearch.dataprepper.plugins.source.s3.configuration.S3ScanSchedulingOptions;
 import org.opensearch.dataprepper.plugins.source.s3.ownership.BucketOwnerProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Class responsible for processing the s3 scan objects with the help of <code>S3ObjectWorker</code>
@@ -37,7 +48,9 @@ import java.util.function.Function;
 public class ScanObjectWorker implements Runnable{
 
     private static final Logger LOG = LoggerFactory.getLogger(ScanObjectWorker.class);
+    private static final Integer MAX_OBJECTS_PER_ACKNOWLEDGMENT_SET = 1;
 
+    static final Duration NO_OBJECTS_FOUND_BEFORE_PARTITION_DELETION_DURATION = Duration.ofMinutes(3);
     private static final int RETRY_BACKOFF_ON_EXCEPTION_MILLIS = 5_000;
 
     static final Duration ACKNOWLEDGEMENT_SET_TIMEOUT = Duration.ofHours(2);
@@ -69,6 +82,12 @@ public class ScanObjectWorker implements Runnable{
     private final long backOffMs;
     private final List<String> partitionKeys;
 
+    private final FolderPartitioningOptions folderPartitioningOptions;
+
+    private final Map<String, Set<DeleteObjectRequest>> objectsToDeleteForAcknowledgmentSets;
+
+    private final Map<String, AtomicInteger> acknowledgmentsRemainingForPartitions;
+
     public ScanObjectWorker(final S3Client s3Client,
                             final List<ScanOptions> scanOptionsBuilderList,
                             final S3ObjectHandler s3ObjectHandler,
@@ -94,8 +113,11 @@ public class ScanObjectWorker implements Runnable{
         acknowledgementSetCallbackCounter = pluginMetrics.counter(ACKNOWLEDGEMENT_SET_CALLBACK_METRIC_NAME);
         this.sourceCoordinator.initialize();
         this.partitionKeys = new ArrayList<>();
+        this.folderPartitioningOptions = s3SourceConfig.getS3ScanScanOptions().getPartitioningOptions();
 
-        this.partitionCreationSupplier = new S3ScanPartitionCreationSupplier(s3Client, bucketOwnerProvider, scanOptionsBuilderList, s3ScanSchedulingOptions);
+        this.partitionCreationSupplier = new S3ScanPartitionCreationSupplier(s3Client, bucketOwnerProvider, scanOptionsBuilderList, s3ScanSchedulingOptions, s3SourceConfig.getS3ScanScanOptions().getPartitioningOptions());
+        this.acknowledgmentsRemainingForPartitions = new ConcurrentHashMap<>();
+        this.objectsToDeleteForAcknowledgmentSets = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -126,7 +148,7 @@ public class ScanObjectWorker implements Runnable{
     }
 
     private void startProcessingObject(final long waitTimeMillis) {
-        final Optional<SourcePartition<S3SourceProgressState>> objectToProcess = sourceCoordinator.getNextPartition(partitionCreationSupplier);
+        final Optional<SourcePartition<S3SourceProgressState>> objectToProcess = sourceCoordinator.getNextPartition(partitionCreationSupplier, folderPartitioningOptions != null);
 
         if (objectToProcess.isEmpty()) {
             try {
@@ -138,12 +160,21 @@ public class ScanObjectWorker implements Runnable{
         }
 
         partitionKeys.add(objectToProcess.get().getPartitionKey());
+        if (folderPartitioningOptions != null) {
+            try {
+                processFolderPartition(objectToProcess.get());
+            } catch (final Exception e) {
+                LOG.error("An exception occurred while processing folder partition {}, giving up this partition", objectToProcess.get().getPartitionKey(), e);
+                sourceCoordinator.giveUpPartition(objectToProcess.get().getPartitionKey(), Instant.now());
+                partitionKeys.remove(objectToProcess.get().getPartitionKey());
+            }
+            return;
+        }
 
         final String bucket = objectToProcess.get().getPartitionKey().split("\\|")[0];
         final String objectKey = objectToProcess.get().getPartitionKey().split("\\|")[1];
 
         try {
-            List<DeleteObjectRequest> waitingForAcknowledgements = new ArrayList<>();
             AcknowledgementSet acknowledgementSet = null;
 
             if (endToEndAcknowledgementsEnabled) {
@@ -152,7 +183,9 @@ public class ScanObjectWorker implements Runnable{
                     // Delete only if this is positive acknowledgement
                     if (result == true) {
                         sourceCoordinator.completePartition(objectToProcess.get().getPartitionKey(), true);
-                        waitingForAcknowledgements.forEach(s3ObjectDeleteWorker::deleteS3Object);
+                        final Set<DeleteObjectRequest> deleteObjectsForPartition = objectsToDeleteForAcknowledgmentSets.get(objectToProcess.get().getPartitionKey());
+                        deleteObjectsForPartition.forEach(s3ObjectDeleteWorker::deleteS3Object);
+                        objectsToDeleteForAcknowledgmentSets.remove(objectToProcess.get().getPartitionKey());
                     } else {
                         sourceCoordinator.giveUpPartition(objectToProcess.get().getPartitionKey());
                     }
@@ -165,7 +198,7 @@ public class ScanObjectWorker implements Runnable{
                     acknowledgementSet, sourceCoordinator, objectToProcess.get());
 
             if (endToEndAcknowledgementsEnabled) {
-                deleteObjectRequest.ifPresent(waitingForAcknowledgements::add);
+                deleteObjectRequest.ifPresent(deleteRequest -> objectsToDeleteForAcknowledgmentSets.put(objectToProcess.get().getPartitionKey(), Set.of(deleteRequest)));
                 sourceCoordinator.updatePartitionForAcknowledgmentWait(objectToProcess.get().getPartitionKey(), ACKNOWLEDGEMENT_SET_TIMEOUT);
                 acknowledgementSet.complete();
             } else {
@@ -198,8 +231,141 @@ public class ScanObjectWorker implements Runnable{
         return Optional.empty();
     }
 
+    private void processFolderPartition(final SourcePartition<S3SourceProgressState> folderPartition) {
+        final String bucket = folderPartition.getPartitionKey().split("\\|")[0];
+        final String s3Prefix = folderPartition.getPartitionKey().split("\\|")[1];
+
+        final List<S3ObjectReference> objectsToProcess = getObjectsForPrefix(bucket, s3Prefix);
+
+        if (objectsToProcess.isEmpty()) {
+            partitionKeys.remove(folderPartition.getPartitionKey());
+            if (shouldDeleteFolderPartition(folderPartition)) {
+                LOG.info("Deleting folder partition {} as no objects have been found from this folder for {} minutes", folderPartition.getPartitionKey(), NO_OBJECTS_FOUND_BEFORE_PARTITION_DELETION_DURATION.toMinutes());
+                sourceCoordinator.deletePartition(folderPartition.getPartitionKey());
+                return;
+            }
+
+            if (folderPartition.getPartitionState().isEmpty()) {
+                final S3SourceProgressState s3SourceProgressState = new S3SourceProgressState(Instant.now().toEpochMilli());
+                sourceCoordinator.saveProgressStateForPartition(folderPartition.getPartitionKey(), s3SourceProgressState);
+            }
+
+            sourceCoordinator.giveUpPartition(folderPartition.getPartitionKey(), Instant.now());
+            return;
+        }
+
+        Optional<S3SourceProgressState> folderPartitionProgressState = folderPartition.getPartitionState();
+        if (folderPartitionProgressState.isEmpty()) {
+            folderPartitionProgressState = Optional.of(new S3SourceProgressState(Instant.now().toEpochMilli()));
+        } else {
+            folderPartitionProgressState.get().setLastTimeObjectsFound(Instant.now().toEpochMilli());
+        }
+
+        // Update the last time objects were found to support deletion of the partition after no objects found for some time
+        sourceCoordinator.saveProgressStateForPartition(folderPartition.getPartitionKey(), folderPartitionProgressState.get());
+
+
+        int objectsProcessed = 0;
+        int objectIndex = 0;
+
+        AcknowledgementSet acknowledgementSet = null;
+        String activeAcknowledgmentSetId = null;
+        while (objectIndex < objectsToProcess.size() && objectsProcessed < folderPartitioningOptions.getMaxObjectsPerOwnership()) {
+            final S3ObjectReference s3ObjectReference = objectsToProcess.get(objectIndex);
+            if (objectsProcessed % MAX_OBJECTS_PER_ACKNOWLEDGMENT_SET == 0) {
+                if (acknowledgementSet != null) {
+                    acknowledgementSet.complete();
+                }
+
+                final String acknowledgmentSetId = UUID.randomUUID().toString();
+                activeAcknowledgmentSetId = acknowledgmentSetId;
+
+                acknowledgementSet = acknowledgementSetManager.create((result) -> {
+                    acknowledgementSetCallbackCounter.increment();
+
+                    // Delete only if this is positive acknowledgement
+                    if (result) {
+                        final Set<DeleteObjectRequest> deleteObjectsForPartition = objectsToDeleteForAcknowledgmentSets.get(acknowledgmentSetId);
+                        deleteObjectsForPartition.forEach(s3ObjectDeleteWorker::deleteS3Object);
+                    }
+
+                    acknowledgmentsRemainingForPartitions.get(folderPartition.getPartitionKey()).decrementAndGet();
+
+                    if (acknowledgmentsRemainingForPartitions.get(folderPartition.getPartitionKey()).intValue() == 0) {
+                        acknowledgmentsRemainingForPartitions.remove(folderPartition.getPartitionKey());
+                        objectsToDeleteForAcknowledgmentSets.remove(acknowledgmentSetId);
+                        partitionKeys.remove(folderPartition.getPartitionKey());
+                        LOG.info("Received all acknowledgments for folder partition {}, giving up this partition", folderPartition.getPartitionKey());
+                        sourceCoordinator.giveUpPartition(folderPartition.getPartitionKey(), Instant.now());
+                    }
+                }, ACKNOWLEDGEMENT_SET_TIMEOUT);
+
+                objectsToDeleteForAcknowledgmentSets.put(acknowledgmentSetId, new HashSet<>());
+
+                final AtomicInteger acknowledgmentsRemainingForPartition = acknowledgmentsRemainingForPartitions.containsKey(folderPartition.getPartitionKey()) ?
+                        acknowledgmentsRemainingForPartitions.get(folderPartition.getPartitionKey()) :
+                        new AtomicInteger();
+
+                acknowledgmentsRemainingForPartition.incrementAndGet();
+
+                acknowledgmentsRemainingForPartitions.put(folderPartition.getPartitionKey(), acknowledgmentsRemainingForPartition);
+            }
+
+            final Optional<DeleteObjectRequest> deleteObjectRequest = processS3Object(s3ObjectReference,
+                    acknowledgementSet, sourceCoordinator, folderPartition);
+
+            if (deleteObjectRequest.isPresent()) {
+                objectsToDeleteForAcknowledgmentSets.get(activeAcknowledgmentSetId).add(deleteObjectRequest.get());
+            }
+
+            objectsProcessed++;
+            objectIndex++;
+        }
+
+        // Complete the final acknowledgment set
+        if (acknowledgementSet != null) {
+            acknowledgementSet.complete();
+        }
+
+        sourceCoordinator.updatePartitionForAcknowledgmentWait(folderPartition.getPartitionKey(), ACKNOWLEDGEMENT_SET_TIMEOUT);
+    }
+
+    private List<S3ObjectReference> getObjectsForPrefix(final String bucket, final String s3Prefix) {
+        ListObjectsV2Response listObjectsV2Response = null;
+        final List<S3ObjectReference> objectsToProcess = new ArrayList<>();
+
+        final ListObjectsV2Request.Builder listObjectsV2Request = ListObjectsV2Request.builder()
+                .bucket(bucket)
+                .prefix(s3Prefix);
+
+        do {
+            listObjectsV2Response = s3Client.listObjectsV2(listObjectsV2Request
+                    .fetchOwner(true)
+                    .continuationToken(Objects.nonNull(listObjectsV2Response) ? listObjectsV2Response.nextContinuationToken() : null)
+                    .build());
+            LOG.info("Found page of {} objects from bucket {} and prefix {}", listObjectsV2Response.keyCount(), bucket, s3Prefix);
+
+            objectsToProcess.addAll(listObjectsV2Response.contents().stream()
+                    .map(s3Object -> S3ObjectReference.bucketAndKey(bucket, s3Object.key()).build())
+                    .collect(Collectors.toList()));
+
+        } while (listObjectsV2Response.isTruncated());
+
+        return objectsToProcess;
+    }
+
     void stop() {
         isStopped = true;
         Thread.currentThread().interrupt();
+    }
+
+    private boolean shouldDeleteFolderPartition(final SourcePartition<S3SourceProgressState> folderPartition) {
+        if (folderPartition.getPartitionState().isPresent() &&
+                Instant.now().toEpochMilli() - folderPartition.getPartitionState().get().getLastTimeObjectsFound()
+                        > NO_OBJECTS_FOUND_BEFORE_PARTITION_DELETION_DURATION.toMillis()) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/FolderPartitioningOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/FolderPartitioningOptions.java
@@ -1,0 +1,20 @@
+package org.opensearch.dataprepper.plugins.source.s3.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class FolderPartitioningOptions {
+
+    @JsonProperty("depth")
+    private Integer folderDepth = 1;
+
+    @JsonProperty("max_objects_per_ownership")
+    private Integer objectsPerOwnership = 50;
+
+    public Integer getFolderDepth() {
+        return folderDepth;
+    }
+
+    public Integer getMaxObjectsPerOwnership() {
+        return objectsPerOwnership;
+    }
+}

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/S3ScanScanOptions.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/configuration/S3ScanScanOptions.java
@@ -22,6 +22,10 @@ import java.util.stream.Stream;
  */
 public class S3ScanScanOptions {
 
+    @JsonProperty("folder_partitions")
+    @Valid
+    private FolderPartitioningOptions folderPartitioningOptions;
+
     @JsonProperty("range")
     private Duration range;
 
@@ -73,4 +77,6 @@ public class S3ScanScanOptions {
     public S3ScanSchedulingOptions getSchedulingOptions() {
         return schedulingOptions;
     }
+
+    public FolderPartitioningOptions getPartitioningOptions() { return folderPartitioningOptions; }
 }

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanObjectWorkerTest.java
@@ -65,6 +65,7 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.s3.ScanObjectWorker.ACKNOWLEDGEMENT_SET_CALLBACK_METRIC_NAME;
 import static org.opensearch.dataprepper.plugins.source.s3.ScanObjectWorker.ACKNOWLEDGEMENT_SET_TIMEOUT;
 import static org.opensearch.dataprepper.plugins.source.s3.ScanObjectWorker.NO_OBJECTS_FOUND_BEFORE_PARTITION_DELETION_DURATION;
+import static org.opensearch.dataprepper.plugins.source.s3.ScanObjectWorker.NO_OBJECTS_FOUND_FOR_FOLDER_PARTITION;
 
 @ExtendWith(MockitoExtension.class)
 class S3ScanObjectWorkerTest {
@@ -108,6 +109,9 @@ class S3ScanObjectWorkerTest {
     @Mock
     private Counter counter;
 
+    @Mock
+    private Counter noObjectsFoundForFolderPartitionCounter;
+
     private List<ScanOptions> scanOptionsList;
 
     @BeforeEach
@@ -120,6 +124,7 @@ class S3ScanObjectWorkerTest {
         when(s3ScanScanOptions.getSchedulingOptions()).thenReturn(s3ScanSchedulingOptions);
         when(s3SourceConfig.getS3ScanScanOptions()).thenReturn(s3ScanScanOptions);
         when(pluginMetrics.counter(ACKNOWLEDGEMENT_SET_CALLBACK_METRIC_NAME)).thenReturn(counter);
+        when(pluginMetrics.counter(NO_OBJECTS_FOUND_FOR_FOLDER_PARTITION)).thenReturn(noObjectsFoundForFolderPartitionCounter);
         final ScanObjectWorker objectUnderTest = new ScanObjectWorker(s3Client, scanOptionsList, s3ObjectHandler, bucketOwnerProvider,
                 sourceCoordinator, s3SourceConfig, acknowledgementSetManager, s3ObjectDeleteWorker, 30000, pluginMetrics);
         verify(sourceCoordinator).initialize();
@@ -382,6 +387,7 @@ class S3ScanObjectWorkerTest {
         final ScanObjectWorker scanObjectWorker = createObjectUnderTest();
         scanObjectWorker.runWithoutInfiniteLoop();
         verify(sourceCoordinator).deletePartition(partitionKey);
+        verify(noObjectsFoundForFolderPartitionCounter).increment();
     }
 
     @Test

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanObjectWorkerTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanObjectWorkerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
@@ -22,16 +23,22 @@ import org.opensearch.dataprepper.model.source.coordinator.SourcePartition;
 import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionNotFoundException;
 import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionNotOwnedException;
 import org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionUpdateException;
+import org.opensearch.dataprepper.plugins.source.s3.configuration.FolderPartitioningOptions;
 import org.opensearch.dataprepper.plugins.source.s3.configuration.S3ScanScanOptions;
 import org.opensearch.dataprepper.plugins.source.s3.configuration.S3ScanSchedulingOptions;
 import org.opensearch.dataprepper.plugins.source.s3.ownership.BucketOwnerProvider;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -41,13 +48,15 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -55,6 +64,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.source.s3.ScanObjectWorker.ACKNOWLEDGEMENT_SET_CALLBACK_METRIC_NAME;
 import static org.opensearch.dataprepper.plugins.source.s3.ScanObjectWorker.ACKNOWLEDGEMENT_SET_TIMEOUT;
+import static org.opensearch.dataprepper.plugins.source.s3.ScanObjectWorker.NO_OBJECTS_FOUND_BEFORE_PARTITION_DELETION_DURATION;
 
 @ExtendWith(MockitoExtension.class)
 class S3ScanObjectWorkerTest {
@@ -103,6 +113,7 @@ class S3ScanObjectWorkerTest {
     @BeforeEach
     void setup() {
         scanOptionsList = new ArrayList<>();
+        when(s3ScanScanOptions.getPartitioningOptions()).thenReturn(null);
     }
 
     private ScanObjectWorker createObjectUnderTest() {
@@ -125,7 +136,7 @@ class S3ScanObjectWorkerTest {
 
         final SourcePartition<S3SourceProgressState> partitionToProcess = SourcePartition.builder(S3SourceProgressState.class).withPartitionKey(partitionKey).build();
 
-        given(sourceCoordinator.getNextPartition(any(Function.class))).willReturn(Optional.of(partitionToProcess));
+        given(sourceCoordinator.getNextPartition(any(Function.class), eq(false))).willReturn(Optional.of(partitionToProcess));
 
         final ArgumentCaptor<S3ObjectReference> objectReferenceArgumentCaptor = ArgumentCaptor.forClass(S3ObjectReference.class);
         doThrow(exception).when(s3ObjectHandler).parseS3Object(objectReferenceArgumentCaptor.capture(), eq(null), eq(sourceCoordinator), eq(partitionKey));
@@ -148,7 +159,7 @@ class S3ScanObjectWorkerTest {
                 .withPartitionClosedCount(0L)
                 .build();
 
-        given(sourceCoordinator.getNextPartition(any(Function.class))).willReturn(Optional.of(partitionToProcess));
+        given(sourceCoordinator.getNextPartition(any(Function.class), eq(false))).willReturn(Optional.of(partitionToProcess));
 
         final ArgumentCaptor<S3ObjectReference> objectReferenceArgumentCaptor = ArgumentCaptor.forClass(S3ObjectReference.class);
         doNothing().when(s3ObjectHandler).parseS3Object(objectReferenceArgumentCaptor.capture(), eq(null), eq(sourceCoordinator), eq(partitionKey));
@@ -177,7 +188,7 @@ class S3ScanObjectWorkerTest {
                 .withPartitionClosedCount(0L)
                 .build();
 
-        given(sourceCoordinator.getNextPartition(any(Function.class))).willReturn(Optional.of(partitionToProcess));
+        given(sourceCoordinator.getNextPartition(any(Function.class), eq(false))).willReturn(Optional.of(partitionToProcess));
 
         final ArgumentCaptor<S3ObjectReference> objectReferenceArgumentCaptor = ArgumentCaptor.forClass(S3ObjectReference.class);
         doNothing().when(s3ObjectHandler).parseS3Object(objectReferenceArgumentCaptor.capture(), eq(acknowledgementSet), eq(sourceCoordinator), eq(partitionKey));
@@ -185,18 +196,22 @@ class S3ScanObjectWorkerTest {
 
         final ScanObjectWorker scanObjectWorker = createObjectUnderTest();
 
-        doAnswer(invocation -> {
-            Consumer<Boolean> consumer = invocation.getArgument(0);
-            consumer.accept(true);
-            return acknowledgementSet;
-        }).when(acknowledgementSetManager).create(any(Consumer.class), any(Duration.class));
+        when(acknowledgementSetManager.create(any(Consumer.class), any(Duration.class))).thenReturn(acknowledgementSet);
 
         scanObjectWorker.runWithoutInfiniteLoop();
 
-        verify(sourceCoordinator).updatePartitionForAcknowledgmentWait(partitionKey, ACKNOWLEDGEMENT_SET_TIMEOUT);
-        verify(sourceCoordinator).completePartition(partitionKey, true);
-        verify(s3ObjectDeleteWorker).buildDeleteObjectRequest(bucket, objectKey);
-        verify(acknowledgementSet).complete();
+        final ArgumentCaptor<Consumer> consumerArgumentCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(acknowledgementSetManager).create(consumerArgumentCaptor.capture(), any(Duration.class));
+
+        final Consumer<Boolean> ackCallback = consumerArgumentCaptor.getValue();
+        ackCallback.accept(true);
+
+        final InOrder inOrder = inOrder(sourceCoordinator, acknowledgementSet, s3ObjectDeleteWorker);
+        inOrder.verify(s3ObjectDeleteWorker).buildDeleteObjectRequest(bucket, objectKey);
+        inOrder.verify(sourceCoordinator).updatePartitionForAcknowledgmentWait(partitionKey, ACKNOWLEDGEMENT_SET_TIMEOUT);
+        inOrder.verify(acknowledgementSet).complete();
+        inOrder.verify(sourceCoordinator).completePartition(partitionKey, true);
+
         verify(counter).increment();
 
         final S3ObjectReference processedObject = objectReferenceArgumentCaptor.getValue();
@@ -219,7 +234,7 @@ class S3ScanObjectWorkerTest {
                 .withPartitionClosedCount(0L)
                 .build();
 
-        given(sourceCoordinator.getNextPartition(any(Function.class))).willReturn(Optional.of(partitionToProcess));
+        given(sourceCoordinator.getNextPartition(any(Function.class), eq(false))).willReturn(Optional.of(partitionToProcess));
 
         final ArgumentCaptor<S3ObjectReference> objectReferenceArgumentCaptor = ArgumentCaptor.forClass(S3ObjectReference.class);
         doNothing().when(s3ObjectHandler).parseS3Object(objectReferenceArgumentCaptor.capture(), eq(null), eq(sourceCoordinator), eq(partitionKey));
@@ -254,7 +269,7 @@ class S3ScanObjectWorkerTest {
                 .withPartitionClosedCount(0L)
                 .build();
 
-        given(sourceCoordinator.getNextPartition(any(Function.class))).willReturn(Optional.of(partitionToProcess));
+        given(sourceCoordinator.getNextPartition(any(Function.class), eq(false))).willReturn(Optional.of(partitionToProcess));
 
         final ArgumentCaptor<S3ObjectReference> objectReferenceArgumentCaptor = ArgumentCaptor.forClass(S3ObjectReference.class);
         doNothing().when(s3ObjectHandler).parseS3Object(objectReferenceArgumentCaptor.capture(), eq(null), eq(sourceCoordinator), eq(partitionKey));
@@ -275,7 +290,7 @@ class S3ScanObjectWorkerTest {
 
     @Test
     void getNextPartition_supplier_is_expected_partitionCreationSupplier() {
-        given(sourceCoordinator.getNextPartition(any(S3ScanPartitionCreationSupplier.class))).willReturn(Optional.empty());
+        given(sourceCoordinator.getNextPartition(any(S3ScanPartitionCreationSupplier.class), eq(false))).willReturn(Optional.empty());
         final ScanObjectWorker objectUnderTest = createObjectUnderTest();
         objectUnderTest.runWithoutInfiniteLoop();
     }
@@ -289,7 +304,7 @@ class S3ScanObjectWorkerTest {
 
         final SourcePartition<S3SourceProgressState> partitionToProcess = SourcePartition.builder(S3SourceProgressState.class).withPartitionKey(partitionKey).build();
 
-        given(sourceCoordinator.getNextPartition(any(Function.class))).willReturn(Optional.of(partitionToProcess));
+        given(sourceCoordinator.getNextPartition(any(Function.class), eq(false))).willReturn(Optional.of(partitionToProcess));
 
         final ArgumentCaptor<S3ObjectReference> objectReferenceArgumentCaptor = ArgumentCaptor.forClass(S3ObjectReference.class);
         doThrow(NoSuchKeyException.class).when(s3ObjectHandler).parseS3Object(objectReferenceArgumentCaptor.capture(), eq(null), eq(sourceCoordinator), eq(partitionKey));
@@ -299,6 +314,223 @@ class S3ScanObjectWorkerTest {
 
         verifyNoMoreInteractions(sourceCoordinator);
     }
+
+    @Test
+    void processing_with_folder_partitions_with_no_objects_gives_up_that_partition() {
+
+        final FolderPartitioningOptions folderPartitioningOptions = mock(FolderPartitioningOptions.class);
+        when(s3ScanScanOptions.getPartitioningOptions()).thenReturn(folderPartitioningOptions);
+
+        final String bucket = UUID.randomUUID().toString();
+        final String folder = UUID.randomUUID().toString();
+        final String partitionKey = bucket + "|" + folder;
+
+        final SourcePartition<S3SourceProgressState> partitionToProcess = SourcePartition.builder(S3SourceProgressState.class).withPartitionKey(partitionKey).build();
+        when(sourceCoordinator.getNextPartition(any(Function.class), eq(true))).thenReturn(Optional.of(partitionToProcess));
+
+        final ListObjectsV2Response listObjectsV2Response = mock(ListObjectsV2Response.class);
+        when(listObjectsV2Response.isTruncated()).thenReturn(false);
+        when(listObjectsV2Response.contents()).thenReturn(Collections.emptyList());
+
+        when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(listObjectsV2Response);
+        doNothing().when(sourceCoordinator).giveUpPartition(eq(partitionKey), any(Instant.class));
+        doNothing().when(sourceCoordinator).saveProgressStateForPartition(eq(partitionKey), any(S3SourceProgressState.class));
+
+        final ScanObjectWorker scanObjectWorker = createObjectUnderTest();
+        scanObjectWorker.runWithoutInfiniteLoop();
+
+        verify(sourceCoordinator).saveProgressStateForPartition(eq(partitionKey), any(S3SourceProgressState.class));
+        verify(sourceCoordinator).giveUpPartition(eq(partitionKey), any(Instant.class));
+
+        final ArgumentCaptor<ListObjectsV2Request> listObjectsV2RequestArgumentCaptor = ArgumentCaptor.forClass(ListObjectsV2Request.class);
+
+        verify(s3Client).listObjectsV2(listObjectsV2RequestArgumentCaptor.capture());
+
+        final ListObjectsV2Request request = listObjectsV2RequestArgumentCaptor.getValue();
+        assertThat(request, notNullValue());
+        assertThat(request.bucket(), equalTo(bucket));
+        assertThat(request.fetchOwner(), equalTo(true));
+        assertThat(request.prefix(), equalTo(folder));
+    }
+
+    @Test
+    void processing_with_folder_partition_with_no_objects_found_for_some_time_deletes_the_partition() {
+        final FolderPartitioningOptions folderPartitioningOptions = mock(FolderPartitioningOptions.class);
+        when(s3ScanScanOptions.getPartitioningOptions()).thenReturn(folderPartitioningOptions);
+
+        final String bucket = UUID.randomUUID().toString();
+        final String folder = UUID.randomUUID().toString();
+        final String partitionKey = bucket + "|" + folder;
+
+        final SourcePartition<S3SourceProgressState> partitionToProcess = SourcePartition
+                .builder(S3SourceProgressState.class)
+                .withPartitionKey(partitionKey)
+                .withPartitionState(new S3SourceProgressState(Instant.now()
+                        .minus(NO_OBJECTS_FOUND_BEFORE_PARTITION_DELETION_DURATION)
+                        .minus(Duration.ofMinutes(1)).toEpochMilli()))
+                .build();
+        when(sourceCoordinator.getNextPartition(any(Function.class), eq(true))).thenReturn(Optional.of(partitionToProcess));
+
+        final ListObjectsV2Response listObjectsV2Response = mock(ListObjectsV2Response.class);
+        when(listObjectsV2Response.isTruncated()).thenReturn(false);
+        when(listObjectsV2Response.contents()).thenReturn(Collections.emptyList());
+
+        when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(listObjectsV2Response);
+
+        doNothing().when(sourceCoordinator).deletePartition(partitionKey);
+
+        final ScanObjectWorker scanObjectWorker = createObjectUnderTest();
+        scanObjectWorker.runWithoutInfiniteLoop();
+        verify(sourceCoordinator).deletePartition(partitionKey);
+    }
+
+    @Test
+    void processing_with_folder_partition_processes_objects_in_folder_and_deletes_them_on_callback() throws IOException {
+        when(s3SourceConfig.getAcknowledgements()).thenReturn(true);
+        when(s3SourceConfig.isDeleteS3ObjectsOnRead()).thenReturn(true);
+
+        final FolderPartitioningOptions folderPartitioningOptions = mock(FolderPartitioningOptions.class);
+        when(folderPartitioningOptions.getMaxObjectsPerOwnership()).thenReturn(3);
+        when(s3ScanScanOptions.getPartitioningOptions()).thenReturn(folderPartitioningOptions);
+
+        final String bucket = UUID.randomUUID().toString();
+        final String folder = UUID.randomUUID().toString();
+        final String partitionKey = bucket + "|" + folder;
+
+        final SourcePartition<S3SourceProgressState> partitionToProcess = SourcePartition
+                .builder(S3SourceProgressState.class)
+                .withPartitionKey(partitionKey)
+                .withPartitionState(new S3SourceProgressState(Instant.now()
+                        .minus(NO_OBJECTS_FOUND_BEFORE_PARTITION_DELETION_DURATION)
+                        .minus(Duration.ofMinutes(1)).toEpochMilli()))
+                .build();
+        when(sourceCoordinator.getNextPartition(any(Function.class), eq(true))).thenReturn(Optional.of(partitionToProcess));
+        doNothing().when(sourceCoordinator).saveProgressStateForPartition(eq(partitionKey), any(S3SourceProgressState.class));
+
+        final ListObjectsV2Response listObjectsV2Response = mock(ListObjectsV2Response.class);
+        when(listObjectsV2Response.isTruncated()).thenReturn(false);
+
+        final S3Object firstObject = mock(S3Object.class);
+        when(firstObject.key()).thenReturn(UUID.randomUUID().toString());
+        final DeleteObjectRequest firstObjectDeleteRequest = mock(DeleteObjectRequest.class);
+        when(s3ObjectDeleteWorker.buildDeleteObjectRequest(bucket, firstObject.key())).thenReturn(firstObjectDeleteRequest);
+
+        final S3Object secondObject = mock(S3Object.class);
+        when(secondObject.key()).thenReturn(UUID.randomUUID().toString());
+        final DeleteObjectRequest secondObjectDeleteRequest = mock(DeleteObjectRequest.class);
+        when(s3ObjectDeleteWorker.buildDeleteObjectRequest(bucket, secondObject.key())).thenReturn(secondObjectDeleteRequest);
+
+        when(listObjectsV2Response.contents()).thenReturn(List.of(firstObject, secondObject));
+        when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(listObjectsV2Response);
+
+        final AcknowledgementSet acknowledgementSet1 = mock(AcknowledgementSet.class);
+        final AcknowledgementSet acknowledgementSet2 = mock(AcknowledgementSet.class);
+
+        when(acknowledgementSetManager.create(any(Consumer.class), any(Duration.class)))
+                .thenReturn(acknowledgementSet1)
+                .thenReturn(acknowledgementSet2);
+
+        doNothing().when(s3ObjectDeleteWorker).deleteS3Object(any(DeleteObjectRequest.class));
+        doNothing().when(s3ObjectHandler).parseS3Object(any(S3ObjectReference.class), any(AcknowledgementSet.class), eq(sourceCoordinator), eq(partitionKey));
+
+        final ScanObjectWorker scanObjectWorker = createObjectUnderTest();
+        scanObjectWorker.runWithoutInfiniteLoop();
+
+        verify(sourceCoordinator).saveProgressStateForPartition(eq(partitionKey), any(S3SourceProgressState.class));
+
+        final ArgumentCaptor<Consumer> consumerArgumentCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(acknowledgementSetManager, times(2)).create(consumerArgumentCaptor.capture(), any(Duration.class));
+
+        final List<Consumer> ackCallbacks = consumerArgumentCaptor.getAllValues();
+        assertThat(ackCallbacks.size(), equalTo(2));
+
+        final InOrder inOrder = inOrder(sourceCoordinator, acknowledgementSet2, acknowledgementSet1, s3ObjectDeleteWorker);
+
+        inOrder.verify(s3ObjectDeleteWorker).buildDeleteObjectRequest(bucket, firstObject.key());
+        inOrder.verify(acknowledgementSet1).complete();
+        inOrder.verify(s3ObjectDeleteWorker).buildDeleteObjectRequest(bucket, secondObject.key());
+        inOrder.verify(acknowledgementSet2).complete();
+        inOrder.verify(sourceCoordinator).updatePartitionForAcknowledgmentWait(partitionKey, ACKNOWLEDGEMENT_SET_TIMEOUT);
+
+        final Consumer<Boolean> firstAckCallback = ackCallbacks.get(0);
+        firstAckCallback.accept(true);
+
+        inOrder.verify(s3ObjectDeleteWorker).deleteS3Object(firstObjectDeleteRequest);
+
+        final Consumer<Boolean> secondAckCallback = ackCallbacks.get(1);
+        secondAckCallback.accept(true);
+
+        inOrder.verify(s3ObjectDeleteWorker).deleteS3Object(secondObjectDeleteRequest);
+        inOrder.verify(sourceCoordinator).giveUpPartition(eq(partitionKey), any(Instant.class));
+    }
+
+    @Test
+    void processing_with_folder_partition_processes_objects_in_folder_until_max_objects_per_ownership_is_reached() throws IOException {
+        when(s3SourceConfig.getAcknowledgements()).thenReturn(true);
+        when(s3SourceConfig.isDeleteS3ObjectsOnRead()).thenReturn(true);
+
+        final FolderPartitioningOptions folderPartitioningOptions = mock(FolderPartitioningOptions.class);
+        when(folderPartitioningOptions.getMaxObjectsPerOwnership()).thenReturn(1);
+        when(s3ScanScanOptions.getPartitioningOptions()).thenReturn(folderPartitioningOptions);
+
+        final String bucket = UUID.randomUUID().toString();
+        final String folder = UUID.randomUUID().toString();
+        final String partitionKey = bucket + "|" + folder;
+
+        final SourcePartition<S3SourceProgressState> partitionToProcess = SourcePartition
+                .builder(S3SourceProgressState.class)
+                .withPartitionKey(partitionKey)
+                .withPartitionState(new S3SourceProgressState(Instant.now()
+                        .minus(NO_OBJECTS_FOUND_BEFORE_PARTITION_DELETION_DURATION)
+                        .minus(Duration.ofMinutes(1)).toEpochMilli()))
+                .build();
+        when(sourceCoordinator.getNextPartition(any(Function.class), eq(true))).thenReturn(Optional.of(partitionToProcess));
+        doNothing().when(sourceCoordinator).saveProgressStateForPartition(eq(partitionKey), any(S3SourceProgressState.class));
+
+        final ListObjectsV2Response listObjectsV2Response = mock(ListObjectsV2Response.class);
+        when(listObjectsV2Response.isTruncated()).thenReturn(false);
+
+        final S3Object firstObject = mock(S3Object.class);
+        when(firstObject.key()).thenReturn(UUID.randomUUID().toString());
+        final DeleteObjectRequest firstObjectDeleteRequest = mock(DeleteObjectRequest.class);
+        when(s3ObjectDeleteWorker.buildDeleteObjectRequest(bucket, firstObject.key())).thenReturn(firstObjectDeleteRequest);
+
+        final S3Object secondObject = mock(S3Object.class);
+        when(secondObject.key()).thenReturn(UUID.randomUUID().toString());
+
+        when(listObjectsV2Response.contents()).thenReturn(List.of(firstObject, secondObject));
+        when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(listObjectsV2Response);
+
+        final AcknowledgementSet acknowledgementSet1 = mock(AcknowledgementSet.class);
+
+        when(acknowledgementSetManager.create(any(Consumer.class), any(Duration.class)))
+                .thenReturn(acknowledgementSet1);
+
+        doNothing().when(s3ObjectDeleteWorker).deleteS3Object(any(DeleteObjectRequest.class));
+        doNothing().when(s3ObjectHandler).parseS3Object(any(S3ObjectReference.class), any(AcknowledgementSet.class), eq(sourceCoordinator), eq(partitionKey));
+
+        final ScanObjectWorker scanObjectWorker = createObjectUnderTest();
+        scanObjectWorker.runWithoutInfiniteLoop();
+
+        verify(sourceCoordinator).saveProgressStateForPartition(eq(partitionKey), any(S3SourceProgressState.class));
+
+        final ArgumentCaptor<Consumer> consumerArgumentCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(acknowledgementSetManager, times(1)).create(consumerArgumentCaptor.capture(), any(Duration.class));
+
+
+        final InOrder inOrder = inOrder(sourceCoordinator, acknowledgementSet1, s3ObjectDeleteWorker);
+
+        inOrder.verify(s3ObjectDeleteWorker).buildDeleteObjectRequest(bucket, firstObject.key());
+        inOrder.verify(acknowledgementSet1).complete();
+        inOrder.verify(sourceCoordinator).updatePartitionForAcknowledgmentWait(partitionKey, ACKNOWLEDGEMENT_SET_TIMEOUT);
+
+        final Consumer<Boolean> ackCallback = consumerArgumentCaptor.getValue();
+        ackCallback.accept(true);
+
+        inOrder.verify(s3ObjectDeleteWorker).deleteS3Object(firstObjectDeleteRequest);
+        inOrder.verify(sourceCoordinator).giveUpPartition(eq(partitionKey), any(Instant.class));
+    }
+
 
     static Stream<Class> exceptionProvider() {
         return Stream.of(PartitionUpdateException.class, PartitionNotFoundException.class, PartitionNotOwnedException.class);

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3SourceConfigTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3SourceConfigTest.java
@@ -10,6 +10,8 @@ import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.plugins.codec.CompressionOption;
 import org.opensearch.dataprepper.plugins.source.s3.configuration.NotificationSourceOption;
 import org.opensearch.dataprepper.plugins.source.s3.configuration.OnErrorOption;
+import org.opensearch.dataprepper.plugins.source.s3.configuration.FolderPartitioningOptions;
+import org.opensearch.dataprepper.plugins.source.s3.configuration.S3ScanScanOptions;
 import org.opensearch.dataprepper.plugins.source.s3.configuration.S3SelectOptions;
 import org.opensearch.dataprepper.test.helper.ReflectivelySetField;
 
@@ -59,6 +61,8 @@ class S3SourceConfigTest {
         final S3SourceConfig s3SourceConfig = new S3SourceConfig();
         ReflectivelySetField.setField(S3SourceConfig.class,s3SourceConfig,"acknowledgments", true);
         assertTrue(s3SourceConfig.getAcknowledgements());
+
+        assertThat(s3SourceConfig.isPrefixPartitionModeValid(), equalTo(true));
     }
 
     @Test
@@ -84,5 +88,19 @@ class S3SourceConfigTest {
     void isCodecProvidedWhenNeeded_returns_false_when_s3SelectOptions_is_null_and_codec_is_null(){
         final S3SourceConfig s3SourceConfig = new S3SourceConfig();
         assertFalse(s3SourceConfig.isCodecProvidedWhenNeeded());
+    }
+
+    @Test
+    void isPartitionModeValid_returns_false_when_using_prefix_mode_without_acknowledgments_enabled() throws NoSuchFieldException, IllegalAccessException {
+        final S3SourceConfig s3SourceConfig = new S3SourceConfig();;
+        final S3ScanScanOptions s3ScanScanOptions = new S3ScanScanOptions();
+        assertThat(s3ScanScanOptions.getPartitioningOptions(), equalTo(null));
+        final FolderPartitioningOptions folderPartitioningOptions = new FolderPartitioningOptions();
+        ReflectivelySetField.setField(S3ScanScanOptions.class, s3ScanScanOptions, "folderPartitioningOptions", folderPartitioningOptions);
+
+        ReflectivelySetField.setField(S3SourceConfig.class,s3SourceConfig,"deleteS3ObjectsOnRead", true);
+        ReflectivelySetField.setField(S3SourceConfig.class,s3SourceConfig,"s3ScanScanOptions", s3ScanScanOptions);
+
+        assertFalse(s3SourceConfig.isPrefixPartitionModeValid());
     }
 }


### PR DESCRIPTION
### Description
This change adds support for the s3 scan source to partition based on folders instead of objects. This means that, unlike object partitions, folder partitions will never be marked as complete, and each node / worker that grabs a folder partition will list and process objects in that folder, then give it up. The use case for this is order guarantee within S3 folders, as well as aggregations within S3 folders, as the same worker / node will process objects from the same S3 folder. To enable this mode, one must set the following configuration. 

```
source:
  s3:
    scan:
      folder_partitions:
        # The depth of the folders to partition on. For example, given object keys "folder-1/folder-3/folder-4/"  and "folder-1/folder-2/folder-5/", a depth of 1 would result in one partition of "folder-1/", while a depth of 2 would result in 2 partitions, "folder-1/folder-3/" and "folder-1/folder-2/". If an object does not contain enough depth, it will not be included in the scan.
        depth: 2 # Defaults to 1
        
        # The max number of objects to process before giving up the folder partition. If the number of objects in the folder is less than this maximum, then all of the objects in the folder will be processed before giving up the partition
        max_objects_per_ownership: 10 # Defaults to 50
```
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
