### PR TITLE
 Revert DocumentDB Source String array host to String host

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/MongoDBConnection.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/MongoDBConnection.java
@@ -54,12 +54,12 @@ public class MongoDBConnection {
             throw new RuntimeException("Unsupported characters in password.");
         }
 
-        if (sourceConfig.getHosts() == null || sourceConfig.getHosts().length == 0) {
-            throw new RuntimeException("The hosts array should at least have one host.");
+        if (sourceConfig.getHost() == null || sourceConfig.getHost().isBlank()) {
+            throw new RuntimeException("The host should not be null or empty.");
         }
 
         // Support for only single host
-        final String hostname = sourceConfig.getHosts()[0];
+        final String hostname = sourceConfig.getHost();
         final int port = sourceConfig.getPort();
         final String tls = sourceConfig.getTls().toString();
         final String invalidHostAllowed = sourceConfig.getSslInsecureDisableVerification().toString();

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfig.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfig.java
@@ -5,7 +5,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfig.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfig.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfig.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfig.java
@@ -12,12 +12,11 @@ public class MongoDBSourceConfig {
     private static final int DEFAULT_PORT = 27017;
     private static final Boolean DEFAULT_INSECURE = false;
     private static final Boolean DEFAULT_INSECURE_DISABLE_VERIFICATION = false;
-    private static final String DEFAULT_SNAPSHOT_FETCH_SIZE = "1000";
     private static final String DEFAULT_READ_PREFERENCE = "primaryPreferred";
     private static final Boolean DEFAULT_DIRECT_CONNECT = true;
     private static final Duration DEFAULT_ACKNOWLEDGEMENT_SET_TIMEOUT = Duration.ofHours(2);
-    @JsonProperty("hosts")
-    private @NotNull String[] hosts;
+    @JsonProperty("host")
+    private @NotNull String host;
     @JsonProperty("port")
     private int port = DEFAULT_PORT;
     @JsonProperty("trust_store_file_path")
@@ -27,8 +26,6 @@ public class MongoDBSourceConfig {
     @JsonProperty("authentication")
     private AuthenticationConfig authenticationConfig;
 
-    @JsonProperty("snapshot_fetch_size")
-    private String snapshotFetchSize;
     @JsonProperty("read_preference")
     private String readPreference;
     @JsonProperty("collections")
@@ -61,7 +58,6 @@ public class MongoDBSourceConfig {
     private AwsConfig awsConfig;
 
     public MongoDBSourceConfig() {
-        this.snapshotFetchSize = DEFAULT_SNAPSHOT_FETCH_SIZE;
         this.readPreference = DEFAULT_READ_PREFERENCE;
         this.collections = new ArrayList<>();
         this.insecure = DEFAULT_INSECURE;
@@ -74,8 +70,8 @@ public class MongoDBSourceConfig {
         return this.authenticationConfig;
     }
 
-    public String[] getHosts() {
-        return this.hosts;
+    public String getHost() {
+        return this.host;
     }
 
     public int getPort() {

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/client/MongoDBConnectionTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/client/MongoDBConnectionTest.java
@@ -36,7 +36,7 @@ public class MongoDBConnectionTest {
         when(mongoDBSourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
         when(authenticationConfig.getUsername()).thenReturn("\uD800\uD800" + UUID.randomUUID());
         when(authenticationConfig.getPassword()).thenReturn("aЯ ⾀sd?q=%%l€0£.lo" + UUID.randomUUID());
-        when(mongoDBSourceConfig.getHosts()).thenReturn(new String[] { UUID.randomUUID().toString() });
+        when(mongoDBSourceConfig.getHost()).thenReturn(UUID.randomUUID().toString());
         when(mongoDBSourceConfig.getPort()).thenReturn(getRandomInteger());
         when(mongoDBSourceConfig.getTls()).thenReturn(getRandomBoolean());
         when(mongoDBSourceConfig.getSslInsecureDisableVerification()).thenReturn(getRandomBoolean());
@@ -71,7 +71,7 @@ public class MongoDBConnectionTest {
         when(mongoDBSourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
         when(authenticationConfig.getUsername()).thenReturn("\uD800\uD800" + UUID.randomUUID());
         when(authenticationConfig.getPassword()).thenReturn("aЯ ⾀sd?q=%%l€0£.lo" + UUID.randomUUID());
-        when(mongoDBSourceConfig.getHosts()).thenReturn(null);
+        when(mongoDBSourceConfig.getHost()).thenReturn(null);
         assertThrows(RuntimeException.class, () -> MongoDBConnection.getMongoClient(mongoDBSourceConfig));
     }
 
@@ -80,7 +80,7 @@ public class MongoDBConnectionTest {
         when(mongoDBSourceConfig.getAuthenticationConfig()).thenReturn(authenticationConfig);
         when(authenticationConfig.getUsername()).thenReturn("\uD800\uD800" + UUID.randomUUID());
         when(authenticationConfig.getPassword()).thenReturn("aЯ ⾀sd?q=%%l€0£.lo" + UUID.randomUUID());
-        when(mongoDBSourceConfig.getHosts()).thenReturn(new String[]{});
+        when(mongoDBSourceConfig.getHost()).thenReturn(" ");
         assertThrows(RuntimeException.class, () -> MongoDBConnection.getMongoClient(mongoDBSourceConfig));
     }
 

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderSchedulerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderSchedulerTest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeast;

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderSchedulerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderSchedulerTest.java
@@ -33,7 +33,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeast;


### PR DESCRIPTION
### Description
 Revert DocumentDB Source String array host to String host
 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
