### PR TITLE
Let data-prepper-core know if docdb has acknowledgments enabled

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/documentdb/DocumentDBSource.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/documentdb/DocumentDBSource.java
@@ -35,6 +35,8 @@ public class DocumentDBSource implements Source<Record<Event>>, UsesEnhancedSour
     private final AcknowledgementSetManager acknowledgementSetManager;
     private DocumentDBService documentDBService;
 
+    private final boolean acknowledgementsEnabled;
+
     @DataPrepperPluginConstructor
     public DocumentDBSource(final PluginMetrics pluginMetrics,
                             final MongoDBSourceConfig sourceConfig,
@@ -44,6 +46,7 @@ public class DocumentDBSource implements Source<Record<Event>>, UsesEnhancedSour
         this.sourceConfig = sourceConfig;
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.pluginConfigObservable = pluginConfigObservable;
+        this.acknowledgementsEnabled = sourceConfig.isAcknowledgmentsEnabled();
     }
 
     @Override
@@ -76,5 +79,10 @@ public class DocumentDBSource implements Source<Record<Event>>, UsesEnhancedSour
     @Override
     public Function<SourcePartitionStoreItem, EnhancedSourcePartition> getPartitionFactory() {
         return new PartitionFactory();
+    }
+
+    @Override
+    public boolean areAcknowledgementsEnabled() {
+        return acknowledgementsEnabled;
     }
 }


### PR DESCRIPTION
### Description
Makes sure data-prepper-core knows when acknowledgments are enabled for the docdb source
 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
