### PR TITLE
Adding 'single_word_only' option to obfuscate processor

### DIFF
--- a/data-prepper-plugins/obfuscate-processor/README.md
+++ b/data-prepper-plugins/obfuscate-processor/README.md
@@ -63,7 +63,9 @@ Below are the list of configuration options.
   the source field will be updated with obfuscated value.
 * `patterns` - (optional) - A list of Regex patterns. You can define multiple patterns for the same field. Only the
   parts that matched the Regex patterns to be obfuscated. If not provided, the full field will be obfuscated.
+* `single_word_only` - (optional) - When set to `true`, a word boundary `\b` is added to the pattern, due to which obfuscation would be applied only to words that are standalone in the input text. By default, it is `false`, meaning obfuscation patterns are applied to all occurrences.
 * `action` - (optional) - Obfuscation action, default to `mask`. Currently, `mask` is the only supported action.
+
 
 ### Configuration - Mask Action
 

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessor.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessor.java
@@ -42,6 +42,7 @@ public class ObfuscationProcessor extends AbstractProcessor<Record<Event>, Recor
 
     private final String source;
     private final String target;
+    private final boolean SingleWordOnly;
 
     private final List<Pattern> patterns;
     private final ObfuscationAction action;
@@ -60,6 +61,7 @@ public class ObfuscationProcessor extends AbstractProcessor<Record<Event>, Recor
         this.patterns = new ArrayList<>();
         this.expressionEvaluator = expressionEvaluator;
         this.obfuscationProcessorConfig = config;
+        this.SingleWordOnly = config.getSingleWordOnly();
 
         config.validateObfuscateWhen(expressionEvaluator);
 
@@ -89,6 +91,9 @@ public class ObfuscationProcessor extends AbstractProcessor<Record<Event>, Recor
                         // Throw exception as the pattern is for sure invalid
                         throw new InvalidPluginConfigurationException("Unable to find a predefined pattern for \"" + rawPattern + "\".");
                     }
+                }
+                if (SingleWordOnly) {
+                    rawPattern = "\\b" + rawPattern + "\\b";
                 }
                 try {
                     Pattern p = Pattern.compile(rawPattern);

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessor.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessor.java
@@ -42,7 +42,7 @@ public class ObfuscationProcessor extends AbstractProcessor<Record<Event>, Recor
 
     private final String source;
     private final String target;
-    private final boolean SingleWordOnly;
+    private final boolean singleWordOnly;
 
     private final List<Pattern> patterns;
     private final ObfuscationAction action;
@@ -61,7 +61,7 @@ public class ObfuscationProcessor extends AbstractProcessor<Record<Event>, Recor
         this.patterns = new ArrayList<>();
         this.expressionEvaluator = expressionEvaluator;
         this.obfuscationProcessorConfig = config;
-        this.SingleWordOnly = config.getSingleWordOnly();
+        this.singleWordOnly = config.getSingleWordOnly();
 
         config.validateObfuscateWhen(expressionEvaluator);
 
@@ -92,7 +92,7 @@ public class ObfuscationProcessor extends AbstractProcessor<Record<Event>, Recor
                         throw new InvalidPluginConfigurationException("Unable to find a predefined pattern for \"" + rawPattern + "\".");
                     }
                 }
-                if (SingleWordOnly) {
+                if (singleWordOnly) {
                     rawPattern = "\\b" + rawPattern + "\\b";
                 }
                 try {

--- a/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
+++ b/data-prepper-plugins/obfuscate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/obfuscation/ObfuscationProcessorConfig.java
@@ -36,15 +36,19 @@ public class ObfuscationProcessorConfig {
     @JsonProperty("tags_on_match_failure")
     private List<String> tagsOnMatchFailure;
 
+    @JsonProperty("single_word_only")
+    private boolean singleWordOnly = false;
+
     public ObfuscationProcessorConfig() {
     }
 
-    public ObfuscationProcessorConfig(String source, List<String> patterns, String target, PluginModel action, List<String> tagsOnMatchFailure) {
+    public ObfuscationProcessorConfig(String source, List<String> patterns, String target, PluginModel action, List<String> tagsOnMatchFailure, boolean singleWordOnly) {
         this.source = source;
         this.patterns = patterns;
         this.target = target;
         this.action = action;
         this.tagsOnMatchFailure = tagsOnMatchFailure;
+        this.singleWordOnly = singleWordOnly;
     }
 
     public String getSource() {
@@ -69,6 +73,10 @@ public class ObfuscationProcessorConfig {
 
     public List<String> getTagsOnMatchFailure() {
         return tagsOnMatchFailure;
+    }
+
+    public boolean getSingleWordOnly() {
+        return singleWordOnly;
     }
 
     void validateObfuscateWhen(final ExpressionEvaluator expressionEvaluator) {


### PR DESCRIPTION
### Description
Adding `single_word_only` configuration option to obfuscate processor. When set to `true` a word boundary `\b` is added to the pattern, due to which obfuscation would be applied only to words that are standalone in the input text. By default, it is `false`, meaning obfuscation patterns are applied to all occurrences.
 
### Issues Resolved
Resolves #4340 
 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).