### PR TITLE
Move MongoDB/DocDB stream checkpoint to separate thread

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -235,14 +234,12 @@ public class StreamWorker {
     }
 
     private void checkpointStream() {
-        String globalCheckpoint = null;
         long lastCheckpointTime = System.currentTimeMillis();
         while (!Thread.currentThread().isInterrupted()) {
-            if (!Objects.equals(globalCheckpoint,lastLocalCheckpoint) && lastLocalRecordCount != null && !sourceConfig.isAcknowledgmentsEnabled() && (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs)) {
+            if (lastLocalRecordCount != null && (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs)) {
                 LOG.debug("Perform regular checkpoint for resume token {} at record count {}", lastLocalCheckpoint, lastLocalRecordCount);
                 partitionCheckpoint.checkpoint(lastLocalCheckpoint, lastLocalRecordCount);
                 lastCheckpointTime = System.currentTimeMillis();
-                globalCheckpoint = lastLocalCheckpoint;
             }
 
             try {

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
@@ -13,6 +13,7 @@ import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
+import org.opensearch.dataprepper.common.concurrent.BackgroundThreadFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.event.Event;
@@ -29,7 +30,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 public class StreamWorker {
@@ -54,6 +58,9 @@ public class StreamWorker {
     private final int bufferWriteIntervalInMs;
     private final int streamBatchSize;
     private boolean stopWorker = false;
+    private final ExecutorService executorService;
+    private String lastLocalCheckpoint;
+    private Long lastLocalRecordCount = null;
     Optional<S3PartitionStatus> s3PartitionStatus = Optional.empty();
 
 
@@ -100,9 +107,13 @@ public class StreamWorker {
         this.successItemsCounter = pluginMetrics.counter(SUCCESS_ITEM_COUNTER_NAME);
         this.failureItemsCounter = pluginMetrics.counter(FAILURE_ITEM_COUNTER_NAME);
         this.bytesReceivedSummary = pluginMetrics.summary(BYTES_RECEIVED);
+        this.executorService = Executors.newSingleThreadExecutor(BackgroundThreadFactory.defaultExecutorThreadFactory("mongodb-stream-checkpoint"));
         if (sourceConfig.isAcknowledgmentsEnabled()) {
             // starts acknowledgement monitoring thread
             streamAcknowledgementManager.init((Void) -> stop());
+        } else {
+            // checkpoint in separate thread
+            this.executorService.submit(this::checkpointStream);
         }
     }
 
@@ -164,8 +175,7 @@ public class StreamWorker {
                     throw new IllegalStateException("S3 partitions are not created. Please check the S3 partition creator thread.");
                 }
                 recordConverter.initializePartitions(s3Partitions);
-                long lastCheckpointTime = System.currentTimeMillis();
-                long lastBufferWriteTime = lastCheckpointTime;
+                long lastBufferWriteTime = System.currentTimeMillis();
                 while (cursor.hasNext() && !Thread.currentThread().isInterrupted() && !stopWorker) {
                     try {
                         final ChangeStreamDocument<Document> document = cursor.next();
@@ -184,13 +194,10 @@ public class StreamWorker {
                         if ((recordCount % recordFlushBatchSize == 0) || (System.currentTimeMillis() - lastBufferWriteTime >= bufferWriteIntervalInMs)) {
                             LOG.debug("Write to buffer for line {} to {}", (recordCount - recordFlushBatchSize), recordCount);
                             writeToBuffer(records, checkPointToken, recordCount);
+                            lastLocalCheckpoint = checkPointToken;
+                            lastLocalRecordCount = recordCount;
                             lastBufferWriteTime = System.currentTimeMillis();
                             records.clear();
-                            if (!sourceConfig.isAcknowledgmentsEnabled() && (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs)) {
-                                LOG.debug("Perform regular checkpointing for resume token {} at record count {}", checkPointToken, recordCount);
-                                partitionCheckpoint.checkpoint(checkPointToken, recordCount);
-                                lastCheckpointTime = System.currentTimeMillis();
-                            }
                         }
                     } catch (Exception e) {
                         // TODO handle documents with size > 10 MB.
@@ -225,6 +232,25 @@ public class StreamWorker {
         final AcknowledgementSet acknowledgementSet = streamAcknowledgementManager.createAcknowledgementSet(checkPointToken, recordCount).orElse(null);
         recordBufferWriter.writeToBuffer(acknowledgementSet, records);
         successItemsCounter.increment(records.size());
+    }
+
+    private void checkpointStream() {
+        String globalCheckpoint = null;
+        long lastCheckpointTime = System.currentTimeMillis();
+        while (!Thread.currentThread().isInterrupted()) {
+            if (!Objects.equals(globalCheckpoint,lastLocalCheckpoint) && lastLocalRecordCount != null && !sourceConfig.isAcknowledgmentsEnabled() && (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs)) {
+                LOG.debug("Perform regular checkpoint for resume token {} at record count {}", lastLocalCheckpoint, lastLocalRecordCount);
+                partitionCheckpoint.checkpoint(lastLocalCheckpoint, lastLocalRecordCount);
+                lastCheckpointTime = System.currentTimeMillis();
+                globalCheckpoint = lastLocalCheckpoint;
+            }
+
+            try {
+                Thread.sleep(checkPointIntervalInMs);
+            } catch (InterruptedException ex) {
+                break;
+            }
+        }
     }
 
     void stop() {

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
@@ -43,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -170,7 +171,7 @@ public class StreamWorkerTest {
         verify(mockRecordBufferWriter).writeToBuffer(eq(null), any());
         verify(successItemsCounter).increment(2);
         verify(failureItemsCounter, never()).increment();
-        verify(mockPartitionCheckpoint, times(2)).checkpoint("{\"resumeToken2\": 234}", 2);
+        verify(mockPartitionCheckpoint, atLeast(2)).checkpoint("{\"resumeToken2\": 234}", 2);
     }
 
 
@@ -265,9 +266,9 @@ public class StreamWorkerTest {
         verify(cursor).close();
         verify(cursor, times(4)).hasNext();
         verify(mockPartitionCheckpoint).getGlobalS3FolderCreationStatus(collection);
-        verify(mockPartitionCheckpoint).checkpoint(resumeToken3, 3);
+        verify(mockPartitionCheckpoint, atLeast(1)).checkpoint(resumeToken3, 3);
         verify(successItemsCounter).increment(1);
-        verify(mockPartitionCheckpoint).checkpoint(resumeToken2, 2);
+        verify(mockPartitionCheckpoint, atLeast(1)).checkpoint(resumeToken2, 2);
         verify(mockRecordBufferWriter, times(2)).writeToBuffer(eq(null), any());
         verify(successItemsCounter).increment(2);
         verify(failureItemsCounter, never()).increment();


### PR DESCRIPTION
### Description
Move MongoDB/DocDB stream checkpoint to separate thread

 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
