### PR TITLE
Fix JacksonEvent to propagate ExternalOriginalTime if its set at the time of construction

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -94,6 +94,10 @@ public class JacksonEvent implements Event {
 
         this.jsonNode = getInitialJsonNode(builder.data);
         this.eventHandle = new DefaultEventHandle(eventMetadata.getTimeReceived());
+        final Instant externalOriginationTime = this.eventMetadata.getExternalOriginationTime();
+        if (externalOriginationTime != null) {
+            eventHandle.setExternalOriginationTime(externalOriginationTime);
+        }
     }
 
     protected JacksonEvent(final JacksonEvent otherEvent) {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -485,6 +485,7 @@ public class JacksonEventTest {
     public void testBuild_withAllMetadataFields() {
 
         final Instant now = Instant.now().minusSeconds(1);
+        final Instant extTime = Instant.now().minusSeconds(10);
         final Map<String, Object> testAttributes = new HashMap<>();
         testAttributes.put(UUID.randomUUID().toString(), UUID.randomUUID());
         testAttributes.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
@@ -492,6 +493,7 @@ public class JacksonEventTest {
 
         final EventMetadata metadata = DefaultEventMetadata.builder()
                 .withEventType(emEventType)
+                .withExternalOriginationTime(extTime)
                 .build();
 
         event = JacksonEvent.builder()
@@ -504,6 +506,8 @@ public class JacksonEventTest {
         assertThat(event.getMetadata().getAttributes(), is(not(equalTo(testAttributes))));
         assertThat(event.getMetadata().getTimeReceived(), is(not(equalTo(now))));
         assertThat(event.getMetadata().getEventType(), is(equalTo(emEventType)));
+        assertThat(event.getMetadata().getExternalOriginationTime(), is(equalTo(extTime)));
+        assertThat(event.getEventHandle().getExternalOriginationTime(), is(equalTo(extTime)));
     }
 
     @Test

--- a/data-prepper-plugins/event-json-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/event_json/EventJsonInputOutputCodecTest.java
+++ b/data-prepper-plugins/event-json-codecs/src/test/java/org/opensearch/dataprepper/plugins/codec/event_json/EventJsonInputOutputCodecTest.java
@@ -145,6 +145,7 @@ inputCodec.parse(new ByteArrayInputStream(outputStream.toByteArray()), records::
             assertThat(e.getMetadata().getTags(), equalTo(tags));
             assertThat(e.getMetadata().getAttributes(), equalTo(Map.of(attrKey, attrValue)));
             assertThat(e.getMetadata().getExternalOriginationTime(), equalTo(origTime));
+            assertThat(e.getEventHandle().getExternalOriginationTime(), equalTo(origTime));
         }
     }
 


### PR DESCRIPTION
### Description
Fix JacksonEvent to propagate ExternalOriginalTime if its set at the time of construction.
With eventjson codec, it is possible for an event to have external origination time at the time of event construction. If it exists, propagate it to event handle.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
