### PR TITLE
Add new S3 source option and modify docdb template

### DIFF
--- a/data-prepper-pipeline-parser/src/main/resources/templates/documentdb-template.yaml
+++ b/data-prepper-pipeline-parser/src/main/resources/templates/documentdb-template.yaml
@@ -21,7 +21,7 @@
          event_collect_timeout: "120s"
          maximum_size: "2mb"
        aggregate_threshold:
-         maximum_size: "256kb"
+         maximum_size: "128mb"
          flush_capacity_ratio: 0
        object_key:
          path_prefix: "${getMetadata(\"s3_partition_key\")}"
@@ -63,7 +63,11 @@
           sts_header_overrides: "<<$.<<pipeline-name>>.source.documentdb.aws.sts_header_overrides>>"
         acknowledgments: true
         delete_s3_objects_on_read: true
+        disable_s3_metadata_in_event: true
         scan:
+          folder_partitions:
+            depth: [ "<<FUNCTION_NAME:calculateDepth,PARAMETER:$.<<pipeline-name>>.source.documentdb.s3_prefix>>" ]
+            max_objects_per_ownership: 50
           buckets:
             - bucket:
                 name: "<<$.<<pipeline-name>>.source.documentdb.s3_bucket>>"

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/S3ObjectWorkerIT.java
@@ -67,7 +67,7 @@ class S3ObjectWorkerIT {
                 .build();
         bucket = System.getProperty("tests.s3source.bucket");
         s3ObjectGenerator = new S3ObjectGenerator(s3Client, bucket);
-        eventMetadataModifier = new EventMetadataModifier(S3SourceConfig.DEFAULT_METADATA_ROOT_KEY);
+        eventMetadataModifier = new EventMetadataModifier(S3SourceConfig.DEFAULT_METADATA_ROOT_KEY, false);
 
         buffer = mock(Buffer.class);
         recordsReceived = 0;

--- a/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanObjectWorkerIT.java
+++ b/data-prepper-plugins/s3-source/src/integrationTest/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanObjectWorkerIT.java
@@ -131,7 +131,7 @@ public class S3ScanObjectWorkerIT {
                 .build();
         bucket = System.getProperty("tests.s3source.bucket");
         s3ObjectGenerator = new S3ObjectGenerator(s3Client, bucket);
-        eventMetadataModifier = new EventMetadataModifier(S3SourceConfig.DEFAULT_METADATA_ROOT_KEY);
+        eventMetadataModifier = new EventMetadataModifier(S3SourceConfig.DEFAULT_METADATA_ROOT_KEY, s3SourceConfig.isDeleteS3MetadataInEvent());
 
         buffer = mock(Buffer.class);
         recordsReceived = 0;

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/EventMetadataModifier.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/EventMetadataModifier.java
@@ -14,15 +14,19 @@ class EventMetadataModifier implements BiConsumer<Event, S3ObjectReference> {
     private static final String BUCKET_FIELD_NAME = "bucket";
     private static final String KEY_FIELD_NAME = "key";
     private final String baseKey;
+    private final boolean deleteS3MetadataInEvent;
 
-    EventMetadataModifier(final String metadataRootKey) {
+    EventMetadataModifier(final String metadataRootKey, boolean deleteS3MetadataInEvent) {
         baseKey = generateBaseKey(metadataRootKey);
+        this.deleteS3MetadataInEvent = deleteS3MetadataInEvent;
     }
 
     @Override
     public void accept(final Event event, final S3ObjectReference s3ObjectReference) {
-        event.put(baseKey + BUCKET_FIELD_NAME, s3ObjectReference.getBucketName());
-        event.put(baseKey + KEY_FIELD_NAME, s3ObjectReference.getKey());
+        if(!deleteS3MetadataInEvent) {
+            event.put(baseKey + BUCKET_FIELD_NAME, s3ObjectReference.getBucketName());
+            event.put(baseKey + KEY_FIELD_NAME, s3ObjectReference.getKey());
+        }
     }
 
     private static String generateBaseKey(String metadataRootKey) {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3Source.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3Source.java
@@ -86,7 +86,7 @@ public class S3Source implements Source<Record<Event>>, UsesSourceCoordination {
         final S3ObjectRequest.Builder s3ObjectRequestBuilder = new S3ObjectRequest.Builder(buffer, s3SourceConfig.getNumberOfRecordsToAccumulate(),
                 s3SourceConfig.getBufferTimeout(), s3ObjectPluginMetrics);
         final BiConsumer<Event, S3ObjectReference> eventMetadataModifier = new EventMetadataModifier(
-                s3SourceConfig.getMetadataRootKey());
+                s3SourceConfig.getMetadataRootKey(), s3SourceConfig.isDeleteS3MetadataInEvent());
         final S3ObjectDeleteWorker s3ObjectDeleteWorker = new S3ObjectDeleteWorker(s3ClientBuilderFactory.getS3Client(), pluginMetrics);
 
         if (s3SelectOptional.isPresent()) {

--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3SourceConfig.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3SourceConfig.java
@@ -97,6 +97,9 @@ public class S3SourceConfig {
     @JsonProperty("delete_s3_objects_on_read")
     private boolean deleteS3ObjectsOnRead = false;
 
+    @JsonProperty("disable_s3_metadata_in_event")
+    private boolean deleteS3MetadataInEvent = false;
+
     @AssertTrue(message = "A codec is required for reading objects.")
     boolean isCodecProvidedWhenNeeded() {
         if(s3SelectOptions == null)
@@ -188,5 +191,9 @@ public class S3SourceConfig {
 
     public String getDefaultBucketOwner() {
         return defaultBucketOwner;
+    }
+
+    public boolean isDeleteS3MetadataInEvent() {
+        return deleteS3MetadataInEvent;
     }
 }


### PR DESCRIPTION
### Description
- Add new S3 source option
`disable_s3_metadata_in_event: true` option will not add bucket name and key to event.

- Modify docdb template
Added `disable_s3_metadata_in_event` and `folder_partitions` options in s3 scan of doc db template
 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
