### PR TITLE
Track last scan time from before scan starts instead of based on last Modified of objects

### DIFF
--- a/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanPartitionCreationSupplier.java
+++ b/data-prepper-plugins/s3-source/src/main/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanPartitionCreationSupplier.java
@@ -87,6 +87,7 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
             if (Objects.nonNull(s3ScanKeyPathOption) && Objects.nonNull(s3ScanKeyPathOption.getS3ScanExcludeSuffixOptions()))
                 excludeItems.addAll(s3ScanKeyPathOption.getS3ScanExcludeSuffixOptions());
 
+            final Instant updatedScanTime = Instant.now();
             if (Objects.nonNull(s3ScanKeyPathOption) && Objects.nonNull(s3ScanKeyPathOption.getS3scanIncludePrefixOptions()))
                 s3ScanKeyPathOption.getS3scanIncludePrefixOptions().forEach(includePath -> {
                     listObjectsV2Request.prefix(includePath);
@@ -96,6 +97,8 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
             else
                 objectsToProcess.addAll(listFilteredS3ObjectsForBucket(excludeItems, listObjectsV2Request,
                         scanOptions.getBucketOption().getName(), scanOptions.getUseStartDateTime(), scanOptions.getUseEndDateTime(), globalStateMap));
+
+            globalStateMap.put(scanOptions.getBucketOption().getName(), updatedScanTime.toString());
         }
 
         globalStateMap.put(SCAN_COUNT, (Integer) globalStateMap.get(SCAN_COUNT) + 1);
@@ -110,13 +113,13 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
                                                                      final LocalDateTime startDateTime,
                                                                      final LocalDateTime endDateTime,
                                                                      final Map<String, Object> globalStateMap) {
-        Instant mostRecentLastModifiedTimestamp = globalStateMap.get(bucket) != null ? Instant.parse((String) globalStateMap.get(bucket)) : null;
+        final Instant previousScanTime = globalStateMap.get(bucket) != null ? Instant.parse((String) globalStateMap.get(bucket)) : null;
         final List<PartitionIdentifier> allPartitionIdentifiers = new ArrayList<>();
         ListObjectsV2Response listObjectsV2Response = null;
         do {
             listObjectsV2Response = s3Client.listObjectsV2(listObjectsV2Request.fetchOwner(true).continuationToken(Objects.nonNull(listObjectsV2Response) ? listObjectsV2Response.nextContinuationToken() : null).build());
             allPartitionIdentifiers.addAll(listObjectsV2Response.contents().stream()
-                    .filter(s3Object -> isLastModifiedTimeAfterMostRecentScanForBucket(bucket, s3Object, globalStateMap))
+                    .filter(s3Object -> isLastModifiedTimeAfterMostRecentScanForBucket(previousScanTime, s3Object))
                     .map(s3Object -> Pair.of(s3Object.key(), instantToLocalDateTime(s3Object.lastModified())))
                     .filter(keyTimestampPair -> !keyTimestampPair.left().endsWith("/"))
                     .filter(keyTimestampPair -> excludeKeyPaths.stream()
@@ -127,11 +130,7 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
                     .collect(Collectors.toList()));
 
             LOG.info("Found page of {} objects from bucket {}", listObjectsV2Response.keyCount(), bucket);
-
-            mostRecentLastModifiedTimestamp = getMostRecentLastModifiedTimestamp(listObjectsV2Response, mostRecentLastModifiedTimestamp);
         } while (listObjectsV2Response.isTruncated());
-
-        globalStateMap.put(bucket, Objects.nonNull(mostRecentLastModifiedTimestamp) ? mostRecentLastModifiedTimestamp.toString() : null);
 
         if (folderPartitioningOptions != null) {
             final Set<PartitionIdentifier> folderPartitions = allPartitionIdentifiers.stream()
@@ -185,32 +184,13 @@ public class S3ScanPartitionCreationSupplier implements Function<Map<String, Obj
         globalStateMap.put(SINGLE_SCAN_COMPLETE, false);
     }
 
-    private boolean isLastModifiedTimeAfterMostRecentScanForBucket(final String bucketName,
-                                                                   final S3Object s3Object,
-                                                                   final Map<String, Object> globalStateMap) {
-        if (!globalStateMap.containsKey(bucketName) || Objects.isNull(globalStateMap.get(bucketName))) {
+    private boolean isLastModifiedTimeAfterMostRecentScanForBucket(final Instant previousScanTime,
+                                                                   final S3Object s3Object) {
+        if (previousScanTime == null) {
             return true;
         }
 
-        final Instant lastProcessedObjectTimestamp = Instant.parse((String) globalStateMap.get(bucketName));
-
-        return s3Object.lastModified().compareTo(lastProcessedObjectTimestamp.minusSeconds(1)) >= 0;
-    }
-
-    private Instant getMostRecentLastModifiedTimestamp(final ListObjectsV2Response listObjectsV2Response,
-                                                       Instant mostRecentLastModifiedTimestamp) {
-
-        if (Objects.isNull(schedulingOptions)) {
-            return null;
-        }
-
-        for (final S3Object s3Object : listObjectsV2Response.contents()) {
-            if (Objects.isNull(mostRecentLastModifiedTimestamp) || s3Object.lastModified().isAfter(mostRecentLastModifiedTimestamp)) {
-                mostRecentLastModifiedTimestamp = s3Object.lastModified();
-            }
-        }
-
-        return mostRecentLastModifiedTimestamp;
+        return s3Object.lastModified().compareTo(previousScanTime) >= 0;
     }
 
     private boolean shouldScanBeSkipped(final Map<String, Object> globalStateMap) {

--- a/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanPartitionCreationSupplierTest.java
+++ b/data-prepper-plugins/s3-source/src/test/java/org/opensearch/dataprepper/plugins/source/s3/S3ScanPartitionCreationSupplierTest.java
@@ -261,11 +261,11 @@ public class S3ScanPartitionCreationSupplierTest {
         assertThat(globalStateMap.containsKey(SCAN_COUNT), equalTo(true));
         assertThat(globalStateMap.get(SCAN_COUNT), equalTo(1));
         assertThat(globalStateMap.containsKey(firstBucket), equalTo(true));
-        assertThat(Instant.parse((CharSequence) globalStateMap.get(firstBucket)).toEpochMilli(), lessThanOrEqualTo(mostRecentFirstScan.toEpochMilli()));
-        assertThat(Instant.parse((CharSequence) globalStateMap.get(firstBucket)).toEpochMilli(), greaterThanOrEqualTo(beforeFirstScan.toEpochMilli()));
+        assertThat(Instant.parse((CharSequence) globalStateMap.get(firstBucket)), lessThanOrEqualTo(mostRecentFirstScan));
+        assertThat(Instant.parse((CharSequence) globalStateMap.get(firstBucket)), greaterThanOrEqualTo(beforeFirstScan));
         assertThat(globalStateMap.containsKey(secondBucket), equalTo(true));
-        assertThat(Instant.parse((CharSequence) globalStateMap.get(secondBucket)).toEpochMilli(), lessThanOrEqualTo(mostRecentFirstScan.toEpochMilli()));
-        assertThat(Instant.parse((CharSequence) globalStateMap.get(secondBucket)).toEpochMilli(), greaterThanOrEqualTo(beforeFirstScan.toEpochMilli()));
+        assertThat(Instant.parse((CharSequence) globalStateMap.get(secondBucket)), lessThanOrEqualTo(mostRecentFirstScan));
+        assertThat(Instant.parse((CharSequence) globalStateMap.get(secondBucket)), greaterThanOrEqualTo(beforeFirstScan));
 
         final Instant beforeSecondScan = Instant.now();
         final List<PartitionIdentifier> secondScanPartitions = partitionCreationSupplier.apply(globalStateMap);
@@ -277,11 +277,11 @@ public class S3ScanPartitionCreationSupplierTest {
         assertThat(globalStateMap.containsKey(SCAN_COUNT), equalTo(true));
         assertThat(globalStateMap.get(SCAN_COUNT), equalTo(2));
         assertThat(globalStateMap.containsKey(firstBucket), equalTo(true));
-        assertThat(Instant.parse((CharSequence) globalStateMap.get(firstBucket)).toEpochMilli(), lessThanOrEqualTo(mostRecentSecondScan.toEpochMilli()));
-        assertThat(Instant.parse((CharSequence) globalStateMap.get(firstBucket)).toEpochMilli(), greaterThanOrEqualTo(beforeSecondScan.toEpochMilli()));
+        assertThat(Instant.parse((CharSequence) globalStateMap.get(firstBucket)), lessThanOrEqualTo(mostRecentSecondScan));
+        assertThat(Instant.parse((CharSequence) globalStateMap.get(firstBucket)), greaterThanOrEqualTo(beforeSecondScan));
         assertThat(globalStateMap.containsKey(secondBucket), equalTo(true));
-        assertThat(Instant.parse((CharSequence) globalStateMap.get(secondBucket)).toEpochMilli(), lessThanOrEqualTo(mostRecentSecondScan.toEpochMilli()));
-        assertThat(Instant.parse((CharSequence) globalStateMap.get(secondBucket)).toEpochMilli(), greaterThan(beforeSecondScan.toEpochMilli()));
+        assertThat(Instant.parse((CharSequence) globalStateMap.get(secondBucket)), lessThanOrEqualTo(mostRecentSecondScan));
+        assertThat(Instant.parse((CharSequence) globalStateMap.get(secondBucket)), greaterThan(beforeSecondScan));
         assertThat(Instant.ofEpochMilli((Long) globalStateMap.get(LAST_SCAN_TIME)).isBefore(Instant.now()), equalTo(true));
 
         assertThat(partitionCreationSupplier.apply(globalStateMap), equalTo(Collections.emptyList()));


### PR DESCRIPTION
### Description
This change makes it so that the filtering done between scans for last modified objects, which is used to reduce lookups to the coordination store, is tracked based on the time before the listObjects call to scan for each bucket is made. This will make it impossible to miss items that are uploaded in the middle or end of a scan
 
### Issues Resolved
Previously attempted to fix with https://github.com/opensearch-project/data-prepper/pull/4124

Original issue: https://github.com/opensearch-project/data-prepper/issues/4123
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
