### PR TITLE
FIX: null certificate value should be valid in opensearch connection

### DIFF
--- a/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfiguration.java
+++ b/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfiguration.java
@@ -12,6 +12,7 @@ import org.opensearch.dataprepper.plugins.certificate.validation.PemObjectValida
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Objects;
 
 public class ConnectionConfiguration {
 
@@ -62,7 +63,7 @@ public class ConnectionConfiguration {
 
   @AssertTrue(message = "certificate must be either valid PEM file path or public key content.")
   boolean isCertificateValid() {
-    if (PemObjectValidator.isPemObject(certificate)) {
+    if (Objects.isNull(certificate) || PemObjectValidator.isPemObject(certificate)) {
       return true;
     }
     try {

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfigurationTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfigurationTest.java
@@ -68,7 +68,7 @@ public class ConnectionConfigurationTest {
     @ParameterizedTest
     @ValueSource(strings = {
             TEST_CERTIFICATE,
-            "/some/file/path",
+            "/some/file/path"
     })
     void connection_configuration_certificate_values_test(final String certificate) throws JsonProcessingException {
 

--- a/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfigurationTest.java
+++ b/data-prepper-plugins/opensearch/src/test/java/org/opensearch/dataprepper/plugins/source/opensearch/configuration/ConnectionConfigurationTest.java
@@ -62,12 +62,13 @@ public class ConnectionConfigurationTest {
         assertThat(connectionConfig.getSocketTimeout(),equalTo(null));
         assertThat(connectionConfig.getConnectTimeout(),equalTo(null));
         assertThat(connectionConfig.isInsecure(),equalTo(true));
+        assertThat(connectionConfig.isCertificateValid(), is(true));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {
             TEST_CERTIFICATE,
-            "/some/file/path"
+            "/some/file/path",
     })
     void connection_configuration_certificate_values_test(final String certificate) throws JsonProcessingException {
 


### PR DESCRIPTION
### Description
When `certificate` is null, it should be identified as valid in jakarta validation. Added a regression test
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ x ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
