### PR TITLE
Add system property to allow pausing and resuming s3 scan worker thread processing, set this property to pause on documentdb leader

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/s3/S3ScanEnvironmentVariables.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/s3/S3ScanEnvironmentVariables.java
@@ -1,0 +1,9 @@
+package org.opensearch.dataprepper.model.source.s3;
+
+import org.opensearch.dataprepper.model.annotations.SkipTestCoverageGenerated;
+
+@SkipTestCoverageGenerated
+public class S3ScanEnvironmentVariables {
+
+    public static final String STOP_S3_SCAN_PROCESSING_PROPERTY = "STOP_S3_SCAN_PROCESSING";
+}

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfig.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/configuration/MongoDBSourceConfig.java
@@ -57,6 +57,9 @@ public class MongoDBSourceConfig {
     @Valid
     private AwsConfig awsConfig;
 
+    @JsonProperty("disable_s3_read_for_leader")
+    private boolean disableS3ReadForLeader = false;
+
     public MongoDBSourceConfig() {
         this.readPreference = DEFAULT_READ_PREFERENCE;
         this.collections = new ArrayList<>();
@@ -124,6 +127,10 @@ public class MongoDBSourceConfig {
 
     public String getS3Region() {
         return this.s3Region;
+    }
+
+    public boolean isDisableS3ReadForLeader() {
+        return disableS3ReadForLeader;
     }
 
     public AwsConfig getAwsConfig() {

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderScheduler.java
@@ -81,7 +81,10 @@ public class LeaderScheduler implements Runnable {
                     if (sourcePartition.isPresent()) {
                         LOG.info("Running as a LEADER node");
                         leaderPartition = (LeaderPartition) sourcePartition.get();
-                        System.setProperty(STOP_S3_SCAN_PROCESSING_PROPERTY, "true");
+
+                        if (sourceConfig.isDisableS3ReadForLeader()) {
+                            System.setProperty(STOP_S3_SCAN_PROCESSING_PROPERTY, "true");
+                        }
                     }
                 }
                 // Once owned, run Normal LEADER node process.
@@ -114,7 +117,9 @@ public class LeaderScheduler implements Runnable {
         // Should Stop
         LOG.warn("Quitting Leader Scheduler");
         if (leaderPartition != null) {
-            System.clearProperty(STOP_S3_SCAN_PROCESSING_PROPERTY);
+            if (sourceConfig.isDisableS3ReadForLeader()) {
+                System.clearProperty(STOP_S3_SCAN_PROCESSING_PROPERTY);
+            }
             coordinator.giveUpPartition(leaderPartition);
         }
     }

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderScheduler.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.opensearch.dataprepper.model.source.s3.S3ScanEnvironmentVariables.STOP_S3_SCAN_PROCESSING_PROPERTY;
 
 public class LeaderScheduler implements Runnable {
 
@@ -80,6 +81,7 @@ public class LeaderScheduler implements Runnable {
                     if (sourcePartition.isPresent()) {
                         LOG.info("Running as a LEADER node");
                         leaderPartition = (LeaderPartition) sourcePartition.get();
+                        System.setProperty(STOP_S3_SCAN_PROCESSING_PROPERTY, "true");
                     }
                 }
                 // Once owned, run Normal LEADER node process.
@@ -112,6 +114,7 @@ public class LeaderScheduler implements Runnable {
         // Should Stop
         LOG.warn("Quitting Leader Scheduler");
         if (leaderPartition != null) {
+            System.clearProperty(STOP_S3_SCAN_PROCESSING_PROPERTY);
             coordinator.giveUpPartition(leaderPartition);
         }
     }


### PR DESCRIPTION
### Description
Sets a system property from DocumentDB source when the Leader ownership is acquired by the same node. This system property will stop S3 Scan pipelines from processing objects. 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
