### PR TITLE
Support Mongo/DocDB stream Delete and other Operation types

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/DataStreamPartitionCheckpoint.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/DataStreamPartitionCheckpoint.java
@@ -60,9 +60,20 @@ public class DataStreamPartitionCheckpoint extends S3FolderPartitionCoordinator 
      * @param recordCount The last processed record count
      */
     public void checkpoint(final String resumeToken, final long recordCount) {
-        LOG.debug("Checkpoint stream partition for collection " + streamPartition.getCollection() + " with record number " + recordCount);
+        LOG.debug("Checkpoint stream partition for collection {} with record number {}", streamPartition.getCollection(), recordCount);
         setProgressState(resumeToken, recordCount);
         enhancedSourceCoordinator.saveProgressStateForPartition(streamPartition, CHECKPOINT_OWNERSHIP_TIMEOUT_INCREASE);
+    }
+
+    /**
+     * This method is to reset checkpoint when change stream is invalid. The current thread will give up partition and new thread
+     * will take ownership of partition. If change stream is valid then new thread proceeds with processing change stream else the
+     * process repeats.
+     */
+    public void resetCheckpoint() {
+        LOG.debug("Resetting checkpoint stream partition for collection {}", streamPartition.getCollection());
+        setProgressState(null, 0);
+        enhancedSourceCoordinator.giveUpPartition(streamPartition);
     }
 
     public Optional<StreamLoadStatus> getGlobalStreamLoadStatus() {

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
@@ -7,6 +7,7 @@ import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.model.changestream.FullDocument;
+import com.mongodb.client.model.changestream.OperationType;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import org.bson.BsonDocument;
@@ -155,7 +156,7 @@ public class StreamWorker {
             MongoDatabase database = mongoClient.getDatabase(collectionDBNameList.get(0));
 
             // Access the collection you want to stream data from
-            MongoCollection<Document> collection = database.getCollection(collectionDBNameList.get(1));
+            MongoCollection<Document> collection = database.getCollection(collectionDbName.substring(collectionDBNameList.get(0).length() + 1));
 
             try (MongoCursor<ChangeStreamDocument<Document>> cursor = getChangeStreamCursor(collection, resumeToken.orElse(null))) {
                 while ((shouldWaitForExport(streamPartition) || shouldWaitForS3Partition(streamPartition.getCollection())) && !Thread.currentThread().isInterrupted()) {
@@ -175,35 +176,55 @@ public class StreamWorker {
                 }
                 recordConverter.initializePartitions(s3Partitions);
                 long lastBufferWriteTime = System.currentTimeMillis();
-                while (cursor.hasNext() && !Thread.currentThread().isInterrupted() && !stopWorker) {
-                    try {
-                        final ChangeStreamDocument<Document> document = cursor.next();
-                        final String record = document.getFullDocument().toJson(writerSettings);
-                        final long eventCreationTimeMillis = document.getClusterTime().getTime() * 1000L;
-                        final long bytes = record.getBytes().length;
-                        bytesReceivedSummary.record(bytes);
+                while (!Thread.currentThread().isInterrupted() && !stopWorker) {
+                    if (cursor.hasNext()) {
+                        try {
+                            final ChangeStreamDocument<Document> document = cursor.next();
+                            final OperationType operationType = document.getOperationType();
+                            LOG.debug("Event Operation type {}", operationType);
+                            if (isCRUDOperation(operationType)) {
+                                final String record;
+                                if (OperationType.DELETE == operationType) {
+                                    record = document.getDocumentKey().toJson(writerSettings);
+                                } else {
+                                    record = document.getFullDocument().toJson(writerSettings);
+                                }
+                                final long eventCreationTimeMillis = document.getClusterTime().getTime() * 1000L;
+                                final long bytes = record.getBytes().length;
+                                bytesReceivedSummary.record(bytes);
 
-                        checkPointToken = document.getResumeToken().toJson(writerSettings);
-                        // TODO fix eventVersionNumber
-                        final Event event = recordConverter.convert(record, eventCreationTimeMillis, eventCreationTimeMillis, document.getOperationTypeString());
+                                checkPointToken = document.getResumeToken().toJson(writerSettings);
+                                // TODO fix eventVersionNumber
+                                final Event event = recordConverter.convert(record, eventCreationTimeMillis, eventCreationTimeMillis, document.getOperationTypeString());
+                                records.add(event);
+                                recordCount += 1;
 
-                        records.add(event);
-                        recordCount += 1;
-
-                        if ((recordCount % recordFlushBatchSize == 0) || (System.currentTimeMillis() - lastBufferWriteTime >= bufferWriteIntervalInMs)) {
-                            LOG.debug("Write to buffer for line {} to {}", (recordCount - recordFlushBatchSize), recordCount);
-                            writeToBuffer(records, checkPointToken, recordCount);
-                            lastLocalCheckpoint = checkPointToken;
-                            lastLocalRecordCount = recordCount;
-                            lastBufferWriteTime = System.currentTimeMillis();
-                            records.clear();
+                                if ((recordCount % recordFlushBatchSize == 0) || (System.currentTimeMillis() - lastBufferWriteTime >= bufferWriteIntervalInMs)) {
+                                    LOG.debug("Write to buffer for line {} to {}", (recordCount - recordFlushBatchSize), recordCount);
+                                    writeToBuffer(records, checkPointToken, recordCount);
+                                    lastLocalCheckpoint = checkPointToken;
+                                    lastLocalRecordCount = recordCount;
+                                    lastBufferWriteTime = System.currentTimeMillis();
+                                    records.clear();
+                                }
+                            } else if(shouldTerminateChangeStream(operationType)){
+                                stop();
+                                partitionCheckpoint.resetCheckpoint();
+                                LOG.warn("The change stream is invalid due to stream operation type {}. Stopping the change stream.", operationType);
+                            } else {
+                                LOG.warn("The change stream operation type {} is not handled", operationType);
+                            }
+                        } catch(Exception e){
+                            // TODO handle documents with size > 10 MB.
+                            // this will only happen if writing to buffer gets interrupted from shutdown,
+                            // otherwise it's infinite backoff and retry
+                            LOG.error("Failed to add records to buffer with error", e);
+                            failureItemsCounter.increment(records.size());
                         }
-                    } catch (Exception e) {
-                        // TODO handle documents with size > 10 MB.
-                        // this will only happen if writing to buffer gets interrupted from shutdown,
-                        // otherwise it's infinite backoff and retry
-                        LOG.error("Failed to add records to buffer with error {}", e.getMessage());
-                        failureItemsCounter.increment(records.size());
+                    } else {
+                        LOG.warn("The change stream cursor didn't return any document. Stopping the change stream.");
+                        stop();
+                        partitionCheckpoint.resetCheckpoint();
                     }
                 }
             }
@@ -227,6 +248,19 @@ public class StreamWorker {
         }
     }
 
+    private boolean isCRUDOperation(final OperationType operationType) {
+        return OperationType.INSERT == operationType ||
+                OperationType.DELETE == operationType ||
+                OperationType.UPDATE == operationType ||
+                OperationType.REPLACE == operationType;
+    }
+
+    private boolean shouldTerminateChangeStream(final OperationType operationType) {
+        return OperationType.INVALIDATE == operationType ||
+                OperationType.DROP == operationType ||
+                OperationType.DROP_DATABASE == operationType;
+    }
+
     private void writeToBuffer(final List<Event> records, final String checkPointToken, final long recordCount) {
         final AcknowledgementSet acknowledgementSet = streamAcknowledgementManager.createAcknowledgementSet(checkPointToken, recordCount).orElse(null);
         recordBufferWriter.writeToBuffer(acknowledgementSet, records);
@@ -235,7 +269,7 @@ public class StreamWorker {
 
     private void checkpointStream() {
         long lastCheckpointTime = System.currentTimeMillis();
-        while (!Thread.currentThread().isInterrupted()) {
+        while (!Thread.currentThread().isInterrupted() && !stopWorker) {
             if (lastLocalRecordCount != null && (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs)) {
                 LOG.debug("Perform regular checkpoint for resume token {} at record count {}", lastLocalCheckpoint, lastLocalRecordCount);
                 partitionCheckpoint.checkpoint(lastLocalCheckpoint, lastLocalRecordCount);
@@ -248,6 +282,7 @@ public class StreamWorker {
                 break;
             }
         }
+        LOG.info("Checkpoint monitoring thread interrupted.");
     }
 
     void stop() {

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/DataStreamPartitionCheckpointTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/DataStreamPartitionCheckpointTest.java
@@ -34,7 +34,7 @@ public class DataStreamPartitionCheckpointTest {
     private DataStreamPartitionCheckpoint dataStreamPartitionCheckpoint;
 
     @Test
-    public void checkpoint() {
+    public void checkpoint_success() {
         final int recordNumber = new Random().nextInt();
         final String checkpointToken = UUID.randomUUID().toString();
         when(streamPartition.getProgressState()).thenReturn(Optional.of(streamProgressState));
@@ -46,10 +46,20 @@ public class DataStreamPartitionCheckpointTest {
     }
 
     @Test
-    public void updateStreamPartitionForAcknowledgmentWait() {
+    public void updateStreamPartitionForAcknowledgmentWait_success() {
         final int minutes = new Random().nextInt();
         final Duration duration = Duration.ofMinutes(minutes);
         dataStreamPartitionCheckpoint.updateStreamPartitionForAcknowledgmentWait(duration);
         verify(enhancedSourceCoordinator).saveProgressStateForPartition(streamPartition, duration);
+    }
+
+    @Test
+    public void resetCheckpoint_success() {
+        when(streamPartition.getProgressState()).thenReturn(Optional.of(streamProgressState));
+        dataStreamPartitionCheckpoint.resetCheckpoint();
+        verify(enhancedSourceCoordinator).giveUpPartition(streamPartition);
+        verify(streamProgressState).setResumeToken(null);
+        verify(streamProgressState).setLoadedRecords(0);
+        verify(streamProgressState).setLastUpdateTimestamp(anyLong());
     }
 }


### PR DESCRIPTION
### Description
Support Mongo/DocDB stream Delete and other Operation types
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
