### PR TITLE
Move stopping of s3 scan from docdb leader scheduler to stream scheduler

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderScheduler.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/leader/LeaderScheduler.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.opensearch.dataprepper.model.source.s3.S3ScanEnvironmentVariables.STOP_S3_SCAN_PROCESSING_PROPERTY;
 
 public class LeaderScheduler implements Runnable {
 
@@ -81,10 +80,6 @@ public class LeaderScheduler implements Runnable {
                     if (sourcePartition.isPresent()) {
                         LOG.info("Running as a LEADER node");
                         leaderPartition = (LeaderPartition) sourcePartition.get();
-
-                        if (sourceConfig.isDisableS3ReadForLeader()) {
-                            System.setProperty(STOP_S3_SCAN_PROCESSING_PROPERTY, "true");
-                        }
                     }
                 }
                 // Once owned, run Normal LEADER node process.
@@ -117,9 +112,6 @@ public class LeaderScheduler implements Runnable {
         // Should Stop
         LOG.warn("Quitting Leader Scheduler");
         if (leaderPartition != null) {
-            if (sourceConfig.isDisableS3ReadForLeader()) {
-                System.clearProperty(STOP_S3_SCAN_PROCESSING_PROPERTY);
-            }
             coordinator.giveUpPartition(leaderPartition);
         }
     }


### PR DESCRIPTION
### Description
Follow up from https://github.com/opensearch-project/data-prepper/pull/4495, StreamScheduler is the node that will work on reading from DocumentDB streams, so the owner of this job should be the one to stop s3 scan processing
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
