### PR TITLE
Support default mapping for Mongo/DocumentDB data types 

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -49,6 +50,10 @@ public class StreamWorker {
     static final String SUCCESS_ITEM_COUNTER_NAME = "streamRecordsSuccessTotal";
     static final String FAILURE_ITEM_COUNTER_NAME = "streamRecordsFailedTotal";
     static final String BYTES_RECEIVED = "bytesReceived";
+    private static final String REGEX_PATTERN = "pattern";
+    private static final String REGEX_OPTIONS = "options";
+    public static final String MONGO_ID_FIELD_NAME = "_id";
+    public static final String DEFAULT_ID_MAPPING_FIELD_NAME = "doc_id";
     private final RecordBufferWriter recordBufferWriter;
     private final PartitionKeyRecordConverter recordConverter;
     private final DataStreamPartitionCheckpoint partitionCheckpoint;
@@ -72,6 +77,20 @@ public class StreamWorker {
     private final JsonWriterSettings writerSettings = JsonWriterSettings.builder()
             .outputMode(JsonMode.RELAXED)
             .objectIdConverter((value, writer) -> writer.writeString(value.toHexString()))
+            .binaryConverter((value, writer) ->  writer.writeString(Base64.getEncoder().encodeToString(value.getData())))
+            .dateTimeConverter((value, writer) -> writer.writeNumber(String.valueOf(value.longValue())))
+            .decimal128Converter((value, writer) -> writer.writeString(value.bigDecimalValue().toPlainString()))
+            .doubleConverter((value, writer) -> writer.writeNumber(String.valueOf(value.doubleValue())))
+            .maxKeyConverter((value, writer) -> writer.writeNull())
+            .minKeyConverter((value, writer) -> writer.writeNull())
+            .regularExpressionConverter((value, writer) -> {
+                writer.writeStartObject();
+                writer.writeString(REGEX_PATTERN, value.getPattern());
+                writer.writeString(REGEX_OPTIONS, value.getOptions());
+                writer.writeEndObject();
+            })
+            .timestampConverter((value, writer) -> writer.writeNumber(String.valueOf(value.getValue())))
+            .undefinedConverter((value, writer) -> writer.writeNull())
             .build();
 
     public static StreamWorker create(final RecordBufferWriter recordBufferWriter,
@@ -201,6 +220,9 @@ public class StreamWorker {
                                 checkPointToken = document.getResumeToken().toJson(writerSettings);
                                 // TODO fix eventVersionNumber
                                 final Event event = recordConverter.convert(record, eventCreationTimeMillis, eventCreationTimeMillis, document.getOperationTypeString());
+                                event.put(DEFAULT_ID_MAPPING_FIELD_NAME, event.get(MONGO_ID_FIELD_NAME, Object.class));
+                                // delete _id
+                                event.delete(MONGO_ID_FIELD_NAME);
                                 records.add(event);
                                 recordCount += 1;
 
@@ -221,6 +243,7 @@ public class StreamWorker {
                             }
                         } catch(Exception e){
                             // TODO handle documents with size > 10 MB.
+                            // collection.find(new Document("_id", "key")).first();
                             // this will only happen if writing to buffer gets interrupted from shutdown,
                             // otherwise it's infinite backoff and retry
                             LOG.error("Failed to add records to buffer with error", e);

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
@@ -80,7 +80,6 @@ public class StreamWorker {
             .binaryConverter((value, writer) ->  writer.writeString(Base64.getEncoder().encodeToString(value.getData())))
             .dateTimeConverter((value, writer) -> writer.writeNumber(String.valueOf(value.longValue())))
             .decimal128Converter((value, writer) -> writer.writeString(value.bigDecimalValue().toPlainString()))
-            .doubleConverter((value, writer) -> writer.writeNumber(String.valueOf(value.doubleValue())))
             .maxKeyConverter((value, writer) -> writer.writeNull())
             .minKeyConverter((value, writer) -> writer.writeNull())
             .regularExpressionConverter((value, writer) -> {
@@ -243,7 +242,6 @@ public class StreamWorker {
                             }
                         } catch(Exception e){
                             // TODO handle documents with size > 10 MB.
-                            // collection.find(new Document("_id", "key")).first();
                             // this will only happen if writing to buffer gets interrupted from shutdown,
                             // otherwise it's infinite backoff and retry
                             LOG.error("Failed to add records to buffer with error", e);

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
@@ -467,7 +467,7 @@ public class StreamWorkerTest {
         when(streamDoc1.getResumeToken()).thenReturn(bsonDoc1);
         when(streamDoc1.getOperationType()).thenReturn(OperationType.INSERT);
         when(cursor.next())
-                .thenReturn(streamDoc1);
+            .thenReturn(streamDoc1);
         when(streamDoc1.getFullDocument()).thenReturn(doc1);
         final String operationType1 = UUID.randomUUID().toString();
         when(streamDoc1.getOperationTypeString()).thenReturn(operationType1);
@@ -491,8 +491,8 @@ public class StreamWorkerTest {
             }
         });
         await()
-                .atMost(Duration.ofSeconds(10))
-                .untilAsserted(() ->  verify(mongoClient).close());
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted(() ->  verify(mongoClient).close());
         verify(mongoDatabase).getCollection(eq("collection"));
         verify(mockPartitionCheckpoint).getGlobalS3FolderCreationStatus(collection);
         verify(mockRecordConverter).initializePartitions(partitions);
@@ -500,28 +500,30 @@ public class StreamWorkerTest {
             "\"_id\": \"6634ed693ac62386d57bcaf0\", " +
             "\"name\": \"Hello User\", " +
             "\"doc\": {" +
-                "\"id\": {\"key1\": \"value1\", " +
-                "\"key2\": \"value2\"" +
+                "\"id\": {" +
+                    "\"key1\": \"value1\", " +
+                    "\"key2\": \"value2\"" +
+                "}, " +
+                "\"nullField\": null, " +
+                "\"numberField\": 123, " +
+                "\"longValue\": 1234567890123456768, " +
+                "\"stringField\": \"Hello, Mongo!\", " +
+                "\"booleanField\": true, " +
+                "\"dateField\": 1714744671155, " +
+                "\"arrayField\": [\"a\", \"b\", \"c\"], " +
+                "\"objectField\": {" +
+                    "\"nestedKey\": \"nestedValue\"" +
+                "}, " +
+                "\"binaryField\": \"AQIDBA==\", " +
+                "\"objectIdField\": \"6634ed5f3ac62386d57bcaef\", " +
+                "\"timestampField\": 7364772325884952605, " +
+                "\"regexField\": {" +
+                    "\"pattern\": \"pattern\", " +
+                    "\"options\": \"i\"" +
+                "}, " +
+                "\"minKeyField\": null, " +
+                "\"maxKeyField\": null" +
             "}, " +
-            "\"nullField\": null, " +
-            "\"numberField\": 123, " +
-            "\"longValue\": 1234567890123456768, " +
-            "\"stringField\": \"Hello, Mongo!\", " +
-            "\"booleanField\": true, " +
-            "\"dateField\": 1714744671155, " +
-            "\"arrayField\": [\"a\", \"b\", \"c\"], " +
-            "\"objectField\": {" +
-                "\"nestedKey\": \"nestedValue\"" +
-            "}, " +
-            "\"binaryField\": \"AQIDBA==\", " +
-            "\"objectIdField\": \"6634ed5f3ac62386d57bcaef\", " +
-            "\"timestampField\": 7364772325884952605, " +
-            "\"regexField\": {" +
-                "\"pattern\": \"pattern\", " +
-                "\"options\": \"i\"" +
-            "}, " +
-            "\"minKeyField\": null, " +
-            "\"maxKeyField\": null}, " +
             "\"price128\": \"123.45\"" +
         "}";
         verify(mockRecordConverter).convert(eq(expectedRecord), eq(timeSecond1 * 1000L), eq(timeSecond1 * 1000L), eq(operationType1));

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
@@ -161,6 +161,9 @@ public class StreamWorkerTest {
         final List<String> partitions = List.of("first", "second");
         when(s3PartitionStatus.getPartitions()).thenReturn(partitions);
         when(mockPartitionCheckpoint.getGlobalS3FolderCreationStatus(collection)).thenReturn(Optional.of(s3PartitionStatus));
+        Event event = mock(Event.class);
+        when(event.get("_id", Object.class)).thenReturn(UUID.randomUUID().toString());
+        when(mockRecordConverter.convert(anyString(), anyLong(), anyLong(), anyString())).thenReturn(event);
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         final Future<?> future = executorService.submit(() -> {
             try (MockedStatic<MongoDBConnection> mongoDBConnectionMockedStatic = mockStatic(MongoDBConnection.class)) {
@@ -256,6 +259,9 @@ public class StreamWorkerTest {
         when(streamDoc1.getClusterTime()).thenReturn(bsonTimestamp1);
         when(streamDoc2.getClusterTime()).thenReturn(bsonTimestamp2);
         when(streamDoc3.getClusterTime()).thenReturn(bsonTimestamp3);
+        when(streamDoc1.getOperationTypeString()).thenReturn(UUID.randomUUID().toString());
+        when(streamDoc2.getOperationTypeString()).thenReturn(UUID.randomUUID().toString());
+        when(streamDoc3.getOperationTypeString()).thenReturn(UUID.randomUUID().toString());
         final String resumeToken1 = UUID.randomUUID().toString();
         final String resumeToken2 = UUID.randomUUID().toString();
         final String resumeToken3 = UUID.randomUUID().toString();
@@ -266,6 +272,9 @@ public class StreamWorkerTest {
         final List<String> partitions = List.of("first", "second");
         when(s3PartitionStatus.getPartitions()).thenReturn(partitions);
         when(mockPartitionCheckpoint.getGlobalS3FolderCreationStatus(collection)).thenReturn(Optional.of(s3PartitionStatus));
+        Event event = mock(Event.class);
+        when(event.get("_id", Object.class)).thenReturn(UUID.randomUUID().toString());
+        when(mockRecordConverter.convert(anyString(), anyLong(), anyLong(), anyString())).thenReturn(event);
         try (MockedStatic<MongoDBConnection> mongoDBConnectionMockedStatic = mockStatic(MongoDBConnection.class)) {
 
             mongoDBConnectionMockedStatic.when(() -> MongoDBConnection.getMongoClient(any(MongoDBSourceConfig.class)))
@@ -366,6 +375,9 @@ public class StreamWorkerTest {
         final List<String> partitions = List.of("first", "second");
         when(s3PartitionStatus.getPartitions()).thenReturn(partitions);
         when(mockPartitionCheckpoint.getGlobalS3FolderCreationStatus(collection)).thenReturn(Optional.of(s3PartitionStatus));
+        Event event = mock(Event.class);
+        when(event.get("_id", Object.class)).thenReturn(UUID.randomUUID().toString());
+        when(mockRecordConverter.convert(anyString(), anyLong(), anyLong(), anyString())).thenReturn(event);
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(() -> {
             try (MockedStatic<MongoDBConnection> mongoDBConnectionMockedStatic = mockStatic(MongoDBConnection.class)) {


### PR DESCRIPTION
### Description
Support default mapping for Mongo/DocumentDB data types
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
