### PR TITLE
Add support to export/full load MongoDB/DocumentDB collection with `_id` field of different data type

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelper.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelper.java
@@ -74,8 +74,8 @@ public class BsonHelper {
         "java.lang.Boolean",
         "java.util.Date",
         "org.bson.BsonDateTime",
-        "org.bson.BsonTimestamp"
-        //MAX_KEY
+        "org.bson.BsonTimestamp",
+        MAX_KEY
         // "org.bson.types.Code" Javascript not supported in DocDB
         // "org.bson.BsonRegularExpression" Regex and Array not support as _id field
     );

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelper.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelper.java
@@ -80,8 +80,8 @@ public class BsonHelper {
         // "org.bson.BsonRegularExpression" Regex and Array not support as _id field
     );
 
-    private final static Function<Object, Bson> GT_FUNCTION = a -> gt("_id", a);
-    private final static Function<Object, Bson> GTE_FUNCTION = a -> gte("_id", a);
+    private static final Function<Object, Bson> GT_FUNCTION = a -> gt("_id", a);
+    private static final Function<Object, Bson> GTE_FUNCTION = a -> gte("_id", a);
     private static final Function<Object, Bson> LTE_FUNCTION = a -> lte("_id", a);
     private static final String REGEX_PATTERN = "pattern";
     private static final String REGEX_OPTIONS = "options";

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelper.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelper.java
@@ -5,109 +5,293 @@
 
 package org.opensearch.dataprepper.plugins.mongo.client;
 
+import org.bson.BsonBinary;
+import org.bson.BsonDateTime;
+import org.bson.BsonInt32;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.BsonTimestamp;
 import org.bson.Document;
 import org.bson.conversions.Bson;
-import org.bson.types.BSONTimestamp;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
 import org.bson.types.Binary;
 import org.bson.types.Code;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 import org.bson.types.Symbol;
 
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Function;
+
 import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.gt;
 import static com.mongodb.client.model.Filters.gte;
+import static com.mongodb.client.model.Filters.in;
 import static com.mongodb.client.model.Filters.lte;
+import static com.mongodb.client.model.Filters.or;
 
 public class BsonHelper {
-    private static final String BINARY_PARTITION_FORMAT = "%s-%s";
-    private static final String BINARY_PARTITION_SPLITTER = "-";
-    private static final String TIMESTAMP_PARTITION_FORMAT = "%s-%s";
-    private static final String TIMESTAMP_PARTITION_SPLITTER = "-";
+    static final String PARTITION_FORMAT = "%s-%s";
+    private static final String PARTITION_SPLITTER = "-";
+    private static final String NUMBER_TYPE = "number";
+    public static final String MAX_KEY = "MaxKey";
+
+    // https://www.mongodb.com/docs/manual/reference/bson-type-comparison-order/
+    /**
+     * MongoDB uses the following comparison order for field types, from lowest to highest:
+     * MinKey (internal type) // not used for _id field
+     * Null // mongo will generate ObjectId for _id field
+     * Numbers (ints, longs, doubles, decimals)
+     * Symbol, String
+     * Object
+     * Array // not support for _id field
+     * BinData
+     * ObjectId
+     * Boolean
+     * Date
+     * Timestamp
+     * Regular Expression // not support for _id field
+     * MaxKey (internal type) // not used for _id field
+     */
+    private static final List<String> RANGE_TYPE_ORDER = Arrays.asList(
+        /*
+        * These are internally represented as number.
+        * java.lang.Integer
+        * java.lang.Long
+        * java.lang.Double
+        * org.bson.types.Decimal128
+        */
+        NUMBER_TYPE,
+        "java.lang.String",
+        // "org.bson.types.Symbol", not supported in DocDB
+        "org.bson.Document",
+        "org.bson.types.Binary",
+        "org.bson.types.ObjectId",
+        "java.lang.Boolean",
+        "java.util.Date",
+        "org.bson.BsonDateTime",
+        "org.bson.BsonTimestamp"
+        //MAX_KEY
+        // "org.bson.types.Code" Javascript not supported in DocDB
+        // "org.bson.BsonRegularExpression" Regex and Array not support as _id field
+    );
+
+    private final static Function<Object, Bson> GT_FUNCTION = a -> gt("_id", a);
+    private final static Function<Object, Bson> GTE_FUNCTION = a -> gte("_id", a);
+    private static final Function<Object, Bson> LTE_FUNCTION = a -> lte("_id", a);
+    private static final String REGEX_PATTERN = "pattern";
+    private static final String REGEX_OPTIONS = "options";
+    public static final String DOCUMENTDB_ID_FIELD_NAME = "_id";
+    // public static final String DEFAULT_ID_MAPPING_FIELD_NAME = "doc_id";
+    public static final JsonWriterSettings JSON_WRITER_SETTINGS = JsonWriterSettings.builder()
+        .outputMode(JsonMode.RELAXED)
+        .objectIdConverter((value, writer) -> writer.writeString(value.toHexString()))
+        .binaryConverter((value, writer) ->  writer.writeString(Base64.getEncoder().encodeToString(value.getData())))
+        .dateTimeConverter((value, writer) -> writer.writeNumber(String.valueOf(value.longValue())))
+        .decimal128Converter((value, writer) -> writer.writeString(value.bigDecimalValue().toPlainString()))
+        .maxKeyConverter((value, writer) -> writer.writeNull())
+        .minKeyConverter((value, writer) -> writer.writeNull())
+        .regularExpressionConverter((value, writer) -> {
+            writer.writeStartObject();
+            writer.writeString(REGEX_PATTERN, value.getPattern());
+            writer.writeString(REGEX_OPTIONS, value.getOptions());
+            writer.writeEndObject();
+        })
+        .timestampConverter((value, writer) -> writer.writeNumber(String.valueOf(value.getValue())))
+        .undefinedConverter((value, writer) -> writer.writeNull())
+        .build();
 
     public static String getPartitionStringFromMongoDBId(Object id, String className) {
         switch (className) {
             case "org.bson.Document":
-                return ((Document) id).toJson();
+                return ((Document) id).toJson(JSON_WRITER_SETTINGS);
             case "org.bson.types.Binary":
                 final byte type = ((Binary) id).getType();
                 final byte[] data = ((Binary) id).getData();
-                String typeString = String.valueOf(type);
-                String dataString = new String(data);
-                return String.format(BINARY_PARTITION_FORMAT, typeString, dataString);
-            case "org.bson.types.BSONTimestamp":
-                final int inc = ((BSONTimestamp) id).getInc();
-                final int time = ((BSONTimestamp) id).getTime();
-                return String.format(TIMESTAMP_PARTITION_FORMAT, inc, time);
+                final String typeString = String.valueOf(type);
+                final String dataString = new String(data);
+                return String.format(PARTITION_FORMAT, typeString, dataString);
+            case "java.util.Date":
+                return String.valueOf(((Date) id).getTime());
+            case "org.bson.BsonDateTime":
+                return String.valueOf(((BsonDateTime) id).getValue());
+            case "org.bson.BsonTimestamp":
+                final int time = ((BsonTimestamp) id).getTime();
+                final int inc = ((BsonTimestamp) id).getInc();
+                return String.format(PARTITION_FORMAT, time, inc);
             case "org.bson.types.Code":
                 return ((Code) id).getCode();
+            case "org.bson.types.Decimal128":
+                return ((Decimal128) id).bigDecimalValue().toPlainString();
             default:
                 return id.toString();
         }
     }
 
-    public static Bson buildAndQuery(String gte, String lte, String className) {
+    private static Bson buildAndQuery(final String gte, final String lte, final String gteClassName, final String lteClassName) {
+        return and(
+            buildQuery(GTE_FUNCTION, gte, gteClassName),
+            buildQuery(LTE_FUNCTION, lte, lteClassName)
+        );
+    }
+
+    private static Bson buildQuery(final Function<Object, Bson> function, final String value, final String className) {
         switch (className) {
             case "java.lang.Integer":
-                return and(
-                        gte("_id", Integer.parseInt(gte)),
-                        lte("_id", Integer.parseInt(lte))
-                );
-            case "java.lang.Double":
-                return and(
-                        gte("_id", Double.parseDouble(gte)),
-                        lte("_id", Double.parseDouble(lte))
-                );
-            case "java.lang.String":
-                return and(
-                        gte("_id", gte),
-                        lte("_id", lte)
-                );
+                return function.apply(Integer.parseInt(value));
             case "java.lang.Long":
-                return and(
-                        gte("_id", Long.parseLong(gte)),
-                        lte("_id", Long.parseLong(lte))
-                );
-            case "org.bson.types.ObjectId":
-                return and(
-                        gte("_id", new ObjectId(gte)),
-                        lte("_id", new ObjectId(lte))
-                );
+                return function.apply(Long.parseLong(value));
+            case "java.lang.Double":
+                return function.apply(Double.parseDouble(value));
             case "org.bson.types.Decimal128":
-                return and(
-                        gte("_id", Decimal128.parse(gte)),
-                        lte("_id", Decimal128.parse(lte))
-                );
-            case "org.bson.types.Binary":
-                String[] gteString = gte.split(BINARY_PARTITION_SPLITTER, 2);
-                String[] lteString = lte.split(BINARY_PARTITION_SPLITTER, 2);
-                return and(
-                        gte("_id", new Binary(Byte.parseByte(gteString[0]), gteString[1].getBytes())),
-                        lte("_id", new Binary(Byte.parseByte(lteString[0]), lteString[1].getBytes()))
-                );
-            case "org.bson.types.BSONTimestamp":
-                String[] gteTimestampString = gte.split(TIMESTAMP_PARTITION_SPLITTER, 2);
-                String[] lteTimestampString = lte.split(TIMESTAMP_PARTITION_SPLITTER, 2);
-                return and(
-                        gte("_id", new BSONTimestamp(Integer.parseInt(gteTimestampString[0]), Integer.parseInt(gteTimestampString[1]))),
-                        lte("_id", new BSONTimestamp(Integer.parseInt(lteTimestampString[0]), Integer.parseInt(lteTimestampString[1])))
-                );
-            case "org.bson.types.Code":
-                return and(
-                        gte("_id", new Code(gte)),
-                        lte("_id", new Code(lte))
-                );
+                return function.apply(Decimal128.parse(value));
+            case "java.lang.String":
+                return function.apply(value);
             case "org.bson.types.Symbol":
-                return and(
-                        gte("_id", new Symbol(gte)),
-                        lte("_id", new Symbol(lte))
-                );
+                return function.apply(new Symbol(value));
             case "org.bson.Document":
-                return and(
-                        gte("_id", Document.parse(gte)),
-                        lte("_id", Document.parse(lte))
-                );
+                return function.apply(Document.parse(value));
+            case "org.bson.types.Binary":
+                String[] binaryString = value.split(PARTITION_SPLITTER, 2);
+                return function.apply(new Binary(Byte.parseByte(binaryString[0]), binaryString[1].getBytes()));
+            case "org.bson.types.ObjectId":
+                return function.apply(new ObjectId(value));
+            case "java.lang.Boolean":
+                return function.apply(Boolean.parseBoolean(value));
+            case "java.util.Date":
+            case "org.bson.BsonDateTime":
+                return function.apply(new BsonDateTime(Long.parseLong(value)));
+            case "org.bson.BsonTimestamp":
+                String[] timestampString = value.split(PARTITION_SPLITTER, 2);
+                return function.apply(new BsonTimestamp(Integer.parseInt(timestampString[0]), Integer.parseInt(timestampString[1])));
+            case "org.bson.types.Code":
+                return function.apply(new Code(value));
             default:
                 throw new RuntimeException("Unexpected _id class not supported: " + className);
         }
+    }
+
+    private static boolean isClassNumber(final String className) {
+        return className.equals("java.lang.Integer") || className.equals("java.lang.Long") || className.equals("java.lang.Double")
+                || className.equals("org.bson.types.Decimal128");
+    }
+
+    public static Bson buildGtQuery(final String greaterThan, final String gtClassName, final String lteClassName) {
+        Bson bsonQuery = buildQuery(GT_FUNCTION, greaterThan, gtClassName);
+        return buildSortOrderQuery(bsonQuery, gtClassName, lteClassName);
+    }
+
+    private static Bson buildGteQuery(final String greaterThanEquals, final String gteClassName, final String lteClassName) {
+        Bson bsonQuery = buildQuery(GTE_FUNCTION, greaterThanEquals, gteClassName);
+        return buildSortOrderQuery(bsonQuery, gteClassName, lteClassName);
+    }
+
+    private static Bson buildSortOrderQuery(Bson bsonQuery, final String gtClassName, final String lteClassName) {
+        int prev_i;
+        if (isClassNumber(gtClassName)) {
+            prev_i = RANGE_TYPE_ORDER.indexOf(NUMBER_TYPE);
+        } else {
+            prev_i = RANGE_TYPE_ORDER.indexOf(gtClassName);
+        }
+        int curr_i;
+        if (isClassNumber(lteClassName)) {
+            curr_i = RANGE_TYPE_ORDER.indexOf(NUMBER_TYPE);
+        } else {
+            curr_i = RANGE_TYPE_ORDER.indexOf(lteClassName);
+        }
+        for (int i = prev_i + 1; i < curr_i; i++) {
+            String className = RANGE_TYPE_ORDER.get(i);
+            switch (className) {
+                case "java.lang.Integer":
+                case "java.lang.Long":
+                case "java.lang.Double":
+                case "org.bson.types.Decimal128":
+                    bsonQuery = or(
+                        bsonQuery,
+                        gte("_id", new BsonInt32(0))
+                    );
+                    break;
+                case "java.lang.String":
+                    bsonQuery = or(
+                        bsonQuery,
+                        gte("_id", new BsonString(""))
+                    );
+                    break;
+                case "org.bson.types.Symbol":
+                    bsonQuery = or(
+                        bsonQuery,
+                        gte("_id", new Symbol(""))
+                    );
+                    break;
+                case "org.bson.Document":
+                    bsonQuery = or(
+                        bsonQuery,
+                        gte("_id", new Document())
+                    );
+                    break;
+                case "org.bson.types.ObjectId":
+                    bsonQuery = or(
+                        bsonQuery,
+                        gte("_id", new BsonObjectId(new ObjectId("000000000000000000000000")))
+                    );
+                    break;
+                case "java.lang.Boolean":
+                    bsonQuery = or(
+                        bsonQuery,
+                        in("_id", true, false)
+                    );
+                    break;
+                case "org.bson.types.Binary":
+                    bsonQuery = or(
+                        bsonQuery,
+                        gte("_id", new BsonBinary(new byte[0]))
+                    );
+                    break;
+                case "java.util.Date":
+                case "org.bson.BsonDateTime":
+                    bsonQuery = or(
+                        bsonQuery,
+                        gte("_id", new BsonDateTime(0))
+                    );
+                    break;
+                case "org.bson.BsonTimestamp":
+                    bsonQuery = or(
+                        bsonQuery,
+                        gte("_id", new BsonTimestamp(0))
+                    );
+                    break;
+                case "org.bson.types.Code":
+                    bsonQuery = or(
+                        bsonQuery,
+                        gte("_id", new Code(""))
+                    );
+                    break;
+                case MAX_KEY:
+                    // do nothing. This is used internally for returning all values GT than a key and less than this
+                    // internal key
+                    break;
+                default:
+                    throw new RuntimeException("Unexpected _id class not supported: " + className);
+            }
+        }
+
+        return bsonQuery;
+    }
+
+    public static Bson buildQuery(final String gte, final String lte, final String gteClassName, final String lteClassName) {
+        if (gteClassName.equals(lteClassName) || (isClassNumber(gteClassName) && isClassNumber(lteClassName))) {
+            return buildAndQuery(gte, lte, gteClassName, lteClassName);
+        }
+
+        final Bson bsonQuery = buildGteQuery(gte, gteClassName, lteClassName);
+
+        return or(
+            bsonQuery,
+            buildQuery(LTE_FUNCTION, lte, lteClassName)
+        );
     }
 }

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/converter/MetadataKeyAttributes.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/converter/MetadataKeyAttributes.java
@@ -7,19 +7,20 @@ package org.opensearch.dataprepper.plugins.mongo.converter;
 
 public class MetadataKeyAttributes {
     static final String PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE = "primary_key";
-    static final String MONGODB_PRIMARY_KEY_ATTRIBUTE_NAME = "_id";
+    public static final String DOCUMENTDB_PRIMARY_KEY_ATTRIBUTE_NAME = "_id";
 
     static final String PARTITION_KEY_METADATA_ATTRIBUTE = "partition_key";
+    static final String DOCUMENTDB_ID_TYPE_METADATA_ATTRIBUTE = "documentdb_id_bson_type";
 
-    static final String MONGODB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE = "mongodb_timestamp";
+    static final String DOCUMENTDB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE = "documentdb_timestamp";
 
     static final String EVENT_VERSION_FROM_TIMESTAMP = "document_version";
 
     static final String EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE = "opensearch_action";
 
-    static final String MONGODB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE = "mongodb_event_name";
+    static final String DOCUMENTDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE = "documentdb_event_name";
 
-    static final String MONGODB_EVENT_COLLECTION_METADATA_ATTRIBUTE = "mongodb_collection";
+    static final String DOCUMENTDB_EVENT_COLLECTION_METADATA_ATTRIBUTE = "documentdb_collection";
 
     static final String INGESTION_EVENT_TYPE_ATTRIBUTE = "ingestion_type";
 

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/converter/RecordConverter.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/converter/RecordConverter.java
@@ -76,13 +76,13 @@ public class RecordConverter {
         final EventMetadata eventMetadata = event.getMetadata();
 
         eventMetadata.setAttribute(MetadataKeyAttributes.INGESTION_EVENT_TYPE_ATTRIBUTE, dataType);
-        eventMetadata.setAttribute(MetadataKeyAttributes.MONGODB_EVENT_COLLECTION_METADATA_ATTRIBUTE, collection);
-        eventMetadata.setAttribute(MetadataKeyAttributes.MONGODB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE, eventCreationTimeMillis);
-        eventMetadata.setAttribute(MetadataKeyAttributes.MONGODB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE, eventName);
+        eventMetadata.setAttribute(MetadataKeyAttributes.DOCUMENTDB_EVENT_COLLECTION_METADATA_ATTRIBUTE, collection);
+        eventMetadata.setAttribute(MetadataKeyAttributes.DOCUMENTDB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE, eventCreationTimeMillis);
+        eventMetadata.setAttribute(MetadataKeyAttributes.DOCUMENTDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE, eventName);
         eventMetadata.setAttribute(MetadataKeyAttributes.EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE, mapStreamEventNameToBulkAction(eventName));
         eventMetadata.setAttribute(MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP, eventVersionNumber);
 
-        final String partitionKey = getAttributeValue(data, MetadataKeyAttributes.MONGODB_PRIMARY_KEY_ATTRIBUTE_NAME);
+        final String partitionKey = getAttributeValue(data, MetadataKeyAttributes.DOCUMENTDB_PRIMARY_KEY_ATTRIBUTE_NAME);
         eventMetadata.setAttribute(MetadataKeyAttributes.PARTITION_KEY_METADATA_ATTRIBUTE, partitionKey);
         eventMetadata.setAttribute(MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE, partitionKey);
 
@@ -109,11 +109,12 @@ public class RecordConverter {
         }
 
         // https://www.mongodb.com/docs/manual/reference/change-events/
-        switch (streamEventName) {
-            case "INSERT":
-            case "MODIFY":
+        switch (streamEventName.toLowerCase()) {
+            case "insert":
+            case "modify":
+            case "replace":
                 return OpenSearchBulkActions.INDEX.toString();
-            case "REMOVE":
+            case "delete":
                 return OpenSearchBulkActions.DELETE.toString();
             default:
                 return DEFAULT_ACTION;

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelperTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelperTest.java
@@ -1,8 +1,9 @@
 package org.opensearch.dataprepper.plugins.mongo.client;
 
+import org.bson.BsonDateTime;
+import org.bson.BsonTimestamp;
 import org.bson.Document;
 import org.bson.conversions.Bson;
-import org.bson.types.BSONTimestamp;
 import org.bson.types.Binary;
 import org.bson.types.Code;
 import org.bson.types.Decimal128;
@@ -11,26 +12,33 @@ import org.bson.types.Symbol;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
+import java.util.Base64;
 import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.dataprepper.plugins.mongo.client.BsonHelper.PARTITION_FORMAT;
 
 @ExtendWith(MockitoExtension.class)
 public class BsonHelperTest {
     private final Random random = new Random();
 
-    @Test
-    public void getDocumentPartitionStringFromMongoDBId() {
-        final Document document = mock(Document.class);
-        when(document.toJson()).thenReturn(UUID.randomUUID().toString());
+    @ParameterizedTest
+    @MethodSource("mongoDataTypeProvider")
+    public void getDocumentPartitionStringFromMongoDBId(final String actualDocument, final String expectedDocument) {
+        final Document document = Document.parse(actualDocument);
         final String partition = BsonHelper.getPartitionStringFromMongoDBId(document, Document.class.getName());
-        assertThat(partition, is(document.toJson()));
+        assertThat(partition, is(expectedDocument));
     }
 
     @Test
@@ -45,12 +53,20 @@ public class BsonHelperTest {
     }
 
     @Test
-    public void getBSONTimestampPartitionStringFromMongoDBId() {
-        final BSONTimestamp document = mock(BSONTimestamp.class);
+    public void getBsonDateTimePartitionStringFromMongoDBId() {
+        final BsonDateTime document = mock(BsonDateTime.class);
+        when(document.getValue()).thenReturn(Long.valueOf(getRandomInteger()));
+        final String partition = BsonHelper.getPartitionStringFromMongoDBId(document, BsonDateTime.class.getName());
+        assertThat(partition, is(String.valueOf(document.getValue())));
+    }
+
+    @Test
+    public void getBsonTimestampPartitionStringFromMongoDBId() {
+        final BsonTimestamp document = mock(BsonTimestamp.class);
         when(document.getInc()).thenReturn(getRandomInteger());
         when(document.getTime()).thenReturn(getRandomInteger());
-        final String partition = BsonHelper.getPartitionStringFromMongoDBId(document, BSONTimestamp.class.getName());
-        assertThat(partition, is(String.format("%s-%s", document.getInc(), document.getTime())));
+        final String partition = BsonHelper.getPartitionStringFromMongoDBId(document, BsonTimestamp.class.getName());
+        assertThat(partition, is(String.format("%s-%s", document.getTime(), document.getInc())));
     }
 
     @Test
@@ -59,6 +75,15 @@ public class BsonHelperTest {
         when(document.getCode()).thenReturn(UUID.randomUUID().toString());
         final String partition = BsonHelper.getPartitionStringFromMongoDBId(document, Code.class.getName());
         assertThat(partition, is(document.getCode()));
+    }
+
+    @Test
+    public void getDecimal128PartitionStringFromMongoDBId() {
+        final Decimal128 document = mock(Decimal128.class);
+        final BigDecimal bigDecimal = BigDecimal.valueOf(new Random().nextDouble());
+        when(document.bigDecimalValue()).thenReturn(bigDecimal);
+        final String partition = BsonHelper.getPartitionStringFromMongoDBId(document, Decimal128.class.getName());
+        assertThat(partition, is(bigDecimal.toPlainString()));
     }
 
     @Test
@@ -75,29 +100,7 @@ public class BsonHelperTest {
         final String lteValue = String.valueOf(getRandomInteger());
         final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": %s}}", gteValue);
         final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": %s}}", lteValue);
-        final Bson bson = BsonHelper.buildAndQuery(gteValue, lteValue, Integer.class.getName());
-        assertThat(bson.toBsonDocument().get("$and").asArray().get(0).toString(), is(expectedGteValueString));
-        assertThat(bson.toBsonDocument().get("$and").asArray().get(1).toString(), is(expectedLteValueString));
-    }
-
-    @Test
-    public void buildAndQueryForDoubleClass() {
-        final String gteValue = String.valueOf(Double.valueOf(getRandomInteger()));
-        final String lteValue = String.valueOf(Double.valueOf(getRandomInteger()));
-        final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": %s}}", gteValue);
-        final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": %s}}", lteValue);
-        final Bson bson = BsonHelper.buildAndQuery(gteValue, lteValue, Double.class.getName());
-        assertThat(bson.toBsonDocument().get("$and").asArray().get(0).toString(), is(expectedGteValueString));
-        assertThat(bson.toBsonDocument().get("$and").asArray().get(1).toString(), is(expectedLteValueString));
-    }
-
-    @Test
-    public void buildAndQueryForStringClass() {
-        final String gteValue = UUID.randomUUID().toString();
-        final String lteValue = UUID.randomUUID().toString();
-        final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": \"%s\"}}", gteValue);
-        final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": \"%s\"}}", lteValue);
-        final Bson bson = BsonHelper.buildAndQuery(gteValue, lteValue, String.class.getName());
+        final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, Integer.class.getName(), Integer.class.getName());
         assertThat(bson.toBsonDocument().get("$and").asArray().get(0).toString(), is(expectedGteValueString));
         assertThat(bson.toBsonDocument().get("$and").asArray().get(1).toString(), is(expectedLteValueString));
     }
@@ -108,7 +111,29 @@ public class BsonHelperTest {
         final String lteValue = String.valueOf(Long.valueOf(getRandomInteger()));
         final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": %s}}", gteValue);
         final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": %s}}", lteValue);
-        final Bson bson = BsonHelper.buildAndQuery(gteValue, lteValue, Long.class.getName());
+        final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, Long.class.getName(), Long.class.getName());
+        assertThat(bson.toBsonDocument().get("$and").asArray().get(0).toString(), is(expectedGteValueString));
+        assertThat(bson.toBsonDocument().get("$and").asArray().get(1).toString(), is(expectedLteValueString));
+    }
+
+    @Test
+    public void buildAndQueryForDoubleClass() {
+        final String gteValue = String.valueOf(Double.valueOf(getRandomInteger()));
+        final String lteValue = String.valueOf(Double.valueOf(getRandomInteger()));
+        final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": %s}}", gteValue);
+        final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": %s}}", lteValue);
+        final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, Double.class.getName(), Double.class.getName());
+        assertThat(bson.toBsonDocument().get("$and").asArray().get(0).toString(), is(expectedGteValueString));
+        assertThat(bson.toBsonDocument().get("$and").asArray().get(1).toString(), is(expectedLteValueString));
+    }
+
+    @Test
+    public void buildAndQueryForStringClass() {
+        final String gteValue = UUID.randomUUID().toString();
+        final String lteValue = UUID.randomUUID().toString();
+        final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": \"%s\"}}", gteValue);
+        final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": \"%s\"}}", lteValue);
+        final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, String.class.getName(), String.class.getName());
         assertThat(bson.toBsonDocument().get("$and").asArray().get(0).toString(), is(expectedGteValueString));
         assertThat(bson.toBsonDocument().get("$and").asArray().get(1).toString(), is(expectedLteValueString));
     }
@@ -119,7 +144,7 @@ public class BsonHelperTest {
         final String lteValue = getRandomHexStringLength24();
         final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": {\"$oid\": \"%s\"}}}", gteValue);
         final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": {\"$oid\": \"%s\"}}}", lteValue);
-        final Bson bson = BsonHelper.buildAndQuery(gteValue, lteValue, ObjectId.class.getName());
+        final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, ObjectId.class.getName(), ObjectId.class.getName());
         assertThat(bson.toBsonDocument().get("$and").asArray().get(0).toString(), is(expectedGteValueString));
         assertThat(bson.toBsonDocument().get("$and").asArray().get(1).toString(), is(expectedLteValueString));
     }
@@ -130,7 +155,7 @@ public class BsonHelperTest {
         final String lteValue = (new Decimal128(getRandomInteger())).toString();
         final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": {\"$numberDecimal\": \"%s\"}}}", gteValue);
         final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": {\"$numberDecimal\": \"%s\"}}}", lteValue);
-        final Bson bson = BsonHelper.buildAndQuery(gteValue, lteValue, Decimal128.class.getName());
+        final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, Decimal128.class.getName(), Decimal128.class.getName());
         assertThat(bson.toBsonDocument().get("$and").asArray().get(0).toString(), is(expectedGteValueString));
         assertThat(bson.toBsonDocument().get("$and").asArray().get(1).toString(), is(expectedLteValueString));
     }
@@ -141,7 +166,7 @@ public class BsonHelperTest {
         final String lteValue = (new Code(UUID.randomUUID().toString())).getCode();
         final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": {\"$code\": \"%s\"}}}", gteValue);
         final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": {\"$code\": \"%s\"}}}", lteValue);
-        final Bson bson = BsonHelper.buildAndQuery(gteValue, lteValue, Code.class.getName());
+        final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, Code.class.getName(), Code.class.getName());
         assertThat(bson.toBsonDocument().get("$and").asArray().get(0).toString(), is(expectedGteValueString));
         assertThat(bson.toBsonDocument().get("$and").asArray().get(1).toString(), is(expectedLteValueString));
     }
@@ -152,7 +177,7 @@ public class BsonHelperTest {
         final String lteValue = (new Symbol(UUID.randomUUID().toString())).getSymbol();
         final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": {\"$symbol\": \"%s\"}}}", gteValue);
         final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": {\"$symbol\": \"%s\"}}}", lteValue);
-        final Bson bson = BsonHelper.buildAndQuery(gteValue, lteValue, Symbol.class.getName());
+        final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, Symbol.class.getName(), Symbol.class.getName());
         assertThat(bson.toBsonDocument().get("$and").asArray().get(0).toString(), is(expectedGteValueString));
         assertThat(bson.toBsonDocument().get("$and").asArray().get(1).toString(), is(expectedLteValueString));
     }
@@ -163,16 +188,100 @@ public class BsonHelperTest {
         final String lteValue = Document.parse(String.format("{\"%s\":\"%s\"}",  UUID.randomUUID(),  UUID.randomUUID())).toJson();
         final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": %s}}", gteValue);
         final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": %s}}", lteValue);
-        final Bson bson = BsonHelper.buildAndQuery(gteValue, lteValue, Document.class.getName());
+        final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, Document.class.getName(), Document.class.getName());
         assertThat(bson.toBsonDocument().get("$and").asArray().get(0).toString(), is(expectedGteValueString));
         assertThat(bson.toBsonDocument().get("$and").asArray().get(1).toString(), is(expectedLteValueString));
     }
 
     @Test
+    public void buildAndQueryForBsonDateTimeClass() {
+        final String gteValue = String.valueOf(Math.abs(new Random().nextLong()));
+        final String lteValue = String.valueOf(Math.abs(new Random().nextLong()));
+        final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": {\"$date\": {\"$numberLong\": \"%s\"}}}}", gteValue);
+        final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": {\"$date\": {\"$numberLong\": \"%s\"}}}}", lteValue);
+        final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, BsonDateTime.class.getName(), BsonDateTime.class.getName());
+        assertThat(bson.toBsonDocument().get("$and").asArray().get(0).toString(), is(expectedGteValueString));
+        assertThat(bson.toBsonDocument().get("$and").asArray().get(1).toString(), is(expectedLteValueString));
+    }
+
+    @Test
+    public void buildAndQueryForBsonTimestampClass() {
+        int tValue1 = Math.abs(new Random().nextInt());
+        int iValue1 = Math.abs(new Random().nextInt());
+        int tValue2 = Math.abs(new Random().nextInt());
+        int iValue2 = Math.abs(new Random().nextInt());
+        final String gteValue = String.format(PARTITION_FORMAT, tValue1, iValue1);
+        final String lteValue = String.format(PARTITION_FORMAT, tValue2, iValue2);
+        final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": {\"$timestamp\": {\"t\": %s, \"i\": %s}}}}", tValue1, iValue1);
+        final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": {\"$timestamp\": {\"t\": %s, \"i\": %s}}}}", tValue2, iValue2);
+        final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, BsonTimestamp.class.getName(), BsonTimestamp.class.getName());
+        assertThat(bson.toBsonDocument().get("$and").asArray().get(0).toString(), is(expectedGteValueString));
+        assertThat(bson.toBsonDocument().get("$and").asArray().get(1).toString(), is(expectedLteValueString));
+    }
+
+    @Test
+    public void buildAndQueryForBinaryClass() {
+        final String bytes1String = UUID.randomUUID().toString();
+        final String bytes1 = new String(Base64.getEncoder().encode(bytes1String.getBytes()));
+        final String bytes1Type = String.format("%02x",(Math.abs(new Random().nextInt(10))));
+        final String bytes2String = UUID.randomUUID().toString();
+        final String bytes2 = new String(Base64.getEncoder().encode(bytes2String.getBytes()));
+        final String bytes2Type = String.format("%02x",(Math.abs(new Random().nextInt(10))));
+        final String gteValue = String.format(PARTITION_FORMAT, bytes1Type, bytes1String);
+        final String lteValue = String.format(PARTITION_FORMAT, bytes2Type, bytes2String);
+        final String expectedGteValueString = String.format("{\"_id\": {\"$gte\": {\"$binary\": {\"base64\": \"%s\", \"subType\": \"%s\"}}}}", bytes1, bytes1Type);
+        final String expectedLteValueString = String.format("{\"_id\": {\"$lte\": {\"$binary\": {\"base64\": \"%s\", \"subType\": \"%s\"}}}}", bytes2, bytes2Type);
+        final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, Binary.class.getName(), Binary.class.getName());
+        assertThat(bson.toBsonDocument().get("$and").asArray().get(0).toString(), is(expectedGteValueString));
+        assertThat(bson.toBsonDocument().get("$and").asArray().get(1).toString(), is(expectedLteValueString));
+    }
+
+    @Test
+    public void buildAndQueryForIntegerAndBinaryClass() {
+        final String gteValue = String.valueOf(Math.abs(new Random(10_000).nextInt()));
+        final String bytesString = UUID.randomUUID().toString();
+        final String bytes = new String(Base64.getEncoder().encode(bytesString.getBytes()));
+        final String bytesType = String.format("%02x",(Math.abs(new Random().nextInt(10))));
+        final String lteValue = String.format(PARTITION_FORMAT, bytesType, bytesString);
+        final String expectedValueString = String.format("{\"$or\": [{\"$or\": [" +
+                "{\"$or\": [{\"_id\": {\"$gte\": %s}}, " +
+                "{\"_id\": {\"$gte\": \"\"}}]}, " +
+                "{\"_id\": {\"$gte\": {}}}]}, " +
+                "{\"_id\": {\"$lte\": {\"$binary\": {\"base64\": \"%s\", \"subType\": \"%s\"}}}}" +
+                "]}",
+                gteValue, bytes, bytesType);
+        final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, Integer.class.getName(), Binary.class.getName());
+        assertThat(bson.toBsonDocument().toJson(), is(expectedValueString));
+    }
+
+    @Test
+    public void buildAndQueryForIntegerAndBsonTimestampClass() {
+        final String gteValue = String.valueOf(Math.abs(new Random(10_000).nextInt()));
+        int tValue1 = Math.abs(new Random().nextInt());
+        int iValue1 = Math.abs(new Random().nextInt());
+        final String lteValue = String.format(PARTITION_FORMAT, tValue1, iValue1);
+        final String expectedValueString = String.format("{\"$or\": [{\"$or\": [{\"$or\": [{\"$or\": [{\"$or\": [{\"$or\": [{\"$or\": [{\"$or\": [" +
+                        "{\"_id\": {\"$gte\": %s}}, " +
+                        "{\"_id\": {\"$gte\": \"\"}}]}, " +
+                        "{\"_id\": {\"$gte\": {}}}]}, " +
+                        "{\"_id\": {\"$gte\": {\"$binary\": {\"base64\": \"\", \"subType\": \"00\"}}}}]}, " +
+                        "{\"_id\": {\"$gte\": {\"$oid\": \"000000000000000000000000\"}}}]}, " +
+                        "{\"_id\": {\"$in\": [true, false]}}]}, " +
+                        "{\"_id\": {\"$gte\": {\"$date\": \"1970-01-01T00:00:00Z\"}}}]}, " +
+                        "{\"_id\": {\"$gte\": {\"$date\": \"1970-01-01T00:00:00Z\"}}}]}, " +
+                        "{\"_id\": {\"$lte\": {\"$timestamp\": {\"t\": %s, \"i\": %s}}}}]}",
+                gteValue, tValue1, iValue1);
+
+        //String.format("{\"_id\": {\"$gte\": {\"$binary\": {\"base64\": \"%s\", \"subType\": \"%s\"}}}}", bytes1, bytes1Type);
+        final Bson bson = BsonHelper.buildQuery(gteValue, lteValue, Integer.class.getName(), BsonTimestamp.class.getName());
+        assertThat(bson.toBsonDocument().toJson(), is(expectedValueString));
+    }
+
+    @Test
     public void buildAndQueryForUnSupportedClass() {
         final String gteValue = new Object().toString();
-        final String lteValue =  new Object().toString();
-        Assertions.assertThrows(RuntimeException.class, () -> BsonHelper.buildAndQuery(gteValue, lteValue, Class.class.getName()));
+        final String lteValue = new Object().toString();
+        Assertions.assertThrows(RuntimeException.class, () -> BsonHelper.buildQuery(gteValue, lteValue, Class.class.getName(), Class.class.getName()));
     }
 
     private byte getRandomByte() {
@@ -192,5 +301,61 @@ public class BsonHelperTest {
         }
 
         return sb.substring(0, numOfChars);
+    }
+
+    private static Stream<Arguments> mongoDataTypeProvider() {
+        return Stream.of(
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"name\": \"Hello User\"}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"name\": \"Hello User\"}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"nullField\": null}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"nullField\": null}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"numberField\": 123}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"numberField\": 123}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"doubleValue\": 3.14159}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"doubleValue\": 3.14159}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"longValue\": { \"$numberLong\": \"1234567890123456768\"}}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"longValue\": 1234567890123456768}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"stringField\": \"Hello, Mongo!\"}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"stringField\": \"Hello, Mongo!\"}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"booleanField\": true}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"booleanField\": true}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"dateField\": { \"$date\": \"2024-05-03T13:57:51.155Z\"}}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"dateField\": 1714744671155}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"arrayField\": [\"a\",\"b\",\"c\"]}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"arrayField\": [\"a\", \"b\", \"c\"]}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"objectField\": { \"nestedKey\": \"nestedValue\"}}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"objectField\": {\"nestedKey\": \"nestedValue\"}}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"binaryField\": { \"$binary\": {\"base64\": \"AQIDBA==\", \"subType\": \"00\"}}}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"binaryField\": \"AQIDBA==\"}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"objectIdField\": { \"$oid\": \"6634ed693ac62386d57b12d0\" }}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"objectIdField\": \"6634ed693ac62386d57b12d0\"}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"timestampField\": { \"$timestamp\": {\"t\": 1714744681, \"i\": 29}}}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"timestampField\": 7364772325884952605}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"regexField\": { \"$regularExpression\": {\"pattern\": \"^ABC\", \"options\": \"i\"}}}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"regexField\": {\"pattern\": \"^ABC\", \"options\": \"i\"}}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"minKeyField\": { \"$minKey\": 1}}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"minKeyField\": null}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"maxKeyField\": { \"$maxKey\": 1}}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"maxKeyField\": null}"),
+                Arguments.of(
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"bigDecimalField\": { \"$numberDecimal\": \"123456789.0123456789\"}}",
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"bigDecimalField\": \"123456789.0123456789\"}")
+        );
     }
 }

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/converter/RecordConverterTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/converter/RecordConverterTest.java
@@ -27,10 +27,10 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.opensearch.dataprepper.plugins.mongo.converter.MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP;
 import static org.opensearch.dataprepper.plugins.mongo.converter.MetadataKeyAttributes.INGESTION_EVENT_TYPE_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.mongo.converter.MetadataKeyAttributes.MONGODB_EVENT_COLLECTION_METADATA_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.mongo.converter.MetadataKeyAttributes.MONGODB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.mongo.converter.MetadataKeyAttributes.DOCUMENTDB_EVENT_COLLECTION_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.mongo.converter.MetadataKeyAttributes.DOCUMENTDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.mongo.converter.MetadataKeyAttributes.EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE;
-import static org.opensearch.dataprepper.plugins.mongo.converter.MetadataKeyAttributes.MONGODB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
+import static org.opensearch.dataprepper.plugins.mongo.converter.MetadataKeyAttributes.DOCUMENTDB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.mongo.converter.MetadataKeyAttributes.PARTITION_KEY_METADATA_ATTRIBUTE;
 import static org.opensearch.dataprepper.plugins.mongo.converter.MetadataKeyAttributes.PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE;
 
@@ -67,10 +67,10 @@ class RecordConverterTest {
         assertThat(event.getMetadata().getAttribute(PARTITION_KEY_METADATA_ATTRIBUTE), equalTo(id));
         assertThat(event.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), equalTo(id));
         assertThat(event.getMetadata().getAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE), equalTo(OpenSearchBulkActions.INDEX.toString()));
-        assertThat(event.getMetadata().getAttribute(MONGODB_EVENT_COLLECTION_METADATA_ATTRIBUTE), equalTo(collection));
-        assertThat(event.getMetadata().getAttribute(MONGODB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE), notNullValue());
-        assertThat(event.getMetadata().getAttribute(MONGODB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE), nullValue());
-        assertThat(event.getMetadata().getAttribute(MONGODB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE), equalTo(exportStartTime));
+        assertThat(event.getMetadata().getAttribute(DOCUMENTDB_EVENT_COLLECTION_METADATA_ATTRIBUTE), equalTo(collection));
+        assertThat(event.getMetadata().getAttribute(DOCUMENTDB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE), notNullValue());
+        assertThat(event.getMetadata().getAttribute(DOCUMENTDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE), nullValue());
+        assertThat(event.getMetadata().getAttribute(DOCUMENTDB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE), equalTo(exportStartTime));
         assertThat(event.getMetadata().getAttribute(EVENT_VERSION_FROM_TIMESTAMP), equalTo(eventVersionNumber));
         assertThat(event.getMetadata().getAttribute(INGESTION_EVENT_TYPE_ATTRIBUTE), equalTo(ExportPartition.PARTITION_TYPE));
         assertThat(event.getEventHandle(), notNullValue());
@@ -97,11 +97,11 @@ class RecordConverterTest {
 
         assertThat(event.getMetadata().getAttribute(PARTITION_KEY_METADATA_ATTRIBUTE), equalTo(id));
         assertThat(event.getMetadata().getAttribute(PRIMARY_KEY_DOCUMENT_ID_METADATA_ATTRIBUTE), equalTo(id));
-        assertThat(event.getMetadata().getAttribute(MONGODB_EVENT_COLLECTION_METADATA_ATTRIBUTE), equalTo(collection));
+        assertThat(event.getMetadata().getAttribute(DOCUMENTDB_EVENT_COLLECTION_METADATA_ATTRIBUTE), equalTo(collection));
         assertThat(event.getMetadata().getAttribute(EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE), equalTo(OpenSearchBulkActions.INDEX.toString()));
-        assertThat(event.getMetadata().getAttribute(MONGODB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE), notNullValue());
-        assertThat(event.getMetadata().getAttribute(MONGODB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE), equalTo(eventName));
-        assertThat(event.getMetadata().getAttribute(MONGODB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE), equalTo(exportStartTime));
+        assertThat(event.getMetadata().getAttribute(DOCUMENTDB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE), notNullValue());
+        assertThat(event.getMetadata().getAttribute(DOCUMENTDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE), equalTo(eventName));
+        assertThat(event.getMetadata().getAttribute(DOCUMENTDB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE), equalTo(exportStartTime));
         assertThat(event.getMetadata().getAttribute(EVENT_VERSION_FROM_TIMESTAMP), equalTo(eventVersionNumber));
         assertThat(event.getMetadata().getAttribute(INGESTION_EVENT_TYPE_ATTRIBUTE), equalTo(StreamPartition.PARTITION_TYPE));
 

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/ExportPartitionWorkerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/ExportPartitionWorkerTest.java
@@ -93,11 +93,11 @@ public class ExportPartitionWorkerTest {
 
     @ParameterizedTest
     @CsvSource({
-            "test.collection|0|1|java.lang.Integer",
-            "test.collection|0|1|java.lang.Double",
-            "test.collection|0|1|java.lang.String",
-            "test.collection|0|1|java.lang.Long",
-            "test.collection|000000000000000000000000|000000000000000000000001|org.bson.types.ObjectId"
+            "test.collection|0|1|java.lang.Integer|java.lang.Integer",
+            "test.collection|0|abc|java.lang.Double|java.lang.String",
+            "test.collection|0|1|java.lang.String|java.lang.String",
+            "test.collection|0|000000000000000000000000|java.lang.Long|org.bson.types.ObjectId",
+            "test.collection|000000000000000000000000|000000000000000000000001|org.bson.types.ObjectId|org.bson.types.ObjectId"
     })
     public void testProcessPartitionSuccess(final String partitionKey) {
         when(sourceCoordinator.acquireAvailablePartition(DataQueryPartition.PARTITION_TYPE)).thenReturn(Optional.of(dataQueryPartition));

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/MongoDBExportPartitionSupplierTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/MongoDBExportPartitionSupplierTest.java
@@ -105,8 +105,8 @@ public class MongoDBExportPartitionSupplierTest {
             verify(mongoDatabase).getCollection(eq("collection"));
             // And partitions are created
             assertThat(partitions.size(), is(2));
-            assertThat(partitions.get(0).getPartitionKey(), is("test.collection|0|3999|java.lang.String"));
-            assertThat(partitions.get(1).getPartitionKey(), is("test.collection|4000|4999|java.lang.String"));
+            assertThat(partitions.get(0).getPartitionKey(), is("test.collection|0|3999|java.lang.String|java.lang.String"));
+            assertThat(partitions.get(1).getPartitionKey(), is("test.collection|4000|4999|java.lang.String|java.lang.String"));
         }
     }
 

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
@@ -162,7 +162,7 @@ public class StreamWorkerTest {
         when(s3PartitionStatus.getPartitions()).thenReturn(partitions);
         when(mockPartitionCheckpoint.getGlobalS3FolderCreationStatus(collection)).thenReturn(Optional.of(s3PartitionStatus));
         Event event = mock(Event.class);
-        when(event.get("_id", Object.class)).thenReturn(UUID.randomUUID().toString());
+        //when(event.get("_id", Object.class)).thenReturn(UUID.randomUUID().toString());
         when(mockRecordConverter.convert(anyString(), anyLong(), anyLong(), anyString())).thenReturn(event);
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         final Future<?> future = executorService.submit(() -> {
@@ -273,7 +273,7 @@ public class StreamWorkerTest {
         when(s3PartitionStatus.getPartitions()).thenReturn(partitions);
         when(mockPartitionCheckpoint.getGlobalS3FolderCreationStatus(collection)).thenReturn(Optional.of(s3PartitionStatus));
         Event event = mock(Event.class);
-        when(event.get("_id", Object.class)).thenReturn(UUID.randomUUID().toString());
+        //when(event.get("_id", Object.class)).thenReturn(UUID.randomUUID().toString());
         when(mockRecordConverter.convert(anyString(), anyLong(), anyLong(), anyString())).thenReturn(event);
         try (MockedStatic<MongoDBConnection> mongoDBConnectionMockedStatic = mockStatic(MongoDBConnection.class)) {
 
@@ -376,7 +376,7 @@ public class StreamWorkerTest {
         when(s3PartitionStatus.getPartitions()).thenReturn(partitions);
         when(mockPartitionCheckpoint.getGlobalS3FolderCreationStatus(collection)).thenReturn(Optional.of(s3PartitionStatus));
         Event event = mock(Event.class);
-        when(event.get("_id", Object.class)).thenReturn(UUID.randomUUID().toString());
+        //when(event.get("_id", Object.class)).thenReturn(UUID.randomUUID().toString());
         when(mockRecordConverter.convert(anyString(), anyLong(), anyLong(), anyString())).thenReturn(event);
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(() -> {
@@ -437,7 +437,7 @@ public class StreamWorkerTest {
         when(s3PartitionStatus.getPartitions()).thenReturn(partitions);
         when(mockPartitionCheckpoint.getGlobalS3FolderCreationStatus(collection)).thenReturn(Optional.of(s3PartitionStatus));
         Event event = mock(Event.class);
-        when(event.get("_id", Object.class)).thenReturn(UUID.randomUUID().toString());
+        //when(event.get("_id", Object.class)).thenReturn(UUID.randomUUID().toString());
         when(mockRecordConverter.convert(anyString(), anyLong(), anyLong(), anyString())).thenReturn(event);
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(() -> {


### PR DESCRIPTION
### Description
Add support to export/full load MongoDB/DocumentDB collection with `_id` field of different data type
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
