### PR TITLE
Add bucket owner support to s3 sink

### DIFF
--- a/data-prepper-pipeline-parser/build.gradle
+++ b/data-prepper-pipeline-parser/build.gradle
@@ -25,6 +25,7 @@ dependencies {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation 'software.amazon.cloudwatchlogs:aws-embedded-metrics:2.0.0-beta-1'
+    implementation 'software.amazon.awssdk:arns'
     testImplementation testLibs.bundles.junit
     testImplementation testLibs.bundles.mockito
     testImplementation testLibs.hamcrest

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformer.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformer.java
@@ -22,6 +22,7 @@ import org.opensearch.dataprepper.pipeline.parser.rule.RuleEvaluator;
 import org.opensearch.dataprepper.pipeline.parser.rule.RuleEvaluatorResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.arns.Arn;
 
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
@@ -365,6 +366,10 @@ public class DynamicConfigTransformer implements PipelineConfigurationTransforme
             return envSourceCoordinationIdentifier;
         }
         return s3Prefix+"/"+envSourceCoordinationIdentifier;
+    }
+
+    public String getAccountIdFromRole(final String roleArn) {
+        return Arn.fromString(roleArn).accountId().orElse(null);
     }
 
     /**

--- a/data-prepper-pipeline-parser/src/main/resources/templates/documentdb-template.yaml
+++ b/data-prepper-pipeline-parser/src/main/resources/templates/documentdb-template.yaml
@@ -27,6 +27,7 @@
          path_prefix: "${getMetadata(\"s3_partition_key\")}"
        codec:
          event_json:
+       default_bucket_owner: "<<FUNCTION_NAME:getAccountIdFromRole,PARAMETER:$.<<pipeline-name>>.source.documentdb.aws.sts_role_arn>>"
     - s3:
         routes:
           - stream_load
@@ -46,7 +47,7 @@
           path_prefix: "${getMetadata(\"s3_partition_key\")}"
         codec:
           event_json:
-
+        default_bucket_owner: "<<FUNCTION_NAME:getAccountIdFromRole,PARAMETER:$.<<pipeline-name>>.source.documentdb.aws.sts_role_arn>>"
 "<<pipeline-name>>-s3":
     workers: "<<$.<<pipeline-name>>.workers>>"
     delay: "<<$.<<pipeline-name>>.delay>>"

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkIT.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkIT.java
@@ -168,6 +168,8 @@ public class S3SinkIT {
         when(expressionEvaluator.isValidFormatExpression(anyString())).thenReturn(true);
 
         when(s3SinkConfig.getDefaultBucket()).thenReturn(null);
+        when(s3SinkConfig.getBucketOwners()).thenReturn(null);
+        when(s3SinkConfig.getDefaultBucketOwner()).thenReturn(null);
     }
 
     private S3Sink createObjectUnderTest() {

--- a/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceIT.java
+++ b/data-prepper-plugins/s3-sink/src/integrationTest/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkServiceIT.java
@@ -62,6 +62,7 @@ import org.opensearch.dataprepper.plugins.sink.s3.configuration.ObjectKeyOptions
 import org.opensearch.dataprepper.plugins.sink.s3.configuration.ThresholdOptions;
 import org.opensearch.dataprepper.plugins.sink.s3.grouping.S3GroupIdentifierFactory;
 import org.opensearch.dataprepper.plugins.sink.s3.grouping.S3GroupManager;
+import org.opensearch.dataprepper.plugins.sink.s3.ownership.BucketOwnerProvider;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -139,6 +140,9 @@ class S3SinkServiceIT {
 
     @Mock
     private ExpressionEvaluator expressionEvaluator;
+
+    @Mock
+    private BucketOwnerProvider bucketOwnerProvider;
 
     private OutputCodec codec;
     private KeyGenerator keyGenerator;
@@ -270,7 +274,7 @@ class S3SinkServiceIT {
     private S3SinkService createObjectUnderTest() {
         OutputCodecContext codecContext = new OutputCodecContext("Tag", Collections.emptyList(), Collections.emptyList());
         final S3GroupIdentifierFactory groupIdentifierFactory = new S3GroupIdentifierFactory(keyGenerator, expressionEvaluator, s3SinkConfig);
-        s3GroupManager = new S3GroupManager(s3SinkConfig, groupIdentifierFactory, bufferFactory, codecFactory, s3AsyncClient);
+        s3GroupManager = new S3GroupManager(s3SinkConfig, groupIdentifierFactory, bufferFactory, codecFactory, s3AsyncClient, bucketOwnerProvider);
 
         return new S3SinkService(s3SinkConfig, codecContext, Duration.ofSeconds(5), pluginMetrics, s3GroupManager);
     }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3Sink.java
@@ -31,6 +31,8 @@ import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionEngine;
 import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionOption;
 import org.opensearch.dataprepper.plugins.sink.s3.grouping.S3GroupIdentifierFactory;
 import org.opensearch.dataprepper.plugins.sink.s3.grouping.S3GroupManager;
+import org.opensearch.dataprepper.plugins.sink.s3.ownership.BucketOwnerProvider;
+import org.opensearch.dataprepper.plugins.sink.s3.ownership.ConfigBucketOwnerProviderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -71,6 +73,8 @@ public class S3Sink extends AbstractSink<Record<Event>> {
         this.sinkContext = sinkContext;
         final PluginModel codecConfiguration = s3SinkConfig.getCodec();
         final CodecFactory codecFactory = new CodecFactory(pluginFactory, codecConfiguration);
+        final ConfigBucketOwnerProviderFactory configBucketOwnerProviderFactory = new ConfigBucketOwnerProviderFactory();
+        final BucketOwnerProvider bucketOwnerProvider = configBucketOwnerProviderFactory.createBucketOwnerProvider(s3SinkConfig);
 
         final PluginSetting codecPluginSettings = new PluginSetting(codecConfiguration.getPluginName(),
                 codecConfiguration.getPluginSettings());
@@ -112,7 +116,7 @@ public class S3Sink extends AbstractSink<Record<Event>> {
         testCodec.validateAgainstCodecContext(s3OutputCodecContext);
 
         final S3GroupIdentifierFactory s3GroupIdentifierFactory = new S3GroupIdentifierFactory(keyGenerator, expressionEvaluator, s3SinkConfig);
-        final S3GroupManager s3GroupManager = new S3GroupManager(s3SinkConfig, s3GroupIdentifierFactory, bufferFactory, codecFactory, s3Client);
+        final S3GroupManager s3GroupManager = new S3GroupManager(s3SinkConfig, s3GroupIdentifierFactory, bufferFactory, codecFactory, s3Client, bucketOwnerProvider);
 
 
         s3SinkService = new S3SinkService(s3SinkConfig, s3OutputCodecContext, RETRY_FLUSH_BACKOFF, pluginMetrics, s3GroupManager);

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkConfig.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkConfig.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.opensearch.dataprepper.aws.validator.AwsAccountId;
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferTypeOptions;
 import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionOption;
@@ -17,6 +18,8 @@ import org.opensearch.dataprepper.plugins.sink.s3.configuration.AggregateThresho
 import org.opensearch.dataprepper.plugins.sink.s3.configuration.AwsAuthenticationOptions;
 import org.opensearch.dataprepper.plugins.sink.s3.configuration.ObjectKeyOptions;
 import org.opensearch.dataprepper.plugins.sink.s3.configuration.ThresholdOptions;
+
+import java.util.Map;
 
 /**
  * s3 sink configuration class contains properties, used to read yaml configuration.
@@ -73,6 +76,13 @@ public class S3SinkConfig {
 
     @JsonProperty("max_retries")
     private int maxUploadRetries = DEFAULT_UPLOAD_RETRIES;
+
+    @JsonProperty("bucket_owners")
+    private Map<String, @AwsAccountId String> bucketOwners;
+
+    @JsonProperty("default_bucket_owner")
+    @AwsAccountId
+    private String defaultBucketOwner;
 
     /**
      * Aws Authentication configuration Options.
@@ -154,4 +164,12 @@ public class S3SinkConfig {
     }
 
     public String getDefaultBucket() { return defaultBucket; }
+
+    public Map<String, String> getBucketOwners() {
+        return bucketOwners;
+    }
+
+    public String getDefaultBucketOwner() {
+        return defaultBucketOwner;
+    }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/BufferFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/BufferFactory.java
@@ -5,10 +5,11 @@
 
 package org.opensearch.dataprepper.plugins.sink.s3.accumulator;
 
+import org.opensearch.dataprepper.plugins.sink.s3.ownership.BucketOwnerProvider;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 import java.util.function.Supplier;
 
 public interface BufferFactory {
-    Buffer getBuffer(S3AsyncClient s3Client, Supplier<String> bucketSupplier, Supplier<String> keySupplier, String defaultBucket);
+    Buffer getBuffer(S3AsyncClient s3Client, Supplier<String> bucketSupplier, Supplier<String> keySupplier, String defaultBucket, BucketOwnerProvider bucketOwnerProvider);
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CodecBufferFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CodecBufferFactory.java
@@ -1,6 +1,7 @@
 package org.opensearch.dataprepper.plugins.sink.s3.accumulator;
 
 import org.opensearch.dataprepper.plugins.sink.s3.codec.BufferedCodec;
+import org.opensearch.dataprepper.plugins.sink.s3.ownership.BucketOwnerProvider;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 import java.util.function.Supplier;
@@ -18,8 +19,9 @@ public class CodecBufferFactory implements BufferFactory {
     public Buffer getBuffer(final S3AsyncClient s3Client,
                             final Supplier<String> bucketSupplier,
                             final Supplier<String> keySupplier,
-                            final String defaultBucket) {
-        Buffer innerBuffer = innerBufferFactory.getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket);
+                            final String defaultBucket,
+                            final BucketOwnerProvider bucketOwnerProvider) {
+        Buffer innerBuffer = innerBufferFactory.getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket, bucketOwnerProvider);
         return new CodecBuffer(innerBuffer, bufferedCodec);
     }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CompressionBufferFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CompressionBufferFactory.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.sink.s3.accumulator;
 
 import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionEngine;
+import org.opensearch.dataprepper.plugins.sink.s3.ownership.BucketOwnerProvider;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 import java.util.Objects;
@@ -17,7 +18,9 @@ public class CompressionBufferFactory implements BufferFactory {
     private final CompressionEngine compressionEngine;
     private final boolean compressionInternal;
 
-    public CompressionBufferFactory(final BufferFactory innerBufferFactory, final CompressionEngine compressionEngine, final OutputCodec codec) {
+    public CompressionBufferFactory(final BufferFactory innerBufferFactory,
+                                    final CompressionEngine compressionEngine,
+                                    final OutputCodec codec) {
         this.innerBufferFactory = Objects.requireNonNull(innerBufferFactory);
         this.compressionEngine = Objects.requireNonNull(compressionEngine);
         compressionInternal = Objects.requireNonNull(codec).isCompressionInternal();
@@ -27,8 +30,9 @@ public class CompressionBufferFactory implements BufferFactory {
     public Buffer getBuffer(final S3AsyncClient s3Client,
                             final Supplier<String> bucketSupplier,
                             final Supplier<String> keySupplier,
-                            final String defaultBucket) {
-        final Buffer internalBuffer = innerBufferFactory.getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket);
+                            final String defaultBucket,
+                            final BucketOwnerProvider bucketOwnerProvider) {
+        final Buffer internalBuffer = innerBufferFactory.getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket, bucketOwnerProvider);
         if(compressionInternal)
             return internalBuffer;
 

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/InMemoryBufferFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/InMemoryBufferFactory.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.sink.s3.accumulator;
 
+import org.opensearch.dataprepper.plugins.sink.s3.ownership.BucketOwnerProvider;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 import java.util.function.Supplier;
@@ -14,7 +15,8 @@ public class InMemoryBufferFactory implements BufferFactory {
     public Buffer getBuffer(final S3AsyncClient s3Client,
                             final Supplier<String> bucketSupplier,
                             final Supplier<String> keySupplier,
-                            final String defaultBucket) {
-        return new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket);
+                            final String defaultBucket,
+                            final BucketOwnerProvider bucketOwnerProvider) {
+        return new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket, bucketOwnerProvider);
     }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/LocalFileBufferFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/LocalFileBufferFactory.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.sink.s3.accumulator;
 
+import org.opensearch.dataprepper.plugins.sink.s3.ownership.BucketOwnerProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -23,12 +24,13 @@ public class LocalFileBufferFactory implements BufferFactory {
     public Buffer getBuffer(final S3AsyncClient s3Client,
                             final Supplier<String> bucketSupplier,
                             final Supplier<String> keySupplier,
-                            final String defaultBucket) {
+                            final String defaultBucket,
+                            final BucketOwnerProvider bucketOwnerProvider) {
         File tempFile = null;
         Buffer localfileBuffer = null;
         try {
             tempFile = File.createTempFile(PREFIX, SUFFIX);
-            localfileBuffer = new LocalFileBuffer(tempFile, s3Client, bucketSupplier, keySupplier, defaultBucket);
+            localfileBuffer = new LocalFileBuffer(tempFile, s3Client, bucketSupplier, keySupplier, defaultBucket, bucketOwnerProvider);
         } catch (IOException e) {
             LOG.error("Unable to create temp file ", e);
         }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/MultipartBufferFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/MultipartBufferFactory.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.sink.s3.accumulator;
 
 import org.opensearch.dataprepper.plugins.codec.parquet.S3OutputStream;
+import org.opensearch.dataprepper.plugins.sink.s3.ownership.BucketOwnerProvider;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 import java.util.function.Supplier;
@@ -15,7 +16,8 @@ public class MultipartBufferFactory implements BufferFactory {
     public Buffer getBuffer(final S3AsyncClient s3Client,
                             final Supplier<String> bucketSupplier,
                             final Supplier<String> keySupplier,
-                            final String defaultBucket) {
-        return new MultipartBuffer(new S3OutputStream(s3Client, bucketSupplier, keySupplier, defaultBucket));
+                            final String defaultBucket,
+                            final BucketOwnerProvider bucketOwnerProvider) {
+        return new MultipartBuffer(new S3OutputStream(s3Client, bucketSupplier, keySupplier, defaultBucket, bucketOwnerProvider));
     }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/BucketOwnerProvider.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/BucketOwnerProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3.ownership;
+
+import java.util.Optional;
+
+/**
+ * Gets the expected owner of an S3 bucket.
+ */
+@FunctionalInterface
+public interface BucketOwnerProvider {
+    /**
+     * Gets the accountId of the owner bucket. Returns an empty optional
+     * if no account owner is known.
+     * @param bucket the name of the bucket
+     * @return The accountId or empty
+     */
+    Optional<String> getBucketOwner(final String bucket);
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/ConfigBucketOwnerProviderFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/ConfigBucketOwnerProviderFactory.java
@@ -54,6 +54,6 @@ public class ConfigBucketOwnerProviderFactory {
             return roleArn.accountId().get();
         }
 
-        return null;
+        throw new RuntimeException(String.format("Unable to extract account id from sts_role_arn %s", s3SinkConfig.getAwsAuthenticationOptions().getAwsStsRoleArn()));
     }
 }

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/ConfigBucketOwnerProviderFactory.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/ConfigBucketOwnerProviderFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3.ownership;
+
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
+import org.opensearch.dataprepper.plugins.sink.s3.S3SinkConfig;
+import software.amazon.awssdk.arns.Arn;
+
+/**
+ * Produces a {@link BucketOwnerProvider} from the S3 sink configuration as
+ * provided in a {@link S3SinkConfig}.
+ */
+public class ConfigBucketOwnerProviderFactory {
+    /**
+     * Creates the {@link BucketOwnerProvider}
+     * @param s3SinkConfig The input {@link S3SinkConfig}
+     * @return The {@link BucketOwnerProvider}
+     */
+    public BucketOwnerProvider createBucketOwnerProvider(final S3SinkConfig s3SinkConfig) {
+        if (s3SinkConfig.getDefaultBucketOwner() == null && s3SinkConfig.getBucketOwners() == null) {
+            return new NoOwnershipBucketOwnerProvider();
+        }
+
+        final StaticBucketOwnerProvider staticBucketOwnerProvider = getStaticBucketOwnerProvider(s3SinkConfig);
+
+        if(s3SinkConfig.getBucketOwners() != null && !s3SinkConfig.getBucketOwners().isEmpty()) {
+            return new MappedBucketOwnerProvider(s3SinkConfig.getBucketOwners(), staticBucketOwnerProvider);
+        } else {
+            return staticBucketOwnerProvider;
+        }
+    }
+
+    private StaticBucketOwnerProvider getStaticBucketOwnerProvider(final S3SinkConfig s3SinkConfig) {
+        final String accountId;
+
+        if(s3SinkConfig.getDefaultBucketOwner() != null)
+            accountId = s3SinkConfig.getDefaultBucketOwner();
+        else if(s3SinkConfig.getAwsAuthenticationOptions() != null && s3SinkConfig.getAwsAuthenticationOptions().getAwsStsRoleArn() != null)
+            accountId = extractStsRoleArnAccountId(s3SinkConfig);
+        else
+            throw new InvalidPluginConfigurationException(
+                    "The S3 sink is unable to determine a bucket owner. Configure the default_bucket_owner for the account Id that owns the bucket. You may also want to configure bucket_owners if you write to S3 buckets in different accounts.");
+
+        return new StaticBucketOwnerProvider(accountId);
+    }
+
+    private String extractStsRoleArnAccountId(final S3SinkConfig s3SinkConfig) {
+        final Arn roleArn = Arn.fromString(s3SinkConfig.getAwsAuthenticationOptions().getAwsStsRoleArn());
+
+        if (roleArn.accountId().isPresent()) {
+            return roleArn.accountId().get();
+        }
+
+        return null;
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/MappedBucketOwnerProvider.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/MappedBucketOwnerProvider.java
@@ -1,0 +1,31 @@
+package org.opensearch.dataprepper.plugins.sink.s3.ownership;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Implements {@link BucketOwnerProvider} using a mapping of bucket
+ * names to account Ids for the bucket owners. Uses a delegate
+ * {@link BucketOwnerProvider} as a fallback when the bucket is not
+ * found in the map.
+ */
+class MappedBucketOwnerProvider implements BucketOwnerProvider {
+    private final Map<String, String> bucketOwnershipMap;
+    private final BucketOwnerProvider fallbackProvider;
+
+    MappedBucketOwnerProvider(Map<String, String> bucketOwnershipMap, BucketOwnerProvider fallbackProvider) {
+        this.bucketOwnershipMap = new HashMap<>(Objects.requireNonNull(bucketOwnershipMap));
+        this.fallbackProvider = Objects.requireNonNull(fallbackProvider);
+    }
+
+    @Override
+    public Optional<String> getBucketOwner(String bucket) {
+        String account = bucketOwnershipMap.get(bucket);
+        if(account != null) {
+            return Optional.of(account);
+        }
+        return fallbackProvider.getBucketOwner(bucket);
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/NoOwnershipBucketOwnerProvider.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/NoOwnershipBucketOwnerProvider.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3.ownership;
+
+import java.util.Optional;
+
+/**
+ * An implementation of {@link BucketOwnerProvider} which does not provide
+ * a bucket owner, effectively skipping owner validation.
+ */
+class NoOwnershipBucketOwnerProvider implements BucketOwnerProvider {
+    @Override
+    public Optional<String> getBucketOwner(final String bucket) {
+        return Optional.empty();
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/StaticBucketOwnerProvider.java
+++ b/data-prepper-plugins/s3-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/StaticBucketOwnerProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3.ownership;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * An implementation of {@link BucketOwnerProvider} which provides the
+ * same owner for all buckets.
+ */
+class StaticBucketOwnerProvider implements BucketOwnerProvider {
+    private final String accountId;
+
+    public StaticBucketOwnerProvider(final String accountId) {
+        this.accountId = Objects.requireNonNull(accountId);
+    }
+
+    @Override
+    public Optional<String> getBucketOwner(final String bucket) {
+        return Optional.of(accountId);
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/codec/parquet/S3OutputStreamTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/codec/parquet/S3OutputStreamTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.sink.s3.ownership.BucketOwnerProvider;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
@@ -50,6 +51,9 @@ public class S3OutputStreamTest {
     @Mock
     private Consumer<Throwable> runOnError;
 
+    @Mock
+    private BucketOwnerProvider bucketOwnerProvider;
+
     private String bucket;
 
     private String defaultBucket;
@@ -64,7 +68,7 @@ public class S3OutputStreamTest {
     }
 
     private S3OutputStream createObjectUnderTest() {
-        return new S3OutputStream(s3Client, () -> bucket, () -> objectKey, defaultBucket);
+        return new S3OutputStream(s3Client, () -> bucket, () -> objectKey, defaultBucket, bucketOwnerProvider);
     }
 
     @Test

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/S3SinkTest.java
@@ -99,6 +99,7 @@ class S3SinkTest {
         when(objectKeyOptions.getNamePattern()).thenReturn(UUID.randomUUID().toString());
         when(s3SinkConfig.getObjectKeyOptions()).thenReturn(objectKeyOptions);
         when(expressionEvaluator.isValidFormatExpression(anyString())).thenReturn(true);
+        when(s3SinkConfig.getDefaultBucketOwner()).thenReturn(UUID.randomUUID().toString());
     }
 
     private S3Sink createObjectUnderTest() {

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CompressionBufferFactoryTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/CompressionBufferFactoryTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.plugins.sink.s3.compression.CompressionEngine;
+import org.opensearch.dataprepper.plugins.sink.s3.ownership.BucketOwnerProvider;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 import java.util.UUID;
@@ -44,6 +45,9 @@ class CompressionBufferFactoryTest {
 
     @Mock
     private Supplier<String> keySupplier;
+
+    @Mock
+    private BucketOwnerProvider bucketOwnerProvider;
 
     @Mock
     private OutputCodec codec;
@@ -87,21 +91,21 @@ class CompressionBufferFactoryTest {
 
         @BeforeEach
         void setUp() {
-            when(innerBufferFactory.getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket)).thenReturn(innerBuffer);
+            when(innerBufferFactory.getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket, bucketOwnerProvider)).thenReturn(innerBuffer);
         }
 
         @Test
         void getBuffer_returns_CompressionBuffer() {
-            final Buffer buffer = createObjectUnderTest().getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket);
+            final Buffer buffer = createObjectUnderTest().getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket, bucketOwnerProvider);
             assertThat(buffer, instanceOf(CompressionBuffer.class));
         }
 
         @Test
         void getBuffer_returns_new_on_each_call() {
             final CompressionBufferFactory objectUnderTest = createObjectUnderTest();
-            final Buffer firstBuffer = objectUnderTest.getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket);
+            final Buffer firstBuffer = objectUnderTest.getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket, bucketOwnerProvider);
 
-            assertThat(objectUnderTest.getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket), not(equalTo(firstBuffer)));
+            assertThat(objectUnderTest.getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket, bucketOwnerProvider), not(equalTo(firstBuffer)));
         }
 
         @Nested
@@ -113,17 +117,17 @@ class CompressionBufferFactoryTest {
 
             @Test
             void getBuffer_returns_innerBuffer_directly() {
-                final Buffer buffer = createObjectUnderTest().getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket);
+                final Buffer buffer = createObjectUnderTest().getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket, bucketOwnerProvider);
                 assertThat(buffer, sameInstance(innerBuffer));
             }
 
             @Test
             void getBuffer_calls_on_each_call() {
                 final CompressionBufferFactory objectUnderTest = createObjectUnderTest();
-                objectUnderTest.getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket);
-                objectUnderTest.getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket);
+                objectUnderTest.getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket, bucketOwnerProvider);
+                objectUnderTest.getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket, bucketOwnerProvider);
 
-                verify(innerBufferFactory, times(2)).getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket);
+                verify(innerBufferFactory, times(2)).getBuffer(s3Client, bucketSupplier, keySupplier, defaultBucket, bucketOwnerProvider);
             }
         }
     }

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/InMemoryBufferFactoryTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/InMemoryBufferFactoryTest.java
@@ -22,7 +22,7 @@ class InMemoryBufferFactoryTest {
     void test_buffer_notNull(){
         InMemoryBufferFactory inMemoryBufferFactory = new InMemoryBufferFactory();
         Assertions.assertNotNull(inMemoryBufferFactory);
-        Buffer buffer = inMemoryBufferFactory.getBuffer(null, null, null, null);
+        Buffer buffer = inMemoryBufferFactory.getBuffer(null, null, null, null, null);
         Assertions.assertNotNull(buffer);
         assertThat(buffer, instanceOf(Buffer.class));
     }

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/InMemoryBufferTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/InMemoryBufferTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.plugins.sink.s3.ownership.BucketOwnerProvider;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
@@ -57,11 +58,14 @@ class InMemoryBufferTest {
     @Mock
     private Consumer<Throwable> mockRunOnFailure;
 
+    @Mock
+    private BucketOwnerProvider bucketOwnerProvider;
+
     private InMemoryBuffer inMemoryBuffer;
 
     @Test
     void test_with_write_event_into_buffer() throws IOException {
-        inMemoryBuffer = new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, null);
+        inMemoryBuffer = new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, null, bucketOwnerProvider);
 
         while (inMemoryBuffer.getEventCount() < MAX_EVENTS) {
             OutputStream outputStream = inMemoryBuffer.getOutputStream();
@@ -89,7 +93,7 @@ class InMemoryBufferTest {
      */
     void getDuration_provides_duration_within_expected_range() throws IOException, InterruptedException {
         Instant startTime = Instant.now();
-        inMemoryBuffer = new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, null);
+        inMemoryBuffer = new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, null, bucketOwnerProvider);
         Instant endTime = Instant.now();
 
 
@@ -118,7 +122,7 @@ class InMemoryBufferTest {
         when(keySupplier.get()).thenReturn(key);
         when(bucketSupplier.get()).thenReturn(bucket);
 
-        inMemoryBuffer = new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, null);
+        inMemoryBuffer = new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, null, bucketOwnerProvider);
         Assertions.assertNotNull(inMemoryBuffer);
 
         final CompletableFuture<PutObjectResponse> expectedFuture = mock(CompletableFuture.class);
@@ -126,7 +130,7 @@ class InMemoryBufferTest {
         try (final MockedStatic<BufferUtilities> bufferUtilitiesMockedStatic = mockStatic(BufferUtilities.class)) {
             bufferUtilitiesMockedStatic.when(() ->
                             BufferUtilities.putObjectOrSendToDefaultBucket(eq(s3Client), any(AsyncRequestBody.class),
-                                    eq(mockRunOnCompletion), eq(mockRunOnFailure), eq(key), eq(bucket), eq(null)))
+                                    eq(mockRunOnCompletion), eq(mockRunOnFailure), eq(key), eq(bucket), eq(null), eq(bucketOwnerProvider)))
                             .thenReturn(expectedFuture);
 
             final Optional<CompletableFuture<?>> result = inMemoryBuffer.flushToS3(mockRunOnCompletion, mockRunOnFailure);
@@ -139,14 +143,14 @@ class InMemoryBufferTest {
 
     @Test
     void getOutputStream_is_PositionOutputStream() {
-        inMemoryBuffer = new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, null);
+        inMemoryBuffer = new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, null, bucketOwnerProvider);
 
         assertThat(inMemoryBuffer.getOutputStream(), instanceOf(PositionOutputStream.class));
     }
 
     @Test
     void getOutputStream_getPos_equals_written_size() throws IOException {
-        inMemoryBuffer = new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, null);
+        inMemoryBuffer = new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, null, bucketOwnerProvider);
 
         while (inMemoryBuffer.getEventCount() < MAX_EVENTS) {
             OutputStream outputStream = inMemoryBuffer.getOutputStream();
@@ -163,7 +167,7 @@ class InMemoryBufferTest {
 
     @Test
     void getSize_across_multiple_in_sequence() throws IOException {
-        inMemoryBuffer = new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, null);
+        inMemoryBuffer = new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, null, bucketOwnerProvider);
 
         while (inMemoryBuffer.getEventCount() < MAX_EVENTS) {
             OutputStream outputStream = inMemoryBuffer.getOutputStream();
@@ -173,7 +177,7 @@ class InMemoryBufferTest {
         }
         assertThat(inMemoryBuffer.getSize(), equalTo((long) MAX_EVENTS * 1000));
 
-        inMemoryBuffer = new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, null);
+        inMemoryBuffer = new InMemoryBuffer(s3Client, bucketSupplier, keySupplier, null, bucketOwnerProvider);
         assertThat(inMemoryBuffer.getSize(), equalTo(0L));
 
         while (inMemoryBuffer.getEventCount() < MAX_EVENTS) {

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/LocalFileBufferFactoryTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/accumulator/LocalFileBufferFactoryTest.java
@@ -21,7 +21,7 @@ class LocalFileBufferFactoryTest {
     void test_buffer_notNull() {
         LocalFileBufferFactory localFileBufferFactory = new LocalFileBufferFactory();
         Assertions.assertNotNull(localFileBufferFactory);
-        Buffer buffer = localFileBufferFactory.getBuffer(null, null, null, null);
+        Buffer buffer = localFileBufferFactory.getBuffer(null, null, null, null, null);
         Assertions.assertNotNull(buffer);
         assertThat(buffer, instanceOf(LocalFileBuffer.class));
     }

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManagerTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/grouping/S3GroupManagerTest.java
@@ -15,6 +15,7 @@ import org.opensearch.dataprepper.plugins.sink.s3.S3SinkConfig;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.Buffer;
 import org.opensearch.dataprepper.plugins.sink.s3.accumulator.BufferFactory;
 import org.opensearch.dataprepper.plugins.sink.s3.codec.CodecFactory;
+import org.opensearch.dataprepper.plugins.sink.s3.ownership.BucketOwnerProvider;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 import java.util.Collection;
@@ -50,8 +51,11 @@ public class S3GroupManagerTest {
     @Mock
     private S3AsyncClient s3Client;
 
+    @Mock
+    private BucketOwnerProvider bucketOwnerProvider;
+
     private S3GroupManager createObjectUnderTest() {
-        return new S3GroupManager(s3SinkConfig, s3GroupIdentifierFactory, bufferFactory, codecFactory, s3Client);
+        return new S3GroupManager(s3SinkConfig, s3GroupIdentifierFactory, bufferFactory, codecFactory, s3Client, bucketOwnerProvider);
     }
 
     @Test
@@ -70,7 +74,7 @@ public class S3GroupManagerTest {
         when(s3SinkConfig.getDefaultBucket()).thenReturn(defaultBucket);
 
         final Buffer buffer = mock(Buffer.class);
-        when(bufferFactory.getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class), eq(defaultBucket)))
+        when(bufferFactory.getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class), eq(defaultBucket), eq(bucketOwnerProvider)))
                 .thenAnswer(invocation -> {
                     Supplier<String> bucketSupplier = invocation.getArgument(1);
                     Supplier<String> objectKeySupplier = invocation.getArgument(2);
@@ -112,7 +116,7 @@ public class S3GroupManagerTest {
 
         final Buffer buffer = mock(Buffer.class);
         final OutputCodec outputCodec = mock(OutputCodec.class);
-        when(bufferFactory.getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class), eq(defaultBucket)))
+        when(bufferFactory.getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class), eq(defaultBucket), eq(bucketOwnerProvider)))
                 .thenReturn(buffer);
         when(codecFactory.provideCodec()).thenReturn(outputCodec);
 
@@ -133,7 +137,7 @@ public class S3GroupManagerTest {
         assertThat(secondResult.getS3GroupIdentifier(), equalTo(s3GroupIdentifier));
         assertThat(secondResult.getBuffer(), equalTo(buffer));
 
-        verify(bufferFactory, times(1)).getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class), eq(defaultBucket));
+        verify(bufferFactory, times(1)).getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class), eq(defaultBucket), eq(bucketOwnerProvider));
 
         final Collection<S3Group> groups = objectUnderTest.getS3GroupEntries();
         assertThat(groups, notNullValue());
@@ -173,7 +177,7 @@ public class S3GroupManagerTest {
         final Buffer thirdBuffer = mock(Buffer.class);
         when(thirdBuffer.getSize()).thenReturn(bufferSizeBase * 3);
 
-        when(bufferFactory.getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class), eq(defaultBucket)))
+        when(bufferFactory.getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class), eq(defaultBucket), eq(bucketOwnerProvider)))
                 .thenReturn(buffer).thenReturn(secondBuffer).thenReturn(thirdBuffer);
 
         final OutputCodec outputCodec = mock(OutputCodec.class);
@@ -219,7 +223,7 @@ public class S3GroupManagerTest {
         final Buffer thirdBuffer = mock(Buffer.class);
         when(thirdBuffer.getSize()).thenReturn(bufferSizeBase * 3);
 
-        when(bufferFactory.getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class), eq(defaultBucket)))
+        when(bufferFactory.getBuffer(eq(s3Client), any(Supplier.class), any(Supplier.class), eq(defaultBucket), eq(bucketOwnerProvider)))
                 .thenReturn(buffer).thenReturn(secondBuffer).thenReturn(thirdBuffer);
 
         final OutputCodec firstOutputCodec = mock(OutputCodec.class);

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/ConfigBucketOwnerProviderFactoryTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/ConfigBucketOwnerProviderFactoryTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3.ownership;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.plugin.InvalidPluginConfigurationException;
+import org.opensearch.dataprepper.plugins.sink.s3.S3SinkConfig;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigBucketOwnerProviderFactoryTest {
+
+    @Mock
+    private S3SinkConfig s3SinkConfig;
+    private String accountId;
+
+    @BeforeEach
+    void setUp() {
+        accountId = RandomStringUtils.randomNumeric(12);
+    }
+
+    private ConfigBucketOwnerProviderFactory createObjectUnderTest() {
+        return new ConfigBucketOwnerProviderFactory();
+    }
+
+    @Test
+    void createBucketOwnerProvider_returns_NoOwnershipBucketOwnerProvider_when_bucketOwners_not_provided() {
+        when(s3SinkConfig.getDefaultBucketOwner()).thenReturn(null);
+        when(s3SinkConfig.getBucketOwners()).thenReturn(null);
+
+        final BucketOwnerProvider bucketOwnerProvider = createObjectUnderTest().createBucketOwnerProvider(s3SinkConfig);
+
+        assertThat(bucketOwnerProvider, instanceOf(NoOwnershipBucketOwnerProvider.class));
+    }
+
+    @Test
+    void createBucketOwnerProvider_returns_ownership_using_default_when_no_bucket_mapping() {
+        when(s3SinkConfig.getDefaultBucketOwner()).thenReturn(accountId);
+
+        BucketOwnerProvider bucketOwnerProvider = createObjectUnderTest().createBucketOwnerProvider(s3SinkConfig);
+
+        assertThat(bucketOwnerProvider, notNullValue());
+
+        final String bucket = UUID.randomUUID().toString();
+        final Optional<String> optionalOwner = bucketOwnerProvider.getBucketOwner(bucket);
+
+        assertThat(optionalOwner, notNullValue());
+        assertThat(optionalOwner.isPresent(), equalTo(true));
+        assertThat(optionalOwner.get(), equalTo(accountId));
+    }
+
+    @Test
+    void createBucketOwnerProvider_returns_ownership_using_default_when_bucket_mapping_does_not_match() {
+        when(s3SinkConfig.getBucketOwners()).thenReturn(Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+        when(s3SinkConfig.getDefaultBucketOwner()).thenReturn(accountId);
+
+        BucketOwnerProvider bucketOwnerProvider = createObjectUnderTest().createBucketOwnerProvider(s3SinkConfig);
+
+        assertThat(bucketOwnerProvider, notNullValue());
+
+        final String bucket = UUID.randomUUID().toString();
+        final Optional<String> optionalOwner = bucketOwnerProvider.getBucketOwner(bucket);
+
+        assertThat(optionalOwner, notNullValue());
+        assertThat(optionalOwner.isPresent(), equalTo(true));
+        assertThat(optionalOwner.get(), equalTo(accountId));
+    }
+
+    @Test
+    void createBucketOwnerProvider_throws_exception_when_ownership_cannot_be_determined() {
+        final ConfigBucketOwnerProviderFactory objectUnderTest = createObjectUnderTest();
+        final InvalidPluginConfigurationException actualException = assertThrows(InvalidPluginConfigurationException.class, () -> objectUnderTest.createBucketOwnerProvider(s3SinkConfig));
+
+        assertThat(actualException.getMessage(), containsString("default_bucket_owner"));
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/MappedBucketOwnerProviderTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/MappedBucketOwnerProviderTest.java
@@ -1,0 +1,120 @@
+package org.opensearch.dataprepper.plugins.sink.s3.ownership;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MappedBucketOwnerProviderTest {
+    private Map<String, String> bucketOwnershipMap;
+    @Mock
+    private BucketOwnerProvider fallbackProvider;
+
+    private MappedBucketOwnerProvider createObjectUnderTest() {
+        return new MappedBucketOwnerProvider(bucketOwnershipMap, fallbackProvider);
+    }
+
+    @Test
+    void constructor_throws_with_null_ownership_map() {
+        bucketOwnershipMap = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void constructor_throws_with_null_fallback() {
+        bucketOwnershipMap = Collections.emptyMap();
+        fallbackProvider = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Nested
+    class WithEmptyOwnersMap {
+        private String bucket;
+        @BeforeEach
+        void setUp() {
+            bucketOwnershipMap = Collections.emptyMap();
+            bucket = UUID.randomUUID().toString();
+        }
+
+        @Test
+        void getBucketOwner_returns_owner_from_fallback_when_not_in_map() {
+            String fallbackAccount = UUID.randomUUID().toString();
+            when(fallbackProvider.getBucketOwner(bucket)).thenReturn(Optional.of(fallbackAccount));
+
+            Optional<String> optionalOwner = createObjectUnderTest().getBucketOwner(bucket);
+            assertThat(optionalOwner, notNullValue());
+            assertThat(optionalOwner.isPresent(), equalTo(true));
+            assertThat(optionalOwner.get(), equalTo(fallbackAccount));
+        }
+
+        @Test
+        void getBucketOwner_returns_empty_when_not_in_map_nor_in_fallback() {
+            when(fallbackProvider.getBucketOwner(bucket)).thenReturn(Optional.empty());
+
+            Optional<String> optionalOwner = createObjectUnderTest().getBucketOwner(bucket);
+            assertThat(optionalOwner, notNullValue());
+            assertThat(optionalOwner.isPresent(), equalTo(false));
+        }
+    }
+
+    @Nested
+    class WithOwnersMap {
+        private String knownBucket;
+        private String knownBucketAccount;
+
+        @BeforeEach
+        void setUp() {
+            knownBucket = UUID.randomUUID().toString();
+            knownBucketAccount = UUID.randomUUID().toString();
+            bucketOwnershipMap = Map.of(
+                    UUID.randomUUID().toString(), UUID.randomUUID().toString(),
+                    UUID.randomUUID().toString(), UUID.randomUUID().toString(),
+                    knownBucket, knownBucketAccount,
+                    UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        }
+
+        @Test
+        void getBucketOwner_returns_owner_from_map_when_found() {
+            Optional<String> optionalOwner = createObjectUnderTest().getBucketOwner(knownBucket);
+            assertThat(optionalOwner, notNullValue());
+            assertThat(optionalOwner.isPresent(), equalTo(true));
+            assertThat(optionalOwner.get(), equalTo(knownBucketAccount));
+        }
+
+        @Test
+        void getBucketOwner_returns_owner_from_fallback_when_not_in_map() {
+            String otherBucket = UUID.randomUUID().toString();
+            String fallbackAccount = UUID.randomUUID().toString();
+            when(fallbackProvider.getBucketOwner(otherBucket)).thenReturn(Optional.of(fallbackAccount));
+
+            Optional<String> optionalOwner = createObjectUnderTest().getBucketOwner(otherBucket);
+            assertThat(optionalOwner, notNullValue());
+            assertThat(optionalOwner.isPresent(), equalTo(true));
+            assertThat(optionalOwner.get(), equalTo(fallbackAccount));
+        }
+
+        @Test
+        void getBucketOwner_returns_empty_when_not_in_map_nor_in_fallback() {
+            String otherBucket = UUID.randomUUID().toString();
+            when(fallbackProvider.getBucketOwner(otherBucket)).thenReturn(Optional.empty());
+
+            Optional<String> optionalOwner = createObjectUnderTest().getBucketOwner(otherBucket);
+            assertThat(optionalOwner, notNullValue());
+            assertThat(optionalOwner.isPresent(), equalTo(false));
+        }
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/NoOwnershipBucketOwnerProviderTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/NoOwnershipBucketOwnerProviderTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3.ownership;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class NoOwnershipBucketOwnerProviderTest {
+    private NoOwnershipBucketOwnerProvider createObjectUnderTest() {
+        return new NoOwnershipBucketOwnerProvider();
+    }
+
+    @Test
+    void getBucketOwner_returns_empty() {
+        final Optional<String> optionalOwner = createObjectUnderTest().getBucketOwner(UUID.randomUUID().toString());
+
+        assertThat(optionalOwner, notNullValue());
+        assertThat(optionalOwner.isPresent(), equalTo(false));
+    }
+}

--- a/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/StaticBucketOwnerProviderTest.java
+++ b/data-prepper-plugins/s3-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/s3/ownership/StaticBucketOwnerProviderTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.s3.ownership;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class StaticBucketOwnerProviderTest {
+    private String accountId;
+
+    @BeforeEach
+    void setUp() {
+        accountId = UUID.randomUUID().toString();
+    }
+
+    private StaticBucketOwnerProvider createObjectUnderTest() {
+        return new StaticBucketOwnerProvider(accountId);
+    }
+
+    @Test
+    void constructor_throws_with_null() {
+        accountId = null;
+        assertThrows(NullPointerException.class, this::createObjectUnderTest);
+    }
+
+    @Test
+    void getBucketOwner_returns_the_predefined_accountId() {
+        final Optional<String> optionalOwner = createObjectUnderTest().getBucketOwner(UUID.randomUUID().toString());
+
+        assertThat(optionalOwner, notNullValue());
+        assertThat(optionalOwner.isPresent(), equalTo(true));
+        assertThat(optionalOwner.get(), equalTo(accountId));
+    }
+}


### PR DESCRIPTION
### Description
Similar to the S3 source, the S3 sink now has `default_bucket_owner` and `bucket_owners` map to be passed to the `expectedBucketOwner` of the S3 sink requests. This is to prevent sending to this bucket if the owner of the bucket changes.
 
### Issues Resolved
Resolves #4468 
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
