### PR TITLE
MAINT: inject external origination timestamp

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -429,6 +429,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         eventMetadata.setAttribute("kafka_topic", topicName);
         eventMetadata.setAttribute("kafka_partition", String.valueOf(partition));
         eventMetadata.setExternalOriginationTime(Instant.ofEpochMilli(consumerRecord.timestamp()));
+        event.getEventHandle().setExternalOriginationTime(Instant.ofEpochMilli(consumerRecord.timestamp()));
 
         return new Record<Event>(event);
     }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -428,6 +428,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
         }
         eventMetadata.setAttribute("kafka_topic", topicName);
         eventMetadata.setAttribute("kafka_partition", String.valueOf(partition));
+        eventMetadata.setExternalOriginationTime(Instant.ofEpochMilli(consumerRecord.timestamp()));
 
         return new Record<Event>(event);
     }

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
@@ -245,6 +245,7 @@ public class KafkaCustomConsumerTest {
                 Assertions.assertEquals(value2, testValue2);
             }
             Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
+            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
         }
     }
     @Test
@@ -283,6 +284,7 @@ public class KafkaCustomConsumerTest {
                 Assertions.assertEquals(value2, testValue2);
             }
             Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
+            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
         }
     }
 
@@ -315,6 +317,7 @@ public class KafkaCustomConsumerTest {
                 Assertions.assertEquals(value2, testValue2);
             }
             Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
+            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
             event.getEventHandle().release(true);
         }
         // Wait for acknowledgement callback function to run
@@ -364,6 +367,7 @@ public class KafkaCustomConsumerTest {
                 Assertions.assertEquals(value2, testValue2);
             }
             Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
+            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
             event.getEventHandle().release(false);
         }
         // Wait for acknowledgement callback function to run
@@ -411,6 +415,7 @@ public class KafkaCustomConsumerTest {
                 testMap2.forEach((k, v) -> assertThat(eventMap, hasEntry(k,v)));
             }
             Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
+            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
         }
     }
 
@@ -465,6 +470,7 @@ public class KafkaCustomConsumerTest {
                 testMap2.forEach((k, v) -> assertThat(eventMap, hasEntry(k,v)));
             }
             Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
+            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
             event.getEventHandle().release(true);
         }
         // Wait for acknowledgement callback function to run
@@ -533,6 +539,7 @@ public class KafkaCustomConsumerTest {
                 testMap2.forEach((k, v) -> assertThat(eventMap, hasEntry(k,v)));
             }
             Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
+            Assertions.assertNotNull(event.getEventHandle().getExternalOriginationTime());
             event.getEventHandle().release(true);
         }
         // Wait for acknowledgement callback function to run

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerTest.java
@@ -244,6 +244,7 @@ public class KafkaCustomConsumerTest {
             if (value2 != null) {
                 Assertions.assertEquals(value2, testValue2);
             }
+            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
         }
     }
     @Test
@@ -281,6 +282,7 @@ public class KafkaCustomConsumerTest {
             if (value2 != null) {
                 Assertions.assertEquals(value2, testValue2);
             }
+            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
         }
     }
 
@@ -312,6 +314,7 @@ public class KafkaCustomConsumerTest {
             if (value2 != null) {
                 Assertions.assertEquals(value2, testValue2);
             }
+            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
             event.getEventHandle().release(true);
         }
         // Wait for acknowledgement callback function to run
@@ -360,6 +363,7 @@ public class KafkaCustomConsumerTest {
             if (value2 != null) {
                 Assertions.assertEquals(value2, testValue2);
             }
+            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
             event.getEventHandle().release(false);
         }
         // Wait for acknowledgement callback function to run
@@ -406,6 +410,7 @@ public class KafkaCustomConsumerTest {
             if (kafkaKey.equals(testKey2)) {
                 testMap2.forEach((k, v) -> assertThat(eventMap, hasEntry(k,v)));
             }
+            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
         }
     }
 
@@ -459,6 +464,7 @@ public class KafkaCustomConsumerTest {
             if (kafkaKey.equals(testKey2)) {
                 testMap2.forEach((k, v) -> assertThat(eventMap, hasEntry(k,v)));
             }
+            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
             event.getEventHandle().release(true);
         }
         // Wait for acknowledgement callback function to run
@@ -526,6 +532,7 @@ public class KafkaCustomConsumerTest {
             if (kafkaKey.equals(testKey2)) {
                 testMap2.forEach((k, v) -> assertThat(eventMap, hasEntry(k,v)));
             }
+            Assertions.assertNotNull(event.getMetadata().getExternalOriginationTime());
             event.getEventHandle().release(true);
         }
         // Wait for acknowledgement callback function to run


### PR DESCRIPTION
### Description
For the purpose of tracking pipelineEndToEndLatency metric.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
