### PR TITLE
Fix depth field in template

### DIFF
--- a/data-prepper-pipeline-parser/src/main/resources/templates/documentdb-template.yaml
+++ b/data-prepper-pipeline-parser/src/main/resources/templates/documentdb-template.yaml
@@ -66,7 +66,7 @@
         disable_s3_metadata_in_event: true
         scan:
           folder_partitions:
-            depth: [ "<<FUNCTION_NAME:calculateDepth,PARAMETER:$.<<pipeline-name>>.source.documentdb.s3_prefix>>" ]
+            depth: "<<FUNCTION_NAME:calculateDepth,PARAMETER:$.<<pipeline-name>>.source.documentdb.s3_prefix>>"
             max_objects_per_ownership: 50
           buckets:
             - bucket:


### PR DESCRIPTION
### Description
Fix depth field in docDB template. It should be just an object type and not an array type.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
