### PR TITLE
Fix document version for DocDB/Mongo Stream events

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/converter/PartitionKeyRecordConverter.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/converter/PartitionKeyRecordConverter.java
@@ -26,11 +26,11 @@ public class PartitionKeyRecordConverter extends RecordConverter {
 
     @Override
     public Event convert(final String record,
-                         final long eventCreationTimeMillis,
+                         final long eventCreateTimeEpochMillis,
                          final long eventVersionNumber,
                          final OperationType eventName,
                          final String primaryKeyBsonType) {
-        final Event event =  super.convert(record, eventCreationTimeMillis, eventVersionNumber, eventName, primaryKeyBsonType);
+        final Event event =  super.convert(record, eventCreateTimeEpochMillis, eventVersionNumber, eventName, primaryKeyBsonType);
         final EventMetadata eventMetadata = event.getMetadata();
         final String partitionKey = String.valueOf(eventMetadata.getAttribute(MetadataKeyAttributes.PARTITION_KEY_METADATA_ATTRIBUTE));
         eventMetadata.setAttribute(MetadataKeyAttributes.EVENT_S3_PARTITION_KEY, s3PathPrefix + S3_PATH_DELIMITER + hashKeyToPartition(partitionKey));

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/converter/RecordConverter.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/converter/RecordConverter.java
@@ -54,13 +54,13 @@ public class RecordConverter {
      * Convert the source data into a JacksonEvent.
      *
      * @param record                  record that will be converted to Event.
-     * @param eventCreationTimeMillis Creation timestamp of the event
+     * @param eventCreateTimeEpochMillis Creation timestamp of the event in epoch millis
      * @param eventVersionNumber      Event version number to handle conflicts
      * @param eventName               Event name
      * @return Jackson document event
      */
     public Event convert(final String record,
-                        final long eventCreationTimeMillis,
+                        final long eventCreateTimeEpochMillis,
                         final long eventVersionNumber,
                         final OperationType eventName,
                         final String primaryKeyBsonType) {
@@ -71,7 +71,7 @@ public class RecordConverter {
 
         // Only set external origination time for stream events, not export
         if (eventName != null) {
-            final Instant externalOriginationTime = Instant.ofEpochMilli(eventCreationTimeMillis);
+            final Instant externalOriginationTime = Instant.ofEpochMilli(eventCreateTimeEpochMillis);
             event.getEventHandle().setExternalOriginationTime(externalOriginationTime);
             event.getMetadata().setExternalOriginationTime(externalOriginationTime);
         }
@@ -79,7 +79,7 @@ public class RecordConverter {
 
         eventMetadata.setAttribute(MetadataKeyAttributes.INGESTION_EVENT_TYPE_ATTRIBUTE, dataType);
         eventMetadata.setAttribute(MetadataKeyAttributes.DOCUMENTDB_EVENT_COLLECTION_METADATA_ATTRIBUTE, collection);
-        eventMetadata.setAttribute(MetadataKeyAttributes.DOCUMENTDB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE, eventCreationTimeMillis);
+        eventMetadata.setAttribute(MetadataKeyAttributes.DOCUMENTDB_EVENT_TIMESTAMP_METADATA_ATTRIBUTE, eventCreateTimeEpochMillis);
         eventMetadata.setAttribute(MetadataKeyAttributes.DOCUMENTDB_STREAM_EVENT_NAME_METADATA_ATTRIBUTE, eventName);
         eventMetadata.setAttribute(MetadataKeyAttributes.EVENT_NAME_BULK_ACTION_METADATA_ATTRIBUTE, mapStreamEventNameToBulkAction(eventName));
         eventMetadata.setAttribute(MetadataKeyAttributes.EVENT_VERSION_FROM_TIMESTAMP, eventVersionNumber);

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
@@ -193,8 +193,8 @@ public class StreamWorkerTest {
         verify(mongoDatabase).getCollection(eq("collection"));
         verify(mockPartitionCheckpoint).getGlobalS3FolderCreationStatus(collection);
         verify(mockRecordConverter).initializePartitions(partitions);
-        verify(mockRecordConverter).convert(eq(doc1Json1), eq(timeSecond1 * 1000L), eq(timeSecond1 * 1000L), eq(OperationType.INSERT), eq(BsonType.INT64.name()));
-        verify(mockRecordConverter).convert(eq(doc1Json2), eq(timeSecond2 * 1000L), eq(timeSecond2 * 1000L), eq(OperationType.DELETE), eq(BsonType.INT32.name()));
+        verify(mockRecordConverter).convert(eq(doc1Json1), eq(timeSecond1 * 1_000L), eq(timeSecond1 * 1_000_000L), eq(OperationType.INSERT), eq(BsonType.INT64.name()));
+        verify(mockRecordConverter).convert(eq(doc1Json2), eq(timeSecond2 * 1_000L), eq(timeSecond2 * 1_000_000L), eq(OperationType.DELETE), eq(BsonType.INT32.name()));
         verify(mockRecordBufferWriter).writeToBuffer(eq(null), any());
         verify(event, times(2)).put(mockSourceConfig.getIdKey(), event.get(DOCUMENTDB_ID_FIELD_NAME, Object.class));
         verify(successItemsCounter).increment(2);
@@ -409,7 +409,7 @@ public class StreamWorkerTest {
         verify(mongoDatabase).getCollection(eq("collection"));
         verify(mockPartitionCheckpoint).getGlobalS3FolderCreationStatus(collection);
         verify(mockRecordConverter).initializePartitions(partitions);
-        verify(mockRecordConverter).convert(eq(doc1Json1), eq(timeSecond1 * 1000L), eq(timeSecond1 * 1000L), eq(operationType1), eq(BsonType.BOOLEAN.name()));
+        verify(mockRecordConverter).convert(eq(doc1Json1), eq(timeSecond1 * 1_000L), eq(timeSecond1 * 1_000_000L), eq(operationType1), eq(BsonType.BOOLEAN.name()));
         verify(mockRecordBufferWriter).writeToBuffer(eq(null), any());
         verify(successItemsCounter).increment(1);
         verify(failureItemsCounter, never()).increment();
@@ -472,7 +472,7 @@ public class StreamWorkerTest {
         verify(mongoDatabase).getCollection(eq("collection"));
         verify(mockPartitionCheckpoint).getGlobalS3FolderCreationStatus(collection);
         verify(mockRecordConverter).initializePartitions(partitions);
-        verify(mockRecordConverter).convert(eq(expectedDocument), eq(timeSecond1 * 1000L), eq(timeSecond1 * 1000L), eq(operationType1), eq(bsonValue.getBsonType().name()));
+        verify(mockRecordConverter).convert(eq(expectedDocument), eq(timeSecond1 * 1_000L), eq(timeSecond1 * 1_000_000L), eq(operationType1), eq(bsonValue.getBsonType().name()));
         verify(mockRecordBufferWriter).writeToBuffer(eq(null), any());
         verify(successItemsCounter).increment(1);
         verify(failureItemsCounter, never()).increment();


### PR DESCRIPTION
### Description
Fix document version for DocDB/Mongo Stream events
 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
