### PR TITLE
Exclude updateDescription field from Mongo/DocDB change stream

### DIFF
--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
@@ -60,6 +60,7 @@ import java.util.stream.Stream;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -135,7 +136,7 @@ public class StreamWorkerTest {
         MongoCursor cursor = mock(MongoCursor.class);
         when(mongoClient.getDatabase(anyString())).thenReturn(mongoDatabase);
         when(mongoDatabase.getCollection(anyString())).thenReturn(col);
-        when(col.watch()).thenReturn(changeStreamIterable);
+        when(col.watch(anyList())).thenReturn(changeStreamIterable);
         when(changeStreamIterable.batchSize(1000)).thenReturn(changeStreamIterable);
         when(changeStreamIterable.fullDocument(FullDocument.UPDATE_LOOKUP)).thenReturn(changeStreamIterable);
         when(changeStreamIterable.iterator()).thenReturn(cursor);
@@ -232,7 +233,7 @@ public class StreamWorkerTest {
         MongoCursor cursor = mock(MongoCursor.class);
         when(mongoClient.getDatabase(anyString())).thenReturn(mongoDatabase);
         when(mongoDatabase.getCollection(anyString())).thenReturn(col);
-        when(col.watch()).thenReturn(changeStreamIterable);
+        when(col.watch(anyList())).thenReturn(changeStreamIterable);
         when(changeStreamIterable.batchSize(1000)).thenReturn(changeStreamIterable);
         when(changeStreamIterable.fullDocument(FullDocument.UPDATE_LOOKUP)).thenReturn(changeStreamIterable);
         when(changeStreamIterable.iterator()).thenReturn(cursor);
@@ -323,7 +324,7 @@ public class StreamWorkerTest {
         MongoCursor cursor = mock(MongoCursor.class);
         when(mongoClient.getDatabase(anyString())).thenReturn(mongoDatabase);
         when(mongoDatabase.getCollection(anyString())).thenReturn(col);
-        when(col.watch()).thenReturn(changeStreamIterable);
+        when(col.watch(anyList())).thenReturn(changeStreamIterable);
         when(changeStreamIterable.batchSize(1000)).thenReturn(changeStreamIterable);
         when(changeStreamIterable.fullDocument(FullDocument.UPDATE_LOOKUP)).thenReturn(changeStreamIterable);
         when(changeStreamIterable.iterator()).thenReturn(cursor);
@@ -361,7 +362,7 @@ public class StreamWorkerTest {
         MongoCursor cursor = mock(MongoCursor.class);
         when(mongoClient.getDatabase(anyString())).thenReturn(mongoDatabase);
         when(mongoDatabase.getCollection(anyString())).thenReturn(col);
-        when(col.watch()).thenReturn(changeStreamIterable);
+        when(col.watch(anyList())).thenReturn(changeStreamIterable);
         when(changeStreamIterable.batchSize(1000)).thenReturn(changeStreamIterable);
         when(changeStreamIterable.fullDocument(FullDocument.UPDATE_LOOKUP)).thenReturn(changeStreamIterable);
         when(changeStreamIterable.iterator()).thenReturn(cursor);
@@ -430,7 +431,7 @@ public class StreamWorkerTest {
         MongoCursor cursor = mock(MongoCursor.class);
         when(mongoClient.getDatabase(anyString())).thenReturn(mongoDatabase);
         when(mongoDatabase.getCollection(anyString())).thenReturn(col);
-        when(col.watch()).thenReturn(changeStreamIterable);
+        when(col.watch(anyList())).thenReturn(changeStreamIterable);
         when(changeStreamIterable.batchSize(1000)).thenReturn(changeStreamIterable);
         when(changeStreamIterable.fullDocument(FullDocument.UPDATE_LOOKUP)).thenReturn(changeStreamIterable);
         when(changeStreamIterable.iterator()).thenReturn(cursor);


### PR DESCRIPTION
### Description
Exclude updateDescription field from Mongo/DocDB change stream. The watch steam uses FullDocument lookup, so updateDescription is redundant and is not used. It also contributes to stream document size, so removing this field to not hit the stream document size limit of 16MB.
 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
