### PR TITLE
Bump parquet version to 1.14.0.

### DIFF
--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
-    implementation 'org.apache.parquet:parquet-common:1.13.1'
+    implementation 'org.apache.parquet:parquet-common:1.14.0'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation libs.commons.lang3
     testImplementation project(':data-prepper-test-common')

--- a/data-prepper-plugins/avro-codecs/build.gradle
+++ b/data-prepper-plugins/avro-codecs/build.gradle
@@ -6,7 +6,7 @@
 dependencies {
     implementation project(path: ':data-prepper-api')
     implementation libs.avro.core
-    implementation 'org.apache.parquet:parquet-common:1.13.1'
+    implementation 'org.apache.parquet:parquet-common:1.14.0'
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:apache-client'
     testImplementation 'org.json:json:20240205'

--- a/data-prepper-plugins/common/build.gradle
+++ b/data-prepper-plugins/common/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation libs.bouncycastle.bcpkix
     implementation libs.reflections.core
     implementation 'io.micrometer:micrometer-core'
-    implementation 'org.apache.parquet:parquet-common:1.13.1'
+    implementation 'org.apache.parquet:parquet-common:1.14.0'
     implementation 'org.xerial.snappy:snappy-java:1.1.10.5'
     testImplementation project(':data-prepper-plugins:blocking-buffer')
     testImplementation project(':data-prepper-test-event')

--- a/data-prepper-plugins/csv-processor/build.gradle
+++ b/data-prepper-plugins/csv-processor/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'io.micrometer:micrometer-core'
-    implementation 'org.apache.parquet:parquet-common:1.13.1'
+    implementation 'org.apache.parquet:parquet-common:1.14.0'
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:apache-client'
     testImplementation project(':data-prepper-plugins:log-generator-source')

--- a/data-prepper-plugins/event-json-codecs/build.gradle
+++ b/data-prepper-plugins/event-json-codecs/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0'
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0'
-    implementation 'org.apache.parquet:parquet-common:1.13.1'
+    implementation 'org.apache.parquet:parquet-common:1.14.0'
     testImplementation project(':data-prepper-test-common')
 }
 

--- a/data-prepper-plugins/newline-codecs/build.gradle
+++ b/data-prepper-plugins/newline-codecs/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     implementation project(':data-prepper-api')
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
-    implementation 'org.apache.parquet:parquet-common:1.13.1'
+    implementation 'org.apache.parquet:parquet-common:1.14.0'
     testImplementation project(':data-prepper-plugins:common')
     testImplementation project(':data-prepper-test-event')
 }

--- a/data-prepper-plugins/parquet-codecs/build.gradle
+++ b/data-prepper-plugins/parquet-codecs/build.gradle
@@ -11,10 +11,10 @@ dependencies {
     implementation(libs.hadoop.mapreduce) {
         exclude group: 'org.apache.hadoop', module: 'hadoop-hdfs-client'
     }
-    implementation 'org.apache.parquet:parquet-avro:1.13.1'
-    implementation 'org.apache.parquet:parquet-column:1.13.1'
-    implementation 'org.apache.parquet:parquet-common:1.13.1'
-    implementation 'org.apache.parquet:parquet-hadoop:1.13.1'
+    implementation 'org.apache.parquet:parquet-avro:1.14.0'
+    implementation 'org.apache.parquet:parquet-column:1.14.0'
+    implementation 'org.apache.parquet:parquet-common:1.14.0'
+    implementation 'org.apache.parquet:parquet-hadoop:1.14.0'
     testImplementation project(':data-prepper-test-common')
     testImplementation project(':data-prepper-test-event')
 

--- a/data-prepper-plugins/parse-json-processor/build.gradle
+++ b/data-prepper-plugins/parse-json-processor/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-ion'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
-    implementation 'org.apache.parquet:parquet-common:1.13.1'
+    implementation 'org.apache.parquet:parquet-common:1.14.0'
     testImplementation project(':data-prepper-test-common')
 }
 

--- a/data-prepper-plugins/s3-sink/build.gradle
+++ b/data-prepper-plugins/s3-sink/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation project(':data-prepper-plugins:avro-codecs')
     implementation libs.avro.core
     implementation libs.hadoop.common
-    implementation 'org.apache.parquet:parquet-avro:1.13.1'
+    implementation 'org.apache.parquet:parquet-avro:1.14.0'
     implementation 'software.amazon.awssdk:apache-client'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22'
     implementation libs.commons.lang3

--- a/data-prepper-plugins/s3-source/build.gradle
+++ b/data-prepper-plugins/s3-source/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'org.xerial.snappy:snappy-java:1.1.10.5'
-    implementation 'org.apache.parquet:parquet-common:1.13.1'
+    implementation 'org.apache.parquet:parquet-common:1.14.0'
     implementation 'dev.failsafe:failsafe:3.3.2'
     implementation 'org.apache.httpcomponents:httpcore:4.4.16'
     testImplementation libs.commons.lang3
@@ -46,10 +46,10 @@ dependencies {
     testImplementation project(':data-prepper-test-event')
     testImplementation libs.avro.core
     testImplementation testLibs.hadoop.common
-    testImplementation 'org.apache.parquet:parquet-avro:1.13.1'
-    testImplementation 'org.apache.parquet:parquet-column:1.13.1'
-    testImplementation 'org.apache.parquet:parquet-common:1.13.1'
-    testImplementation 'org.apache.parquet:parquet-hadoop:1.13.1'
+    testImplementation 'org.apache.parquet:parquet-avro:1.14.0'
+    testImplementation 'org.apache.parquet:parquet-column:1.14.0'
+    testImplementation 'org.apache.parquet:parquet-common:1.14.0'
+    testImplementation 'org.apache.parquet:parquet-hadoop:1.14.0'
 }
 
 test {


### PR DESCRIPTION
### Description
1.14.0 has critical bug fixes for parquet files written in OCSF 1.1 schema.
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
