### PR TITLE
Key value processor enhancements

### DIFF
--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -315,7 +315,7 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
         return -1;
     }
     
-    private List<String> executeAutoMode(String str) {
+    private List<String> parseWithValueGrouping(String str) {
         String fieldDelimiter = keyValueProcessorConfig.getFieldSplitCharacters();
         int i = 0;
         int start = i;
@@ -326,7 +326,6 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
                 continue;
             }
             int groupIndex = findInStartGroup(str, i);
-            System.out.println("+++++++++"+str+"_____"+i+"....."+groupIndex);
             if (groupIndex >= 0) {
                 i = skipToEndChar(str, i+1, endGroupChars[groupIndex])+2;
             } else if (str.substring(i,i+fieldDelimiter.length()).equals(fieldDelimiter)) {
@@ -368,9 +367,8 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
                     continue;
                 }
                 String[] groups;
-                if (keyValueProcessorConfig.getAutoMode()) {
-                    //groups = (String[])executeAutoMode(groupsRaw).toArray();
-                    groups = executeAutoMode(groupsRaw).stream().toArray(String[]::new);
+                if (keyValueProcessorConfig.getValueGrouping()) {
+                    groups = parseWithValueGrouping(groupsRaw).stream().toArray(String[]::new);
                 } else {
                     groups = fieldDelimiterPattern.split(groupsRaw, 0);
                 }

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -300,8 +300,13 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
         int j = 0;
         while (j < startGroupStrings.length) {
             try {
-                if (startGroupStrings[j].equals(str.substring(idx, idx+startGroupStrings[j].length())))
-                    return j;
+                if (startGroupStrings[j].equals(str.substring(idx, idx+startGroupStrings[j].length()))) {
+                    if (j <= 1 && idx > 0 && str.charAt(idx-1) != '\\') {
+                        return j;
+                    } else if (j > 1) {
+                        return j;
+                    }
+                }
             } catch (Exception e) {
                 return -1;
             }
@@ -321,6 +326,7 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
                 continue;
             }
             int groupIndex = findInStartGroup(str, i);
+            System.out.println("+++++++++"+str+"_____"+i+"....."+groupIndex);
             if (groupIndex >= 0) {
                 i = skipToEndChar(str, i+1, endGroupChars[groupIndex])+2;
             } else if (str.substring(i,i+fieldDelimiter.length()).equals(fieldDelimiter)) {

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -276,8 +276,7 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
     }
 
     public int findInStartGroup(final String str, int idx) {
-        int j = 0;
-        while (j < startGroupStrings.length) {
+        for (int j = 0; j < startGroupStrings.length; j++) {
             try {
                 if (startGroupStrings[j].equals(str.substring(idx, idx+startGroupStrings[j].length()))) {
                     if (j <= 1 && idx > 0 && str.charAt(idx-1) != '\\') {
@@ -289,7 +288,6 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
             } catch (Exception e) {
                 return -1;
             }
-            j++;
         }
         return -1;
     }

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -292,7 +292,6 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
     private void addPart(List<String> parts, final String str, final int start, final int end) {
         String part = str.substring(start,end).trim();
         if (part.length() > 0 && isKeyValueDelimiterPresentInPart(part)) {
-            System.out.println("====="+part);
             parts.add(part);
         }
     }

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.plugins.processor.keyvalue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.AssertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +30,7 @@ public class KeyValueProcessorConfig {
     static final String DEFAULT_WHITESPACE = "lenient";
     static final boolean DEFAULT_SKIP_DUPLICATE_VALUES = false;
     static final boolean DEFAULT_REMOVE_BRACKETS = false;
-    static final boolean DEFAULT_AUTO_MODE = false;
+    static final boolean DEFAULT_VALUE_GROUPING = false;
     static final boolean DEFAULT_RECURSIVE = false;
 
     @NotEmpty
@@ -91,9 +92,8 @@ public class KeyValueProcessorConfig {
     @NotNull
     private boolean removeBrackets = DEFAULT_REMOVE_BRACKETS;
 
-    @JsonProperty("auto")
-    private boolean autoMode = DEFAULT_AUTO_MODE;
-    
+    @JsonProperty("value_grouping")
+    private boolean valueGrouping = DEFAULT_VALUE_GROUPING;
 
     @JsonProperty("recursive")
     @NotNull
@@ -108,6 +108,11 @@ public class KeyValueProcessorConfig {
     @JsonProperty("key_value_when")
     private String keyValueWhen;
 
+    @AssertTrue(message = "Invalid Configuration. valueGrouping option and field_delimiter_regex are mutually exclusive")
+    boolean isValidValueGroupingAndFieldDelimiterRegex() {
+        return (!valueGrouping || fieldDelimiterRegex == null);
+    }
+
     public String getSource() {
         return source;
     }
@@ -116,8 +121,8 @@ public class KeyValueProcessorConfig {
         return destination;
     }
 
-    public boolean getAutoMode() {
-        return autoMode;
+    public boolean getValueGrouping() {
+        return valueGrouping;
     }
 
     public String getFieldDelimiterRegex() {

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -29,6 +29,7 @@ public class KeyValueProcessorConfig {
     static final String DEFAULT_WHITESPACE = "lenient";
     static final boolean DEFAULT_SKIP_DUPLICATE_VALUES = false;
     static final boolean DEFAULT_REMOVE_BRACKETS = false;
+    static final boolean DEFAULT_AUTO_MODE = false;
     static final boolean DEFAULT_RECURSIVE = false;
 
     @NotEmpty
@@ -90,6 +91,10 @@ public class KeyValueProcessorConfig {
     @NotNull
     private boolean removeBrackets = DEFAULT_REMOVE_BRACKETS;
 
+    @JsonProperty("auto")
+    private boolean autoMode = DEFAULT_AUTO_MODE;
+    
+
     @JsonProperty("recursive")
     @NotNull
     private boolean recursive = DEFAULT_RECURSIVE;
@@ -109,6 +114,10 @@ public class KeyValueProcessorConfig {
 
     public String getDestination() {
         return destination;
+    }
+
+    public boolean getAutoMode() {
+        return autoMode;
     }
 
     public String getFieldDelimiterRegex() {

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -111,7 +111,7 @@ public class KeyValueProcessorConfig {
     @JsonProperty("key_value_when")
     private String keyValueWhen;
 
-    @AssertTrue(message = "Invalid Configuration. valueGrouping option and field_delimiter_regex are mutually exclusive")
+    @AssertTrue(message = "Invalid Configuration. value_grouping option and field_delimiter_regex are mutually exclusive")
     boolean isValidValueGroupingAndFieldDelimiterRegex() {
         return (!valueGrouping || fieldDelimiterRegex == null);
     }

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -105,6 +105,9 @@ public class KeyValueProcessorConfig {
     @JsonProperty("overwrite_if_destination_exists")
     private boolean overwriteIfDestinationExists = true;
 
+    @JsonProperty("drop_keys_with_no_value")
+    private boolean dropKeysWithNoValue = false;
+
     @JsonProperty("key_value_when")
     private String keyValueWhen;
 
@@ -143,6 +146,10 @@ public class KeyValueProcessorConfig {
 
     public Map<String, Object> getDefaultValues() {
         return defaultValues;
+    }
+
+    public boolean getDropKeysWithNoValue() {
+        return dropKeysWithNoValue;
     }
 
     public String getKeyValueDelimiterRegex() {

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -165,9 +166,8 @@ public class KeyValueProcessorTests {
         assertThatKeyEquals(parsed_message, "key2", "value2");
     }
 
-    @Test
     @ParameterizedTest
-    @MethodSource(booleans = {true, false})
+    @MethodSource("getKeyValueAutoModeTestdata")
     void testMultipleKvToObjectKeyValueProcessorInAutoMode() {
         lenient().when(mockConfig.getAutoMode()).thenReturn(true);
         final KeyValueProcessor objectUnderTest = createObjectUnderTest();
@@ -180,6 +180,12 @@ public class KeyValueProcessorTests {
         assertThatKeyEquals(parsed_message, "key2", "value2");
     }
 
+    private static Stream<Arguments> getKeyValueAutoModeTestdata() {
+        return Stream.of (
+                Arguments.of(),
+                Arguments.of(),
+                Arguments.of()
+               );
     @Test
     void testWriteToRoot() {
         when(mockConfig.getDestination()).thenReturn(null);

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -175,7 +175,9 @@ public class KeyValueProcessorTests {
         lenient().when(mockConfig.getFieldSplitCharacters()).thenReturn(fieldDelimiters);
         final KeyValueProcessor objectUnderTest = createObjectUnderTest();
         final Record<Event> record = getMessage(input);
+        System.out.println("IN________"+record.getData().toJsonString());
         final List<Record<Event>> editedRecords = (List<Record<Event>>) objectUnderTest.doExecute(Collections.singletonList(record));
+        System.out.println("OUT________"+editedRecords.get(0).getData().toJsonString());
         final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
 
         assertThat(parsed_message.size(), equalTo(expectedResultMap.size()));
@@ -191,7 +193,7 @@ public class KeyValueProcessorTests {
                 Arguments.of(",", "key1=value1 key2=value2", Map.of("key1", "value1", "key2", "value2")),
                 Arguments.of(",", "key1=value1 ,key2=value2", Map.of("key1", "value1", "key2", "value2")),
                 Arguments.of(",", "key1=value1, key2=value2", Map.of("key1", "value1", "key2", "value2")),
-                Arguments.of(",", "key1=It\'sValue1, key2=value2", Map.of("key1", "It\'sValue1", "key2", "value2")),
+                Arguments.of(",", "key1=It\\'sValue1, key2=value2", Map.of("key1", "It\\'sValue1", "key2", "value2")),
                 Arguments.of(",", "text1 text2 key1=value1, key2=value2 text3 text4", Map.of("key1", "value1", "key2", "value2")),
                 Arguments.of(",", "text1 text2 foo key1=value1 url=http://foo.com?bar=text,text&foo=zoo  bar k2=\"http://bar.com?a=b&c=foo bar\" bar", Map.of("key1", "value1", "url", "http://foo.com?bar=text,text&foo=zoo", "k2", "\"http://bar.com?a=b&c=foo bar\"")),
                 Arguments.of(",", "vendorMessage=VendorMessage(uid=1847060493-1712778523223, feedValue=https://syosetu.org/novel/147705/15.html, bundleId=, linkType=URL, vendor=DOUBLEVERIFY, platform=DESKTOP, deviceTypeId=1, bidCount=6, appStoreTld=, feedSource=DSP, regions=[APAC], timestamp=1712778523223, externalId=)", Map.of("vendorMessage", "VendorMessage(uid=1847060493-1712778523223, feedValue=https://syosetu.org/novel/147705/15.html, bundleId=, linkType=URL, vendor=DOUBLEVERIFY, platform=DESKTOP, deviceTypeId=1, bidCount=6, appStoreTld=, feedSource=DSP, regions=[APAC], timestamp=1712778523223, externalId=)")),

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -85,6 +85,7 @@ public class KeyValueProcessorTests {
         lenient().when(mockConfig.getRemoveBrackets()).thenReturn(defaultConfig.getRemoveBrackets());
         lenient().when(mockConfig.getRecursive()).thenReturn(defaultConfig.getRecursive());
         lenient().when(mockConfig.getOverwriteIfDestinationExists()).thenReturn(defaultConfig.getOverwriteIfDestinationExists());
+        lenient().when(mockConfig.getAutoMode()).thenReturn(false);
 
         final String keyValueWhen = UUID.randomUUID().toString();
         when(mockConfig.getKeyValueWhen()).thenReturn(keyValueWhen);
@@ -157,6 +158,21 @@ public class KeyValueProcessorTests {
     void testMultipleKvToObjectKeyValueProcessor() {
         final Record<Event> record = getMessage("key1=value1&key2=value2");
         final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
+        final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
+
+        assertThat(parsed_message.size(), equalTo(2));
+        assertThatKeyEquals(parsed_message, "key1", "value1");
+        assertThatKeyEquals(parsed_message, "key2", "value2");
+    }
+
+    @Test
+    @ParameterizedTest
+    @MethodSource(booleans = {true, false})
+    void testMultipleKvToObjectKeyValueProcessorInAutoMode() {
+        lenient().when(mockConfig.getAutoMode()).thenReturn(true);
+        final KeyValueProcessor objectUnderTest = createObjectUnderTest();
+        final Record<Event> record = getMessage("key1=value1,key2=value2");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) objectUnderTest.doExecute(Collections.singletonList(record));
         final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
 
         assertThat(parsed_message.size(), equalTo(2));

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -89,6 +89,7 @@ public class KeyValueProcessorTests {
         lenient().when(mockConfig.getRecursive()).thenReturn(defaultConfig.getRecursive());
         lenient().when(mockConfig.getOverwriteIfDestinationExists()).thenReturn(defaultConfig.getOverwriteIfDestinationExists());
         lenient().when(mockConfig.getValueGrouping()).thenReturn(false);
+        lenient().when(mockConfig.getDropKeysWithNoValue()).thenReturn(false);
 
         final String keyValueWhen = UUID.randomUUID().toString();
         when(mockConfig.getKeyValueWhen()).thenReturn(keyValueWhen);
@@ -166,6 +167,20 @@ public class KeyValueProcessorTests {
         assertThat(parsed_message.size(), equalTo(2));
         assertThatKeyEquals(parsed_message, "key1", "value1");
         assertThatKeyEquals(parsed_message, "key2", "value2");
+    }
+
+    @Test
+    void testDropKeysWithNoValue() {
+        lenient().when(mockConfig.getDropKeysWithNoValue()).thenReturn(true);
+
+        keyValueProcessor = createObjectUnderTest();
+
+        final Record<Event> record = getMessage("key1=value1&key2");
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
+        final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
+
+        assertThat(parsed_message.size(), equalTo(1));
+        assertThatKeyEquals(parsed_message, "key1", "value1");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Description
Two new config options are added

1. `value_grouping: true/false`
   This option groups the values when values start with "(" "[" "<" "{" , single quote, double quote and "http://" and "https://"
   When a value starts with one of the above mentioned strings, all the characters after that are considered part of the value until the corresponding end character is found (ie no keyvalue or field value parsing happens). If the corresponding end character is not found, an error is displayed. When this option is enabled, `field_delimiter_regex` option is not allowed. All other existing options are valid with this config option.

2. `drop_keys_with_no_value:true/false`
   This option drops keys that do not have a value associated with them. This is done after `default_values` option is processed. Even after default values are assigned, if keys have `null` value, they are dropped when this config option is set to true
 
### Issues Resolved
Resolves #4447 
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
