### PR TITLE
Clear system property to disable s3 scan when stream worker exits, set s3 sink threshold to 15 seconds for docdb streams

### DIFF
--- a/data-prepper-pipeline-parser/src/main/resources/templates/documentdb-template.yaml
+++ b/data-prepper-pipeline-parser/src/main/resources/templates/documentdb-template.yaml
@@ -38,7 +38,7 @@
           sts_header_overrides: "<<$.<<pipeline-name>>.source.documentdb.aws.sts_header_overrides>>"
         bucket: "<<$.<<pipeline-name>>.source.documentdb.s3_bucket>>"
         threshold:
-          event_collect_timeout: "30s"
+          event_collect_timeout: "15s"
           maximum_size: "1mb"
         aggregate_threshold:
           maximum_size: "128mb"

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static org.opensearch.dataprepper.model.source.s3.S3ScanEnvironmentVariables.STOP_S3_SCAN_PROCESSING_PROPERTY;
 import static org.opensearch.dataprepper.plugins.mongo.client.BsonHelper.JSON_WRITER_SETTINGS;
 import static org.opensearch.dataprepper.plugins.mongo.client.BsonHelper.DOCUMENTDB_ID_FIELD_NAME;
 import static org.opensearch.dataprepper.plugins.mongo.client.BsonHelper.UNKNOWN_TYPE;
@@ -264,6 +265,8 @@ public class StreamWorker {
             if (!sourceConfig.isAcknowledgmentsEnabled()) {
                 partitionCheckpoint.checkpoint(checkPointToken, recordCount);
             }
+
+            System.clearProperty(STOP_S3_SCAN_PROCESSING_PROPERTY);
 
             // shutdown acknowledgement monitoring thread
             if (streamAcknowledgementManager != null) {


### PR DESCRIPTION
### Description
Clears the system property to re-enable s3 scan pipeline when documentdb stream worker exits
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
