### PR TITLE
Modify typeof operator grammar and add support for ArrayList

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DataType.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DataType.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.model.event;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -98,7 +99,7 @@ public enum DataType {
           case MAP:
             return (object instanceof Map);
           case ARRAY:
-            return (object.getClass().isArray());
+            return (object instanceof ArrayList || object.getClass().isArray());
           case DOUBLE:
             return (object instanceof Double);
           case BOOLEAN:

--- a/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
+++ b/data-prepper-expression/src/main/antlr/DataPrepperExpression.g4
@@ -91,7 +91,7 @@ relationalOperator
     ;
 
 typeOfOperatorExpression
-    : JsonPointer TYPEOF String
+    : JsonPointer TYPEOF DataTypes
     ;
 
 setOperatorExpression
@@ -285,6 +285,16 @@ EscapeSequence
     : '\\' [btnfr"'\\$]
     ;
 
+DataTypes
+    : INTEGER
+    | BOOLEAN
+    | LONG
+    | MAP
+    | ARRAY
+    | DOUBLE
+    | STRING
+    ;
+
 SET_DELIMITER
     : COMMA
     ;
@@ -323,6 +333,14 @@ EXPONENTLETTER
     : 'E'
     | 'e'
     ;
+
+INTEGER: 'integer';
+BOOLEAN: 'boolean';
+LONG   : 'long';
+DOUBLE : 'double';
+STRING : 'string';
+MAP    : 'map';
+ARRAY  : 'array';
 
 fragment
 SPACE : ' ';

--- a/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
+++ b/data-prepper-expression/src/main/java/org/opensearch/dataprepper/expression/ParseTreeCoercionService.java
@@ -82,6 +82,9 @@ class ParseTreeCoercionService {
                 return Boolean.valueOf(nodeStringValue);
             case DataPrepperExpressionParser.Null:
                 return null;
+            case DataPrepperExpressionParser.DataTypes:
+                return nodeStringValue;
+
             default:
                 throw new ExpressionCoercionException("Unsupported terminal node type symbol string: " +
                         DataPrepperExpressionParser.VOCABULARY.getDisplayName(nodeType));

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/ParseTreeCoercionServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.antlr.DataPrepperExpressionParser;
@@ -110,6 +111,18 @@ class ParseTreeCoercionServiceTest {
         final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
         assertThat(result, instanceOf(Float.class));
         assertThat(result, equalTo(testFloat));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings={"integer", "boolean", "long", "string", "double", "map", "array"})
+    void testCoerceTerminalNodeDataTypesType(String testString) {
+        when(token.getType()).thenReturn(DataPrepperExpressionParser.DataTypes);
+        when(terminalNode.getSymbol()).thenReturn(token);
+        when(terminalNode.getText()).thenReturn(testString);
+        final Event testEvent = createTestEvent(new HashMap<>());
+        final Object result = objectUnderTest.coercePrimaryTerminalNode(terminalNode, testEvent);
+        assertThat(result, instanceOf(String.class));
+        assertThat(result, equalTo(testString));
     }
 
     @Test

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/TypeOfOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/TypeOfOperatorTest.java
@@ -20,6 +20,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -66,6 +68,7 @@ class TypeOfOperatorTest {
 
     private static Stream<Arguments> getTypeOfTestData() {
         int testArray[] = {1,2};
+        List<Integer> testArrayList = new ArrayList<Integer>(){{add(1);add(2);}};
         return Stream.of(
             Arguments.of(2, "integer", true),
             Arguments.of("testString", "string", true),
@@ -74,6 +77,7 @@ class TypeOfOperatorTest {
             Arguments.of(true, "boolean", true),
             Arguments.of(Map.of("k","v"), "map", true),
             Arguments.of(testArray, "array", true),
+            Arguments.of(testArrayList, "array", true),
             Arguments.of(2.0, "integer", false),
             Arguments.of(2, "string", false),
             Arguments.of("testString", "long", false),

--- a/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/TypeOfOperatorTest.java
+++ b/data-prepper-expression/src/test/java/org/opensearch/dataprepper/expression/TypeOfOperatorTest.java
@@ -68,7 +68,9 @@ class TypeOfOperatorTest {
 
     private static Stream<Arguments> getTypeOfTestData() {
         int testArray[] = {1,2};
-        List<Integer> testArrayList = new ArrayList<Integer>(){{add(1);add(2);}};
+        List<Integer> testArrayList = new ArrayList<Integer>();
+        testArrayList.add(1);
+        testArrayList.add(2);
         return Stream.of(
             Arguments.of(2, "integer", true),
             Arguments.of("testString", "string", true),


### PR DESCRIPTION
### Description
Modify typeof operator to accept the types without double quotes.
For example, after this change the expression with typeof operator will be like this
`/field typeof "integer"` to `/field typeof integer`

Also, modified to support check for "array" to return true for ArrayList too
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
