### PR TITLE
Write stream events that timeout to write to internal buffer in separate thread

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/DataStreamPartitionCheckpoint.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/DataStreamPartitionCheckpoint.java
@@ -66,6 +66,11 @@ public class DataStreamPartitionCheckpoint extends S3FolderPartitionCoordinator 
         enhancedSourceCoordinator.saveProgressStateForPartition(streamPartition, CHECKPOINT_OWNERSHIP_TIMEOUT_INCREASE);
     }
 
+    public void extendLease() {
+        LOG.debug("Extending lease of stream partition for collection {}", streamPartition.getCollection());
+        enhancedSourceCoordinator.saveProgressStateForPartition(streamPartition, CHECKPOINT_OWNERSHIP_TIMEOUT_INCREASE);
+    }
+
     /**
      * This method is to reset checkpoint when change stream is invalid. The current thread will give up partition and new thread
      * will take ownership of partition. If change stream is valid then new thread proceeds with processing change stream else the

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManager.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManager.java
@@ -80,8 +80,8 @@ public class StreamAcknowledgementManager {
                     }
                 } else {
                     if (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs) {
-                        LOG.debug("No records processed. Checkpoint to extend the lease of the worker");
-                        partitionCheckpoint.checkpoint(null, 0);
+                        LOG.debug("No records processed. Extend the lease of the partition worker.");
+                        partitionCheckpoint.extendLease();
                         lastCheckpointTime = System.currentTimeMillis();
                     }
                 }

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManager.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManager.java
@@ -53,30 +53,41 @@ public class StreamAcknowledgementManager {
         long lastCheckpointTime = System.currentTimeMillis();
         CheckpointStatus lastCheckpointStatus = null;
         while (!Thread.currentThread().isInterrupted()) {
-            final CheckpointStatus checkpointStatus = checkpoints.peek();
-            if (checkpointStatus != null) {
-                if (checkpointStatus.isAcknowledged()) {
-                    lastCheckpointStatus = checkpoints.poll();
-                    ackStatus.remove(checkpointStatus.getResumeToken());
-                    if (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs) {
-                        LOG.debug("Perform regular checkpointing for resume token {} at record count {}", checkpointStatus.getResumeToken(), checkpointStatus.getRecordCount());
-                        partitionCheckpoint.checkpoint(checkpointStatus.getResumeToken(), checkpointStatus.getRecordCount());
-                        lastCheckpointTime = System.currentTimeMillis();
+            try {
+                final CheckpointStatus checkpointStatus = checkpoints.peek();
+                if (checkpointStatus != null) {
+                    if (checkpointStatus.isAcknowledged()) {
+                        lastCheckpointStatus = checkpoints.poll();
+                        ackStatus.remove(checkpointStatus.getResumeToken());
+                        if (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs) {
+                            LOG.debug("Perform regular checkpointing for resume token {} at record count {}", checkpointStatus.getResumeToken(), checkpointStatus.getRecordCount());
+                            partitionCheckpoint.checkpoint(checkpointStatus.getResumeToken(), checkpointStatus.getRecordCount());
+                            lastCheckpointTime = System.currentTimeMillis();
+                        }
+                    } else {
+                        LOG.debug("Checkpoint not complete for resume token {}", checkpointStatus.getResumeToken());
+                        final Duration ackWaitDuration = Duration.between(Instant.ofEpochMilli(checkpointStatus.getCreateTimestamp()), Instant.now());
+                        // Acknowledgement not received for the checkpoint after twice ack wait time
+                        if (ackWaitDuration.getSeconds() >= partitionAcknowledgmentTimeout.getSeconds() * 2) {
+                            // Give up partition and should interrupt parent thread to stop processing stream
+                            if (lastCheckpointStatus != null && lastCheckpointStatus.isAcknowledged()) {
+                                partitionCheckpoint.checkpoint(lastCheckpointStatus.getResumeToken(), lastCheckpointStatus.getRecordCount());
+                            }
+                            LOG.warn("Acknowledgement not received for the checkpoint {} past wait time. Giving up partition.", checkpointStatus.getResumeToken());
+                            partitionCheckpoint.giveUpPartition();
+                            break;
+                        }
                     }
                 } else {
-                    LOG.debug("Checkpoint not complete for resume token {}", checkpointStatus.getResumeToken());
-                    final Duration ackWaitDuration = Duration.between(Instant.ofEpochMilli(checkpointStatus.getCreateTimestamp()), Instant.now());
-                    // Acknowledgement not received for the checkpoint after twice ack wait time
-                    if (ackWaitDuration.getSeconds() >= partitionAcknowledgmentTimeout.getSeconds() * 2) {
-                        // Give up partition and should interrupt parent thread to stop processing stream
-                        if (lastCheckpointStatus != null && lastCheckpointStatus.isAcknowledged()) {
-                            partitionCheckpoint.checkpoint(lastCheckpointStatus.getResumeToken(), lastCheckpointStatus.getRecordCount());
-                        }
-                        LOG.warn("Acknowledgement not received for the checkpoint {} past wait time. Giving up partition.", checkpointStatus.getResumeToken());
-                        partitionCheckpoint.giveUpPartition();
-                        break;
+                    if (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs) {
+                        LOG.debug("No records processed. Checkpoint to extend the lease of the worker");
+                        partitionCheckpoint.checkpoint(null, 0);
+                        lastCheckpointTime = System.currentTimeMillis();
                     }
                 }
+            } catch (Exception e) {
+                LOG.warn("Exception monitoring acknowledgments. The stream record processing will start from previous checkpoint.", e);
+                break;
             }
 
             try {

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamScheduler.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamScheduler.java
@@ -26,7 +26,7 @@ import static org.opensearch.dataprepper.model.source.s3.S3ScanEnvironmentVariab
 public class StreamScheduler implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(StreamScheduler.class);
     private static final int DEFAULT_TAKE_LEASE_INTERVAL_MILLIS = 60_000;
-    static final int DEFAULT_CHECKPOINT_INTERVAL_MILLS = 120_000;
+    static final int DEFAULT_CHECKPOINT_INTERVAL_MILLS = 60_000;
     static final int DEFAULT_BUFFER_WRITE_INTERVAL_MILLS = 15_000;
     private static final int DEFAULT_MONITOR_WAIT_TIME_MS = 15_000;
     /**

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
@@ -354,7 +354,7 @@ public class StreamWorker {
                         LOG.debug("Perform regular checkpoint for resume token {} at record count {}", lastLocalCheckpoint, lastLocalRecordCount);
                         partitionCheckpoint.checkpoint(lastLocalCheckpoint, lastLocalRecordCount);
                     } catch (Exception e) {
-                        LOG.error("Exception checkpointing the current state. New thread should start the stream from previous checkpoint.", e);
+                        LOG.warn("Exception checkpointing the current state. New thread should start the stream from previous checkpoint.", e);
                         stop();
                     } finally {
                         lock.unlock();;

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
@@ -29,6 +29,7 @@ import org.opensearch.dataprepper.plugins.mongo.model.StreamLoadStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -36,6 +37,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static org.opensearch.dataprepper.model.source.s3.S3ScanEnvironmentVariables.STOP_S3_SCAN_PROCESSING_PROPERTY;
 import static org.opensearch.dataprepper.plugins.mongo.client.BsonHelper.JSON_WRITER_SETTINGS;
@@ -73,11 +76,17 @@ public class StreamWorker {
     private final int streamBatchSize;
     private boolean stopWorker = false;
     private final ExecutorService executorService;
-    private String lastLocalCheckpoint;
-    private Long lastLocalRecordCount = null;
+    private String lastLocalCheckpoint = null;
+    private long lastLocalRecordCount = 0;
     Optional<S3PartitionStatus> s3PartitionStatus = Optional.empty();
     private Integer currentEpochSecond;
     private int recordsSeenThisSecond = 0;
+    final List<Event> records = new ArrayList<>();
+    final List<Long> recordBytes = new ArrayList<>();
+    long lastBufferWriteTime = System.currentTimeMillis();
+    private String checkPointToken = null;
+    private long recordCount = 0;
+    private final Lock lock;
 
     public static StreamWorker create(final RecordBufferWriter recordBufferWriter,
                          final PartitionKeyRecordConverter recordConverter,
@@ -119,13 +128,14 @@ public class StreamWorker {
         this.bytesReceivedSummary = pluginMetrics.summary(BYTES_RECEIVED);
         this.bytesProcessedSummary = pluginMetrics.summary(BYTES_PROCESSED);
         this.executorService = Executors.newSingleThreadExecutor(BackgroundThreadFactory.defaultExecutorThreadFactory("mongodb-stream-checkpoint"));
+        this.lock = new ReentrantLock();
         if (sourceConfig.isAcknowledgmentsEnabled()) {
             // starts acknowledgement monitoring thread
             streamAcknowledgementManager.init((Void) -> stop());
-        } else {
-            // checkpoint in separate thread
-            this.executorService.submit(this::checkpointStream);
         }
+        // buffer write and checkpoint in separate thread on timeout
+        this.executorService.submit(this::bufferWriteAndCheckpointStream);
+
     }
 
     private MongoCursor<ChangeStreamDocument<Document>> getChangeStreamCursor(final MongoCollection<Document> collection,
@@ -156,15 +166,16 @@ public class StreamWorker {
 
     public void processStream(final StreamPartition streamPartition) {
         Optional<String> resumeToken = streamPartition.getProgressState().map(StreamProgressState::getResumeToken);
+        resumeToken.ifPresent(token -> checkPointToken = token);
+        Optional<Long> loadedRecords = streamPartition.getProgressState().map(StreamProgressState::getLoadedRecords);
+        loadedRecords.ifPresent(count -> recordCount = count);
+
         final String collectionDbName = streamPartition.getCollection();
         List<String> collectionDBNameList = List.of(collectionDbName.split(COLLECTION_SPLITTER));
         if (collectionDBNameList.size() < 2) {
             throw new IllegalArgumentException("Invalid Collection Name. Must be in db.collection format");
         }
-        long recordCount = 0;
-        final List<Event> records = new ArrayList<>();
-        final List<Long> recordBytes = new ArrayList<>();
-        String checkPointToken = null;
+
         try (MongoClient mongoClient = MongoDBConnection.getMongoClient(sourceConfig)) {
             // Access the database
             MongoDatabase database = mongoClient.getDatabase(collectionDBNameList.get(0));
@@ -189,7 +200,6 @@ public class StreamWorker {
                     throw new IllegalStateException("S3 partitions are not created. Please check the S3 partition creator thread.");
                 }
                 recordConverter.initializePartitions(s3Partitions);
-                long lastBufferWriteTime = System.currentTimeMillis();
                 while (!Thread.currentThread().isInterrupted() && !stopWorker) {
                     if (cursor.hasNext()) {
                         try {
@@ -208,7 +218,6 @@ public class StreamWorker {
                                 final long bytes = record.getBytes().length;
                                 bytesReceivedSummary.record(bytes);
 
-                                checkPointToken = document.getResumeToken().toJson(JSON_WRITER_SETTINGS);
                                 final Optional<BsonDocument> primaryKeyDoc = Optional.ofNullable(document.getDocumentKey());
                                 final String primaryKeyBsonType = primaryKeyDoc.map(bsonDocument -> bsonDocument.get(DOCUMENTDB_ID_FIELD_NAME).getBsonType().name()).orElse(UNKNOWN_TYPE);
                                 final Event event = recordConverter.convert(record, eventCreateTimeEpochMillis, eventCreationTimeEpochNanos,
@@ -220,18 +229,19 @@ public class StreamWorker {
                                 event.delete(DOCUMENTDB_ID_FIELD_NAME);
                                 records.add(event);
                                 recordBytes.add(bytes);
-                                recordCount += 1;
 
-                                if ((recordCount % recordFlushBatchSize == 0) || (System.currentTimeMillis() - lastBufferWriteTime >= bufferWriteIntervalInMs)) {
-                                    LOG.debug("Write to buffer for line {} to {}", (recordCount - recordFlushBatchSize), recordCount);
-                                    writeToBuffer(records, checkPointToken, recordCount);
-                                    lastLocalCheckpoint = checkPointToken;
-                                    lastLocalRecordCount = recordCount;
-                                    lastBufferWriteTime = System.currentTimeMillis();
-                                    bytesProcessedSummary.record(recordBytes.stream().mapToLong(Long::longValue).sum());
-                                    records.clear();
-                                    recordBytes.clear();
+                                lock.lock();
+                                try {
+                                    recordCount += 1;
+                                    checkPointToken = document.getResumeToken().toJson(JSON_WRITER_SETTINGS);
+
+                                    if ((recordCount % recordFlushBatchSize == 0) || (System.currentTimeMillis() - lastBufferWriteTime >= bufferWriteIntervalInMs)) {
+                                        writeToBuffer();
+                                    }
+                                } finally {
+                                    lock.unlock();
                                 }
+
                             } else if(shouldTerminateChangeStream(operationType)){
                                 stop();
                                 partitionCheckpoint.resetCheckpoint();
@@ -240,7 +250,6 @@ public class StreamWorker {
                                 LOG.warn("The change stream operation type {} is not handled", operationType);
                             }
                         } catch(Exception e){
-                            // TODO handle documents with size > 10 MB.
                             // this will only happen if writing to buffer gets interrupted from shutdown,
                             // otherwise it's infinite backoff and retry
                             LOG.error("Failed to add records to buffer with error", e);
@@ -267,6 +276,11 @@ public class StreamWorker {
             }
 
             System.clearProperty(STOP_S3_SCAN_PROCESSING_PROPERTY);
+
+            // stop other threads for this worker
+            stop();
+
+            partitionCheckpoint.giveUpPartition();
 
             // shutdown acknowledgement monitoring thread
             if (streamAcknowledgementManager != null) {
@@ -304,13 +318,49 @@ public class StreamWorker {
         successItemsCounter.increment(records.size());
     }
 
-    private void checkpointStream() {
+    private void writeToBuffer() {
+        LOG.debug("Write to buffer for line {} to {}", (recordCount - recordFlushBatchSize), recordCount);
+        writeToBuffer(records, checkPointToken, recordCount);
+        lastLocalCheckpoint = checkPointToken;
+        lastLocalRecordCount = recordCount;
+        lastBufferWriteTime = System.currentTimeMillis();
+        bytesProcessedSummary.record(recordBytes.stream().mapToLong(Long::longValue).sum());
+        records.clear();
+        recordBytes.clear();
+    }
+
+    private void bufferWriteAndCheckpointStream() {
         long lastCheckpointTime = System.currentTimeMillis();
         while (!Thread.currentThread().isInterrupted() && !stopWorker) {
-            if (lastLocalRecordCount != null && (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs)) {
-                LOG.debug("Perform regular checkpoint for resume token {} at record count {}", lastLocalCheckpoint, lastLocalRecordCount);
-                partitionCheckpoint.checkpoint(lastLocalCheckpoint, lastLocalRecordCount);
-                lastCheckpointTime = System.currentTimeMillis();
+            if (!records.isEmpty() && lastBufferWriteTime < Instant.now().minusMillis(checkPointIntervalInMs).toEpochMilli()) {
+                lock.lock();
+                LOG.debug("Writing to buffer due to buffer write delay");
+                try {
+                    writeToBuffer();
+                } catch(Exception e){
+                    // this will only happen if writing to buffer gets interrupted from shutdown,
+                    // otherwise it's infinite backoff and retry
+                    LOG.error("Failed to add records to buffer with error", e);
+                    failureItemsCounter.increment(records.size());
+                } finally {
+                    lock.unlock();
+                }
+            }
+
+            if (!sourceConfig.isAcknowledgmentsEnabled()) {
+                if (System.currentTimeMillis() - lastCheckpointTime >= checkPointIntervalInMs) {
+                    try {
+                        lock.lock();
+                        LOG.debug("Perform regular checkpoint for resume token {} at record count {}", lastLocalCheckpoint, lastLocalRecordCount);
+                        partitionCheckpoint.checkpoint(lastLocalCheckpoint, lastLocalRecordCount);
+                    } catch (Exception e) {
+                        LOG.error("Exception checkpointing the current state. New thread should start the stream from previous checkpoint.", e);
+                        stop();
+                    } finally {
+                        lock.unlock();;
+                    }
+                    lastCheckpointTime = System.currentTimeMillis();
+                }
             }
 
             try {

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/DataStreamPartitionCheckpointTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/DataStreamPartitionCheckpointTest.java
@@ -62,4 +62,10 @@ public class DataStreamPartitionCheckpointTest {
         verify(streamProgressState).setLoadedRecords(0);
         verify(streamProgressState).setLastUpdateTimestamp(anyLong());
     }
+
+    @Test
+    public void extendLease_success() {
+        dataStreamPartitionCheckpoint.extendLease();
+        verify(enhancedSourceCoordinator).saveProgressStateForPartition(streamPartition, CHECKPOINT_OWNERSHIP_TIMEOUT_INCREASE);
+    }
 }

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
@@ -310,9 +310,8 @@ public class StreamWorkerTest {
         verify(cursor).close();
         verify(cursor, times(4)).hasNext();
         verify(mockPartitionCheckpoint).getGlobalS3FolderCreationStatus(collection);
-        //verify(mockPartitionCheckpoint, atLeast(1)).checkpoint(resumeToken3, 3);
+        verify(mockPartitionCheckpoint, atLeast(1)).checkpoint(resumeToken3, 3);
         verify(successItemsCounter).increment(1);
-        //verify(mockPartitionCheckpoint, atLeast(1)).checkpoint(resumeToken2, 2);
         verify(mockRecordBufferWriter, times(2)).writeToBuffer(eq(null), any());
         verify(successItemsCounter).increment(2);
         verify(failureItemsCounter, never()).increment();

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
@@ -118,7 +118,7 @@ public class StreamWorkerTest {
         when(mockPluginMetrics.summary(BYTES_PROCESSED)).thenReturn(bytesProcessedSummary);
         when(mockSourceConfig.isAcknowledgmentsEnabled()).thenReturn(false);
         streamWorker = new StreamWorker(mockRecordBufferWriter, mockRecordConverter, mockSourceConfig, mockStreamAcknowledgementManager,
-                mockPartitionCheckpoint, mockPluginMetrics, 2, 0, 10_000, 1_000);
+                mockPartitionCheckpoint, mockPluginMetrics, 2, 1000, 10_000, 1_000);
     }
 
     @Test
@@ -180,8 +180,8 @@ public class StreamWorkerTest {
         final List<String> partitions = List.of("first", "second");
         when(s3PartitionStatus.getPartitions()).thenReturn(partitions);
         when(mockPartitionCheckpoint.getGlobalS3FolderCreationStatus(collection)).thenReturn(Optional.of(s3PartitionStatus));
-        Event event = mock(Event.class);
         when(mockSourceConfig.getIdKey()).thenReturn("docdb_id");
+        Event event = mock(Event.class);
         when(event.get("_id", Object.class)).thenReturn(UUID.randomUUID().toString());
         when(mockRecordConverter.convert(anyString(), anyLong(), anyLong(), any(OperationType.class), anyString())).thenReturn(event);
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -207,7 +207,7 @@ public class StreamWorkerTest {
         verify(successItemsCounter).increment(2);
         verify(bytesProcessedSummary).record(doc1Json1.getBytes().length + doc1Json2.getBytes().length);
         verify(failureItemsCounter, never()).increment();
-        verify(mockPartitionCheckpoint, atLeast(2)).checkpoint("{\"resumeToken2\": 234}", 2);
+        verify(mockPartitionCheckpoint, atLeast(1)).checkpoint("{\"resumeToken2\": 234}", 2);
     }
 
 
@@ -310,9 +310,9 @@ public class StreamWorkerTest {
         verify(cursor).close();
         verify(cursor, times(4)).hasNext();
         verify(mockPartitionCheckpoint).getGlobalS3FolderCreationStatus(collection);
-        verify(mockPartitionCheckpoint, atLeast(1)).checkpoint(resumeToken3, 3);
+        //verify(mockPartitionCheckpoint, atLeast(1)).checkpoint(resumeToken3, 3);
         verify(successItemsCounter).increment(1);
-        verify(mockPartitionCheckpoint, atLeast(1)).checkpoint(resumeToken2, 2);
+        //verify(mockPartitionCheckpoint, atLeast(1)).checkpoint(resumeToken2, 2);
         verify(mockRecordBufferWriter, times(2)).writeToBuffer(eq(null), any());
         verify(successItemsCounter).increment(2);
         verify(failureItemsCounter, never()).increment();


### PR DESCRIPTION
Write stream events that timeout to write to internal buffer in separate thread

 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
