### PR TITLE
Complete AcknowledgementSet for checkpoint thread & fix BsonTimeStamp field conversion

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelper.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelper.java
@@ -102,7 +102,7 @@ public class BsonHelper {
             writer.writeString(REGEX_OPTIONS, value.getOptions());
             writer.writeEndObject();
         })
-        .timestampConverter((value, writer) -> writer.writeNumber(String.valueOf(value.getValue())))
+        .timestampConverter((value, writer) -> writer.writeNumber(String.valueOf(value.getTime())))
         .undefinedConverter((value, writer) -> writer.writeNull())
         .build();
 

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManager.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManager.java
@@ -108,6 +108,7 @@ public class StreamAcknowledgementManager {
         final CheckpointStatus checkpointStatus = new CheckpointStatus(resumeToken, recordNumber, Instant.now().toEpochMilli());
         checkpoints.add(checkpointStatus);
         ackStatus.put(resumeToken, checkpointStatus);
+        LOG.debug("Creating acknowledgment for resumeToken {}", checkpointStatus.getResumeToken());
         return Optional.of(acknowledgementSetManager.create((result) -> {
             if (result) {
                 final CheckpointStatus ackCheckpointStatus = ackStatus.get(resumeToken);

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamScheduler.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamScheduler.java
@@ -27,7 +27,7 @@ public class StreamScheduler implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(StreamScheduler.class);
     private static final int DEFAULT_TAKE_LEASE_INTERVAL_MILLIS = 60_000;
     static final int DEFAULT_CHECKPOINT_INTERVAL_MILLS = 60_000;
-    static final int DEFAULT_BUFFER_WRITE_INTERVAL_MILLS = 15_000;
+    static final int DEFAULT_BUFFER_WRITE_INTERVAL_MILLS = 5_000;
     private static final int DEFAULT_MONITOR_WAIT_TIME_MS = 15_000;
     /**
      * Number of records to accumulate before flushing to buffer

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
@@ -317,10 +317,13 @@ public class StreamWorker {
         final AcknowledgementSet acknowledgementSet = streamAcknowledgementManager.createAcknowledgementSet(checkPointToken, recordCount).orElse(null);
         recordBufferWriter.writeToBuffer(acknowledgementSet, records);
         successItemsCounter.increment(records.size());
+        if (acknowledgementSet != null) {
+            acknowledgementSet.complete();
+        }
     }
 
     private void writeToBuffer() {
-        LOG.debug("Write to buffer for line {} to {}", (recordCount - recordFlushBatchSize), recordCount);
+        LOG.debug("Write to buffer for line {} to {}", lastLocalRecordCount, recordCount);
         writeToBuffer(records, checkPointToken, recordCount);
         lastLocalCheckpoint = checkPointToken;
         lastLocalRecordCount = recordCount;

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelperTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/client/BsonHelperTest.java
@@ -343,7 +343,7 @@ public class BsonHelperTest {
                         "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"objectIdField\": \"6634ed693ac62386d57b12d0\"}"),
                 Arguments.of(
                         "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"timestampField\": { \"$timestamp\": {\"t\": 1714744681, \"i\": 29}}}",
-                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"timestampField\": 7364772325884952605}"),
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"timestampField\": 1714744681}"),
                 Arguments.of(
                         "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"regexField\": { \"$regularExpression\": {\"pattern\": \"^ABC\", \"options\": \"i\"}}}",
                         "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"regexField\": {\"pattern\": \"^ABC\", \"options\": \"i\"}}"),

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorkerTest.java
@@ -505,9 +505,9 @@ public class StreamWorkerTest {
                         new BsonTimestamp(Math.abs(random.nextLong())),
                         "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"doubleValue\": 3.14159}"),
                 Arguments.of(
-                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"longValue\": { \"$numberLong\": \"1234567890123456768\"}}",
+                        "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"longValue\": { \"$numberLong\": \"9223372036854775801\"}}",
                         new BsonObjectId(new ObjectId()),
-                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"longValue\": 1234567890123456768}"),
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"longValue\": 9223372036854775801}"),
                 Arguments.of(
                         "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"stringField\": \"Hello, Mongo!\"}",
                         new BsonDocument(),
@@ -539,7 +539,7 @@ public class StreamWorkerTest {
                 Arguments.of(
                         "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"timestampField\": { \"$timestamp\": {\"t\": 1714744681, \"i\": 29}}}",
                         new BsonObjectId(new ObjectId()),
-                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"timestampField\": 7364772325884952605}"),
+                        "{\"_id\": \"6634ed693ac62386d57bcaf0\", \"timestampField\": 1714744681}"),
                 Arguments.of(
                         "{\"_id\": { \"$oid\": \"6634ed693ac62386d57bcaf0\" }, \"regexField\": { \"$regularExpression\": {\"pattern\": \"^ABC\", \"options\": \"i\"}}}",
                         new BsonObjectId(new ObjectId()),


### PR DESCRIPTION
### Description
* Complete AcknowledgementSet for checkpoint thread when Ack is enabled
* Use time in seconds for BsonTimeStamp field when converting to record
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
