### PR TITLE
Address route and subpipeline for pipeline tranformation

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PipelineModel.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PipelineModel.java
@@ -37,8 +37,8 @@ public class PipelineModel {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final PluginModel buffer;
 
-    @JsonProperty("route")
-    @JsonAlias("routes")
+    @JsonProperty("routes")
+    @JsonAlias("route")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private final List<ConditionalRoute> routes;
 
@@ -68,7 +68,7 @@ public class PipelineModel {
             @JsonProperty("source") final PluginModel source,
             @JsonProperty("buffer") final PluginModel buffer,
             @JsonProperty("processor") final List<PluginModel> processors,
-            @JsonProperty("route")@JsonAlias("routes") final List<ConditionalRoute> routes,
+            @JsonProperty("routes")@JsonAlias("route") final List<ConditionalRoute> routes,
             @JsonProperty("sink") final List<SinkModel> sinks,
             @JsonProperty("workers") final Integer workers,
             @JsonProperty("delay") final Integer delay) {

--- a/data-prepper-api/src/test/resources/pipelines_data_flow_route.yaml
+++ b/data-prepper-api/src/test/resources/pipelines_data_flow_route.yaml
@@ -3,7 +3,7 @@ test-pipeline:
     testSource: null
   processor:
   - testPrepper: null
-  route:
+  routes:
   - my-route: "/a==b"
   sink:
   - testSink:

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/rule/RuleEvaluator.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/rule/RuleEvaluator.java
@@ -41,6 +41,7 @@ public class RuleEvaluator {
     }
 
     public RuleEvaluatorResult isTransformationNeeded(PipelinesDataFlowModel pipelineModel) {
+        //TODO - Dynamically scan the rules folder and get the corresponding template.
         return isDocDBSource(pipelineModel);
     }
 

--- a/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformer.java
+++ b/data-prepper-pipeline-parser/src/main/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformer.java
@@ -219,14 +219,11 @@ public class DynamicConfigTransformer implements PipelineConfigurationTransforme
         pipelines.forEach((pipelineName, pipeline) -> {
             if (!pipelineName.equals(pipelineNameThatNeedsTransformation)) {
                 if(subPipelineNames.size()>0 && subPipelineNames.contains(pipelineName)){ //if there are subpipelines
-                    for(String subPipelineName: subPipelineNames){
-                        String pipelineJson = null;
-                        try {
-                            PipelineModel subPipeline = getSubPipeline(pipeline, pipelineNameThatNeedsTransformation);
-                            transformedPipelines.put(pipelineName, subPipeline);
-                        } catch (JsonProcessingException e) {
-                            throw new RuntimeException(e);
-                        }
+                    try {
+                        PipelineModel subPipeline = getSubModifiedPipeline(pipeline, pipelineNameThatNeedsTransformation);
+                        transformedPipelines.put(pipelineName, subPipeline);
+                    } catch (JsonProcessingException e) {
+                        throw new RuntimeException(e);
                     }
                 }else {
                     transformedPipelines.put(pipelineName, pipeline);
@@ -245,13 +242,11 @@ public class DynamicConfigTransformer implements PipelineConfigurationTransforme
         return transformedPipelinesDataFlowModel;
     }
 
-    private PipelineModel getSubPipeline(PipelineModel pipeline,
+    private PipelineModel getSubModifiedPipeline(PipelineModel pipeline,
                                          String pipelineNameThatNeedsTransformation) throws JsonProcessingException {
-        String pipelineJson;
-        pipelineJson = objectMapper.writeValueAsString(pipeline);
+        String pipelineJson = objectMapper.writeValueAsString(pipeline);
         JsonNode pipelineNode = objectMapper.readTree(pipelineJson);
-        String parentPath = SUBPIPELINE_PATH;
-        JsonNode parentNode = JsonPath.using(parseConfigWithJsonNode).parse(pipelineNode).read(parentPath);
+        JsonNode parentNode = JsonPath.using(parseConfigWithJsonNode).parse(pipelineNode).read(SUBPIPELINE_PATH);
 
         //TODO - Dynamically detect the 2nd pipeline in the template of the transformed pipeline
         JsonNode newNode = new TextNode(pipelineNameThatNeedsTransformation +"-s3");

--- a/data-prepper-pipeline-parser/src/main/resources/templates/documentdb-template.yaml
+++ b/data-prepper-pipeline-parser/src/main/resources/templates/documentdb-template.yaml
@@ -78,4 +78,4 @@
             interval: "60s"
     processor: "<<$.<<pipeline-name>>.processor>>"
     sink: "<<$.<<pipeline-name>>.sink>>"
-    routes: "<<$.<<pipeline-name>>.routes>>"
+    route: "<<$.<<pipeline-name>>.route>>" # In placeholder, routes or route (defined as alias) will be transformed to route in json as route will be primarily picked in pipelineModel.

--- a/data-prepper-pipeline-parser/src/main/resources/templates/documentdb-template.yaml
+++ b/data-prepper-pipeline-parser/src/main/resources/templates/documentdb-template.yaml
@@ -78,4 +78,4 @@
             interval: "60s"
     processor: "<<$.<<pipeline-name>>.processor>>"
     sink: "<<$.<<pipeline-name>>.sink>>"
-    route: "<<$.<<pipeline-name>>.route>>" # In placeholder, routes or route (defined as alias) will be transformed to route in json as route will be primarily picked in pipelineModel.
+    routes: "<<$.<<pipeline-name>>.routes>>" # In placeholder, routes or route (defined as alias) will be transformed to route in json as route will be primarily picked in pipelineModel.

--- a/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/TestConfigurationProvider.java
+++ b/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/TestConfigurationProvider.java
@@ -44,6 +44,9 @@ public class TestConfigurationProvider {
     public static final String USER_CONFIG_TRANSFORMATION_DOCDB2_CONFIG_FILE = "src/test/resources/transformation/userConfig/documentdb2-userconfig.yaml";
     public static final String USER_CONFIG_TRANSFORMATION_DOCUMENTDB_CONFIG_FILE = "src/test/resources/transformation/userConfig/documentdb-userconfig.yaml";
     public static final String USER_CONFIG_TRANSFORMATION_DOCUMENTDB_SUBPIPELINES_CONFIG_FILE = "src/test/resources/transformation/userConfig/documentdb-subpipelines-userconfig.yaml";
+    public static final String USER_CONFIG_TRANSFORMATION_DOCUMENTDB_ROUTES_CONFIG_FILE = "src/test/resources/transformation/userConfig/documentdb-routes-userconfig.yaml";
+    public static final String USER_CONFIG_TRANSFORMATION_DOCUMENTDB_ROUTE_CONFIG_FILE = "src/test/resources/transformation/userConfig/documentdb-route-userconfig.yaml";
+    public static final String USER_CONFIG_TRANSFORMATION_DOCUMENTDB_SUBPIPELINES_ROUTES_CONFIG_FILE = "src/test/resources/transformation/userConfig/documentdb-subpipelines-routes-userconfig.yaml";
     public static final String USER_CONFIG_TRANSFORMATION_DOCUMENTDB_FUNCTION_CONFIG_FILE = "src/test/resources/transformation/userConfig/documentdb-function-userconfig.yaml";
 
     public static final String RULES_TRANSFORMATION_DOCDB1_CONFIG_FILE = "src/test/resources/transformation/rules/documentdb1-rule.yaml";
@@ -55,12 +58,16 @@ public class TestConfigurationProvider {
     public static final String TEMPLATE_TRANSFORMATION_DOCDB2_CONFIG_FILE = "src/test/resources/transformation/templates/testSource/documentdb2-template.yaml";
     public static final String TEMPLATE_TRANSFORMATION_DOCUMENTDB_CONFIG_FILE = "src/test/resources/transformation/templates/testSource/documentdb-template.yaml";
     public static final String TEMPLATE_TRANSFORMATION_DOCUMENTDB_SUBPIPELINES_CONFIG_FILE = "src/test/resources/transformation/templates/testSource/documentdb-subpipelines-template.yaml";
+    public static final String TEMPLATE_TRANSFORMATION_DOCUMENTDB_FINAL_CONFIG_FILE = "src/test/resources/transformation/templates/testSource/documentdb-template-final.yaml";
     public static final String TEMPLATE_TRANSFORMATION_DOCUMENTDB_FUNCTION_CONFIG_FILE = "src/test/resources/transformation/templates/testSource/documentdb-function-template.yaml";
 
     public static final String EXPECTED_TRANSFORMATION_DOCDB1_CONFIG_FILE = "src/test/resources/transformation/expected/documentdb1-expected.yaml";
     public static final String EXPECTED_TRANSFORMATION_DOCDB2_CONFIG_FILE = "src/test/resources/transformation/expected/documentdb2-expected.yaml";
     public static final String EXPECTED_TRANSFORMATION_DOCUMENTDB_CONFIG_FILE = "src/test/resources/transformation/expected/documentdb-expected.yaml";
     public static final String EXPECTED_TRANSFORMATION_DOCUMENTDB_SUBPIPLINES_CONFIG_FILE = "src/test/resources/transformation/expected/documentdb-subpipelines-expected.yaml";
+    public static final String EXPECTED_TRANSFORMATION_DOCUMENTDB_ROUTES_CONFIG_FILE = "src/test/resources/transformation/expected/documentdb-routes-expected.yaml";
+    public static final String EXPECTED_TRANSFORMATION_DOCUMENTDB_ROUTE_CONFIG_FILE = "src/test/resources/transformation/expected/documentdb-route-expected.yaml";
+    public static final String EXPECTED_TRANSFORMATION_DOCUMENTDB_SUBPIPELINES_ROUTES_CONFIG_FILE = "src/test/resources/transformation/expected/documentdb-subpipelines-routes-expected.yaml";
     public static final String EXPECTED_TRANSFORMATION_DOCUMENTDB_FUNCTION_CONFIG_FILE = "src/test/resources/transformation/expected/documentdb-function-expected.yaml";
 
 

--- a/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformerTest.java
+++ b/data-prepper-pipeline-parser/src/test/java/org/opensearch/dataprepper/pipeline/parser/transformer/DynamicConfigTransformerTest.java
@@ -206,6 +206,115 @@ class DynamicConfigTransformerTest {
     }
 
     @Test
+    void test_successful_transformation_with_routes_keyword() throws IOException {
+
+        String docDBUserConfig = TestConfigurationProvider.USER_CONFIG_TRANSFORMATION_DOCUMENTDB_ROUTES_CONFIG_FILE;
+        String templateDocDBFilePath = TestConfigurationProvider.TEMPLATE_TRANSFORMATION_DOCUMENTDB_FINAL_CONFIG_FILE;
+        String ruleDocDBFilePath = TestConfigurationProvider.RULES_TRANSFORMATION_DOCDB1_CONFIG_FILE;
+        String expectedDocDBFilePath = TestConfigurationProvider.EXPECTED_TRANSFORMATION_DOCUMENTDB_ROUTES_CONFIG_FILE;
+        String pluginName = "documentdb";
+        PipelineConfigurationReader pipelineConfigurationReader = new PipelineConfigurationFileReader(docDBUserConfig);
+        final PipelinesDataflowModelParser pipelinesDataflowModelParser =
+                new PipelinesDataflowModelParser(pipelineConfigurationReader);
+
+        transformersFactory = Mockito.spy(new TransformersFactory(RULES_DIRECTORY_PATH,
+                TEMPLATES_DIRECTORY_PATH));
+        when(transformersFactory.getPluginRuleFileLocation(pluginName)).thenReturn(ruleDocDBFilePath);
+        when(transformersFactory.getPluginTemplateFileLocation(pluginName)).thenReturn(templateDocDBFilePath);
+        InputStream ruleStream = new FileInputStream(ruleDocDBFilePath);
+        InputStream templateStream = new FileInputStream(templateDocDBFilePath);
+        when(transformersFactory.getPluginRuleFileStream(pluginName)).thenReturn(ruleStream);
+        when(transformersFactory.getPluginTemplateFileStream(pluginName)).thenReturn(templateStream);
+        ruleEvaluator = new RuleEvaluator(transformersFactory);
+
+        // Load the original and template YAML files from the test resources directory
+        PipelinesDataFlowModel pipelinesDataFlowModel = pipelinesDataflowModelParser.parseConfiguration();
+        PipelineConfigurationTransformer transformer = new DynamicConfigTransformer(ruleEvaluator);
+        PipelinesDataFlowModel transformedModel = transformer.transformConfiguration(pipelinesDataFlowModel);
+        String transformedYaml = yamlMapper.writeValueAsString(transformedModel);
+
+        Map<String, Object> transformedYamlasMap = yamlMapper.readValue(transformedYaml, Map.class);
+
+        Map<String, Object> expectedYamlasMap = yamlMapper.readValue(new File(expectedDocDBFilePath), Map.class);
+        assertThat(expectedYamlasMap).usingRecursiveComparison().isEqualTo(transformedYamlasMap);
+    }
+
+
+
+    @Test
+    void test_successful_transformation_with_route_keyword() throws IOException {
+
+        String docDBUserConfig = TestConfigurationProvider.USER_CONFIG_TRANSFORMATION_DOCUMENTDB_ROUTE_CONFIG_FILE;
+        String templateDocDBFilePath = TestConfigurationProvider.TEMPLATE_TRANSFORMATION_DOCUMENTDB_FINAL_CONFIG_FILE;
+        String ruleDocDBFilePath = TestConfigurationProvider.RULES_TRANSFORMATION_DOCDB1_CONFIG_FILE;
+        //should be same as with routes keyword
+        String expectedDocDBFilePath = TestConfigurationProvider.EXPECTED_TRANSFORMATION_DOCUMENTDB_ROUTES_CONFIG_FILE;
+        String pluginName = "documentdb";
+        PipelineConfigurationReader pipelineConfigurationReader = new PipelineConfigurationFileReader(docDBUserConfig);
+        final PipelinesDataflowModelParser pipelinesDataflowModelParser =
+                new PipelinesDataflowModelParser(pipelineConfigurationReader);
+
+        transformersFactory = Mockito.spy(new TransformersFactory(RULES_DIRECTORY_PATH,
+                TEMPLATES_DIRECTORY_PATH));
+        when(transformersFactory.getPluginRuleFileLocation(pluginName)).thenReturn(ruleDocDBFilePath);
+        when(transformersFactory.getPluginTemplateFileLocation(pluginName)).thenReturn(templateDocDBFilePath);
+        InputStream ruleStream = new FileInputStream(ruleDocDBFilePath);
+        InputStream templateStream = new FileInputStream(templateDocDBFilePath);
+        when(transformersFactory.getPluginRuleFileStream(pluginName)).thenReturn(ruleStream);
+        when(transformersFactory.getPluginTemplateFileStream(pluginName)).thenReturn(templateStream);
+        ruleEvaluator = new RuleEvaluator(transformersFactory);
+
+        // Load the original and template YAML files from the test resources directory
+        PipelinesDataFlowModel pipelinesDataFlowModel = pipelinesDataflowModelParser.parseConfiguration();
+        PipelineConfigurationTransformer transformer = new DynamicConfigTransformer(ruleEvaluator);
+        PipelinesDataFlowModel transformedModel = transformer.transformConfiguration(pipelinesDataFlowModel);
+        String transformedYaml = yamlMapper.writeValueAsString(transformedModel);
+
+        Map<String, Object> transformedYamlasMap = yamlMapper.readValue(transformedYaml, Map.class);
+
+        Map<String, Object> expectedYamlasMap = yamlMapper.readValue(new File(expectedDocDBFilePath), Map.class);
+        assertThat(expectedYamlasMap).usingRecursiveComparison().isEqualTo(transformedYamlasMap);
+    }
+
+
+    @Test
+    void test_successful_transformation_with_routes_and_subpipelines() throws IOException {
+
+        String docDBUserConfig = TestConfigurationProvider.USER_CONFIG_TRANSFORMATION_DOCUMENTDB_SUBPIPELINES_ROUTES_CONFIG_FILE;
+        String templateDocDBFilePath = TestConfigurationProvider.TEMPLATE_TRANSFORMATION_DOCUMENTDB_FINAL_CONFIG_FILE;
+        String ruleDocDBFilePath = TestConfigurationProvider.RULES_TRANSFORMATION_DOCDB1_CONFIG_FILE;
+        String expectedDocDBFilePath = TestConfigurationProvider.EXPECTED_TRANSFORMATION_DOCUMENTDB_SUBPIPELINES_ROUTES_CONFIG_FILE;
+        String pluginName = "documentdb";
+        PipelineConfigurationReader pipelineConfigurationReader = new PipelineConfigurationFileReader(docDBUserConfig);
+        final PipelinesDataflowModelParser pipelinesDataflowModelParser =
+                new PipelinesDataflowModelParser(pipelineConfigurationReader);
+
+        transformersFactory = Mockito.spy(new TransformersFactory(RULES_DIRECTORY_PATH,
+                TEMPLATES_DIRECTORY_PATH));
+        when(transformersFactory.getPluginRuleFileLocation(pluginName)).thenReturn(ruleDocDBFilePath);
+        when(transformersFactory.getPluginTemplateFileLocation(pluginName)).thenReturn(templateDocDBFilePath);
+        InputStream ruleStream = new FileInputStream(ruleDocDBFilePath);
+        InputStream ruleStream2 = new FileInputStream(ruleDocDBFilePath);
+        InputStream ruleStream3 = new FileInputStream(ruleDocDBFilePath);
+        InputStream templateStream = new FileInputStream(templateDocDBFilePath);
+
+        when(transformersFactory.getPluginRuleFileStream(pluginName)).thenReturn(ruleStream).thenReturn(ruleStream2).thenReturn(ruleStream3);
+        when(transformersFactory.getPluginTemplateFileStream(pluginName)).thenReturn(templateStream);
+        ruleEvaluator = new RuleEvaluator(transformersFactory);
+
+        // Load the original and template YAML files from the test resources directory
+        PipelinesDataFlowModel pipelinesDataFlowModel = pipelinesDataflowModelParser.parseConfiguration();
+        PipelineConfigurationTransformer transformer = new DynamicConfigTransformer(ruleEvaluator);
+        PipelinesDataFlowModel transformedModel = transformer.transformConfiguration(pipelinesDataFlowModel);
+        String transformedYaml = yamlMapper.writeValueAsString(transformedModel);
+
+        Map<String, Object> transformedYamlasMap = yamlMapper.readValue(transformedYaml, Map.class);
+
+        Map<String, Object> expectedYamlasMap = yamlMapper.readValue(new File(expectedDocDBFilePath), Map.class);
+        assertThat(expectedYamlasMap).usingRecursiveComparison().isEqualTo(transformedYamlasMap);
+    }
+
+    @Test
     void testInvalidJsonPathThrowsException() throws IOException {
         String docDBUserConfig = TestConfigurationProvider.USER_CONFIG_TRANSFORMATION_DOCDB_SIMPLE_CONFIG_FILE;
         String templateDocDBFilePath = TestConfigurationProvider.TEMPLATE_TRANSFORMATION_DOCDB_SIMPLE_CONFIG_FILE;

--- a/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb-expected.yaml
+++ b/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb-expected.yaml
@@ -23,7 +23,7 @@ dodb-pipeline-transformed:
     bounded_blocking:
       batch_size: 125000
       buffer_size: 1000000
-  route:
+  routes:
     - initial_load: "getMetadata(\"ingestion_type\") == \"EXPORT\""
     - stream_load: "getMetadata(\"ingestion_type\") == \"STREAM\""
   sink:

--- a/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb-route-expected.yaml
+++ b/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb-route-expected.yaml
@@ -29,7 +29,7 @@ documentdb-pipeline-s3:
         match:
           log:
             - "%{COMMONAPACHELOG_DATATYPED}"
-  route:
+  routes:
     - "2xx_status": "/response >= 200 and /response < 300"
     - "3xx_status": "/response >= 300 and /response < 400"
     - "4xx_status": "/response >= 400 and /response < 500"
@@ -80,7 +80,7 @@ documentdb-pipeline:
       aws:
         sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
       s3_bucket: "benebucket"
-  route:
+  routes:
     - initial_load: "getMetadata(\"ingestion_type\") == \"EXPORT\""
     - stream_load: "getMetadata(\"ingestion_type\") == \"STREAM\""
   sink:

--- a/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb-route-expected.yaml
+++ b/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb-route-expected.yaml
@@ -1,0 +1,126 @@
+documentdb-pipeline-s3:
+  source:
+    s3:
+      codec:
+        event_json: null
+      disable_s3_metadata_in_event: true
+      scan:
+        folder_partitions:
+          depth: "4"
+          max_objects_per_ownership: 50
+        buckets:
+          - bucket:
+              name: "benebucket"
+              filter:
+                include_prefix:
+                  - null
+        scheduling:
+          interval: "60s"
+      acknowledgments: true
+      compression: "none"
+      aws:
+        region: "us-west-2"
+        sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+        sts_external_id: null
+        sts_header_overrides: null
+      delete_s3_objects_on_read: true
+  processor:
+    - grok:
+        match:
+          log:
+            - "%{COMMONAPACHELOG_DATATYPED}"
+  route:
+    - "2xx_status": "/response >= 200 and /response < 300"
+    - "3xx_status": "/response >= 300 and /response < 400"
+    - "4xx_status": "/response >= 400 and /response < 500"
+    - "5xx_status": "/response >= 500 and /response < 600"
+  sink:
+    - opensearch:
+        routes:
+          - "2xx_status"
+        exclude_keys:
+          - "_id"
+        document_version_type: "external"
+        hosts:
+          - "https://search-osis-fgac2-bxzuq7pzdkvygg6gaecl4jrfqy.us-west-2.es.amazonaws.com"
+        index: "docdb-gd-l1transf-route"
+        action: "${getMetadata(\"opensearch_action\")}"
+        document_id: "${getMetadata(\"primary_key\")}"
+        document_version: "${getMetadata(\"document_version\")}"
+        aws:
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          region: "us-west-2"
+        index_type: "custom"
+    - opensearch:
+        routes:
+          - "3xx_status"
+        exclude_keys:
+          - "_id"
+        document_version_type: "external"
+        hosts:
+          - "https://search-osis-fgac2-bxzuq7pzdkvygg6gaecl4jrfqy.us-west-2.es.amazonaws.com"
+        index: "docdb-gd-l1transf-route"
+        action: "${getMetadata(\"opensearch_action\")}"
+        document_id: "${getMetadata(\"primary_key\")}"
+        document_version: "${getMetadata(\"document_version\")}"
+        aws:
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          region: "us-west-2"
+        index_type: "custom"
+documentdb-pipeline:
+  source:
+    documentdb:
+      s3_region: "us-west-2"
+      collections:
+        - collection: "gharchive.events"
+          export: true
+          stream: true
+      host: "documentdb.cluster-c0acx1an8oxg.us-west-2.docdb.amazonaws.com"
+      acknowledgments: true
+      aws:
+        sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+      s3_bucket: "benebucket"
+  route:
+    - initial_load: "getMetadata(\"ingestion_type\") == \"EXPORT\""
+    - stream_load: "getMetadata(\"ingestion_type\") == \"STREAM\""
+  sink:
+    - s3:
+        routes:
+          - "initial_load"
+        bucket: "benebucket"
+        codec:
+          event_json: null
+        object_key:
+          path_prefix: "${getMetadata(\"s3_partition_key\")}"
+        default_bucket_owner: "123123123123"
+        aggregate_threshold:
+          maximum_size: "128mb"
+          flush_capacity_ratio: 0
+        threshold:
+          event_collect_timeout: "120s"
+          maximum_size: "2mb"
+        aws:
+          region: "us-west-2"
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          sts_external_id: null
+          sts_header_overrides: null
+    - s3:
+        routes:
+          - "stream_load"
+        bucket: "benebucket"
+        codec:
+          event_json: null
+        object_key:
+          path_prefix: "${getMetadata(\"s3_partition_key\")}"
+        default_bucket_owner: "123123123123"
+        aggregate_threshold:
+          maximum_size: "128mb"
+          flush_capacity_ratio: 0
+        threshold:
+          event_collect_timeout: "15s"
+          maximum_size: "1mb"
+        aws:
+          region: "us-west-2"
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          sts_external_id: null
+          sts_header_overrides: null

--- a/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb-routes-expected.yaml
+++ b/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb-routes-expected.yaml
@@ -29,7 +29,7 @@ documentdb-pipeline-s3:
         match:
           log:
             - "%{COMMONAPACHELOG_DATATYPED}"
-  route:
+  routes:
     - "2xx_status": "/response >= 200 and /response < 300"
     - "3xx_status": "/response >= 300 and /response < 400"
     - "4xx_status": "/response >= 400 and /response < 500"
@@ -80,7 +80,7 @@ documentdb-pipeline:
       aws:
         sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
       s3_bucket: "benebucket"
-  route:
+  routes:
     - initial_load: "getMetadata(\"ingestion_type\") == \"EXPORT\""
     - stream_load: "getMetadata(\"ingestion_type\") == \"STREAM\""
   sink:

--- a/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb-routes-expected.yaml
+++ b/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb-routes-expected.yaml
@@ -1,0 +1,126 @@
+documentdb-pipeline-s3:
+  source:
+    s3:
+      codec:
+        event_json: null
+      disable_s3_metadata_in_event: true
+      scan:
+        folder_partitions:
+          depth: "4"
+          max_objects_per_ownership: 50
+        buckets:
+          - bucket:
+              name: "benebucket"
+              filter:
+                include_prefix:
+                  - null
+        scheduling:
+          interval: "60s"
+      acknowledgments: true
+      compression: "none"
+      aws:
+        region: "us-west-2"
+        sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+        sts_external_id: null
+        sts_header_overrides: null
+      delete_s3_objects_on_read: true
+  processor:
+    - grok:
+        match:
+          log:
+            - "%{COMMONAPACHELOG_DATATYPED}"
+  route:
+    - "2xx_status": "/response >= 200 and /response < 300"
+    - "3xx_status": "/response >= 300 and /response < 400"
+    - "4xx_status": "/response >= 400 and /response < 500"
+    - "5xx_status": "/response >= 500 and /response < 600"
+  sink:
+    - opensearch:
+        routes:
+          - "2xx_status"
+        exclude_keys:
+          - "_id"
+        document_version_type: "external"
+        hosts:
+          - "https://search-osis-fgac2-bxzuq7pzdkvygg6gaecl4jrfqy.us-west-2.es.amazonaws.com"
+        index: "docdb-gd-l1transf-route"
+        action: "${getMetadata(\"opensearch_action\")}"
+        document_id: "${getMetadata(\"primary_key\")}"
+        document_version: "${getMetadata(\"document_version\")}"
+        aws:
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          region: "us-west-2"
+        index_type: "custom"
+    - opensearch:
+        routes:
+          - "3xx_status"
+        exclude_keys:
+          - "_id"
+        document_version_type: "external"
+        hosts:
+          - "https://search-osis-fgac2-bxzuq7pzdkvygg6gaecl4jrfqy.us-west-2.es.amazonaws.com"
+        index: "docdb-gd-l1transf-route"
+        action: "${getMetadata(\"opensearch_action\")}"
+        document_id: "${getMetadata(\"primary_key\")}"
+        document_version: "${getMetadata(\"document_version\")}"
+        aws:
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          region: "us-west-2"
+        index_type: "custom"
+documentdb-pipeline:
+  source:
+    documentdb:
+      s3_region: "us-west-2"
+      collections:
+        - collection: "gharchive.events"
+          export: true
+          stream: true
+      host: "documentdb.cluster-c0acx1an8oxg.us-west-2.docdb.amazonaws.com"
+      acknowledgments: true
+      aws:
+        sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+      s3_bucket: "benebucket"
+  route:
+    - initial_load: "getMetadata(\"ingestion_type\") == \"EXPORT\""
+    - stream_load: "getMetadata(\"ingestion_type\") == \"STREAM\""
+  sink:
+    - s3:
+        routes:
+          - "initial_load"
+        bucket: "benebucket"
+        codec:
+          event_json: null
+        object_key:
+          path_prefix: "${getMetadata(\"s3_partition_key\")}"
+        default_bucket_owner: "123123123123"
+        aggregate_threshold:
+          maximum_size: "128mb"
+          flush_capacity_ratio: 0
+        threshold:
+          event_collect_timeout: "120s"
+          maximum_size: "2mb"
+        aws:
+          region: "us-west-2"
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          sts_external_id: null
+          sts_header_overrides: null
+    - s3:
+        routes:
+          - "stream_load"
+        bucket: "benebucket"
+        codec:
+          event_json: null
+        object_key:
+          path_prefix: "${getMetadata(\"s3_partition_key\")}"
+        default_bucket_owner: "123123123123"
+        aggregate_threshold:
+          maximum_size: "128mb"
+          flush_capacity_ratio: 0
+        threshold:
+          event_collect_timeout: "15s"
+          maximum_size: "1mb"
+        aws:
+          region: "us-west-2"
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          sts_external_id: null
+          sts_header_overrides: null

--- a/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb-subpipelines-routes-expected.yaml
+++ b/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb-subpipelines-routes-expected.yaml
@@ -1,0 +1,140 @@
+documentdb-pipeline-s3:
+  source:
+    s3:
+      codec:
+        event_json: null
+      disable_s3_metadata_in_event: true
+      scan:
+        folder_partitions:
+          depth: "4"
+          max_objects_per_ownership: 50
+        buckets:
+          - bucket:
+              name: "benebucket"
+              filter:
+                include_prefix:
+                  - null
+        scheduling:
+          interval: "60s"
+      acknowledgments: true
+      compression: "none"
+      aws:
+        region: "us-west-2"
+        sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+        sts_external_id: null
+        sts_header_overrides: null
+      delete_s3_objects_on_read: true
+  processor:
+    - grok:
+        match:
+          log:
+            - "%{COMMONAPACHELOG_DATATYPED}"
+  route:
+    - "2xx_status": "/response >= 200 and /response < 300"
+    - "3xx_status": "/response >= 300 and /response < 400"
+    - "4xx_status": "/response >= 400 and /response < 500"
+    - "5xx_status": "/response >= 500 and /response < 600"
+  sink:
+    - pipeline:
+        routes:
+          - "2xx_status"
+        name: "sub-pipe1"
+    - pipeline:
+        routes:
+          - "3xx_status"
+        name: "sub-pipe2"
+documentdb-pipeline:
+  source:
+    documentdb:
+      s3_region: "us-west-2"
+      collections:
+        - collection: "gharchive.events"
+          export: true
+          stream: true
+      host: "docdb-gd-documentdb.cluster-c0acx1an8oxg.us-west-2.docdb.amazonaws.com"
+      acknowledgments: true
+      aws:
+        sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+      s3_bucket: "benebucket"
+  route:
+    - initial_load: "getMetadata(\"ingestion_type\") == \"EXPORT\""
+    - stream_load: "getMetadata(\"ingestion_type\") == \"STREAM\""
+  sink:
+    - s3:
+        routes:
+          - "initial_load"
+        bucket: "benebucket"
+        codec:
+          event_json: null
+        object_key:
+          path_prefix: "${getMetadata(\"s3_partition_key\")}"
+        default_bucket_owner: "123123123123"
+        aggregate_threshold:
+          maximum_size: "128mb"
+          flush_capacity_ratio: 0
+        threshold:
+          event_collect_timeout: "120s"
+          maximum_size: "2mb"
+        aws:
+          region: "us-west-2"
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          sts_external_id: null
+          sts_header_overrides: null
+    - s3:
+        routes:
+          - "stream_load"
+        bucket: "benebucket"
+        codec:
+          event_json: null
+        object_key:
+          path_prefix: "${getMetadata(\"s3_partition_key\")}"
+        default_bucket_owner: "123123123123"
+        aggregate_threshold:
+          maximum_size: "128mb"
+          flush_capacity_ratio: 0
+        threshold:
+          event_collect_timeout: "15s"
+          maximum_size: "1mb"
+        aws:
+          region: "us-west-2"
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          sts_external_id: null
+          sts_header_overrides: null
+sub-pipe2:
+  source:
+    pipeline:
+      name: "documentdb-pipeline-s3"
+  sink:
+    - opensearch:
+        exclude_keys:
+          - "_id"
+        document_version_type: "external"
+        hosts:
+          - "https://search-osis-fgac2-bxzuq7pzdkvygg6gaecl4jrfqy.us-west-2.es.amazonaws.com"
+        index: "docdb-gd-l1transf-subpipe"
+        action: "${getMetadata(\"opensearch_action\")}"
+        document_id: "${getMetadata(\"primary_key\")}"
+        document_version: "${getMetadata(\"document_version\")}"
+        aws:
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          region: "us-west-2"
+        index_type: "custom"
+sub-pipe1:
+  source:
+    pipeline:
+      name: "documentdb-pipeline-s3"
+  sink:
+    - opensearch:
+        exclude_keys:
+          - "_id"
+        document_version_type: "external"
+        hosts:
+          - "https://search-osis-fgac2-bxzuq7pzdkvygg6gaecl4jrfqy.us-west-2.es.amazonaws.com"
+        index: "docdb-gd-l1transf-subpipe"
+        action: "${getMetadata(\"opensearch_action\")}"
+        document_id: "${getMetadata(\"primary_key\")}"
+        document_version: "${getMetadata(\"document_version\")}"
+        aws:
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          region: "us-west-2"
+        index_type: "custom"

--- a/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb-subpipelines-routes-expected.yaml
+++ b/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb-subpipelines-routes-expected.yaml
@@ -29,7 +29,7 @@ documentdb-pipeline-s3:
         match:
           log:
             - "%{COMMONAPACHELOG_DATATYPED}"
-  route:
+  routes:
     - "2xx_status": "/response >= 200 and /response < 300"
     - "3xx_status": "/response >= 300 and /response < 400"
     - "4xx_status": "/response >= 400 and /response < 500"
@@ -56,7 +56,7 @@ documentdb-pipeline:
       aws:
         sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
       s3_bucket: "benebucket"
-  route:
+  routes:
     - initial_load: "getMetadata(\"ingestion_type\") == \"EXPORT\""
     - stream_load: "getMetadata(\"ingestion_type\") == \"STREAM\""
   sink:

--- a/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb2-expected.yaml
+++ b/data-prepper-pipeline-parser/src/test/resources/transformation/expected/documentdb2-expected.yaml
@@ -65,7 +65,7 @@ documentdb-pipeline-reader:
         username: "${{aws_secrets:secret:password}}"
         password: "${{aws_secrets:secret:password}}"
       s3_prefix: "folder1/folder2"
-  route:
+  routes:
     - initial_load: "getMetadata(\"ingestion_type\") == \"EXPORT\""
     - stream_load: "getMetadata(\"ingestion_type\") == \"STREAM\""
   sink:

--- a/data-prepper-pipeline-parser/src/test/resources/transformation/templates/testSource/documentdb-template-final.yaml
+++ b/data-prepper-pipeline-parser/src/test/resources/transformation/templates/testSource/documentdb-template-final.yaml
@@ -1,0 +1,81 @@
+"<<pipeline-name>>":
+  workers: "<<$.<<pipeline-name>>.workers>>"
+  delay: "<<$.<<pipeline-name>>.delay>>"
+  buffer: "<<$.<<pipeline-name>>.buffer>>"
+  source:
+    documentdb: "<<$.<<pipeline-name>>.source.documentdb>>"
+  routes:
+    - initial_load: 'getMetadata("ingestion_type") == "EXPORT"'
+    - stream_load: 'getMetadata("ingestion_type") == "STREAM"'
+  sink:
+    - s3:
+        routes:
+          - initial_load
+        aws:
+          region:  "<<$.<<pipeline-name>>.source.documentdb.s3_region>>"
+          sts_role_arn: "<<$.<<pipeline-name>>.source.documentdb.aws.sts_role_arn>>"
+          sts_external_id: "<<$.<<pipeline-name>>.source.documentdb.aws.sts_external_id>>"
+          sts_header_overrides: "<<$.<<pipeline-name>>.source.documentdb.aws.sts_header_overrides>>"
+        bucket: "<<$.<<pipeline-name>>.source.documentdb.s3_bucket>>"
+        threshold:
+          event_collect_timeout: "120s"
+          maximum_size: "2mb"
+        aggregate_threshold:
+          maximum_size: "128mb"
+          flush_capacity_ratio: 0
+        object_key:
+          path_prefix: "${getMetadata(\"s3_partition_key\")}"
+        codec:
+          event_json:
+        default_bucket_owner: "<<FUNCTION_NAME:getAccountIdFromRole,PARAMETER:$.<<pipeline-name>>.source.documentdb.aws.sts_role_arn>>"
+    - s3:
+        routes:
+          - stream_load
+        aws:
+          region:  "<<$.<<pipeline-name>>.source.documentdb.s3_region>>"
+          sts_role_arn: "<<$.<<pipeline-name>>.source.documentdb.aws.sts_role_arn>>"
+          sts_external_id: "<<$.<<pipeline-name>>.source.documentdb.aws.sts_external_id>>"
+          sts_header_overrides: "<<$.<<pipeline-name>>.source.documentdb.aws.sts_header_overrides>>"
+        bucket: "<<$.<<pipeline-name>>.source.documentdb.s3_bucket>>"
+        threshold:
+          event_collect_timeout: "15s"
+          maximum_size: "1mb"
+        aggregate_threshold:
+          maximum_size: "128mb"
+          flush_capacity_ratio: 0
+        object_key:
+          path_prefix: "${getMetadata(\"s3_partition_key\")}"
+        codec:
+          event_json:
+        default_bucket_owner: "<<FUNCTION_NAME:getAccountIdFromRole,PARAMETER:$.<<pipeline-name>>.source.documentdb.aws.sts_role_arn>>"
+"<<pipeline-name>>-s3":
+  workers: "<<$.<<pipeline-name>>.workers>>"
+  delay: "<<$.<<pipeline-name>>.delay>>"
+  buffer: "<<$.<<pipeline-name>>.buffer>>"
+  source:
+    s3:
+      codec:
+        event_json:
+      compression: "none"
+      aws:
+        region:  "<<$.<<pipeline-name>>.source.documentdb.s3_region>>"
+        sts_role_arn: "<<$.<<pipeline-name>>.source.documentdb.aws.sts_role_arn>>"
+        sts_external_id: "<<$.<<pipeline-name>>.source.documentdb.aws.sts_external_id>>"
+        sts_header_overrides: "<<$.<<pipeline-name>>.source.documentdb.aws.sts_header_overrides>>"
+      acknowledgments: true
+      delete_s3_objects_on_read: true
+      disable_s3_metadata_in_event: true
+      scan:
+        folder_partitions:
+          depth: "<<FUNCTION_NAME:calculateDepth,PARAMETER:$.<<pipeline-name>>.source.documentdb.s3_prefix>>"
+          max_objects_per_ownership: 50
+        buckets:
+          - bucket:
+              name: "<<$.<<pipeline-name>>.source.documentdb.s3_bucket>>"
+              filter:
+                include_prefix: ["<<FUNCTION_NAME:getSourceCoordinationIdentifierEnvVariable,PARAMETER:$.<<pipeline-name>>.source.documentdb.s3_prefix>>"]
+        scheduling:
+          interval: "60s"
+  processor: "<<$.<<pipeline-name>>.processor>>"
+  sink: "<<$.<<pipeline-name>>.sink>>"
+  routes: "<<$.<<pipeline-name>>.route>>" # In placeholder, routes or route (defined as alias) will be transformed to route in json as route will be primarily picked in pipelineModel.

--- a/data-prepper-pipeline-parser/src/test/resources/transformation/templates/testSource/documentdb-template-final.yaml
+++ b/data-prepper-pipeline-parser/src/test/resources/transformation/templates/testSource/documentdb-template-final.yaml
@@ -78,4 +78,4 @@
           interval: "60s"
   processor: "<<$.<<pipeline-name>>.processor>>"
   sink: "<<$.<<pipeline-name>>.sink>>"
-  routes: "<<$.<<pipeline-name>>.route>>" # In placeholder, routes or route (defined as alias) will be transformed to route in json as route will be primarily picked in pipelineModel.
+  routes: "<<$.<<pipeline-name>>.routes>>"

--- a/data-prepper-pipeline-parser/src/test/resources/transformation/templates/testSource/documentdb-template.yaml
+++ b/data-prepper-pipeline-parser/src/test/resources/transformation/templates/testSource/documentdb-template.yaml
@@ -6,7 +6,7 @@
     bounded_blocking:
       batch_size: 125000
       buffer_size: 1000000
-  route:
+  routes:
     - initial_load: 'getMetadata("ingestion_type") == "EXPORT"'
     - stream_load: 'getMetadata("ingestion_type") == "STREAM"'
   sink:

--- a/data-prepper-pipeline-parser/src/test/resources/transformation/userConfig/documentdb-route-userconfig.yaml
+++ b/data-prepper-pipeline-parser/src/test/resources/transformation/userConfig/documentdb-route-userconfig.yaml
@@ -1,0 +1,69 @@
+version: "2"
+documentdb-pipeline:
+  source:
+    documentdb:
+      acknowledgments: true
+      host: "documentdb.cluster-c0acx1an8oxg.us-west-2.docdb.amazon\
+        aws.com"
+      aws:
+        sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+      s3_bucket: "benebucket"
+      s3_region: "us-west-2"
+      collections:
+        - collection: "gharchive.events"
+          export: true
+          stream: true
+  processor:
+    - grok:
+        match:
+          log: [ "%{COMMONAPACHELOG_DATATYPED}" ]
+  route:
+    - 2xx_status: "/response >= 200 and /response < 300"
+    - 3xx_status: "/response >= 300 and /response < 400"
+    - 4xx_status: "/response >= 400 and /response < 500"
+    - 5xx_status: "/response >= 500 and /response < 600"
+  sink:
+    - opensearch:
+        # REQUIRED: Provide an AWS OpenSearch endpoint
+        hosts:
+          [
+            "https://search-osis-fgac2-bxzuq7pzdkvygg6gaecl4jrfqy.us-west-2.es.amazonaws.com"
+          ]
+        index: "docdb-gd-l1transf-route"
+        index_type: custom
+        # DocumentDB _docId
+        exclude_keys: [ "_id" ]
+        document_id: "${getMetadata(\"primary_key\")}"
+        action: "${getMetadata(\"opensearch_action\")}"
+        # DocumentDB record creation or event timestamp
+        document_version: "${getMetadata(\"document_version\")}"
+        document_version_type: "external"
+        aws:
+          # REQUIRED: Provide a Role ARN with access to the domain. This role should have a trust relationship with osis-pipelines.amazonaws.com
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          # Provide the region of the domain.
+          region: "us-west-2"
+        routes:
+          - 2xx_status
+    - opensearch:
+        # REQUIRED: Provide an AWS OpenSearch endpoint
+        hosts:
+          [
+            "https://search-osis-fgac2-bxzuq7pzdkvygg6gaecl4jrfqy.us-west-2.es.amazonaws.com"
+          ]
+        index: "docdb-gd-l1transf-route"
+        index_type: custom
+        # DocumentDB _docId
+        exclude_keys: [ "_id" ]
+        document_id: "${getMetadata(\"primary_key\")}"
+        action: "${getMetadata(\"opensearch_action\")}"
+        # DocumentDB record creation or event timestamp
+        document_version: "${getMetadata(\"document_version\")}"
+        document_version_type: "external"
+        aws:
+          # REQUIRED: Provide a Role ARN with access to the domain. This role should have a trust relationship with osis-pipelines.amazonaws.com
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          # Provide the region of the domain.
+          region: "us-west-2"
+        routes:
+          - 3xx_status

--- a/data-prepper-pipeline-parser/src/test/resources/transformation/userConfig/documentdb-routes-userconfig.yaml
+++ b/data-prepper-pipeline-parser/src/test/resources/transformation/userConfig/documentdb-routes-userconfig.yaml
@@ -1,0 +1,69 @@
+version: "2"
+documentdb-pipeline:
+  source:
+    documentdb:
+      acknowledgments: true
+      host: "documentdb.cluster-c0acx1an8oxg.us-west-2.docdb.amazon\
+        aws.com"
+      aws:
+        sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+      s3_bucket: "benebucket"
+      s3_region: "us-west-2"
+      collections:
+        - collection: "gharchive.events"
+          export: true
+          stream: true
+  processor:
+    - grok:
+        match:
+          log: [ "%{COMMONAPACHELOG_DATATYPED}" ]
+  routes:
+    - 2xx_status: "/response >= 200 and /response < 300"
+    - 3xx_status: "/response >= 300 and /response < 400"
+    - 4xx_status: "/response >= 400 and /response < 500"
+    - 5xx_status: "/response >= 500 and /response < 600"
+  sink:
+    - opensearch:
+        # REQUIRED: Provide an AWS OpenSearch endpoint
+        hosts:
+          [
+            "https://search-osis-fgac2-bxzuq7pzdkvygg6gaecl4jrfqy.us-west-2.es.amazonaws.com"
+          ]
+        index: "docdb-gd-l1transf-route"
+        index_type: custom
+        # DocumentDB _docId
+        exclude_keys: [ "_id" ]
+        document_id: "${getMetadata(\"primary_key\")}"
+        action: "${getMetadata(\"opensearch_action\")}"
+        # DocumentDB record creation or event timestamp
+        document_version: "${getMetadata(\"document_version\")}"
+        document_version_type: "external"
+        aws:
+          # REQUIRED: Provide a Role ARN with access to the domain. This role should have a trust relationship with osis-pipelines.amazonaws.com
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          # Provide the region of the domain.
+          region: "us-west-2"
+        routes:
+          - 2xx_status
+    - opensearch:
+        # REQUIRED: Provide an AWS OpenSearch endpoint
+        hosts:
+          [
+            "https://search-osis-fgac2-bxzuq7pzdkvygg6gaecl4jrfqy.us-west-2.es.amazonaws.com"
+          ]
+        index: "docdb-gd-l1transf-route"
+        index_type: custom
+        # DocumentDB _docId
+        exclude_keys: [ "_id" ]
+        document_id: "${getMetadata(\"primary_key\")}"
+        action: "${getMetadata(\"opensearch_action\")}"
+        # DocumentDB record creation or event timestamp
+        document_version: "${getMetadata(\"document_version\")}"
+        document_version_type: "external"
+        aws:
+          # REQUIRED: Provide a Role ARN with access to the domain. This role should have a trust relationship with osis-pipelines.amazonaws.com
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          # Provide the region of the domain.
+          region: "us-west-2"
+        routes:
+          - 3xx_status

--- a/data-prepper-pipeline-parser/src/test/resources/transformation/userConfig/documentdb-subpipelines-routes-userconfig.yaml
+++ b/data-prepper-pipeline-parser/src/test/resources/transformation/userConfig/documentdb-subpipelines-routes-userconfig.yaml
@@ -1,0 +1,83 @@
+version: "2"
+documentdb-pipeline:
+  source:
+    documentdb:
+      acknowledgments: true
+      host: "docdb-gd-documentdb.cluster-c0acx1an8oxg.us-west-2.docdb.amazon\
+        aws.com"
+      aws:
+        sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+      s3_bucket: "benebucket"
+      s3_region: "us-west-2"
+      collections:
+        - collection: "gharchive.events"
+          export: true
+          stream: true
+  processor:
+    - grok:
+        match:
+          log: [ "%{COMMONAPACHELOG_DATATYPED}" ]
+  routes:
+    - 2xx_status: "/response >= 200 and /response < 300"
+    - 3xx_status: "/response >= 300 and /response < 400"
+    - 4xx_status: "/response >= 400 and /response < 500"
+    - 5xx_status: "/response >= 500 and /response < 600"
+  sink:
+    - pipeline:
+        name: "sub-pipe1"
+        routes:
+          - 2xx_status
+    - pipeline:
+        name: "sub-pipe2"
+        routes:
+          - 3xx_status
+sub-pipe1:
+  source:
+    pipeline:
+      name: "documentdb-pipeline"
+  sink:
+    - opensearch:
+        # REQUIRED: Provide an AWS OpenSearch endpoint
+        hosts:
+          [
+            "https://search-osis-fgac2-bxzuq7pzdkvygg6gaecl4jrfqy.us-west-2.es.amazonaws.com"
+          ]
+        index: "docdb-gd-l1transf-subpipe"
+        index_type: custom
+        # DocumentDB _docId
+        exclude_keys: [ "_id" ]
+        document_id: "${getMetadata(\"primary_key\")}"
+        action: "${getMetadata(\"opensearch_action\")}"
+        # DocumentDB record creation or event timestamp
+        document_version: "${getMetadata(\"document_version\")}"
+        document_version_type: "external"
+        aws:
+          # REQUIRED: Provide a Role ARN with access to the domain. This role should have a trust relationship with osis-pipelines.amazonaws.com
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          # Provide the region of the domain.
+          region: "us-west-2"
+sub-pipe2:
+  source:
+    pipeline:
+      name: "documentdb-pipeline"
+  sink:
+    - opensearch:
+        # REQUIRED: Provide an AWS OpenSearch endpoint
+        hosts:
+          [
+            "https://search-osis-fgac2-bxzuq7pzdkvygg6gaecl4jrfqy.us-west-2.es.amazonaws.com"
+          ]
+        index: "docdb-gd-l1transf-subpipe"
+        index_type: custom
+        # DocumentDB _docId
+        exclude_keys: [ "_id" ]
+        document_id: "${getMetadata(\"primary_key\")}"
+        action: "${getMetadata(\"opensearch_action\")}"
+        # DocumentDB record creation or event timestamp
+        document_version: "${getMetadata(\"document_version\")}"
+        document_version_type: "external"
+        aws:
+          # REQUIRED: Provide a Role ARN with access to the domain. This role should have a trust relationship with osis-pipelines.amazonaws.com
+          sts_role_arn: "arn:aws:iam::123123123123:role/Admin"
+          # Provide the region of the domain.
+          region: "us-west-2"

--- a/docs/pipeline_configuration_transformation.md
+++ b/docs/pipeline_configuration_transformation.md
@@ -73,3 +73,13 @@ there can be only one pipeline that can support transformation.
 4. `<<$ .. >>` is the placeholder in the template.
 `<< pipeline-name >>` is handled differently as compared to other placeholders
 as other placeholders are jsonPaths.
+
+### Developer Guide
+When defining a placeholder for routes. Always define it as route.
+```aidl
+routes: "<<$.<<pipeline-name>>.route>>" # routes or route (defined as alias) will be transformed to route in json as route will be primarily picked in pipelineModel.
+```
+OR
+```
+route: "<<$.<<pipeline-name>>.route>>"
+```

--- a/docs/pipeline_configuration_transformation.md
+++ b/docs/pipeline_configuration_transformation.md
@@ -77,9 +77,5 @@ as other placeholders are jsonPaths.
 ### Developer Guide
 When defining a placeholder for routes. Always define it as route.
 ```aidl
-routes: "<<$.<<pipeline-name>>.route>>" # routes or route (defined as alias) will be transformed to route in json as route will be primarily picked in pipelineModel.
-```
-OR
-```
-route: "<<$.<<pipeline-name>>.route>>"
+routes: "<<$.<<pipeline-name>>.routes>>" # routes or route (defined as alias) will be transformed to routes in json as routes will be primarily picked in pipelineModel.
 ```


### PR DESCRIPTION
### Description
Address route and subpipeline for pipeline tranformation.
1. PipelineModel uses route and routes as alias, which needs to be addressed in the transformation. 
Routes or route (defined as alias in Pipeline Model) will be always be transformed to route in json , as route will be primarily picked in pipelineModel when converting model to json or the other way round.

2. Subpipelines within one pipeline was addressed in the transformation.
Earlier, subpipelines were using the untransformed pipeline name. Made changes to make it pick the transformed pipeline name.

 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
