### PR TITLE
Fix aggregate processor local mode

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwarding.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwarding.java
@@ -30,4 +30,15 @@ public interface RequiresPeerForwarding {
     default boolean isApplicableEventForPeerForwarding(Event event) {
         return true;
     }
+
+    /**
+     * Determines if an event should be handled on the local node only
+     *
+     * @param event input event
+     *
+     * @return true if the event should be processed locally only
+     */
+    default boolean isForLocalProcessingOnly(Event event) {
+        return false;
+    }
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwardingTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/peerforwarder/RequiresPeerForwardingTest.java
@@ -27,6 +27,7 @@ class RequiresPeerForwardingTest {
         Event event = mock(Event.class);
         RequiresPeerForwarding requiresPeerForwarding = new SimpleRequiresPeerForwarding();
         assertThat(requiresPeerForwarding.isApplicableEventForPeerForwarding(event), equalTo(true));
+        assertThat(requiresPeerForwarding.isForLocalProcessingOnly(event), equalTo(false));
     }
 }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
@@ -81,23 +81,29 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
     @Override
     public Collection<Record<Event>> execute(final Collection<Record<Event>> records) {
         final Collection<Record<Event>> recordsToProcess = new ArrayList<>();
+        Collection<Record<Event>> recordsToProcessLocally = new ArrayList<>();
         final Collection<Record<Event>> recordsSkipped = new ArrayList<>();
         for (Record<Event> record: records) {
             if (((RequiresPeerForwarding)innerProcessor).isApplicableEventForPeerForwarding(record.getData())) {
                 recordsToProcess.add(record);
+            } else if (((RequiresPeerForwarding)innerProcessor).isForLocalProcessingOnly(record.getData())){
+                recordsToProcessLocally.add(record);
             } else {
                 recordsSkipped.add(record);
             }
         }
         final Collection<Record<Event>> recordsToProcessOnLocalPeer = peerForwarder.forwardRecords(recordsToProcess);
 
+        recordsToProcessLocally = CollectionUtils.union(recordsToProcessLocally, recordsToProcessOnLocalPeer);
+
         final Collection<Record<Event>> receivedRecordsFromBuffer = peerForwarder.receiveRecords();
 
-        final Collection<Record<Event>> recordsToProcessLocally = CollectionUtils.union(
-                recordsToProcessOnLocalPeer, receivedRecordsFromBuffer);
+        recordsToProcessLocally = CollectionUtils.union(recordsToProcessLocally, receivedRecordsFromBuffer);
 
-        Collection<Record<Event>> recordsOut = innerProcessor.execute(recordsToProcessLocally);
-        recordsOut.addAll(recordsSkipped);
+        Collection<Record<Event>> recordsOut = recordsSkipped;
+        if (recordsToProcessLocally.size() > 0) {
+            recordsOut.addAll(innerProcessor.execute(recordsToProcessLocally));
+        }
         return recordsOut;
     }
 

--- a/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
+++ b/data-prepper-core/src/main/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessorDecorator.java
@@ -100,10 +100,8 @@ public class PeerForwardingProcessorDecorator implements Processor<Record<Event>
 
         recordsToProcessLocally = CollectionUtils.union(recordsToProcessLocally, receivedRecordsFromBuffer);
 
-        Collection<Record<Event>> recordsOut = recordsSkipped;
-        if (recordsToProcessLocally.size() > 0) {
-            recordsOut.addAll(innerProcessor.execute(recordsToProcessLocally));
-        }
+        Collection<Record<Event>> recordsOut = innerProcessor.execute(recordsToProcessLocally);
+        recordsOut.addAll(recordsSkipped);
         return recordsOut;
     }
 

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
@@ -250,13 +250,10 @@ class PeerForwardingProcessingDecoratorTest {
             Record aggregatedRecord = mock(Record.class);
             List<Record> aggregatedRecords = new ArrayList<>();
             aggregatedRecords.add(aggregatedRecord);
-            //when(processor.execute(anyCollection())).thenReturn(aggregatedRecords);
             when(requiresPeerForwarding.isApplicableEventForPeerForwarding(event1)).thenReturn(true);
             when(requiresPeerForwarding.isApplicableEventForPeerForwarding(event2)).thenReturn(false);
             when(requiresPeerForwarding.isApplicableEventForPeerForwarding(event3)).thenReturn(true);
-            //when(requiresPeerForwarding.isForLocalProcessingOnly(event1)).thenReturn(false);
             when(requiresPeerForwarding.isForLocalProcessingOnly(event2)).thenReturn(false);
-            //when(requiresPeerForwarding.isForLocalProcessingOnly(event3)).thenReturn(false);
             final List<Processor> processors = createObjectUnderTesDecoratedProcessors(Collections.singletonList(processor));
             when(record1.getData()).thenReturn(event1);
             when(record2.getData()).thenReturn(event2);

--- a/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
+++ b/data-prepper-core/src/test/java/org/opensearch/dataprepper/peerforwarder/PeerForwardingProcessingDecoratorTest.java
@@ -186,7 +186,7 @@ class PeerForwardingProcessingDecoratorTest {
 
             assertThat(processors.size(), equalTo(1));
             processors.get(0).execute(testData);
-            verify(processor, times(0)).execute(anyCollection());
+            verify(processor).execute(anyCollection());
         }
 
 
@@ -265,7 +265,7 @@ class PeerForwardingProcessingDecoratorTest {
 
             assertThat(processors.size(), equalTo(1));
             Collection<Record<Event>> recordsOut = processors.get(0).execute(recordsIn);
-            verify(processor, times(0)).execute(anyCollection());
+            verify(processor).execute(anyCollection());
             // one record skipped, no records locally processed
             assertThat(recordsOut.size(), equalTo(1));
             assertTrue(recordsOut.contains(record2));

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -152,6 +152,11 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
 
     @Override
     public boolean isForLocalProcessingOnly(Event event) {
+        // no need to check for when condition here because it is
+        // done in doExecute(). isApplicableEventForPeerForwarding()
+        // checks for when condition because it is an optimization to
+        // not send events not matching the condition to remote peer
+        // only to be skipped later.
         return localMode;
     }
 

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessor.java
@@ -151,6 +151,11 @@ public class AggregateProcessor extends AbstractProcessor<Record<Event>, Record<
     }
 
     @Override
+    public boolean isForLocalProcessingOnly(Event event) {
+        return localMode;
+    }
+
+    @Override
     public boolean isApplicableEventForPeerForwarding(Event event) {
         if (localMode) {
             return false;

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -360,6 +360,9 @@ public class AggregateProcessorTest {
             assertThat(objectUnderTest.isApplicableEventForPeerForwarding(event), equalTo(false));
             assertThat(objectUnderTest.isApplicableEventForPeerForwarding(firstEvent), equalTo(false));
             assertThat(objectUnderTest.isApplicableEventForPeerForwarding(secondEvent), equalTo(false));
+            assertThat(objectUnderTest.isForLocalProcessingOnly(event), equalTo(true));
+            assertThat(objectUnderTest.isForLocalProcessingOnly(firstEvent), equalTo(true));
+            assertThat(objectUnderTest.isForLocalProcessingOnly(secondEvent), equalTo(true));
             final List<Record<Event>> recordsOut = (List<Record<Event>>) objectUnderTest.doExecute(c);
 
             assertThat(recordsOut.size(), equalTo(3));


### PR DESCRIPTION
### Description
Local mode option added to aggregate processor in PR #4306 has a bug that when local mode is turned on the events are not passed to the remote peer but also skipped from passing it to the local inner processor. This change fixes the issue so that local mode works as expected.
 
### Issues Resolved
Resolves #
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
