### PR TITLE
Add DocDB source aggregate metrics

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/documentdb/DocumentDBService.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/documentdb/DocumentDBService.java
@@ -12,6 +12,7 @@ import org.opensearch.dataprepper.plugins.mongo.configuration.CollectionConfig;
 import org.opensearch.dataprepper.plugins.mongo.configuration.MongoDBSourceConfig;
 import org.opensearch.dataprepper.plugins.mongo.leader.LeaderScheduler;
 import org.opensearch.dataprepper.plugins.mongo.s3partition.S3PartitionCreatorScheduler;
+import org.opensearch.dataprepper.plugins.mongo.utils.DocumentDBSourceAggregateMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +31,7 @@ public class DocumentDBService {
     private final MongoDBSourceConfig sourceConfig;
     private final AcknowledgementSetManager acknowledgementSetManager;
     private final PluginConfigObservable pluginConfigObservable;
+    private final DocumentDBSourceAggregateMetrics documentDBAggregateMetrics;
     private ExecutorService leaderExecutor;
     public DocumentDBService(final EnhancedSourceCoordinator sourceCoordinator,
                              final MongoDBSourceConfig sourceConfig,
@@ -41,6 +43,7 @@ public class DocumentDBService {
         this.acknowledgementSetManager = acknowledgementSetManager;
         this.sourceConfig = sourceConfig;
         this.pluginConfigObservable = pluginConfigObservable;
+        this.documentDBAggregateMetrics = new DocumentDBSourceAggregateMetrics();
     }
 
     /**
@@ -69,7 +72,7 @@ public class DocumentDBService {
                 buffer, sourceCoordinator, pluginMetrics, acknowledgementSetManager,
                 numThread -> Executors.newFixedThreadPool(
                         numThread, BackgroundThreadFactory.defaultExecutorThreadFactory("documentdb-source")),
-                s3PathPrefix);
+                s3PathPrefix, documentDBAggregateMetrics);
         mongoTasksRefresher.initialize(sourceConfig);
         pluginConfigObservable.addPluginConfigObserver(
                 pluginConfig -> mongoTasksRefresher.update((MongoDBSourceConfig) pluginConfig));

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/export/MongoDBExportPartitionSupplier.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/export/MongoDBExportPartitionSupplier.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.mongo.export;
 
+import com.mongodb.MongoClientException;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
@@ -19,6 +20,7 @@ import org.opensearch.dataprepper.plugins.mongo.configuration.MongoDBSourceConfi
 import org.opensearch.dataprepper.plugins.mongo.coordination.partition.ExportPartition;
 import org.opensearch.dataprepper.plugins.mongo.coordination.state.ExportProgressState;
 import org.opensearch.dataprepper.plugins.mongo.model.PartitionIdentifierBatch;
+import org.opensearch.dataprepper.plugins.mongo.utils.DocumentDBSourceAggregateMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,16 +38,21 @@ public class MongoDBExportPartitionSupplier implements Function<ExportPartition,
     private static final String COLLECTION_SPLITTER = "\\.";
 
     private final MongoDBSourceConfig sourceConfig;
+    private final DocumentDBSourceAggregateMetrics documentDBAggregateMetrics;
 
-    public MongoDBExportPartitionSupplier(final MongoDBSourceConfig sourceConfig) {
+    public MongoDBExportPartitionSupplier(final MongoDBSourceConfig sourceConfig,
+                                          final DocumentDBSourceAggregateMetrics documentDBAggregateMetrics) {
         this.sourceConfig = sourceConfig;
+        this.documentDBAggregateMetrics = documentDBAggregateMetrics;
     }
 
     private PartitionIdentifierBatch buildPartitions(final ExportPartition exportPartition) {
+        documentDBAggregateMetrics.getExportApiInvocations().increment();
         final List<PartitionIdentifier> collectionPartitions = new ArrayList<>();
         final String collectionDbName = exportPartition.getCollection();
         List<String> collection = List.of(collectionDbName.split(COLLECTION_SPLITTER));
         if (collection.size() < 2) {
+            documentDBAggregateMetrics.getExport4xxErrors().increment();
             throw new IllegalArgumentException("Invalid Collection Name. Must be in db.collection format");
         }
         final Optional<ExportProgressState> exportProgressStateOptional = exportPartition
@@ -112,12 +119,20 @@ public class MongoDBExportPartitionSupplier implements Function<ExportPartition,
                             .projection(new Document("_id", 1))
                             .sort(new Document("_id", 1))
                             .limit(1);
-                } catch (Exception e) {
-                    LOG.error("Failed to read start cursor when build partitions", e);
-                    throw new RuntimeException(e);
                 }
             }
+        } catch (final IllegalArgumentException | MongoClientException e) {
+            // IllegalArgumentException is thrown when database or collection name is not valid
+            // MongoClientException is thrown for exceptions indicating a failure condition with the MongoClient
+            documentDBAggregateMetrics.getExport4xxErrors().increment();
+            LOG.error("Client side exception while build partitions.", e);
+            throw new RuntimeException(e);
+        } catch (final Exception e) {
+            documentDBAggregateMetrics.getExport5xxErrors().increment();
+            LOG.error("Server side exception while build partitions.", e);
+            throw new RuntimeException(e);
         }
+
         return new PartitionIdentifierBatch(collectionPartitions, isLastBatch, endDocId);
     }
 

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamWorker.java
@@ -1,5 +1,6 @@
 package org.opensearch.dataprepper.plugins.mongo.stream;
 
+import com.mongodb.MongoClientException;
 import com.mongodb.client.ChangeStreamIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
@@ -26,6 +27,7 @@ import org.opensearch.dataprepper.plugins.mongo.coordination.partition.StreamPar
 import org.opensearch.dataprepper.plugins.mongo.coordination.state.StreamProgressState;
 import org.opensearch.dataprepper.plugins.mongo.model.S3PartitionStatus;
 import org.opensearch.dataprepper.plugins.mongo.model.StreamLoadStatus;
+import org.opensearch.dataprepper.plugins.mongo.utils.DocumentDBSourceAggregateMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,6 +77,7 @@ public class StreamWorker {
     private final int checkPointIntervalInMs;
     private final int bufferWriteIntervalInMs;
     private final int streamBatchSize;
+    private final DocumentDBSourceAggregateMetrics documentDBAggregateMetrics;
     private boolean stopWorker = false;
     private final ExecutorService executorService;
     private String lastLocalCheckpoint = null;
@@ -98,10 +101,11 @@ public class StreamWorker {
                          final int recordFlushBatchSize,
                          final int checkPointIntervalInMs,
                          final int bufferWriteIntervalInMs,
-                         final int streamBatchSize
+                         final int streamBatchSize,
+                         final DocumentDBSourceAggregateMetrics documentDBAggregateMetrics
     ) {
         return new StreamWorker(recordBufferWriter, recordConverter, sourceConfig, streamAcknowledgementManager, partitionCheckpoint,
-                pluginMetrics, recordFlushBatchSize, checkPointIntervalInMs, bufferWriteIntervalInMs, streamBatchSize);
+                pluginMetrics, recordFlushBatchSize, checkPointIntervalInMs, bufferWriteIntervalInMs, streamBatchSize, documentDBAggregateMetrics);
     }
     public StreamWorker(final RecordBufferWriter recordBufferWriter,
                         final PartitionKeyRecordConverter recordConverter,
@@ -112,7 +116,8 @@ public class StreamWorker {
                         final int recordFlushBatchSize,
                         final int checkPointIntervalInMs,
                         final int bufferWriteIntervalInMs,
-                        final int streamBatchSize
+                        final int streamBatchSize,
+                        final DocumentDBSourceAggregateMetrics documentDBAggregateMetrics
                         ) {
         this.recordBufferWriter = recordBufferWriter;
         this.recordConverter  = recordConverter;
@@ -124,6 +129,7 @@ public class StreamWorker {
         this.checkPointIntervalInMs = checkPointIntervalInMs;
         this.bufferWriteIntervalInMs = bufferWriteIntervalInMs;
         this.streamBatchSize = streamBatchSize;
+        this.documentDBAggregateMetrics = documentDBAggregateMetrics;
         this.successItemsCounter = pluginMetrics.counter(SUCCESS_ITEM_COUNTER_NAME);
         this.failureItemsCounter = pluginMetrics.counter(FAILURE_ITEM_COUNTER_NAME);
         this.bytesReceivedSummary = pluginMetrics.summary(BYTES_RECEIVED);
@@ -166,6 +172,8 @@ public class StreamWorker {
     }
 
     public void processStream(final StreamPartition streamPartition) {
+        documentDBAggregateMetrics.getStreamApiInvocations().increment();
+
         Optional<String> resumeToken = streamPartition.getProgressState().map(StreamProgressState::getResumeToken);
         resumeToken.ifPresent(token -> checkPointToken = token);
         Optional<Long> loadedRecords = streamPartition.getProgressState().map(StreamProgressState::getLoadedRecords);
@@ -174,10 +182,12 @@ public class StreamWorker {
         final String collectionDbName = streamPartition.getCollection();
         List<String> collectionDBNameList = List.of(collectionDbName.split(COLLECTION_SPLITTER));
         if (collectionDBNameList.size() < 2) {
+            documentDBAggregateMetrics.getStream4xxErrors().increment();
             throw new IllegalArgumentException("Invalid Collection Name. Must be in db.collection format");
         }
 
         try (MongoClient mongoClient = MongoDBConnection.getMongoClient(sourceConfig)) {
+
             // Access the database
             MongoDatabase database = mongoClient.getDatabase(collectionDBNameList.get(0));
 
@@ -198,6 +208,7 @@ public class StreamWorker {
                 final List<String> s3Partitions = s3PartitionStatus.get().getPartitions();
                 if (s3Partitions.isEmpty()) {
                     // This should not happen unless the S3 partition creator failed.
+                    documentDBAggregateMetrics.getStream5xxErrors().increment();
                     throw new IllegalStateException("S3 partitions are not created. Please check the S3 partition creator thread.");
                 }
                 recordConverter.initializePartitions(s3Partitions);
@@ -263,8 +274,15 @@ public class StreamWorker {
                     }
                 }
             }
+        } catch (final IllegalArgumentException | MongoClientException e) {
+            // IllegalArgumentException is thrown when database or collection name is not valid
+            // MongoClientException is thrown for exceptions indicating a failure condition with the MongoClient
+            documentDBAggregateMetrics.getStream4xxErrors().increment();
+            LOG.error("Client side exception connecting to cluster and processing stream", e);
+            throw new RuntimeException(e);
         } catch (final Exception e) {
-            LOG.error("Exception connecting to cluster and processing stream", e);
+            documentDBAggregateMetrics.getStream5xxErrors().increment();
+            LOG.error("Server side exception connecting to cluster and processing stream", e);
             throw new RuntimeException(e);
         } finally {
             if (!records.isEmpty()) {

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/utils/DocumentDBSourceAggregateMetrics.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/utils/DocumentDBSourceAggregateMetrics.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.mongo.utils;
+
+import io.micrometer.core.instrument.Counter;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+
+public class DocumentDBSourceAggregateMetrics {
+    private static final String DOCUMENT_DB = "documentdb";
+
+    private static final String DOCUMENT_DB_STREAM_5XX_EXCEPTIONS = "stream5xxErrors";
+    private static final String DOCUMENT_DB_STREAM_4XX_EXCEPTIONS = "stream4xxErrors";
+    private static final String DOCUMENT_DB_STREAM_API_INVOCATIONS = "streamApiInvocations";
+    private static final String DOCUMENT_DB_EXPORT_5XX_ERRORS = "export5xxErrors";
+    private static final String DOCUMENT_DB_EXPORT_4XX_ERRORS = "export4xxErrors";
+    private static final String DOCUMENT_DB_EXPORT_API_INVOCATIONS = "exportApiInvocations";
+
+
+
+    private final PluginMetrics pluginMetrics;
+
+    private final Counter stream5xxErrors;
+    private final Counter stream4xxErrors;
+    private final Counter streamApiInvocations;
+    private final Counter export5xxErrors;
+    private final Counter export4xxErrors;
+    private final Counter exportApiInvocations;
+
+    public DocumentDBSourceAggregateMetrics() {
+        this.pluginMetrics = PluginMetrics.fromPrefix(DOCUMENT_DB);
+        this.stream5xxErrors = pluginMetrics.counter(DOCUMENT_DB_STREAM_5XX_EXCEPTIONS);
+        this.stream4xxErrors = pluginMetrics.counter(DOCUMENT_DB_STREAM_4XX_EXCEPTIONS);
+        this.streamApiInvocations = pluginMetrics.counter(DOCUMENT_DB_STREAM_API_INVOCATIONS);
+        this.export5xxErrors = pluginMetrics.counter(DOCUMENT_DB_EXPORT_5XX_ERRORS);
+        this.export4xxErrors = pluginMetrics.counter(DOCUMENT_DB_EXPORT_4XX_ERRORS);
+        this.exportApiInvocations = pluginMetrics.counter(DOCUMENT_DB_EXPORT_API_INVOCATIONS);
+    }
+
+    public Counter getStream5xxErrors() {
+        return stream5xxErrors;
+    }
+
+    public Counter getStream4xxErrors() {
+        return stream4xxErrors;
+    }
+
+    public Counter getStreamApiInvocations() {
+        return streamApiInvocations;
+    }
+
+    public Counter getExport5xxErrors() {
+        return export5xxErrors;
+    }
+
+    public Counter getExport4xxErrors() {
+        return export4xxErrors;
+    }
+
+    public Counter getExportApiInvocations() {
+        return exportApiInvocations;
+    }
+}

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/documentdb/MongoTasksRefresherTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/documentdb/MongoTasksRefresherTest.java
@@ -22,6 +22,7 @@ import org.opensearch.dataprepper.plugins.mongo.configuration.MongoDBSourceConfi
 import org.opensearch.dataprepper.plugins.mongo.export.ExportScheduler;
 import org.opensearch.dataprepper.plugins.mongo.export.ExportWorker;
 import org.opensearch.dataprepper.plugins.mongo.stream.StreamScheduler;
+import org.opensearch.dataprepper.plugins.mongo.utils.DocumentDBSourceAggregateMetrics;
 
 import java.util.List;
 import java.util.UUID;
@@ -76,6 +77,9 @@ class MongoTasksRefresherTest {
     private CollectionConfig collectionConfig;
 
     @Mock
+    private DocumentDBSourceAggregateMetrics documentDBSourceAggregateMetrics;
+
+    @Mock
     private Counter credentialsChangeCounter;
 
     @Mock
@@ -84,7 +88,7 @@ class MongoTasksRefresherTest {
     private MongoTasksRefresher createObjectUnderTest() {
         return new MongoTasksRefresher(
                 buffer, enhancedSourceCoordinator, pluginMetrics, acknowledgementSetManager,
-                executorServiceFunction, S3_PATH_PREFIX);
+                executorServiceFunction, S3_PATH_PREFIX, documentDBSourceAggregateMetrics);
     }
 
     @BeforeEach
@@ -248,6 +252,6 @@ class MongoTasksRefresherTest {
     void testTaskRefreshWithNullS3PathPrefix() {
         assertThrows(IllegalArgumentException.class, () -> new MongoTasksRefresher(
                 buffer, enhancedSourceCoordinator, pluginMetrics, acknowledgementSetManager,
-                executorServiceFunction, null));
+                executorServiceFunction, null, documentDBSourceAggregateMetrics));
     }
 }

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/ExportWorkerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/ExportWorkerTest.java
@@ -14,6 +14,7 @@ import org.opensearch.dataprepper.model.source.coordinator.enhanced.EnhancedSour
 import org.opensearch.dataprepper.plugins.mongo.buffer.RecordBufferWriter;
 import org.opensearch.dataprepper.plugins.mongo.configuration.MongoDBSourceConfig;
 import org.opensearch.dataprepper.plugins.mongo.coordination.partition.DataQueryPartition;
+import org.opensearch.dataprepper.plugins.mongo.utils.DocumentDBSourceAggregateMetrics;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -46,11 +47,14 @@ public class ExportWorkerTest {
     @Mock
     private RecordBufferWriter recordBufferWriter;
 
+    @Mock
+    private DocumentDBSourceAggregateMetrics documentDBSourceAggregateMetrics;
+
     private ExportWorker exportWorker;
 
     @BeforeEach
     public void setup() throws Exception {
-        exportWorker = new ExportWorker(sourceCoordinator, buffer, pluginMetrics, acknowledgementSetManager, sourceConfig, S3_PATH_PREFIX);
+        exportWorker = new ExportWorker(sourceCoordinator, buffer, pluginMetrics, acknowledgementSetManager, sourceConfig, S3_PATH_PREFIX, documentDBSourceAggregateMetrics);
     }
 
     @Test
@@ -67,7 +71,7 @@ public class ExportWorkerTest {
 
     @Test
     void test_export_withNullS3PathPrefix() {
-        assertThrows(IllegalArgumentException.class, () -> new ExportWorker(sourceCoordinator, buffer, pluginMetrics, acknowledgementSetManager, sourceConfig, null));
+        assertThrows(IllegalArgumentException.class, () -> new ExportWorker(sourceCoordinator, buffer, pluginMetrics, acknowledgementSetManager, sourceConfig, null, documentDBSourceAggregateMetrics));
     }
 
 }

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamSchedulerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamSchedulerTest.java
@@ -17,6 +17,7 @@ import org.opensearch.dataprepper.plugins.mongo.configuration.CollectionConfig;
 import org.opensearch.dataprepper.plugins.mongo.configuration.MongoDBSourceConfig;
 import org.opensearch.dataprepper.plugins.mongo.converter.PartitionKeyRecordConverter;
 import org.opensearch.dataprepper.plugins.mongo.coordination.partition.StreamPartition;
+import org.opensearch.dataprepper.plugins.mongo.utils.DocumentDBSourceAggregateMetrics;
 
 import java.time.Duration;
 import java.util.List;
@@ -63,6 +64,9 @@ public class StreamSchedulerTest {
     private CollectionConfig collectionConfig;
 
     @Mock
+    private DocumentDBSourceAggregateMetrics documentDBSourceAggregateMetrics;
+
+    @Mock
     private StreamWorker streamWorker;
 
 
@@ -71,7 +75,7 @@ public class StreamSchedulerTest {
     @BeforeEach
     void setup() {
         lenient().when(sourceConfig.getCollections()).thenReturn(List.of(collectionConfig));
-        streamScheduler = new StreamScheduler(sourceCoordinator, buffer, acknowledgementSetManager, sourceConfig, S3_PATH_PREFIX, pluginMetrics);
+        streamScheduler = new StreamScheduler(sourceCoordinator, buffer, acknowledgementSetManager, sourceConfig, S3_PATH_PREFIX, pluginMetrics, documentDBSourceAggregateMetrics);
     }
 
 
@@ -102,7 +106,7 @@ public class StreamSchedulerTest {
             try (MockedStatic<StreamWorker> streamWorkerMockedStatic = mockStatic(StreamWorker.class)) {
                 streamWorkerMockedStatic.when(() -> StreamWorker.create(any(RecordBufferWriter.class), any(PartitionKeyRecordConverter.class), eq(sourceConfig),
                     any(StreamAcknowledgementManager.class), any(DataStreamPartitionCheckpoint.class), eq(pluginMetrics), eq(DEFAULT_RECORD_FLUSH_BATCH_SIZE),
-                        eq(DEFAULT_CHECKPOINT_INTERVAL_MILLS), eq(DEFAULT_BUFFER_WRITE_INTERVAL_MILLS), eq(streamBatchSize)))
+                        eq(DEFAULT_CHECKPOINT_INTERVAL_MILLS), eq(DEFAULT_BUFFER_WRITE_INTERVAL_MILLS), eq(streamBatchSize), any(DocumentDBSourceAggregateMetrics.class)))
                     .thenReturn(streamWorker);
                 streamScheduler.run();
             }
@@ -131,7 +135,7 @@ public class StreamSchedulerTest {
             try (MockedStatic<StreamWorker> streamWorkerMockedStatic = mockStatic(StreamWorker.class)) {
                 streamWorkerMockedStatic.when(() -> StreamWorker.create(any(RecordBufferWriter.class), any(PartitionKeyRecordConverter.class), eq(sourceConfig),
                                 any(StreamAcknowledgementManager.class), any(DataStreamPartitionCheckpoint.class), eq(pluginMetrics), eq(DEFAULT_RECORD_FLUSH_BATCH_SIZE),
-                                eq(DEFAULT_CHECKPOINT_INTERVAL_MILLS), eq(DEFAULT_BUFFER_WRITE_INTERVAL_MILLS), eq(streamBatchSize)))
+                                eq(DEFAULT_CHECKPOINT_INTERVAL_MILLS), eq(DEFAULT_BUFFER_WRITE_INTERVAL_MILLS), eq(streamBatchSize), any(DocumentDBSourceAggregateMetrics.class)))
                         .thenThrow(RuntimeException.class);
                 streamScheduler.run();
             }
@@ -165,6 +169,6 @@ public class StreamSchedulerTest {
 
     @Test
     void test_stream_withNullS3PathPrefix() {
-        assertThrows(IllegalArgumentException.class, () -> new StreamScheduler(sourceCoordinator, buffer, acknowledgementSetManager, sourceConfig, null, pluginMetrics));
+        assertThrows(IllegalArgumentException.class, () -> new StreamScheduler(sourceCoordinator, buffer, acknowledgementSetManager, sourceConfig, null, pluginMetrics, documentDBSourceAggregateMetrics));
     }
 }


### PR DESCRIPTION
### Description
Add DocDB source aggregate metrics - 4xxErrors, 5xxErrors, ApiInvocations for both export and stream.

The metrics are used to track errors across pipelines when connecting to and querying DocDB.

The metrics are incremented in ExportPartitionWorker, MongoDBExportPartitionSupplier and StreamWorker.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
