### PR TITLE
MAINT: rename aws secrets extension and reference keywords

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperExtensionPlugin.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/annotations/DataPrepperExtensionPlugin.java
@@ -13,10 +13,17 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
 public @interface DataPrepperExtensionPlugin {
+    String DEFAULT_DEPRECATED_ROOT_KEY_JSON_PATH = "";
+
     /**
      * @return extension plugin configuration class.
      */
     Class<?> modelType();
+
+    /**
+     * @return valid JSON path string starts with "/" pointing towards the configuration block.
+     */
+    String deprecatedRootKeyJsonPath() default DEFAULT_DEPRECATED_ROOT_KEY_JSON_PATH;
 
     /**
      * @return valid JSON path string starts with "/" pointing towards the configuration block.

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigValueTranslator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/plugin/PluginConfigValueTranslator.java
@@ -1,7 +1,13 @@
 package org.opensearch.dataprepper.model.plugin;
 
 public interface PluginConfigValueTranslator {
+    String DEFAULT_DEPRECATED_PREFIX = "";
+
     Object translate(final String value);
+
+    default String getDeprecatedPrefix() {
+        return DEFAULT_DEPRECATED_PREFIX;
+    }
 
     String getPrefix();
 }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExtensionLoader.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ExtensionLoader.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static org.opensearch.dataprepper.model.annotations.DataPrepperExtensionPlugin.DEFAULT_DEPRECATED_ROOT_KEY_JSON_PATH;
+
 @Named
 public class ExtensionLoader {
     private final ExtensionPluginConfigurationConverter extensionPluginConfigurationConverter;
@@ -51,9 +53,22 @@ public class ExtensionLoader {
         } else {
             final Class<?> pluginConfigurationType = pluginAnnotation.modelType();
             final String rootKey = pluginAnnotation.rootKeyJsonPath();
+            final String deprecatedRootKey = pluginAnnotation.deprecatedRootKeyJsonPath();
             final Object configuration = extensionPluginConfigurationConverter.convert(
                     pluginAnnotation.allowInPipelineConfigurations(),
                     pluginConfigurationType, rootKey);
+            if (!DEFAULT_DEPRECATED_ROOT_KEY_JSON_PATH.equals(deprecatedRootKey)) {
+                if (configuration != null) {
+                    throw new InvalidPluginDefinitionException(
+                            String.format(
+                                    "Deprecated extension json path [%s] cannot be configured together with " +
+                                            "the current extension json path [%s].", deprecatedRootKey, rootKey));
+                }
+                final Object deprecatedConfiguration = extensionPluginConfigurationConverter.convert(
+                        pluginAnnotation.allowInPipelineConfigurations(),
+                        pluginConfigurationType, deprecatedRootKey);
+                return new SingleConfigArgumentArgumentsContext(deprecatedConfiguration);
+            }
             return new SingleConfigArgumentArgumentsContext(configuration);
         }
     }

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/VariableExpander.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/VariableExpander.java
@@ -20,6 +20,8 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.opensearch.dataprepper.model.plugin.PluginConfigValueTranslator.DEFAULT_DEPRECATED_PREFIX;
+
 @Named
 public class VariableExpander {
     static final String VALUE_REFERENCE_KEY = "valueReferenceKey";
@@ -34,9 +36,17 @@ public class VariableExpander {
             final Set<PluginConfigValueTranslator> pluginConfigValueTranslators) {
         this.objectMapper = objectMapper;
         patternPluginConfigValueTranslatorMap = pluginConfigValueTranslators.stream().collect(Collectors.toMap(
-                pluginConfigValueTranslator -> Pattern.compile(
-                        String.format(SECRETS_REFERENCE_PATTERN_STRING,
-                                pluginConfigValueTranslator.getPrefix(), VALUE_REFERENCE_KEY)),
+                pluginConfigValueTranslator -> {
+                    final String prefix = DEFAULT_DEPRECATED_PREFIX.equals(
+                            pluginConfigValueTranslator.getDeprecatedPrefix()) ?
+                            pluginConfigValueTranslator.getPrefix() :
+                            "(" + String.join("|",
+                                    pluginConfigValueTranslator.getDeprecatedPrefix(),
+                                    pluginConfigValueTranslator.getPrefix()) + ")";
+                    return Pattern.compile(
+                            String.format(SECRETS_REFERENCE_PATTERN_STRING,
+                                    prefix, VALUE_REFERENCE_KEY));
+                },
                 Function.identity()));
     }
 

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestExtensionWithDeprecatedRootJsonPath.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugins/test/TestExtensionWithDeprecatedRootJsonPath.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.test;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperExtensionPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.plugin.ExtensionPlugin;
+import org.opensearch.dataprepper.model.plugin.ExtensionPoints;
+import org.opensearch.dataprepper.model.plugin.ExtensionProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@DataPrepperExtensionPlugin(modelType = TestExtensionConfig.class,
+        deprecatedRootKeyJsonPath = "/deprecated_test_extension_name",
+        rootKeyJsonPath = "/test_extension_name", allowInPipelineConfigurations = true)
+public class TestExtensionWithDeprecatedRootJsonPath implements ExtensionPlugin {
+    private static final Logger LOG = LoggerFactory.getLogger(TestExtensionWithDeprecatedRootJsonPath.class);
+    private static final AtomicInteger CONSTRUCTED_COUNT = new AtomicInteger(0);
+    private final String extensionId;
+    private TestExtensionConfig testExtensionConfig;
+
+    @DataPrepperPluginConstructor
+    public TestExtensionWithDeprecatedRootJsonPath(final TestExtensionConfig testExtensionConfig) {
+        LOG.info("Constructing test extension plugin.");
+        CONSTRUCTED_COUNT.incrementAndGet();
+        extensionId = UUID.randomUUID().toString();
+        this.testExtensionConfig = testExtensionConfig;
+    }
+
+    @Override
+    public void apply(final ExtensionPoints extensionPoints) {
+        LOG.info("Applying test extension.");
+        extensionPoints.addExtensionProvider(new TestExtensionProvider());
+    }
+
+    public static void reset() {
+        CONSTRUCTED_COUNT.set(0);
+    }
+
+    public static int getConstructedInstances() {
+        return CONSTRUCTED_COUNT.get();
+    }
+
+    public static class TestModel {
+        private final String extensionId;
+
+        private final String testAttribute;
+
+        private TestModel(final String extensionId, final String testAttribute) {
+
+            this.extensionId = extensionId;
+            this.testAttribute = testAttribute;
+        }
+        public String getExtensionId() {
+            return this.extensionId;
+        }
+
+        public String getTestAttribute() {
+            return testAttribute;
+        }
+    }
+
+    private class TestExtensionProvider implements ExtensionProvider<TestModel> {
+
+        @Override
+        public Optional<TestModel> provideInstance(final Context context) {
+            return Optional.of(new TestModel(extensionId, testExtensionConfig.getTestAttribute()));
+        }
+
+        @Override
+        public Class<TestModel> supportedClass() {
+            return TestModel.class;
+        }
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPlugin.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretPlugin.java
@@ -21,7 +21,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
-@DataPrepperExtensionPlugin(modelType = AwsSecretPluginConfig.class, rootKeyJsonPath = "/aws/secrets",
+@DataPrepperExtensionPlugin(modelType = AwsSecretPluginConfig.class, deprecatedRootKeyJsonPath = "/aws/secrets_manager",
+        rootKeyJsonPath = "/aws/secrets",
         allowInPipelineConfigurations = true)
 public class AwsSecretPlugin implements ExtensionPlugin {
     static final int PERIOD_IN_SECONDS = 60;

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigValueTranslator.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigValueTranslator.java
@@ -11,7 +11,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class AwsSecretsPluginConfigValueTranslator implements PluginConfigValueTranslator {
-    static final String AWS_SECRETS_PREFIX = "aws_secrets";
+    static final String DEPRECATED_AWS_SECRETS_PREFIX = "aws_secrets";
+    static final String AWS_SECRETS_PREFIX = "aws:secrets";
     static final String SECRET_CONFIGURATION_ID_GROUP = "secretConfigurationId";
     static final String SECRET_KEY_GROUP = "secretKey";
     static final Pattern SECRETS_REF_PATTERN = Pattern.compile(
@@ -37,6 +38,11 @@ public class AwsSecretsPluginConfigValueTranslator implements PluginConfigValueT
                     "Unable to parse %s or %s according to pattern %s",
                     SECRET_CONFIGURATION_ID_GROUP, SECRET_KEY_GROUP, SECRETS_REF_PATTERN.pattern()));
         }
+    }
+
+    @Override
+    public String getDeprecatedPrefix() {
+        return DEPRECATED_AWS_SECRETS_PREFIX;
     }
 
     @Override

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigValueTranslatorTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigValueTranslatorTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.opensearch.dataprepper.plugins.aws.AwsSecretsPluginConfigValueTranslator.AWS_SECRETS_PREFIX;
+import static org.opensearch.dataprepper.plugins.aws.AwsSecretsPluginConfigValueTranslator.DEPRECATED_AWS_SECRETS_PREFIX;
 
 @ExtendWith(MockitoExtension.class)
 class AwsSecretsPluginConfigValueTranslatorTest {
@@ -37,6 +38,11 @@ class AwsSecretsPluginConfigValueTranslatorTest {
     @Test
     void testGetPrefix() {
         assertThat(objectUnderTest.getPrefix(), equalTo(AWS_SECRETS_PREFIX));
+    }
+
+    @Test
+    void testGetDeprecatedPrefix() {
+        assertThat(objectUnderTest.getDeprecatedPrefix(), equalTo(DEPRECATED_AWS_SECRETS_PREFIX));
     }
 
     @ParameterizedTest

--- a/e2e-test/log/src/integrationTest/resources/basic-grok-e2e-pipeline-with-aws-secrets.yml
+++ b/e2e-test/log/src/integrationTest/resources/basic-grok-e2e-pipeline-with-aws-secrets.yml
@@ -15,7 +15,7 @@ grok-pipeline:
   sink:
     - opensearch:
         hosts: [ "https://node-0.example.com:9200" ]
-        username: "${{aws_secrets:opensearch-sink:username}}"
-        password: "${{aws_secrets:opensearch-sink:password}}"
+        username: "${{aws:secrets:opensearch-sink:username}}"
+        password: "${{aws:secrets:opensearch-sink:password}}"
         index: "test-grok-index"
         flush_timeout: 5000


### PR DESCRIPTION
### Description
This PR
* set up framework for introducing new AWS secret extension json path: /aws/secrets_manager
* introduce new reference pattern: ${{aws:secrets:<secret-config-id>:<secret-key>}}
* move current names to deprecated

After this change, the pipeline YAML will be as follows:
```
extension:
  aws:
    secrets_manager:
      opensearch-sink:
        secret_id: "opensearch-sink-basic-credentials"
        region: "us-east-2"
grok-pipeline:
  source:
    http:
      path: "/${pipelineName}/logs"
  processor:
    - grok:
        match:
          log: [ "%{COMMONAPACHELOG}" ]
  sink:
    - opensearch:
        hosts: [ "https://node-0.example.com:9200" ]
        username: "${{aws:secrets:opensearch-sink:username}}"
        password: "${{aws:secrets:opensearch-sink:password}}"
        index: "test-grok-index"
        flush_timeout: 5000
```
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
