### PR TITLE
Updates werkzeug to 3.0.3 in examples to fix CVE-2024-34069. 

### DIFF
--- a/examples/trace-analytics-sample-app/sample-app/requirements.txt
+++ b/examples/trace-analytics-sample-app/sample-app/requirements.txt
@@ -7,4 +7,4 @@ opentelemetry-instrumentation-requests==0.41b0
 opentelemetry-sdk==1.20.0
 protobuf==3.20.3
 urllib3==2.0.7
-werkzeug==3.0.1
+werkzeug==3.0.3


### PR DESCRIPTION
### Description

Updates werkzeug to 3.0.3 in examples to fix CVE-2024-34069. 
 
### Issues Resolved

Resolves #4515
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
