### PR TITLE
Fix DocDB export and stream processing self recovery with invalid database or collection name

### DIFF
--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/ExportSchedulerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/export/ExportSchedulerTest.java
@@ -165,7 +165,7 @@ public class ExportSchedulerTest {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         final Future<?> future = executorService.submit(() -> exportScheduler.run());
         await()
-            .atMost(Duration.ofMillis(DEFAULT_GET_PARTITION_BACKOFF_MILLIS).plus(Duration.ofSeconds(60)))
+            .atMost(Duration.ofMillis(DEFAULT_GET_PARTITION_BACKOFF_MILLIS).plus(Duration.ofSeconds(2)))
             .untilAsserted(() -> verify(coordinator, times(1)).createPartition(any()));
 
         future.cancel(true);


### PR DESCRIPTION
Fix DocDB export and stream processing self recovery with invalid database or collection name

### Description
Creating Stream global status when there are no records to export. This should unblock processing stream records.
 
### Issues Resolved
Resolves #[[4544](https://github.com/opensearch-project/data-prepper/issues/4544)]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
