### PR TITLE
Introduced BigDecimalConverter 

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DataType.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DataType.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.model.event;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Map;
@@ -48,6 +49,13 @@ public enum DataType {
      * @since 2.8
      */
     DOUBLE("double"),
+
+    /**
+     * Type of <i>BigDecimal</i>. No precision loss possible type. Compatible with the Java <b>BigDecimal</b> primitive data type.
+     *
+     * @since 2.8
+     */
+    BIGDECIMAL("bigdecimal"),
 
     /**
      * Type of <i>map</i>. Compatible with the Java <b>map</b> primitive data type.
@@ -96,20 +104,22 @@ public enum DataType {
         if (type == null)
             throw new IllegalArgumentException("Unknown DataType");
         switch (type) {
-          case MAP:
-            return (object instanceof Map);
-          case ARRAY:
-            return (object instanceof ArrayList || object.getClass().isArray());
-          case DOUBLE:
-            return (object instanceof Double);
-          case BOOLEAN:
-            return (object instanceof Boolean);
-          case INTEGER:
-            return (object instanceof Integer);
-          case LONG:
-            return (object instanceof Long);
-          default: // STRING
-            return (object instanceof String);
+            case MAP:
+                return (object instanceof Map);
+            case ARRAY:
+                return (object instanceof ArrayList || object.getClass().isArray());
+            case DOUBLE:
+                return (object instanceof Double);
+            case BOOLEAN:
+                return (object instanceof Boolean);
+            case INTEGER:
+                return (object instanceof Integer);
+            case LONG:
+                return (object instanceof Long);
+            case BIGDECIMAL:
+                return (object instanceof BigDecimal);
+            default: // STRING
+                return (object instanceof String);
         }
     }
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DataType.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DataType.java
@@ -55,7 +55,7 @@ public enum DataType {
      *
      * @since 2.8
      */
-    BIGDECIMAL("bigdecimal"),
+    BIG_DECIMAL("big_decimal"),
 
     /**
      * Type of <i>map</i>. Compatible with the Java <b>map</b> primitive data type.
@@ -116,7 +116,7 @@ public enum DataType {
                 return (object instanceof Integer);
             case LONG:
                 return (object instanceof Long);
-            case BIGDECIMAL:
+            case BIG_DECIMAL:
                 return (object instanceof BigDecimal);
             default: // STRING
                 return (object instanceof String);

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -11,8 +11,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.cfg.JsonNodeFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -62,10 +63,12 @@ public class JacksonEvent implements Event {
 
     private static final String SEPARATOR = "/";
 
-    private static final ObjectMapper mapper = new ObjectMapper()
+    private static final ObjectMapper mapper = JsonMapper.builder()
+            .disable(JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES)
+            .build()
             .registerModule(new JavaTimeModule())
-            .registerModule(new Jdk8Module()) // required for using Optional with Jackson. Ref: https://github.com/FasterXML/jackson-modules-java8
-            .setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+            .registerModule(new Jdk8Module()); // required for using Optional with Jackson. Ref: https://github.com/FasterXML/jackson-modules-java8
+
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {
     };

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -63,9 +64,10 @@ public class JacksonEvent implements Event {
 
     private static final ObjectMapper mapper = new ObjectMapper()
             .registerModule(new JavaTimeModule())
-            .registerModule(new Jdk8Module()); // required for using Optional with Jackson. Ref: https://github.com/FasterXML/jackson-modules-java8
+            .registerModule(new Jdk8Module()) // required for using Optional with Jackson. Ref: https://github.com/FasterXML/jackson-modules-java8
+            .setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
 
-    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {
     };
 
     private final EventMetadata eventMetadata;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourceCoordinator.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/source/coordinator/SourceCoordinator.java
@@ -122,6 +122,7 @@ public interface SourceCoordinator<T> {
     /**
      * Should be called by the source when it is shutting down to indicate that it will no longer be able to perform work on partitions,
      * or can be called to give up ownership of its partitions in order to pick up new ones with {@link #getNextPartition(Function)} ()}.
+     * @param partitionKey - Key used as the partition key.
      * @param priorityTimestamp - A timestamp that will determine the order that UNASSIGNED partitions are acquired after they are given up.
      * @throws org.opensearch.dataprepper.model.source.coordinator.exceptions.PartitionUpdateException if the partition could not be given up due to some failure
      * @since 2.8

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverter.java
@@ -14,8 +14,8 @@ import java.math.RoundingMode;
  */
 public class BigDecimalConverter implements TypeConverter<BigDecimal> {
 
-    public BigDecimal convert(Object source) throws IllegalArgumentException {
-        return this.convert(source, 0);
+    public BigDecimal convert(Object source, ConverterArguments arguments) throws IllegalArgumentException {
+        return this.convert(source, arguments.getScale());
     }
 
     public BigDecimal convert(Object source, int scale) throws IllegalArgumentException {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverter.java
@@ -13,16 +13,12 @@ import java.math.RoundingMode;
  * If required, the scale can be set using the setScale method.
  */
 public class BigDecimalConverter implements TypeConverter<BigDecimal> {
-    // Scale declared here becomes the state of this converter.
-    // If the same instance of the converter is used for multiple conversions,
-    // scale value set will be preserved and applied on the next conversion.
-    private int scale = 0;
-
-    public void setScale(int scale) {
-        this.scale = scale;
-    }
 
     public BigDecimal convert(Object source) throws IllegalArgumentException {
+        return this.convert(source, 0);
+    }
+
+    public BigDecimal convert(Object source, int scale) throws IllegalArgumentException {
         BigDecimal result = null;
         if (source instanceof String) {
             result = new BigDecimal((String)source);

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverter.java
@@ -13,9 +13,9 @@ import java.math.RoundingMode;
  * If required, the scale can be set using the setScale method.
  */
 public class BigDecimalConverter implements TypeConverter<BigDecimal> {
-    //TODO: Scale declared here becomes the state of this converter which
-    // makes it globally applied for this pipeline right from the first use, which may not be right.
-    // Need to think of a better way to handle this.
+    // Scale declared here becomes the state of this converter.
+    // If the same instance of the converter is used for multiple conversions,
+    // scale value set will be preserved and applied on the next conversion.
     private int scale = 0;
 
     public void setScale(int scale) {

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ package org.opensearch.dataprepper.typeconverter;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * Converter class for BigDecimal data type. By default, it applies zero scaling keeping the original value as it is.
+ * If required, the scale can be set using the setScale method.
+ */
+public class BigDecimalConverter implements TypeConverter<BigDecimal> {
+    //TODO: Scale declared here becomes the state of this converter which
+    // makes it globally applied for this pipeline right from the first use, which may not be right.
+    // Need to think of a better way to handle this.
+    private int scale = 0;
+
+    public void setScale(int scale) {
+        this.scale = scale;
+    }
+
+    public BigDecimal convert(Object source) throws IllegalArgumentException {
+        BigDecimal result = null;
+        if (source instanceof String) {
+            result = new BigDecimal((String)source);
+        }
+        else if (source instanceof Float) {
+            result = BigDecimal.valueOf((Float)source);
+        }
+        else if (source instanceof Double) {
+            result = BigDecimal.valueOf((Double)source);
+        }
+        else if (source instanceof Boolean) {
+            result = ((Boolean)source) ? BigDecimal.valueOf(1L) : BigDecimal.valueOf(0L);
+        }
+        else if (source instanceof Integer) {
+            result = BigDecimal.valueOf((Integer)source);
+        }
+        else if (source instanceof Long) {
+            result = BigDecimal.valueOf((Long)source);
+        }
+        else if (source instanceof BigDecimal) {
+            result = ((BigDecimal)source);
+        }
+
+        if(result!=null) {
+            if(scale!=0) {
+                result = result.setScale(scale, RoundingMode.HALF_EVEN);
+            }
+            return result;
+        }
+        throw new IllegalArgumentException("Unsupported type conversion. From Source class: " + source.getClass() + " to BigDecimal");
+    }
+}
+ 

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverter.java
@@ -14,6 +14,10 @@ import java.math.RoundingMode;
  */
 public class BigDecimalConverter implements TypeConverter<BigDecimal> {
 
+    public BigDecimal convert(Object source) throws IllegalArgumentException {
+        return this.convert(source, 0);
+    }
+
     public BigDecimal convert(Object source, ConverterArguments arguments) throws IllegalArgumentException {
         return this.convert(source, arguments.getScale());
     }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BooleanConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BooleanConverter.java
@@ -6,7 +6,12 @@
 package org.opensearch.dataprepper.typeconverter;
 
 public class BooleanConverter implements TypeConverter<Boolean> {
+
     public Boolean convert(Object source, ConverterArguments arguments) throws IllegalArgumentException {
+        return this.convert(source);
+    }
+
+    public Boolean convert(Object source) throws IllegalArgumentException {
         if (source instanceof String) {
             return Boolean.parseBoolean((String)source);
         }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BooleanConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BooleanConverter.java
@@ -6,7 +6,7 @@
 package org.opensearch.dataprepper.typeconverter;
 
 public class BooleanConverter implements TypeConverter<Boolean> {
-    public Boolean convert(Object source) throws IllegalArgumentException {
+    public Boolean convert(Object source, ConverterArguments arguments) throws IllegalArgumentException {
         if (source instanceof String) {
             return Boolean.parseBoolean((String)source);
         }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BooleanConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/BooleanConverter.java
@@ -17,12 +17,12 @@ public class BooleanConverter implements TypeConverter<Boolean> {
         }
         if (source instanceof Number) {
             Number number = (Number)source;
-            return ((number.intValue() != 0) ||
-                    (number.longValue() != 0) ||
+            return ((number instanceof Integer && number.intValue() != 0) ||
+                    (number instanceof Long && number.longValue() != 0) ||
+                    (number instanceof Short && number.shortValue() != 0) ||
+                    (number instanceof Byte && number.byteValue() != 0)) ||
                     (number.floatValue() != 0) ||
-                    (number.doubleValue() != 0) ||
-                    (number.shortValue() != 0) ||
-                    (number.byteValue() != 0)) ? true : false;
+                    (number.doubleValue() != 0);
         }
         if (source instanceof Boolean) {
             return (Boolean)source;

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/ConverterArguments.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/ConverterArguments.java
@@ -1,0 +1,10 @@
+package org.opensearch.dataprepper.typeconverter;
+
+/**
+ * Interface for arguments passed to the {@link TypeConverter}
+ *
+ * @since 1.2
+ */
+public interface ConverterArguments {
+    int getScale();
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/DoubleConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/DoubleConverter.java
@@ -6,7 +6,12 @@
 package org.opensearch.dataprepper.typeconverter;
 
 public class DoubleConverter implements TypeConverter<Double> {
+
     public Double convert(Object source, ConverterArguments arguments) throws IllegalArgumentException {
+        return convert(source);
+    }
+
+    public Double convert(Object source) throws IllegalArgumentException {
         if (source instanceof String) {
             return Double.parseDouble((String)source);
         }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/DoubleConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/DoubleConverter.java
@@ -6,7 +6,7 @@
 package org.opensearch.dataprepper.typeconverter;
 
 public class DoubleConverter implements TypeConverter<Double> {
-    public Double convert(Object source) throws IllegalArgumentException {
+    public Double convert(Object source, ConverterArguments arguments) throws IllegalArgumentException {
         if (source instanceof String) {
             return Double.parseDouble((String)source);
         }
@@ -17,7 +17,7 @@ public class DoubleConverter implements TypeConverter<Double> {
             return (((Number)source).doubleValue());
         }
         if (source instanceof Boolean) {
-            return (double)(((Boolean)source) ? 1.0 : 0.0);
+            return ((Boolean)source) ? 1.0 : 0.0;
         }
         throw new IllegalArgumentException("Unsupported type conversion. Source class: " + source.getClass());
     }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/IntegerConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/IntegerConverter.java
@@ -7,7 +7,7 @@ package org.opensearch.dataprepper.typeconverter;
 
 import java.math.BigDecimal;
 public class IntegerConverter implements TypeConverter<Integer> {
-    public Integer convert(Object source) throws IllegalArgumentException {
+    public Integer convert(Object source, ConverterArguments arguments) throws IllegalArgumentException {
         if (source instanceof String) {
             return Integer.parseInt((String)source);
         }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/IntegerConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/IntegerConverter.java
@@ -7,7 +7,12 @@ package org.opensearch.dataprepper.typeconverter;
 
 import java.math.BigDecimal;
 public class IntegerConverter implements TypeConverter<Integer> {
+
     public Integer convert(Object source, ConverterArguments arguments) throws IllegalArgumentException {
+        return convert(source);
+    }
+
+    public Integer convert(Object source) throws IllegalArgumentException {
         if (source instanceof String) {
             return Integer.parseInt((String)source);
         }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/LongConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/LongConverter.java
@@ -7,7 +7,7 @@
 
  import java.math.BigDecimal;
  public class LongConverter implements TypeConverter<Long> {
-     public Long convert(Object source) throws IllegalArgumentException {
+     public Long convert(Object source, ConverterArguments arguments) throws IllegalArgumentException {
          if (source instanceof String) {
              return Long.parseLong((String)source);
          }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/LongConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/LongConverter.java
@@ -7,7 +7,12 @@
 
  import java.math.BigDecimal;
  public class LongConverter implements TypeConverter<Long> {
+
      public Long convert(Object source, ConverterArguments arguments) throws IllegalArgumentException {
+         return this.convert(source);
+     }
+
+     public Long convert(Object source) throws IllegalArgumentException {
          if (source instanceof String) {
              return Long.parseLong((String)source);
          }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/StringConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/StringConverter.java
@@ -6,7 +6,12 @@
 package org.opensearch.dataprepper.typeconverter;
 
 public class StringConverter implements TypeConverter<String> {
+
     public String convert(Object source, ConverterArguments arguments) throws IllegalArgumentException {
+        return this.convert(source);
+    }
+
+    public String convert(Object source) throws IllegalArgumentException {
         if (source instanceof Number || source instanceof Boolean || source instanceof String)  {
             return source.toString();
         }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/StringConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/StringConverter.java
@@ -6,7 +6,7 @@
 package org.opensearch.dataprepper.typeconverter;
 
 public class StringConverter implements TypeConverter<String> {
-    public String convert(Object source) throws IllegalArgumentException {
+    public String convert(Object source, ConverterArguments arguments) throws IllegalArgumentException {
         if (source instanceof Number || source instanceof Boolean || source instanceof String)  {
             return source.toString();
         }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/TypeConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/TypeConverter.java
@@ -6,5 +6,6 @@
 package org.opensearch.dataprepper.typeconverter;
 
 public interface TypeConverter<T> {
+  T convert(Object source);
   T convert(Object source, ConverterArguments arguments);
 }

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/TypeConverter.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/typeconverter/TypeConverter.java
@@ -6,5 +6,5 @@
 package org.opensearch.dataprepper.typeconverter;
 
 public interface TypeConverter<T> {
-  T convert(Object source);
+  T convert(Object source, ConverterArguments arguments);
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DataTypeTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DataTypeTest.java
@@ -44,7 +44,7 @@ class DataTypeTest {
             Arguments.of("testString", "string", true),
             Arguments.of(2L, "long", true),
             Arguments.of(2.0, "double", true),
-            Arguments.of(BigDecimal.valueOf(2.34567), "bigdecimal", true),
+            Arguments.of(BigDecimal.valueOf(2.34567), "big_decimal", true),
             Arguments.of(true, "boolean", true),
             Arguments.of(Map.of("k","v"), "map", true),
             Arguments.of(testArray, "array", true),

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DataTypeTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DataTypeTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.math.BigDecimal;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -37,12 +38,13 @@ class DataTypeTest {
     }
 
     private static Stream<Arguments> getSameTypeTestData() {
-        int testArray[] = {1,2};
+        int[] testArray = {1,2};
         return Stream.of(
             Arguments.of(2, "integer", true),
             Arguments.of("testString", "string", true),
             Arguments.of(2L, "long", true),
             Arguments.of(2.0, "double", true),
+            Arguments.of(BigDecimal.valueOf(2.34567), "bigdecimal", true),
             Arguments.of(true, "boolean", true),
             Arguments.of(Map.of("k","v"), "map", true),
             Arguments.of(testArray, "array", true),

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DataTypeTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DataTypeTest.java
@@ -16,6 +16,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -39,6 +41,7 @@ class DataTypeTest {
 
     private static Stream<Arguments> getSameTypeTestData() {
         int[] testArray = {1,2};
+        List<Integer> testList = new ArrayList<>();
         return Stream.of(
             Arguments.of(2, "integer", true),
             Arguments.of("testString", "string", true),
@@ -48,6 +51,7 @@ class DataTypeTest {
             Arguments.of(true, "boolean", true),
             Arguments.of(Map.of("k","v"), "map", true),
             Arguments.of(testArray, "array", true),
+            Arguments.of(testList, "array", true),
             Arguments.of(2.0, "integer", false),
             Arguments.of(2, "string", false),
             Arguments.of("testString", "long", false),

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
@@ -177,6 +177,20 @@ public class DefaultEventMetadataTest {
     }
 
     @Test
+    public void testAttributes_with_attributes_of_not_map_type() {
+        Object v1 = new Object();
+        eventMetadata = DefaultEventMetadata.builder()
+                .withEventType(testEventType)
+                .withTimeReceived(testTimeReceived)
+                .withAttributes(Map.of("key1", v1))
+                .build();
+        assertThat(eventMetadata.getAttribute("key1"), equalTo(v1));
+        assertThat(eventMetadata.getAttribute("key1/key2/"), equalTo(null));
+        assertThat(eventMetadata.getAttribute("key3"), equalTo(null));
+
+    }
+
+    @Test
     public void testBuild_withoutTimeReceived() {
 
         final Instant before = Instant.now();
@@ -303,6 +317,40 @@ public class DefaultEventMetadataTest {
         @Test
         void equals_returns_false_for_null() {
             assertThat(event.equals(null), equalTo(false));
+            assertThat(event.equals(new Object()), equalTo(false));
+        }
+
+        @Test
+        void equals_returns_false_when_timeinstance_not_match() {
+            DefaultEventMetadata newEvent = DefaultEventMetadata.builder()
+                    .withEventType(eventType)
+                    .withTimeReceived(Instant.now())
+                    .withAttributes(Collections.singletonMap(attributeKey, attributeValue))
+                    .build();
+            assertThat(event.equals(newEvent), equalTo(false));
+        }
+
+        @Test
+        void equals_returns_false_when_attributes_not_match() {
+            String newAttributeKey = UUID.randomUUID().toString();
+            String newAttributeValue = UUID.randomUUID().toString();
+            DefaultEventMetadata newEvent = DefaultEventMetadata.builder()
+                    .withEventType(eventType)
+                    .withTimeReceived(timeReceived)
+                    .withAttributes(Collections.singletonMap(newAttributeKey, newAttributeValue))
+                    .build();
+            assertThat(event.equals(newEvent), equalTo(false));
+        }
+
+        @Test
+        void equals_returns_false_when_tags_not_match() {
+            DefaultEventMetadata newEvent = DefaultEventMetadata.builder()
+                    .withEventType(eventType)
+                    .withTimeReceived(timeReceived)
+                    .withAttributes(Collections.singletonMap(attributeKey, attributeValue))
+                    .withTags(Set.of("some","new","tag"))
+                    .build();
+            assertThat(event.equals(newEvent), equalTo(false));
         }
 
         @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -781,6 +781,13 @@ public class JacksonEventTest {
                 .build();
 
         // Include Keys must start with / and also ordered, This is pre-processed in SinkModel
+        List<String> includeNullKey = null;
+        assertThat(event.jsonBuilder().rootKey(null).includeKeys(includeNullKey).toJsonString(), equalTo(jsonString));
+
+        List<String> includeEmptyKey = List.of();
+        assertThat(event.jsonBuilder().rootKey(null).includeKeys(includeEmptyKey).toJsonString(), equalTo(jsonString));
+
+        // Include Keys must start with / and also ordered, This is pre-processed in SinkModel
         List<String> includeKeys1 = Arrays.asList("foo", "info");
         final String expectedJsonString1 = "{\"foo\":\"bar\",\"info\":{\"name\":\"hello\",\"foo\":\"bar\"}}";
         assertThat(event.jsonBuilder().rootKey(null).includeKeys(includeKeys1).toJsonString(), equalTo(expectedJsonString1));
@@ -865,7 +872,16 @@ public class JacksonEventTest {
     }
 
     @ParameterizedTest
-    @CsvSource(value = {"test_key, true", "/test_key, true", "inv(alid, false", "getMetadata(\"test_key\"), false"})
+    @CsvSource(value = {"test_key, true",
+            "/test_key, true",
+            "inv(alid, false",
+            "getMetadata(\"test_key\"), false",
+            "key.with.dot, true",
+            "key-with-hyphen, true",
+            "key_with_underscore, true",
+            "key@with@at, true",
+            "key[with]brackets, true"
+    })
     void isValidEventKey_returns_expected_result(final String key, final boolean isValid) {
         assertThat(JacksonEvent.isValidEventKey(key), equalTo(isValid));
     }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventTest.java
@@ -9,11 +9,14 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.model.event.exceptions.EventKeyNotFoundException;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
@@ -22,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -880,6 +884,26 @@ public class JacksonEventTest {
             currentObject = nextObject;
         }
         return dataObject;
+    }
+
+    @ParameterizedTest
+    @MethodSource("getBigDecimalPutTestData")
+    void testPutAndGet_withBigDecimal(final String value) {
+        final String key = "bigDecimalKey";
+        event.put(key, new BigDecimal(value));
+        final Object result = event.get(key, Object.class);
+        assertThat(result, is(notNullValue()));
+        assertThat(result.toString(), is(equalTo(value)));
+    }
+
+    private static Stream<Arguments> getBigDecimalPutTestData() {
+        return Stream.of(
+                Arguments.of("702062202420"),
+                Arguments.of("1.23345E+9"),
+                Arguments.of("1.2345E+60"),
+                Arguments.of("1.2345E+6"),
+                Arguments.of("1.000")
+        );
     }
 
 }

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverterTests.java
@@ -73,6 +73,7 @@ public class BigDecimalConverterTests {
             expectedBigDecimal = expectedBigDecimal.setScale(scale, RoundingMode.HALF_EVEN);
         }
         assertThat(converter.convert(actualValue, scale), equalTo(expectedBigDecimal));
+        assertThat(converter.convert(actualValue, () -> scale), equalTo(expectedBigDecimal));
     }
 
     private static Stream<Arguments> decimalToBigDecimalValueProvider() {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverterTests.java
@@ -27,12 +27,21 @@ public class BigDecimalConverterTests {
         final String stringConstant = "12345678912.12345";
         assertThat(converter.convert(stringConstant), equalTo(new BigDecimal(stringConstant)));
     }
+
     @Test
     void testIntegerToBigDecimalConversion() {
         BigDecimalConverter converter = new BigDecimalConverter();
         final int intConstant = 12345;
         assertThat(converter.convert(intConstant), equalTo(BigDecimal.valueOf(intConstant)));
     }
+
+    @Test
+    void testLongToBigDecimalConversion() {
+        BigDecimalConverter converter = new BigDecimalConverter();
+        final long longConstant = 123456789012L;
+        assertThat(converter.convert(longConstant).longValue(), equalTo(longConstant));
+    }
+
     @Test
     void testBooleanToBigDecimalConversion() {
         BigDecimalConverter converter = new BigDecimalConverter();
@@ -40,6 +49,13 @@ public class BigDecimalConverterTests {
         assertThat(converter.convert(boolFalseConstant), equalTo(BigDecimal.valueOf(0)));
         final Boolean boolTrueConstant = true;
         assertThat(converter.convert(boolTrueConstant), equalTo(BigDecimal.valueOf(1)));
+    }
+
+    @Test
+    void testFloatToBigDecimalConversion() {
+        BigDecimalConverter converter = new BigDecimalConverter();
+        final float fval = 12345.6789f;
+        assertThat(converter.convert(fval).floatValue(), equalTo(fval));
     }
 
     @Test
@@ -76,6 +92,7 @@ public class BigDecimalConverterTests {
             Arguments.of(BigDecimal.valueOf(Double.MIN_VALUE), Double.MIN_VALUE, 0)
         );
     }
+
     @Test
     void testInvalidBigDecimalConversion() {
         BigDecimalConverter converter = new BigDecimalConverter();

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverterTests.java
@@ -87,6 +87,7 @@ public class BigDecimalConverterTests {
             Arguments.of(new BigDecimal ("-12345678912.12345"), -12345678912.12345, 1),
             Arguments.of(BigDecimal.ONE, BigDecimal.ONE.doubleValue(), 1),
             Arguments.of(new BigDecimal("1.7976931348623157E+308"), 1.7976931348623157E+308, 0),
+            Arguments.of(new BigDecimal("1702062202420"), 1.70206220242E+12, 12),
             Arguments.of(BigDecimal.valueOf(Double.MAX_VALUE), Double.MAX_VALUE, 0),
             Arguments.of(BigDecimal.valueOf(Double.MIN_VALUE), Double.MIN_VALUE, 0)
         );

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverterTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.typeconverter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class BigDecimalConverterTests {
+    @Test
+    void testStringToBigDecimalConversion() {
+        BigDecimalConverter converter = new BigDecimalConverter();
+        final String stringConstant = "12345678912.12345";
+        assertThat(converter.convert(stringConstant), equalTo(new BigDecimal(stringConstant)));
+    }
+    @Test
+    void testIntegerToBigDecimalConversion() {
+        BigDecimalConverter converter = new BigDecimalConverter();
+        final int intConstant = 12345;
+        assertThat(converter.convert(intConstant), equalTo(BigDecimal.valueOf(intConstant)));
+    }
+    @Test
+    void testBooleanToBigDecimalConversion() {
+        BigDecimalConverter converter = new BigDecimalConverter();
+        final Boolean boolFalseConstant = false;
+        assertThat(converter.convert(boolFalseConstant), equalTo(BigDecimal.valueOf(0)));
+        final Boolean boolTrueConstant = true;
+        assertThat(converter.convert(boolTrueConstant), equalTo(BigDecimal.valueOf(1)));
+    }
+
+    @Test
+    void testBigDecimalToBigDecimalConversion() {
+        BigDecimalConverter converter = new BigDecimalConverter();
+        BigDecimal bigDecimal = new BigDecimal("12345.6789");
+        assertThat(converter.convert(bigDecimal), equalTo(bigDecimal));
+    }
+
+    @ParameterizedTest
+    @MethodSource("decimalToBigDecimalValueProvider")
+    void testDoubleToBigDecimalConversion(BigDecimal expectedBigDecimal, double actualValue, int scale) {
+        BigDecimalConverter converter = new BigDecimalConverter();
+        if(scale!=0) {
+            converter.setScale(scale);
+            expectedBigDecimal = expectedBigDecimal.setScale(scale, RoundingMode.HALF_EVEN);
+        }
+        assertThat(converter.convert(actualValue), equalTo(expectedBigDecimal));
+    }
+
+    private static Stream<Arguments> decimalToBigDecimalValueProvider() {
+        return Stream.of(
+            Arguments.of(new BigDecimal ("0.0"), 0, 1),
+            Arguments.of(new BigDecimal ("0.0"), 0.0, 1),
+            Arguments.of(new BigDecimal ("0.00000000000000000000000"), 0.00000000000000000000000, 1),
+            Arguments.of(BigDecimal.ZERO, BigDecimal.ZERO.doubleValue(), 1),
+            Arguments.of(new BigDecimal ("1"), (double)1, 1),
+            Arguments.of(new BigDecimal ("1703908514.045833"), 1703908514.045833, 6),
+            Arguments.of(new BigDecimal ("1.00000000000000000000000"), 1.00000000000000000000000, 1),
+            Arguments.of(new BigDecimal ("-12345678912.12345"), -12345678912.12345, 1),
+            Arguments.of(BigDecimal.ONE, BigDecimal.ONE.doubleValue(), 1),
+            Arguments.of(new BigDecimal("1.7976931348623157E+308"), 1.7976931348623157E+308, 0),
+            Arguments.of(BigDecimal.valueOf(Double.MAX_VALUE), Double.MAX_VALUE, 0),
+            Arguments.of(BigDecimal.valueOf(Double.MIN_VALUE), Double.MIN_VALUE, 0)
+        );
+    }
+    @Test
+    void testInvalidBigDecimalConversion() {
+        BigDecimalConverter converter = new BigDecimalConverter();
+        final Map<Object, Object> map = Collections.emptyMap();
+        assertThrows(IllegalArgumentException.class, () -> converter.convert(map));
+    }
+}

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverterTests.java
@@ -26,6 +26,7 @@ public class BigDecimalConverterTests {
         BigDecimalConverter converter = new BigDecimalConverter();
         final String stringConstant = "12345678912.12345";
         assertThat(converter.convert(stringConstant), equalTo(new BigDecimal(stringConstant)));
+        assertThat(converter.convert(stringConstant, () -> 0), equalTo(new BigDecimal(stringConstant)));
     }
 
     @Test
@@ -33,6 +34,7 @@ public class BigDecimalConverterTests {
         BigDecimalConverter converter = new BigDecimalConverter();
         final int intConstant = 12345;
         assertThat(converter.convert(intConstant), equalTo(BigDecimal.valueOf(intConstant)));
+        assertThat(converter.convert(intConstant, () -> 0), equalTo(new BigDecimal(intConstant)));
     }
 
     @Test
@@ -40,6 +42,7 @@ public class BigDecimalConverterTests {
         BigDecimalConverter converter = new BigDecimalConverter();
         final long longConstant = 123456789012L;
         assertThat(converter.convert(longConstant).longValue(), equalTo(longConstant));
+        assertThat(converter.convert(longConstant, () -> 0).longValue(), equalTo(longConstant));
     }
 
     @Test
@@ -49,6 +52,7 @@ public class BigDecimalConverterTests {
         assertThat(converter.convert(boolFalseConstant), equalTo(BigDecimal.valueOf(0)));
         final Boolean boolTrueConstant = true;
         assertThat(converter.convert(boolTrueConstant), equalTo(BigDecimal.valueOf(1)));
+        assertThat(converter.convert(boolTrueConstant, () -> 0), equalTo(BigDecimal.valueOf(1)));
     }
 
     @Test
@@ -56,6 +60,7 @@ public class BigDecimalConverterTests {
         BigDecimalConverter converter = new BigDecimalConverter();
         final float fval = 12345.6789f;
         assertThat(converter.convert(fval).floatValue(), equalTo(fval));
+        assertThat(converter.convert(fval, () -> 0).floatValue(), equalTo(fval));
     }
 
     @Test
@@ -63,6 +68,7 @@ public class BigDecimalConverterTests {
         BigDecimalConverter converter = new BigDecimalConverter();
         BigDecimal bigDecimal = new BigDecimal("12345.6789");
         assertThat(converter.convert(bigDecimal), equalTo(bigDecimal));
+        assertThat(converter.convert(bigDecimal, () -> 0), equalTo(bigDecimal));
     }
 
     @ParameterizedTest

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BigDecimalConverterTests.java
@@ -70,10 +70,9 @@ public class BigDecimalConverterTests {
     void testDoubleToBigDecimalConversion(BigDecimal expectedBigDecimal, double actualValue, int scale) {
         BigDecimalConverter converter = new BigDecimalConverter();
         if(scale!=0) {
-            converter.setScale(scale);
             expectedBigDecimal = expectedBigDecimal.setScale(scale, RoundingMode.HALF_EVEN);
         }
-        assertThat(converter.convert(actualValue), equalTo(expectedBigDecimal));
+        assertThat(converter.convert(actualValue, scale), equalTo(expectedBigDecimal));
     }
 
     private static Stream<Arguments> decimalToBigDecimalValueProvider() {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BooleanConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BooleanConverterTests.java
@@ -21,11 +21,19 @@ import java.math.BigDecimal;
 import java.util.stream.Stream;
 
 public class BooleanConverterTests {
+
+    @Test
+    void testStringToBooleanConversionWithArguments() {
+        BooleanConverter converter = new BooleanConverter();
+        final String stringConstant = "12345678912.12345";
+        assertThat(converter.convert(stringConstant, () -> 0), equalTo(false));
+    }
+
     @Test
     void testStringToBooleanConversion() {
         BooleanConverter converter = new BooleanConverter();
         final String stringConstant = "12345678912.12345";
-        assertThat(converter.convert(stringConstant), equalTo(Boolean.parseBoolean(stringConstant)));
+        assertThat(converter.convert(stringConstant), equalTo(false));
     }
     @Test
     void testIntegerToBooleanConversion() {

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BooleanConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/BooleanConverterTests.java
@@ -54,7 +54,7 @@ public class BooleanConverterTests {
     @Test
     void testLongToBooleanConversion() {
         BooleanConverter converter = new BooleanConverter();
-        final Long longTrueConstant = (long)1234578912;
+        final Long longTrueConstant = 1234578912345L;
         assertThat(converter.convert(longTrueConstant), equalTo(true));
         final Long longFalseConstant = (long)0;
         assertThat(converter.convert(longFalseConstant), equalTo(false));

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/DoubleConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/DoubleConverterTests.java
@@ -25,6 +25,7 @@ public class DoubleConverterTests {
         DoubleConverter converter = new DoubleConverter();
         final String stringConstant = "12345678912.12345";
         assertThat(converter.convert(stringConstant), equalTo(Double.parseDouble(stringConstant)));
+        assertThat(converter.convert(stringConstant, () -> 0), equalTo(Double.parseDouble(stringConstant)));
     }
     @Test
     void testIntegerToDoubleConversion() {
@@ -43,7 +44,7 @@ public class DoubleConverterTests {
     @Test
     void testDoubleToDoubleConversion() {
         DoubleConverter converter = new DoubleConverter();
-        final Double doubleConstant = (double)12345.123;
+        final Double doubleConstant = 12345.123;
         assertThat(converter.convert(doubleConstant), equalTo(doubleConstant));
     }
     @ParameterizedTest
@@ -56,16 +57,16 @@ public class DoubleConverterTests {
         return Stream.of(
             Arguments.of(new BigDecimal ("0"), (double)0),
             Arguments.of(new BigDecimal ("0.0"), (double)0),
-            Arguments.of(new BigDecimal ("0.00000000000000000000000"), (double)0.00000000000000000000000),
+            Arguments.of(new BigDecimal ("0.00000000000000000000000"), 0.00000000000000000000000),
             Arguments.of(BigDecimal.ZERO, BigDecimal.ZERO.doubleValue()),
             Arguments.of(new BigDecimal ("1"), (double)1),
-            Arguments.of(new BigDecimal ("1703908514.045833"), (double)1703908514.045833),
-            Arguments.of(new BigDecimal ("1.00000000000000000000000"), (double)1.00000000000000000000000),
-            Arguments.of(new BigDecimal ("-12345678912.12345"), (double)-12345678912.12345),
+            Arguments.of(new BigDecimal ("1703908514.045833"), 1703908514.045833),
+            Arguments.of(new BigDecimal ("1.00000000000000000000000"), 1.00000000000000000000000),
+            Arguments.of(new BigDecimal ("-12345678912.12345"), -12345678912.12345),
             Arguments.of(BigDecimal.ONE, BigDecimal.ONE.doubleValue()),
-            Arguments.of(new BigDecimal("1.7976931348623157E+308"), (double)1.7976931348623157E+308),
-            Arguments.of(new BigDecimal(Double.MAX_VALUE), (double)Double.MAX_VALUE),
-            Arguments.of(new BigDecimal(Double.MIN_VALUE), (double)Double.MIN_VALUE)
+            Arguments.of(new BigDecimal("1.7976931348623157E+308"), 1.7976931348623157E+308),
+            Arguments.of(new BigDecimal(Double.MAX_VALUE), Double.MAX_VALUE),
+            Arguments.of(new BigDecimal(Double.MIN_VALUE), Double.MIN_VALUE)
         );
     }
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/IntegerConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/IntegerConverterTests.java
@@ -23,6 +23,7 @@ public class IntegerConverterTests {
         IntegerConverter converter = new IntegerConverter();
         final String stringConstant = "1234";
         assertThat(converter.convert(stringConstant), equalTo(Integer.parseInt(stringConstant)));
+        assertThat(converter.convert(stringConstant, () -> 0), equalTo(Integer.parseInt(stringConstant)));
     }
     @Test
     void testFloatToIntegerConversion() {
@@ -41,7 +42,7 @@ public class IntegerConverterTests {
     @Test
     void testIntegerToIntegerConversion() {
         IntegerConverter converter = new IntegerConverter();
-        final Integer intConstant = (int)1234;
+        final Integer intConstant = 1234;
         assertThat(converter.convert(intConstant), equalTo(intConstant));
     }
     @ParameterizedTest
@@ -52,18 +53,18 @@ public class IntegerConverterTests {
     }
     private static Stream<Arguments> BigDecimalValueProvider() {
         return Stream.of(
-            Arguments.of(new BigDecimal ("0"), (int)0),
-            Arguments.of(new BigDecimal ("0.0"), (int)0),
-            Arguments.of(new BigDecimal ("0.00000000000000000000000"), (int)0),
+            Arguments.of(new BigDecimal ("0"), 0),
+            Arguments.of(new BigDecimal ("0.0"), 0),
+            Arguments.of(new BigDecimal ("0.00000000000000000000000"), 0),
             Arguments.of(BigDecimal.ZERO, BigDecimal.ZERO.intValue()),
-            Arguments.of(new BigDecimal ("1"), (int)1),
-            Arguments.of(new BigDecimal ("1703908514.045833"), (int)1703908514),
-            Arguments.of(new BigDecimal ("1.00000000000000000000000"), (int)1),
-            Arguments.of(new BigDecimal ("-12345678.12345"), (int)-12345678),
+            Arguments.of(new BigDecimal ("1"), 1),
+            Arguments.of(new BigDecimal ("1703908514.045833"), 1703908514),
+            Arguments.of(new BigDecimal ("1.00000000000000000000000"), 1),
+            Arguments.of(new BigDecimal ("-12345678.12345"), -12345678),
             Arguments.of(BigDecimal.ONE, BigDecimal.ONE.intValue()),
-            Arguments.of(new BigDecimal("1.7976931348623157E+308"), (int)0),
-            Arguments.of(new BigDecimal(Integer.MAX_VALUE), (int)Integer.MAX_VALUE),
-            Arguments.of(new BigDecimal(Integer.MIN_VALUE), (int)Integer.MIN_VALUE)
+            Arguments.of(new BigDecimal("1.7976931348623157E+308"), 0),
+            Arguments.of(new BigDecimal(Integer.MAX_VALUE), Integer.MAX_VALUE),
+            Arguments.of(new BigDecimal(Integer.MIN_VALUE), Integer.MIN_VALUE)
         );
     }
     @Test

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/LongConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/LongConverterTests.java
@@ -24,18 +24,19 @@ import org.junit.jupiter.params.provider.ValueSource;
      void testStringToLongConversion(String stringValue) {
          LongConverter converter = new LongConverter();
          assertThat(converter.convert(stringValue), equalTo(Long.parseLong(stringValue)));
+         assertThat(converter.convert(stringValue, () -> 0), equalTo(Long.parseLong(stringValue)));
      }
      @ParameterizedTest
      @ValueSource(floats = {(float)1234.56789, Float.MAX_VALUE, Float.MIN_VALUE})
      void testfloatToLongConversion(float floatValue) {
          LongConverter converter = new LongConverter();
-         assertThat(converter.convert(floatValue), equalTo((long)(float)floatValue));
+         assertThat(converter.convert(floatValue), equalTo((long) floatValue));
      }
      @ParameterizedTest
      @ValueSource(doubles = {12345678.12345678, 2.0 * Integer.MAX_VALUE, Double.MAX_VALUE, Double.MIN_VALUE})
      void testDoubleToLongConversion(double doubleValue) {
         LongConverter converter = new LongConverter();
-        assertThat(converter.convert(doubleValue), equalTo((long)(double)doubleValue));
+        assertThat(converter.convert(doubleValue), equalTo((long) doubleValue));
      }
      @ParameterizedTest
      @ValueSource(booleans = {false,true})
@@ -77,8 +78,8 @@ import org.junit.jupiter.params.provider.ValueSource;
             Arguments.of(new BigDecimal("1.7976931348623157E+308"), (long)0),
             Arguments.of(new BigDecimal(Integer.MAX_VALUE), (long)Integer.MAX_VALUE),
             Arguments.of(new BigDecimal(Integer.MIN_VALUE), (long)Integer.MIN_VALUE),   
-            Arguments.of(new BigDecimal(Long.MAX_VALUE), (long)Long.MAX_VALUE),
-            Arguments.of(new BigDecimal(Long.MIN_VALUE), (long)Long.MIN_VALUE),
+            Arguments.of(new BigDecimal(Long.MAX_VALUE), Long.MAX_VALUE),
+            Arguments.of(new BigDecimal(Long.MIN_VALUE), Long.MIN_VALUE),
             Arguments.of(new BigDecimal("267694723"), (long)267694723)
 
         );

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/StringConverterTests.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/typeconverter/StringConverterTests.java
@@ -25,6 +25,7 @@ public class StringConverterTests {
         StringConverter converter = new StringConverter();
         final Long longConstant = (long)100000000 * (long)10000000;
         assertThat(converter.convert(longConstant), equalTo(longConstant.toString()));
+        assertThat(converter.convert(longConstant, () -> 0), equalTo(longConstant.toString()));
     }
     @Test
     void testDoubleToStringConversion() {

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DataPrepperScalarTypeDeserializerTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/DataPrepperScalarTypeDeserializerTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.stream.Stream;
 
@@ -53,6 +54,7 @@ class DataPrepperScalarTypeDeserializerTest {
                 Arguments.of(Long.class, 200L),
                 Arguments.of(Double.class, 1.23d),
                 Arguments.of(Float.class, 2.15f),
-                Arguments.of(Character.class, 'c'));
+                Arguments.of(Character.class, 'c'),
+                Arguments.of(BigDecimal.class, 1.2345E+5));
     }
 }

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/VariableExpanderTest.java
@@ -21,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.plugin.PluginConfigValueTranslator;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
@@ -113,6 +114,7 @@ class VariableExpanderTest {
                 Arguments.of(Long.class, "200", 200L),
                 Arguments.of(Double.class, "1.23", 1.23d),
                 Arguments.of(Float.class, "2.15", 2.15f),
+                Arguments.of(BigDecimal.class, "2.15", BigDecimal.valueOf(2.15)),
                 Arguments.of(Map.class, "{}", Collections.emptyMap()));
     }
 
@@ -127,6 +129,7 @@ class VariableExpanderTest {
                 Arguments.of(Long.class, "\"200\"", 200L),
                 Arguments.of(Double.class, "\"1.23\"", 1.23d),
                 Arguments.of(Float.class, "\"2.15\"", 2.15f),
+                Arguments.of(BigDecimal.class, "\"2.15\"", BigDecimal.valueOf(2.15)),
                 Arguments.of(Character.class, "\"c\"", 'c'));
     }
 }

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessor.java
@@ -13,7 +13,7 @@ import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.record.Record;
-import org.opensearch.dataprepper.typeconverter.BigDecimalConverter;
+import org.opensearch.dataprepper.typeconverter.ConverterArguments;
 import org.opensearch.dataprepper.typeconverter.TypeConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,12 +37,14 @@ public class ConvertEntryTypeProcessor  extends AbstractProcessor<Record<Event>,
     private int scale = 0;
 
     private final ExpressionEvaluator expressionEvaluator;
+    private final ConverterArguments converterArguments;
 
     @DataPrepperPluginConstructor
     public ConvertEntryTypeProcessor(final PluginMetrics pluginMetrics,
                                      final ConvertEntryTypeProcessorConfig convertEntryTypeProcessorConfig,
                                      final ExpressionEvaluator expressionEvaluator) {
         super(pluginMetrics);
+        this.converterArguments = convertEntryTypeProcessorConfig;
         this.convertEntryKeys = getKeysToConvert(convertEntryTypeProcessorConfig);
         TargetType targetType = convertEntryTypeProcessorConfig.getType();
         this.type = targetType.name();
@@ -71,11 +73,7 @@ public class ConvertEntryTypeProcessor  extends AbstractProcessor<Record<Event>,
                     if (keyVal != null) {
                         if (!nullValues.contains(keyVal.toString())) {
                             try {
-                                if(converter instanceof BigDecimalConverter) {
-                                    recordEvent.put(key, ((BigDecimalConverter)converter).convert(keyVal, scale));
-                                }else {
-                                    recordEvent.put(key, converter.convert(keyVal));
-                                }
+                                recordEvent.put(key, converter.convert(keyVal, converterArguments));
                             } catch (final RuntimeException e) {
                                 LOG.error(EVENT, "Unable to convert key: {} with value: {} to {}", key, keyVal, type, e);
                                 recordEvent.getMetadata().addTags(tagsOnFailure);

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
@@ -6,7 +6,6 @@
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.opensearch.dataprepper.typeconverter.BigDecimalConverter;
 
 import java.util.List;
 import java.util.Optional;
@@ -42,12 +41,9 @@ public class ConvertEntryTypeProcessorConfig  {
 
     public List<String> getKeys() { return keys; }
 
-    public TargetType getType() {
-        if(type == TargetType.BIGDECIMAL && scale!=0) {
-            ((BigDecimalConverter) type.getTargetConverter()).setScale(scale);
-        }
-        return type;
-    }
+    public TargetType getType() { return type;  }
+
+    public int getScale() { return scale;  }
 
     public String getConvertWhen() { return convertWhen; }
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
@@ -6,11 +6,12 @@
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.opensearch.dataprepper.typeconverter.ConverterArguments;
 
 import java.util.List;
 import java.util.Optional;
 
-public class ConvertEntryTypeProcessorConfig  {
+public class ConvertEntryTypeProcessorConfig implements ConverterArguments {
     @JsonProperty("key")
     private String key;
 
@@ -43,6 +44,7 @@ public class ConvertEntryTypeProcessorConfig  {
 
     public TargetType getType() { return type;  }
 
+    @Override
     public int getScale() { return scale;  }
 
     public String getConvertWhen() { return convertWhen; }

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorConfig.java
@@ -6,6 +6,7 @@
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.opensearch.dataprepper.typeconverter.BigDecimalConverter;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +20,12 @@ public class ConvertEntryTypeProcessorConfig  {
 
     @JsonProperty("type")
     private TargetType type = TargetType.INTEGER;
+
+    /**
+     * Optional scale value used only in the case of BigDecimal converter
+     */
+    @JsonProperty("scale")
+    private int scale = 0;
 
     @JsonProperty("convert_when")
     private String convertWhen;
@@ -36,6 +43,9 @@ public class ConvertEntryTypeProcessorConfig  {
     public List<String> getKeys() { return keys; }
 
     public TargetType getType() {
+        if(type == TargetType.BIGDECIMAL && scale!=0) {
+            ((BigDecimalConverter) type.getTargetConverter()).setScale(scale);
+        }
         return type;
     }
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/TargetType.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/TargetType.java
@@ -7,10 +7,16 @@ package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.opensearch.dataprepper.model.event.DataType;
-import org.opensearch.dataprepper.typeconverter.*;
+import org.opensearch.dataprepper.typeconverter.BigDecimalConverter;
+import org.opensearch.dataprepper.typeconverter.BooleanConverter;
+import org.opensearch.dataprepper.typeconverter.DoubleConverter;
+import org.opensearch.dataprepper.typeconverter.IntegerConverter;
+import org.opensearch.dataprepper.typeconverter.LongConverter;
+import org.opensearch.dataprepper.typeconverter.StringConverter;
+import org.opensearch.dataprepper.typeconverter.TypeConverter;
 
-import java.util.Map;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public enum TargetType {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/TargetType.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/TargetType.java
@@ -7,12 +7,7 @@ package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.opensearch.dataprepper.model.event.DataType;
-import org.opensearch.dataprepper.typeconverter.TypeConverter;
-import org.opensearch.dataprepper.typeconverter.IntegerConverter;
-import org.opensearch.dataprepper.typeconverter.StringConverter;
-import org.opensearch.dataprepper.typeconverter.DoubleConverter;
-import org.opensearch.dataprepper.typeconverter.BooleanConverter;
-import org.opensearch.dataprepper.typeconverter.LongConverter;
+import org.opensearch.dataprepper.typeconverter.*;
 
 import java.util.Map;
 import java.util.Arrays;
@@ -23,7 +18,8 @@ public enum TargetType {
     STRING(DataType.STRING, new StringConverter()),
     DOUBLE(DataType.DOUBLE, new DoubleConverter()),
     BOOLEAN(DataType.BOOLEAN, new BooleanConverter()),
-    LONG(DataType.LONG, new LongConverter());
+    LONG(DataType.LONG, new LongConverter()),
+    BIGDECIMAL(DataType.BIGDECIMAL, new BigDecimalConverter());
 
     private static final Map<String, TargetType> OPTIONS_MAP = Arrays.stream(TargetType.values())
             .collect(Collectors.toMap(

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/TargetType.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/TargetType.java
@@ -25,7 +25,7 @@ public enum TargetType {
     DOUBLE(DataType.DOUBLE, new DoubleConverter()),
     BOOLEAN(DataType.BOOLEAN, new BooleanConverter()),
     LONG(DataType.LONG, new LongConverter()),
-    BIGDECIMAL(DataType.BIGDECIMAL, new BigDecimalConverter());
+    BIG_DECIMAL(DataType.BIG_DECIMAL, new BigDecimalConverter());
 
     private static final Map<String, TargetType> OPTIONS_MAP = Arrays.stream(TargetType.values())
             .collect(Collectors.toMap(

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
@@ -57,7 +57,7 @@ public class ConvertEntryTypeProcessorTests {
     }
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         lenient().when(mockConfig.getKey()).thenReturn(TEST_KEY);
         lenient().when(mockConfig.getKeys()).thenReturn(null);
         lenient().when(mockConfig.getConvertWhen()).thenReturn(null);

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
@@ -18,20 +18,19 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.record.Record;
-import org.opensearch.dataprepper.typeconverter.BigDecimalConverter;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.math.BigDecimal;
 import java.util.stream.Stream;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
@@ -64,15 +63,15 @@ public class ConvertEntryTypeProcessorTests {
         lenient().when(mockConfig.getConvertWhen()).thenReturn(null);
     }
 
-    private Record<Event> getMessage(String message, String key, Object value) {
-        final Map<String, Object> testData = new HashMap();
+    private Record<Event> getMessage(String message, Object value) {
+        final Map<String, Object> testData = new HashMap<>();
         testData.put("message", message);
-        testData.put(key, value);
+        testData.put(ConvertEntryTypeProcessorTests.TEST_KEY, value);
         return buildRecordWithEvent(testData);
     }
 
     private Event executeAndGetProcessedEvent(final Object testValue) {
-        final Record<Event> record = getMessage(UUID.randomUUID().toString(), TEST_KEY, testValue);
+        final Record<Event> record = getMessage(UUID.randomUUID().toString(), testValue);
         final List<Record<Event>> processedRecords = (List<Record<Event>>) typeConversionProcessor.doExecute(Collections.singletonList(record));
         assertThat(processedRecords.size(), equalTo(1));
         assertThat(processedRecords.get(0), notNullValue());
@@ -121,13 +120,12 @@ public class ConvertEntryTypeProcessorTests {
     void testDecimalToBigDecimalWithScaleConvertEntryTypeProcessor() {
         String testValue = "2147483647";
         TargetType bigdecimalTargetType = TargetType.fromOptionValue("bigdecimal");
-        ((BigDecimalConverter)bigdecimalTargetType.getTargetConverter()).setScale(5);
         when(mockConfig.getType()).thenReturn(bigdecimalTargetType);
+        when(mockConfig.getScale()).thenReturn(5);
         typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
         Event event = executeAndGetProcessedEvent(testValue);
         //As we set the scale to 5, we expect to see 5 positions filled with zeros
         assertThat(event.get(TEST_KEY, BigDecimal.class), equalTo(new BigDecimal(testValue+".00000")));
-        ((BigDecimalConverter)bigdecimalTargetType.getTargetConverter()).setScale(0);
     }
 
     @ParameterizedTest
@@ -135,8 +133,8 @@ public class ConvertEntryTypeProcessorTests {
     void testDecimalToBigDecimalWithRoundingConvertEntryTypeProcessor(String source, String target) {
 
         TargetType bigdecimalTargetType = TargetType.fromOptionValue("bigdecimal");
-        ((BigDecimalConverter)bigdecimalTargetType.getTargetConverter()).setScale(5);
         when(mockConfig.getType()).thenReturn(bigdecimalTargetType);
+        when(mockConfig.getScale()).thenReturn(5);
         typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
         //Default HALF_ROUND_UP applied for all the conversions
         Event event1 = executeAndGetProcessedEvent(source);
@@ -253,7 +251,7 @@ public class ConvertEntryTypeProcessorTests {
 
     @Test
     void testDoubleToStringConvertEntryTypeProcessor() {
-        Double testValue = (double)123.456;
+        Double testValue = 123.456;
         String expectedValue = testValue.toString();
         when(mockConfig.getType()).thenReturn(TargetType.fromOptionValue("string"));
         typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
@@ -292,7 +290,7 @@ public class ConvertEntryTypeProcessorTests {
         when(mockConfig.getType()).thenReturn(TargetType.fromOptionValue("integer"));
         when(mockConfig.getConvertWhen()).thenReturn(convertWhen);
 
-        final Record<Event> record = getMessage(UUID.randomUUID().toString(), TEST_KEY, testValue);
+        final Record<Event> record = getMessage(UUID.randomUUID().toString(), testValue);
         when(expressionEvaluator.evaluateConditional(convertWhen, record.getData())).thenReturn(false);
         typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
         Event event = executeAndGetProcessedEvent(record);
@@ -308,11 +306,11 @@ public class ConvertEntryTypeProcessorTests {
         when(mockConfig.getKey()).thenReturn(null);
         when(mockConfig.getKeys()).thenReturn(List.of(testKey1, testKey2));
         when(mockConfig.getType()).thenReturn(TargetType.fromOptionValue("string"));
-        final Map<String, Object> testData = new HashMap();
+        final Map<String, Object> testData = new HashMap<>();
         testData.put("message", "testMessage");
         testData.put(testKey1, testValue);
         testData.put(testKey2, testValue);
-        Record record = buildRecordWithEvent(testData);
+        Record<Event> record = buildRecordWithEvent(testData);
         typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
         Event event = executeAndGetProcessedEvent(record);
         assertThat(event.get(testKey1, String.class), equalTo(expectedValue));

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
@@ -8,6 +8,9 @@ package org.opensearch.dataprepper.plugins.processor.mutateevent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
@@ -15,6 +18,7 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.typeconverter.BigDecimalConverter;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -22,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.math.BigDecimal;
+import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -53,7 +58,7 @@ public class ConvertEntryTypeProcessorTests {
     }
 
     @BeforeEach
-    private void setup() {
+    public void setup() {
         lenient().when(mockConfig.getKey()).thenReturn(TEST_KEY);
         lenient().when(mockConfig.getKeys()).thenReturn(null);
         lenient().when(mockConfig.getConvertWhen()).thenReturn(null);
@@ -101,6 +106,51 @@ public class ConvertEntryTypeProcessorTests {
         typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
         Event event = executeAndGetProcessedEvent(testValue.toString());
         assertThat(event.get(TEST_KEY, Integer.class), equalTo(testValue.intValue()));
+    }
+
+    @Test
+    void testDecimalToBigDecimalConvertEntryTypeProcessor() {
+        BigDecimal testValue = new BigDecimal(Integer.MAX_VALUE);
+        when(mockConfig.getType()).thenReturn(TargetType.fromOptionValue("bigdecimal"));
+        typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
+        Event event = executeAndGetProcessedEvent(testValue.toString());
+        assertThat(event.get(TEST_KEY, BigDecimal.class), equalTo(testValue));
+    }
+
+    @Test
+    void testDecimalToBigDecimalWithScaleConvertEntryTypeProcessor() {
+        String testValue = "2147483647";
+        TargetType bigdecimalTargetType = TargetType.fromOptionValue("bigdecimal");
+        ((BigDecimalConverter)bigdecimalTargetType.getTargetConverter()).setScale(5);
+        when(mockConfig.getType()).thenReturn(bigdecimalTargetType);
+        typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
+        Event event = executeAndGetProcessedEvent(testValue);
+        //As we set the scale to 5, we expect to see 5 positions filled with zeros
+        assertThat(event.get(TEST_KEY, BigDecimal.class), equalTo(new BigDecimal(testValue+".00000")));
+        ((BigDecimalConverter)bigdecimalTargetType.getTargetConverter()).setScale(0);
+    }
+
+    @ParameterizedTest
+    @MethodSource("decimalFormatKeysArgumentProvider")
+    void testDecimalToBigDecimalWithRoundingConvertEntryTypeProcessor(String source, String target) {
+
+        TargetType bigdecimalTargetType = TargetType.fromOptionValue("bigdecimal");
+        ((BigDecimalConverter)bigdecimalTargetType.getTargetConverter()).setScale(5);
+        when(mockConfig.getType()).thenReturn(bigdecimalTargetType);
+        typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
+        //Default HALF_ROUND_UP applied for all the conversions
+        Event event1 = executeAndGetProcessedEvent(source);
+        assertThat(event1.get(TEST_KEY, BigDecimal.class), equalTo(new BigDecimal(target)));
+    }
+
+    private static Stream<Arguments> decimalFormatKeysArgumentProvider() {
+        //Default HALF_ROUND_UP applied for all the conversions
+        return Stream.of(
+                Arguments.of("1703908412.707011", "1703908412.70701"),
+                Arguments.of("1703908412.707016", "1703908412.70702"),
+                Arguments.of("1703908412.707015", "1703908412.70702"),
+                Arguments.of("1703908412.707014", "1703908412.70701")
+        );
     }
 
     @Test

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/ConvertEntryTypeProcessorTests.java
@@ -110,7 +110,7 @@ public class ConvertEntryTypeProcessorTests {
     @Test
     void testDecimalToBigDecimalConvertEntryTypeProcessor() {
         BigDecimal testValue = new BigDecimal(Integer.MAX_VALUE);
-        when(mockConfig.getType()).thenReturn(TargetType.fromOptionValue("bigdecimal"));
+        when(mockConfig.getType()).thenReturn(TargetType.fromOptionValue("big_decimal"));
         typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
         Event event = executeAndGetProcessedEvent(testValue.toString());
         assertThat(event.get(TEST_KEY, BigDecimal.class), equalTo(testValue));
@@ -119,7 +119,7 @@ public class ConvertEntryTypeProcessorTests {
     @Test
     void testDecimalToBigDecimalWithScaleConvertEntryTypeProcessor() {
         String testValue = "2147483647";
-        TargetType bigdecimalTargetType = TargetType.fromOptionValue("bigdecimal");
+        TargetType bigdecimalTargetType = TargetType.fromOptionValue("big_decimal");
         when(mockConfig.getType()).thenReturn(bigdecimalTargetType);
         when(mockConfig.getScale()).thenReturn(5);
         typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);
@@ -132,7 +132,7 @@ public class ConvertEntryTypeProcessorTests {
     @MethodSource("decimalFormatKeysArgumentProvider")
     void testDecimalToBigDecimalWithRoundingConvertEntryTypeProcessor(String source, String target) {
 
-        TargetType bigdecimalTargetType = TargetType.fromOptionValue("bigdecimal");
+        TargetType bigdecimalTargetType = TargetType.fromOptionValue("big_decimal");
         when(mockConfig.getType()).thenReturn(bigdecimalTargetType);
         when(mockConfig.getScale()).thenReturn(5);
         typeConversionProcessor = new ConvertEntryTypeProcessor(pluginMetrics, mockConfig, expressionEvaluator);

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/TargetTypeTest.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/TargetTypeTest.java
@@ -39,7 +39,8 @@ class TargetTypeTest {
                     arguments(DataType.BOOLEAN.getTypeName(), TargetType.BOOLEAN),
                     arguments(DataType.INTEGER.getTypeName(), TargetType.INTEGER),
                     arguments(DataType.LONG.getTypeName(), TargetType.LONG),
-                    arguments(DataType.DOUBLE.getTypeName(), TargetType.DOUBLE)
+                    arguments(DataType.DOUBLE.getTypeName(), TargetType.DOUBLE),
+                    arguments(DataType.BIG_DECIMAL.getTypeName(), TargetType.BIG_DECIMAL)
             );
         }
     }


### PR DESCRIPTION
Introduced BigDecimal Converter that users can use as part of convert_entry_type processor that currently exists. Optionally, users can also specify required scaling needed while converting to BigDecimal. If scale value is given by the user then we apply [HALF_EVEN](https://docs.oracle.com/javase/8/docs/api/java/math/RoundingMode.html) rounding strategy if the original number has more decimal digits than the scale value given.

### Description

Fix for the issue described at => https://github.com/opensearch-project/data-prepper/issues/3840

IMPORTANT Note: This PR is disabling [STRIP_TRAILING_BIGDECIMAL_ZEROES](https://www.javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/latest/com/fasterxml/jackson/databind/cfg/JsonNodeFeature.html#STRIP_TRAILING_BIGDECIMAL_ZEROES) by default. In other words, we won't be calling `bigDecimal.stripTrailingZeros()` method while deserializing a BigDecimal value. A value of `1.00` won't be stripped down to `1.0` or `1` while deserializing. It will be deserialized into `1.00`. It could impact all existing pipelines as well if they depend on BigDecimal datatype. This PR itself is introducing BigDecimal converter so the assumption is that no one is depending on the BigDecimal type so far. Even if they depend on BigDecimal and are ingesting this non-stripped version of a number into OpenSearch sink, it won't be an issue. This will become an issue only if they look for a specific number of decimal places in a numeric value or if they do String comparison on the numbers.

After this change merged, user will have an option to choose a BigDecimal converter with optional scale (positions after the decimal point) with `HALF_EVEN` rounding strategy. Check [here](https://docs.oracle.com/javase/8/docs/api/java/math/RoundingMode.html) for more details on this rounding strategy.
Example to use this new converter:


 ```
 processor:
    - convert_entry_type:
        key: "column1"
        type: "bigdecimal"
        scale: 5
    - convert_entry_type:
        key: "column2"
        type: "bigdecimal"
        scale: 2
```

Note: Usage of scale attribute is optional. If specified, trailing zero's will be added to match the scale given like in the examples given. 
 
Example-1:
`1.703908412707e11` will be deserialized into `170390841270.70000` with scale value set to 5. If no scale value given for this case then it will be deserialized into `170390841270.7` 
 
Example-2:
If no scale value is given then a number like `17020622024e1` will be deserialized into `1.7020622024E+11`. In case if user want to avoid scientific notation in the deserialized value then he need to provide a scale value  that can cover up all the digits in the decimal places.

scale = 0 is also an acceptable value, which essentially like no scale given
Giving a negative for scale is also an acceptable value
If given, scale should always be a numeric value, Otherwise, data-prepper will fail to start

### Issues Resolved
Resolves #[https://github.com/opensearch-project/data-prepper/issues/3840] 
Above issue will get resolved after this change merged in as it gives the user an option to convert the output to BigDecimal format with a specific scale mentioned. That should eliminate scientific notation values printed in the output stream causing the failure in the above issue.
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
