### PR TITLE
Add default role configuration to the data-prepper-config.yaml via ex…

### DIFF
--- a/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsSupplier.java
+++ b/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsSupplier.java
@@ -6,6 +6,9 @@
 package org.opensearch.dataprepper.aws.api;
 
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.Optional;
 
 /**
  * An interface available to plugins via the AWS Plugin Extension which supplies
@@ -19,4 +22,10 @@ public interface AwsCredentialsSupplier {
      * @return An {@link AwsCredentialsProvider} to use.
      */
     AwsCredentialsProvider getProvider(AwsCredentialsOptions options);
+
+    /**
+     * Gets the default region if it is configured. Otherwise returns null
+     * @return Default {@link Region}
+     */
+    Optional<Region> getDefaultRegion();
 }

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsPlugin.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsPlugin.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.aws;
 
+import org.opensearch.dataprepper.model.annotations.DataPrepperExtensionPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.plugin.ExtensionPlugin;
 import org.opensearch.dataprepper.model.plugin.ExtensionPoints;
@@ -13,12 +14,18 @@ import org.opensearch.dataprepper.model.plugin.ExtensionPoints;
  * The {@link ExtensionPlugin} class which adds the AWS Plugin to
  * Data Prepper as an extension plugin. Everything starts from here.
  */
+@DataPrepperExtensionPlugin(modelType = AwsPluginConfig.class, rootKeyJsonPath = "/aws/configurations")
 public class AwsPlugin implements ExtensionPlugin {
     private final DefaultAwsCredentialsSupplier defaultAwsCredentialsSupplier;
 
+    private final AwsPluginConfig awsPluginConfig;
+
     @DataPrepperPluginConstructor
-    public AwsPlugin() {
-        final CredentialsProviderFactory credentialsProviderFactory = new CredentialsProviderFactory();
+    public AwsPlugin(final AwsPluginConfig awsPluginConfig) {
+
+        this.awsPluginConfig = awsPluginConfig;
+
+        final CredentialsProviderFactory credentialsProviderFactory = new CredentialsProviderFactory(awsPluginConfig != null ? awsPluginConfig.getDefaultStsConfiguration() : new AwsStsConfiguration());
         final CredentialsCache credentialsCache = new CredentialsCache();
         defaultAwsCredentialsSupplier = new DefaultAwsCredentialsSupplier(credentialsProviderFactory, credentialsCache);
     }

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfig.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfig.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AwsPluginConfig {
+
+    @JsonProperty("default")
+    private AwsStsConfiguration defaultStsConfiguration = new AwsStsConfiguration();
+
+    public AwsStsConfiguration getDefaultStsConfiguration() {
+        return defaultStsConfiguration;
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigPublisher.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsSecretsPluginConfigPublisher.java
@@ -5,8 +5,8 @@
 
 package org.opensearch.dataprepper.plugins.aws;
 
-import org.opensearch.dataprepper.model.plugin.PluginConfigPublisher;
 import org.opensearch.dataprepper.model.plugin.PluginConfigObservable;
+import org.opensearch.dataprepper.model.plugin.PluginConfigPublisher;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfiguration.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
+import software.amazon.awssdk.regions.Region;
+
+public class AwsStsConfiguration {
+
+    @JsonProperty("region")
+    @Size(min = 1, message = "Region cannot be empty string")
+    private String awsRegion;
+
+    @JsonProperty("sts_role_arn")
+    @Size(min = 20, max = 2048, message = "awsStsRoleArn length should be between 1 and 2048 characters")
+    private String awsStsRoleArn;
+
+    public Region getAwsRegion() {
+        return awsRegion != null ? Region.of(awsRegion) : null;
+    }
+
+    public String getAwsStsRoleArn() {
+        return awsStsRoleArn;
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplier.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplier.java
@@ -8,6 +8,9 @@ package org.opensearch.dataprepper.plugins.aws;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.Optional;
 
 class DefaultAwsCredentialsSupplier implements AwsCredentialsSupplier {
     private final CredentialsProviderFactory credentialsProviderFactory;
@@ -21,5 +24,10 @@ class DefaultAwsCredentialsSupplier implements AwsCredentialsSupplier {
     @Override
     public AwsCredentialsProvider getProvider(final AwsCredentialsOptions options) {
         return credentialsCache.getOrCreate(options, () -> credentialsProviderFactory.providerFromOptions(options));
+    }
+
+    @Override
+    public Optional<Region> getDefaultRegion() {
+        return Optional.ofNullable(credentialsProviderFactory.getDefaultRegion());
     }
 }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfigTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginConfigTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class AwsPluginConfigTest {
+
+    @Test
+    void testDefault() {
+        final AwsPluginConfig objectUnderTest = new AwsPluginConfig();
+
+        assertThat(objectUnderTest, notNullValue());
+        assertThat(objectUnderTest.getDefaultStsConfiguration(), notNullValue());
+        assertThat(objectUnderTest.getDefaultStsConfiguration().getAwsRegion(), nullValue());
+        assertThat(objectUnderTest.getDefaultStsConfiguration().getAwsStsRoleArn(), nullValue());
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginIT.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.dataprepper.plugins.aws;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -28,17 +29,29 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class AwsPluginIT {
+    @Mock
+    private AwsPluginConfig awsPluginConfig;
+
     @Mock
     private ExtensionPoints extensionPoints;
 
     @Mock
     private ExtensionProvider.Context context;
 
+    @Mock
+    private AwsStsConfiguration awsDefaultStsConfiguration;
+
+    @BeforeEach
+    void setup() {
+        when(awsPluginConfig.getDefaultStsConfiguration()).thenReturn(awsDefaultStsConfiguration);
+    }
+
     private AwsPlugin createObjectUnderTest() {
-        return new AwsPlugin();
+        return new AwsPlugin(awsPluginConfig);
     }
 
     @Test
@@ -78,6 +91,8 @@ public class AwsPluginIT {
 
     @Test
     void test_AwsPlugin_without_STS_role() {
+        when(awsDefaultStsConfiguration.getAwsStsRoleArn()).thenReturn(null);
+
         createObjectUnderTest().apply(extensionPoints);
 
         final ArgumentCaptor<ExtensionProvider<AwsCredentialsSupplier>> extensionProviderArgumentCaptor = ArgumentCaptor.forClass(ExtensionProvider.class);
@@ -98,6 +113,40 @@ public class AwsPluginIT {
         final AwsCredentialsProvider awsCredentialsProvider1 = awsCredentialsSupplier.getProvider(awsCredentialsOptions1);
 
         assertThat(awsCredentialsProvider1, instanceOf(DefaultCredentialsProvider.class));
+
+        final AwsCredentialsOptions awsCredentialsOptions2 = AwsCredentialsOptions.builder()
+                .withRegion(Region.US_EAST_1)
+                .build();
+
+        final AwsCredentialsProvider awsCredentialsProvider2 = awsCredentialsSupplier.getProvider(awsCredentialsOptions2);
+
+        assertThat(awsCredentialsProvider2, sameInstance(awsCredentialsProvider1));
+    }
+
+    @Test
+    void test_AwsPlugin_without_STS_role_and_with_default_role_uses_default_role() {
+        when(awsDefaultStsConfiguration.getAwsStsRoleArn()).thenReturn(createStsRole());
+
+        createObjectUnderTest().apply(extensionPoints);
+
+        final ArgumentCaptor<ExtensionProvider<AwsCredentialsSupplier>> extensionProviderArgumentCaptor = ArgumentCaptor.forClass(ExtensionProvider.class);
+        verify(extensionPoints).addExtensionProvider(extensionProviderArgumentCaptor.capture());
+
+        final ExtensionProvider<AwsCredentialsSupplier> extensionProvider = extensionProviderArgumentCaptor.getValue();
+
+        final Optional<AwsCredentialsSupplier> optionalSupplier = extensionProvider.provideInstance(context);
+        assertThat(optionalSupplier, notNullValue());
+        assertThat(optionalSupplier.isPresent(), equalTo(true));
+
+        final AwsCredentialsSupplier awsCredentialsSupplier = optionalSupplier.get();
+
+        final AwsCredentialsOptions awsCredentialsOptions1 = AwsCredentialsOptions.builder()
+                .withRegion(Region.US_EAST_1)
+                .build();
+
+        final AwsCredentialsProvider awsCredentialsProvider1 = awsCredentialsSupplier.getProvider(awsCredentialsOptions1);
+
+        assertThat(awsCredentialsProvider1, instanceOf(StsAssumeRoleCredentialsProvider.class));
 
         final AwsCredentialsOptions awsCredentialsOptions2 = AwsCredentialsOptions.builder()
                 .withRegion(Region.US_EAST_1)

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsPluginTest.java
@@ -16,19 +16,42 @@ import org.opensearch.dataprepper.model.plugin.ExtensionProvider;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AwsPluginTest {
+
+    @Mock
+    private AwsPluginConfig awsPluginConfig;
+
     @Mock
     private ExtensionPoints extensionPoints;
 
     private AwsPlugin createObjectUnderTest() {
-        return new AwsPlugin();
+        return new AwsPlugin(awsPluginConfig);
     }
 
     @Test
     void apply_should_addExtensionProvider() {
+        when(awsPluginConfig.getDefaultStsConfiguration()).thenReturn(new AwsStsConfiguration());
+
         createObjectUnderTest().apply(extensionPoints);
+
+        final ArgumentCaptor<ExtensionProvider> extensionProviderArgumentCaptor =
+                ArgumentCaptor.forClass(ExtensionProvider.class);
+
+        verify(extensionPoints).addExtensionProvider(extensionProviderArgumentCaptor.capture());
+
+        final ExtensionProvider actualExtensionProvider = extensionProviderArgumentCaptor.getValue();
+
+        assertThat(actualExtensionProvider, instanceOf(AwsExtensionProvider.class));
+    }
+
+    @Test
+    void null_aws_plugin_config_applies_extensions_correctly() {
+        final AwsPlugin objectUnderTest = new AwsPlugin(null);
+
+        objectUnderTest.apply(extensionPoints);
 
         final ArgumentCaptor<ExtensionProvider> extensionProviderArgumentCaptor =
                 ArgumentCaptor.forClass(ExtensionProvider.class);

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfigurationTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/AwsStsConfigurationTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.aws;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class AwsStsConfigurationTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @ParameterizedTest
+    @MethodSource("getRegions")
+    void testStsConfiguration(final Region region) throws JsonProcessingException {
+
+        final String defaultConfigurationAsString = "{\"region\": \"" + region.toString() + "\", \"sts_role_arn\": \"arn:aws:iam::123456789012:role/test-role\"}";
+
+        final AwsStsConfiguration objectUnderTest = OBJECT_MAPPER.readValue(defaultConfigurationAsString, AwsStsConfiguration.class);
+
+        assertThat(objectUnderTest, notNullValue());
+        assertThat(objectUnderTest.getAwsStsRoleArn(), equalTo("arn:aws:iam::123456789012:role/test-role"));
+        assertThat(objectUnderTest.getAwsRegion(), equalTo(region));
+    }
+
+    private static List<Region> getRegions() {
+        return Region.regions();
+    }
+}

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -31,6 +32,7 @@ import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -58,8 +60,11 @@ class CredentialsProviderFactoryTest {
     @Mock
     private AwsCredentialsOptions awsCredentialsOptions;
 
+    @Mock
+    private AwsStsConfiguration defaultStsConfiguration;
+
     private CredentialsProviderFactory createObjectUnderTest() {
-        return new CredentialsProviderFactory();
+        return new CredentialsProviderFactory(defaultStsConfiguration);
     }
 
     @Test
@@ -97,6 +102,22 @@ class CredentialsProviderFactoryTest {
                 .thenReturn(Region.US_EAST_1);
         final AwsCredentialsProvider awsCredentialsProvider = createObjectUnderTest().providerFromOptions(awsCredentialsOptions);
         assertThat(awsCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getRegions")
+    void getDefaultRegion_returns_expected_region(final Region region) {
+        when(defaultStsConfiguration.getAwsRegion()).thenReturn(region);
+
+        final CredentialsProviderFactory credentialsProviderFactory = createObjectUnderTest();
+
+        final Region actualRegion = credentialsProviderFactory.getDefaultRegion();
+
+        assertThat(actualRegion, equalTo(region));
+    }
+
+    private static List<Region> getRegions() {
+        return Region.regions();
     }
 
 

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplierTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplierTest.java
@@ -7,12 +7,18 @@ package org.opensearch.dataprepper.plugins.aws;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -61,5 +67,28 @@ class DefaultAwsCredentialsSupplierTest {
         final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
         when(credentialsProviderFactory.providerFromOptions(options)).thenReturn(awsCredentialsProvider);
         assertThat(actualCredentialsSupplier.get(), equalTo(awsCredentialsProvider));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getRegions")
+    void getDefaultRegion_returns_default_region(final Region region) {
+        when(credentialsProviderFactory.getDefaultRegion()).thenReturn(region);
+
+        final AwsCredentialsSupplier objectUnderTest = createObjectUnderTest();
+        assertThat(objectUnderTest.getDefaultRegion().isPresent(), equalTo(true));
+        assertThat(objectUnderTest.getDefaultRegion().get(), equalTo(credentialsProviderFactory.getDefaultRegion()));
+    }
+
+    @Test
+    void no_default_region_returns_empty_optional() {
+        when(credentialsProviderFactory.getDefaultRegion()).thenReturn(null);
+
+        final AwsCredentialsSupplier objectUnderTest = createObjectUnderTest();
+        assertThat(objectUnderTest.getDefaultRegion(), equalTo(Optional.empty()));
+
+    }
+
+    private static List<Region> getRegions() {
+        return Region.regions();
     }
 }

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer_KmsIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/buffer/KafkaBuffer_KmsIT.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
+import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import org.opensearch.dataprepper.model.CheckpointState;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSet;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
@@ -72,6 +74,9 @@ public class KafkaBuffer_KmsIT {
     @Mock
     private AcknowledgementSet acknowledgementSet;
 
+    @Mock
+    private AwsCredentialsSupplier awsCredentialsSupplier;
+
     private Random random;
 
     private BufferTopicConfig topicConfig;
@@ -121,10 +126,12 @@ public class KafkaBuffer_KmsIT {
         kmsClient = KmsClient.create();
 
         byteDecoder = null;
+
+        when(awsCredentialsSupplier.getProvider(any(AwsCredentialsOptions.class))).thenAnswer(options -> DefaultCredentialsProvider.create());
     }
 
     private KafkaBuffer createObjectUnderTest() {
-        return new KafkaBuffer(pluginSetting, kafkaBufferConfig, acknowledgementSetManager, null, ignored -> DefaultCredentialsProvider.create(), null);
+        return new KafkaBuffer(pluginSetting, kafkaBufferConfig, acknowledgementSetManager, null, awsCredentialsSupplier, null);
     }
 
     @Nested


### PR DESCRIPTION
…tension plugin

### Description
This change adds the following configuration to be used in the `data-prepper-config.yaml` as defaults so that individual plugins are not required to contain values for `region` and `sts_role_arn`. 

A follow up PR will provide wire the default region back to the clients in the plugins using the `AwsCredentialsSupplier::getDefaultRegion` method
 
### Issues Resolved
Related to #2570 
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
