### PR TITLE
Revert addition of default region function from AwsCredentialsSupplier

### DIFF
--- a/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsSupplier.java
+++ b/data-prepper-plugins/aws-plugin-api/src/main/java/org/opensearch/dataprepper/aws/api/AwsCredentialsSupplier.java
@@ -6,9 +6,7 @@
 package org.opensearch.dataprepper.aws.api;
 
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
 
-import java.util.Optional;
 
 /**
  * An interface available to plugins via the AWS Plugin Extension which supplies
@@ -22,10 +20,4 @@ public interface AwsCredentialsSupplier {
      * @return An {@link AwsCredentialsProvider} to use.
      */
     AwsCredentialsProvider getProvider(AwsCredentialsOptions options);
-
-    /**
-     * Gets the default region if it is configured. Otherwise returns null
-     * @return Default {@link Region}
-     */
-    Optional<Region> getDefaultRegion();
 }

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactory.java
@@ -43,10 +43,6 @@ class CredentialsProviderFactory {
         this.defaultStsConfiguration = defaultStsConfiguration;
     }
 
-    Region getDefaultRegion() {
-        return defaultStsConfiguration.getAwsRegion();
-    }
-
     AwsCredentialsProvider providerFromOptions(final AwsCredentialsOptions credentialsOptions) {
         Objects.requireNonNull(credentialsOptions);
 

--- a/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplier.java
+++ b/data-prepper-plugins/aws-plugin/src/main/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplier.java
@@ -8,9 +8,7 @@ package org.opensearch.dataprepper.plugins.aws;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
 
-import java.util.Optional;
 
 class DefaultAwsCredentialsSupplier implements AwsCredentialsSupplier {
     private final CredentialsProviderFactory credentialsProviderFactory;
@@ -24,10 +22,5 @@ class DefaultAwsCredentialsSupplier implements AwsCredentialsSupplier {
     @Override
     public AwsCredentialsProvider getProvider(final AwsCredentialsOptions options) {
         return credentialsCache.getOrCreate(options, () -> credentialsProviderFactory.providerFromOptions(options));
-    }
-
-    @Override
-    public Optional<Region> getDefaultRegion() {
-        return Optional.ofNullable(credentialsProviderFactory.getDefaultRegion());
     }
 }

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/CredentialsProviderFactoryTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -32,7 +31,6 @@ import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -102,22 +100,6 @@ class CredentialsProviderFactoryTest {
                 .thenReturn(Region.US_EAST_1);
         final AwsCredentialsProvider awsCredentialsProvider = createObjectUnderTest().providerFromOptions(awsCredentialsOptions);
         assertThat(awsCredentialsProvider, instanceOf(StsAssumeRoleCredentialsProvider.class));
-    }
-
-    @ParameterizedTest
-    @MethodSource("getRegions")
-    void getDefaultRegion_returns_expected_region(final Region region) {
-        when(defaultStsConfiguration.getAwsRegion()).thenReturn(region);
-
-        final CredentialsProviderFactory credentialsProviderFactory = createObjectUnderTest();
-
-        final Region actualRegion = credentialsProviderFactory.getDefaultRegion();
-
-        assertThat(actualRegion, equalTo(region));
-    }
-
-    private static List<Region> getRegions() {
-        return Region.regions();
     }
 
 

--- a/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplierTest.java
+++ b/data-prepper-plugins/aws-plugin/src/test/java/org/opensearch/dataprepper/plugins/aws/DefaultAwsCredentialsSupplierTest.java
@@ -7,18 +7,12 @@ package org.opensearch.dataprepper.plugins.aws;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.aws.api.AwsCredentialsOptions;
-import org.opensearch.dataprepper.aws.api.AwsCredentialsSupplier;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -67,28 +61,5 @@ class DefaultAwsCredentialsSupplierTest {
         final AwsCredentialsProvider awsCredentialsProvider = mock(AwsCredentialsProvider.class);
         when(credentialsProviderFactory.providerFromOptions(options)).thenReturn(awsCredentialsProvider);
         assertThat(actualCredentialsSupplier.get(), equalTo(awsCredentialsProvider));
-    }
-
-    @ParameterizedTest
-    @MethodSource("getRegions")
-    void getDefaultRegion_returns_default_region(final Region region) {
-        when(credentialsProviderFactory.getDefaultRegion()).thenReturn(region);
-
-        final AwsCredentialsSupplier objectUnderTest = createObjectUnderTest();
-        assertThat(objectUnderTest.getDefaultRegion().isPresent(), equalTo(true));
-        assertThat(objectUnderTest.getDefaultRegion().get(), equalTo(credentialsProviderFactory.getDefaultRegion()));
-    }
-
-    @Test
-    void no_default_region_returns_empty_optional() {
-        when(credentialsProviderFactory.getDefaultRegion()).thenReturn(null);
-
-        final AwsCredentialsSupplier objectUnderTest = createObjectUnderTest();
-        assertThat(objectUnderTest.getDefaultRegion(), equalTo(Optional.empty()));
-
-    }
-
-    private static List<Region> getRegions() {
-        return Region.regions();
     }
 }


### PR DESCRIPTION
### Description
This change removes the function to return the default region from the `AwsCredentialsSupplier` class. Rather than passing this region all of the clients, we will rely on the default SDK behavior to choose a region when one is not supplied. The region for STS will continue to use the configured `default` region in the `data-prepper-config.yaml`

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
