### PR TITLE
Add support for Kafka headers and timestamp in the Kafka Source

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventMetadata.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/DefaultEventMetadata.java
@@ -100,8 +100,19 @@ public class DefaultEventMetadata implements EventMetadata {
     public Object getAttribute(final String attributeKey) {
         String key = (attributeKey.charAt(0) == '/') ? attributeKey.substring(1) : attributeKey;
 
-        // Does not support recursive or inner-object lookups for now.
-        return attributes.get(key);
+        Map<String, Object> mapObject = attributes;
+        if (key.contains("/")) {
+            String[] keys = key.split("/");
+            for (int i = 0; i < keys.length-1; i++) {
+                Object value = mapObject.get(keys[i]);
+                if (value == null || !(value instanceof Map)) {
+                    return null;
+                }
+                mapObject = (Map<String, Object>)value;
+                key = keys[i+1];
+            }
+        }
+        return mapObject.get(key);
     }
 
     @Override

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/DefaultEventMetadataTest.java
@@ -134,6 +134,25 @@ public class DefaultEventMetadataTest {
         assertThat(eventMetadata.getAttribute(key), equalTo(value));
     }
 
+    private static Stream<Arguments> getNestedAttributeTestInputs() {
+        return Stream.of(Arguments.of(Map.of("k1", "v1", "k2", Map.of("k3", "v3")), "k1", "v1"),
+                         Arguments.of(Map.of("k1", "v1", "k2", Map.of("k3", "v3")), "k2/k3", "v3"),
+                         Arguments.of(Map.of("k1", "v1", "k2", Map.of("k3", Map.of("k4", 4))), "k2/k3/k4", 4),
+                         Arguments.of(Map.of("k1", "v1", "k2", Map.of("k3", 4)), "k2/k3/k4", null),
+                         Arguments.of(Map.of("k1","v1"),"k1", "v1"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getNestedAttributeTestInputs")
+    public void testNestedGetAttribute(Map<String, Object> attributes, final String key, final Object expectedValue) {
+        eventMetadata = DefaultEventMetadata.builder()
+                .withEventType(testEventType)
+                .withTimeReceived(testTimeReceived)
+                .withAttributes(attributes)
+                .build();
+        assertThat(eventMetadata.getAttribute(key), equalTo(expectedValue));
+    }
+
     @Test
     public void test_with_ExternalOriginationTime() {
         Instant now = Instant.now();

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
@@ -196,7 +196,7 @@ public class KafkaSourceJsonTypeIT {
     }
 
     @Test
-    public void TestJsonRecordsWithNullKeyKK() throws Exception {
+    public void TestJsonRecordsWithNullKey() throws Exception {
         final int numRecords = 1;
         when(encryptionConfig.getType()).thenReturn(EncryptionType.NONE);
         when(jsonTopic.getConsumerMaxPollRecords()).thenReturn(numRecords);
@@ -224,10 +224,12 @@ public class KafkaSourceJsonTypeIT {
             assertThat(map.get("kafka_key"), equalTo(null));
             assertThat(metadata.getAttributes().get("kafka_topic"), equalTo(testTopic));
             assertThat(metadata.getAttributes().get("kafka_partition"), equalTo("0"));
-            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) map.get("kafka_headers");
+            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
-            assertThat(map.get("kakfaCreateTime_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttributes().get("kafkaCreateTime_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttribute("kafka_headers/"+headerKey1), equalTo(headerValue1));
+            assertThat(metadata.getAttribute("kafka_headers/"+headerKey2), equalTo(headerValue2));
         }
     }
 
@@ -259,9 +261,12 @@ public class KafkaSourceJsonTypeIT {
             assertThat(map.get("status"), equalTo(true));
             assertThat(metadata.getAttributes().get("kafka_topic"), equalTo(testTopic));
             assertThat(metadata.getAttributes().get("kafka_partition"), equalTo("0"));
-            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) map.get("kafka_headers");
+            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
+            assertThat(metadata.getAttributes().get("kafkaCreateTime_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttribute("kafka_headers/"+headerKey1), equalTo(headerValue1));
+            assertThat(metadata.getAttribute("kafka_headers/"+headerKey2), equalTo(headerValue2));
             event.getEventHandle().release(false);
         }
         receivedRecords.clear();
@@ -280,9 +285,12 @@ public class KafkaSourceJsonTypeIT {
             assertThat(map.get("status"), equalTo(true));
             assertThat(metadata.getAttributes().get("kafka_topic"), equalTo(testTopic));
             assertThat(metadata.getAttributes().get("kafka_partition"), equalTo("0"));
-            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) map.get("kafka_headers");
+            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
+            assertThat(metadata.getAttributes().get("kafkaCreateTime_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttribute("kafka_headers/"+headerKey1), equalTo(headerValue1));
+            assertThat(metadata.getAttribute("kafka_headers/"+headerKey2), equalTo(headerValue2));
             event.getEventHandle().release(true);
         }
     }
@@ -314,9 +322,12 @@ public class KafkaSourceJsonTypeIT {
             assertThat(map.get("status"), equalTo(true));
             assertThat(metadata.getAttributes().get("kafka_topic"), equalTo(testTopic));
             assertThat(metadata.getAttributes().get("kafka_partition"), equalTo("0"));
-            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) map.get("kafka_headers");
+            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
+            assertThat(metadata.getAttributes().get("kafkaCreateTime_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttribute("kafka_headers/"+headerKey1), equalTo(headerValue1));
+            assertThat(metadata.getAttribute("kafka_headers/"+headerKey2), equalTo(headerValue2));
         }
     }
 
@@ -348,9 +359,12 @@ public class KafkaSourceJsonTypeIT {
             assertThat(map.get("kafka_key"), equalTo(testKey));
             assertThat(metadata.getAttributes().get("kafka_topic"), equalTo(testTopic));
             assertThat(metadata.getAttributes().get("kafka_partition"), equalTo("0"));
-            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) map.get("kafka_headers");
+            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
+            assertThat(metadata.getAttributes().get("kafkaCreateTime_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttribute("kafka_headers/"+headerKey1), equalTo(headerValue1));
+            assertThat(metadata.getAttribute("kafka_headers/"+headerKey2), equalTo(headerValue2));
         }
     }
 
@@ -382,9 +396,12 @@ public class KafkaSourceJsonTypeIT {
             assertThat(metadata.getAttributes().get("kafka_key"), equalTo(testKey));
             assertThat(metadata.getAttributes().get("kafka_topic"), equalTo(testTopic));
             assertThat(metadata.getAttributes().get("kafka_partition"), equalTo("0"));
-            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) map.get("kafka_headers");
+            Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
+            assertThat(metadata.getAttributes().get("kafkaCreateTime_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttribute("kafka_headers/"+headerKey1), equalTo(headerValue1));
+            assertThat(metadata.getAttribute("kafka_headers/"+headerKey2), equalTo(headerValue2));
         }
     }
 

--- a/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
+++ b/data-prepper-plugins/kafka-plugins/src/integrationTest/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceJsonTypeIT.java
@@ -227,7 +227,8 @@ public class KafkaSourceJsonTypeIT {
             Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
-            assertThat(metadata.getAttributes().get("kafkaCreateTime_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttributes().get("kafka_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttributes().get("kafka_timestamp_type"), equalTo("CreateTime"));
             assertThat(metadata.getAttribute("kafka_headers/"+headerKey1), equalTo(headerValue1));
             assertThat(metadata.getAttribute("kafka_headers/"+headerKey2), equalTo(headerValue2));
         }
@@ -264,7 +265,8 @@ public class KafkaSourceJsonTypeIT {
             Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
-            assertThat(metadata.getAttributes().get("kafkaCreateTime_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttributes().get("kafka_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttributes().get("kafka_timestamp_type"), equalTo("CreateTime"));
             assertThat(metadata.getAttribute("kafka_headers/"+headerKey1), equalTo(headerValue1));
             assertThat(metadata.getAttribute("kafka_headers/"+headerKey2), equalTo(headerValue2));
             event.getEventHandle().release(false);
@@ -288,7 +290,8 @@ public class KafkaSourceJsonTypeIT {
             Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
-            assertThat(metadata.getAttributes().get("kafkaCreateTime_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttributes().get("kafka_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttributes().get("kafka_timestamp_type"), equalTo("CreateTime"));
             assertThat(metadata.getAttribute("kafka_headers/"+headerKey1), equalTo(headerValue1));
             assertThat(metadata.getAttribute("kafka_headers/"+headerKey2), equalTo(headerValue2));
             event.getEventHandle().release(true);
@@ -325,7 +328,8 @@ public class KafkaSourceJsonTypeIT {
             Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
-            assertThat(metadata.getAttributes().get("kafkaCreateTime_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttributes().get("kafka_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttributes().get("kafka_timestamp_type"), equalTo("CreateTime"));
             assertThat(metadata.getAttribute("kafka_headers/"+headerKey1), equalTo(headerValue1));
             assertThat(metadata.getAttribute("kafka_headers/"+headerKey2), equalTo(headerValue2));
         }
@@ -362,7 +366,8 @@ public class KafkaSourceJsonTypeIT {
             Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
-            assertThat(metadata.getAttributes().get("kafkaCreateTime_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttributes().get("kafka_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttributes().get("kafka_timestamp_type"), equalTo("CreateTime"));
             assertThat(metadata.getAttribute("kafka_headers/"+headerKey1), equalTo(headerValue1));
             assertThat(metadata.getAttribute("kafka_headers/"+headerKey2), equalTo(headerValue2));
         }
@@ -399,7 +404,8 @@ public class KafkaSourceJsonTypeIT {
             Map<String, byte[]> kafkaHeaders = (Map<String, byte[]>) metadata.getAttributes().get("kafka_headers");
             assertThat(kafkaHeaders.get(headerKey1), equalTo(headerValue1));
             assertThat(kafkaHeaders.get(headerKey2), equalTo(headerValue2));
-            assertThat(metadata.getAttributes().get("kafkaCreateTime_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttributes().get("kafka_timestamp"), not(equalTo(null)));
+            assertThat(metadata.getAttributes().get("kafka_timestamp_type"), equalTo("CreateTime"));
             assertThat(metadata.getAttribute("kafka_headers/"+headerKey1), equalTo(headerValue1));
             assertThat(metadata.getAttribute("kafka_headers/"+headerKey2), equalTo(headerValue2));
         }

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -19,7 +19,6 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.RecordDeserializationException;

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -17,6 +17,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.RecordDeserializationException;
@@ -421,6 +424,16 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
             }
             data.put(key, value);
         }
+        Headers headers = consumerRecord.headers();
+        if (headers != null) {
+            Map<String, byte[]> headerData = new HashMap<>();
+            for (Header header: headers) {
+                headerData.put(header.key(), header.value());
+            }
+            data.put("kafka_headers", headerData);
+        }
+        String kafkaTimestampKey = consumerRecord.timestampType() != TimestampType.NO_TIMESTAMP_TYPE ? consumerRecord.timestampType().toString() : "";
+        data.put("kakfa"+kafkaTimestampKey+"_timestamp", consumerRecord.timestamp());
         event = JacksonLog.builder().withData(data).build();
         EventMetadata eventMetadata = event.getMetadata();
         if (kafkaKeyMode == KafkaKeyMode.INCLUDE_AS_METADATA) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -437,8 +437,8 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
             }
             eventMetadata.setAttribute("kafka_headers", headerData);
         }
-        String kafkaTimestampKey = consumerRecord.timestampType() != TimestampType.NO_TIMESTAMP_TYPE ? consumerRecord.timestampType().toString() : "";
-        eventMetadata.setAttribute("kafka"+kafkaTimestampKey+"_timestamp", consumerRecord.timestamp());
+        eventMetadata.setAttribute("kafka_timestamp", consumerRecord.timestamp());
+        eventMetadata.setAttribute("kafka_timestamp_type", consumerRecord.timestampType().toString());
         eventMetadata.setAttribute("kafka_topic", topicName);
         eventMetadata.setAttribute("kafka_partition", String.valueOf(partition));
         eventMetadata.setExternalOriginationTime(Instant.ofEpochMilli(consumerRecord.timestamp()));

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -424,21 +424,21 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
             }
             data.put(key, value);
         }
+        event = JacksonLog.builder().withData(data).build();
+        EventMetadata eventMetadata = event.getMetadata();
+        if (kafkaKeyMode == KafkaKeyMode.INCLUDE_AS_METADATA) {
+            eventMetadata.setAttribute("kafka_key", key);
+        }
         Headers headers = consumerRecord.headers();
         if (headers != null) {
             Map<String, byte[]> headerData = new HashMap<>();
             for (Header header: headers) {
                 headerData.put(header.key(), header.value());
             }
-            data.put("kafka_headers", headerData);
+            eventMetadata.setAttribute("kafka_headers", headerData);
         }
         String kafkaTimestampKey = consumerRecord.timestampType() != TimestampType.NO_TIMESTAMP_TYPE ? consumerRecord.timestampType().toString() : "";
-        data.put("kafka"+kafkaTimestampKey+"_timestamp", consumerRecord.timestamp());
-        event = JacksonLog.builder().withData(data).build();
-        EventMetadata eventMetadata = event.getMetadata();
-        if (kafkaKeyMode == KafkaKeyMode.INCLUDE_AS_METADATA) {
-            eventMetadata.setAttribute("kafka_key", key);
-        }
+        eventMetadata.setAttribute("kafka"+kafkaTimestampKey+"_timestamp", consumerRecord.timestamp());
         eventMetadata.setAttribute("kafka_topic", topicName);
         eventMetadata.setAttribute("kafka_partition", String.valueOf(partition));
         eventMetadata.setExternalOriginationTime(Instant.ofEpochMilli(consumerRecord.timestamp()));

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumer.java
@@ -433,7 +433,7 @@ public class KafkaCustomConsumer implements Runnable, ConsumerRebalanceListener 
             data.put("kafka_headers", headerData);
         }
         String kafkaTimestampKey = consumerRecord.timestampType() != TimestampType.NO_TIMESTAMP_TYPE ? consumerRecord.timestampType().toString() : "";
-        data.put("kakfa"+kafkaTimestampKey+"_timestamp", consumerRecord.timestamp());
+        data.put("kafka"+kafkaTimestampKey+"_timestamp", consumerRecord.timestamp());
         event = JacksonLog.builder().withData(data).build();
         EventMetadata eventMetadata = event.getMetadata();
         if (kafkaKeyMode == KafkaKeyMode.INCLUDE_AS_METADATA) {


### PR DESCRIPTION
### Description
Add support for Kafka headers and timestamp in the Kafka Source.
If the consumer Record has any headers, they are included in the event. Similarly, timestamp is included in the event.
 
### Issues Resolved
Resolves #4565 
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
