### PR TITLE
Add support to track the source of request for Kafka server

### DIFF
--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/buffer/BufferTopicConfig.java
@@ -65,6 +65,11 @@ class BufferTopicConfig extends CommonTopicConfig implements TopicProducerConfig
     @Size(min = 1, max = 255, message = "size of group id should be between 1 and 255")
     private String groupId;
 
+    @JsonProperty("client_id")
+    @Valid
+    @Size(min = 1, max = 255, message = "size of client id should be between 1 and 255")
+    private String clientId;
+
     @JsonProperty("workers")
     @Valid
     @Size(min = 1, max = 200, message = "Number of worker threads should lies between 1 and 200")
@@ -133,6 +138,11 @@ class BufferTopicConfig extends CommonTopicConfig implements TopicProducerConfig
     @Override
     public String getGroupId() {
         return groupId;
+    }
+
+    @Override
+    public String getClientId() {
+        return clientId;
     }
 
     @Override

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConsumerConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/configuration/TopicConsumerConfig.java
@@ -16,6 +16,8 @@ public interface TopicConsumerConfig extends TopicConfig {
 
     String getGroupId();
 
+    String getClientId();
+
     Boolean getAutoCommit();
 
     String getAutoOffsetReset();

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/consumer/KafkaCustomConsumerFactory.java
@@ -134,14 +134,19 @@ public class KafkaCustomConsumerFactory {
                     break;
             }
         }
-        setConsumerTopicProperties(properties, topicConfig);
+        setConsumerTopicProperties(properties, topicConfig, topicConfig.getGroupId());
         setSchemaRegistryProperties(sourceConfig, properties, topicConfig);
         LOG.debug("Starting consumer with the properties : {}", properties);
         return properties;
     }
 
-    private void setConsumerTopicProperties(final Properties properties, final TopicConsumerConfig topicConfig) {
-        properties.put(ConsumerConfig.GROUP_ID_CONFIG, topicConfig.getGroupId());
+
+    public static void setConsumerTopicProperties(final Properties properties, final TopicConsumerConfig topicConfig,
+                                                  final String groupId) {
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        if (Objects.nonNull(topicConfig.getClientId())) {
+            properties.put(ConsumerConfig.CLIENT_ID_CONFIG, topicConfig.getClientId());
+        }
         properties.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, (int)topicConfig.getMaxPartitionFetchBytes());
         properties.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, ((Long)topicConfig.getRetryBackoff().toMillis()).intValue());
         properties.put(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG, ((Long)topicConfig.getReconnectBackoff().toMillis()).intValue());

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSource.java
@@ -37,6 +37,7 @@ import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaConfig;
 import org.opensearch.dataprepper.plugins.kafka.configuration.SchemaRegistryType;
 import org.opensearch.dataprepper.plugins.kafka.configuration.TopicConfig;
 import org.opensearch.dataprepper.plugins.kafka.consumer.KafkaCustomConsumer;
+import org.opensearch.dataprepper.plugins.kafka.consumer.KafkaCustomConsumerFactory;
 import org.opensearch.dataprepper.plugins.kafka.consumer.PauseConsumePredicate;
 import org.opensearch.dataprepper.plugins.kafka.extension.KafkaClusterConfigSupplier;
 import org.opensearch.dataprepper.plugins.kafka.util.ClientDNSLookupType;
@@ -318,25 +319,7 @@ public class KafkaSource implements Source<Record<Event>> {
     }
 
     private void setConsumerTopicProperties(Properties properties, TopicConsumerConfig topicConfig) {
-        properties.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroupID);
-        properties.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, (int) topicConfig.getMaxPartitionFetchBytes());
-        properties.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, ((Long) topicConfig.getRetryBackoff().toMillis()).intValue());
-        properties.put(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG, ((Long) topicConfig.getReconnectBackoff().toMillis()).intValue());
-        properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
-                topicConfig.getAutoCommit());
-        properties.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG,
-                ((Long) topicConfig.getCommitInterval().toMillis()).intValue());
-        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
-                topicConfig.getAutoOffsetReset());
-        properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG,
-                topicConfig.getConsumerMaxPollRecords());
-        properties.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG,
-                ((Long) topicConfig.getMaxPollInterval().toMillis()).intValue());
-        properties.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, ((Long) topicConfig.getSessionTimeOut().toMillis()).intValue());
-        properties.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, ((Long) topicConfig.getHeartBeatInterval().toMillis()).intValue());
-        properties.put(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, (int) topicConfig.getFetchMaxBytes());
-        properties.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, topicConfig.getFetchMaxWait());
-        properties.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, (int) topicConfig.getFetchMinBytes());
+        KafkaCustomConsumerFactory.setConsumerTopicProperties(properties, topicConfig, consumerGroupID);
     }
 
     private void setPropertiesForSchemaRegistryConnectivity(Properties properties) {

--- a/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/SourceTopicConfig.java
+++ b/data-prepper-plugins/kafka-plugins/src/main/java/org/opensearch/dataprepper/plugins/kafka/source/SourceTopicConfig.java
@@ -49,6 +49,11 @@ class SourceTopicConfig extends CommonTopicConfig implements TopicConsumerConfig
     @Size(min = 1, max = 255, message = "size of group id should be between 1 and 255")
     private String groupId;
 
+    @JsonProperty("client_id")
+    @Valid
+    @Size(min = 1, max = 255, message = "size of client id should be between 1 and 255")
+    private String clientId;
+
     @JsonProperty("workers")
     @Valid
     @Size(min = 1, max = 200, message = "Number of worker threads should lies between 1 and 200")
@@ -119,6 +124,11 @@ class SourceTopicConfig extends CommonTopicConfig implements TopicConsumerConfig
     @Override
     public String getGroupId() {
         return groupId;
+    }
+
+    @Override
+    public String getClientId() {
+        return clientId;
     }
 
     @Override

--- a/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceTest.java
+++ b/data-prepper-plugins/kafka-plugins/src/test/java/org/opensearch/dataprepper/plugins/kafka/source/KafkaSourceTest.java
@@ -82,6 +82,7 @@ class KafkaSourceTest {
     private PluginConfigObservable pluginConfigObservable;
 
     private static final String TEST_GROUP_ID = "testGroupId";
+    private static final String TEST_CLIENT_ID = "testClientId";
 
     public KafkaSource createObjectUnderTest() {
         return new KafkaSource(
@@ -107,6 +108,8 @@ class KafkaSourceTest {
         when(topic2.getConsumerMaxPollRecords()).thenReturn(1);
         when(topic1.getGroupId()).thenReturn(TEST_GROUP_ID);
         when(topic2.getGroupId()).thenReturn(TEST_GROUP_ID);
+        when(topic1.getClientId()).thenReturn(TEST_CLIENT_ID);
+        when(topic2.getClientId()).thenReturn(TEST_CLIENT_ID);
         when(topic1.getMaxPollInterval()).thenReturn(Duration.ofSeconds(5));
         when(topic2.getMaxPollInterval()).thenReturn(Duration.ofSeconds(5));
         when(topic1.getHeartBeatInterval()).thenReturn(Duration.ofSeconds(5));
@@ -150,6 +153,18 @@ class KafkaSourceTest {
     void test_kafkaSource_basicFunctionality() {
         when(topic1.getSessionTimeOut()).thenReturn(Duration.ofSeconds(15));
         when(topic2.getSessionTimeOut()).thenReturn(Duration.ofSeconds(15));
+        kafkaSource = createObjectUnderTest();
+        assertTrue(Objects.nonNull(kafkaSource));
+        kafkaSource.start(buffer);
+        assertTrue(Objects.nonNull(kafkaSource.getConsumer()));
+    }
+
+    @Test
+    void test_kafkaSource_basicFunctionalityWithClientIdNull() {
+        when(topic1.getSessionTimeOut()).thenReturn(Duration.ofSeconds(15));
+        when(topic2.getSessionTimeOut()).thenReturn(Duration.ofSeconds(15));
+        when(topic1.getClientId()).thenReturn(null);
+        when(topic1.getClientId()).thenReturn(null);
         kafkaSource = createObjectUnderTest();
         assertTrue(Objects.nonNull(kafkaSource));
         kafkaSource.start(buffer);


### PR DESCRIPTION
### Description
Add support to track the source of request for Kafka server. The will enable to track the source of requests from a logical application name to be included in server-side kafka request logging.
 
### Issues Resolved
Resolves #[4571]
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
