### PR TITLE
Aggrerate processor : add option to allow raw events

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.processor.aggregate;
 
 import org.opensearch.dataprepper.model.configuration.PluginModel;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
@@ -32,8 +33,11 @@ public class AggregateProcessorConfig {
     @NotNull
     private Boolean localMode = false;
 
-    @JsonProperty("allow_raw_events")
-    private Boolean allowRawEvents;
+    @JsonProperty("output_unaggregated_events")
+    private Boolean outputUnaggregatedEvents = false;
+
+    @JsonProperty("aggregated_events_tag")
+    private String aggregatedEventsTag;
 
     @JsonProperty("aggregate_when")
     private String whenCondition;
@@ -50,12 +54,21 @@ public class AggregateProcessorConfig {
         return whenCondition;
     }
 
-    public Boolean getAllowRawEvents() {
-        return allowRawEvents;
+    public String getAggregatedEventsTag() {
+        return aggregatedEventsTag;
+    }
+
+    public Boolean getOutputUnaggregatedEvents() {
+        return outputUnaggregatedEvents;
     }
 
     public Boolean getLocalMode() {
         return localMode;
+    }
+
+    @AssertTrue(message="Aggragated Events Tag must be set when output_unaggregated_events is set")
+    boolean isValidConfig() {
+        return (!outputUnaggregatedEvents || (outputUnaggregatedEvents && aggregatedEventsTag != null));
     }
 
     public PluginModel getAggregateAction() { return aggregateAction; }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorConfig.java
@@ -32,6 +32,9 @@ public class AggregateProcessorConfig {
     @NotNull
     private Boolean localMode = false;
 
+    @JsonProperty("allow_raw_events")
+    private Boolean allowRawEvents;
+
     @JsonProperty("aggregate_when")
     private String whenCondition;
 
@@ -45,6 +48,10 @@ public class AggregateProcessorConfig {
 
     public String getWhenCondition() {
         return whenCondition;
+    }
+
+    public Boolean getAllowRawEvents() {
+        return allowRawEvents;
     }
 
     public Boolean getLocalMode() {

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
@@ -127,7 +127,7 @@ public class AggregateProcessorIT {
 
         pluginMetrics = PluginMetrics.fromNames(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
-        when(aggregateProcessorConfig.getAllowRawEvents()).thenReturn(false);
+        when(aggregateProcessorConfig.getOutputUnaggregatedEvents()).thenReturn(false);
         when(aggregateProcessorConfig.getIdentificationKeys()).thenReturn(identificationKeys);
         when(aggregateProcessorConfig.getAggregateAction()).thenReturn(actionConfiguration);
         when(actionConfiguration.getPluginName()).thenReturn(UUID.randomUUID().toString());
@@ -447,8 +447,10 @@ public class AggregateProcessorIT {
     }
 
     @RepeatedTest(value = 2)
-    void aggregateWithCountAggregateActionWithRawEvents() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
-        when(aggregateProcessorConfig.getAllowRawEvents()).thenReturn(true);
+    void aggregateWithCountAggregateActionWithUnaggregatedEvents() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
+        when(aggregateProcessorConfig.getOutputUnaggregatedEvents()).thenReturn(true);
+        String tag = UUID.randomUUID().toString();
+        when(aggregateProcessorConfig.getAggregatedEventsTag()).thenReturn(tag);
         CountAggregateActionConfig countAggregateActionConfig = new CountAggregateActionConfig();
         setField(CountAggregateActionConfig.class, countAggregateActionConfig, "outputFormat", OutputFormat.RAW.toString());
         aggregateAction = new CountAggregateAction(countAggregateActionConfig);
@@ -482,6 +484,7 @@ public class AggregateProcessorIT {
         expectedEventMap.put(DEFAULT_COUNT_KEY, NUM_THREADS * NUM_EVENTS_PER_BATCH);
 
         final Record<Event> record = (Record<Event>)results.toArray()[0];
+        assertTrue(record.getData().getMetadata().hasTags(List.of(tag)));
         expectedEventMap.forEach((k, v) -> assertThat(record.getData().toMap(), hasEntry(k,v)));
         assertThat(record.getData().toMap(), hasKey(DEFAULT_START_TIME_KEY));
     }

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -417,6 +418,8 @@ public class AggregateProcessorTest {
             assertThat(recordsOut.get(0).getData(), equalTo(event));
             assertThat(recordsOut.get(1), notNullValue());
             assertThat(recordsOut.get(1).getData(), equalTo(event));
+            Event receivedEvent = recordsOut.get(1).getData();
+            assertTrue(receivedEvent.getMetadata().hasTags(List.of(AggregateProcessor.AGGREGATED_TAG)));
 
             verify(actionHandleEventsOutCounter).increment(1);
             verify(actionHandleEventsDroppedCounter).increment(0);

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -124,6 +124,7 @@ public class AggregateProcessorTest {
     @BeforeEach
     void setUp() {
         when(aggregateProcessorConfig.getAggregateAction()).thenReturn(actionConfiguration);
+        when(aggregateProcessorConfig.getAllowRawEvents()).thenReturn(false);
         when(aggregateProcessorConfig.getLocalMode()).thenReturn(false);
         when(actionConfiguration.getPluginName()).thenReturn(UUID.randomUUID().toString());
         when(actionConfiguration.getPluginSettings()).thenReturn(Collections.emptyMap());
@@ -396,6 +397,29 @@ public class AggregateProcessorTest {
             verify(actionHandleEventsOutCounter).increment(1);
             verify(actionHandleEventsDroppedCounter).increment(0);
             verifyNoInteractions(actionConcludeGroupEventsDroppedCounter);
+            verifyNoInteractions(actionConcludeGroupEventsOutCounter);
+
+            verify(aggregateGroupManager).getGroupsToConclude(eq(false));
+        }
+        @Test
+        void handleEvent_returning_with_event_adds_event_to_records_out_with_allow_raw_events() {
+            when(aggregateProcessorConfig.getAllowRawEvents()).thenReturn(true);
+            final AggregateProcessor objectUnderTest = createObjectUnderTest();
+            final Map.Entry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup> groupEntry = new AbstractMap.SimpleEntry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>(identificationKeysMap, aggregateGroup);
+            when(aggregateGroupManager.getGroupsToConclude(eq(false))).thenReturn(Collections.singletonList(groupEntry));
+            when(aggregateActionResponse.getEvent()).thenReturn(event);
+            when(aggregateActionSynchronizer.concludeGroup(identificationKeysMap, aggregateGroup, false)).thenReturn(new AggregateActionOutput(List.of()));
+
+            final List<Record<Event>> recordsOut = (List<Record<Event>>) objectUnderTest.doExecute(Collections.singletonList(new Record<>(event)));
+
+            assertThat(recordsOut.size(), equalTo(2));
+            assertThat(recordsOut.get(0), notNullValue());
+            assertThat(recordsOut.get(0).getData(), equalTo(event));
+            assertThat(recordsOut.get(1), notNullValue());
+            assertThat(recordsOut.get(1).getData(), equalTo(event));
+
+            verify(actionHandleEventsOutCounter).increment(1);
+            verify(actionHandleEventsDroppedCounter).increment(0);
             verifyNoInteractions(actionConcludeGroupEventsOutCounter);
 
             verify(aggregateGroupManager).getGroupsToConclude(eq(false));

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorTest.java
@@ -125,7 +125,7 @@ public class AggregateProcessorTest {
     @BeforeEach
     void setUp() {
         when(aggregateProcessorConfig.getAggregateAction()).thenReturn(actionConfiguration);
-        when(aggregateProcessorConfig.getAllowRawEvents()).thenReturn(false);
+        when(aggregateProcessorConfig.getOutputUnaggregatedEvents()).thenReturn(false);
         when(aggregateProcessorConfig.getLocalMode()).thenReturn(false);
         when(actionConfiguration.getPluginName()).thenReturn(UUID.randomUUID().toString());
         when(actionConfiguration.getPluginSettings()).thenReturn(Collections.emptyMap());
@@ -403,8 +403,10 @@ public class AggregateProcessorTest {
             verify(aggregateGroupManager).getGroupsToConclude(eq(false));
         }
         @Test
-        void handleEvent_returning_with_event_adds_event_to_records_out_with_allow_raw_events() {
-            when(aggregateProcessorConfig.getAllowRawEvents()).thenReturn(true);
+        void handleEvent_returning_with_event_adds_event_to_records_out_with_output_unaggregated_events() {
+            when(aggregateProcessorConfig.getOutputUnaggregatedEvents()).thenReturn(true);
+            String tag = UUID.randomUUID().toString();
+            when(aggregateProcessorConfig.getAggregatedEventsTag()).thenReturn(tag);
             final AggregateProcessor objectUnderTest = createObjectUnderTest();
             final Map.Entry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup> groupEntry = new AbstractMap.SimpleEntry<IdentificationKeysHasher.IdentificationKeysMap, AggregateGroup>(identificationKeysMap, aggregateGroup);
             when(aggregateGroupManager.getGroupsToConclude(eq(false))).thenReturn(Collections.singletonList(groupEntry));
@@ -419,7 +421,7 @@ public class AggregateProcessorTest {
             assertThat(recordsOut.get(1), notNullValue());
             assertThat(recordsOut.get(1).getData(), equalTo(event));
             Event receivedEvent = recordsOut.get(1).getData();
-            assertTrue(receivedEvent.getMetadata().hasTags(List.of(AggregateProcessor.AGGREGATED_TAG)));
+            assertTrue(receivedEvent.getMetadata().hasTags(List.of(tag)));
 
             verify(actionHandleEventsOutCounter).increment(1);
             verify(actionHandleEventsDroppedCounter).increment(0);


### PR DESCRIPTION
### Description
Aggrerate processor : add option to allow raw events.
Aggregate processor only sends aggregated events by default. This option allows sending the raw events in addition to the aggregated events.  The aggregated events are tagged to be identify the events separately from the raw events.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
