### PR TITLE
Modify Key Value processor to support string literal grouping

### DIFF
--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -42,7 +42,6 @@ import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
 @DataPrepperPlugin(name = "key_value", pluginType = Processor.class, pluginConfigurationType = KeyValueProcessorConfig.class)
 public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
     private static final Logger LOG = LoggerFactory.getLogger(KeyValueProcessor.class);
-    private static final String DOUBLE_QUOTE = "\"";
     private static String startGroupStrings[] = {"\"","'", "(", "[", "<", "{", "http://", "https://"};
     private static Character endGroupChars[] ={'"', '\'', ')', ']', '>', '}', ' ', ' '};
 

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -114,6 +114,15 @@ public class KeyValueProcessorConfig {
     @JsonProperty("key_value_when")
     private String keyValueWhen;
 
+    @JsonProperty("strict_grouping")
+    private boolean strictGrouping = false;
+
+    @JsonProperty("ignore_text_in_double_quotes")
+    private boolean ignoreTextInDoubleQuotes = false;
+
+    @JsonProperty("allow_keys")
+    private List<String> allowKeys = null;
+
     @AssertTrue(message = "Invalid Configuration. value_grouping option and field_delimiter_regex are mutually exclusive")
     boolean isValidValueGroupingAndFieldDelimiterRegex() {
         return (!valueGrouping || fieldDelimiterRegex == null);
@@ -121,6 +130,18 @@ public class KeyValueProcessorConfig {
 
     public String getSource() {
         return source;
+    }
+
+    public List<String> getAllowKeys() {
+        return allowKeys;
+    }
+
+    public boolean getIgnoreTextInDoubleQuotes() {
+        return ignoreTextInDoubleQuotes;
+    }
+
+    public boolean isStrictGroupingEnabled() {
+        return strictGrouping;
     }
 
     public String getDestination() {

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -108,6 +108,9 @@ public class KeyValueProcessorConfig {
     @JsonProperty("drop_keys_with_no_value")
     private boolean dropKeysWithNoValue = false;
 
+    @JsonProperty("enable_double_quote_grouping")
+    private boolean enableDoubleQuoteGrouping = false;
+
     @JsonProperty("key_value_when")
     private String keyValueWhen;
 
@@ -126,6 +129,10 @@ public class KeyValueProcessorConfig {
 
     public boolean getValueGrouping() {
         return valueGrouping;
+    }
+
+    public boolean getEnableDoubleQuoteGrouping() {
+        return enableDoubleQuoteGrouping;
     }
 
     public String getFieldDelimiterRegex() {

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -108,9 +108,6 @@ public class KeyValueProcessorConfig {
     @JsonProperty("drop_keys_with_no_value")
     private boolean dropKeysWithNoValue = false;
 
-    @JsonProperty("enable_double_quote_grouping")
-    private boolean enableDoubleQuoteGrouping = false;
-
     @JsonProperty("key_value_when")
     private String keyValueWhen;
 

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -117,11 +117,8 @@ public class KeyValueProcessorConfig {
     @JsonProperty("strict_grouping")
     private boolean strictGrouping = false;
 
-    @JsonProperty("ignore_text_in_double_quotes")
-    private boolean ignoreTextInDoubleQuotes = false;
-
-    @JsonProperty("allow_keys")
-    private List<String> allowKeys = null;
+    @JsonProperty("string_literal_character")
+    private Character stringLiteralCharacter = null;
 
     @AssertTrue(message = "Invalid Configuration. value_grouping option and field_delimiter_regex are mutually exclusive")
     boolean isValidValueGroupingAndFieldDelimiterRegex() {
@@ -132,12 +129,8 @@ public class KeyValueProcessorConfig {
         return source;
     }
 
-    public List<String> getAllowKeys() {
-        return allowKeys;
-    }
-
-    public boolean getIgnoreTextInDoubleQuotes() {
-        return ignoreTextInDoubleQuotes;
+    public Character getStringLiteralCharacter() {
+        return stringLiteralCharacter;
     }
 
     public boolean isStrictGroupingEnabled() {
@@ -150,10 +143,6 @@ public class KeyValueProcessorConfig {
 
     public boolean getValueGrouping() {
         return valueGrouping;
-    }
-
-    public boolean getEnableDoubleQuoteGrouping() {
-        return enableDoubleQuoteGrouping;
     }
 
     public String getFieldDelimiterRegex() {

--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorConfig.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Size;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -115,11 +116,22 @@ public class KeyValueProcessorConfig {
     private boolean strictGrouping = false;
 
     @JsonProperty("string_literal_character")
-    private Character stringLiteralCharacter = null;
+    @Size(min = 0, max = 1, message = "string_literal_character may only have character")
+    private String stringLiteralCharacter = null;
 
     @AssertTrue(message = "Invalid Configuration. value_grouping option and field_delimiter_regex are mutually exclusive")
     boolean isValidValueGroupingAndFieldDelimiterRegex() {
         return (!valueGrouping || fieldDelimiterRegex == null);
+    }
+
+    @AssertTrue(message = "Invalid Configuration. String literal character config is valid only when value_grouping is enabled, and only double quote (\") and single quote are (') are valid string literal characters.")
+    boolean isValidStringLiteralConfig() {
+        if (stringLiteralCharacter == null)
+            return true;
+        if ((!stringLiteralCharacter.equals("\"") &&
+                (!stringLiteralCharacter.equals("'"))))
+            return false;
+        return valueGrouping;
     }
 
     public String getSource() {
@@ -127,7 +139,7 @@ public class KeyValueProcessorConfig {
     }
 
     public Character getStringLiteralCharacter() {
-        return stringLiteralCharacter;
+        return stringLiteralCharacter == null ? null : stringLiteralCharacter.charAt(0);
     }
 
     public boolean isStrictGroupingEnabled() {

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -170,20 +170,6 @@ public class KeyValueProcessorTests {
         assertThatKeyEquals(parsed_message, "key2", "value2");
     }
 
-/*
-    @Test
-    void testMultipleKvToObjectKeyValueProcessorWithAllowKeys() {
-        lenient().when(mockConfig.getIncludeKeys()).thenReturn(List.of("key1"));
-        final Record<Event> record = getMessage("key1=value1&key2=value2");
-        final KeyValueProcessor objectUnderTest = createObjectUnderTest();
-        final List<Record<Event>> editedRecords = (List<Record<Event>>) objectUnderTest.doExecute(Collections.singletonList(record));
-        final LinkedHashMap<String, Object> parsed_message = getLinkedHashMap(editedRecords);
-
-        assertThat(parsed_message.size(), equalTo(1));
-        assertThatKeyEquals(parsed_message, "key1", "value1");
-    }
-*/
-
     @Test
     void testDropKeysWithNoValue() {
         lenient().when(mockConfig.getDropKeysWithNoValue()).thenReturn(true);
@@ -257,7 +243,7 @@ public class KeyValueProcessorTests {
 
                 Arguments.of(", ", "foo \"key1=key2 bar\" key2=val2 baz", Map.of("key2", "val2")),
                 Arguments.of(", ", "foo  key1=https://bar.baz/?key2=val2&url=https://quz.fred/ bar", Map.of("key1","https://bar.baz/?key2=val2&url=https://quz.fred/")),
-                //Arguments.of(", ", "foo key1=\"bar \" qux\" fred", Map.of("key1", "\"bar \"")),
+                Arguments.of(", ", "foo key1=\"bar \" qux\" fred", Map.of("key1", "\"bar \"")),
                 Arguments.of(", ", "foo key1=\"bar \\\" qux\" fred", Map.of("key1", "\"bar \\\" qux\"")),
 
                 Arguments.of(", ", "key1=\"value1,value2\", key3=value3", Map.of("key1", "\"value1,value2\"", "key3", "value3"))

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -69,7 +69,6 @@ public class KeyValueProcessorTests {
     @BeforeEach
     void setup() {
         final KeyValueProcessorConfig defaultConfig = new KeyValueProcessorConfig();
-        lenient().when(mockConfig.getAllowKeys()).thenReturn(null);
         lenient().when(mockConfig.getSource()).thenReturn(defaultConfig.getSource());
         lenient().when(mockConfig.getDestination()).thenReturn(defaultConfig.getDestination());
         lenient().when(mockConfig.getFieldDelimiterRegex()).thenReturn(defaultConfig.getFieldDelimiterRegex());
@@ -170,9 +169,10 @@ public class KeyValueProcessorTests {
         assertThatKeyEquals(parsed_message, "key2", "value2");
     }
 
+/*
     @Test
     void testMultipleKvToObjectKeyValueProcessorWithAllowKeys() {
-        lenient().when(mockConfig.getAllowKeys()).thenReturn(List.of("key1"));
+        lenient().when(mockConfig.getIncludeKeys()).thenReturn(List.of("key1"));
         final Record<Event> record = getMessage("key1=value1&key2=value2");
         final KeyValueProcessor objectUnderTest = createObjectUnderTest();
         final List<Record<Event>> editedRecords = (List<Record<Event>>) objectUnderTest.doExecute(Collections.singletonList(record));
@@ -181,6 +181,7 @@ public class KeyValueProcessorTests {
         assertThat(parsed_message.size(), equalTo(1));
         assertThatKeyEquals(parsed_message, "key1", "value1");
     }
+*/
 
     @Test
     void testDropKeysWithNoValue() {
@@ -200,7 +201,7 @@ public class KeyValueProcessorTests {
     @MethodSource("getKeyValueGroupingTestdata")
     void testMultipleKvToObjectKeyValueProcessorWithValueGrouping(String fieldDelimiters, String input, Map<String, Object> expectedResultMap) {
         lenient().when(mockConfig.getValueGrouping()).thenReturn(true);
-        lenient().when(mockConfig.getEnableDoubleQuoteGrouping()).thenReturn(true);
+        lenient().when(mockConfig.getStringLiteralCharacter()).thenReturn('\"');
         lenient().when(mockConfig.getDropKeysWithNoValue()).thenReturn(true);
         lenient().when(mockConfig.getFieldSplitCharacters()).thenReturn(fieldDelimiters);
         final KeyValueProcessor objectUnderTest = createObjectUnderTest();
@@ -263,10 +264,12 @@ public class KeyValueProcessorTests {
     }
 
     @Test
-    void testDoubleQuoteGrouping() {
+    void testStringLiteralCharacter() {
         when(mockConfig.getDestination()).thenReturn(null);
-        lenient().when(mockConfig.getEnableDoubleQuoteGrouping()).thenReturn(true);
-        final Record<Event> record = getMessage("\"ignore this\"key1=value1&key2=value2 \"ignore=this&too\"");
+        lenient().when(mockConfig.getStringLiteralCharacter()).thenReturn('\"');
+        lenient().when(mockConfig.getFieldSplitCharacters()).thenReturn(" &");
+        lenient().when(mockConfig.getValueGrouping()).thenReturn(true);
+        final Record<Event> record = getMessage("\"ignore this\" key1=value1&key2=value2 \"ignore=this&too\"");
         keyValueProcessor = createObjectUnderTest();
         final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
 

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -250,13 +250,15 @@ public class KeyValueProcessorTests {
                );
     }
 
-    @Test
-    void testStringLiteralCharacter() {
+    @ParameterizedTest
+    @ValueSource(strings = {"\"", "'"})
+    void testStringLiteralCharacter(String literalString) {
         when(mockConfig.getDestination()).thenReturn(null);
-        lenient().when(mockConfig.getStringLiteralCharacter()).thenReturn('\"');
+        String message = literalString+"ignore this "+literalString+" key1=value1&key2=value2 "+literalString+"ignore=this&too"+literalString;
+        lenient().when(mockConfig.getStringLiteralCharacter()).thenReturn(literalString.charAt(0));
         lenient().when(mockConfig.getFieldSplitCharacters()).thenReturn(" &");
         lenient().when(mockConfig.getValueGrouping()).thenReturn(true);
-        final Record<Event> record = getMessage("\"ignore this\" key1=value1&key2=value2 \"ignore=this&too\"");
+        final Record<Event> record = getMessage(message);
         keyValueProcessor = createObjectUnderTest();
         final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
 

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -70,6 +70,7 @@ public class KeyValueProcessorTests {
     void setup() {
         final KeyValueProcessorConfig defaultConfig = new KeyValueProcessorConfig();
         lenient().when(mockConfig.getSource()).thenReturn(defaultConfig.getSource());
+        lenient().when(mockConfig.getStringLiteralCharacter()).thenReturn(null);
         lenient().when(mockConfig.getDestination()).thenReturn(defaultConfig.getDestination());
         lenient().when(mockConfig.getFieldDelimiterRegex()).thenReturn(defaultConfig.getFieldDelimiterRegex());
         lenient().when(mockConfig.getFieldSplitCharacters()).thenReturn(defaultConfig.getFieldSplitCharacters());


### PR DESCRIPTION
### Description
Adds the following new features
1. Supports string literal grouping when valueGrouping option is enabled. String literal grouping allows text inside double quotes OR single quotes to be treated as one entity. When combined with `drop_keys_with_no_value` such text can be dropped from the output
2. Support `strict_grouping` option where a group with the starting group character and missing  end group character does not throw error and instead considered as the group till the end of the text
3. Fix `value_grouping` to strictly apply grouping to values and not to keys and other parts of input.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
