### PR TITLE
Fix KeyValue Processor value grouping bug

### DIFF
--- a/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
+++ b/data-prepper-plugins/key-value-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessor.java
@@ -321,7 +321,7 @@ public class KeyValueProcessor extends AbstractProcessor<Record<Event>, Record<E
             if (groupIndex >= 0) {
                 String[] s = keyValueDelimiterPattern.split(str.substring(start,i+1));
                 // Only handle Grouping patterns in the values, not keys
-                if (s.length > 1 || startGroupStrings[groupIndex].charAt(0) == stringLiteralCharacter) {
+                if (s.length > 1 || (stringLiteralCharacter != null && startGroupStrings[groupIndex].charAt(0) == stringLiteralCharacter)) {
                     i = skipGroup(str, i+1, endGroupChars[groupIndex]);
                     skippedGroup = true;
                 }

--- a/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
+++ b/data-prepper-plugins/key-value-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/keyvalue/KeyValueProcessorTests.java
@@ -250,6 +250,24 @@ public class KeyValueProcessorTests {
                );
     }
 
+    @Test
+    void testValueGroupingWithOutStringLiterals() {
+        when(mockConfig.getDestination()).thenReturn(null);
+        String message = "text1 text2 [ key1=value1  value2";
+        lenient().when(mockConfig.getStringLiteralCharacter()).thenReturn(null);
+        lenient().when(mockConfig.getFieldSplitCharacters()).thenReturn(" ,");
+        lenient().when(mockConfig.getValueGrouping()).thenReturn(true);
+        final Record<Event> record = getMessage(message);
+        keyValueProcessor = createObjectUnderTest();
+        final List<Record<Event>> editedRecords = (List<Record<Event>>) keyValueProcessor.doExecute(Collections.singletonList(record));
+
+        final Event event = editedRecords.get(0).getData();
+        assertThat(event.containsKey("parsed_message"), is(false));
+
+        assertThat(event.containsKey("key1"), is(true));
+        assertThat(event.get("key1", Object.class), is("value1"));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"\"", "'"})
     void testStringLiteralCharacter(String literalString) {


### PR DESCRIPTION
### Description
Fix KeyValue Processor with value grouping enabled causes exception when string literal character is null. Fix is to check if the string literal character is null.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
