### PR TITLE
Updates Python requests to 2.32.3 in smoke tests project to address CVE-2024-35195

### DIFF
--- a/release/smoke-tests/otel-span-exporter/requirements.txt
+++ b/release/smoke-tests/otel-span-exporter/requirements.txt
@@ -13,7 +13,7 @@ opentelemetry-proto==1.7.1
 opentelemetry-sdk==1.7.1
 opentelemetry-semantic-conventions==0.26b1
 protobuf==3.19.5
-requests==2.31.0
+requests==2.32.3
 six==1.16.0
 urllib3==1.26.18
 wrapt==1.13.3


### PR DESCRIPTION
### Description

Resolves CVE-2024-35195 by updating Python reqests to 2.32.3.
 
### Issues Resolved

Resolves #4562
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
