### PR TITLE
Add support for start and end times in count and histogram aggregate actions

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
@@ -18,6 +18,8 @@ import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateAction;
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionInput;
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionOutput;
 import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateActionResponse;
+import org.opensearch.dataprepper.plugins.processor.aggregate.AggregateProcessor;
+import static org.opensearch.dataprepper.plugins.processor.aggregate.AggregateProcessor.getTimeNanos;
 import org.opensearch.dataprepper.plugins.processor.aggregate.GroupState;
 import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
 
@@ -44,6 +46,7 @@ public class CountAggregateAction implements AggregateAction {
     static final boolean SUM_METRIC_IS_MONOTONIC = true;
     public final String countKey;
     public final String startTimeKey;
+    public final String endTimeKey;
     public final String outputFormat;
     private long startTimeNanos;
 
@@ -51,13 +54,8 @@ public class CountAggregateAction implements AggregateAction {
     public CountAggregateAction(final CountAggregateActionConfig countAggregateActionConfig) {
         this.countKey = countAggregateActionConfig.getCountKey();
         this.startTimeKey = countAggregateActionConfig.getStartTimeKey();
+        this.endTimeKey = countAggregateActionConfig.getEndTimeKey();
         this.outputFormat = countAggregateActionConfig.getOutputFormat();
-    }
-
-    private long getTimeNanos(Instant time) {
-        final long NANO_MULTIPLIER = 1_000 * 1_000 * 1_000;
-        long currentTimeNanos = time.getEpochSecond() * NANO_MULTIPLIER + time.getNano();
-        return currentTimeNanos;
     }
 
     public Exemplar createExemplar(final Event event) {
@@ -81,15 +79,33 @@ public class CountAggregateAction implements AggregateAction {
     @Override
     public AggregateActionResponse handleEvent(final Event event, final AggregateActionInput aggregateActionInput) {
         final GroupState groupState = aggregateActionInput.getGroupState();
+        Instant eventStartTime = Instant.now();
+        Instant eventEndTime = eventStartTime;
+        Object startTime = event.get(startTimeKey, Object.class);
+        Object endTime = event.get(endTimeKey, Object.class);
+
+        if (startTime != null) {
+            eventStartTime = AggregateProcessor.convertObjectToInstant(startTime);
+        }
+        if (endTime != null) {
+            eventEndTime = AggregateProcessor.convertObjectToInstant(endTime);
+        }
         if (groupState.get(countKey) == null) {
-            groupState.put(startTimeKey, Instant.now());
             groupState.putAll(aggregateActionInput.getIdentificationKeys());
             groupState.put(countKey, 1);
             groupState.put(exemplarKey, createExemplar(event));
+            groupState.put(startTimeKey, eventStartTime);
+            groupState.put(endTimeKey, eventEndTime);
         } else {
             Integer v = (Integer)groupState.get(countKey) + 1;
             groupState.put(countKey, v);
-        } 
+            Instant groupStartTime = (Instant)groupState.get(startTimeKey);
+            Instant groupEndTime = (Instant)groupState.get(endTimeKey);
+            if (eventStartTime.isBefore(groupStartTime))
+                groupState.put(startTimeKey, eventStartTime);
+            if (eventEndTime.isAfter(groupEndTime))
+                groupState.put(endTimeKey, eventEndTime);
+        }
         return AggregateActionResponse.nullEventResponse();
     }
 
@@ -98,6 +114,8 @@ public class CountAggregateAction implements AggregateAction {
         GroupState groupState = aggregateActionInput.getGroupState();
         Event event;
         Instant startTime = (Instant)groupState.get(startTimeKey);
+        Instant endTime = (Instant)groupState.get(endTimeKey);
+        groupState.remove(endTimeKey);
         if (outputFormat.equals(OutputFormat.RAW.toString())) {
             groupState.put(startTimeKey, startTime.atZone(ZoneId.of(ZoneId.systemDefault().toString())).format(DateTimeFormatter.ofPattern(DATE_FORMAT)));
             event = JacksonEvent.builder()
@@ -110,14 +128,14 @@ public class CountAggregateAction implements AggregateAction {
             groupState.remove(exemplarKey);
             groupState.remove(countKey);
             groupState.remove(startTimeKey);
-            long currentTimeNanos = getTimeNanos(Instant.now());
+            long endTimeNanos = getTimeNanos(endTime);
             long startTimeNanos = getTimeNanos(startTime);
             Map<String, Object> attr = new HashMap<String, Object>();
             groupState.forEach((k, v) -> attr.put((String)k, v));
             JacksonSum sum = JacksonSum.builder()
                 .withName(SUM_METRIC_NAME)
                 .withDescription(SUM_METRIC_DESCRIPTION)
-                .withTime(OTelProtoCodec.convertUnixNanosToISO8601(currentTimeNanos))
+                .withTime(OTelProtoCodec.convertUnixNanosToISO8601(endTimeNanos))
                 .withStartTime(OTelProtoCodec.convertUnixNanosToISO8601(startTimeNanos))
                 .withIsMonotonic(SUM_METRIC_IS_MONOTONIC)
                 .withUnit(SUM_METRIC_UNIT)
@@ -128,7 +146,7 @@ public class CountAggregateAction implements AggregateAction {
                 .build(false);
             event = (Event)sum;
         }
-        
+
         return new AggregateActionOutput(List.of(event));
     }
 }

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionConfig.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class CountAggregateActionConfig {
     public static final String DEFAULT_COUNT_KEY = "aggr._count";
     public static final String DEFAULT_START_TIME_KEY = "aggr._start_time";
+    public static final String DEFAULT_END_TIME_KEY = "aggr._end_time";
     public static final Set<String> validOutputFormats = new HashSet<>(Set.of(OutputFormat.OTEL_METRICS.toString(), OutputFormat.RAW.toString()));
 
     @JsonProperty("count_key")
@@ -20,11 +21,18 @@ public class CountAggregateActionConfig {
     @JsonProperty("start_time_key")
     String startTimeKey = DEFAULT_START_TIME_KEY;
 
+    @JsonProperty("end_time_key")
+    String endTimeKey = DEFAULT_END_TIME_KEY;
+
     @JsonProperty("output_format")
     String outputFormat = OutputFormat.OTEL_METRICS.toString();
 
     public String getCountKey() {
         return countKey;
+    }
+
+    public String getEndTimeKey() {
+        return endTimeKey;
     }
 
     public String getStartTimeKey() {
@@ -37,4 +45,4 @@ public class CountAggregateActionConfig {
         }
         return outputFormat;
     }
-} 
+}

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorStaticFunctionsTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorStaticFunctionsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.aggregate;
+
+import org.junit.jupiter.api.Test;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.time.Duration;
+
+public class AggregateProcessorStaticFunctionsTest {
+    @Test
+    public void testConvertObjectToInstant() {
+        Instant now = Instant.now();
+        assertThat(AggregateProcessor.convertObjectToInstant(now), equalTo(now));
+        String nowStr = now.toString();
+        long nowSeconds = now.getEpochSecond();
+        long nowMillis = now.toEpochMilli();
+        int nowNanos = now.getNano();
+        double nowDouble = nowSeconds+(double)nowNanos/1000_000_000;
+        assertThat(AggregateProcessor.convertObjectToInstant(nowStr), equalTo(now));
+        assertThat(AggregateProcessor.convertObjectToInstant(nowSeconds), equalTo(Instant.ofEpochSecond(nowSeconds)));
+        assertThat(AggregateProcessor.convertObjectToInstant(nowMillis), equalTo(Instant.ofEpochMilli(nowMillis)));
+        Duration tolerance = Duration.ofNanos(1000);
+        assertTrue((Duration.between(AggregateProcessor.convertObjectToInstant(nowDouble), Instant.ofEpochSecond(nowSeconds, nowNanos))).abs().compareTo(tolerance) <= 0);
+    }
+
+    @Test
+    public void testGetTimeNanos() {
+        Instant now = Instant.now();
+        assertThat(AggregateProcessor.getTimeNanos(now) / 1000_000_000, equalTo(now.getEpochSecond()));
+        assertThat(AggregateProcessor.getTimeNanos(now) % 1000_000_000, equalTo((long)now.getNano()));
+    }
+}
+

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
@@ -25,8 +25,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
+import java.time.Instant;
 
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -119,6 +123,90 @@ public class CountAggregateActionTest {
         assertThat(result.get(0).toMap().get("attributes"), equalTo(eventMap));
         JacksonMetric metric = (JacksonMetric) result.get(0);
         assertThat(metric.toJsonString().indexOf("attributes"), not(-1));
+        assertThat(result.get(0).toMap(), hasKey("startTime"));
+        assertThat(result.get(0).toMap(), hasKey("time"));
+        List<Map<String, Object>> exemplars = (List <Map<String, Object>>)result.get(0).toMap().get("exemplars");
+        assertThat(exemplars.size(), equalTo(1));
+        Map<String, Object> exemplar = exemplars.get(0);
+        Map<String, Object> attributes = (Map<String, Object>)exemplar.get("attributes");
+        assertThat(attributes.get(key1), equalTo(value1));
+        assertTrue(attributes.containsKey(dataKey1));
+
+        actionOutput = countAggregateAction.concludeGroup(aggregateActionInput2);
+        final List<Event> result2 = actionOutput.getEvents();
+        assertThat(result2.size(), equalTo(1));
+
+        exemplars = (List <Map<String, Object>>)result2.get(0).toMap().get("exemplars");
+        assertThat(exemplars.size(), equalTo(1));
+        exemplar = exemplars.get(0);
+        attributes = (Map<String, Object>)exemplar.get("attributes");
+        assertThat(attributes.get(key2), equalTo(value2));
+        assertTrue(attributes.containsKey(dataKey2));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 100})
+    void testCountAggregateOTelFormatWithStartAndEndTimesInTheEvent(int testCount) {
+        CountAggregateActionConfig mockConfig = mock(CountAggregateActionConfig.class);
+        when(mockConfig.getCountKey()).thenReturn(CountAggregateActionConfig.DEFAULT_COUNT_KEY);
+        String startTimeKey = UUID.randomUUID().toString();
+        String endTimeKey = UUID.randomUUID().toString();
+        when(mockConfig.getStartTimeKey()).thenReturn(startTimeKey);
+        when(mockConfig.getEndTimeKey()).thenReturn(endTimeKey);
+        when(mockConfig.getOutputFormat()).thenReturn(OutputFormat.OTEL_METRICS.toString());
+        countAggregateAction = createObjectUnderTest(mockConfig);
+        final String key1 = "key-"+UUID.randomUUID().toString();
+        final String value1 = UUID.randomUUID().toString();
+        final String dataKey1 = "datakey-"+UUID.randomUUID().toString();
+        final String key2 = "key-"+UUID.randomUUID().toString();
+        final String value2 = UUID.randomUUID().toString();
+        final String dataKey2 = "datakey-"+UUID.randomUUID().toString();
+        final Instant testTime = Instant.ofEpochSecond(Instant.now().getEpochSecond());
+        Map<Object, Object> eventMap = Collections.singletonMap(key1, value1);
+        Event testEvent = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(eventMap)
+                .build();
+        Map<Object, Object> eventMap2 = Collections.singletonMap(key2, value2);
+        JacksonEvent testEvent2 = JacksonEvent.builder()
+                .withEventType("event")
+                .withData(eventMap2)
+                .build();
+        AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(eventMap);
+        AggregateActionInput aggregateActionInput2 = new AggregateActionTestUtils.TestAggregateActionInput(eventMap2);
+        Random random = new Random();
+        for (int i = 0; i < testCount; i++) {
+            testEvent.put(dataKey1, UUID.randomUUID().toString());
+            Instant sTime = (i == 0) ? testTime : testTime.plusSeconds(random.nextInt(5));
+            Instant eTime = (i == testCount-1) ? testTime.plusSeconds(100) : testTime.plusSeconds (50+random.nextInt(45));
+            testEvent.put(startTimeKey, sTime);
+            testEvent.put(endTimeKey,  eTime);
+            testEvent2.put(dataKey2, UUID.randomUUID().toString());
+            testEvent2.put(startTimeKey, sTime.toString());
+            testEvent2.put(endTimeKey,  eTime.toString());
+            AggregateActionResponse aggregateActionResponse = countAggregateAction.handleEvent(testEvent, aggregateActionInput);
+            assertThat(aggregateActionResponse.getEvent(), equalTo(null));
+            aggregateActionResponse = countAggregateAction.handleEvent(testEvent2, aggregateActionInput2);
+            assertThat(aggregateActionResponse.getEvent(), equalTo(null));
+        }
+
+        AggregateActionOutput actionOutput = countAggregateAction.concludeGroup(aggregateActionInput);
+        final List<Event> result = actionOutput.getEvents();
+        assertThat(result.size(), equalTo(1));
+        Map<String, Object> expectedEventMap = new HashMap<>();
+        expectedEventMap.put("value", (double)testCount);
+        expectedEventMap.put("name", "count");
+        expectedEventMap.put("description", "Number of events");
+        expectedEventMap.put("isMonotonic", true);
+        expectedEventMap.put("aggregationTemporality", "AGGREGATION_TEMPORALITY_DELTA");
+        expectedEventMap.put("unit", "1");
+        expectedEventMap.forEach((k, v) -> assertThat(result.get(0).toMap(), hasEntry(k,v)));
+        assertThat(result.get(0).toMap().get("attributes"), equalTo(eventMap));
+        JacksonMetric metric = (JacksonMetric) result.get(0);
+        assertThat(metric.toJsonString().indexOf("attributes"), not(-1));
+        assertThat(result.get(0).get("startTime", String.class), equalTo(testTime.toString()));
+        assertThat(result.get(0).get("time", String.class), equalTo(testTime.plusSeconds(100).toString()));
+
         assertThat(result.get(0).toMap(), hasKey("startTime"));
         assertThat(result.get(0).toMap(), hasKey("time"));
         List<Map<String, Object>> exemplars = (List <Map<String, Object>>)result.get(0).toMap().get("exemplars");

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
@@ -23,13 +23,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.apache.commons.lang3.RandomStringUtils;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
-import java.util.ArrayList;
+import java.util.Random;
+import java.util.UUID;
+import java.time.Instant;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -234,5 +239,133 @@ public class HistogramAggregateActionTests {
                 expectedBucketMax = Float.MAX_VALUE;
             }
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {10, 20, 50, 100})
+    void testHistogramAggregateOTelFormatWithStartAndEndTimesInTheEvent(int testCount) throws NoSuchFieldException, IllegalAccessException {
+        HistogramAggregateActionConfig mockConfig = mock(HistogramAggregateActionConfig.class);
+        String startTimeKey = UUID.randomUUID().toString();
+        String endTimeKey = UUID.randomUUID().toString();
+        final String testKeyPrefix = RandomStringUtils.randomAlphabetic(5)+"_";
+        when(mockConfig.getStartTimeKey()).thenReturn(startTimeKey);
+        when(mockConfig.getEndTimeKey()).thenReturn(endTimeKey);
+        when(mockConfig.getOutputFormat()).thenReturn(OutputFormat.OTEL_METRICS.toString());
+        String keyPrefix = UUID.randomUUID().toString();
+        final String testUnits = "ms";
+        when(mockConfig.getUnits()).thenReturn(testUnits);
+        when(mockConfig.getRecordMinMax()).thenReturn(true);
+        final double TEST_VALUE_RANGE_MIN = 0.0;
+        final double TEST_VALUE_RANGE_MAX = 6.0;
+        final double TEST_VALUE_RANGE_STEP = 2.0;
+        final double bucket1 = TEST_VALUE_RANGE_MIN;
+        final double bucket2 = bucket1 + TEST_VALUE_RANGE_STEP;
+        final double bucket3 = bucket2 + TEST_VALUE_RANGE_STEP;
+        List<Number> buckets = new ArrayList<Number>();
+        buckets.add(bucket1);
+        buckets.add(bucket2);
+        buckets.add(bucket3);
+        when(mockConfig.getBuckets()).thenReturn(buckets);
+        final String testKey = RandomStringUtils.randomAlphabetic(10);
+        when(mockConfig.getKey()).thenReturn(testKey);
+        final String testPrefix = RandomStringUtils.randomAlphabetic(7);
+        when(mockConfig.getSumKey()).thenReturn(testPrefix+"sum");
+        when(mockConfig.getMinKey()).thenReturn(testPrefix+"min");
+        when(mockConfig.getMaxKey()).thenReturn(testPrefix+"max");
+        when(mockConfig.getCountKey()).thenReturn(testPrefix+"count");
+        when(mockConfig.getBucketsKey()).thenReturn(testPrefix+"buckets");
+        when(mockConfig.getBucketCountsKey()).thenReturn(testPrefix+"bucketcounts");
+        when(mockConfig.getDurationKey()).thenReturn(testPrefix+"duration");
+        histogramAggregateAction = createObjectUnderTest(mockConfig);
+        final String dataKey = RandomStringUtils.randomAlphabetic(10);
+        final String dataValue = RandomStringUtils.randomAlphabetic(15);
+        final AggregateActionInput aggregateActionInput = new AggregateActionTestUtils.TestAggregateActionInput(Map.of(dataKey, dataValue));
+        Long[] expectedBucketCounts = new Long[buckets.size()+1];
+        double expectedSum = 0.0;
+        double expectedMin = TEST_VALUE_RANGE_MAX+TEST_VALUE_RANGE_STEP+1.0;
+        double expectedMax = TEST_VALUE_RANGE_MIN-TEST_VALUE_RANGE_STEP-1.0;
+        Arrays.fill(expectedBucketCounts, (long)0);
+        Random random = new Random();
+        final Instant testTime = Instant.ofEpochSecond(Instant.now().getEpochSecond());
+        for (int i = 0; i < testCount; i++) {
+            final double value = ThreadLocalRandom.current().nextDouble(TEST_VALUE_RANGE_MIN-TEST_VALUE_RANGE_STEP, TEST_VALUE_RANGE_MAX+TEST_VALUE_RANGE_STEP);
+            if (value < bucket1) {
+                expectedBucketCounts[0]++;
+            } else if (value < bucket2) {
+                expectedBucketCounts[1]++;
+            } else if (value < bucket3) {
+                expectedBucketCounts[2]++;
+            } else {
+                expectedBucketCounts[3]++;
+            }
+            expectedSum += value;
+            if (value < expectedMin) {
+                expectedMin = value;
+            }
+            if (value > expectedMax) {
+                expectedMax = value;
+            }
+            Instant sTime = (i == 0) ? testTime : testTime.plusSeconds(random.nextInt(5));
+            Instant eTime = (i == testCount-1) ? testTime.plusSeconds(100) : testTime.plusSeconds (50+random.nextInt(45));
+            Map<Object, Object> eventMap = Collections.synchronizedMap(Map.of(testKey, value, startTimeKey, sTime, endTimeKey, eTime));
+            Event testEvent = JacksonEvent.builder()
+                    .withEventType("event")
+                    .withData(eventMap)
+                    .build();
+            final AggregateActionResponse aggregateActionResponse = histogramAggregateAction.handleEvent(testEvent, aggregateActionInput);
+            assertThat(aggregateActionResponse.getEvent(), equalTo(null));
+        }
+
+        final AggregateActionOutput actionOutput = histogramAggregateAction.concludeGroup(aggregateActionInput);
+        final List<Event> result = actionOutput.getEvents();
+        assertThat(result.size(), equalTo(1));
+        final String expectedCountKey = mockConfig.getCountKey();
+        final String expectedStartTimeKey = mockConfig.getStartTimeKey();
+        Map<String, Object> expectedEventMap = new HashMap<>(Collections.singletonMap("count", (long)testCount));
+        expectedEventMap.put("unit", testUnits);
+        expectedEventMap.put("name", HistogramAggregateAction.HISTOGRAM_METRIC_NAME);
+        expectedEventMap.put("sum", expectedSum);
+        expectedEventMap.put("min", expectedMin);
+        expectedEventMap.put("max", expectedMax);
+        expectedEventMap.put("bucketCounts", expectedBucketCounts.length);
+        expectedEventMap.put("explicitBoundsCount", expectedBucketCounts.length-1);
+
+        expectedEventMap.forEach((k, v) -> assertThat(result.get(0).toMap(), hasEntry(k, v)));
+        assertThat(result.get(0).toMap(), hasKey("startTime"));
+        assertThat(result.get(0).toMap(), hasKey("time"));
+        final List<Long> bucketCountsFromResult = (ArrayList<Long>)result.get(0).toMap().get("bucketCountsList");
+        for (int i = 0; i < expectedBucketCounts.length; i++) {
+            assertThat(expectedBucketCounts[i], equalTo(bucketCountsFromResult.get(i)));
+        }
+        assertThat(((Map<String, String>)result.get(0).toMap().get("attributes")), hasEntry(HistogramAggregateAction.HISTOGRAM_METRIC_NAME+"_key", testKey));
+        List<Exemplar> exemplars = (List <Exemplar>)result.get(0).toMap().get("exemplars");
+        assertThat(exemplars.size(), equalTo(2));
+        assertThat(((Map<String, String>)result.get(0).toMap().get("attributes")), hasEntry(dataKey, dataValue));
+        final String expectedDurationKey = mockConfig.getDurationKey();
+        assertThat(((Map<String, String>)result.get(0).toMap().get("attributes")), hasKey(expectedDurationKey));
+        JacksonMetric metric = (JacksonMetric) result.get(0);
+        assertThat(metric.toJsonString().indexOf("attributes"), not(-1));
+        final List<Double> explicitBoundsFromResult = (ArrayList<Double>)result.get(0).toMap().get("explicitBounds");
+        double bucketVal = TEST_VALUE_RANGE_MIN;
+        for (int i = 0; i < explicitBoundsFromResult.size(); i++) {
+            assertThat(explicitBoundsFromResult.get(i), equalTo(bucketVal));
+            bucketVal += TEST_VALUE_RANGE_STEP;
+        }
+        final List<Map<String, Object>> bucketsFromResult = (ArrayList<Map<String, Object>>)result.get(0).toMap().get("buckets");
+        double expectedBucketMin = -Float.MAX_VALUE;
+        double expectedBucketMax = TEST_VALUE_RANGE_MIN;
+        for (int i = 0; i < bucketsFromResult.size(); i++) {
+            assertThat(bucketsFromResult.get(i), hasEntry("min", expectedBucketMin));
+            assertThat(bucketsFromResult.get(i), hasEntry("max", expectedBucketMax));
+            assertThat(bucketsFromResult.get(i), hasEntry("count", expectedBucketCounts[i]));
+            expectedBucketMin = expectedBucketMax;
+            expectedBucketMax += TEST_VALUE_RANGE_STEP;
+            if (i == bucketsFromResult.size()-2) {
+                expectedBucketMax = Float.MAX_VALUE;
+            }
+        }
+
+        assertThat(result.get(0).get("startTime", String.class), equalTo(testTime.toString()));
+        assertThat(result.get(0).get("time", String.class), equalTo(testTime.plusSeconds(100).toString()));
     }
 }


### PR DESCRIPTION
### Description
Add support for start and end times in count and histogram aggregate actions.
Count and Histogram aggregate actions include start and end times based on the real time of aggregation. Adding support to include start and end times based on the times in the event.
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
