### PR TITLE
Caffeine-based caching parser for the user_agent processor

### DIFF
--- a/data-prepper-plugins/opensearch/build.gradle
+++ b/data-prepper-plugins/opensearch/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:opensearchserverless'
     implementation libs.commons.lang3
-    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+    implementation libs.caffeine
     implementation 'software.amazon.awssdk:apache-client'
     implementation 'software.amazon.awssdk:netty-nio-client'
     implementation 'co.elastic.clients:elasticsearch-java:7.17.0'

--- a/data-prepper-plugins/otel-trace-raw-processor/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-processor/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation libs.armeria.grpc
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+    implementation libs.caffeine
     testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation testLibs.mockito.inline
 }

--- a/data-prepper-plugins/user-agent-processor/build.gradle
+++ b/data-prepper-plugins/user-agent-processor/build.gradle
@@ -11,7 +11,8 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation "com.github.ua-parser:uap-java:1.6.1"
+    implementation 'com.github.ua-parser:uap-java:1.6.1'
+    implementation libs.caffeine
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/CaffeineCachingParser.java
+++ b/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/CaffeineCachingParser.java
@@ -25,7 +25,8 @@ class CaffeineCachingParser extends Parser {
     private final Cache<String, OS> osCache;
 
     /**
-     * Constructs a new instance with a given cache size.
+     * Constructs a new instance with a given cache size. Each parse method
+     * will have its own cache.
      *
      * @param cacheSize The size of the cache as a count of items.
      */

--- a/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/CaffeineCachingParser.java
+++ b/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/CaffeineCachingParser.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.useragent;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import ua_parser.Client;
+import ua_parser.Device;
+import ua_parser.OS;
+import ua_parser.Parser;
+import ua_parser.UserAgent;
+
+import java.util.function.Function;
+
+/**
+ * A superclass of {@link Parser} which uses Caffeine as a cache.
+ */
+class CaffeineCachingParser extends Parser {
+    private final Cache<String, Client> clientCache;
+    private final Cache<String, UserAgent> userAgentCache;
+    private final Cache<String, Device> deviceCache;
+    private final Cache<String, OS> osCache;
+
+    /**
+     * Constructs a new instance with a given cache size.
+     *
+     * @param cacheSize The size of the cache as a count of items.
+     */
+    CaffeineCachingParser(final long cacheSize) {
+        userAgentCache = createCache(cacheSize);
+        clientCache = createCache(cacheSize);
+        deviceCache = createCache(cacheSize);
+        osCache = createCache(cacheSize);
+    }
+
+    @Override
+    public Client parse(final String agentString) {
+        return parseCaching(agentString, clientCache, super::parse);
+    }
+
+    @Override
+    public UserAgent parseUserAgent(final String agentString) {
+        return parseCaching(agentString, userAgentCache, super::parseUserAgent);
+    }
+
+    @Override
+    public Device parseDevice(final String agentString) {
+        return parseCaching(agentString, deviceCache, super::parseDevice);
+    }
+
+    @Override
+    public OS parseOS(final String agentString) {
+        return parseCaching(agentString, osCache, super::parseOS);
+    }
+
+    private <T> T parseCaching(
+            final String agentString,
+            final Cache<String, T> cache,
+            final Function<String, T> parseFunction) {
+        if (agentString == null) {
+            return null;
+        }
+        return cache.get(agentString, parseFunction);
+    }
+
+    private static <T> Cache<String, T> createCache(final long maximumSize) {
+        return Caffeine.newBuilder()
+                .maximumSize(maximumSize)
+                .build();
+    }
+}

--- a/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessor.java
+++ b/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessor.java
@@ -14,7 +14,6 @@ import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.record.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ua_parser.CachingParser;
 import ua_parser.Client;
 import ua_parser.Parser;
 
@@ -36,7 +35,7 @@ public class UserAgentProcessor extends AbstractProcessor<Record<Event>, Record<
     public UserAgentProcessor(final PluginMetrics pluginMetrics, final UserAgentProcessorConfig config) {
         super(pluginMetrics);
         this.config = config;
-        this.userAgentParser = new CachingParser(config.getCacheSize());
+        this.userAgentParser = new CaffeineCachingParser(config.getCacheSize());
     }
 
     @Override

--- a/data-prepper-plugins/user-agent-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/useragent/CaffeineCachingParserTest.java
+++ b/data-prepper-plugins/user-agent-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/useragent/CaffeineCachingParserTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.processor.useragent;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ua_parser.Client;
+import ua_parser.Device;
+import ua_parser.OS;
+import ua_parser.UserAgent;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@SuppressWarnings("StringOperationCanBeSimplified")
+class CaffeineCachingParserTest {
+    private static final String KNOWN_USER_AGENT_STRING = "Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1";
+    long cacheSize;
+
+    @BeforeEach
+    void setUp() {
+        cacheSize = 1000;
+    }
+
+    private CaffeineCachingParser createObjectUnderTest() {
+        return new CaffeineCachingParser(cacheSize);
+    }
+
+    @Test
+    void parse_returns_expected_results() {
+        final Client client = createObjectUnderTest().parse(KNOWN_USER_AGENT_STRING);
+
+        assertThat(client, notNullValue());
+        assertThat(client.userAgent, notNullValue());
+        assertThat(client.userAgent.family, equalTo("Mobile Safari"));
+        assertThat(client.userAgent.major, equalTo("13"));
+        assertThat(client.device.family, equalTo("iPhone"));
+        assertThat(client.os.family, equalTo("iOS"));
+    }
+
+    @Test
+    void parse_with_null_returns_null() {
+        assertThat(createObjectUnderTest().parse(null),
+                nullValue());
+    }
+
+    @Test
+    void parse_called_multiple_times_returns_same_instance() {
+        final CaffeineCachingParser objectUnderTest = createObjectUnderTest();
+
+        final String userAgentString = KNOWN_USER_AGENT_STRING;
+        final Client client = objectUnderTest.parse(userAgentString);
+
+        assertThat(client, notNullValue());
+
+        assertThat(objectUnderTest.parse(new String(userAgentString)), sameInstance(client));
+        assertThat(objectUnderTest.parse(new String(userAgentString)), sameInstance(client));
+        assertThat(objectUnderTest.parse(new String(userAgentString)), sameInstance(client));
+    }
+
+    @Test
+    void parseUserAgent_returns_expected_results() {
+        final CaffeineCachingParser objectUnderTest = createObjectUnderTest();
+
+        final UserAgent userAgent = objectUnderTest.parseUserAgent(KNOWN_USER_AGENT_STRING);
+
+        assertThat(userAgent, notNullValue());
+        assertThat(userAgent.family, equalTo("Mobile Safari"));
+        assertThat(userAgent.major, equalTo("13"));
+    }
+
+    @Test
+    void parseUserAgent_with_null_returns_null() {
+        assertThat(createObjectUnderTest().parseUserAgent(null),
+                nullValue());
+    }
+
+    @Test
+    void parseUserAgent_called_multiple_times_returns_same_instance() {
+        final CaffeineCachingParser objectUnderTest = createObjectUnderTest();
+
+        final String userAgentString = KNOWN_USER_AGENT_STRING;
+        final UserAgent userAgent = objectUnderTest.parseUserAgent(userAgentString);
+
+        assertThat(userAgent, notNullValue());
+
+        assertThat(objectUnderTest.parseUserAgent(new String(userAgentString)), sameInstance(userAgent));
+        assertThat(objectUnderTest.parseUserAgent(new String(userAgentString)), sameInstance(userAgent));
+        assertThat(objectUnderTest.parseUserAgent(new String(userAgentString)), sameInstance(userAgent));
+    }
+
+    @Test
+    void parseDevice_returns_expected_results() {
+        final CaffeineCachingParser objectUnderTest = createObjectUnderTest();
+
+        final Device device = objectUnderTest.parseDevice(KNOWN_USER_AGENT_STRING);
+
+        assertThat(device, notNullValue());
+        assertThat(device.family, equalTo("iPhone"));
+    }
+
+    @Test
+    void parseDevice_with_null_returns_null() {
+        assertThat(createObjectUnderTest().parseDevice(null),
+                nullValue());
+    }
+
+    @Test
+    void parseDevice_called_multiple_times_returns_same_instance() {
+        final CaffeineCachingParser objectUnderTest = createObjectUnderTest();
+
+        final String userAgentString = KNOWN_USER_AGENT_STRING;
+        final Device device = objectUnderTest.parseDevice(userAgentString);
+
+        assertThat(device, notNullValue());
+
+        assertThat(objectUnderTest.parseDevice(new String(userAgentString)), sameInstance(device));
+        assertThat(objectUnderTest.parseDevice(new String(userAgentString)), sameInstance(device));
+        assertThat(objectUnderTest.parseDevice(new String(userAgentString)), sameInstance(device));
+    }
+
+    @Test
+    void parseOS_returns_expected_results() {
+        final CaffeineCachingParser objectUnderTest = createObjectUnderTest();
+
+        final OS os = objectUnderTest.parseOS(KNOWN_USER_AGENT_STRING);
+
+        assertThat(os, notNullValue());
+        assertThat(os.family, equalTo("iOS"));
+        assertThat(os.major, equalTo("13"));
+    }
+
+    @Test
+    void parseOS_with_null_returns_null() {
+        assertThat(createObjectUnderTest().parseOS(null),
+                nullValue());
+    }
+
+    @Test
+    void parseOS_called_multiple_times_returns_same_instance() {
+        final CaffeineCachingParser objectUnderTest = createObjectUnderTest();
+
+        final String userAgentString = KNOWN_USER_AGENT_STRING;
+        final OS os = objectUnderTest.parseOS(userAgentString);
+
+        assertThat(os, notNullValue());
+
+        assertThat(objectUnderTest.parseOS(new String(userAgentString)), sameInstance(os));
+        assertThat(objectUnderTest.parseOS(new String(userAgentString)), sameInstance(os));
+        assertThat(objectUnderTest.parseOS(new String(userAgentString)), sameInstance(os));
+    }
+}

--- a/data-prepper-plugins/user-agent-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/useragent/CaffeineCachingParserTest.java
+++ b/data-prepper-plugins/user-agent-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/useragent/CaffeineCachingParserTest.java
@@ -66,9 +66,7 @@ class CaffeineCachingParserTest {
 
     @Test
     void parseUserAgent_returns_expected_results() {
-        final CaffeineCachingParser objectUnderTest = createObjectUnderTest();
-
-        final UserAgent userAgent = objectUnderTest.parseUserAgent(KNOWN_USER_AGENT_STRING);
+        final UserAgent userAgent = createObjectUnderTest().parseUserAgent(KNOWN_USER_AGENT_STRING);
 
         assertThat(userAgent, notNullValue());
         assertThat(userAgent.family, equalTo("Mobile Safari"));
@@ -97,9 +95,7 @@ class CaffeineCachingParserTest {
 
     @Test
     void parseDevice_returns_expected_results() {
-        final CaffeineCachingParser objectUnderTest = createObjectUnderTest();
-
-        final Device device = objectUnderTest.parseDevice(KNOWN_USER_AGENT_STRING);
+        final Device device = createObjectUnderTest().parseDevice(KNOWN_USER_AGENT_STRING);
 
         assertThat(device, notNullValue());
         assertThat(device.family, equalTo("iPhone"));
@@ -127,9 +123,7 @@ class CaffeineCachingParserTest {
 
     @Test
     void parseOS_returns_expected_results() {
-        final CaffeineCachingParser objectUnderTest = createObjectUnderTest();
-
-        final OS os = objectUnderTest.parseOS(KNOWN_USER_AGENT_STRING);
+        final OS os = createObjectUnderTest().parseOS(KNOWN_USER_AGENT_STRING);
 
         assertThat(os, notNullValue());
         assertThat(os.family, equalTo("iOS"));

--- a/settings.gradle
+++ b/settings.gradle
@@ -65,6 +65,7 @@ dependencyResolutionManagement {
             library('hadoop-mapreduce', 'org.apache.hadoop', 'hadoop-mapreduce-client-core').versionRef('hadoop')
             version('avro', '1.11.3')
             library('avro-core', 'org.apache.avro', 'avro').versionRef('avro')
+            library('caffeine', 'com.github.ben-manes.caffeine', 'caffeine').version('3.1.8')
         }
         testLibs {
             version('junit', '5.8.2')


### PR DESCRIPTION
### Description

Adds and uses a Caffeine-based caching parser for the `user_agent` processor. Also, adds a Gradle version catalog for Caffeine since we now use it in three projects.
 
### Issues Resolved

Resolves #4618
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
