### PR TITLE
Tools to generate User Agent strings in the performance-test project

### DIFF
--- a/performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/tools/Templates.java
+++ b/performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/tools/Templates.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.test.performance.tools;
 
 import io.gatling.javaapi.core.Session;
 import org.opensearch.dataprepper.test.data.generation.IpAddress;
+import org.opensearch.dataprepper.test.data.generation.UserAgent;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -39,8 +40,22 @@ public final class Templates {
         };
     }
 
+    public static Function<Session, String> userAgent(final int batchSize) {
+        return session -> {
+            final List<String> logs = IntStream.range(0, batchSize)
+                    .mapToObj(i -> "{\"log\": \"" + userAgent() + "\"}")
+                    .collect(Collectors.toList());
+            final String logArray = String.join(",", logs);
+            return "[" + logArray + "]";
+        };
+    }
+
     private static String ipAddress() {
         return IpAddress.getInstance().ipAddress();
+    }
+
+    private static String userAgent() {
+        return UserAgent.getInstance().userAgent();
     }
 
     private static String httpMethod() {

--- a/performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/tools/Templates.java
+++ b/performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/tools/Templates.java
@@ -14,6 +14,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -31,22 +32,20 @@ public final class Templates {
     }
     
     public static Function<Session, String> apacheCommonLogTemplate(final int batchSize) {
-        return session -> {
-            final List<String> logs = IntStream.range(0, batchSize)
-                    .mapToObj(i -> "{\"log\": \"" + ipAddress() + " - frank [" + now() + "] \\\"" + httpMethod() + " /apache_pb.gif HTTP/1.0\\\" "+ statusCode() + " " + responseSize() + "\"}")
-                    .collect(Collectors.toList());
-            final String logArray = String.join(",", logs);
-            return "[" + logArray + "]";
-        };
+        return generateLogArray(batchSize,
+                () -> ipAddress() + " - frank [" + now() + "] \\\"" + httpMethod() + " /apache_pb.gif HTTP/1.0\\\" "+ statusCode() + " " + responseSize());
     }
 
     public static Function<Session, String> userAgent(final int batchSize) {
+        return generateLogArray(batchSize, () -> userAgent());
+    }
+
+    private static Function<Session, String> generateLogArray(final int batchSize, final Supplier<String> stringSupplier) {
         return session -> {
             final List<String> logs = IntStream.range(0, batchSize)
-                    .mapToObj(i -> "{\"log\": \"" + userAgent() + "\"}")
+                    .mapToObj(i -> "{\"log\": \"" + stringSupplier.get() + "\"}")
                     .collect(Collectors.toList());
-            final String logArray = String.join(",", logs);
-            return "[" + logArray + "]";
+            return logs.stream().collect(Collectors.joining(",", "[", "]"));
         };
     }
 

--- a/performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/tools/Templates.java
+++ b/performance-test/src/gatling/java/org/opensearch/dataprepper/test/performance/tools/Templates.java
@@ -41,12 +41,9 @@ public final class Templates {
     }
 
     private static Function<Session, String> generateLogArray(final int batchSize, final Supplier<String> stringSupplier) {
-        return session -> {
-            final List<String> logs = IntStream.range(0, batchSize)
-                    .mapToObj(i -> "{\"log\": \"" + stringSupplier.get() + "\"}")
-                    .collect(Collectors.toList());
-            return logs.stream().collect(Collectors.joining(",", "[", "]"));
-        };
+        return session -> IntStream.range(0, batchSize)
+                .mapToObj(i -> "{\"log\": \"" + stringSupplier.get() + "\"}")
+                .collect(Collectors.joining(",", "[", "]"));
     }
 
     private static String ipAddress() {

--- a/performance-test/src/main/java/org/opensearch/dataprepper/test/data/generation/UserAgent.java
+++ b/performance-test/src/main/java/org/opensearch/dataprepper/test/data/generation/UserAgent.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.test.data.generation;
+
+import java.util.Random;
+import java.util.UUID;
+
+public class UserAgent {
+    private static final UserAgent USER_AGENT = new UserAgent();
+    private final Random random;
+
+    private UserAgent() {
+        random = new Random();
+    }
+
+    public static UserAgent getInstance() {
+        return USER_AGENT;
+    }
+
+    public String userAgent() {
+        final StringBuilder userAgentBuilder = new StringBuilder();
+
+        buildBrowserPart(userAgentBuilder);
+        userAgentBuilder.append(" (");
+
+        buildDevicePart(userAgentBuilder);
+        userAgentBuilder.append(" ");
+
+        buildOsPart(userAgentBuilder);
+        userAgentBuilder.append(")");
+
+        return userAgentBuilder.toString();
+    }
+
+    private void buildOsPart(final StringBuilder userAgentBuilder) {
+        userAgentBuilder.append(randomString());
+        userAgentBuilder.append(" ");
+        buildVersionString(userAgentBuilder);
+    }
+
+    private void buildDevicePart(final StringBuilder userAgentBuilder) {
+        userAgentBuilder.append(randomString());
+        userAgentBuilder.append(";");
+    }
+
+    private void buildBrowserPart(final StringBuilder userAgentBuilder) {
+        userAgentBuilder.append(randomString());
+        userAgentBuilder.append("/");
+        buildVersionString(userAgentBuilder);
+    }
+
+    private void buildVersionString(final StringBuilder userAgentBuilder) {
+        userAgentBuilder.append(random.nextInt(9) + 1);
+        userAgentBuilder.append(".");
+        userAgentBuilder.append(random.nextInt(30));
+        userAgentBuilder.append(".");
+        userAgentBuilder.append(random.nextInt(30));
+    }
+
+    private static String randomString() {
+        return UUID.randomUUID().toString().replaceAll("-", "");
+    }
+}

--- a/performance-test/src/test/java/org/opensearch/dataprepper/test/data/generation/UserAgentTest.java
+++ b/performance-test/src/test/java/org/opensearch/dataprepper/test/data/generation/UserAgentTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.test.data.generation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+class UserAgentTest {
+    @Test
+    void userAgent_returns_string() {
+        final String userAgent = UserAgent.getInstance().userAgent();
+
+        assertThat(userAgent, notNullValue());
+        assertThat(userAgent.length(), greaterThanOrEqualTo(10));
+
+        assertThat(userAgent, containsString("/"));
+        assertThat(userAgent, containsString("("));
+        assertThat(userAgent, containsString("."));
+    }
+
+    @Test
+    void userAgent_returns_unique_value_on_multiple_calls() {
+        final UserAgent objectUnderTest = UserAgent.getInstance();
+        final String userAgent = objectUnderTest.userAgent();
+
+        assertThat(userAgent, notNullValue());
+        assertThat(objectUnderTest.userAgent(), not(equalTo(userAgent)));
+        assertThat(objectUnderTest.userAgent(), not(equalTo(userAgent)));
+        assertThat(objectUnderTest.userAgent(), not(equalTo(userAgent)));
+    }
+}

--- a/performance-test/src/test/java/org/opensearch/dataprepper/test/data/generation/UserAgentTest.java
+++ b/performance-test/src/test/java/org/opensearch/dataprepper/test/data/generation/UserAgentTest.java
@@ -8,9 +8,9 @@ package org.opensearch.dataprepper.test.data.generation;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -22,9 +22,9 @@ class UserAgentTest {
         assertThat(userAgent, notNullValue());
         assertThat(userAgent.length(), greaterThanOrEqualTo(10));
 
-        assertThat(userAgent, containsString("/"));
-        assertThat(userAgent, containsString("("));
-        assertThat(userAgent, containsString("."));
+        String expectedRegex = "^[A-Za-z0-9]+/[0-9]+.[0-9]+.[0-9]+ \\([A-Za-z0-9]+; [A-Za-z0-9]+ [0-9]+.[0-9]+.[0-9]+\\)$";
+
+        assertThat(userAgent, matchesPattern(expectedRegex));
     }
 
     @Test


### PR DESCRIPTION
### Description

Adds tools to the performance-test project to generate random User Agent strings. I created this to reproduce #4618 and then verify that the solution I provided in #4619 solved the problem.
 
#### To Use

Change `Chain::sendApacheCommonLogPostRequest` to:

```
    public static ChainBuilder sendApacheCommonLogPostRequest(final String name, final int batchSize) {
        return CoreDsl.exec(
                HttpDsl.http(name)
                        .post(PathTarget.getPath())
                        .body(CoreDsl.StringBody(Templates.userAgent(batchSize))));
    }
```

Run:

```
./gradlew :performance-test:gatlingRun-org.opensearch.dataprepper.test.performance.TargetRpsSimulation
```

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
