### PR TITLE
Deprecates PluginSetting which should not be used for plugins anymore.

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/configuration/PluginSetting.java
@@ -5,10 +5,22 @@
 
 package org.opensearch.dataprepper.model.configuration;
 
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Deprecated class for getting plugin settings.
+ * <p>
+ * Only projects within data-prepper-core should use this. It is currently used
+ * extensively in plugin framework to load plugins. In Data Prepper 3.0 this
+ * class will be moved into data-prepper-core and not exposed to plugins anymore.
+ *
+ * @deprecated Use {@link DataPrepperPlugin#pluginConfigurationType()} or {@link PipelineDescription} instead.
+ */
+@Deprecated
 public class PluginSetting implements PipelineDescription {
 
     private static final String UNEXPECTED_ATTRIBUTE_TYPE_MSG = "Unexpected type [%s] for attribute [%s]";


### PR DESCRIPTION
### Description

In #469, we added a POJO-based approach for getting plugin settings. This is more compatible with validations and should be used by all plugins. To help promote this, I submitted this PR to deprecate the `PluginSetting` class. In Data Prepper 3.0, we can move it into data-prepper-core.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
