### PR TITLE
Adds the EventKey and EventKeyFactory. 

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/Event.java
@@ -29,11 +29,31 @@ public interface Event extends Serializable {
     /**
      * Adds or updates the key with a given value in the Event
      *
+     * @param key where the value will be set
+     * @param value value to set the key to
+     * @since 2.8
+     */
+    void put(EventKey key, Object value);
+
+    /**
+     * Adds or updates the key with a given value in the Event
+     *
      * @param key   where the value will be set
      * @param value value to set the key to
      * @since 1.2
      */
     void put(String key, Object value);
+
+    /**
+     * Retrieves the given key from the Event
+     *
+     * @param key the value to retrieve from
+     * @param clazz the return type of the value
+     * @param <T> The type
+     * @return T a clazz object from the key
+     * @since 2.8
+     */
+    <T> T get(EventKey key, Class<T> clazz);
 
     /**
      * Retrieves the given key from the Event
@@ -53,9 +73,28 @@ public interface Event extends Serializable {
      * @param clazz the return type of elements in the list
      * @param <T>   The type
      * @return {@literal List<T>} a list of clazz elements
+     * @since 2.8
+     */
+    <T> List<T> getList(EventKey key, Class<T> clazz);
+
+    /**
+     * Retrieves the given key from the Event as a List
+     *
+     * @param key   the value to retrieve from
+     * @param clazz the return type of elements in the list
+     * @param <T>   The type
+     * @return {@literal List<T>} a list of clazz elements
      * @since 1.2
      */
     <T> List<T> getList(String key, Class<T> clazz);
+
+    /**
+     * Deletes the given key from the Event
+     *
+     * @param key the field to be deleted
+     * @since 2.8
+     */
+    void delete(EventKey key);
 
     /**
      * Deletes the given key from the Event
@@ -92,6 +131,15 @@ public interface Event extends Serializable {
      *
      * @param key the field to be returned
      * @return Json string of the field
+     * @since 2.8
+     */
+    String getAsJsonString(EventKey key);
+
+    /**
+     * Gets a serialized Json string of the specific key in the Event
+     *
+     * @param key the field to be returned
+     * @return Json string of the field
      * @since 2.2
      */
     String getAsJsonString(String key);
@@ -109,9 +157,27 @@ public interface Event extends Serializable {
      *
      * @param key name of the key to look for
      * @return returns true if the key exists, otherwise false
+     * @since 2.8
+     */
+    boolean containsKey(EventKey key);
+
+    /**
+     * Checks if the key exists.
+     *
+     * @param key name of the key to look for
+     * @return returns true if the key exists, otherwise false
      * @since 1.2
      */
     boolean containsKey(String key);
+
+    /**
+     * Checks if the value stored for the key is list
+     *
+     * @param key name of the key to look for
+     * @return returns true if the key is a list, otherwise false
+     * @since 2.8
+     */
+    boolean isValueAList(EventKey key);
 
     /**
      * Checks if the value stored for the key is list

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventKey.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventKey.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+/**
+ * Model class to represent a key into a Data Prepper {@link Event}.
+ *
+ * @since 2.9
+ */
+public interface EventKey {
+    /**
+     * The original key provided as a string.
+     *
+     * @return The key as a string
+     * @since 2.9
+     */
+    String getKey();
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventKeyFactory.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/EventKeyFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+/**
+ * A factory for producing {@link EventKey} objects.
+ *
+ * @since 2.9
+ */
+public interface EventKeyFactory {
+    /**
+     * Creates an {@link EventKey} with given actions.
+     *
+     * @param key The key
+     * @param forActions Actions to support
+     * @return The EventKey
+     * @since 2.9
+     */
+    EventKey createEventKey(String key, EventAction... forActions);
+
+    /**
+     * Creates an {@link EventKey} for the default actions, which are all.
+     *
+     * @param key The key
+     * @return The EventKey
+     * @since 2.9
+     */
+    default EventKey createEventKey(final String key) {
+        return createEventKey(key, EventAction.ALL);
+    }
+
+    /**
+     * An action on an Event.
+     *
+     * @since 2.9
+     */
+    enum EventAction {
+        GET,
+        DELETE,
+        PUT,
+        ALL;
+
+        boolean isMutableAction() {
+            return this != GET;
+        }
+
+        boolean supports(final EventAction eventAction) {
+            if(this == ALL)
+                return true;
+            return this == eventAction;
+        }
+    }
+}

--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEventKey.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEventKey.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+import com.fasterxml.jackson.core.JsonPointer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+class JacksonEventKey implements EventKey {
+    private static final String SEPARATOR = "/";
+    private static final int MAX_KEY_LENGTH = 2048;
+    private final String key;
+    private final EventKeyFactory.EventAction[] eventActions;
+    private final String trimmedKey;
+    private final List<String> keyPathList;
+    private final JsonPointer jsonPointer;
+
+    JacksonEventKey(final String key, final EventKeyFactory.EventAction... eventActions) {
+        this.key = Objects.requireNonNull(key, "Parameter key cannot be null for EventKey.");
+        this.eventActions = eventActions.length == 0 ? new EventKeyFactory.EventAction[] { EventKeyFactory.EventAction.ALL } : eventActions;
+
+        if(key.isEmpty()) {
+            for (final EventKeyFactory.EventAction action : eventActions) {
+                if (action.isMutableAction()) {
+                    throw new IllegalArgumentException("Event key cannot be an empty string for " + action + " actions.");
+                }
+            }
+        }
+
+        trimmedKey = checkAndTrimKey(key);
+
+        keyPathList = Collections.unmodifiableList(Arrays.asList(trimmedKey.split(SEPARATOR, -1)));
+        jsonPointer = toJsonPointer(trimmedKey);
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    String getTrimmedKey() {
+        return trimmedKey;
+    }
+
+    List<String> getKeyPathList() {
+        return keyPathList;
+    }
+
+    JsonPointer getJsonPointer() {
+        return jsonPointer;
+    }
+
+    boolean supports(final EventKeyFactory.EventAction eventAction) {
+        return Arrays.stream(eventActions).anyMatch(a -> a.supports(eventAction));
+    }
+
+    private String checkAndTrimKey(final String key) {
+        checkKey(key);
+        return trimTrailingSlashInKey(key);
+    }
+
+    private static void checkKey(final String key) {
+        checkNotNull(key, "key cannot be null");
+        if (key.isEmpty()) {
+            // Empty string key is valid
+            return;
+        }
+        if (key.length() > MAX_KEY_LENGTH) {
+            throw new IllegalArgumentException("key cannot be longer than " + MAX_KEY_LENGTH + " characters");
+        }
+        if (!isValidKey(key)) {
+            throw new IllegalArgumentException("key " + key + " must contain only alphanumeric chars with .-_@/ and must follow JsonPointer (ie. 'field/to/key')");
+        }
+    }
+
+
+    static String trimTrailingSlashInKey(final String key) {
+        return key.length() > 1 && key.endsWith(SEPARATOR) ? key.substring(0, key.length() - 1) : key;
+    }
+
+    private static boolean isValidKey(final String key) {
+        for (int i = 0; i < key.length(); i++) {
+            char c = key.charAt(i);
+
+            if (!(c >= 48 && c <= 57
+                    || c >= 65 && c <= 90
+                    || c >= 97 && c <= 122
+                    || c == '.'
+                    || c == '-'
+                    || c == '_'
+                    || c == '@'
+                    || c == '/'
+                    || c == '['
+                    || c == ']')) {
+
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private JsonPointer toJsonPointer(final String key) {
+        final String jsonPointerExpression;
+        if (key.isEmpty() || key.startsWith("/")) {
+            jsonPointerExpression = key;
+        } else {
+            jsonPointerExpression = SEPARATOR + key;
+        }
+        return JsonPointer.compile(jsonPointerExpression);
+    }
+
+    static boolean isValidEventKey(final String key) {
+        try {
+            checkKey(key);
+            return true;
+        } catch (final Exception e) {
+            return false;
+        }
+    }
+}

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/EventActionTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/EventActionTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class EventActionTest {
+    @ParameterizedTest
+    @EnumSource(value = EventKeyFactory.EventAction.class, mode = EnumSource.Mode.EXCLUDE, names = {"GET"})
+    void isMutableAction_is_true_for_mutable_actions(final EventKeyFactory.EventAction eventAction) {
+        assertThat(eventAction.isMutableAction(), equalTo(true));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = EventKeyFactory.EventAction.class, mode = EnumSource.Mode.INCLUDE, names = {"GET"})
+    void isMutableAction_is_false_for_mutable_actions(final EventKeyFactory.EventAction eventAction) {
+        assertThat(eventAction.isMutableAction(), equalTo(false));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = EventKeyFactory.EventAction.class)
+    void supports_returns_true_for_self(final EventKeyFactory.EventAction eventAction) {
+        assertThat(eventAction.supports(eventAction), equalTo(true));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = EventKeyFactory.EventAction.class)
+    void supports_returns_true_for_all_actions_when_ALL(final EventKeyFactory.EventAction eventAction) {
+        assertThat(EventKeyFactory.EventAction.ALL.supports(eventAction), equalTo(true));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SupportsArgumentsProvider.class)
+    void supports_returns_expected_value(final EventKeyFactory.EventAction eventAction, final EventKeyFactory.EventAction otherAction, boolean expectedSupports) {
+        assertThat(eventAction.supports(otherAction), equalTo(expectedSupports));
+    }
+
+    static class SupportsArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) throws Exception {
+            return Stream.of(
+                    arguments(EventKeyFactory.EventAction.GET, EventKeyFactory.EventAction.PUT, false),
+                    arguments(EventKeyFactory.EventAction.GET, EventKeyFactory.EventAction.DELETE, false),
+                    arguments(EventKeyFactory.EventAction.GET, EventKeyFactory.EventAction.ALL, false),
+                    arguments(EventKeyFactory.EventAction.PUT, EventKeyFactory.EventAction.GET, false),
+                    arguments(EventKeyFactory.EventAction.PUT, EventKeyFactory.EventAction.DELETE, false),
+                    arguments(EventKeyFactory.EventAction.PUT, EventKeyFactory.EventAction.ALL, false),
+                    arguments(EventKeyFactory.EventAction.DELETE, EventKeyFactory.EventAction.GET, false),
+                    arguments(EventKeyFactory.EventAction.DELETE, EventKeyFactory.EventAction.PUT, false),
+                    arguments(EventKeyFactory.EventAction.DELETE, EventKeyFactory.EventAction.ALL, false)
+            );
+        }
+    }
+}

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/EventKeyFactoryTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/EventKeyFactoryTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventKeyFactoryTest {
+
+    private String keyPath;
+
+    @Mock
+    private EventKey eventKey;
+
+    @BeforeEach
+    void setUp() {
+        keyPath = UUID.randomUUID().toString();
+    }
+
+    private EventKeyFactory createObjectUnderTest() {
+        return mock(EventKeyFactory.class);
+    }
+
+    @Test
+    void createEventKey_calls_with_ALL_action() {
+        final EventKeyFactory objectUnderTest = createObjectUnderTest();
+        when(objectUnderTest.createEventKey(anyString())).thenCallRealMethod();
+        when(objectUnderTest.createEventKey(keyPath, EventKeyFactory.EventAction.ALL)).thenReturn(eventKey);
+
+        assertThat(objectUnderTest.createEventKey(keyPath), equalTo(eventKey));
+    }
+}

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventKeyTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventKeyTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class JacksonEventKeyTest {
+    @Test
+    void constructor_throws_with_null_key() {
+        assertThrows(NullPointerException.class, () -> new JacksonEventKey(null));
+    }
+
+    @Test
+    void getKey_with_empty_string_for_GET() {
+        final JacksonEventKey objectUnderTest = new JacksonEventKey("", EventKeyFactory.EventAction.GET);
+        assertThat(objectUnderTest.getKey(), equalTo(""));
+        assertThat(objectUnderTest.getTrimmedKey(), equalTo(""));
+        assertThat(objectUnderTest.getKeyPathList(), notNullValue());
+        assertThat(objectUnderTest.getKeyPathList(), equalTo(List.of("")));
+        assertThat(objectUnderTest.getJsonPointer(), notNullValue());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = EventKeyFactory.EventAction.class, mode = EnumSource.Mode.EXCLUDE, names = {"GET"})
+    void constructor_throws_with_empty_string_for_unsupported_actions(final EventKeyFactory.EventAction eventAction) {
+        assertThrows(IllegalArgumentException.class, () -> new JacksonEventKey("", eventAction));
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "inv(alid",
+            "getMetadata(\"test_key\")"
+    })
+    void constructor_throws_with_invalid_key(final String key) {
+        assertThrows(IllegalArgumentException.class, () -> new JacksonEventKey(key));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "test_key",
+            "/test_key",
+            "key.with.dot",
+            "key-with-hyphen",
+            "key_with_underscore",
+            "key@with@at",
+            "key[with]brackets"
+    })
+    void getKey_returns_expected_result(final String key) {
+        assertThat(new JacksonEventKey(key).getKey(), equalTo(key));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "test_key, test_key",
+            "/test_key, /test_key",
+            "/test_key/, /test_key",
+            "key.with.dot, key.with.dot",
+            "key-with-hyphen, key-with-hyphen",
+            "key_with_underscore, key_with_underscore",
+            "key@with@at, key@with@at",
+            "key[with]brackets, key[with]brackets"
+    })
+    void getTrimmedKey_returns_expected_result(final String key, final String expectedTrimmedKey) {
+        assertThat(new JacksonEventKey(key).getTrimmedKey(), equalTo(expectedTrimmedKey));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(KeyPathListArgumentsProvider.class)
+    void getKeyPathList_returns_expected_value(final String key, final List<String> expectedKeyPathList) {
+        assertThat(new JacksonEventKey(key).getKeyPathList(), equalTo(expectedKeyPathList));
+    }
+
+    @Test
+    void getJsonPointer_returns_a_valid_JsonPointer() {
+        final String testKey = UUID.randomUUID().toString();
+        final JacksonEventKey objectUnderTest = new JacksonEventKey(testKey);
+
+        final JsonPointer jsonPointer = objectUnderTest.getJsonPointer();
+        assertThat(jsonPointer, notNullValue());
+        assertThat(jsonPointer.toString(), equalTo("/" + testKey));
+    }
+
+    @Test
+    void getJsonPointer_returns_the_same_instance_for_multiple_calls() {
+        final String testKey = UUID.randomUUID().toString();
+        final JacksonEventKey objectUnderTest = new JacksonEventKey(testKey);
+
+        final JsonPointer jsonPointer = objectUnderTest.getJsonPointer();
+        assertThat(objectUnderTest.getJsonPointer(), sameInstance(jsonPointer));
+        assertThat(objectUnderTest.getJsonPointer(), sameInstance(jsonPointer));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SupportsArgumentsProvider.class)
+    void supports_returns_true_if_any_supports(final List<EventKeyFactory.EventAction> eventActionsList, final EventKeyFactory.EventAction otherAction, final boolean expectedSupports) {
+        final String testKey = UUID.randomUUID().toString();
+        final EventKeyFactory.EventAction[] eventActions = new EventKeyFactory.EventAction[eventActionsList.size()];
+        eventActionsList.toArray(eventActions);
+        assertThat(new JacksonEventKey(testKey, eventActions).supports(otherAction), equalTo(expectedSupports));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "test_key, true",
+            "/test_key, true",
+            "inv(alid, false",
+            "getMetadata(\"test_key\"), false",
+            "key.with.dot, true",
+            "key-with-hyphen, true",
+            "key_with_underscore, true",
+            "key@with@at, true",
+            "key[with]brackets, true"
+    })
+    void isValidEventKey_returns_expected_result(final String key, final boolean isValid) {
+        assertThat(JacksonEventKey.isValidEventKey(key), equalTo(isValid));
+    }
+
+
+    static class KeyPathListArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return Stream.of(
+                    arguments("test_key", List.of("test_key")),
+                    arguments("a/b", List.of("a", "b")),
+                    arguments("a/b/", List.of("a", "b")),
+                    arguments("a/b/c", List.of("a", "b", "c")),
+                    arguments("a/b/c/", List.of("a", "b", "c"))
+            );
+        }
+    }
+
+    static class SupportsArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) throws Exception {
+            return Stream.of(
+                    arguments(List.of(EventKeyFactory.EventAction.GET), EventKeyFactory.EventAction.PUT, false),
+                    arguments(List.of(EventKeyFactory.EventAction.GET, EventKeyFactory.EventAction.PUT), EventKeyFactory.EventAction.PUT, true),
+                    arguments(List.of(EventKeyFactory.EventAction.PUT, EventKeyFactory.EventAction.GET), EventKeyFactory.EventAction.PUT, true),
+                    arguments(List.of(EventKeyFactory.EventAction.DELETE), EventKeyFactory.EventAction.PUT, false),
+                    arguments(List.of(EventKeyFactory.EventAction.DELETE, EventKeyFactory.EventAction.GET), EventKeyFactory.EventAction.PUT, false),
+                    arguments(List.of(EventKeyFactory.EventAction.DELETE, EventKeyFactory.EventAction.GET, EventKeyFactory.EventAction.PUT), EventKeyFactory.EventAction.PUT, true),
+                    arguments(List.of(EventKeyFactory.EventAction.ALL), EventKeyFactory.EventAction.GET, true),
+                    arguments(List.of(EventKeyFactory.EventAction.ALL), EventKeyFactory.EventAction.PUT, true),
+                    arguments(List.of(EventKeyFactory.EventAction.ALL), EventKeyFactory.EventAction.DELETE, true)
+            );
+        }
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/ProcessorPipelineIT.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/integration/ProcessorPipelineIT.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.plugins.InMemorySinkAccessor;
+import org.opensearch.dataprepper.plugins.InMemorySourceAccessor;
+import org.opensearch.dataprepper.test.framework.DataPrepperTestRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+class ProcessorPipelineIT {
+    private static final Logger LOG = LoggerFactory.getLogger(ProcessorPipelineIT.class);
+    private static final String IN_MEMORY_IDENTIFIER = "ProcessorPipelineIT";
+    private static final String PIPELINE_CONFIGURATION_UNDER_TEST = "processor-pipeline.yaml";
+    private DataPrepperTestRunner dataPrepperTestRunner;
+    private InMemorySourceAccessor inMemorySourceAccessor;
+    private InMemorySinkAccessor inMemorySinkAccessor;
+
+    @BeforeEach
+    void setUp() {
+        dataPrepperTestRunner = DataPrepperTestRunner.builder()
+                .withPipelinesDirectoryOrFile(PIPELINE_CONFIGURATION_UNDER_TEST)
+                .build();
+
+        inMemorySourceAccessor = dataPrepperTestRunner.getInMemorySourceAccessor();
+        inMemorySinkAccessor = dataPrepperTestRunner.getInMemorySinkAccessor();
+        dataPrepperTestRunner.start();
+        LOG.info("Started test runner.");
+    }
+
+    @AfterEach
+    void tearDown() {
+        LOG.info("Test tear down. Stop the test runner.");
+        dataPrepperTestRunner.stop();
+    }
+
+    @Test
+    void run_with_single_record() {
+        final String messageValue = UUID.randomUUID().toString();
+        final Event event = JacksonEvent.fromMessage(messageValue);
+        final Record<Event> eventRecord = new Record<>(event);
+
+        LOG.info("Submitting a single record.");
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, Collections.singletonList(eventRecord));
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER), not(empty()));
+        });
+
+        final List<Record<Event>> records = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
+
+        assertThat(records.size(), equalTo(1));
+
+        assertThat(records.get(0), notNullValue());
+        assertThat(records.get(0).getData(), notNullValue());
+        assertThat(records.get(0).getData().get("message", String.class), equalTo(messageValue));
+        assertThat(records.get(0).getData().get("test1", String.class), equalTo("knownPrefix10"));
+    }
+
+    @Test
+    void pipeline_with_single_batch_of_records() {
+        final int recordsToCreate = 200;
+        final List<Record<Event>> inputRecords = IntStream.range(0, recordsToCreate)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .map(JacksonEvent::fromMessage)
+                .map(Record::new)
+                .collect(Collectors.toList());
+
+        LOG.info("Submitting a batch of record.");
+        inMemorySourceAccessor.submit(IN_MEMORY_IDENTIFIER, inputRecords);
+
+        await().atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+            assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER), not(empty()));
+        });
+
+        assertThat(inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER).size(), equalTo(recordsToCreate));
+
+        final List<Record<Event>> sinkRecords = inMemorySinkAccessor.get(IN_MEMORY_IDENTIFIER);
+
+        for (int i = 0; i < sinkRecords.size(); i++) {
+            final Record<Event> inputRecord = inputRecords.get(i);
+            final Record<Event> sinkRecord = sinkRecords.get(i);
+            assertThat(sinkRecord, notNullValue());
+            final Event recordData = sinkRecord.getData();
+            assertThat(recordData, notNullValue());
+            assertThat(
+                    recordData.get("message", String.class),
+                    equalTo(inputRecord.getData().get("message", String.class)));
+            assertThat(recordData.get("test1", String.class),
+                    equalTo("knownPrefix1" + i));
+        }
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySourceAccessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/InMemorySourceAccessor.java
@@ -6,20 +6,19 @@
 package org.opensearch.dataprepper.plugins;
 
 import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
-import org.opensearch.dataprepper.model.record.Record;
-import org.opensearch.dataprepper.model.event.EventFactory;
 import org.opensearch.dataprepper.model.event.EventBuilder;
+import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.UUID;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Provides a mechanism to write records to an in_memory source. This allows the pipeline to execute
@@ -62,8 +61,8 @@ public class InMemorySourceAccessor {
         for (int i = 0; i < numRecords; i++) {
             Map<String, Object> eventMap = Map.of("message", UUID.randomUUID().toString());
             EventBuilder eventBuilder = (EventBuilder) eventFactory.eventBuilder(EventBuilder.class).withData(eventMap);
-            JacksonEvent event = (JacksonEvent) eventBuilder.build();
-            records.add(new Record<Event>(event));
+            Event event = eventBuilder.build();
+            records.add(new Record<>(event));
         }
         submit(testingKey, records);
     }
@@ -79,8 +78,8 @@ public class InMemorySourceAccessor {
             int status = (int)(Math.random() * (max - min + 1) + min);
             Map<String, Object> eventMap = Map.of("message", UUID.randomUUID().toString(), "status", status);
             EventBuilder eventBuilder = (EventBuilder) eventFactory.eventBuilder(EventBuilder.class).withData(eventMap);
-            JacksonEvent event = (JacksonEvent) eventBuilder.build();
-            records.add(new Record<Event>(event));
+            Event event = eventBuilder.build();
+            records.add(new Record<>(event));
         }
         submit(testingKey, records);
     }

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/SimpleProcessor.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/SimpleProcessor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins;
+
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+import org.opensearch.dataprepper.model.processor.Processor;
+import org.opensearch.dataprepper.model.record.Record;
+
+import java.util.Collection;
+
+@DataPrepperPlugin(name = "simple_test", pluginType = Processor.class, pluginConfigurationType = SimpleProcessorConfig.class)
+public class SimpleProcessor implements Processor<Record<Event>, Record<Event>> {
+    private final EventKey eventKey1;
+    private final String valuePrefix1;
+    int count = 0;
+
+    @DataPrepperPluginConstructor
+    public SimpleProcessor(
+            final SimpleProcessorConfig simpleProcessorConfig,
+            final EventKeyFactory eventKeyFactory) {
+        eventKey1 = eventKeyFactory.createEventKey(simpleProcessorConfig.getKey1());
+        valuePrefix1 = simpleProcessorConfig.getValuePrefix1();
+    }
+
+    @Override
+    public Collection<Record<Event>> execute(final Collection<Record<Event>> records) {
+        for (final Record<Event> record : records) {
+            record.getData().put(eventKey1, valuePrefix1 + count);
+            count++;
+        }
+
+        return records;
+    }
+
+    @Override
+    public void prepareForShutdown() {
+
+    }
+
+    @Override
+    public boolean isReadyForShutdown() {
+        return false;
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+}

--- a/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/SimpleProcessorConfig.java
+++ b/data-prepper-core/src/integrationTest/java/org/opensearch/dataprepper/plugins/SimpleProcessorConfig.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins;
+
+public class SimpleProcessorConfig {
+    private String key1;
+    private String valuePrefix1;
+
+    public String getKey1() {
+        return key1;
+    }
+
+    public String getValuePrefix1() {
+        return valuePrefix1;
+    }
+}

--- a/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/processor-pipeline.yaml
+++ b/data-prepper-core/src/integrationTest/resources/org/opensearch/dataprepper/pipeline/processor-pipeline.yaml
@@ -1,0 +1,14 @@
+processor-pipeline:
+  delay: 10
+  source:
+    in_memory:
+      testing_key: ProcessorPipelineIT
+
+  processor:
+    - simple_test:
+        key1: /test1
+        value_prefix1: knownPrefix1
+
+  sink:
+    - in_memory:
+        testing_key: ProcessorPipelineIT

--- a/data-prepper-event/src/main/java/org/opensearch/dataprepper/core/event/DefaultEventKeyFactory.java
+++ b/data-prepper-event/src/main/java/org/opensearch/dataprepper/core/event/DefaultEventKeyFactory.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.core.event;
+
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+import org.opensearch.dataprepper.model.event.InternalOnlyEventKeyBridge;
+
+import javax.inject.Named;
+
+@Named
+public class DefaultEventKeyFactory implements EventKeyFactory {
+    @Override
+    public EventKey createEventKey(final String key, final EventAction... forActions) {
+        return InternalOnlyEventKeyBridge.createEventKey(key, forActions);
+    }
+}

--- a/data-prepper-event/src/main/java/org/opensearch/dataprepper/model/event/InternalOnlyEventKeyBridge.java
+++ b/data-prepper-event/src/main/java/org/opensearch/dataprepper/model/event/InternalOnlyEventKeyBridge.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.model.event;
+
+/**
+ * Until we remove {@link JacksonEvent} from data-prepper-api,
+ * we will need this class to give us access to the package-protected
+ * {@link JacksonEventKey}.
+ */
+public class InternalOnlyEventKeyBridge {
+    public static EventKey createEventKey(final String key, final EventKeyFactory.EventAction... forAction) {
+        return new JacksonEventKey(key, forAction);
+    }
+}

--- a/data-prepper-event/src/test/java/org/opensearch/dataprepper/core/event/DefaultEventKeyFactoryTest.java
+++ b/data-prepper-event/src/test/java/org/opensearch/dataprepper/core/event/DefaultEventKeyFactoryTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.core.event;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class DefaultEventKeyFactoryTest {
+
+    private DefaultEventKeyFactory createObjectUnderTest() {
+        return new DefaultEventKeyFactory();
+    }
+
+    @Test
+    void createEventKey_returns_correct_EventKey() {
+        final String keyPath = UUID.randomUUID().toString();
+        final EventKey eventKey = createObjectUnderTest().createEventKey(keyPath);
+
+        assertThat(eventKey, notNullValue());
+        assertThat(eventKey.getKey(), equalTo(keyPath));
+    }
+
+    @Test
+    void createEventKey_with_EventAction_returns_correct_EventKey() {
+        final String keyPath = UUID.randomUUID().toString();
+        final EventKey eventKey = createObjectUnderTest().createEventKey(keyPath, EventKeyFactory.EventAction.GET);
+
+        assertThat(eventKey, notNullValue());
+        assertThat(eventKey.getKey(), equalTo(keyPath));
+    }
+
+    @Test
+    void createEventKey_returns_JacksonEventKey() {
+        final String keyPath = UUID.randomUUID().toString();
+        final EventKey eventKey = createObjectUnderTest().createEventKey(keyPath);
+
+        assertThat(eventKey, notNullValue());
+        assertThat(eventKey.getClass().getSimpleName(), equalTo("JacksonEventKey"));
+
+        assertThat(eventKey.getKey(), equalTo(keyPath));
+    }
+}

--- a/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ApplicationContextToTypedSuppliers.java
+++ b/data-prepper-plugin-framework/src/main/java/org/opensearch/dataprepper/plugin/ApplicationContextToTypedSuppliers.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.plugin;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
 import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.inject.Inject;
@@ -31,6 +32,7 @@ class ApplicationContextToTypedSuppliers {
     @Inject
     ApplicationContextToTypedSuppliers(
             final EventFactory eventFactory,
+            final EventKeyFactory eventKeyFactory,
             final AcknowledgementSetManager acknowledgementSetManager,
             @Autowired(required = false) final CircuitBreaker circuitBreaker
     ) {
@@ -39,6 +41,7 @@ class ApplicationContextToTypedSuppliers {
 
         typedSuppliers = Map.of(
                 EventFactory.class, () -> eventFactory,
+                EventKeyFactory.class, () -> eventKeyFactory,
                 AcknowledgementSetManager.class, () -> acknowledgementSetManager,
                 CircuitBreaker.class, () -> circuitBreaker
         );

--- a/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ApplicationContextToTypedSuppliersTest.java
+++ b/data-prepper-plugin-framework/src/test/java/org/opensearch/dataprepper/plugin/ApplicationContextToTypedSuppliersTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.dataprepper.model.acknowledgements.AcknowledgementSetManager;
 import org.opensearch.dataprepper.model.breaker.CircuitBreaker;
 import org.opensearch.dataprepper.model.event.EventFactory;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
 
 import java.util.Map;
 import java.util.function.Supplier;
@@ -29,6 +30,9 @@ class ApplicationContextToTypedSuppliersTest {
     private EventFactory eventFactory;
 
     @Mock
+    private EventKeyFactory eventKeyFactory;
+
+    @Mock
     private AcknowledgementSetManager acknowledgementSetManager;
 
     @Mock
@@ -37,6 +41,7 @@ class ApplicationContextToTypedSuppliersTest {
     private ApplicationContextToTypedSuppliers createObjectUnderTest() {
         return new ApplicationContextToTypedSuppliers(
                 eventFactory,
+                eventKeyFactory,
                 acknowledgementSetManager,
                 circuitBreaker
         );
@@ -58,11 +63,15 @@ class ApplicationContextToTypedSuppliersTest {
     void getArgumentsSuppliers_returns_map_with_expected_classes() {
         final Map<Class<?>, Supplier<Object>> argumentsSuppliers = createObjectUnderTest().getArgumentsSuppliers();
 
-        assertThat(argumentsSuppliers.size(), equalTo(3));
+        assertThat(argumentsSuppliers.size(), equalTo(4));
 
         assertThat(argumentsSuppliers, hasKey(EventFactory.class));
         assertThat(argumentsSuppliers.get(EventFactory.class), notNullValue());
         assertThat(argumentsSuppliers.get(EventFactory.class).get(), equalTo(eventFactory));
+
+        assertThat(argumentsSuppliers, hasKey(EventKeyFactory.class));
+        assertThat(argumentsSuppliers.get(EventKeyFactory.class), notNullValue());
+        assertThat(argumentsSuppliers.get(EventKeyFactory.class).get(), equalTo(eventKeyFactory));
 
         assertThat(argumentsSuppliers, hasKey(AcknowledgementSetManager.class));
         assertThat(argumentsSuppliers.get(AcknowledgementSetManager.class), notNullValue());
@@ -79,11 +88,15 @@ class ApplicationContextToTypedSuppliersTest {
 
         final Map<Class<?>, Supplier<Object>> argumentsSuppliers = createObjectUnderTest().getArgumentsSuppliers();
 
-        assertThat(argumentsSuppliers.size(), equalTo(3));
+        assertThat(argumentsSuppliers.size(), equalTo(4));
 
         assertThat(argumentsSuppliers, hasKey(EventFactory.class));
         assertThat(argumentsSuppliers.get(EventFactory.class), notNullValue());
         assertThat(argumentsSuppliers.get(EventFactory.class).get(), equalTo(eventFactory));
+
+        assertThat(argumentsSuppliers, hasKey(EventKeyFactory.class));
+        assertThat(argumentsSuppliers.get(EventKeyFactory.class), notNullValue());
+        assertThat(argumentsSuppliers.get(EventKeyFactory.class).get(), equalTo(eventKeyFactory));
 
         assertThat(argumentsSuppliers, hasKey(AcknowledgementSetManager.class));
         assertThat(argumentsSuppliers.get(AcknowledgementSetManager.class), notNullValue());

--- a/data-prepper-test-event/src/main/java/org/opensearch/dataprepper/event/TestEventContext.java
+++ b/data-prepper-test-event/src/main/java/org/opensearch/dataprepper/event/TestEventContext.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.event;
+
+import org.opensearch.dataprepper.core.event.EventFactoryApplicationContextMarker;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+class TestEventContext {
+    private static AnnotationConfigApplicationContext APPLICATION_CONTEXT;
+
+    private TestEventContext() {}
+
+    static <T> T getFromContext(final Class<T> targetClass) {
+        if(APPLICATION_CONTEXT == null) {
+            APPLICATION_CONTEXT = new AnnotationConfigApplicationContext();
+            APPLICATION_CONTEXT.scan(EventFactoryApplicationContextMarker.class.getPackageName());
+            APPLICATION_CONTEXT.refresh();
+        }
+        return APPLICATION_CONTEXT.getBean(targetClass);
+    }
+}

--- a/data-prepper-test-event/src/main/java/org/opensearch/dataprepper/event/TestEventFactory.java
+++ b/data-prepper-test-event/src/main/java/org/opensearch/dataprepper/event/TestEventFactory.java
@@ -5,18 +5,15 @@
 
 package org.opensearch.dataprepper.event;
 
-import org.opensearch.dataprepper.core.event.EventFactoryApplicationContextMarker;
 import org.opensearch.dataprepper.model.event.BaseEventBuilder;
 import org.opensearch.dataprepper.model.event.Event;
 import org.opensearch.dataprepper.model.event.EventFactory;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 /**
  * An implementation of {@link EventFactory} that is useful for integration and unit tests
  * in other projects.
  */
 public class TestEventFactory implements EventFactory {
-    private static AnnotationConfigApplicationContext APPLICATION_CONTEXT;
     private static EventFactory DEFAULT_EVENT_FACTORY;
     private final EventFactory innerEventFactory;
 
@@ -25,11 +22,8 @@ public class TestEventFactory implements EventFactory {
     }
 
     public static EventFactory getTestEventFactory() {
-        if(APPLICATION_CONTEXT == null) {
-            APPLICATION_CONTEXT = new AnnotationConfigApplicationContext();
-            APPLICATION_CONTEXT.scan(EventFactoryApplicationContextMarker.class.getPackageName());
-            APPLICATION_CONTEXT.refresh();
-            DEFAULT_EVENT_FACTORY = APPLICATION_CONTEXT.getBean(EventFactory.class);
+        if(DEFAULT_EVENT_FACTORY == null) {
+            DEFAULT_EVENT_FACTORY = TestEventContext.getFromContext(EventFactory.class);
         }
         return new TestEventFactory(DEFAULT_EVENT_FACTORY);
     }

--- a/data-prepper-test-event/src/main/java/org/opensearch/dataprepper/event/TestEventKeyFactory.java
+++ b/data-prepper-test-event/src/main/java/org/opensearch/dataprepper/event/TestEventKeyFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.event;
+
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+
+public class TestEventKeyFactory implements EventKeyFactory {
+    private static EventKeyFactory DEFAULT_EVENT_KEY_FACTORY;
+    private final EventKeyFactory innerEventKeyFactory;
+
+    TestEventKeyFactory(final EventKeyFactory innerEventKeyFactory) {
+        this.innerEventKeyFactory = innerEventKeyFactory;
+    }
+
+    public static EventKeyFactory getTestEventFactory() {
+        if(DEFAULT_EVENT_KEY_FACTORY == null) {
+            DEFAULT_EVENT_KEY_FACTORY = TestEventContext.getFromContext(EventKeyFactory.class);
+        }
+        return new TestEventKeyFactory(DEFAULT_EVENT_KEY_FACTORY);
+    }
+
+    @Override
+    public EventKey createEventKey(final String key, final EventAction... forActions) {
+        return innerEventKeyFactory.createEventKey(key, forActions);
+    }
+}

--- a/data-prepper-test-event/src/test/java/org/opensearch/dataprepper/event/TestEventKeyFactoryTest.java
+++ b/data-prepper-test-event/src/test/java/org/opensearch/dataprepper/event/TestEventKeyFactoryTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestEventKeyFactoryTest {
+
+    @Mock
+    private EventKeyFactory innerEventKeyFactory;
+
+    @Mock
+    private EventKey eventKey;
+
+    private TestEventKeyFactory createObjectUnderTest() {
+        return new TestEventKeyFactory(innerEventKeyFactory);
+    }
+
+    @Test
+    void createEventKey_returns_from_inner_EventKeyFactory() {
+        final String keyPath = UUID.randomUUID().toString();
+        when(innerEventKeyFactory.createEventKey(keyPath, EventKeyFactory.EventAction.ALL))
+                .thenReturn(eventKey);
+
+        assertThat(createObjectUnderTest().createEventKey(keyPath),
+                equalTo(eventKey));
+    }
+
+    @ParameterizedTest
+    @EnumSource(EventKeyFactory.EventAction.class)
+    void createEventKey_with_Actions_returns_from_inner_EventKeyFactory(final EventKeyFactory.EventAction eventAction) {
+        final String keyPath = UUID.randomUUID().toString();
+        when(innerEventKeyFactory.createEventKey(keyPath, eventAction))
+                .thenReturn(eventKey);
+
+        assertThat(createObjectUnderTest().createEventKey(keyPath, eventAction),
+                equalTo(eventKey));
+    }
+}


### PR DESCRIPTION
### Description

This PR adds an `EventKey` model for accessing data within the `Event` model. This allows for faster validations and for caching internal details between calls.
 
### Issues Resolved

Resolves #1916.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
