### PR TITLE
Updates the user_agent processor to use the EventKey.

### DIFF
--- a/data-prepper-plugins/user-agent-processor/build.gradle
+++ b/data-prepper-plugins/user-agent-processor/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.github.ua-parser:uap-java:1.6.1'
     implementation libs.caffeine
+    testImplementation project(':data-prepper-test-event')
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessor.java
+++ b/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessor.java
@@ -43,7 +43,7 @@ public class UserAgentProcessor extends AbstractProcessor<Record<Event>, Record<
         super(pluginMetrics);
         this.config = config;
         this.userAgentParser = new CaffeineCachingParser(config.getCacheSize());
-        sourceKey = eventKeyFactory.createEventKey(config.getSource(), EventKeyFactory.EventAction.GET);
+        sourceKey = config.getSource();
         targetKey = eventKeyFactory.createEventKey(config.getTarget(), EventKeyFactory.EventAction.PUT);
     }
 

--- a/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessor.java
+++ b/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessor.java
@@ -65,7 +65,7 @@ public class UserAgentProcessor extends AbstractProcessor<Record<Event>, Record<
                 event.put(targetKey, parsedUserAgent);
             } catch (Exception e) {
                 LOG.error(EVENT, "An exception occurred when parsing user agent data from event [{}] with source key [{}]",
-                        event, sourceKey.getKey(), e);
+                        event, sourceKey, e);
 
                 final List<String> tagsOnParseFailure = config.getTagsOnParseFailure();
                 if (Objects.nonNull(tagsOnParseFailure) && tagsOnParseFailure.size() > 0) {

--- a/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessor.java
+++ b/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessor.java
@@ -43,8 +43,8 @@ public class UserAgentProcessor extends AbstractProcessor<Record<Event>, Record<
         super(pluginMetrics);
         this.config = config;
         this.userAgentParser = new CaffeineCachingParser(config.getCacheSize());
-        sourceKey = config.getSource();
-        targetKey = eventKeyFactory.createEventKey(config.getTarget(), EventKeyFactory.EventAction.PUT);
+        this.sourceKey = config.getSource();
+        this.targetKey = eventKeyFactory.createEventKey(config.getTarget(), EventKeyFactory.EventAction.PUT);
     }
 
     @Override

--- a/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessorConfig.java
+++ b/data-prepper-plugins/user-agent-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessorConfig.java
@@ -8,6 +8,9 @@ package org.opensearch.dataprepper.plugins.processor.useragent;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyConfiguration;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
 
 import java.util.List;
 
@@ -18,7 +21,8 @@ public class UserAgentProcessorConfig {
     @NotEmpty
     @NotNull
     @JsonProperty("source")
-    private String source;
+    @EventKeyConfiguration(EventKeyFactory.EventAction.GET)
+    private EventKey source;
 
     @NotNull
     @JsonProperty("target")
@@ -34,7 +38,7 @@ public class UserAgentProcessorConfig {
     @JsonProperty("tags_on_parse_failure")
     private List<String> tagsOnParseFailure;
 
-    public String getSource() {
+    public EventKey getSource() {
         return source;
     }
 

--- a/data-prepper-plugins/user-agent-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessorTest.java
+++ b/data-prepper-plugins/user-agent-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessorTest.java
@@ -12,8 +12,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.event.TestEventKeyFactory;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.record.Record;
 
@@ -37,6 +39,8 @@ class UserAgentProcessorTest {
 
     @Mock
     private UserAgentProcessorConfig mockConfig;
+
+    private final EventKeyFactory eventKeyFactory = TestEventKeyFactory.getTestEventFactory();
 
     @ParameterizedTest
     @MethodSource("userAgentStringArguments")
@@ -109,6 +113,7 @@ class UserAgentProcessorTest {
     public void testParsingWhenUserAgentStringNotExist() {
         when(mockConfig.getSource()).thenReturn("bad_source");
         when(mockConfig.getCacheSize()).thenReturn(TEST_CACHE_SIZE);
+        when(mockConfig.getTarget()).thenReturn("user_agent");
 
         final UserAgentProcessor processor = createObjectUnderTest();
         final Record<Event> testRecord = createTestRecord(UUID.randomUUID().toString());
@@ -122,6 +127,7 @@ class UserAgentProcessorTest {
     public void testTagsAddedOnParseFailure() {
         when(mockConfig.getSource()).thenReturn("bad_source");
         when(mockConfig.getCacheSize()).thenReturn(TEST_CACHE_SIZE);
+        when(mockConfig.getTarget()).thenReturn("user_agent");
 
         final String tagOnFailure1 = UUID.randomUUID().toString();
         final String tagOnFailure2 = UUID.randomUUID().toString();
@@ -138,7 +144,7 @@ class UserAgentProcessorTest {
     }
 
     private UserAgentProcessor createObjectUnderTest() {
-        return new UserAgentProcessor(pluginMetrics, mockConfig);
+        return new UserAgentProcessor(mockConfig, eventKeyFactory, pluginMetrics);
     }
 
     private Record<Event> createTestRecord(String uaString) {

--- a/data-prepper-plugins/user-agent-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessorTest.java
+++ b/data-prepper-plugins/user-agent-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/useragent/UserAgentProcessorTest.java
@@ -46,7 +46,7 @@ class UserAgentProcessorTest {
     @MethodSource("userAgentStringArguments")
     public void testParsingUserAgentStrings(
             String uaString, String uaName, String uaVersion, String osName, String osVersion, String osFull, String deviceName) {
-        when(mockConfig.getSource()).thenReturn("source");
+        when(mockConfig.getSource()).thenReturn(eventKeyFactory.createEventKey("source"));
         when(mockConfig.getTarget()).thenReturn("user_agent");
         when(mockConfig.getCacheSize()).thenReturn(TEST_CACHE_SIZE);
 
@@ -68,7 +68,7 @@ class UserAgentProcessorTest {
     @MethodSource("userAgentStringArguments")
     public void testParsingUserAgentStringsWithCustomTarget(
             String uaString, String uaName, String uaVersion, String osName, String osVersion, String osFull, String deviceName) {
-        when(mockConfig.getSource()).thenReturn("source");
+        when(mockConfig.getSource()).thenReturn(eventKeyFactory.createEventKey("source"));
         when(mockConfig.getTarget()).thenReturn("my_target");
         when(mockConfig.getCacheSize()).thenReturn(TEST_CACHE_SIZE);
 
@@ -90,7 +90,7 @@ class UserAgentProcessorTest {
     @MethodSource("userAgentStringArguments")
     public void testParsingUserAgentStringsExcludeOriginal(
             String uaString, String uaName, String uaVersion, String osName, String osVersion, String osFull, String deviceName) {
-        when(mockConfig.getSource()).thenReturn("source");
+        when(mockConfig.getSource()).thenReturn(eventKeyFactory.createEventKey("source"));
         when(mockConfig.getTarget()).thenReturn("user_agent");
         when(mockConfig.getExcludeOriginal()).thenReturn(true);
         when(mockConfig.getCacheSize()).thenReturn(TEST_CACHE_SIZE);
@@ -111,7 +111,7 @@ class UserAgentProcessorTest {
 
     @Test
     public void testParsingWhenUserAgentStringNotExist() {
-        when(mockConfig.getSource()).thenReturn("bad_source");
+        when(mockConfig.getSource()).thenReturn(eventKeyFactory.createEventKey("bad_source"));
         when(mockConfig.getCacheSize()).thenReturn(TEST_CACHE_SIZE);
         when(mockConfig.getTarget()).thenReturn("user_agent");
 
@@ -125,7 +125,7 @@ class UserAgentProcessorTest {
 
     @Test
     public void testTagsAddedOnParseFailure() {
-        when(mockConfig.getSource()).thenReturn("bad_source");
+        when(mockConfig.getSource()).thenReturn(eventKeyFactory.createEventKey("bad_source"));
         when(mockConfig.getCacheSize()).thenReturn(TEST_CACHE_SIZE);
         when(mockConfig.getTarget()).thenReturn("user_agent");
 


### PR DESCRIPTION
### Description

This draft PR updates the `user_agent` processor to use the `EventKey`. It depends on changes from #4627, so this is a draft PR for now.
 
### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
