### PR TITLE
Implements equals, hashCode, and toString for JacksonEventKey.

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEventKey.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEventKey.java
@@ -71,6 +71,26 @@ class JacksonEventKey implements EventKey {
         return supportedActions.contains(eventAction);
     }
 
+    @Override
+    public boolean equals(final Object other) {
+        if (this == other)
+            return true;
+        if (other == null || getClass() != other.getClass())
+            return false;
+        final JacksonEventKey that = (JacksonEventKey) other;
+        return Objects.equals(key, that.key) && Arrays.equals(eventActions, that.eventActions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, Arrays.hashCode(eventActions));
+    }
+
+    @Override
+    public String toString() {
+        return key;
+    }
+
     private String checkAndTrimKey(final String key) {
         checkKey(key);
         return trimTrailingSlashInKey(key);

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventKeyTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventKeyTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -175,5 +176,92 @@ class JacksonEventKeyTest {
                     arguments(List.of(EventKeyFactory.EventAction.ALL), EventKeyFactory.EventAction.DELETE, true)
             );
         }
+    }
+
+    @ParameterizedTest
+    @EnumSource(EventKeyFactory.EventAction.class)
+    void equals_returns_true_for_same_key_and_actions(final EventKeyFactory.EventAction eventAction) {
+        final String testKey = UUID.randomUUID().toString();
+        final JacksonEventKey objectUnderTest = new JacksonEventKey(testKey, eventAction);
+        final JacksonEventKey other = new JacksonEventKey(testKey, eventAction);
+
+        assertThat(objectUnderTest.equals(other), equalTo(true));
+    }
+
+    @Test
+    void equals_returns_true_for_same_instance() {
+        final JacksonEventKey objectUnderTest = new JacksonEventKey(UUID.randomUUID().toString(),
+                EventKeyFactory.EventAction.PUT);
+
+        assertThat(objectUnderTest.equals(objectUnderTest), equalTo(true));
+    }
+
+    @Test
+    void equals_returns_false_for_null() {
+        final JacksonEventKey objectUnderTest = new JacksonEventKey(UUID.randomUUID().toString(),
+                EventKeyFactory.EventAction.PUT);
+
+        assertThat(objectUnderTest.equals(null), equalTo(false));
+    }
+
+    @Test
+    void equals_returns_false_for_non_EventKey() {
+        final String testKey = UUID.randomUUID().toString();
+        final JacksonEventKey objectUnderTest = new JacksonEventKey(testKey,
+                EventKeyFactory.EventAction.PUT);
+
+        assertThat(objectUnderTest.equals(testKey), equalTo(false));
+    }
+
+    @Test
+    void equals_returns_false_for_same_key_but_different_actions() {
+        final String testKey = UUID.randomUUID().toString();
+        final JacksonEventKey objectUnderTest = new JacksonEventKey(testKey, EventKeyFactory.EventAction.PUT);
+        final JacksonEventKey other = new JacksonEventKey(testKey, EventKeyFactory.EventAction.GET);
+
+        assertThat(objectUnderTest.equals(other), equalTo(false));
+    }
+
+    @ParameterizedTest
+    @EnumSource(EventKeyFactory.EventAction.class)
+    void equals_returns_false_for_different_key_but_same_actions(final EventKeyFactory.EventAction eventAction) {
+        final JacksonEventKey objectUnderTest = new JacksonEventKey(UUID.randomUUID().toString(), eventAction);
+        final JacksonEventKey other = new JacksonEventKey(UUID.randomUUID().toString(), eventAction);
+
+        assertThat(objectUnderTest.equals(other), equalTo(false));
+    }
+
+    @ParameterizedTest
+    @EnumSource(EventKeyFactory.EventAction.class)
+    void hashCode_is_the_same_for_same_key_and_actions(final EventKeyFactory.EventAction eventAction) {
+        final String testKey = UUID.randomUUID().toString();
+        final JacksonEventKey objectUnderTest = new JacksonEventKey(testKey, eventAction);
+        final JacksonEventKey other = new JacksonEventKey(testKey, eventAction);
+
+        assertThat(objectUnderTest.hashCode(), equalTo(other.hashCode()));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "test, PUT, test2, PUT",
+            "test, PUT, test2, PUT",
+            "test, PUT, test, GET"
+    })
+    void hashCode_is_the_different_for_same_key_and_actions(
+            final String testKey, final EventKeyFactory.EventAction eventAction,
+            final String testKeyOther, final EventKeyFactory.EventAction eventActionOther) {
+        final JacksonEventKey objectUnderTest = new JacksonEventKey(testKey, eventAction);
+        final JacksonEventKey other = new JacksonEventKey(testKeyOther, eventActionOther);
+
+        assertThat(objectUnderTest.hashCode(), not(equalTo(other.hashCode())));
+    }
+
+    @ParameterizedTest
+    @EnumSource(EventKeyFactory.EventAction.class)
+    void toString_returns_the_key(final EventKeyFactory.EventAction eventAction) {
+        final String testKey = UUID.randomUUID().toString();
+        final JacksonEventKey objectUnderTest = new JacksonEventKey(testKey, eventAction);
+
+        assertThat(objectUnderTest.toString(), equalTo(testKey));
     }
 }


### PR DESCRIPTION
### Description

Implements the `equals()`, `hashCode()`, and `toString()` methods for `JacksonEventKey`.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
