### PR TITLE
Update the rename_keys and delete_entries processors to use EventKey

### DIFF
--- a/data-prepper-plugins/mutate-event-processors/build.gradle
+++ b/data-prepper-plugins/mutate-event-processors/build.gradle
@@ -22,4 +22,6 @@ dependencies {
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    testImplementation project(':data-prepper-test-event')
+    testImplementation testLibs.slf4j.simple
 }

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessor.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessor.java
@@ -10,6 +10,7 @@ import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
 import org.opensearch.dataprepper.model.processor.AbstractProcessor;
 import org.opensearch.dataprepper.model.processor.Processor;
 import org.opensearch.dataprepper.model.record.Record;
@@ -17,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
@@ -25,7 +27,7 @@ import static org.opensearch.dataprepper.logging.DataPrepperMarkers.EVENT;
 public class DeleteEntryProcessor extends AbstractProcessor<Record<Event>, Record<Event>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(DeleteEntryProcessor.class);
-    private final String[] entries;
+    private final List<EventKey> entries;
     private final String deleteWhen;
 
     private final ExpressionEvaluator expressionEvaluator;
@@ -49,7 +51,7 @@ public class DeleteEntryProcessor extends AbstractProcessor<Record<Event>, Recor
                 }
 
 
-                for (String entry : entries) {
+                for (final EventKey entry : entries) {
                     recordEvent.delete(entry);
                 }
             } catch (final Exception e) {

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorConfig.java
@@ -8,17 +8,23 @@ package org.opensearch.dataprepper.plugins.processor.mutateevent;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyConfiguration;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+
+import java.util.List;
 
 public class DeleteEntryProcessorConfig {
     @NotEmpty
     @NotNull
     @JsonProperty("with_keys")
-    private String[] withKeys;
+    @EventKeyConfiguration(EventKeyFactory.EventAction.DELETE)
+    private List<@NotNull @NotEmpty EventKey> withKeys;
 
     @JsonProperty("delete_when")
     private String deleteWhen;
 
-    public String[] getWithKeys() {
+    public List<EventKey> getWithKeys() {
         return withKeys;
     }
 

--- a/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
+++ b/data-prepper-plugins/mutate-event-processors/src/main/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorConfig.java
@@ -9,6 +9,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyConfiguration;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
 
 import java.util.List;
 
@@ -17,12 +20,14 @@ public class RenameKeyProcessorConfig {
         @NotEmpty
         @NotNull
         @JsonProperty("from_key")
-        private String fromKey;
+        @EventKeyConfiguration({EventKeyFactory.EventAction.GET, EventKeyFactory.EventAction.DELETE})
+        private EventKey fromKey;
 
         @NotEmpty
         @NotNull
         @JsonProperty("to_key")
-        private String toKey;
+        @EventKeyConfiguration(EventKeyFactory.EventAction.PUT)
+        private EventKey toKey;
 
         @JsonProperty("overwrite_if_to_key_exists")
         private boolean overwriteIfToKeyExists = false;
@@ -30,11 +35,11 @@ public class RenameKeyProcessorConfig {
         @JsonProperty("rename_when")
         private String renameWhen;
 
-        public String getFromKey() {
+        public EventKey getFromKey() {
             return fromKey;
         }
 
-        public String getToKey() {
+        public EventKey getToKey() {
             return toKey;
         }
 
@@ -44,7 +49,7 @@ public class RenameKeyProcessorConfig {
 
         public String getRenameWhen() { return renameWhen; }
 
-        public Entry(final String fromKey, final String toKey, final boolean overwriteIfKeyExists, final String renameWhen) {
+        public Entry(final EventKey fromKey, final EventKey toKey, final boolean overwriteIfKeyExists, final String renameWhen) {
             this.fromKey = fromKey;
             this.toKey = toKey;
             this.overwriteIfToKeyExists = overwriteIfKeyExists;

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/DeleteEntryProcessorTests.java
@@ -5,15 +5,17 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
-import org.opensearch.dataprepper.expression.ExpressionEvaluator;
-import org.opensearch.dataprepper.metrics.PluginMetrics;
-import org.opensearch.dataprepper.model.event.Event;
-import org.opensearch.dataprepper.model.event.JacksonEvent;
-import org.opensearch.dataprepper.model.record.Record;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.dataprepper.event.TestEventKeyFactory;
+import org.opensearch.dataprepper.expression.ExpressionEvaluator;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.record.Record;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -36,9 +38,11 @@ public class DeleteEntryProcessorTests {
     @Mock
     private ExpressionEvaluator expressionEvaluator;
 
+    private final EventKeyFactory eventKeyFactory = TestEventKeyFactory.getTestEventFactory();
+
     @Test
     public void testSingleDeleteProcessorTest() {
-        when(mockConfig.getWithKeys()).thenReturn(new String[] { "message" });
+        when(mockConfig.getWithKeys()).thenReturn(List.of(eventKeyFactory.createEventKey("message", EventKeyFactory.EventAction.DELETE)));
         when(mockConfig.getDeleteWhen()).thenReturn(null);
 
         final DeleteEntryProcessor processor = createObjectUnderTest();
@@ -52,7 +56,7 @@ public class DeleteEntryProcessorTests {
 
     @Test
     public void testWithKeyDneDeleteProcessorTest() {
-        when(mockConfig.getWithKeys()).thenReturn(new String[] { "message2" });
+        when(mockConfig.getWithKeys()).thenReturn(List.of(eventKeyFactory.createEventKey("message2", EventKeyFactory.EventAction.DELETE)));
         when(mockConfig.getDeleteWhen()).thenReturn(null);
 
         final DeleteEntryProcessor processor = createObjectUnderTest();
@@ -67,7 +71,9 @@ public class DeleteEntryProcessorTests {
 
     @Test
     public void testMultiDeleteProcessorTest() {
-        when(mockConfig.getWithKeys()).thenReturn(new String[] { "message", "message2" });
+        when(mockConfig.getWithKeys()).thenReturn(List.of(
+                eventKeyFactory.createEventKey("message", EventKeyFactory.EventAction.DELETE),
+                eventKeyFactory.createEventKey("message2", EventKeyFactory.EventAction.DELETE)));
         when(mockConfig.getDeleteWhen()).thenReturn(null);
 
         final DeleteEntryProcessor processor = createObjectUnderTest();
@@ -83,7 +89,7 @@ public class DeleteEntryProcessorTests {
 
     @Test
     public void testKeyIsNotDeleted_when_deleteWhen_returns_false() {
-        when(mockConfig.getWithKeys()).thenReturn(new String[] { "message" });
+        when(mockConfig.getWithKeys()).thenReturn(List.of(eventKeyFactory.createEventKey("message", EventKeyFactory.EventAction.DELETE)));
         final String deleteWhen = UUID.randomUUID().toString();
         when(mockConfig.getDeleteWhen()).thenReturn(deleteWhen);
 
@@ -98,8 +104,9 @@ public class DeleteEntryProcessorTests {
         assertThat(editedRecords.get(0).getData().containsKey("newMessage"), is(true));
     }
 
+    @Test
     public void testNestedDeleteProcessorTest() {
-        when(mockConfig.getWithKeys()).thenReturn(new String[]{"nested/foo"});
+        when(mockConfig.getWithKeys()).thenReturn(List.of(eventKeyFactory.createEventKey("nested/foo", EventKeyFactory.EventAction.DELETE)));
 
         Map<String, Object> nested = Map.of("foo", "bar", "fizz", 42);
 

--- a/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorTests.java
+++ b/data-prepper-plugins/mutate-event-processors/src/test/java/org/opensearch/dataprepper/plugins/processor/mutateevent/RenameKeyProcessorTests.java
@@ -5,9 +5,12 @@
 
 package org.opensearch.dataprepper.plugins.processor.mutateevent;
 
+import org.opensearch.dataprepper.event.TestEventKeyFactory;
 import org.opensearch.dataprepper.expression.ExpressionEvaluator;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.event.EventKey;
+import org.opensearch.dataprepper.model.event.EventKeyFactory;
 import org.opensearch.dataprepper.model.event.JacksonEvent;
 import org.opensearch.dataprepper.model.record.Record;
 import org.junit.jupiter.api.Test;
@@ -38,6 +41,8 @@ public class RenameKeyProcessorTests {
 
     @Mock
     private ExpressionEvaluator expressionEvaluator;
+
+    private final EventKeyFactory eventKeyFactory = TestEventKeyFactory.getTestEventFactory();
 
     @Test
     public void testSingleOverwriteRenameProcessorTests() {
@@ -136,7 +141,9 @@ public class RenameKeyProcessorTests {
     }
 
     private RenameKeyProcessorConfig.Entry createEntry(final String fromKey, final String toKey, final boolean overwriteIfToKeyExists, final String renameWhen) {
-        return new RenameKeyProcessorConfig.Entry(fromKey, toKey, overwriteIfToKeyExists, renameWhen);
+        final EventKey fromEventKey = eventKeyFactory.createEventKey(fromKey);
+        final EventKey toEventKey = eventKeyFactory.createEventKey(toKey);
+        return new RenameKeyProcessorConfig.Entry(fromEventKey, toEventKey, overwriteIfToKeyExists, renameWhen);
     }
 
     private List<RenameKeyProcessorConfig.Entry> createListOfEntries(final RenameKeyProcessorConfig.Entry... entries) {


### PR DESCRIPTION
### Description

This PR builds on the work in #4627 and #4635 to support the `EventKey` in the `rename_keys` and `delete_entries` processors.

Additionally, it checks for not empty and not null on entries in the `delete_entries` processor. This was probably intended, but not actually verified.

This depends on #4635 to be merged first. I'm creating this as a draft PR for now.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
