### PR TITLE
Add support to configure metric name for count and histogram actions

### DIFF
--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
@@ -48,7 +48,7 @@ public class CountAggregateAction implements AggregateAction {
     public final String endTimeKey;
     public final String outputFormat;
     private long startTimeNanos;
-    private final String name;
+    private final String metricName;
 
     @DataPrepperPluginConstructor
     public CountAggregateAction(final CountAggregateActionConfig countAggregateActionConfig) {
@@ -56,7 +56,7 @@ public class CountAggregateAction implements AggregateAction {
         this.startTimeKey = countAggregateActionConfig.getStartTimeKey();
         this.endTimeKey = countAggregateActionConfig.getEndTimeKey();
         this.outputFormat = countAggregateActionConfig.getOutputFormat();
-        this.name = countAggregateActionConfig.getName();
+        this.metricName = countAggregateActionConfig.getMetricName();
     }
 
     public Exemplar createExemplar(final Event event) {
@@ -134,7 +134,7 @@ public class CountAggregateAction implements AggregateAction {
             Map<String, Object> attr = new HashMap<String, Object>();
             groupState.forEach((k, v) -> attr.put((String)k, v));
             JacksonSum sum = JacksonSum.builder()
-                .withName(this.name)
+                .withName(this.metricName)
                 .withDescription(SUM_METRIC_DESCRIPTION)
                 .withTime(OTelProtoCodec.convertUnixNanosToISO8601(endTimeNanos))
                 .withStartTime(OTelProtoCodec.convertUnixNanosToISO8601(startTimeNanos))

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateAction.java
@@ -40,7 +40,6 @@ public class CountAggregateAction implements AggregateAction {
     private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
     private static final String exemplarKey = "__exemplar";
     static final String EVENT_TYPE = "event";
-    static final String SUM_METRIC_NAME = "count";
     static final String SUM_METRIC_DESCRIPTION = "Number of events";
     static final String SUM_METRIC_UNIT = "1";
     static final boolean SUM_METRIC_IS_MONOTONIC = true;
@@ -49,6 +48,7 @@ public class CountAggregateAction implements AggregateAction {
     public final String endTimeKey;
     public final String outputFormat;
     private long startTimeNanos;
+    private final String name;
 
     @DataPrepperPluginConstructor
     public CountAggregateAction(final CountAggregateActionConfig countAggregateActionConfig) {
@@ -56,6 +56,7 @@ public class CountAggregateAction implements AggregateAction {
         this.startTimeKey = countAggregateActionConfig.getStartTimeKey();
         this.endTimeKey = countAggregateActionConfig.getEndTimeKey();
         this.outputFormat = countAggregateActionConfig.getOutputFormat();
+        this.name = countAggregateActionConfig.getName();
     }
 
     public Exemplar createExemplar(final Event event) {
@@ -133,7 +134,7 @@ public class CountAggregateAction implements AggregateAction {
             Map<String, Object> attr = new HashMap<String, Object>();
             groupState.forEach((k, v) -> attr.put((String)k, v));
             JacksonSum sum = JacksonSum.builder()
-                .withName(SUM_METRIC_NAME)
+                .withName(this.name)
                 .withDescription(SUM_METRIC_DESCRIPTION)
                 .withTime(OTelProtoCodec.convertUnixNanosToISO8601(endTimeNanos))
                 .withStartTime(OTelProtoCodec.convertUnixNanosToISO8601(startTimeNanos))

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionConfig.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class CountAggregateActionConfig {
+    static final String SUM_METRIC_NAME = "count";
     public static final String DEFAULT_COUNT_KEY = "aggr._count";
     public static final String DEFAULT_START_TIME_KEY = "aggr._start_time";
     public static final String DEFAULT_END_TIME_KEY = "aggr._end_time";
@@ -17,6 +18,9 @@ public class CountAggregateActionConfig {
 
     @JsonProperty("count_key")
     String countKey = DEFAULT_COUNT_KEY;
+
+    @JsonProperty("name")
+    String name = SUM_METRIC_NAME;
 
     @JsonProperty("start_time_key")
     String startTimeKey = DEFAULT_START_TIME_KEY;
@@ -26,6 +30,10 @@ public class CountAggregateActionConfig {
 
     @JsonProperty("output_format")
     String outputFormat = OutputFormat.OTEL_METRICS.toString();
+
+    public String getName() {
+        return name;
+    }
 
     public String getCountKey() {
         return countKey;

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionConfig.java
@@ -19,8 +19,8 @@ public class CountAggregateActionConfig {
     @JsonProperty("count_key")
     String countKey = DEFAULT_COUNT_KEY;
 
-    @JsonProperty("name")
-    String name = SUM_METRIC_NAME;
+    @JsonProperty("metric_name")
+    String metricName = SUM_METRIC_NAME;
 
     @JsonProperty("start_time_key")
     String startTimeKey = DEFAULT_START_TIME_KEY;
@@ -31,8 +31,8 @@ public class CountAggregateActionConfig {
     @JsonProperty("output_format")
     String outputFormat = OutputFormat.OTEL_METRICS.toString();
 
-    public String getName() {
-        return name;
+    public String getMetricName() {
+        return metricName;
     }
 
     public String getCountKey() {

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
@@ -44,7 +44,6 @@ import java.util.ArrayList;
 public class HistogramAggregateAction implements AggregateAction {
     private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
     private static final String EVENT_TYPE = "event";
-    public static final String HISTOGRAM_METRIC_NAME = "histogram";
     private final String countKey;
     private final String bucketCountsKey;
     private final String bucketsKey;
@@ -62,6 +61,7 @@ public class HistogramAggregateAction implements AggregateAction {
     private Event maxEvent;
     private double minValue;
     private double maxValue;
+    private final String name;
 
     private long startTimeNanos;
     private double[] buckets;
@@ -72,6 +72,7 @@ public class HistogramAggregateAction implements AggregateAction {
         List<Number> bucketList = histogramAggregateActionConfig.getBuckets();
         this.buckets = new double[bucketList.size()+2];
         int bucketIdx = 0;
+        this.name = histogramAggregateActionConfig.getName();
         this.buckets[bucketIdx++] = -Float.MAX_VALUE;
         for (int i = 0; i < bucketList.size(); i++) {
             this.buckets[bucketIdx++] = convertToDouble(bucketList.get(i));
@@ -212,7 +213,7 @@ public class HistogramAggregateAction implements AggregateAction {
         Instant endTime = (Instant)groupState.get(endTimeKey);
         long startTimeNanos = getTimeNanos(startTime);
         long endTimeNanos = getTimeNanos(endTime);
-        String histogramKey = HISTOGRAM_METRIC_NAME + "_key";
+        String histogramKey = this.name + "_key";
         List<Exemplar> exemplarList = new ArrayList<>();
         exemplarList.add(createExemplar("min", minEvent, minValue));
         exemplarList.add(createExemplar("max", maxEvent, maxValue));
@@ -245,7 +246,7 @@ public class HistogramAggregateAction implements AggregateAction {
             Integer count = (Integer)groupState.get(countKey);
             String description = String.format("Histogram of %s in the events", key);
             JacksonHistogram histogram = JacksonHistogram.builder()
-                .withName(HISTOGRAM_METRIC_NAME)
+                .withName(this.name)
                 .withDescription(description)
                 .withTime(OTelProtoCodec.convertUnixNanosToISO8601(endTimeNanos))
                 .withStartTime(OTelProtoCodec.convertUnixNanosToISO8601(startTimeNanos))

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateAction.java
@@ -61,7 +61,7 @@ public class HistogramAggregateAction implements AggregateAction {
     private Event maxEvent;
     private double minValue;
     private double maxValue;
-    private final String name;
+    private final String metricName;
 
     private long startTimeNanos;
     private double[] buckets;
@@ -72,7 +72,7 @@ public class HistogramAggregateAction implements AggregateAction {
         List<Number> bucketList = histogramAggregateActionConfig.getBuckets();
         this.buckets = new double[bucketList.size()+2];
         int bucketIdx = 0;
-        this.name = histogramAggregateActionConfig.getName();
+        this.metricName = histogramAggregateActionConfig.getMetricName();
         this.buckets[bucketIdx++] = -Float.MAX_VALUE;
         for (int i = 0; i < bucketList.size(); i++) {
             this.buckets[bucketIdx++] = convertToDouble(bucketList.get(i));
@@ -213,7 +213,7 @@ public class HistogramAggregateAction implements AggregateAction {
         Instant endTime = (Instant)groupState.get(endTimeKey);
         long startTimeNanos = getTimeNanos(startTime);
         long endTimeNanos = getTimeNanos(endTime);
-        String histogramKey = this.name + "_key";
+        String histogramKey = this.metricName + "_key";
         List<Exemplar> exemplarList = new ArrayList<>();
         exemplarList.add(createExemplar("min", minEvent, minValue));
         exemplarList.add(createExemplar("max", maxEvent, maxValue));
@@ -246,7 +246,7 @@ public class HistogramAggregateAction implements AggregateAction {
             Integer count = (Integer)groupState.get(countKey);
             String description = String.format("Histogram of %s in the events", key);
             JacksonHistogram histogram = JacksonHistogram.builder()
-                .withName(this.name)
+                .withName(this.metricName)
                 .withDescription(description)
                 .withTime(OTelProtoCodec.convertUnixNanosToISO8601(endTimeNanos))
                 .withStartTime(OTelProtoCodec.convertUnixNanosToISO8601(startTimeNanos))

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfig.java
@@ -33,8 +33,8 @@ public class HistogramAggregateActionConfig {
     @NotNull
     String units;
 
-    @JsonProperty("name")
-    String name = HISTOGRAM_METRIC_NAME;
+    @JsonProperty("metric_name")
+    String metricName = HISTOGRAM_METRIC_NAME;
 
     @JsonProperty("generated_key_prefix")
     String generatedKeyPrefix = DEFAULT_GENERATED_KEY_PREFIX;
@@ -49,8 +49,8 @@ public class HistogramAggregateActionConfig {
     @JsonProperty("record_minmax")
     boolean recordMinMax = false;
 
-    public String getName() {
-        return name;
+    public String getMetricName() {
+        return metricName;
     }
 
     public boolean getRecordMinMax() {

--- a/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfig.java
+++ b/data-prepper-plugins/aggregate-processor/src/main/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfig.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 
 public class HistogramAggregateActionConfig {
+    public static final String HISTOGRAM_METRIC_NAME = "histogram";
     public static final String DEFAULT_GENERATED_KEY_PREFIX = "aggr._";
     public static final String SUM_KEY = "sum";
     public static final String COUNT_KEY = "count";
@@ -32,6 +33,9 @@ public class HistogramAggregateActionConfig {
     @NotNull
     String units;
 
+    @JsonProperty("name")
+    String name = HISTOGRAM_METRIC_NAME;
+
     @JsonProperty("generated_key_prefix")
     String generatedKeyPrefix = DEFAULT_GENERATED_KEY_PREFIX;
 
@@ -44,6 +48,10 @@ public class HistogramAggregateActionConfig {
 
     @JsonProperty("record_minmax")
     boolean recordMinMax = false;
+
+    public String getName() {
+        return name;
+    }
 
     public boolean getRecordMinMax() {
         return recordMinMax;

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/AggregateProcessorIT.java
@@ -533,7 +533,7 @@ public class AggregateProcessorIT {
                 countDownLatch.countDown();
             });
         }
-        Thread.sleep(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE * 1000);
+        Thread.sleep(GROUP_DURATION_FOR_ONLY_SINGLE_CONCLUDE * 1500);
 
         boolean allThreadsFinished = countDownLatch.await(5L, TimeUnit.SECONDS);
         assertThat(allThreadsFinished, equalTo(true));

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionConfigTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionConfigTests.java
@@ -38,7 +38,7 @@ public class CountAggregateActionConfigTests {
         assertThat(countAggregateActionConfig.getCountKey(), equalTo(DEFAULT_COUNT_KEY));
         assertThat(countAggregateActionConfig.getStartTimeKey(), equalTo(DEFAULT_START_TIME_KEY));
         assertThat(countAggregateActionConfig.getOutputFormat(), equalTo(OutputFormat.OTEL_METRICS.toString()));
-        assertThat(countAggregateActionConfig.getName(), equalTo(CountAggregateActionConfig.SUM_METRIC_NAME));
+        assertThat(countAggregateActionConfig.getMetricName(), equalTo(CountAggregateActionConfig.SUM_METRIC_NAME));
     }
 
     @Test
@@ -53,8 +53,8 @@ public class CountAggregateActionConfigTests {
         setField(CountAggregateActionConfig.class, countAggregateActionConfig, "outputFormat", testOutputFormat);
         assertThat(countAggregateActionConfig.getOutputFormat(), equalTo(OutputFormat.OTEL_METRICS.toString()));
         final String testName = UUID.randomUUID().toString();
-        setField(CountAggregateActionConfig.class, countAggregateActionConfig, "name", testName);
-        assertThat(countAggregateActionConfig.getName(), equalTo(testName));
+        setField(CountAggregateActionConfig.class, countAggregateActionConfig, "metricName", testName);
+        assertThat(countAggregateActionConfig.getMetricName(), equalTo(testName));
     }
 
     @Test

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionConfigTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionConfigTests.java
@@ -38,6 +38,7 @@ public class CountAggregateActionConfigTests {
         assertThat(countAggregateActionConfig.getCountKey(), equalTo(DEFAULT_COUNT_KEY));
         assertThat(countAggregateActionConfig.getStartTimeKey(), equalTo(DEFAULT_START_TIME_KEY));
         assertThat(countAggregateActionConfig.getOutputFormat(), equalTo(OutputFormat.OTEL_METRICS.toString()));
+        assertThat(countAggregateActionConfig.getName(), equalTo(CountAggregateActionConfig.SUM_METRIC_NAME));
     }
 
     @Test
@@ -51,6 +52,9 @@ public class CountAggregateActionConfigTests {
         final String testOutputFormat = OutputFormat.OTEL_METRICS.toString();
         setField(CountAggregateActionConfig.class, countAggregateActionConfig, "outputFormat", testOutputFormat);
         assertThat(countAggregateActionConfig.getOutputFormat(), equalTo(OutputFormat.OTEL_METRICS.toString()));
+        final String testName = UUID.randomUUID().toString();
+        setField(CountAggregateActionConfig.class, countAggregateActionConfig, "name", testName);
+        assertThat(countAggregateActionConfig.getName(), equalTo(testName));
     }
 
     @Test

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
@@ -83,7 +83,7 @@ public class CountAggregateActionTest {
     void testCountAggregateOTelFormat(int testCount) throws NoSuchFieldException, IllegalAccessException {
         CountAggregateActionConfig countAggregateActionConfig = new CountAggregateActionConfig();
         final String testName = UUID.randomUUID().toString();
-        setField(CountAggregateActionConfig.class, countAggregateActionConfig, "name", testName);
+        setField(CountAggregateActionConfig.class, countAggregateActionConfig, "metricName", testName);
         countAggregateAction = createObjectUnderTest(countAggregateActionConfig);
         final String key1 = "key-"+UUID.randomUUID().toString();
         final String value1 = UUID.randomUUID().toString();
@@ -154,7 +154,7 @@ public class CountAggregateActionTest {
         CountAggregateActionConfig mockConfig = mock(CountAggregateActionConfig.class);
         when(mockConfig.getCountKey()).thenReturn(CountAggregateActionConfig.DEFAULT_COUNT_KEY);
         final String testName = UUID.randomUUID().toString();
-        when(mockConfig.getName()).thenReturn(testName);
+        when(mockConfig.getMetricName()).thenReturn(testName);
         String startTimeKey = UUID.randomUUID().toString();
         String endTimeKey = UUID.randomUUID().toString();
         when(mockConfig.getStartTimeKey()).thenReturn(startTimeKey);

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/CountAggregateActionTest.java
@@ -50,6 +50,7 @@ public class CountAggregateActionTest {
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 10, 100})
     void testCountAggregate(int testCount) throws NoSuchFieldException, IllegalAccessException {
+        final String testName = UUID.randomUUID().toString();
         CountAggregateActionConfig countAggregateActionConfig = new CountAggregateActionConfig();
         setField(CountAggregateActionConfig.class, countAggregateActionConfig, "outputFormat", OutputFormat.RAW.toString());
         countAggregateAction = createObjectUnderTest(countAggregateActionConfig);
@@ -79,8 +80,10 @@ public class CountAggregateActionTest {
 
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 10, 100})
-    void testCountAggregateOTelFormat(int testCount) {
+    void testCountAggregateOTelFormat(int testCount) throws NoSuchFieldException, IllegalAccessException {
         CountAggregateActionConfig countAggregateActionConfig = new CountAggregateActionConfig();
+        final String testName = UUID.randomUUID().toString();
+        setField(CountAggregateActionConfig.class, countAggregateActionConfig, "name", testName);
         countAggregateAction = createObjectUnderTest(countAggregateActionConfig);
         final String key1 = "key-"+UUID.randomUUID().toString();
         final String value1 = UUID.randomUUID().toString();
@@ -119,6 +122,7 @@ public class CountAggregateActionTest {
         expectedEventMap.put("isMonotonic", true);
         expectedEventMap.put("aggregationTemporality", "AGGREGATION_TEMPORALITY_DELTA");
         expectedEventMap.put("unit", "1");
+        expectedEventMap.put("name", testName);
         expectedEventMap.forEach((k, v) -> assertThat(result.get(0).toMap(), hasEntry(k,v)));
         assertThat(result.get(0).toMap().get("attributes"), equalTo(eventMap));
         JacksonMetric metric = (JacksonMetric) result.get(0);
@@ -149,6 +153,8 @@ public class CountAggregateActionTest {
     void testCountAggregateOTelFormatWithStartAndEndTimesInTheEvent(int testCount) {
         CountAggregateActionConfig mockConfig = mock(CountAggregateActionConfig.class);
         when(mockConfig.getCountKey()).thenReturn(CountAggregateActionConfig.DEFAULT_COUNT_KEY);
+        final String testName = UUID.randomUUID().toString();
+        when(mockConfig.getName()).thenReturn(testName);
         String startTimeKey = UUID.randomUUID().toString();
         String endTimeKey = UUID.randomUUID().toString();
         when(mockConfig.getStartTimeKey()).thenReturn(startTimeKey);
@@ -195,7 +201,7 @@ public class CountAggregateActionTest {
         assertThat(result.size(), equalTo(1));
         Map<String, Object> expectedEventMap = new HashMap<>();
         expectedEventMap.put("value", (double)testCount);
-        expectedEventMap.put("name", "count");
+        expectedEventMap.put("name", testName);
         expectedEventMap.put("description", "Number of events");
         expectedEventMap.put("isMonotonic", true);
         expectedEventMap.put("aggregationTemporality", "AGGREGATION_TEMPORALITY_DELTA");

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfigTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfigTests.java
@@ -43,7 +43,7 @@ public class HistogramAggregateActionConfigTests {
         assertThat(histogramAggregateActionConfig.getGeneratedKeyPrefix(), equalTo(DEFAULT_GENERATED_KEY_PREFIX));
         assertThat(histogramAggregateActionConfig.getRecordMinMax(), equalTo(false));
         assertThat(histogramAggregateActionConfig.getOutputFormat(), equalTo(OutputFormat.OTEL_METRICS.toString()));
-        assertThat(histogramAggregateActionConfig.getName(), equalTo(HistogramAggregateActionConfig.HISTOGRAM_METRIC_NAME));
+        assertThat(histogramAggregateActionConfig.getMetricName(), equalTo(HistogramAggregateActionConfig.HISTOGRAM_METRIC_NAME));
     }
 
     @Test
@@ -110,8 +110,8 @@ public class HistogramAggregateActionConfigTests {
         setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "buckets", longBuckets);
         assertThat(histogramAggregateActionConfig.getBuckets(), containsInAnyOrder(longBuckets.toArray()));
         final String testName = UUID.randomUUID().toString();
-        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "name", testName);
-        assertThat(histogramAggregateActionConfig.getName(), equalTo(testName));
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "metricName", testName);
+        assertThat(histogramAggregateActionConfig.getMetricName(), equalTo(testName));
     }
 
     @Test

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfigTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionConfigTests.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.apache.commons.lang3.RandomStringUtils;
 
+import java.util.UUID;
+
 import static org.opensearch.dataprepper.plugins.processor.aggregate.actions.HistogramAggregateActionConfig.DEFAULT_GENERATED_KEY_PREFIX;
 
 import java.util.concurrent.ThreadLocalRandom;
@@ -41,6 +43,7 @@ public class HistogramAggregateActionConfigTests {
         assertThat(histogramAggregateActionConfig.getGeneratedKeyPrefix(), equalTo(DEFAULT_GENERATED_KEY_PREFIX));
         assertThat(histogramAggregateActionConfig.getRecordMinMax(), equalTo(false));
         assertThat(histogramAggregateActionConfig.getOutputFormat(), equalTo(OutputFormat.OTEL_METRICS.toString()));
+        assertThat(histogramAggregateActionConfig.getName(), equalTo(HistogramAggregateActionConfig.HISTOGRAM_METRIC_NAME));
     }
 
     @Test
@@ -106,6 +109,9 @@ public class HistogramAggregateActionConfigTests {
         longBuckets.add(longValue2);
         setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "buckets", longBuckets);
         assertThat(histogramAggregateActionConfig.getBuckets(), containsInAnyOrder(longBuckets.toArray()));
+        final String testName = UUID.randomUUID().toString();
+        setField(HistogramAggregateActionConfig.class, histogramAggregateActionConfig, "name", testName);
+        assertThat(histogramAggregateActionConfig.getName(), equalTo(testName));
     }
 
     @Test

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
@@ -198,7 +198,7 @@ public class HistogramAggregateActionTests {
         final String expectedStartTimeKey = histogramAggregateActionConfig.getStartTimeKey();
         Map<String, Object> expectedEventMap = new HashMap<>(Collections.singletonMap("count", (long)testCount));
         expectedEventMap.put("unit", testUnits);
-        expectedEventMap.put("name", HistogramAggregateAction.HISTOGRAM_METRIC_NAME);
+        expectedEventMap.put("name", HistogramAggregateActionConfig.HISTOGRAM_METRIC_NAME);
         expectedEventMap.put("sum", expectedSum);
         expectedEventMap.put("min", expectedMin);
         expectedEventMap.put("max", expectedMax);
@@ -212,7 +212,7 @@ public class HistogramAggregateActionTests {
         for (int i = 0; i < expectedBucketCounts.length; i++) {
             assertThat(expectedBucketCounts[i], equalTo(bucketCountsFromResult.get(i)));
         }
-        assertThat(((Map<String, String>)result.get(0).toMap().get("attributes")), hasEntry(HistogramAggregateAction.HISTOGRAM_METRIC_NAME+"_key", testKey));
+        assertThat(((Map<String, String>)result.get(0).toMap().get("attributes")), hasEntry(HistogramAggregateActionConfig.HISTOGRAM_METRIC_NAME+"_key", testKey));
         List<Exemplar> exemplars = (List <Exemplar>)result.get(0).toMap().get("exemplars");
         assertThat(exemplars.size(), equalTo(2));
         assertThat(((Map<String, String>)result.get(0).toMap().get("attributes")), hasEntry(dataKey, dataValue));
@@ -250,6 +250,8 @@ public class HistogramAggregateActionTests {
         final String testKeyPrefix = RandomStringUtils.randomAlphabetic(5)+"_";
         when(mockConfig.getStartTimeKey()).thenReturn(startTimeKey);
         when(mockConfig.getEndTimeKey()).thenReturn(endTimeKey);
+        final String testName = UUID.randomUUID().toString();
+        when(mockConfig.getName()).thenReturn(testName);
         when(mockConfig.getOutputFormat()).thenReturn(OutputFormat.OTEL_METRICS.toString());
         String keyPrefix = UUID.randomUUID().toString();
         final String testUnits = "ms";
@@ -323,7 +325,7 @@ public class HistogramAggregateActionTests {
         final String expectedStartTimeKey = mockConfig.getStartTimeKey();
         Map<String, Object> expectedEventMap = new HashMap<>(Collections.singletonMap("count", (long)testCount));
         expectedEventMap.put("unit", testUnits);
-        expectedEventMap.put("name", HistogramAggregateAction.HISTOGRAM_METRIC_NAME);
+        expectedEventMap.put("name", testName);
         expectedEventMap.put("sum", expectedSum);
         expectedEventMap.put("min", expectedMin);
         expectedEventMap.put("max", expectedMax);
@@ -337,7 +339,7 @@ public class HistogramAggregateActionTests {
         for (int i = 0; i < expectedBucketCounts.length; i++) {
             assertThat(expectedBucketCounts[i], equalTo(bucketCountsFromResult.get(i)));
         }
-        assertThat(((Map<String, String>)result.get(0).toMap().get("attributes")), hasEntry(HistogramAggregateAction.HISTOGRAM_METRIC_NAME+"_key", testKey));
+        assertThat(((Map<String, String>)result.get(0).toMap().get("attributes")), hasEntry(testName+"_key", testKey));
         List<Exemplar> exemplars = (List <Exemplar>)result.get(0).toMap().get("exemplars");
         assertThat(exemplars.size(), equalTo(2));
         assertThat(((Map<String, String>)result.get(0).toMap().get("attributes")), hasEntry(dataKey, dataValue));

--- a/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
+++ b/data-prepper-plugins/aggregate-processor/src/test/java/org/opensearch/dataprepper/plugins/processor/aggregate/actions/HistogramAggregateActionTests.java
@@ -251,7 +251,7 @@ public class HistogramAggregateActionTests {
         when(mockConfig.getStartTimeKey()).thenReturn(startTimeKey);
         when(mockConfig.getEndTimeKey()).thenReturn(endTimeKey);
         final String testName = UUID.randomUUID().toString();
-        when(mockConfig.getName()).thenReturn(testName);
+        when(mockConfig.getMetricName()).thenReturn(testName);
         when(mockConfig.getOutputFormat()).thenReturn(OutputFormat.OTEL_METRICS.toString());
         String keyPrefix = UUID.randomUUID().toString();
         final String testUnits = "ms";


### PR DESCRIPTION
### Description
Add support to configure metric name for count and histogram actions
 
### Issues Resolved
Resolves #[Issue number to be closed when this PR is merged]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [X ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
