### PR TITLE
DocumentDB Source improvements

### DIFF
--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/CheckpointStatus.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/stream/CheckpointStatus.java
@@ -3,14 +3,20 @@ package org.opensearch.dataprepper.plugins.mongo.stream;
 public class CheckpointStatus {
     private final String resumeToken;
     private final long recordCount;
-    private boolean acknowledged;
+    private AcknowledgmentStatus acknowledgeStatus;
     private final long createTimestamp;
     private Long acknowledgedTimestamp;
+
+    enum AcknowledgmentStatus {
+        POSITIVE_ACK,
+        NEGATIVE_ACK,
+        NO_ACK
+    }
 
     public CheckpointStatus(final String resumeToken, final long recordCount, final long createTimestamp) {
         this.resumeToken = resumeToken;
         this.recordCount = recordCount;
-        this.acknowledged = false;
+        this.acknowledgeStatus = AcknowledgmentStatus.NO_ACK;
         this.createTimestamp = createTimestamp;
     }
 
@@ -18,8 +24,8 @@ public class CheckpointStatus {
         this.acknowledgedTimestamp = acknowledgedTimestamp;
     }
 
-    public void setAcknowledged(boolean acknowledged) {
-        this.acknowledged = acknowledged;
+    public void setAcknowledged(final AcknowledgmentStatus acknowledgmentStatus) {
+        this.acknowledgeStatus = acknowledgmentStatus;
     }
 
     public String getResumeToken() {
@@ -29,8 +35,12 @@ public class CheckpointStatus {
         return recordCount;
     }
 
-    public boolean isAcknowledged() {
-        return acknowledged;
+    public boolean isPositiveAcknowledgement() {
+        return this.acknowledgeStatus == AcknowledgmentStatus.POSITIVE_ACK;
+    }
+
+    public boolean isNegativeAcknowledgement() {
+        return this.acknowledgeStatus == AcknowledgmentStatus.NEGATIVE_ACK;
     }
 
     public long getCreateTimestamp() {

--- a/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/utils/DocumentDBSourceAggregateMetrics.java
+++ b/data-prepper-plugins/mongodb/src/main/java/org/opensearch/dataprepper/plugins/mongo/utils/DocumentDBSourceAggregateMetrics.java
@@ -17,8 +17,7 @@ public class DocumentDBSourceAggregateMetrics {
     private static final String DOCUMENT_DB_EXPORT_5XX_ERRORS = "export5xxErrors";
     private static final String DOCUMENT_DB_EXPORT_4XX_ERRORS = "export4xxErrors";
     private static final String DOCUMENT_DB_EXPORT_API_INVOCATIONS = "exportApiInvocations";
-
-
+    private static final String DOCUMENT_DB_EXPORT_PARTITION_QUERY_COUNT = "exportPartitionQueryCount";
 
     private final PluginMetrics pluginMetrics;
 
@@ -28,6 +27,7 @@ public class DocumentDBSourceAggregateMetrics {
     private final Counter export5xxErrors;
     private final Counter export4xxErrors;
     private final Counter exportApiInvocations;
+    private final Counter exportPartitionQueryCount;
 
     public DocumentDBSourceAggregateMetrics() {
         this.pluginMetrics = PluginMetrics.fromPrefix(DOCUMENT_DB);
@@ -37,6 +37,7 @@ public class DocumentDBSourceAggregateMetrics {
         this.export5xxErrors = pluginMetrics.counter(DOCUMENT_DB_EXPORT_5XX_ERRORS);
         this.export4xxErrors = pluginMetrics.counter(DOCUMENT_DB_EXPORT_4XX_ERRORS);
         this.exportApiInvocations = pluginMetrics.counter(DOCUMENT_DB_EXPORT_API_INVOCATIONS);
+        this.exportPartitionQueryCount = pluginMetrics.counter(DOCUMENT_DB_EXPORT_PARTITION_QUERY_COUNT);
     }
 
     public Counter getStream5xxErrors() {
@@ -61,5 +62,9 @@ public class DocumentDBSourceAggregateMetrics {
 
     public Counter getExportApiInvocations() {
         return exportApiInvocations;
+    }
+
+    public Counter getExportPartitionQueryCount() {
+        return exportPartitionQueryCount;
     }
 }

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/documentdb/MongoTasksRefresherTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/documentdb/MongoTasksRefresherTest.java
@@ -254,4 +254,18 @@ class MongoTasksRefresherTest {
                 buffer, enhancedSourceCoordinator, pluginMetrics, acknowledgementSetManager,
                 executorServiceFunction, null, documentDBSourceAggregateMetrics));
     }
+
+    @Test
+    void testTaskRefreshShutdown() {
+        final MongoTasksRefresher objectUnderTest = createObjectUnderTest();
+        objectUnderTest.initialize(sourceConfig);
+        objectUnderTest.shutdown();
+        verify(executorServiceFunction).apply(eq(3));
+        verify(executorService).submit(any(ExportScheduler.class));
+        verify(executorService).submit(any(ExportWorker.class));
+        verify(executorService).submit(any(StreamScheduler.class));
+        verify(executorService).shutdownNow();
+        verifyNoMoreInteractions(executorServiceFunction);
+
+    }
 }

--- a/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManagerTest.java
+++ b/data-prepper-plugins/mongodb/src/test/java/org/opensearch/dataprepper/plugins/mongo/stream/StreamAcknowledgementManagerTest.java
@@ -73,7 +73,7 @@ public class StreamAcknowledgementManagerTest {
         consumer.accept(true);
         final ConcurrentHashMap<String, CheckpointStatus> ackStatus = streamAckManager.getAcknowledgementStatus();
         final CheckpointStatus ackCheckpointStatus = ackStatus.get(resumeToken);
-        assertThat(ackCheckpointStatus.isAcknowledged(), is(true));
+        assertThat(ackCheckpointStatus.isPositiveAcknowledgement(), is(true));
         await()
            .atMost(Duration.ofSeconds(10)).untilAsserted(() ->
                 verify(partitionCheckpoint).checkpoint(resumeToken, recordCount));
@@ -109,7 +109,7 @@ public class StreamAcknowledgementManagerTest {
         consumers.get(1).accept(true);
         ConcurrentHashMap<String, CheckpointStatus> ackStatus = streamAckManager.getAcknowledgementStatus();
         CheckpointStatus ackCheckpointStatus = ackStatus.get(resumeToken2);
-        assertThat(ackCheckpointStatus.isAcknowledged(), is(true));
+        assertThat(ackCheckpointStatus.isPositiveAcknowledgement(), is(true));
         await()
             .atMost(Duration.ofSeconds(10)).untilAsserted(() ->
                 verify(partitionCheckpoint).checkpoint(resumeToken2, recordCount2));
@@ -143,7 +143,7 @@ public class StreamAcknowledgementManagerTest {
         consumers.get(1).accept(true);
         ConcurrentHashMap<String, CheckpointStatus> ackStatus = streamAckManager.getAcknowledgementStatus();
         CheckpointStatus ackCheckpointStatus = ackStatus.get(resumeToken2);
-        assertThat(ackCheckpointStatus.isAcknowledged(), is(true));
+        assertThat(ackCheckpointStatus.isPositiveAcknowledgement(), is(true));
         await()
             .atMost(Duration.ofSeconds(10)).untilAsserted(() ->
                 verify(partitionCheckpoint).giveUpPartition());
@@ -169,7 +169,7 @@ public class StreamAcknowledgementManagerTest {
         consumer.accept(false);
         final ConcurrentHashMap<String, CheckpointStatus> ackStatus = streamAckManager.getAcknowledgementStatus();
         final CheckpointStatus ackCheckpointStatus = ackStatus.get(resumeToken);
-        assertThat(ackCheckpointStatus.isAcknowledged(), is(false));
+        assertThat(ackCheckpointStatus.isPositiveAcknowledgement(), is(false));
         await()
             .atMost(Duration.ofSeconds(10)).untilAsserted(() ->
                 verify(stopWorkerConsumer).accept(null));


### PR DESCRIPTION
### Description
1. Extend the export partition ownership during query partition creation
2. Add support to shutdown task refresher that starts export, stream scheduler and worker
3. Add AcknowledgmentStatus enum and code refactor to fail negative ack right away
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
