### PR TITLE
Fixes performance regression with JacksonEvent put/delete operations.

### DIFF
--- a/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
+++ b/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/event/JacksonEvent.java
@@ -170,7 +170,7 @@ public class JacksonEvent implements Event {
      */
     @Override
     public void put(final String key, final Object value) {
-        final JacksonEventKey jacksonEventKey = new JacksonEventKey(key, EventKeyFactory.EventAction.PUT);
+        final JacksonEventKey jacksonEventKey = new JacksonEventKey(key, true, EventKeyFactory.EventAction.PUT);
         put(jacksonEventKey, value);
     }
 
@@ -229,7 +229,7 @@ public class JacksonEvent implements Event {
      */
     @Override
     public <T> T get(final String key, final Class<T> clazz) {
-        final JacksonEventKey jacksonEventKey = new JacksonEventKey(key, EventKeyFactory.EventAction.GET);
+        final JacksonEventKey jacksonEventKey = new JacksonEventKey(key, true, EventKeyFactory.EventAction.GET);
         return get(jacksonEventKey, clazz);
     }
 
@@ -274,7 +274,7 @@ public class JacksonEvent implements Event {
      */
     @Override
     public <T> List<T> getList(final String key, final Class<T> clazz) {
-        JacksonEventKey jacksonEventKey = new JacksonEventKey(key, EventKeyFactory.EventAction.GET);
+        JacksonEventKey jacksonEventKey = new JacksonEventKey(key, true, EventKeyFactory.EventAction.GET);
         return getList(jacksonEventKey, clazz);
     }
 
@@ -330,7 +330,7 @@ public class JacksonEvent implements Event {
      */
     @Override
     public void delete(final String key) {
-        final JacksonEventKey jacksonEventKey = new JacksonEventKey(key, EventKeyFactory.EventAction.DELETE);
+        final JacksonEventKey jacksonEventKey = new JacksonEventKey(key, true, EventKeyFactory.EventAction.DELETE);
         delete(jacksonEventKey);
     }
 
@@ -362,7 +362,7 @@ public class JacksonEvent implements Event {
 
     @Override
     public String getAsJsonString(final String key) {
-        JacksonEventKey jacksonEventKey = new JacksonEventKey(key, EventKeyFactory.EventAction.GET);
+        JacksonEventKey jacksonEventKey = new JacksonEventKey(key, true, EventKeyFactory.EventAction.GET);
         return getAsJsonString(jacksonEventKey);
     }
 
@@ -459,7 +459,7 @@ public class JacksonEvent implements Event {
 
     @Override
     public boolean containsKey(final String key) {
-        JacksonEventKey jacksonEventKey = new JacksonEventKey(key, EventKeyFactory.EventAction.GET);
+        JacksonEventKey jacksonEventKey = new JacksonEventKey(key, true, EventKeyFactory.EventAction.GET);
         return containsKey(jacksonEventKey);
     }
 
@@ -474,7 +474,7 @@ public class JacksonEvent implements Event {
 
     @Override
     public boolean isValueAList(final String key) {
-        JacksonEventKey jacksonEventKey = new JacksonEventKey(key, EventKeyFactory.EventAction.GET);
+        JacksonEventKey jacksonEventKey = new JacksonEventKey(key, true, EventKeyFactory.EventAction.GET);
         return isValueAList(jacksonEventKey);
     }
 

--- a/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventKeyTest.java
+++ b/data-prepper-api/src/test/java/org/opensearch/dataprepper/model/event/JacksonEventKeyTest.java
@@ -116,6 +116,23 @@ class JacksonEventKeyTest {
     }
 
     @ParameterizedTest
+    @EnumSource(value = EventKeyFactory.EventAction.class)
+    void getJsonPointer_returns_valid_JsonPointer_when_constructed_with_fromJacksonEvent(final EventKeyFactory.EventAction eventAction) {
+        final String testKey = UUID.randomUUID().toString();
+        final JacksonEventKey objectUnderTest = new JacksonEventKey(testKey, true, eventAction);
+
+        final JsonPointer jsonPointer = objectUnderTest.getJsonPointer();
+        assertThat(jsonPointer, notNullValue());
+        assertThat(jsonPointer.toString(), equalTo("/" + testKey));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(KeyPathListArgumentsProvider.class)
+    void getKeyPathList_returns_expected_value_when_constructed_with_fromJacksonEvent(final String key, final List<String> expectedKeyPathList) {
+        assertThat(new JacksonEventKey(key, true).getKeyPathList(), equalTo(expectedKeyPathList));
+    }
+
+    @ParameterizedTest
     @ArgumentsSource(SupportsArgumentsProvider.class)
     void supports_returns_true_if_any_supports(final List<EventKeyFactory.EventAction> eventActionsList, final EventKeyFactory.EventAction otherAction, final boolean expectedSupports) {
         final String testKey = UUID.randomUUID().toString();


### PR DESCRIPTION
### Description

With the addition of the `EventKey` (see #1916), `JacksonEvent` always creates a `JacksonEventKey` in order to use the same code for all paths. However, when put/delete calls are made with a String key, `JacksonEvent` does not need the JSON Pointer. But, it is created anyway. This adds more work to the put/delete calls that have not yet migrated to the String version. 

This fixes regression by adding a lazy initialization option when used in `JacksonEvent`. We should not be lazy when used with the `EventKeyFactory` since we may lose some up-front validations.

### Issues Resolved

N/A
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
